### PR TITLE
Decouple skill I/O paths from Holon and improve artifact observability

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -1212,9 +1212,27 @@ jobs:
         id: result
         if: always()
         run: |
+          set -euo pipefail
+
           OUTPUT_DIR='${{ steps.ctx.outputs.output_dir }}'
           SHOULD_RUN="$GATE_SHOULD_RUN"
           REASON="$GATE_REASON"
+
+          HAS_MANIFEST='false'
+          HAS_SUMMARY='false'
+          if [ -f "$OUTPUT_DIR/manifest.json" ]; then
+            HAS_MANIFEST='true'
+          fi
+          if [ -f "$OUTPUT_DIR/summary.md" ]; then
+            HAS_SUMMARY='true'
+          fi
+
+          {
+            echo "### Holon Output"
+            echo "- output_dir: \`$OUTPUT_DIR\`"
+            echo "- manifest.json: $HAS_MANIFEST"
+            echo "- summary.md: $HAS_SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$SHOULD_RUN" != 'true' ]; then
             {
@@ -1226,10 +1244,11 @@ jobs:
           fi
 
           # Check for summary
-          if [ -f "$OUTPUT_DIR/summary.md" ]; then
+          if [ "$HAS_SUMMARY" = 'true' ]; then
             cat "$OUTPUT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
             echo "summary=$OUTPUT_DIR/summary.md" >> "$GITHUB_OUTPUT"
           else
+            echo "- warning: summary.md not found under output_dir; inspect uploaded artifact for diagnostics." >> "$GITHUB_STEP_SUMMARY"
             echo "summary=" >> "$GITHUB_OUTPUT"
           fi
 
@@ -1292,6 +1311,22 @@ jobs:
           if [ -d "$OUTPUT_DIR" ]; then
             cp -a "$OUTPUT_DIR/." "$ARTIFACT_DIR/output/" || true
           fi
+
+          HAS_MANIFEST='false'
+          HAS_SUMMARY='false'
+          if [ -f "$OUTPUT_DIR/manifest.json" ]; then
+            HAS_MANIFEST='true'
+          fi
+          if [ -f "$OUTPUT_DIR/summary.md" ]; then
+            HAS_SUMMARY='true'
+          fi
+
+          cat > "$ARTIFACT_DIR/artifact-metadata.txt" <<EOF
+          input_dir=$INPUT_DIR
+          output_dir=$OUTPUT_DIR
+          manifest_present=$HAS_MANIFEST
+          summary_present=$HAS_SUMMARY
+          EOF
 
           echo "artifact_dir=$ARTIFACT_DIR" >> "$GITHUB_OUTPUT"
 

--- a/cmd/holon/runner.go
+++ b/cmd/holon/runner.go
@@ -293,6 +293,12 @@ output:
 	if _, exists := envVars["HOLON_OUTPUT_DIR"]; !exists {
 		envVars["HOLON_OUTPUT_DIR"] = docker.ContainerOutputDir
 	}
+	if _, exists := envVars["GITHUB_OUTPUT_DIR"]; !exists {
+		envVars["GITHUB_OUTPUT_DIR"] = docker.ContainerOutputDir
+	}
+	if _, exists := envVars["GITHUB_CONTEXT_DIR"]; !exists {
+		envVars["GITHUB_CONTEXT_DIR"] = filepath.Join(envVars["GITHUB_OUTPUT_DIR"], "github-context")
+	}
 	if _, exists := envVars["HOLON_STATE_DIR"]; !exists {
 		envVars["HOLON_STATE_DIR"] = docker.ContainerStateDir
 	}

--- a/cmd/holon/serve.go
+++ b/cmd/holon/serve.go
@@ -816,6 +816,8 @@ func (h *cliControllerHandler) ensureControllerLocked(ctx context.Context, ref s
 		"HOLON_WORKSPACE_INDEX_PATH":          "/root/state/workspace-index.json",
 		"HOLON_INPUT_DIR":                     docker.ContainerInputDir,
 		"HOLON_OUTPUT_DIR":                    docker.ContainerOutputDir,
+		"GITHUB_OUTPUT_DIR":                   docker.ContainerOutputDir,
+		"GITHUB_CONTEXT_DIR":                  filepath.Join(docker.ContainerOutputDir, "github-context"),
 		"HOLON_STATE_DIR":                     docker.ContainerStateDir,
 		"CLAUDE_CONFIG_DIR":                   "/state/claude-config",
 		"HOLON_CONTROLLER_ROLE":               h.controllerRoleLabel,

--- a/pkg/prompt/assets/contracts/common.md
+++ b/pkg/prompt/assets/contracts/common.md
@@ -21,7 +21,7 @@ Your primary objective is to execute the user's task by modifying files in the w
     *   Root: `{{ .WorkingDir }}`
 
 2.  **Artifacts & Output**:
-    *   All outputs (plans, intermediate documents, reports, diffs) must be written to `/holon/output`.
+    *   All outputs (plans, intermediate documents, reports, diffs) must be written to the runtime-recommended output directory (typically `/output`).
     *   Do NOT clutter the workspace with temporary files or plans.
 
 3.  **Agent Home**:
@@ -42,7 +42,7 @@ Your primary objective is to execute the user's task by modifying files in the w
     *   If you are stuck, fail fast with a clear error message in `manifest.json`.
 
 5.  **Reporting**:
-    *   Finally, create a `summary.md` file in the `/holon/output` directory with a concise summary of your changes and the outcome.
+    *   Finally, create a `summary.md` file in the runtime-recommended output directory (typically `/output`) with a concise summary of your changes and the outcome.
 
 6.  **Context**:
-    *   Additional context files may be provided in `/holon/input/context/`. You should read them if the task goal or user prompt references them.
+    *   Additional context files may be provided in the runtime context directory (typically `/input/context/`). You should read them if the task goal or user prompt references them.

--- a/pkg/prompt/assets/modes/pr-fix/contract.md
+++ b/pkg/prompt/assets/modes/pr-fix/contract.md
@@ -3,7 +3,7 @@
 PR-Fix mode is designed for GitHub PR fix operations. The agent analyzes PR feedback (review threads, CI/check failures) and generates structured responses to make the PR mergeable.
 
 **GitHub Context:**
-- PR context is provided under `/holon/input/context/github/`:
+- PR context is provided under `/input/context/github/`:
   - `pr.json`: Pull request metadata
   - `review_threads.json`: Review threads with comment metadata (optional, includes `comment_id`)
   - `pr.diff`: The code changes being reviewed (optional but recommended)
@@ -13,9 +13,9 @@ PR-Fix mode is designed for GitHub PR fix operations. The agent analyzes PR feed
 **Important:** When responding to review comments, use your GitHub identity (from common contract) to avoid replying to your own comments.
 
 **Required Outputs:**
-1. **`/holon/output/summary.md`**: Human-readable summary of your analysis and actions taken
-2. **`/holon/output/pr-fix.json`**: Structured JSON containing fix status and responses
-   - Must conform to `/holon/input/context/pr-fix.schema.json` (read it if needed)
+1. **`/output/summary.md`**: Human-readable summary of your analysis and actions taken (runtime-recommended output path)
+2. **`/output/pr-fix.json`**: Structured JSON containing fix status and responses (runtime-recommended output path)
+   - Must conform to `/input/context/pr-fix.schema.json` (read it if needed)
 
 **Execution Behavior:**
 - You are running **HEADLESSLY** - do not wait for user input or confirmation
@@ -176,7 +176,7 @@ When review comments request substantial refactoring, testing, or enhancements t
 
 **Analyzing Test Failures:**
 
-When CI/check runs fail, test failure logs are downloaded to `/holon/input/context/github/test-failure-logs.txt`. Use these logs to diagnose failures:
+When CI/check runs fail, test failure logs are downloaded to `/input/context/github/test-failure-logs.txt`. Use these logs to diagnose failures:
 
 **How logs are obtained:**
 - Logs are downloaded from the GitHub Actions API using the check run's DetailsURL
@@ -191,13 +191,13 @@ When CI/check runs fail, test failure logs are downloaded to `/holon/input/conte
 2. **Read the logs**: Use grep to find specific test failures:
    ```bash
    # Find all failing tests
-   grep -E "(FAIL|FAIL:|FAILED)" /holon/input/context/github/test-failure-logs.txt
+   grep -E "(FAIL|FAIL:|FAILED)" /input/context/github/test-failure-logs.txt
 
    # Search for a specific test name
-   grep "TestRunner_Run_EnvVariablePrecedence" /holon/input/context/github/test-failure-logs.txt
+   grep "TestRunner_Run_EnvVariablePrecedence" /input/context/github/test-failure-logs.txt
 
    # Show context around a failure
-   grep -A 20 "FAIL:" /holon/input/context/github/test-failure-logs.txt
+   grep -A 20 "FAIL:" /input/context/github/test-failure-logs.txt
    ```
 3. **Analyze the failure**:
    - What error message or assertion failed?
@@ -208,7 +208,7 @@ When CI/check runs fail, test failure logs are downloaded to `/holon/input/conte
 **Important**: The `check_runs.json` only contains metadata (name, status, conclusion). The actual test failure details are in `test-failure-logs.txt`. Always read the logs when diagnosing test failures.
 
 **Context Files:**
-Additional context files may be provided in `/holon/input/context/`. Read them if they contain relevant information for addressing the review comments or CI failures.
+Additional context files may be provided in `/input/context/`. Read them if they contain relevant information for addressing the review comments or CI failures.
 
 **Test Failure Diagnosis and Reproduction:**
 
@@ -243,12 +243,12 @@ relevance → Fix or not-applicable   ↓ Can run test?
 ### Step 1: Check Available Information
 
 1. **Read CI logs** (if available):
-   - Check `/holon/input/context/github/test-failure-logs.txt` for failure details
+   - Check `/input/context/github/test-failure-logs.txt` for failure details
    - Search for specific failures (FAIL, error, exception patterns)
    - Identify failing test names and stack traces
 
 2. **Read check_runs.json** for test names and failure details:
-   - Check `/holon/input/context/github/check_runs.json` for structured test failure information
+   - Check `/input/context/github/check_runs.json` for structured test failure information
    - Extract test names, job IDs, and failure summaries
 
 3. **If logs are complete and clear**:
@@ -519,21 +519,21 @@ Before finalizing a diagnosis, ask yourself:
     "reasoning": "Local tests pass (32/32) but CI fails with EACCES permission denied. This suggests an environment difference, but could also indicate code that executes differently during module import vs explicit test invocation.",
     "evidence_supporting": [
       "Local test run: 32/32 passed",
-      "CI error: EACCES permission denied creating /holon/output/evidence",
-      "Error path /holon/output/evidence is a protected system path"
+      "CI error: EACCES permission denied creating /output/evidence",
+      "Error path /output/evidence is a protected system path"
     ],
     "evidence_conflicting": [
-      "If it were a simple environment issue, why would the code need to create /holon/output/evidence?",
+      "If it were a simple environment issue, why would the code need to create /output/evidence?",
       "Tests don't fail locally even though they import the same agent.ts file"
     ],
     "alternative_explanations": [
-      "Explanation A: CI environment lacks write permissions to /holon (environment issue)",
+      "Explanation A: CI environment lacks write permissions to /output (environment issue)",
       "Explanation B: agent.ts has module-level code that auto-executes and tries to create paths during import (code issue)",
       "Explanation C: Test setup mocks paths differently in CI vs local"
     ],
     "investigation_needed": [
       "Check agent.ts for module-level code that auto-executes",
-      "Verify when /holon/output/evidence creation is triggered",
+      "Verify when /output/evidence creation is triggered",
       "Compare test environment setup between local and CI"
     ]
   }

--- a/skills/ghx/SKILL.md
+++ b/skills/ghx/SKILL.md
@@ -13,10 +13,9 @@ It combines two capabilities:
 
 ## Environment Variables
 
-- `GITHUB_OUTPUT_DIR`: artifact directory (default `/holon/output` if available)
+- `GITHUB_OUTPUT_DIR`: artifact directory (caller-provided; defaults to a temporary directory when unset)
 - `GITHUB_CONTEXT_DIR`: context directory (default `${GITHUB_OUTPUT_DIR}/github-context`)
 - `GITHUB_TOKEN` / `GH_TOKEN`: GitHub token for `gh`
-- `HOLON_GITHUB_BOT_LOGIN`: bot login for idempotency checks (default `holonbot[bot]`)
 - `DRY_RUN`: preview mode (`true|false`)
 
 ## Commands

--- a/skills/ghx/scripts/collect.sh
+++ b/skills/ghx/scripts/collect.sh
@@ -9,7 +9,8 @@
 #   repo_hint: Optional owner/repo when ref is numeric
 #
 # Environment:
-#   GITHUB_CONTEXT_DIR   Output directory (default: /holon/output/github-context if present, else tmp)
+#   GITHUB_CONTEXT_DIR   Output directory (default: ${GITHUB_OUTPUT_DIR}/github-context if set, else tmp)
+#   GITHUB_OUTPUT_DIR    Optional base output directory used when GITHUB_CONTEXT_DIR is unset
 #   TRIGGER_COMMENT_ID   Comment ID to mark as trigger
 #   INCLUDE_DIFF         Include PR diff (default: true)
 #   INCLUDE_CHECKS       Include check runs + logs (default: true)
@@ -36,8 +37,8 @@ MANIFEST_PROVIDER="${MANIFEST_PROVIDER:-ghx}"
 
 # Default output directory
 if [[ -z "${GITHUB_CONTEXT_DIR:-}" ]]; then
-    if [[ -d /holon/output ]]; then
-        GITHUB_CONTEXT_DIR="/holon/output/github-context"
+    if [[ -n "${GITHUB_OUTPUT_DIR:-}" ]]; then
+        GITHUB_CONTEXT_DIR="${GITHUB_OUTPUT_DIR}/github-context"
     else
         GITHUB_CONTEXT_DIR="$(mktemp -d /tmp/holon-ghctx-XXXXXX)"
     fi
@@ -63,7 +64,8 @@ Arguments:
   repo_hint  Optional repository hint (e.g., "owner/repo") for numeric refs
 
 Environment:
-  GITHUB_CONTEXT_DIR   Output directory (default: /holon/output/github-context if present, else temp dir)
+  GITHUB_CONTEXT_DIR   Output directory (default: ${GITHUB_OUTPUT_DIR}/github-context if set, else temp dir)
+  GITHUB_OUTPUT_DIR    Optional base output directory used when GITHUB_CONTEXT_DIR is unset
   TRIGGER_COMMENT_ID   Comment ID to mark as trigger
   INCLUDE_DIFF         Include PR diff (default: true)
   INCLUDE_CHECKS       Include CI checks (default: true)

--- a/skills/ghx/scripts/publish.sh
+++ b/skills/ghx/scripts/publish.sh
@@ -8,11 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -z "${GITHUB_OUTPUT_DIR:-}" ]]; then
-  if [[ -d /holon/output && -w /holon/output ]]; then
-    GITHUB_OUTPUT_DIR="/holon/output"
-  else
-    GITHUB_OUTPUT_DIR="$(mktemp -d /tmp/holon-ghpub-XXXXXX)"
-  fi
+  GITHUB_OUTPUT_DIR="$(mktemp -d /tmp/holon-ghpub-XXXXXX)"
 fi
 INTENT_FILE=""
 DRY_RUN=false
