### PR TITLE
tui: improve chat-like interaction and editing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.11
 
 require (
+	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/docker/docker v28.5.2+incompatible
@@ -23,7 +24,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.20.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -57,6 +57,7 @@ const (
 	focusInput focusArea = iota
 	focusConversation
 	focusLogs
+	focusCount
 )
 
 // ConversationMessage represents a message in the conversation timeline
@@ -241,7 +242,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		if a.focus == focusInput {
+		if a.focus == focusInput && !a.sending {
 			var cmd tea.Cmd
 			a.input, cmd = a.input.Update(msg)
 			return a, cmd
@@ -581,7 +582,7 @@ func (a *App) renderHelp() string {
 		inputState = " [Send Failed]"
 	}
 
-	help := fmt.Sprintf("Commands: [Tab] Switch Focus | [Enter] Send%s | [Ctrl+J] Newline | [p] Pause | [r] Resume | [R] Refresh | [Space] Toggle Auto-Refresh | [q] Quit",
+	help := fmt.Sprintf("Commands: [Tab] Switch Focus | [Enter] Send%s | [Ctrl+J] Newline | [Ctrl+U] Clear Input | [↑/↓] Scroll Line | [PgUp/PgDn] Scroll Page | [p] Pause | [r] Resume | [R] Refresh | [Space] Toggle Auto-Refresh | [q] Quit",
 		inputState)
 	return helpStyle.Render(help)
 }
@@ -729,12 +730,12 @@ type pauseSuccessMsg struct {
 }
 
 func (a *App) nextFocus() tea.Cmd {
-	a.focus = (a.focus + 1) % 3
+	a.focus = (a.focus + 1) % focusCount
 	return a.applyFocus()
 }
 
 func (a *App) prevFocus() tea.Cmd {
-	a.focus = (a.focus + 2) % 3
+	a.focus = (a.focus + focusCount - 1) % focusCount
 	return a.applyFocus()
 }
 
@@ -761,8 +762,8 @@ func (a *App) panelWidth() int {
 
 func (a *App) resize() {
 	width := a.panelWidth() - 4
-	if width < 30 {
-		width = 30
+	if width < 1 {
+		width = 1
 	}
 	conversationHeight := 14
 	logHeight := 8

--- a/pkg/tui/app_test.go
+++ b/pkg/tui/app_test.go
@@ -81,4 +81,16 @@ func TestAppTabSwitchesFocus(t *testing.T) {
 	if app.focus != focusLogs {
 		t.Fatalf("focus after second tab = %v, want %v", app.focus, focusLogs)
 	}
+
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = model.(*App)
+	if app.focus != focusInput {
+		t.Fatalf("focus after third tab = %v, want %v", app.focus, focusInput)
+	}
+
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	app = model.(*App)
+	if app.focus != focusLogs {
+		t.Fatalf("focus after shift+tab = %v, want %v", app.focus, focusLogs)
+	}
 }


### PR DESCRIPTION
## Summary
- migrate `holon tui` input box to `bubbles/textarea` so editing/deleting works reliably across terminals
- add panel focus model (`input` / `conversation` / `logs`) with `Tab` and `Shift+Tab`
- migrate conversation and logs to `bubbles/viewport` for proper scrolling and long-content viewing
- keep `Enter` as send and map `Ctrl+J` to newline insertion in the input area
- add TUI unit tests covering input deletion, newline insertion, send trigger, and focus switching

## Testing
- `go test ./pkg/tui ./cmd/holon -count=1`
