### PR TITLE
workflow: use local built agent bundle for source builds

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -1198,6 +1198,16 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ ! -d "agents/claude" ]; then
+            echo "::error::agents/claude directory not found"
+            exit 1
+          fi
+
+          if [ ! -f "agents/claude/package.json" ]; then
+            echo "::error::agents/claude/package.json not found"
+            exit 1
+          fi
+
           cd agents/claude
           npm ci
           npm run bundle
@@ -1229,6 +1239,7 @@ jobs:
             echo "agent_ref=$LOCAL_AGENT" >> "$GITHUB_OUTPUT"
             echo "Using local source-built agent bundle: $LOCAL_AGENT"
           else
+            # Keep empty to trigger composite action fallback (no --agent flag).
             echo "agent_ref=" >> "$GITHUB_OUTPUT"
             echo "Using action default agent resolution (channel latest)"
           fi


### PR DESCRIPTION
## Summary
- update `holon-solve` reusable workflow to build a local Claude agent bundle when `build_from_source=true` and `agent` is not explicitly provided
- resolve effective agent input with precedence: explicit `inputs.agent` > locally built bundle > default channel resolution
- pass resolved agent path into the composite action so source-build runs test the current branch agent implementation instead of release `latest`

## Validation
- YAML parse check for `.github/workflows/holon-solve.yml`
