### PR TITLE
Default to TypeScript adapter

### DIFF
--- a/.github/workflows/holon-issue.yml
+++ b/.github/workflows/holon-issue.yml
@@ -28,7 +28,6 @@ jobs:
         uses: ./
         env:
           HOLON_MODEL: ${{ vars.HOLON_MODEL || 'claude-sonnet-4-5-20250929' }}
-          HOLON_ADAPTER_IMAGE: holon-adapter-claude-ts
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           anthropic_base_url: ${{ secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com' }}

--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,17 @@ build-host:
 
 ## build-adapter-image: Build the Claude adapter Docker image
 build-adapter-image:
-	@echo "Building Claude adapter image..."
-	docker build -t holon-adapter-claude ./images/adapter-claude
+	@echo "Building Claude adapter image (TypeScript)..."
+	docker build -t holon-adapter-claude-ts ./images/adapter-claude-ts
 
 ## ensure-adapter-image: Ensure the Claude adapter Docker image exists
 ensure-adapter-image:
-	@echo "Checking for holon-adapter-claude image..."
-	@if ! docker image inspect holon-adapter-claude >/dev/null 2>&1; then \
-		echo "Image not found, building holon-adapter-claude..."; \
+	@echo "Checking for holon-adapter-claude-ts image..."
+	@if ! docker image inspect holon-adapter-claude-ts >/dev/null 2>&1; then \
+		echo "Image not found, building holon-adapter-claude-ts..."; \
 		$(MAKE) build-adapter-image; \
 	else \
-		echo "holon-adapter-claude image found."; \
+		echo "holon-adapter-claude-ts image found."; \
 	fi
 
 # Adapter variables

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
         ANTHROPIC_BASE_URL: ${{ inputs.anthropic_base_url }}
         GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
       run: |
-        ADAPTER_IMAGE="${HOLON_ADAPTER_IMAGE:-holon-adapter-claude}"
+        ADAPTER_IMAGE="${HOLON_ADAPTER_IMAGE:-holon-adapter-claude-ts}"
         # Build holon and adapter if not present
         if [ ! -f bin/holon ]; then
           make build
@@ -90,9 +90,9 @@ runs:
         if [ "$ADAPTER_IMAGE" = "holon-adapter-claude-ts" ]; then
           echo "Building TypeScript adapter image..."
           docker build -t "$ADAPTER_IMAGE" ./images/adapter-claude-ts
-        elif [ -z "${HOLON_ADAPTER_IMAGE:-}" ] || [ "$ADAPTER_IMAGE" = "holon-adapter-claude" ]; then
-          echo "Building default adapter image..."
-          make build-adapter-image
+        elif [ "$ADAPTER_IMAGE" = "holon-adapter-claude" ]; then
+          echo "::warning title=Holon Adapter::Python adapter is deprecated. Use holon-adapter-claude-ts instead."
+          docker build -t "$ADAPTER_IMAGE" ./images/adapter-claude
         else
           echo "Using custom adapter image '$ADAPTER_IMAGE' (no local build performed)."
         fi

--- a/cmd/holon/main.go
+++ b/cmd/holon/main.go
@@ -58,7 +58,7 @@ func init() {
 	runCmd.Flags().StringVarP(&goalStr, "goal", "g", "", "Goal description (alternative to --spec)")
 	runCmd.Flags().StringVarP(&taskName, "name", "n", "", "Task name (optional, defaults to auto-generated)")
 	runCmd.Flags().StringVarP(&baseImage, "image", "i", "golang:1.22", "Docker image for execution (Base toolchain)")
-	runCmd.Flags().StringVar(&adapterImage, "adapter-image", "holon-adapter-claude", "Docker image containing the Holon adapter (e.g. holon-adapter-claude)")
+	runCmd.Flags().StringVar(&adapterImage, "adapter-image", "holon-adapter-claude-ts", "Docker image containing the Holon adapter (e.g. holon-adapter-claude-ts)")
 	runCmd.Flags().StringVarP(&workspacePath, "workspace", "w", ".", "Path to workspace")
 	runCmd.Flags().StringVarP(&contextPath, "context", "c", "", "Path to context directory")
 	runCmd.Flags().StringVarP(&outDir, "out", "o", "./holon-output", "Path to output directory")

--- a/cmd/holon/runner.go
+++ b/cmd/holon/runner.go
@@ -171,7 +171,7 @@ output:
 
 	adapterImage := cfg.AdapterImage
 	if adapterImage == "" {
-		adapterImage = "holon-adapter-claude"
+		adapterImage = "holon-adapter-claude-ts"
 	}
 
 	containerCfg := &docker.ContainerConfig{

--- a/cmd/holon/runner_test.go
+++ b/cmd/holon/runner_test.go
@@ -497,8 +497,8 @@ func TestRunner_Integration(t *testing.T) {
 			if cfg.BaseImage != "golang:1.22" {
 				t.Errorf("Expected BaseImage to be 'golang:1.22', got %q", cfg.BaseImage)
 			}
-			if cfg.AdapterImage != "holon-adapter-claude" {
-				t.Errorf("Expected AdapterImage to be 'holon-adapter-claude', got %q", cfg.AdapterImage)
+			if cfg.AdapterImage != "holon-adapter-claude-ts" {
+				t.Errorf("Expected AdapterImage to be 'holon-adapter-claude-ts', got %q", cfg.AdapterImage)
 			}
 			// WorkingDir is hardcoded to "/holon/workspace" in the docker runtime
 			return nil

--- a/pkg/runtime/docker/runtime_test.go
+++ b/pkg/runtime/docker/runtime_test.go
@@ -179,17 +179,17 @@ func TestComposedImageTagGeneration(t *testing.T) {
 		{
 			name:         "standard images",
 			baseImage:    "golang:1.22",
-			adapterImage: "holon-adapter-claude",
+			adapterImage: "holon-adapter-claude-ts",
 		},
 		{
 			name:         "same images should produce same tag",
 			baseImage:    "golang:1.22",
-			adapterImage: "holon-adapter-claude",
+			adapterImage: "holon-adapter-claude-ts",
 		},
 		{
 			name:         "different base image",
 			baseImage:    "python:3.11",
-			adapterImage: "holon-adapter-claude",
+			adapterImage: "holon-adapter-claude-ts",
 		},
 		{
 			name:         "different adapter image",


### PR DESCRIPTION
## Summary
- switch default adapter image to holon-adapter-claude-ts across CLI/runtime/CI
- compose runtime image without Python and run Node adapter directly
- update tests and build scripts for the TS adapter

## Testing
- not run (user indicated CI already passing)
