### PR TITLE
fix(holonbot): allow PR refs in OIDC default-branch policy

### DIFF
--- a/holonbot/README.md
+++ b/holonbot/README.md
@@ -188,6 +188,7 @@ Optional (defaults shown):
 - `HOLON_REQUIRE_JOB_WORKFLOW_REF=true`
 - `HOLON_ALLOWED_WORKFLOW_REFS=` (comma-separated exact refs)
 - `HOLON_REQUIRE_DEFAULT_BRANCH_REF=true`
+- `HOLON_ALLOW_PULL_REQUEST_REF=true` (when default-branch enforcement is on, also allow `refs/pull/*/(merge|head)`)
 - `HOLON_ENABLE_REPLAY_PROTECTION=true`
 - `HOLON_REPLAY_WINDOW_SECONDS=3600`
 - `HOLON_ENABLE_RATE_LIMIT=true`

--- a/holonbot/api/exchange-token.js
+++ b/holonbot/api/exchange-token.js
@@ -308,6 +308,7 @@ export default async function handler(req, res) {
         }
 
         const enforceDefaultRef = parseBool(process.env.HOLON_REQUIRE_DEFAULT_BRANCH_REF, true);
+        const allowPullRequestRef = parseBool(process.env.HOLON_ALLOW_PULL_REQUEST_REF, true);
         if (enforceDefaultRef) {
             let validated;
             try {
@@ -316,6 +317,7 @@ export default async function handler(req, res) {
                     allowedWorkflowRefs: parseCSV(process.env.HOLON_ALLOWED_WORKFLOW_REFS),
                     requireDefaultBranchRef: true,
                     defaultBranch: repoResponse.data.default_branch,
+                    allowPullRequestRef,
                 });
             } catch (error) {
                 throw new HttpError(403, 'oidc.invalid_claims', error.message);

--- a/holonbot/test/oidc.test.js
+++ b/holonbot/test/oidc.test.js
@@ -70,6 +70,43 @@ describe('OIDC Validation', () => {
             allowedWorkflowRefs: ['holon-run/holon/.github/workflows/holon-trigger.yml@refs/heads/main']
         })).toThrow('job_workflow_ref is not allowed');
     });
+
+    test('should allow pull request refs when default-branch enforcement is enabled', () => {
+        const claims = {
+            repository: 'holon-run/holon',
+            repository_id: '123456',
+            repository_owner: 'holon-run',
+            actor: 'jolestar',
+            ref: 'refs/pull/621/merge',
+            sub: 'repo:holon-run/holon:pull_request',
+            job_workflow_ref: 'holon-run/holon/.github/workflows/holon-trigger.yml@refs/pull/621/merge',
+        };
+
+        const result = validateClaims(claims, {
+            requireDefaultBranchRef: true,
+            defaultBranch: 'main',
+        });
+
+        expect(result.ref).toBe('refs/pull/621/merge');
+    });
+
+    test('should reject pull request refs when explicitly disabled', () => {
+        const claims = {
+            repository: 'holon-run/holon',
+            repository_id: '123456',
+            repository_owner: 'holon-run',
+            actor: 'jolestar',
+            ref: 'refs/pull/621/merge',
+            sub: 'repo:holon-run/holon:pull_request',
+            job_workflow_ref: 'holon-run/holon/.github/workflows/holon-trigger.yml@refs/pull/621/merge',
+        };
+
+        expect(() => validateClaims(claims, {
+            requireDefaultBranchRef: true,
+            defaultBranch: 'main',
+            allowPullRequestRef: false,
+        })).toThrow('ref is not default branch: expected refs/heads/main');
+    });
 });
 
 describe('verifyOIDCToken', () => {


### PR DESCRIPTION
## Summary
- fix Holonbot token broker OIDC `ref` validation to allow PR refs (`refs/pull/<number>/(merge|head)`) while default-branch policy is enabled
- add `HOLON_ALLOW_PULL_REQUEST_REF` env switch (default `true`) so strict default-branch-only behavior can still be enforced if needed
- add tests for both OIDC validation and exchange-token option propagation
- document the new broker security option

## Root Cause
PR review runs can present OIDC `ref` as `refs/pull/<number>/merge`.
Broker-side default-branch enforcement previously only accepted `refs/heads/<default-branch>`, so token exchange failed and action fell back to `github.token`.

## Validation
- `cd holonbot && npm test -- --runTestsByPath test/oidc.test.js test/exchange-token.test.js`

## Notes
- This keeps default-branch enforcement enabled, but includes PR refs as an allowed trusted ref shape for PR-triggered workflows.
