### PR TITLE
agent: make runtime paths env-driven

### DIFF
--- a/agents/claude/package-lock.json
+++ b/agents/claude/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "holon-agent-claude",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "holon-agent-claude",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.75",
-        "@anthropic-ai/claude-code": "^2.0.74",
+        "@anthropic-ai/claude-code": "^2.1.3",
         "yaml": "^2.5.0",
         "zod": "^3.24.1"
       },
@@ -398,6 +398,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/agents/claude/package.json
+++ b/agents/claude/package.json
@@ -8,7 +8,7 @@
     "bundle": "./scripts/build-bundle.sh",
     "smoke-test": "./scripts/smoke-test.sh",
     "verify-bundle": "./scripts/verify-bundle.sh",
-    "test": "node --test tests/agent.test.js tests/ci-compatibility.test.js tests/stream-limiter.test.js tests/stream-assistant-text.test.js",
+    "test": "node --test tests/agent.test.js tests/ci-compatibility.test.js tests/runtime-paths.test.js tests/stream-limiter.test.js tests/stream-assistant-text.test.js",
     "test:all": "node --test tests/*.test.js",
     "test:watch": "node --test --watch tests/*.test.js"
   },

--- a/agents/claude/src/runtimePaths.ts
+++ b/agents/claude/src/runtimePaths.ts
@@ -1,0 +1,38 @@
+import path from "path";
+
+export interface RuntimePaths {
+  workspaceDir: string;
+  inputDir: string;
+  outputDir: string;
+  stateDir: string;
+  agentHome: string;
+  specPath: string;
+  systemPromptPath: string;
+  userPromptPath: string;
+  eventPayloadPath: string;
+}
+
+function envOrDefault(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : fallback;
+}
+
+export function resolveRuntimePaths(env: NodeJS.ProcessEnv = process.env): RuntimePaths {
+  const workspaceDir = envOrDefault(env.HOLON_WORKSPACE_DIR, "/holon/workspace");
+  const inputDir = envOrDefault(env.HOLON_INPUT_DIR, "/holon/input");
+  const outputDir = envOrDefault(env.HOLON_OUTPUT_DIR, "/holon/output");
+  const stateDir = envOrDefault(env.HOLON_STATE_DIR, "/holon/state");
+  const agentHome = envOrDefault(env.HOLON_AGENT_HOME, "/root");
+
+  return {
+    workspaceDir,
+    inputDir,
+    outputDir,
+    stateDir,
+    agentHome,
+    specPath: path.join(inputDir, "spec.yaml"),
+    systemPromptPath: path.join(inputDir, "prompts", "system.md"),
+    userPromptPath: path.join(inputDir, "prompts", "user.md"),
+    eventPayloadPath: path.join(inputDir, "context", "event.json"),
+  };
+}

--- a/agents/claude/src/types.ts
+++ b/agents/claude/src/types.ts
@@ -30,7 +30,7 @@ export interface MockOperation {
   type: "write_file" | "append_file" | "delete_file" | "write_output";
   /**
    * Path relative to workspace root for file operations,
-   * or relative to /holon/output/ for write_output operations.
+   * or relative to HOLON_OUTPUT_DIR (default /holon/output) for write_output operations.
    */
   path: string;
   /** Content to write or append (not used for delete_file) */

--- a/agents/claude/tests/runtime-paths.test.js
+++ b/agents/claude/tests/runtime-paths.test.js
@@ -1,0 +1,52 @@
+import { test, describe, afterEach } from "node:test";
+import assert from "node:assert";
+import path from "path";
+import { resolveRuntimePaths } from "../dist/runtimePaths.js";
+
+const managedEnvKeys = [
+  "HOLON_WORKSPACE_DIR",
+  "HOLON_INPUT_DIR",
+  "HOLON_OUTPUT_DIR",
+  "HOLON_STATE_DIR",
+  "HOLON_AGENT_HOME",
+];
+
+afterEach(() => {
+  for (const key of managedEnvKeys) {
+    delete process.env[key];
+  }
+});
+
+describe("resolveRuntimePaths", () => {
+  test("uses defaults when env vars are absent", () => {
+    const paths = resolveRuntimePaths({});
+    assert.strictEqual(paths.workspaceDir, "/holon/workspace");
+    assert.strictEqual(paths.inputDir, "/holon/input");
+    assert.strictEqual(paths.outputDir, "/holon/output");
+    assert.strictEqual(paths.stateDir, "/holon/state");
+    assert.strictEqual(paths.agentHome, "/root");
+    assert.strictEqual(paths.specPath, "/holon/input/spec.yaml");
+    assert.strictEqual(paths.systemPromptPath, "/holon/input/prompts/system.md");
+    assert.strictEqual(paths.userPromptPath, "/holon/input/prompts/user.md");
+    assert.strictEqual(paths.eventPayloadPath, "/holon/input/context/event.json");
+  });
+
+  test("reads and trims HOLON_* path env vars", () => {
+    const paths = resolveRuntimePaths({
+      HOLON_WORKSPACE_DIR: " /tmp/ws ",
+      HOLON_INPUT_DIR: "/tmp/input",
+      HOLON_OUTPUT_DIR: "/tmp/out",
+      HOLON_STATE_DIR: "/tmp/state",
+      HOLON_AGENT_HOME: "/tmp/home",
+    });
+    assert.strictEqual(paths.workspaceDir, "/tmp/ws");
+    assert.strictEqual(paths.inputDir, "/tmp/input");
+    assert.strictEqual(paths.outputDir, "/tmp/out");
+    assert.strictEqual(paths.stateDir, "/tmp/state");
+    assert.strictEqual(paths.agentHome, "/tmp/home");
+    assert.strictEqual(paths.specPath, path.join("/tmp/input", "spec.yaml"));
+    assert.strictEqual(paths.systemPromptPath, path.join("/tmp/input", "prompts", "system.md"));
+    assert.strictEqual(paths.userPromptPath, path.join("/tmp/input", "prompts", "user.md"));
+    assert.strictEqual(paths.eventPayloadPath, path.join("/tmp/input", "context", "event.json"));
+  });
+});

--- a/cmd/holon/runner.go
+++ b/cmd/holon/runner.go
@@ -284,7 +284,25 @@ output:
 	} else {
 		envVars["ASSISTANT_OUTPUT"] = "none" // Default to none
 	}
