### PR TITLE
Unify default git author identity to holonbot[bot]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ log_level: "debug"
 
 # Git identity overrides for container operations
 git:
-  author_name: "Holon Bot"
+  author_name: "holonbot[bot]"
   author_email: "holon@example.com"
 ```
 

--- a/cmd/holon/runner_test.go
+++ b/cmd/holon/runner_test.go
@@ -1403,9 +1403,9 @@ func TestRunner_GitConfigOverride(t *testing.T) {
 	}{
 		{
 			name:           "both git name and email set",
-			gitAuthorName:  "Holon Bot",
+			gitAuthorName:  "holonbot[bot]",
 			gitAuthorEmail: "holon@example.com",
-			expectedName:   "Holon Bot",
+			expectedName:   "holonbot[bot]",
 			expectedEmail:  "holon@example.com",
 		},
 		{

--- a/docs/git-configuration.md
+++ b/docs/git-configuration.md
@@ -6,8 +6,8 @@ When Holon performs git operations (e.g., creating PRs, publishing changes), it 
 
 If no git identity is configured, Holon uses default fallback values:
 
-- **Name**: `Holon Bot`
-- **Email**: `bot@holon.run`
+- **Name**: `holonbot[bot]`
+- **Email**: `250454749+holonbot[bot]@users.noreply.github.com`
 
 ## Configuration Priority
 
@@ -16,7 +16,7 @@ Holon determines git identity using a **centralized resolver** (`git.ResolveConf
 1. **Host git config** (local > global > system) - Your system's git configuration
 2. **ProjectConfig** - Project-level configuration in `.holon/config.yaml`
 3. **Environment variables** - `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL`
-4. **Default values** - `Holon Bot <bot@holon.run>`
+4. **Default values** - `holonbot[bot] <250454749+holonbot[bot]@users.noreply.github.com>`
 
 **Important**: The centralized resolver ensures consistent behavior across all commands (`run`, `publish`, `solve`). Host git config always has highest priority, respecting your personal git identity.
 
@@ -119,8 +119,8 @@ Commit this file to your repository so all team members use the same bot identit
 **Recommended**: Use host git config on the bot machine
 
 ```bash
-sudo -u holon-bot git config --global user.name "Holon Bot"
-sudo -u holon-bot git config --global user.email "bot@holon.run"
+sudo -u holon-bot git config --global user.name "holonbot[bot]"
+sudo -u holon-bot git config --global user.email "250454749+holonbot[bot]@users.noreply.github.com"
 ```
 
 ## Troubleshooting
