### PR TITLE
Fix: Unify @holonbot trigger commands and workflow quoting

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -175,7 +175,7 @@ jobs:
             FIRST_LINE="$(printf '%s\n' "$COMMENT_BODY" | head -n1 | xargs || true)"
 
             if [ "$IS_PR" = 'true' ]; then
-              if [ "$FIRST_LINE" = '@holonbot fix' ] || [ "$FIRST_LINE" = '@holonbot pr-fix' ]; then
+              if [ "$FIRST_LINE" = '@holonbot fix' ] || [ "$FIRST_LINE" = '@holonbot solve' ]; then
                 :
               else
                 REASON="Comment command not recognized for PR: '$FIRST_LINE'"
@@ -323,16 +323,16 @@ jobs:
 
           # If mode is explicitly provided, use it
           if [ -n "$PROVIDED_MODE" ]; then
-            echo "mode=$PROVIDED_MODE" >> $GITHUB_OUTPUT
+            echo "mode=$PROVIDED_MODE" >> "$GITHUB_OUTPUT"
             echo "✅ Using provided mode: $PROVIDED_MODE"
             exit 0
           fi
 
           if [ "$IS_PR" = 'true' ]; then
-            echo "mode=pr-fix" >> $GITHUB_OUTPUT
+            echo "mode=pr-fix" >> "$GITHUB_OUTPUT"
             echo "✅ Detected: PR → mode=pr-fix"
           else
-            echo "mode=solve" >> $GITHUB_OUTPUT
+            echo "mode=solve" >> "$GITHUB_OUTPUT"
             echo "✅ Detected: Issue → mode=solve"
           fi
         env:
@@ -425,10 +425,10 @@ jobs:
 
           # Check for summary
           if [ -f "$OUTPUT_DIR/summary.md" ]; then
-            cat "$OUTPUT_DIR/summary.md" >> $GITHUB_STEP_SUMMARY
-            echo "summary=$OUTPUT_DIR/summary.md" >> $GITHUB_OUTPUT
+            cat "$OUTPUT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+            echo "summary=$OUTPUT_DIR/summary.md" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=" >> $GITHUB_OUTPUT
+            echo "summary=" >> "$GITHUB_OUTPUT"
           fi
 
           # Set result based on job status


### PR DESCRIPTION
## Summary

Fixes the workflow trigger issue where `@holonbot solve` command was not recognized on PRs, causing "command not found" errors.

## Changes

1. **Unified trigger commands** (holon-solve.yml):
   - Changed PR trigger from `@holonbot pr-fix` to `@holonbot solve`
   - Now both PR and Issue support the same commands:
     - `@holonbot solve` - works on both PR and Issue
     - `@holonbot fix` - works on both PR and Issue
   - Provides consistent UX and eliminates confusion

2. **Fixed shell script quoting** (holon-solve.yml):
   - Added quotes around `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY` redirect targets
   - Prevents potential word-splitting issues
   - Lines: 326, 332, 335, 428, 429, 431

## Root Cause

The original error "solve: command not found" occurred because:
- Users commented `@holonbot solve` on PR #321
- The gate logic only accepted `@holonbot fix` or `@holonbot pr-fix` for PRs
- Gate rejected the command with "Comment command not recognized for PR: '@holonbot solve'"
- Workflow exited early without running holon

## Testing

After this fix:
- `@holonbot solve` will work on PRs (auto-detects `pr-fix` mode)
- `@holonbot fix` will continue to work on PRs (auto-detects `pr-fix` mode)
- Both commands work on Issues (auto-detects `solve` mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)