+	if _, exists := envVars["HOLON_WORKSPACE_DIR"]; !exists {
+		envVars["HOLON_WORKSPACE_DIR"] = "/holon/workspace"
+	}
+	if _, exists := envVars["HOLON_INPUT_DIR"]; !exists {
+		envVars["HOLON_INPUT_DIR"] = "/holon/input"
+	}
+	if _, exists := envVars["HOLON_OUTPUT_DIR"]; !exists {
+		envVars["HOLON_OUTPUT_DIR"] = "/holon/output"
+	}
+	if absStateDir != "" {
+		if _, exists := envVars["HOLON_STATE_DIR"]; !exists {
+			envVars["HOLON_STATE_DIR"] = "/holon/state"
+		}
+	}
 	if absAgentHome != "" {
+		if _, exists := envVars["HOLON_AGENT_HOME"]; !exists {
+			envVars["HOLON_AGENT_HOME"] = "/root"
+		}
+	} else if _, exists := envVars["HOLON_AGENT_HOME"]; !exists {
 		envVars["HOLON_AGENT_HOME"] = "/root"
 	}
 

--- a/cmd/holon/runner_test.go
+++ b/cmd/holon/runner_test.go
@@ -715,6 +715,15 @@ func TestRunner_Integration(t *testing.T) {
 			if got := cfg.Env["HOLON_AGENT_HOME"]; got != "/root" {
 				t.Errorf("HOLON_AGENT_HOME = %q, want /root", got)
 			}
+			if got := cfg.Env["HOLON_WORKSPACE_DIR"]; got != "/holon/workspace" {
+				t.Errorf("HOLON_WORKSPACE_DIR = %q, want /holon/workspace", got)
+			}
+			if got := cfg.Env["HOLON_INPUT_DIR"]; got != "/holon/input" {
+				t.Errorf("HOLON_INPUT_DIR = %q, want /holon/input", got)
+			}
+			if got := cfg.Env["HOLON_OUTPUT_DIR"]; got != "/holon/output" {
+				t.Errorf("HOLON_OUTPUT_DIR = %q, want /holon/output", got)
+			}
 			// WorkingDir is hardcoded to "/holon/workspace" in the docker runtime
 			return "", nil
 		},

--- a/cmd/holon/serve.go
+++ b/cmd/holon/serve.go
@@ -808,6 +808,10 @@ func (h *cliControllerHandler) ensureControllerLocked(ctx context.Context, ref s
 	env := map[string]string{
 		"HOLON_AGENT_SESSION_MODE":            "serve",
 		"HOLON_AGENT_HOME":                    "/root",
+		"HOLON_WORKSPACE_DIR":                 "/holon/workspace",
+		"HOLON_INPUT_DIR":                     "/holon/input",
+		"HOLON_OUTPUT_DIR":                    "/holon/output",
+		"HOLON_STATE_DIR":                     "/holon/state",
 		"CLAUDE_CONFIG_DIR":                   "/holon/state/claude-config",
 		"HOLON_CONTROLLER_ROLE":               h.controllerRoleLabel,
 		"HOLON_CONTROLLER_EVENT_CHANNEL":      "/holon/state/event-channel.ndjson",


### PR DESCRIPTION
## Summary
- make Claude agent runtime path resolution env-driven via `HOLON_WORKSPACE_DIR`, `HOLON_INPUT_DIR`, `HOLON_OUTPUT_DIR`, and `HOLON_STATE_DIR` (with safe defaults)
- remove critical `/holon/*` hardcoding from agent runtime flow and mock driver write paths
- standardize path env injection from host side (`runner` + `serve` controller session env)
- add runtime-path unit tests and extend runner integration assertions for new env contracts

## Changes
- Added `agents/claude/src/runtimePaths.ts` and wired it into:
  - `agents/claude/src/agent.ts`
  - `agents/claude/src/mockDriver.ts`
- Updated comment contract in `agents/claude/src/types.ts`
- Added `agents/claude/tests/runtime-paths.test.js` and included it in `npm test`
- Injected path env contracts in:
  - `cmd/holon/runner.go`
  - `cmd/holon/serve.go`
- Added assertions in `cmd/holon/runner_test.go`

## Testing
- `make test-agent`
- `go test ./cmd/holon ./pkg/runtime/docker`

Closes #650
