### PR TITLE
Decouple github-pr-fix from ghx internal intent schema

### DIFF
--- a/skills/ghx/SKILL.md
+++ b/skills/ghx/SKILL.md
@@ -27,7 +27,7 @@ Use `scripts/ghx.sh` as the primary entrypoint.
 
 - **Public capability contract (for other skills):** call `ghx.sh` commands and depend on stable output artifacts (for example `publish-results.json`).
 - **Internal implementation contract (within ghx):** files like `publish-intent.json` and action schema details are internal to ghx and may evolve.
-- Other skills should describe desired publish outcomes (for example replies from `pr-fix.json`), not hardcode ghx internal action schemas.
+- Other skills should describe desired publish outcomes, not hardcode ghx internal action schemas.
 
 ### Context
 
@@ -49,7 +49,6 @@ scripts/ghx.sh review publish --pr=holon-run/holon#123 --body-file=review.md --c
 scripts/ghx.sh pr create --repo=holon-run/holon --title="Title" --body-file=summary.md --head=feature/x --base=main
 scripts/ghx.sh pr update --pr=holon-run/holon#123 --title="New title" --body-file=summary.md
 scripts/ghx.sh pr comment --pr=holon-run/holon#123 --body-file=summary.md
-scripts/ghx.sh pr reply-reviews --pr=holon-run/holon#123 --pr-fix-json=pr-fix.json
 ```
 
 ## Output Contract

--- a/skills/ghx/references/github-publishing.md
+++ b/skills/ghx/references/github-publishing.md
@@ -18,7 +18,6 @@ scripts/ghx.sh intent run --intent=${GITHUB_OUTPUT_DIR}/publish-intent.json
 
 ```bash
 scripts/ghx.sh pr comment --pr=owner/repo#123 --body-file=summary.md
-scripts/ghx.sh pr reply-reviews --pr=owner/repo#123 --pr-fix-json=pr-fix.json
 scripts/ghx.sh review publish --pr=owner/repo#123 --body-file=review.md --comments-file=review.json
 ```
 


### PR DESCRIPTION
## Summary
- decouple `github-pr-fix` from ghx internal `publish-intent.json` schema
- make `github-pr-fix` express publish requirements via capability commands (`ghx.sh pr reply-reviews`) instead of internal action shapes
- standardize publish result artifact naming to `publish-results.json` in `github-pr-fix` docs
- improve `ghx` skill docs with explicit contract boundary:
  - public contract: capability commands + stable output artifacts
  - internal contract: intent action schema may evolve

## Why
External skills should depend on ghx capabilities, not ghx internal intent schema details. This reduces coupling and avoids breakage when ghx internals evolve.

## Validation
- docs-only changes
