### PR TITLE
refactor: reuse run env injection in serve controller

### DIFF
--- a/cmd/holon/env_injection.go
+++ b/cmd/holon/env_injection.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gh "github.com/holon-run/holon/pkg/github"
+	holonlog "github.com/holon-run/holon/pkg/log"
+)
+
+type runtimeEnvOptions struct {
+	IncludeClaudeSettingsFallback bool
+	IncludeGitHubActorIdentity    bool
+	ResolveGitHubActor            func(context.Context, string) *gh.ActorInfo
+	IncludeHolonClaudeConfig      bool
+}
+
+func applyRuntimeAutoEnv(ctx context.Context, envVars map[string]string, opts runtimeEnvOptions) {
+	anthropicFallback := map[string]string{}
+	if opts.IncludeClaudeSettingsFallback {
+		fallback, err := readAnthropicEnvFromClaudeSettingsFile()
+		if err != nil {
+			holonlog.Debug("failed to read Anthropic fallback from Claude settings", "error", err)
+		} else {
+			anthropicFallback = fallback
+		}
+	}
+
+	applyAnthropicAutoEnv(envVars, anthropicFallback)
+	githubToken := applyGitHubTokenAutoEnv(envVars)
+	applyGitHubActorAutoEnv(ctx, envVars, githubToken, opts)
+	if opts.IncludeHolonClaudeConfig {
+		applyHolonClaudeAutoEnv(envVars)
+	}
+}
+
+func applyAnthropicAutoEnv(envVars map[string]string, fallback map[string]string) {
+	anthropicKey := strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+	if anthropicKey == "" {
+		anthropicKey = strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+		if anthropicKey != "" {
+			holonlog.Warn("using legacy ANTHROPIC_API_KEY; consider migrating to ANTHROPIC_AUTH_TOKEN")
+		}
+	}
+	if anthropicKey == "" {
+		anthropicKey = strings.TrimSpace(fallback["ANTHROPIC_AUTH_TOKEN"])
+	}
+	if anthropicKey == "" {
+		anthropicKey = strings.TrimSpace(fallback["ANTHROPIC_API_KEY"])
+	}
+	if anthropicKey != "" {
+		envVars["ANTHROPIC_AUTH_TOKEN"] = anthropicKey
+		envVars["ANTHROPIC_API_KEY"] = anthropicKey
+	}
+
+	anthropicURL := strings.TrimSpace(os.Getenv("ANTHROPIC_BASE_URL"))
+	if anthropicURL == "" {
+		anthropicURL = strings.TrimSpace(os.Getenv("ANTHROPIC_API_URL"))
+	}
+	if anthropicURL == "" {
+		anthropicURL = strings.TrimSpace(fallback["ANTHROPIC_BASE_URL"])
+	}
+	if anthropicURL == "" {
+		anthropicURL = strings.TrimSpace(fallback["ANTHROPIC_API_URL"])
+	}
+	if anthropicURL != "" {
+		envVars["ANTHROPIC_BASE_URL"] = anthropicURL
+		envVars["ANTHROPIC_API_URL"] = anthropicURL
+	}
+}
+
+func applyGitHubTokenAutoEnv(envVars map[string]string) string {
+	if token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); token != "" {
+		envVars["GITHUB_TOKEN"] = token
+		envVars["GH_TOKEN"] = token
+		return token
+	}
+	if token := strings.TrimSpace(os.Getenv("GH_TOKEN")); token != "" {
+		envVars["GITHUB_TOKEN"] = token
+		envVars["GH_TOKEN"] = token
+		return token
+	}
+	return ""
+}
+
+func applyGitHubActorAutoEnv(ctx context.Context, envVars map[string]string, githubToken string, opts runtimeEnvOptions) {
+	actorInfoProvided := false
+	if actorLogin := strings.TrimSpace(os.Getenv("HOLON_ACTOR_LOGIN")); actorLogin != "" {
+		envVars["HOLON_ACTOR_LOGIN"] = actorLogin
+		actorInfoProvided = true
+
+		actorType := ""
+		if actorType = strings.TrimSpace(os.Getenv("HOLON_ACTOR_TYPE")); actorType != "" {
+			envVars["HOLON_ACTOR_TYPE"] = actorType
+		}
+		if actorSource := strings.TrimSpace(os.Getenv("HOLON_ACTOR_SOURCE")); actorSource != "" {
+			envVars["HOLON_ACTOR_SOURCE"] = actorSource
+		}
+		if actorAppSlug := strings.TrimSpace(os.Getenv("HOLON_ACTOR_APP_SLUG")); actorAppSlug != "" {
+			envVars["HOLON_ACTOR_APP_SLUG"] = actorAppSlug
+		}
+		holonlog.Info("using explicit github actor identity", "login", actorLogin, "type", actorType)
+	}
+
+	if !opts.IncludeGitHubActorIdentity || actorInfoProvided || githubToken == "" || opts.ResolveGitHubActor == nil {
+		return
+	}
+
+	if actorType := strings.TrimSpace(os.Getenv("HOLON_ACTOR_TYPE")); actorType == "App" {
+		holonlog.Info("skipping github actor identity lookup for App token without explicit login")
+		return
+	}
+
+	actorInfo := opts.ResolveGitHubActor(ctx, githubToken)
+	if actorInfo == nil {
+		holonlog.Info("github actor identity lookup failed, continuing without identity")
+		return
+	}
+
+	envVars["HOLON_ACTOR_LOGIN"] = actorInfo.Login
+	envVars["HOLON_ACTOR_TYPE"] = actorInfo.Type
+	if actorInfo.Source != "" {
+		envVars["HOLON_ACTOR_SOURCE"] = actorInfo.Source
+	}
+	if actorInfo.AppSlug != "" {
+		envVars["HOLON_ACTOR_APP_SLUG"] = actorInfo.AppSlug
+	}
+	holonlog.Info("github actor identity resolved", "login", actorInfo.Login, "type", actorInfo.Type)
+}
+
+func applyHolonClaudeAutoEnv(envVars map[string]string) {
+	if driver := strings.TrimSpace(os.Getenv("HOLON_CLAUDE_DRIVER")); driver != "" {
+		envVars["HOLON_CLAUDE_DRIVER"] = driver
+	}
+	if fixture := strings.TrimSpace(os.Getenv("HOLON_CLAUDE_MOCK_FIXTURE")); fixture != "" {
+		envVars["HOLON_CLAUDE_MOCK_FIXTURE"] = fixture
+	}
+}
+
+func readAnthropicEnvFromClaudeSettingsFile() (map[string]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		if err == nil {
+			return nil, fmt.Errorf("user home directory is empty")
+		}
+		return nil, err
+	}
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	return readAnthropicEnvFromClaudeSettings(settingsPath)
+}
+
+func readAnthropicEnvFromClaudeSettings(path string) (map[string]string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload struct {
+		Env map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse settings.json: %w", err)
+	}
+
+	result := map[string]string{}
+	for _, key := range []string{
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_API_URL",
+	} {
+		if v := strings.TrimSpace(payload.Env[key]); v != "" {
+			result[key] = v
+		}
+	}
+	return result, nil
+}

