### PR TITLE
fix: Enable skill mode in GitHub Actions workflow

### DIFF
--- a/.github/workflows/holon-trigger.yml
+++ b/.github/workflows/holon-trigger.yml
@@ -29,6 +29,9 @@ jobs:
       comment_id: ${{ github.event.comment.id || 0 }}
       review_id: ${{ github.event.review.id || 0 }}
 
+      # Use skill mode for GitHub workflows
+      skill: 'github-solve'
+
       # Repo-local workflow uses the current branch Holon implementation.
       log_level: 'debug'
       build_from_source: true


### PR DESCRIPTION
## Problem

PR #516 was created using publisher-based publishing instead of skill-driven publishing, despite the project having `.holon/config.yaml` configured with `skills: [github-solve]`.

## Root Cause

In GitHub Actions environment, the current working directory when `holon solve` executes may not be the project root directory, causing `config.LoadFromCurrentDir()` to not find the `.holon/config.yaml` file.

## Solution

Explicitly pass `skill: 'github-solve'` parameter to the holon-solve workflow in holon-trigger.yml. This ensures skill mode is enabled regardless of project config detection.

## Changes

- `.github/workflows/holon-trigger.yml`: Add `skill: 'github-solve'` parameter

## Benefits

1. **Consistent behavior**: Skill mode works reliably in all environments (local, CI)
2. **Explicit intent**: Workflow clearly shows it uses skill mode
3. **No reliance on cwd**: Not affected by working directory issues in container

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] Trigger @holonbot on a test issue to verify skill mode is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)