### PR TITLE
Fix auto-review skip for holonbot PRs

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -405,8 +405,10 @@ jobs:
             PARSE_TEXT="$REVIEW_BODY"
           fi
 
-          # Avoid bot loops
-          if [ "$ACTOR" = 'holonbot[bot]' ]; then
+          # Avoid bot loops for command-style triggers.
+          # Allow PR auto-review runs initiated by holonbot.
+          if [ "$ACTOR" = 'holonbot[bot]' ] && \
+             { [ "$EVENT_NAME" = 'issue_comment' ] || [ "$EVENT_NAME" = 'pull_request_review' ] || [ "$EVENT_NAME" = 'pull_request_review_comment' ]; }; then
             REASON='Actor is holonbot[bot]'
             echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
             echo "reason=$REASON" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/holon-trigger.yml
+++ b/.github/workflows/holon-trigger.yml
@@ -27,9 +27,6 @@ jobs:
       review_id: ${{ github.event.review.id || 0 }}
       auto_review: ${{ fromJSON(vars.HOLON_AUTO_REVIEW || 'false') }}
 
-      # Use skill mode for GitHub workflows
-      skill: 'github-solve'
-
       # Repo-local workflow uses the current branch Holon implementation.
       log_level: 'debug'
       build_from_source: true


### PR DESCRIPTION
## What changed
- allow `pull_request` auto-review flow even when `github.actor` is `holonbot[bot]`
- keep bot-loop protection for command-style events (`issue_comment`, `pull_request_review`, `pull_request_review_comment`)
- remove hardcoded `skill: github-solve` from trigger so reusable workflow can select `github-review` for auto-review

## Why
Auto-review runs for holonbot-created PRs were being skipped by the bot guard before auto-review gating was evaluated.

## Validation
- reviewed workflow gate order and conditions
- verified trigger no longer forces solve skill for PR auto-review path
