### PR TITLE
fix: generate solve goal from selected skill

### DIFF
--- a/cmd/holon/solve_test.go
+++ b/cmd/holon/solve_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pkggithub "github.com/holon-run/holon/pkg/github"
+)
+
+func TestBuildGoal_SkillModePRReviewUsesGithubReviewSkill(t *testing.T) {
+	ref := &pkggithub.SolveRef{Owner: "holon-run", Repo: "holon", Number: 564}
+	goal := buildGoal("", ref, "pr", "", true, "github-review")
+
+	if !strings.Contains(goal, "Use the github-review skill") {
+		t.Fatalf("expected github-review goal, got: %s", goal)
+	}
+	if strings.Contains(goal, "github-pr-fix") {
+		t.Fatalf("expected goal to avoid github-pr-fix for review skill, got: %s", goal)
+	}
+}
+
+func TestBuildGoal_SkillModePRFixUsesGithubPrFixSkill(t *testing.T) {
+	ref := &pkggithub.SolveRef{Owner: "holon-run", Repo: "holon", Number: 564}
+	goal := buildGoal("", ref, "pr", "", true, "github-pr-fix")
+
+	if !strings.Contains(goal, "Use the github-pr-fix skill") {
+		t.Fatalf("expected github-pr-fix goal, got: %s", goal)
+	}
+}
+
+func TestBuildGoal_SkillModeIssueUsesGithubIssueSolveSkill(t *testing.T) {
+	ref := &pkggithub.SolveRef{Owner: "holon-run", Repo: "holon", Number: 527}
+	goal := buildGoal("", ref, "issue", "", true, "github-issue-solve")
+
+	if !strings.Contains(goal, "Use the github-issue-solve skill") {
+		t.Fatalf("expected github-issue-solve goal, got: %s", goal)
+	}
+}


### PR DESCRIPTION
## What
- make `buildGoal` use the selected skill in skill mode instead of hardcoding `github-pr-fix` for all PR refs
- generate PR review goal text when selected skill is `github-review`
- keep existing `github-pr-fix` and `github-issue-solve` wording for their respective skills
- add tests for PR review, PR fix, and issue solve skill-goal mapping

## Why
PR auto-review runs were correctly selecting `github-review`, but the Task Goal log still said `github-pr-fix`, which is misleading and can steer agent behavior incorrectly.

## Validation
- `go test ./cmd/holon`