--- a/cmd/holon/serve.go
+++ b/cmd/holon/serve.go
@@ -425,7 +425,7 @@ func (h *cliControllerHandler) ensureControllerLocked(ctx context.Context, ref s
 		"HOLON_CONTROLLER_EVENT_CURSOR":       "/holon/state/event-channel.cursor",
 		"HOLON_CONTROLLER_SESSION_STATE_PATH": "/holon/state/controller-session.json",
 	}
-	for k, v := range resolveServeLLMEnv() {
+	for k, v := range resolveServeRuntimeEnv(ctx) {
 		env[k] = v
 	}
 	if sessionID := h.readSessionID(); sessionID != "" {
@@ -466,64 +466,14 @@ func (h *cliControllerHandler) ensureControllerLocked(ctx context.Context, ref s
 	return nil
 }
 
-func resolveServeLLMEnv() map[string]string {
-	// Priority is per-key: process env wins, settings fallback fills only missing keys.
+func resolveServeRuntimeEnv(ctx context.Context) map[string]string {
 	result := map[string]string{}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = ""
-	}
-	if home != "" {
-		settingsPath := filepath.Join(home, ".claude", "settings.json")
-		fallback, readErr := readAnthropicEnvFromClaudeSettings(settingsPath)
-		if readErr != nil {
-			holonlog.Debug("failed to read Anthropic fallback from Claude settings", "path", settingsPath, "error", readErr)
-		} else {
-			for k, v := range fallback {
-				result[k] = v
-			}
-		}
-	}
-
-	for _, key := range []string{
-		"ANTHROPIC_AUTH_TOKEN",
-		"ANTHROPIC_BASE_URL",
-		"ANTHROPIC_API_KEY",
-		"ANTHROPIC_API_URL",
-	} {
-		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
-			result[key] = v
-		}
-	}
+	applyRuntimeAutoEnv(ctx, result, runtimeEnvOptions{
+		IncludeClaudeSettingsFallback: true,
+		IncludeGitHubActorIdentity:    false,
+		IncludeHolonClaudeConfig:      false,
+	})
 	return result
-}
-
-func readAnthropicEnvFromClaudeSettings(path string) (map[string]string, error) {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var payload struct {
-		Env map[string]string `json:"env"`
-	}
-	if err := json.Unmarshal(raw, &payload); err != nil {
-		return nil, fmt.Errorf("failed to parse settings.json: %w", err)
-	}
-
-	result := map[string]string{}
-	for _, key := range []string{
-		"ANTHROPIC_AUTH_TOKEN",
-		"ANTHROPIC_BASE_URL",
-		"ANTHROPIC_API_KEY",
-		"ANTHROPIC_API_URL",
-	} {
-		if v := strings.TrimSpace(payload.Env[key]); v != "" {
-			result[key] = v
-		}
-	}
-	return result, nil
 }
 
 func (h *cliControllerHandler) compactChannelBestEffortLocked() {

--- a/cmd/holon/serve_test.go
+++ b/cmd/holon/serve_test.go
@@ -242,11 +242,11 @@ func TestReadAnthropicEnvFromClaudeSettings(t *testing.T) {
 	}
 }
 
-func TestResolveServeLLMEnv_PrefersProcessEnv(t *testing.T) {
+func TestResolveServeRuntimeEnv_PrefersProcessEnv(t *testing.T) {
 	t.Setenv("ANTHROPIC_AUTH_TOKEN", "token-from-env")
 	t.Setenv("ANTHROPIC_BASE_URL", "https://env.ai")
 
-	got := resolveServeLLMEnv()
+	got := resolveServeRuntimeEnv(context.Background())
 	if got["ANTHROPIC_AUTH_TOKEN"] != "token-from-env" {
 		t.Fatalf("ANTHROPIC_AUTH_TOKEN = %q", got["ANTHROPIC_AUTH_TOKEN"])
 	}
@@ -255,7 +255,7 @@ func TestResolveServeLLMEnv_PrefersProcessEnv(t *testing.T) {
 	}
 }
 
-func TestResolveServeLLMEnv_MergesSettingsFallbackForMissingKeys(t *testing.T) {
+func TestResolveServeRuntimeEnv_MergesSettingsFallbackForMissingKeys(t *testing.T) {
 	td := t.TempDir()
 	claudeDir := filepath.Join(td, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
@@ -275,12 +275,25 @@ func TestResolveServeLLMEnv_MergesSettingsFallbackForMissingKeys(t *testing.T) {
 	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
 	t.Setenv("ANTHROPIC_BASE_URL", "https://env.ai")
 
-	got := resolveServeLLMEnv()
+	got := resolveServeRuntimeEnv(context.Background())
 	if got["ANTHROPIC_BASE_URL"] != "https://env.ai" {
 		t.Fatalf("ANTHROPIC_BASE_URL = %q, want env value", got["ANTHROPIC_BASE_URL"])
 	}
 	if got["ANTHROPIC_AUTH_TOKEN"] != "token-from-settings" {
 		t.Fatalf("ANTHROPIC_AUTH_TOKEN = %q, want settings fallback value", got["ANTHROPIC_AUTH_TOKEN"])
+	}
+}
+
+func TestResolveServeRuntimeEnv_InjectsGitHubToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "gh-token-from-env")
+	t.Setenv("GH_TOKEN", "")
+
+	got := resolveServeRuntimeEnv(context.Background())
+	if got["GITHUB_TOKEN"] != "gh-token-from-env" {
+		t.Fatalf("GITHUB_TOKEN = %q", got["GITHUB_TOKEN"])
+	}
+	if got["GH_TOKEN"] != "gh-token-from-env" {
+		t.Fatalf("GH_TOKEN = %q", got["GH_TOKEN"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- extract automatic runtime env injection into shared `cmd/holon/env_injection.go`
- refactor `runner.collectEnvVars` to reuse the shared env injection logic
- refactor `serve` controller env assembly to reuse the same logic (with Claude settings fallback enabled)
- fix controller runtime missing GitHub auth env by injecting `GITHUB_TOKEN`/`GH_TOKEN` in `serve` mode too
- add/adjust tests for `serve` runtime env resolution and GitHub token injection

## Why
`holon run` and `holon serve` had diverged env resolution paths. `serve` only handled Anthropic env, so controller sessions could ingest events but fail to execute GitHub actions due to missing token env inside the container.

This change unifies the mechanism and keeps behavior configurable per mode.

## Validation
- `go test ./cmd/holon -count=1`
- `go test ./pkg/serve -count=1`
