### PR TITLE
docs/tests: define holon run GA contract semantics (#665)

### DIFF
--- a/docs/modes.md
+++ b/docs/modes.md
@@ -2,6 +2,8 @@
 
 Holon uses a **skill-first** execution model where context collection and publishing are delegated to skills, not the runtime. This provides flexibility and control over the IO workflow.
 
+For release-level compatibility guarantees of `holon run`, see `docs/run-ga-contract.md`.
+
 ## Architecture Overview
 
 ### Skill-First IO (Default)
@@ -26,7 +28,12 @@ Holon uses a **skill-first** execution model where context collection and publis
 ### `holon run`
 - Lower-level entrypoint for running with custom goals/specs
 - Always uses skill-first mode
-- Skills loaded from project config or `--skill` flag
+- Skills are resolved and merged with precedence:
+  - CLI (`--skill`, `--skills`)
+  - Project config
+  - Spec metadata
+  - Auto-discovered workspace skills
+- `--skill`/`--skills` are activation inputs for the current run, not install commands
 
 ## Publishing Semantics
 
@@ -62,7 +69,7 @@ base_image: auto-detect
 ```
 
 ### CLI Flags
-- `--skill <path>`: Override skill (repeatable)
-- `--skills <list>`: Comma-separated skill paths
+- `--skill <path>`: Add/override active skills for this run (repeatable, highest precedence)
+- `--skills <list>`: Comma-separated active skills for this run (highest precedence)
 - `--workspace <path>`: Use existing workspace
 - `--output <dir>`: Output directory

--- a/docs/run-ga-contract.md
+++ b/docs/run-ga-contract.md
@@ -1,0 +1,60 @@
+# `holon run` GA Contract (v0.11)
+
+This document defines the compatibility contract for `holon run` in v0.11.
+
+## Goal
+
+`holon run` is the stable execution kernel:
+- run an agent safely in sandboxed runtime,
+- accept explicit run-time inputs,
+- produce deterministic machine-readable execution results.
+
+## Stable (GA) Contract Surface
+
+### 1. Runtime and isolation boundary
+
+- Execution happens in containerized sandbox runtime.
+- Runtime controls container mounts and environment injection.
+- Agent/skill execution is isolated from host by container boundary.
+
+### 2. Input/output contract
+
+- Runtime provides input, workspace, and output boundaries to agent.
+- `manifest.json` is the required execution record output.
+- Optional artifacts are skill-defined and enumerated via manifest.
+
+### 3. Skill activation semantics
+
+`--skill`/`--skills` are run-time activation inputs, not lifecycle installation commands.
+
+- `holon run --skill/--skills` means: "enable these skills for this run".
+- Resolution precedence is stable:
+  - CLI (`--skill`, `--skills`)
+  - project config
+  - spec metadata
+  - auto-discovered workspace skills
+- CLI skills have highest precedence but do not disable lower-precedence sources.
+
+### 4. Default agent-home behavior
+
+- `holon run` without `--agent-id`/`--agent-home` uses ephemeral agent-home by default.
+- `holon run` with `--agent-id` or `--agent-home` uses persistent agent-home.
+- `holon serve` default remains persistent `main` agent-home.
+
+### 5. Error/exit behavior
+
+- Invalid inputs and contract violations return explicit errors.
+- Missing required outputs (for active contract checks) are surfaced deterministically.
+
+## Explicitly Non-GA / Experimental
+
+- `holon serve` control-plane and ingress protocol evolution.
+- TUI interaction model and RPC method evolution.
+- External subscription transport strategy and connectors.
+- Agent-level skill management UX beyond run-time activation.
+
+## Notes for Operators
+
+- Use `holon run` for stable one-shot execution.
+- Use `holon solve` as higher-level wrapper over `run`.
+- Treat `holon serve` as preview/experimental in v0.11.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -95,6 +95,9 @@ Holon automatically discovers skills from the `.claude/skills/` directory in you
 3. **Spec file** (`metadata.skills` field)
 4. **Auto-discovered** from `.claude/skills/` - lowest priority
 
+`--skill` / `--skills` are run-time activation inputs for the current execution. They are not persistent installation commands.
+When CLI skills are provided, Holon still merges lower-precedence sources (project config, spec, auto-discovery) and deduplicates by resolved skill path.
+
 **Skill Reference Formats:**
 Skills can be specified using any of these formats:
 - **Catalog references**: `skills:<package>` (skills.sh catalog), `gh:<owner>/<repo>` (GitHub)
@@ -133,6 +136,7 @@ Add a SHA256 checksum via URL fragment to verify download integrity:
 
 **Caching:**
 Downloaded skills are cached in `~/.holon/cache/skills/` based on URL and checksum (if provided). Subsequent runs use the cache automatically.
+This cache improves future runs but does not change the per-run activation semantics described above.
 
 ## Remote Skills Behavior Matrix
 

--- a/pkg/agenthome/agenthome_test.go
+++ b/pkg/agenthome/agenthome_test.go
@@ -54,6 +54,26 @@ func TestResolveEphemeral(t *testing.T) {
 	}
 }
 
+func TestResolveRunWithAgentID_IsPersistent(t *testing.T) {
+	res, err := Resolve(ResolveOptions{
+		Command:          "run",
+		AgentID:          "custom",
+		EphemeralAllowed: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve run with agent id: %v", err)
+	}
+	if res.AgentID != "custom" {
+		t.Fatalf("expected custom agent id, got %s", res.AgentID)
+	}
+	if filepath.Base(res.AgentHome) != "custom" {
+		t.Fatalf("expected agent home suffix custom, got %s", res.AgentHome)
+	}
+	if res.Ephemeral {
+		t.Fatalf("run with explicit agent id should not be ephemeral")
+	}
+}
+
 func TestEnsureLayout(t *testing.T) {
 	td := t.TempDir()
 	home := filepath.Join(td, "agent-home")

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -348,6 +348,30 @@ func TestResolver_Resolve(t *testing.T) {
 		}
 	})
 
+	// Test 1.1: CLI skills do not imply "only" mode
+	t.Run("cli still merges lower precedence", func(t *testing.T) {
+		cliSkills := []string{cliSkillDir}
+		configSkills := []string{configSkillDir}
+		specSkills := []string{specSkillDir}
+
+		resolved, err := resolver.Resolve(cliSkills, configSkills, specSkills)
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+
+		// CLI skills are highest precedence, but config/spec/discovered are still active.
+		if len(resolved) != 5 {
+			t.Fatalf("expected 5 merged skills, got %d", len(resolved))
+		}
+
+		wantSources := []string{"cli", "config", "spec", "discovered", "discovered"}
+		for i, got := range resolved {
+			if got.Source != wantSources[i] {
+				t.Fatalf("skill[%d] source mismatch: want %q, got %q", i, wantSources[i], got.Source)
+			}
+		}
+	})
+
 	// Test 2: Deduplication - discovered skills don't duplicate explicit skills
 	t.Run("deduplication", func(t *testing.T) {
 		// Add discovered1 (which is also in .claude/skills/) to CLI


### PR DESCRIPTION
## Summary
- add `docs/run-ga-contract.md` to define v0.11 GA surface for `holon run`
- clarify in docs that `--skill/--skills` are per-run activation inputs (not installation commands)
- lock the merged skill precedence semantics with tests (`CLI > config > spec > discovered`)
- add agenthome resolution test to freeze run behavior with explicit `--agent-id`

## Testing
- go test ./pkg/skills ./pkg/agenthome
- go test ./cmd/holon

## Related
- Closes #665
