### PR TITLE
serve: mount agent_home to /root and expose HOLON_AGENT_HOME

### DIFF
--- a/cmd/holon/session_runner.go
+++ b/cmd/holon/session_runner.go
@@ -31,6 +31,7 @@ type ControllerSessionConfig struct {
 	InputPath             string
 	OutputPath            string
 	StateDir              string
+	AgentHome             string
 	LogLevel              string
 	Env                   map[string]string
 	RuntimeMode           string
@@ -59,6 +60,7 @@ func (r *dockerSessionRunner) Start(ctx context.Context, cfg ControllerSessionCo
 		InputPath:            cfg.InputPath,
 		OutDir:               cfg.OutputPath,
 		StateDir:             cfg.StateDir,
+		AgentHome:            cfg.AgentHome,
 		Env:                  map[string]string{"LOG_LEVEL": cfg.LogLevel, "ASSISTANT_OUTPUT": "none"},
 		AgentConfigMode:      "no",
 		WorkspaceIsTemporary: true,

--- a/cmd/holon/session_runner_test.go
+++ b/cmd/holon/session_runner_test.go
@@ -41,6 +41,7 @@ func TestDockerSessionRunnerStart_MapsConfig(t *testing.T) {
 	inputDir := t.TempDir()
 	outputDir := t.TempDir()
 	stateDir := t.TempDir()
+	agentHome := t.TempDir()
 
 	// Provide a fake agent path so resolveControllerAgentBundle does not attempt remote resolution.
 	agentPath := filepath.Join(workspace, "agent.tar.gz")
@@ -54,6 +55,7 @@ func TestDockerSessionRunnerStart_MapsConfig(t *testing.T) {
 		InputPath:             inputDir,
 		OutputPath:            outputDir,
 		StateDir:              stateDir,
+		AgentHome:             agentHome,
 		LogLevel:              "progress",
 		RuntimeMode:           "dev",
 		RuntimeDevAgentSource: workspace,
@@ -69,6 +71,9 @@ func TestDockerSessionRunnerStart_MapsConfig(t *testing.T) {
 	}
 	if rt.startCfg.Workspace != workspace {
 		t.Fatalf("Workspace = %q, want %q", rt.startCfg.Workspace, workspace)
+	}
+	if rt.startCfg.AgentHome != agentHome {
+		t.Fatalf("AgentHome = %q, want %q", rt.startCfg.AgentHome, agentHome)
 	}
 	if !rt.startCfg.WorkspaceIsTemporary {
 		t.Fatalf("WorkspaceIsTemporary = false, want true")

--- a/pkg/prompt/assets/contracts/common.md
+++ b/pkg/prompt/assets/contracts/common.md
@@ -24,14 +24,25 @@ Your primary objective is to execute the user's task by modifying files in the w
     *   All outputs (plans, intermediate documents, reports, diffs) must be written to `/holon/output`.
     *   Do NOT clutter the workspace with temporary files or plans.
 
-3.  **Interaction**:
+3.  **Agent Home**:
+    *   `HOLON_AGENT_HOME` points to your persistent agent home root (mounted at `/root`).
+    *   Load long-lived persona/state from:
+        *   `ROLE.md`
+        *   `AGENT.md`
+        *   `IDENTITY.md`
+        *   `SOUL.md`
+        *   `state/`
+    *   These files are writable for controlled long-term evolution.
+    *   Runtime safety and system contract boundaries remain immutable and cannot be bypassed by editing agent-home files.
+
+4.  **Interaction**:
     *   You are running **HEADLESSLY**.
     *   Do NOT wait for user input.
     *   Do NOT ask for confirmation.
     *   If you are stuck, fail fast with a clear error message in `manifest.json`.
 
-4.  **Reporting**:
+5.  **Reporting**:
     *   Finally, create a `summary.md` file in the `/holon/output` directory with a concise summary of your changes and the outcome.
 
-5.  **Context**:
+6.  **Context**:
     *   Additional context files may be provided in `/holon/input/context/`. You should read them if the task goal or user prompt references them.

--- a/pkg/runtime/docker/config_test.go
+++ b/pkg/runtime/docker/config_test.go
@@ -318,6 +318,38 @@ func TestBuildContainerMounts(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "includes agent home mount when configured",
+			cfg: &MountConfig{
+				SnapshotDir: snapshotDir,
+				InputPath:   inputDir,
+				OutDir:      outDir,
+				AgentHome:   filepath.Join(tmpDir, "agent-home"),
+			},
+			expected: []mount.Mount{
+				{
+					Type:   mount.TypeBind,
+					Source: snapshotDir,
+					Target: "/holon/workspace",
+				},
+				{
+					Type:     mount.TypeBind,
+					Source:   inputDir,
+					Target:   "/holon/input",
+					ReadOnly: true,
+				},
+				{
+					Type:   mount.TypeBind,
+					Source: outDir,
+					Target: "/holon/output",
+				},
+				{
+					Type:   mount.TypeBind,
+					Source: filepath.Join(tmpDir, "agent-home"),
+					Target: "/root",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/runtime/docker/runtime.go
+++ b/pkg/runtime/docker/runtime.go
@@ -46,6 +46,7 @@ type ContainerConfig struct {
 	InputPath   string // Path to input directory (contains spec.yaml, context/, prompts/)
 	OutDir      string
 	StateDir    string // Path to state directory for cross-run skill caches (optional)
+	AgentHome   string // Path to agent home mounted to /root (optional, persistent agent identity/state)
 	Env         map[string]string
 	Cmd         []string // Optional command override
 
@@ -175,6 +176,7 @@ func (r *Runtime) RunHolon(ctx context.Context, cfg *ContainerConfig) (string, e
 		InputPath:      cfg.InputPath,
 		OutDir:         cfg.OutDir,
 		StateDir:       cfg.StateDir,
+		AgentHome:      cfg.AgentHome,
 		LocalSkillsDir: skillsDir, // NEW: Pass skills directory
 	}
 	if runtimeMode == RuntimeModeDev {
@@ -391,6 +393,7 @@ func (r *Runtime) StartSession(ctx context.Context, cfg *ContainerConfig) (*Sess
 		InputPath:      cfg.InputPath,
 		OutDir:         cfg.OutDir,
 		StateDir:       cfg.StateDir,
+		AgentHome:      cfg.AgentHome,
 		LocalSkillsDir: skillsDir,
 	}
 	if runtimeMode == RuntimeModeDev {


### PR DESCRIPTION
## Summary
- mount host `agent_home` into runtime container at `/root`
- expose `HOLON_AGENT_HOME=/root` for run/solve/serve runtime sessions
- remove host-side persona concatenation and shift persona loading responsibility to agent runtime
- update system contracts to define writable agent-home files and immutable safety boundary
- align serve controller prompts/session wiring with the new agent-home contract
- add tests for mounts/env mapping/prompt behavior

## Testing
- `go test ./cmd/holon -run 'Test(LoadControllerRole|ControllerPrompts|Runner_Integration|DockerSessionRunnerStart_MapsConfig|HandleEvent_PersistentControllerAndReconnect)' -count=1`
- `go test ./pkg/runtime/docker -run 'Test(BuildContainerMounts|ValidateMountTargets|ContainerConfigurationAssembly|InputMountReadOnly|WorkspaceAndOutputMountsReadWrite)' -count=1`
- `go test $(go list ./... | rg -v '^github.com/holon-run/holon/tests/integration$')`

Closes #649
