### PR TITLE
docs: publish v0.11 operator guide and changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased]
+
+### Documentation
+
+- Added `docs/operator-guide-v0.11.md` to define the v0.11 operator boundary:
+  - Stable: `holon run`, `holon solve`
+  - Preview: `holon serve`
+  - Upgrade notes, known limitations, and troubleshooting entry points
+- Added top-level docs links from `README.md` and `README.zh.md` to the operator guide.
+
+### Breaking Changes (Documented)
+
+- `holon solve` uses skill-first IO as the default behavior.
+  - Collect/publish behavior is delegated to skills.
+  - Operator workflows should migrate to skill-driven collect/publish assumptions.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The state directory is mounted at `/holon/state` inside the container and persis
 
 ## Development & docs
 - Build CLI: `make build`; test: `make test`; agent bundle: `(cd agents/claude && npm run bundle)`.
+- Operator guide (v0.11): `docs/operator-guide-v0.11.md`
+- `run` GA contract: `docs/run-ga-contract.md`
 - Skills guide: `docs/skills.md`
 - Serve GitHub MVP: `docs/serve-github-mvp.md`
 - Design/architecture: `docs/holon-architecture.md`

--- a/README.zh.md
+++ b/README.zh.md
@@ -87,6 +87,8 @@ holon solve https://github.com/owner/repo/issues/123
 
 ## 开发与文档
 - 构建 CLI：`make build`；测试：`make test`；Agent Bundle：`(cd agents/claude && npm run bundle)`。
+- Operator 指南（v0.11）：`docs/operator-guide-v0.11.md`
+- `run` GA 契约：`docs/run-ga-contract.md`
 - 架构设计：`docs/holon-architecture.md`
 - Agent 契约：`rfc/0002-agent-scheme.md`
 - 模式说明：`docs/modes.md`

--- a/docs/holon-architecture.md
+++ b/docs/holon-architecture.md
@@ -27,10 +27,12 @@ Holon’s default integration boundary is a patch file (`diff.patch`) because it
 - agent/engine neutrality (not every tool supports native “create PR”).
 
 ## Why “context injection”
-Holon does not fetch issue/PR context itself. The caller (workflow/local script) injects context files under `${HOLON_INPUT_DIR}/context/` so:
-- agents remain tool/platform-agnostic,
-- runs are auditable (context is part of the execution record),
-- workflows can decide what to include (issue body, linked issues, diffs, logs, etc.).
+Holon keeps context as explicit inputs under `${HOLON_INPUT_DIR}/context/`.
+
+- For `holon run`, the caller/workflow injects context directly.
+- For `holon solve`, skill workflows collect GitHub context and write it under the same input contract.
+
+This keeps runs auditable (context is part of execution record) and preserves agent/runtime neutrality.
 
 ## Image composition (Build-on-Run)
 Many tasks need a project toolchain (Go/Node/Java/etc.). Holon supports composing an execution image at run time:
@@ -40,6 +42,7 @@ Many tasks need a project toolchain (Go/Node/Java/etc.). Holon supports composin
 This avoids maintaining a large prebuilt agent×toolchain matrix.
 
 ## Related docs
-- `docs/modes.md`: design for `mode` as the single user-facing selector (solve/plan/review).
+- `docs/operator-guide-v0.11.md`: operator-facing boundary for stable (`run`/`solve`) vs preview (`serve`) surfaces.
+- `docs/modes.md`: skill-first architecture and CLI behavior.
 - `docs/agent-encapsulation.md`: non-normative description of the agent pattern and image composition approach.
 - `docs/agent-claude.md`: reference implementation notes for the Claude agent.

