### PR TITLE
Fix auto-review triggering on PR issue_comment events

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: number
         default: 0
+      lane:
+        description: 'Concurrency lane (e.g., review, command, meta)'
+        required: false
+        type: string
+        default: ''
       comment_id:
         description: 'Comment ID for feedback reactions and replies'
         required: false
@@ -574,7 +579,7 @@ jobs:
     needs: gate
     if: needs.gate.outputs.should_run == 'true'
     concurrency:
-      group: holon-${{ github.repository }}-${{ inputs.issue_number != 0 && inputs.issue_number || github.event.issue.number || github.event.pull_request.number || github.run_id }}
+      group: holon-${{ github.repository }}-${{ needs.gate.outputs.issue_number || github.run_id }}-${{ inputs.lane || 'default' }}
       cancel-in-progress: true
     runs-on: ${{ (startsWith(inputs.runs_on, '[') && fromJSON(inputs.runs_on)) || inputs.runs_on || 'ubuntu-latest' }}
     permissions:

--- a/.github/workflows/holon-trigger.yml
+++ b/.github/workflows/holon-trigger.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/holon-solve.yml
     with:
       issue_number: ${{ github.event.issue.number || github.event.pull_request.number }}
+      lane: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && 'review' || (github.event_name == 'issue_comment' && 'command' || 'meta') }}
       label_name: ${{ github.event.label.name || '' }}
       assignee_login: ${{ github.event.assignee.login || '' }}
       comment_id: ${{ github.event.comment.id || 0 }}


### PR DESCRIPTION
## Problem
PR bot comments (for example Cloudflare Pages deployment comments) arrive as `issue_comment` events on PRs. With `auto_review=true`, the reusable gate treated any PR-targeted event as eligible and launched a run, which then flowed into PR-fix behavior.

## Changes
- Restrict auto-review gate fallback to event types:
  - `pull_request`
  - `pull_request_review`
- Explicitly avoid auto-review fallback on PR `issue_comment` events.
- Update trigger PR event types to include:
  - `opened`
  - `synchronize`
  - `reopened`
  - `ready_for_review`
  - `labeled`

## Result
- Bot comments in PR discussion no longer trigger auto-review runs.
- Auto-review still runs on PR lifecycle updates where it is expected.
