### PR TITLE
ci: fix auto_review input type in holon-trigger

### DIFF
--- a/.github/workflows/holon-trigger.yml
+++ b/.github/workflows/holon-trigger.yml
@@ -24,7 +24,7 @@ jobs:
       assignee_login: ${{ github.event.assignee.login || '' }}
       comment_id: ${{ github.event.comment.id || 0 }}
       review_id: ${{ github.event.review.id || 0 }}
-      auto_review: ${{ vars.HOLON_AUTO_REVIEW || false }}
+      auto_review: ${{ fromJSON(vars.HOLON_AUTO_REVIEW || 'false') }}
 
       # Use skill mode for GitHub workflows
       skill: 'github-solve'


### PR DESCRIPTION
## Summary\n- cast HOLON_AUTO_REVIEW to boolean in holon-trigger using fromJSON\n- fixes workflow-call validation error when var is set to string 'true'\n\n## Testing\n- not run (workflow change only)