--- a/docs/operator-guide-v0.11.md
+++ b/docs/operator-guide-v0.11.md
@@ -1,0 +1,82 @@
+# Holon v0.11 Operator Guide
+
+This guide is for operators running Holon in local environments or CI.
+
+## Capability Boundary (v0.11)
+
+| Surface | Status in v0.11 | Operator expectation |
+|---|---|---|
+| `holon run` | Stable (GA) | Contract-first execution kernel with deterministic artifact validation. |
+| `holon solve` | Stable (GA wrapper over `run`) | End-to-end issue/PR automation with skill-driven collect/publish. |
+| `holon serve` | Preview | API/ingress/control-plane behavior may change between minor releases. |
+
+For the normative `run` contract, see `docs/run-ga-contract.md`.
+
+## Stable Surfaces
+
+### `holon run`
+
+Use `holon run` when you need explicit control over goal/spec and artifact processing.
+
+Stable operator assumptions:
+- Containerized, sandboxed execution boundary.
+- Output contract based on `HOLON_OUTPUT_DIR`.
+- Required execution record: `manifest.json`.
+- Stable skill activation precedence (`--skill/--skills`, project config, spec metadata, auto-discovered skills).
+
+### `holon solve`
+
+Use `holon solve` for GitHub issue/PR workflows.
+
+Stable operator assumptions:
+- Skill-first IO is the default behavior.
+- `solve` orchestrates workspace preparation, agent execution, and publish validation.
+- Issue and PR flows are handled by GitHub-focused skills.
+
+Upgrade impact to keep in mind:
+- Existing workflows that relied on legacy Go collector/publisher defaults should migrate to skill-driven behavior and skill configuration.
+
+## Preview Surface
+
+### `holon serve`
+
+`holon serve` is preview in v0.11.
+
+Preview caveats:
+- Ingress/control-plane paths and method set can evolve.
+- Webhook mode is primarily for local development/testing.
+- Backward compatibility for serve-specific APIs is not guaranteed at the same level as `run`/`solve`.
+
+Current webhook docs and caveats: `docs/serve-webhook.md`.
+
+## Upgrade Notes (to v0.11)
+
+1. Treat `run` and `solve` as the stable operator entrypoints.
+2. Treat `serve` as preview; pin versions and validate behavior before rollout.
+3. For `solve`, align automation to skill-first IO and skill outputs.
+4. Ensure automation reads artifacts via env contract (`HOLON_OUTPUT_DIR`) instead of hardcoded absolute paths.
+
+## Known Limitations and Mitigations
+
+1. `serve` webhook mode is local-first and includes explicit caveats.
+Mitigation: keep production automation centered on `run`/`solve` until serve API is finalized.
+
+2. Skill workflows depend on GitHub credentials/tooling.
+Mitigation: standardize token provisioning (`GITHUB_TOKEN`/`GH_TOKEN`) and verify auth in CI preflight.
+
+3. Skill outputs can vary by workflow while still honoring manifest contract.
+Mitigation: gate automation on `manifest.json` status/outcome and documented required metadata.
+
+## Troubleshooting Entry Points
+
+- Runtime and contract safety: `docs/run-safety-checklist.md`
+- Skill-first architecture and behavior: `docs/modes.md`
+- Manifest/output semantics: `docs/manifest-format.md`
+- State mount and persistence: `docs/state-mount.md`
+- Serve webhook preview operation: `docs/serve-webhook.md`
+- Contributor/debug reference: `docs/development.md`
+
+## Release Notes Mapping
+
+- Operator-facing boundary statement for v0.11: this document.
+- Changelog entries: `CHANGELOG.md`.


### PR DESCRIPTION
## Summary

This PR publishes an operator-facing v0.11 guide and links it from top-level docs.
It also folds in the deferred changelog ask from #586.

### What changed

- Added `docs/operator-guide-v0.11.md` with:
  - Stable vs preview boundary (`run`/`solve` stable, `serve` preview)
  - Upgrade notes for v0.11
  - Known limitations and mitigations
  - Troubleshooting entry points
- Added `CHANGELOG.md` with:
  - Operator guide documentation entry
  - Documented breaking behavior note for `solve` skill-first default
- Updated top-level docs links in:
  - `README.md`
  - `README.zh.md`
- Updated `docs/holon-architecture.md` context section to align with current skill-first behavior and added operator guide reference.

## Validation

- Documentation-only change
- Manually reviewed links and wording consistency with current `solve` and `run` behavior

Closes #669
Closes #586
