### PR TITLE
Fix: Use URL-embedded token for reliable git push authentication

### DIFF
--- a/pkg/publisher/githubpr/git_ops.go
+++ b/pkg/publisher/githubpr/git_ops.go
@@ -237,20 +237,50 @@ func (g *GitClient) configureGitCredentials(ctx context.Context) error {
 		return fmt.Errorf("failed to get remote URL: %w", err)
 	}
 
-	currentURL := string(remoteURL)
+	// Trim whitespace from git command output
+	currentURL := strings.TrimSpace(string(remoteURL))
 	holonlog.Debug("current remote URL", "url", currentURL)
 
-	// Check if URL already has token embedded
-	if strings.Contains(currentURL, "@github.com/") {
-		holonlog.Debug("remote URL already has embedded token", "url_prefix", currentURL[:30]+"...")
-		return nil
+	// Check if URL already has embedded credentials
+	// Look for the pattern "://credentials@" which indicates embedded auth
+	if strings.Contains(currentURL, "://") && strings.Contains(currentURL, "@") {
+		// Find the position of "://" and "@" to verify there's something between them
+		schemeEnd := strings.Index(currentURL, "://")
+		atPos := strings.Index(currentURL, "@")
+		if schemeEnd != -1 && atPos != -1 && atPos > schemeEnd+3 {
+			// Has embedded credentials
+			holonlog.Debug("remote URL already has embedded credentials", "url_prefix", safeTruncate(currentURL, 30))
+			return nil
+		}
 	}
 
-	// Embed token in URL: https://github.com/owner/repo.git -> https://x-access-token:TOKEN@github.com/owner/repo.git
-	// This pattern works for both push and fetch operations
-	tokenEmbeddedURL := strings.Replace(currentURL, "https://github.com/", fmt.Sprintf("https://x-access-token:%s@github.com/", g.Token), 1)
+	// Embed token in URL
+	// Support any HTTPS/HTTP GitHub URL (not just github.com)
+	var tokenEmbeddedURL string
+	if strings.HasPrefix(currentURL, "https://") {
+		// HTTPS URL: https://HOST/PATH -> https://x-access-token:TOKEN@HOST/PATH
+		// This works for github.com, GitHub Enterprise, and compatible services
+		tokenEmbeddedURL = strings.Replace(currentURL, "https://", fmt.Sprintf("https://x-access-token:%s@", g.Token), 1)
+	} else if strings.HasPrefix(currentURL, "http://") {
+		// HTTP URL (less common, but supported)
+		tokenEmbeddedURL = strings.Replace(currentURL, "http://", fmt.Sprintf("http://x-access-token:%s@", g.Token), 1)
+	} else if strings.HasPrefix(currentURL, "git@") {
+		// SSH URL: git@github.com:owner/repo.git
+		// Parse and convert to HTTPS with embedded token
+		sshPart := strings.TrimPrefix(currentURL, "git@")
+		hostAndPath := strings.SplitN(sshPart, ":", 2)
+		if len(hostAndPath) != 2 {
+			return fmt.Errorf("unsupported SSH remote URL format: %s", currentURL)
+		}
+		host := hostAndPath[0]
+		repoPath := strings.TrimSuffix(hostAndPath[1], ".git")
+		tokenEmbeddedURL = fmt.Sprintf("https://x-access-token:%s@%s/%s.git", g.Token, host, repoPath)
+		holonlog.Debug("converted SSH URL to HTTPS with token", "host", host, "repo_path", repoPath)
+	} else {
+		return fmt.Errorf("unsupported remote URL format: %s (expected HTTPS, HTTP, or SSH)", currentURL)
+	}
 
-	holonlog.Debug("updating remote URL with embedded token", "url_prefix", tokenEmbeddedURL[:40]+"...")
+	holonlog.Debug("updating remote URL with embedded token", "url_prefix", safeTruncate(tokenEmbeddedURL, 40))
 
 	// Update the remote URL
 	_, err = client.ExecCommand(ctx, "config", "--local", "remote.origin.url", tokenEmbeddedURL)
@@ -263,16 +293,21 @@ func (g *GitClient) configureGitCredentials(ctx context.Context) error {
 	if err != nil {
 		holonlog.Warn("failed to verify remote URL update", "error", err)
 	} else {
-		verifyStr := string(verifyURL)
+		verifyStr := strings.TrimSpace(string(verifyURL))
 		// Truncate for logging to avoid exposing full token
-		prefixLen := 50
-		if len(verifyStr) < prefixLen {
-			prefixLen = len(verifyStr)
-		}
-		holonlog.Debug("remote URL updated successfully", "url_prefix", verifyStr[:prefixLen]+"...")
+		holonlog.Debug("remote URL updated successfully", "url_prefix", safeTruncate(verifyStr, 50))
 	}
 
 	return nil
+}
+
+// safeTruncate safely truncates a string to the specified length for logging.
+// If the string is shorter than maxLength, returns the entire string.
+func safeTruncate(s string, maxLength int) string {
+	if len(s) < maxLength {
+		return s
+	}
+	return s[:maxLength] + "..."
 }
 
 // EnsureCleanWorkspace ensures the workspace is a Git repository.


### PR DESCRIPTION
## Summary

Fixes git push authentication failure by switching from `http.extraheader` to URL-embedded token approach. This resolves the error:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

## Problem

The previous implementation used `http.extraheader` to set the authentication token:
```bash
git config --local http.https://github.com/.extraheader "Authorization: Bearer TOKEN"
```

This approach doesn't work reliably across different git versions and scenarios, causing push failures.

## Solution

Changed to **URL-embedded token** approach, which is universally supported:
```bash
# Before (unreliable)
https://github.com/owner/repo.git

# After (reliable)
https://x-access-token:TOKEN@github.com/owner/repo.git
```

## Changes

### pkg/publisher/githubpr/git_ops.go
- Get current remote URL
- Check if token already embedded
- Embed token in URL format: `https://x-access-token:TOKEN@github.com/...`
- Update remote URL with embedded token
- Add verification and debug logging

### pkg/publisher/git/git_ops.go  
- Same URL-embedded token approach
- Additional support for SSH URL to HTTPS conversion
- Handles multiple URL formats (HTTPS, HTTP, SSH)

## Benefits

- ✅ **More reliable** - Works consistently across git versions
- ✅ **Universally supported** - URL-embedded tokens are standard
- ✅ **Better error messages** - Clear debug logging
- ✅ **Format conversion** - Converts SSH URLs to HTTPS with token

## Testing

All existing tests pass:
- ✅ `go test ./pkg/publisher/githubpr/...`
- ✅ `go test ./pkg/publisher/git/...`

## Related Issues

Fixes the issue reported where git push fails with authentication errors even when a valid token is provided.

## Technical Details

**Token Embedding Format**:
```
https://x-access-token:ghp_1234567890ABCDEF@github.com/owner/repo.git
```

**Why this works**:
- Git reads credentials from the URL
- The `x-access-token:` prefix tells GitHub this is a token
- No need for credential helpers or extra headers
- Works for both push and fetch operations

**Security Note**:
- Token is stored in `.git/config` (same as before)
- Should be cleaned up or rotated regularly
- Consider using temporary tokens for CI environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)