@@ -39,7 +35,7 @@ usage() {
 Usage: publish.sh [OPTIONS] [COMMAND [ARGS]]
 
 Batch mode:
-  publish.sh --intent=/holon/output/publish-intent.json [OPTIONS]
+  publish.sh --intent=/path/to/publish-intent.json [OPTIONS]
 
 Direct command mode:
   publish.sh --pr=OWNER/REPO#NUM comment --body-file summary.md

--- a/skills/github-issue-solve/SKILL.md
+++ b/skills/github-issue-solve/SKILL.md
@@ -26,7 +26,7 @@ This skill can use:
 ## Environment & Paths
 
 - **`GITHUB_OUTPUT_DIR`**: Where this skill writes artifacts  
-  - Default: `/holon/output` if present; otherwise a temp dir `/tmp/holon-ghissue-*`
+  - Default: system-recommended output directory if provided by caller; otherwise a temp dir `/tmp/holon-ghissue-*`
 - **`GITHUB_CONTEXT_DIR`**: Where `ghx` writes collected data  
   - Default: `${GITHUB_OUTPUT_DIR}/github-context`
 - **`GITHUB_TOKEN` / `GH_TOKEN`**: Token used for GitHub operations (scopes: `repo` or `public_repo`)

--- a/skills/github-pr-fix/SKILL.md
+++ b/skills/github-pr-fix/SKILL.md
@@ -24,11 +24,10 @@ This skill can use:
 ## Environment & Paths
 
 - **`GITHUB_OUTPUT_DIR`**: Where this skill writes artifacts  
-  - Default: `/holon/output` if present; otherwise a temp dir `/tmp/holon-ghprfix-*`
+  - Default: system-recommended output directory if provided by caller; otherwise a temp dir `/tmp/holon-ghprfix-*`
 - **`GITHUB_CONTEXT_DIR`**: Where `ghx` writes collected data  
   - Default: `${GITHUB_OUTPUT_DIR}/github-context`
 - **`GITHUB_TOKEN` / `GH_TOKEN`**: Token for GitHub operations (scopes: `repo` or `public_repo`)
-- **`HOLON_GITHUB_BOT_LOGIN`**: Bot login for idempotency (default `holonbot[bot]`)
 
 ## Inputs & Outputs
 

--- a/skills/github-review/SKILL.md
+++ b/skills/github-review/SKILL.md
@@ -18,7 +18,7 @@ This skill uses environment variables to stay portable across Holon, local shell
 ### Key Environment Variables
 
 - **`GITHUB_OUTPUT_DIR`**: Where this skill writes artifacts  
-  - Default: `/holon/output` if present; otherwise a temp dir `/tmp/holon-ghreview-*`
+  - Default: system-recommended output directory if provided by caller; otherwise a temp dir `/tmp/holon-ghreview-*`
 - **`GITHUB_CONTEXT_DIR`**: Directory for collected PR data  
   - Default: `${GITHUB_OUTPUT_DIR}/github-context`
 - **`GITHUB_TOKEN` / `GH_TOKEN`**: Token used for GitHub operations (scopes: `repo` or `public_repo`)
@@ -27,8 +27,8 @@ This skill uses environment variables to stay portable across Holon, local shell
 ### Path Examples
 
 ```bash
-# Holon container (default picked up automatically)
-export GITHUB_OUTPUT_DIR=/holon/output
+# Runtime-provided output directory (recommended)
+export GITHUB_OUTPUT_DIR=/path/to/output
 
 # Local development (keeps workspace clean by defaulting to /tmp if unset)
 export GITHUB_OUTPUT_DIR=./output

--- a/skills/github-review/references/SCRIPTS.md
+++ b/skills/github-review/references/SCRIPTS.md
@@ -56,7 +56,7 @@ collect.sh <pr_ref> [repo_hint]
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GITHUB_OUTPUT_DIR` | `/holon/output` if present, else `/tmp/holon-ghreview-*` | Output directory for artifacts |
+| `GITHUB_OUTPUT_DIR` | Caller-provided output dir; else `/tmp/holon-ghreview-*` | Output directory for artifacts |
 | `GITHUB_CONTEXT_DIR` | `${GITHUB_OUTPUT_DIR}/github-context` | Context subdirectory |
 | `MAX_FILES` | `100` | Maximum files to fetch (prevents overwhelming context) |
 | `INCLUDE_THREADS` | `true` | Include existing review threads |
@@ -122,7 +122,7 @@ MAX_INLINE=10 POST_EMPTY=false skills/ghx/scripts/ghx.sh review publish --pr=own
 - `--post-empty` or `POST_EMPTY=true`: Post even when `review.json` is empty
 - `--pr=OWNER/REPO#NUMBER`: Target PR reference
 
-### Required artifacts (in `${GITHUB_OUTPUT_DIR}`; defaults to `/holon/output` or temp)
+### Required artifacts (in `${GITHUB_OUTPUT_DIR}`; defaults to temp when unset)
 - `review.md`: Review summary/body
 - `review.json`: Structured findings with `path`/`line`/`severity`/`message` (and optional `suggestion`)
 - `github-context/manifest.json`: Collection manifest (for PR ref and head SHA)
@@ -135,7 +135,7 @@ MAX_INLINE=10 POST_EMPTY=false skills/ghx/scripts/ghx.sh review publish --pr=own
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GITHUB_OUTPUT_DIR` | `/holon/output` | Directory containing review artifacts |
+| `GITHUB_OUTPUT_DIR` | Temp dir when unset | Directory containing review artifacts |
 | `DRY_RUN` | `false` | Preview without posting |
 | `MAX_INLINE` | `20` | Maximum inline comments to post |
 | `POST_EMPTY` | `false` | Post review even with no findings |

--- a/skills/github-review/scripts/collect.sh
+++ b/skills/github-review/scripts/collect.sh
@@ -7,11 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SHARED_COLLECTOR="$SCRIPT_DIR/../../ghx/scripts/collect.sh"
 
 # Default output and context dirs (aligned with shared github-context layout)
-if [[ -d /holon/output ]]; then
-    GITHUB_OUTPUT_DIR="${GITHUB_OUTPUT_DIR:-/holon/output}"
-else
-    GITHUB_OUTPUT_DIR="${GITHUB_OUTPUT_DIR:-$(mktemp -d /tmp/holon-ghreview-XXXXXX)}"
-fi
+GITHUB_OUTPUT_DIR="${GITHUB_OUTPUT_DIR:-$(mktemp -d /tmp/holon-ghreview-XXXXXX)}"
 
 if [[ -z "${GITHUB_CONTEXT_DIR:-}" ]]; then
     GITHUB_CONTEXT_DIR="$GITHUB_OUTPUT_DIR/github-context"


### PR DESCRIPTION
## Summary
- decouple GitHub skills from Holon-specific runtime paths and env assumptions
- make skills rely on caller-provided `GITHUB_OUTPUT_DIR`/`GITHUB_CONTEXT_DIR` or temp fallback
- have Holon runtime inject `GITHUB_OUTPUT_DIR` and `GITHUB_CONTEXT_DIR` so workflow packaging remains stable
- update prompt contracts to runtime-recommended output/context wording
- improve `holon-solve` artifact observability in workflow summary and uploaded metadata

## Changes
- Skills/scripts:
  - `skills/ghx/scripts/collect.sh`
  - `skills/ghx/scripts/publish.sh`
  - `skills/github-review/scripts/collect.sh`
- Skill docs:
  - `skills/ghx/SKILL.md`
  - `skills/github-issue-solve/SKILL.md`
  - `skills/github-pr-fix/SKILL.md`
  - `skills/github-review/SKILL.md`
  - `skills/github-review/references/SCRIPTS.md`
- Runtime env wiring:
  - `cmd/holon/runner.go`
  - `cmd/holon/serve.go`
- Prompt contracts:
  - `pkg/prompt/assets/contracts/common.md`
  - `pkg/prompt/assets/modes/pr-fix/contract.md`
- Workflow:
  - `.github/workflows/holon-solve.yml`

## Validation
- `go generate ./pkg/builtin`
- `make test-agent`
- `go test ./cmd/holon ./pkg/prompt`
- `go test ./pkg/builtin ./pkg/runtime/docker`
