### PR TITLE
Enforce mandatory PR publish in issue-solve mode

### DIFF
--- a/cmd/holon/solve.go
+++ b/cmd/holon/solve.go
@@ -862,7 +862,7 @@ func buildGoal(inputDir string, ref *pkggithub.SolveRef, refType string, trigger
 		}
 	} else {
 		if useSkillMode {
-			baseGoal = fmt.Sprintf("Use the github-issue-solve skill to solve the GitHub issue %s end-to-end. Success requires all of the following: (1) Collect GitHub context, (2) Implement the solution, (3) Generate publish-intent.json, (4) Invoke github-publish, and (5) Actually create or update a GitHub PR and record its URL/number in outputs. Producing publish-intent.json alone is NOT success.", ref.URL())
+			baseGoal = fmt.Sprintf("Use the github-issue-solve skill to solve the GitHub issue %s end-to-end. Success requires all of the following: (1) Collect GitHub context, (2) Implement the solution, (3) Generate ${GITHUB_OUTPUT_DIR}/publish-intent.json, (4) Invoke github-publish so it actually creates or updates a GitHub PR, and (5) After publish completes, ensure ${GITHUB_OUTPUT_DIR}/summary.md and ${GITHUB_OUTPUT_DIR}/manifest.json contain pr_number and pr_url for that PR. Producing publish-intent.json alone is NOT success.", ref.URL())
 		} else {
 			baseGoal = fmt.Sprintf("Implement a solution for the issue described in %s. Make the necessary code changes to resolve the issue. Focus on implementing the solution; the system will handle committing changes and creating any pull requests.", ref.URL())
 		}

--- a/skills/github-issue-solve/SKILL.md
+++ b/skills/github-issue-solve/SKILL.md
@@ -111,7 +111,7 @@ Execution metadata:
 
 ### 5. Create Pull Request
 
-Produce `${GITHUB_OUTPUT_DIR}/publish-intent.json` and invoke the `github-publish` skill to create the PR:
+Produce `${GITHUB_OUTPUT_DIR}/publish-intent.json` and invoke the `github-publish` skill to create/update the PR:
 ```json
 {
   "actions": [
@@ -128,6 +128,8 @@ Produce `${GITHUB_OUTPUT_DIR}/publish-intent.json` and invoke the `github-publis
 ```
 
 Run `github-publish` with this intent file. Treat publish execution as mandatory completion work, not optional cleanup.
+
+After publish succeeds, update `${GITHUB_OUTPUT_DIR}/summary.md` and `${GITHUB_OUTPUT_DIR}/manifest.json` to include `pr_number` and `pr_url`.
 
 ## Output Contract
 
@@ -183,7 +185,7 @@ git push -u origin feature/issue-<number>
 You MAY use these commands:
 - `gh issue view <number>` - View issue details
 - `gh issue comment <number>` - Comment on issues
-- `gh pr create` - Create pull requests (or use `github-publish` skill)
+- `gh pr view <number>` - Inspect PR details when validating publish results
 
 ## Important Notes
 

--- a/skills/github-issue-solve/references/issue-solve-workflow.md
+++ b/skills/github-issue-solve/references/issue-solve-workflow.md
@@ -19,21 +19,27 @@ When issue context is detected (no PR):
    git commit -m "Feature: <brief description>"
    git push -u origin feature/issue-<number>
    ```
-4. **Create PR**:
+4. **Draft output artifacts before publish**:
+   - Write an initial `${GITHUB_OUTPUT_DIR}/summary.md` (implementation/testing summary used for PR body)
+   - Write `${GITHUB_OUTPUT_DIR}/manifest.json` with execution metadata
+   - Write `${GITHUB_OUTPUT_DIR}/publish-intent.json` for PR creation/update
+5. **Publish via `github-publish` (mandatory)**:
    ```bash
-   gh pr create \
-     --title "Feature: <title>" \
-     --body-file ${GITHUB_OUTPUT_DIR}/summary.md \
-     --base main
+   # Preferred: invoke github-publish skill
+   # The skill executes scripts/publish.sh with the intent file
+   scripts/publish.sh --intent=${GITHUB_OUTPUT_DIR}/publish-intent.json
    ```
-   Or create `${GITHUB_OUTPUT_DIR}/publish-intent.json` and execute publishing via `github-publish`.
-5. **Document**: Write `${GITHUB_OUTPUT_DIR}/summary.md` explaining what was done
+6. **Finalize outputs after publish**:
+   - Update `${GITHUB_OUTPUT_DIR}/summary.md` and `${GITHUB_OUTPUT_DIR}/manifest.json`
+   - Record publish result fields (`pr_number`, `pr_url`, branch/ref)
+   - If publish fails, mark failure and include actionable error details
 
 ## Completion Criteria (Mandatory)
 
 Do not mark the run successful unless a PR was actually created or updated.
 
 - `publish-intent.json` by itself is not sufficient.
+- `github-publish` invocation is mandatory for completion.
 - A successful run must include publish result data (`pr_number` and/or `pr_url`) in `summary.md` and `manifest.json`.
 - If publishing fails, mark the run as failed and record the actionable error details.
 


### PR DESCRIPTION
## What changed
- strengthen solve skill-mode goal so issue solve is only successful after actual PR create/update
- add strict Definition of Done and failure rules to github-issue-solve skill
- update issue-solve workflow reference with mandatory publish completion criteria

## Why
Issue runs could finish with only `publish-intent.json` and no PR side effect. This change makes publish execution and PR creation explicit success criteria.

## Validation
- `go test ./...`
  - package tests passed for affected code paths
  - existing integration tests in `pkg/github` failed due to GitHub API rate limit (403), unrelated to this change
