### PR TITLE
fix: Ensure skill parameter takes precedence over auto-detected mode

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -1045,8 +1045,16 @@ jobs:
           set -euo pipefail
 
           PROVIDED_MODE="${{ inputs.mode }}"
+          PROVIDED_SKILL="${{ inputs.skill }}"
 
           IS_PR='${{ steps.ctx.outputs.is_pr }}'
+
+          # If skill is provided, skip mode detection (skill mode takes precedence)
+          if [ -n "$PROVIDED_SKILL" ]; then
+            echo "mode=" >> "$GITHUB_OUTPUT"
+            echo "✅ Skill mode enabled (skill: $PROVIDED_SKILL)"
+            exit 0
+          fi
 
           # If mode is explicitly provided, use it
           if [ -n "$PROVIDED_MODE" ]; then
@@ -1055,6 +1063,7 @@ jobs:
             exit 0
           fi
 
+          # Auto-detect mode based on ref type
           if [ "$IS_PR" = 'true' ]; then
             echo "mode=pr-fix" >> "$GITHUB_OUTPUT"
             echo "✅ Detected: PR → mode=pr-fix"


### PR DESCRIPTION
## Problem

PR #518 was created using publisher-based publishing instead of skill-driven publishing, even though the project has `.holon/config.yaml` configured with `skills: [github-solve]` and PR #517 added `skill: 'github-solve'` to the workflow.

## Root Cause

The workflow's `detect` step was **always** setting the `mode` parameter (auto-detecting `solve` or `pr-fix`), even when the `skill` parameter was provided.

In `cmd/holon/solve.go`, the skill mode logic is:
```go
modeExplicitByUser := solveMode != ""
useSkillMode := len(allSkills) > 0 && !modeExplicitByUser
```

When both `--mode solve` and `--skill github-solve` are passed:
- `modeExplicitByUser` becomes `true` (because `--mode` is set)
- `useSkillMode` becomes `false` (due to `!modeExplicitByUser`)
- Publisher is used instead of skill-driven publishing

## Solution

Modified the `detect` step to check if `skill` parameter is provided **before** mode detection:
- If `skill` is provided → set `mode` to empty string
- If `mode` is explicitly provided → use it
- Otherwise → auto-detect mode based on issue/PR type

This ensures skill parameter takes precedence over auto-detected mode.

## Changes

- `.github/workflows/holon-solve.yml`: Add skill check in detect step (lines 1048-1057)

## Benefits

1. **Skill mode works correctly**: When skill parameter is provided, it's actually used
2. **Backward compatible**: When no skill is provided, mode auto-detection works as before
3. **Explicit mode still works**: Manually specified mode parameter takes precedence over auto-detection

## Test Plan

- [x] Workflow syntax is valid
- [ ] Merge this PR
- [ ] Trigger @holonbot on a test issue to verify skill mode is used
- [ ] Verify output shows "Skill mode enabled: skipping Go publisher"

🤖 Generated with [Claude Code](https://claude.com/claude-code)