@@ -170,7 +170,7 @@ The centralized resolver enforces priority as:
 1. **Host git config** (local > global > system) - highest priority
 2. **ProjectConfig** (`.holon/config.yaml`)
 3. **Environment variables** (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`)
-4. **Defaults** (`Holon Bot <bot@holon.run>`)
+4. **Defaults** (`holonbot[bot] <250454749+holonbot[bot]@users.noreply.github.com>`)
 
 This means:
 - Your personal git identity (host config) is always respected

--- a/examples/holon-config.yaml
+++ b/examples/holon-config.yaml
@@ -27,7 +27,7 @@ log_level: "progress"
 # These settings override the host's git config when running inside containers
 git:
   # Override git config user.name for containers
-  # author_name: "Holon Bot"
+  # author_name: "holonbot[bot]"
 
   # Override git config user.email for containers
   # author_email: "holon@example.com"

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -13,10 +13,10 @@ import (
 )
 
 // DefaultAuthorName is the default git author name when no other config is available.
-const DefaultAuthorName = "Holon Bot"
+const DefaultAuthorName = "holonbot[bot]"
 
 // DefaultAuthorEmail is the default git author email when no other config is available.
-const DefaultAuthorEmail = "bot@holon.run"
+const DefaultAuthorEmail = "250454749+holonbot[bot]@users.noreply.github.com"
 
 // Config holds resolved git configuration.
 type Config struct {
@@ -55,7 +55,7 @@ type ConfigOptions struct {
 // 2. Host git config (local > global > system)
 // 3. Environment variables (GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL)
 // 4. ProjectConfig (.holon/config.yaml git.author_*)
-// 5. Defaults ("Holon Bot <bot@holon.run>")
+// 5. Defaults ("holonbot[bot] <250454749+holonbot[bot]@users.noreply.github.com>")
 //
 // This function consolidates all git config resolution logic into one place.
 // It reads host git config with proper scope awareness (local > global > system).
@@ -147,7 +147,7 @@ func GetHostGitConfig(key string) string {
 // 2. Host git config (global > system)
 // 3. Environment variables (GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL)
 // 4. ProjectConfig (.holon/config.yaml git.author_*)
-// 5. Defaults ("Holon Bot <bot@holon.run>")
+// 5. Defaults ("holonbot[bot] <250454749+holonbot[bot]@users.noreply.github.com>")
 func ResolveConfigForWorkspace(ctx context.Context, workspaceDir string, opts ConfigOptions) (Config, error) {
 	cfg := Config{
 		AuthorName: DefaultAuthorName,

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -43,8 +43,8 @@ type ClientOptions struct {
 // DefaultClientOptions returns the default client options.
 func DefaultClientOptions() *ClientOptions {
 	return &ClientOptions{
-		UserName:  "Holon Bot",
-		UserEmail: "bot@holon.run",
+		UserName:  "holonbot[bot]",
+		UserEmail: "250454749+holonbot[bot]@users.noreply.github.com",
 		Quiet:     true,
 		DryRun:    false,
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1226,16 +1226,16 @@ func TestClient_InitRepository_AutoConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConfigGet user.name failed: %v", err)
 	}
-	if name != "Holon Bot" {
-		t.Errorf("user.name = %q, want 'Holon Bot'", name)
+	if name != "holonbot[bot]" {
+		t.Errorf("user.name = %q, want 'holonbot[bot]'", name)
 	}
 
 	email, err := client.ConfigGet(ctx, "user.email")
 	if err != nil {
 		t.Fatalf("ConfigGet user.email failed: %v", err)
 	}
-	if email != "bot@holon.run" {
-		t.Errorf("user.email = %q, want 'bot@holon.run'", email)
+	if email != "250454749+holonbot[bot]@users.noreply.github.com" {
+		t.Errorf("user.email = %q, want '250454749+holonbot[bot]@users.noreply.github.com'", email)
 	}
 
 	// Create a file and commit to verify config works
@@ -1331,8 +1331,8 @@ func TestClient_InitRepository_OverwritesExistingConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConfigGet user.name failed: %v", err)
 	}
-	// Current behavior: gets "Holon Bot", not "Existing User"
-	if name != "Holon Bot" {
+	// Current behavior: gets "holonbot[bot]", not "Existing User"
+	if name != "holonbot[bot]" {
 		t.Logf("Note: InitRepository overwrites existing config (user.name: %q)", name)
 	}
 }

--- a/pkg/publisher/git/git_ops.go
+++ b/pkg/publisher/git/git_ops.go
@@ -165,11 +165,11 @@ func (g *GitClient) CommitChanges(ctx context.Context, message string) (string, 
 	// Determine author name and email (use defaults if not configured)
 	authorName := g.AuthorName
 	if authorName == "" {
-		authorName = "Holon Bot"
+		authorName = holonGit.DefaultAuthorName
 	}
 	authorEmail := g.AuthorEmail
 	if authorEmail == "" {
-		authorEmail = "bot@holon.run"
+		authorEmail = holonGit.DefaultAuthorEmail
 	}
 
 	// Configure git user.name and user.email BEFORE committing

--- a/pkg/publisher/git/types.go
+++ b/pkg/publisher/git/types.go
@@ -20,9 +20,9 @@ type GitPublisherConfig struct {
 	// WorkspaceDir is the path to the git workspace
 	WorkspaceDir string
 
-	// AuthorName is the git author name for commits (if empty, uses "Holon Bot")
+	// AuthorName is the git author name for commits (if empty, uses "holonbot[bot]")
 	AuthorName string
 
-	// AuthorEmail is the git author email for commits (if empty, uses "bot@holon.run")
+	// AuthorEmail is the git author email for commits (if empty, uses holonbot noreply address)
 	AuthorEmail string
 }

--- a/pkg/publisher/githubpr/git_ops.go
+++ b/pkg/publisher/githubpr/git_ops.go
@@ -155,11 +155,11 @@ func (g *GitClient) CommitChanges(ctx context.Context, message string) (string, 
 	// Determine author name and email (use defaults if not configured)
 	authorName := g.AuthorName
 	if authorName == "" {
-		authorName = "Holon Bot"
+		authorName = holonGit.DefaultAuthorName
 	}
 	authorEmail := g.AuthorEmail
 	if authorEmail == "" {
-		authorEmail = "bot@holon.run"
+		authorEmail = holonGit.DefaultAuthorEmail
 	}
 
 	// Configure git user.name and user.email BEFORE committing

--- a/pkg/publisher/githubpr/publisher_test.go
+++ b/pkg/publisher/githubpr/publisher_test.go
@@ -677,7 +677,7 @@ func TestGitClient_CommitChangesWithoutPreconfiguredGit(t *testing.T) {
 
 	// This should succeed by auto-configuring git during CommitChanges
 	// Before fix PR #382: would fail with "Committer identity unknown"
-	// After fix: should succeed with default "Holon Bot <bot@holon.run>"
+	// After fix: should succeed with default "holonbot[bot] <250454749+holonbot[bot]@users.noreply.github.com>"
 	sha, err := gitClient.CommitChanges(ctx, "test commit from GitClient")
 	if err != nil {
 		t.Fatalf("CommitChanges() failed without pre-configured git: %v", err)
@@ -692,16 +692,16 @@ func TestGitClient_CommitChangesWithoutPreconfiguredGit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConfigGet user.name failed: %v", err)
 	}
-	if name != "Holon Bot" {
-		t.Errorf("user.name = %q, want 'Holon Bot'", name)
+	if name != "holonbot[bot]" {
+		t.Errorf("user.name = %q, want 'holonbot[bot]'", name)
 	}
 
 	email, err := client.ConfigGet(ctx, "user.email")
 	if err != nil {
 		t.Fatalf("ConfigGet user.email failed: %v", err)
 	}
-	if email != "bot@holon.run" {
-		t.Errorf("user.email = %q, want 'bot@holon.run'", email)
+	if email != "250454749+holonbot[bot]@users.noreply.github.com" {
+		t.Errorf("user.email = %q, want '250454749+holonbot[bot]@users.noreply.github.com'", email)
 	}
 }
 

--- a/pkg/publisher/githubpr/types.go
+++ b/pkg/publisher/githubpr/types.go
@@ -22,10 +22,10 @@ type PRPublisherConfig struct {
 	// IssueID is the optional issue number to reference in the PR
 	IssueID string
 
-	// AuthorName is the git author name for commits (if empty, uses "Holon Bot")
+	// AuthorName is the git author name for commits (if empty, uses "holonbot[bot]")
 	AuthorName string
 
-	// AuthorEmail is the git author email for commits (if empty, uses "bot@holon.run")
+	// AuthorEmail is the git author email for commits (if empty, uses holonbot noreply address)
 	AuthorEmail string
 
 	// DryRun if true, validates without making changes


### PR DESCRIPTION
## Summary
- unify default git author name/email to holonbot[bot] noreply address
- reuse shared defaults in git publishers
- update docs, examples, and tests

## Testing
- `go test ./...` (fails: TestIntegration/mock-solve-pr requires downloading builtin agent; got "failed to download agent bundle: unexpected EOF")