### PR TITLE
Clarify prompt requirements synthesis

### DIFF
--- a/pkg/prompt/assets/modes/pr-fix/context.md
+++ b/pkg/prompt/assets/modes/pr-fix/context.md
@@ -11,6 +11,13 @@ The following context is mounted at `/holon/input/context/`:
 - If `github/check_runs.json` or `github/commit_status.json` exist, summarize any non-success checks in `pr-fix.json.checks` and mention them in `summary.md`.
 - Use `github/pr.json` for PR title/branch/context; avoid replying to your own comments (see identity above).
 
+### REQUIREMENTS SYNTHESIS
+- Use `github/pr.json` and `github/review_threads.json` as primary requirements.
+- Integrate `github/comments.json` as deltas when they explicitly change requirements or add constraints.
+- Prefer clarifications from the PR author or reviewers when conflicts exist.
+- If conflicts remain unresolved, do not guess; report what needs clarification.
+- `is_trigger=true` only indicates the trigger; it does not imply higher priority.
+
 ### PR Comments
 Additional context is available in `github/comments.json`, which contains general discussion comments from the PR page. These often contain:
 - Important debugging hints from reviewers
@@ -18,10 +25,7 @@ Additional context is available in `github/comments.json`, which contains genera
 - Context about why certain approaches were taken
 - Human analysis of CI failures
 
-**Prioritize human analysis over automated diagnostics**. When diagnosing issues:
-1. First check `github/comments.json` for human insights
-2. Then examine `github/review_threads.json` for code-specific feedback
-3. Finally, perform your own investigation
+**Prioritize human analysis over automated diagnostics**. When diagnosing issues, incorporate insights from `github/comments.json` and `github/review_threads.json` alongside your own investigation.
 
 Pay special attention to comments discussing:
 - Root cause analysis of failures

--- a/pkg/prompt/assets/modes/solve/context.md
+++ b/pkg/prompt/assets/modes/solve/context.md
@@ -7,5 +7,16 @@ The following context is mounted at `/holon/input/context/`:
 {{- end }}
 
 ### SOLVE CONTEXT USAGE
-- If `github/issue.json` exists, read it first to understand the task and any comments.
+- Read `github/issue.json` first to understand the task and baseline context.
+- Read `github/comments.json` for discussion and updates.
 - If other provider context files are present, use them as authoritative requirements before modifying code.
+
+### REQUIREMENTS SYNTHESIS
+- Build a single requirement list by reconciling the issue body with all human comments.
+- Treat comments as deltas: only override earlier requirements when a comment explicitly changes them.
+- Prefer clarifications from the issue author or assignee when conflicts exist.
+- If comments conflict without a clear resolution, do not guess; report what needs clarification.
+
+### COMMENT FILTERING
+- Ignore bot/deploy/status comments unless they contain explicit tasks.
+- `is_trigger=true` only indicates the trigger; it does not imply higher priority.


### PR DESCRIPTION
## Summary
- clarify solve prompt guidance to synthesize requirements from issue body + comments
- add explicit conflict/priority rules and trigger-comment guidance
- align pr-fix prompt with the same synthesis rules and avoid strict comment ordering

## Testing
- not run (prompt text changes only)