### PR TITLE
fix: use git-compatible GitHub credential helper

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -31,7 +31,7 @@ type Client struct {
 //
 // It prefers GITHUB_TOKEN/GH_TOKEN from environment, and falls back to
 // `gh auth token` when env tokens are not present.
-const GitHubCredentialHelperScript = `!f(){ op="$1"; [ "$op" = get ] || exit 0; tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"; if [ -z "$tok" ]; then tok="$(gh auth token 2>/dev/null || true)"; fi; [ -n "$tok" ] || exit 0; echo username=x-access-token; echo password="$tok"; }; f`
+const GitHubCredentialHelperScript = `!f(){ op="$1"; [ "$op" = get ] || exit 0; tok="${GITHUB_TOKEN:-${GH_TOKEN:-}}"; if [ -z "$tok" ]; then tok="$(gh auth token 2>/dev/null || true)"; fi; [ -n "$tok" ] || exit 0; echo username=x-access-token; echo password="$tok"; }; f "$@"`
 
 // ClientOptions holds configuration for git operations.
 type ClientOptions struct {

--- a/pkg/runtime/docker/runtime.go
+++ b/pkg/runtime/docker/runtime.go
@@ -903,18 +903,18 @@ func prepareWorkspace(ctx context.Context, cfg *ContainerConfig) (string, string
 						holonlog.Warn("failed to preserve origin from source", "url", originURL, "error", err)
 					}
 
-						// Configure git credential helper for GitHub HTTPS authentication.
-						// This works for both skill mode and traditional mode:
-						// - Skill mode: agent can push branches using gh auth
-						// - Traditional mode: publisher can push (simplifies publisher logic)
-						if err := snapshotClient.ConfigCredentialHelper(ctx, git.GitHubCredentialHelperScript); err != nil {
-							holonlog.Warn("failed to configure git credential helper", "error", err)
-						} else {
-							holonlog.Info("configured git credential helper for GitHub auth")
-						}
+					// Configure git credential helper for GitHub HTTPS authentication.
+					// This works for both skill mode and traditional mode:
+					// - Skill mode: agent can push branches using gh auth
+					// - Traditional mode: publisher can push (simplifies publisher logic)
+					if err := snapshotClient.ConfigCredentialHelper(ctx, git.GitHubCredentialHelperScript); err != nil {
+						holonlog.Warn("failed to configure git credential helper", "error", err)
+					} else {
+						holonlog.Info("configured git credential helper for GitHub auth")
 					}
 				}
 			}
+		}
 	}
 
 	// Log preparation details


### PR DESCRIPTION
## Summary
This PR fixes GitHub push authentication in solve workflows by replacing an invalid git credential helper configuration.

Previously runtime configured:
- `credential.helper = !gh auth token`

That command is not a valid git credential helper protocol implementation. Git invokes helpers with an action argument (`get`/`store`/`erase`), which caused failures like:
- `accepts 0 arg(s), received 1`
- `fatal: could not read Username for 'https://github.com/...': No such device or address`

## Changes
- Add `git.GitHubCredentialHelperScript` in `pkg/git/git.go`:
  - handles git helper action argument
  - returns `username=x-access-token`
  - returns `password` from `GITHUB_TOKEN` / `GH_TOKEN`
  - falls back to `gh auth token` when env token is missing
- Update runtime setup in `pkg/runtime/docker/runtime.go` to use this helper script
- Add regression test `TestClient_ConfigCredentialHelper_GitHubScript` in `pkg/git/git_test.go`

## Validation
- `go test ./pkg/git ./pkg/runtime/docker`

## Impact
This makes `git push` from solve/publish paths work with HTTPS remotes and prevents PR creation from failing due to missing authenticated push.
