### PR TITLE
test: add manual e2e case for holon run + remote pptx skill

### DIFF
--- a/e2e-manual/README.md
+++ b/e2e-manual/README.md
@@ -14,6 +14,7 @@ Each subdirectory under `e2e-manual/` is one test case.
 ## Case List
 
 - `serve-github-issue-solve`: Validate `holon serve` issue-comment trigger flow end-to-end.
+- `run-pptx-remote-skill`: Validate `holon run` auto-init + remote `pptx` skill + local agent bundle.
 
 ## Add a New Case
 

--- a/e2e-manual/run-pptx-remote-skill/CASE.md
+++ b/e2e-manual/run-pptx-remote-skill/CASE.md
@@ -1,0 +1,71 @@
+# run-pptx-remote-skill
+
+## Purpose
+
+Validate `holon run` end-to-end with:
+
+- local agent bundle (built from current workspace)
+- automatic agent-home initialization
+- remote non-code skill activation via `--skills`
+- concrete artifact generation (`.pptx`)
+
+This case focuses on productized run reliability rather than code changes.
+
+## Preconditions
+
+- `bin/holon` exists (`make build` if missing).
+- Docker daemon is running.
+- `gh` is installed (for remote skill fetch via GitHub path resolver).
+- Anthropic credentials are available either:
+  - env vars: `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`
+  - or `~/.claude/settings.json` with `.env` entries.
+- Network is available (required for remote skill download and model calls).
+
+## Steps
+
+1. Build local agent bundle from current source tree.
+2. Run `holon run` with:
+   - empty/new `--agent-home`
+   - `--agent <local bundle path>`
+   - `--skills ghpath:anthropics/skills/skills/pptx@main`
+3. Ask agent to create a short PPT file in workspace.
+4. Collect logs and artifacts.
+
+Use `run.sh` for scripted execution.
+
+## Expected
+
+- Run exits successfully.
+- Agent home is auto-initialized.
+- A `.pptx` file is created under workspace.
+- Run logs show selected local bundle path and remote skill resolution.
+
+## Pass / Fail Criteria
+
+- Pass:
+  - `holon run` returns exit code `0`
+  - at least one `*.pptx` exists in workspace
+  - `agent-home/agent.yaml` exists
+- Fail (`infra-fail`):
+  - local bundle build fails
+  - remote skill cannot be downloaded/resolved
+  - runtime/container startup fails
+- Fail (`agent-fail`):
+  - run succeeds but no PPT artifact is produced
+  - produced file is empty or obviously invalid
+
+## Evidence to Capture
+
+- run log (`run.log`)
+- run metadata (`run-meta.env`)
+- workspace file list
+- agent-home file list
+- generated `.pptx` artifact
+
+Use `collect.sh` to gather evidence into `artifacts/`.
+
+## Known Failure Modes
+
+- Missing Anthropic token/base URL.
+- Remote GitHub path ref unavailable or rate-limited.
+- Model completes without creating output file (instruction-following miss).

--- a/e2e-manual/run-pptx-remote-skill/collect.sh
+++ b/e2e-manual/run-pptx-remote-skill/collect.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOT
+Usage: $0 --run-dir <path> [--out <path>]
+EOT
+}
+
+RUN_DIR=""
+OUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-dir)
+      RUN_DIR="$2"
+      shift 2
+      ;;
+    --out)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$RUN_DIR" ]]; then
+  echo "error: --run-dir is required" >&2
+  usage
+  exit 1
+fi
+if [[ ! -d "$RUN_DIR" ]]; then
+  echo "error: run dir not found: $RUN_DIR" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/artifacts/collect-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$OUT_DIR"
+
+copy_if_exists() {
+  local src="$1"
+  local dst="$2"
+  if [[ -f "$src" ]]; then
+    cp "$src" "$dst"
+  fi
+}
+
+copy_if_exists "$RUN_DIR/run.log" "$OUT_DIR/run.log"
+copy_if_exists "$RUN_DIR/run-meta.env" "$OUT_DIR/run-meta.env"
+copy_if_exists "$RUN_DIR/goal.txt" "$OUT_DIR/goal.txt"
+
+WORKSPACE=""
+AGENT_HOME=""
+if [[ -f "$RUN_DIR/run-meta.env" ]]; then
+  WORKSPACE="$(grep '^WORKSPACE=' "$RUN_DIR/run-meta.env" | head -n1 | cut -d= -f2-)"
+  AGENT_HOME="$(grep '^AGENT_HOME=' "$RUN_DIR/run-meta.env" | head -n1 | cut -d= -f2-)"
+fi
+
+if [[ -n "${WORKSPACE:-}" && -d "$WORKSPACE" ]]; then
+  find "$WORKSPACE" -maxdepth 3 -type f | sort >"$OUT_DIR/workspace-files.txt"
+  PPT_PATH="$(find "$WORKSPACE" -maxdepth 3 -type f -name '*.pptx' | head -n 1 || true)"
+  if [[ -n "$PPT_PATH" && -f "$PPT_PATH" ]]; then
+    cp "$PPT_PATH" "$OUT_DIR/"
+  fi
+fi
+
+if [[ -n "${AGENT_HOME:-}" && -d "$AGENT_HOME" ]]; then
+  find "$AGENT_HOME" -maxdepth 3 -type f | sort >"$OUT_DIR/agent-home-files.txt"
+  copy_if_exists "$AGENT_HOME/agent.yaml" "$OUT_DIR/agent.yaml"
+  copy_if_exists "$AGENT_HOME/ROLE.md" "$OUT_DIR/ROLE.md"
+fi
+
+cat >"$OUT_DIR/summary.txt" <<EOT
+run_dir=$RUN_DIR
+collected_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+files:
+$(ls -1 "$OUT_DIR")
+EOT
+
+echo "evidence collected at: $OUT_DIR"

--- a/e2e-manual/run-pptx-remote-skill/run.sh
+++ b/e2e-manual/run-pptx-remote-skill/run.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="${OUT_DIR:-/tmp/holon-run-pptx-e2e-$RUN_ID}"
+AGENT_HOME="${AGENT_HOME:-/tmp/holon-run-pptx-agent-$(date +%s)}"
+WORKSPACE="${WORKSPACE:-/tmp/holon-run-pptx-workspace-$RUN_ID}"
+INPUT_DIR="${INPUT_DIR:-$OUT_DIR/input}"
+OUTPUT_DIR="${OUTPUT_DIR:-$OUT_DIR/output}"
+SKILL_REF="${SKILL_REF:-ghpath:anthropics/skills/skills/pptx@main}"
+RUN_TIMEOUT_SECONDS="${RUN_TIMEOUT_SECONDS:-900}"
+HOLON_BIN="${HOLON_BIN:-$(cd "$ROOT_DIR/../.." && pwd)/bin/holon}"
+
+mkdir -p "$OUT_DIR" "$WORKSPACE" "$INPUT_DIR" "$OUTPUT_DIR"
+
+if [[ ! -x "$HOLON_BIN" ]]; then
+  echo "error: holon binary not found: $HOLON_BIN. run 'make build' first." >&2
+  exit 1
+fi
+
+ANTHROPIC_AUTH_TOKEN="${ANTHROPIC_AUTH_TOKEN:-$(jq -r '.env.ANTHROPIC_AUTH_TOKEN // empty' ~/.claude/settings.json 2>/dev/null || true)}"
+ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-$(jq -r '.env.ANTHROPIC_BASE_URL // empty' ~/.claude/settings.json 2>/dev/null || true)}"
+
+if [[ -z "$ANTHROPIC_AUTH_TOKEN" || -z "$ANTHROPIC_BASE_URL" ]]; then
+  echo "error: missing ANTHROPIC_AUTH_TOKEN or ANTHROPIC_BASE_URL" >&2
+  exit 1
+fi
+
+if [[ -z "${AGENT_BUNDLE:-}" ]]; then
+  echo "[1/4] building local agent bundle"
+  ./agents/claude/scripts/build-bundle.sh
+  AGENT_BUNDLE="$(ls -t agents/claude/dist/agent-bundles/agent-bundle-*.tar.gz | head -n 1)"
+fi
+
+if [[ -n "${AGENT_BUNDLE:-}" && -f "${AGENT_BUNDLE:-}" ]]; then
+  AGENT_BUNDLE="$(cd "$(dirname "$AGENT_BUNDLE")" && pwd)/$(basename "$AGENT_BUNDLE")"
+fi
+
+if [[ ! -f "$AGENT_BUNDLE" ]]; then
+  echo "error: agent bundle not found: $AGENT_BUNDLE" >&2
+  exit 1
+fi
+
+RUN_LOG="$OUT_DIR/run.log"
+RUN_META="$OUT_DIR/run-meta.env"
+GOAL_FILE="$OUT_DIR/goal.txt"
+
+cat >"$GOAL_FILE" <<'EOT'
+Use the pptx skill to create a polished presentation file named "holon-run-e2e.pptx" in the current workspace root.
+
+Requirements:
+1. Topic: "Holon Run E2E Integration Test".
+2. 6-8 slides.
+3. Include sections: overview, test scope, setup, execution steps, observed results, risks and next actions.
+4. Keep content concise and practical.
+5. After creation, print the exact file path you wrote.
+EOT
+
+{
+  echo "OUT_DIR=$OUT_DIR"
+  echo "AGENT_HOME=$AGENT_HOME"
+  echo "WORKSPACE=$WORKSPACE"
+  echo "INPUT_DIR=$INPUT_DIR"
+  echo "OUTPUT_DIR=$OUTPUT_DIR"
+  echo "AGENT_BUNDLE=$AGENT_BUNDLE"
+  echo "SKILL_REF=$SKILL_REF"
+  echo "RUN_TIMEOUT_SECONDS=$RUN_TIMEOUT_SECONDS"
+  echo "HOLON_BIN=$HOLON_BIN"
+} >"$RUN_META"
+
+echo "[2/4] running holon run with remote pptx skill"
+set +e
+(
+  cd /tmp
+  ANTHROPIC_AUTH_TOKEN="$ANTHROPIC_AUTH_TOKEN" \
+  ANTHROPIC_BASE_URL="$ANTHROPIC_BASE_URL" \
+  "$HOLON_BIN" run \
+    --agent "$AGENT_BUNDLE" \
+    --agent-home "$AGENT_HOME" \
+    --workspace "$WORKSPACE" \
+    --input "$INPUT_DIR" \
+    --output "$OUTPUT_DIR" \
+    --skills "$SKILL_REF" \
+    --goal "$(cat "$GOAL_FILE")" \
+    --log-level debug \
+    >"$RUN_LOG" 2>&1
+) &
+RUN_PID=$!
+echo "RUN_PID=$RUN_PID" >>"$RUN_META"
+
+SECONDS_WAITED=0
+TIMED_OUT=0
+while kill -0 "$RUN_PID" 2>/dev/null; do
+  if (( SECONDS_WAITED >= RUN_TIMEOUT_SECONDS )); then
+    TIMED_OUT=1
+    break
+  fi
+  sleep 2
+  SECONDS_WAITED=$((SECONDS_WAITED + 2))
+done
+
+if (( TIMED_OUT == 1 )); then
+  echo "warning: holon run timed out after ${RUN_TIMEOUT_SECONDS}s; killing pid $RUN_PID" >&2
+  kill "$RUN_PID" 2>/dev/null || true
+  sleep 2
+  kill -9 "$RUN_PID" 2>/dev/null || true
+  RUN_EXIT=124
+else
+  wait "$RUN_PID"
+  RUN_EXIT=$?
+fi
+set -e
+
+echo "RUN_EXIT=$RUN_EXIT" >>"$RUN_META"
+
+echo "[3/4] validating outputs"
+PPT_PATH="$(find "$WORKSPACE" -maxdepth 2 -type f -name '*.pptx' | head -n 1 || true)"
+if [[ -z "$PPT_PATH" ]]; then
+  echo "error: no .pptx artifact found under workspace: $WORKSPACE" >&2
+  echo "hint: check run log at $RUN_LOG" >&2
+  exit 1
+fi
+
+if [[ ! -f "$AGENT_HOME/agent.yaml" ]]; then
+  echo "error: expected auto-initialized agent home file missing: $AGENT_HOME/agent.yaml" >&2
+  exit 1
+fi
+
+echo "PPT_PATH=$PPT_PATH" >>"$RUN_META"
+echo "PPT_SIZE=$(wc -c <"$PPT_PATH")" >>"$RUN_META"
+
+if [[ "$RUN_EXIT" -ne 0 ]]; then
+  echo "error: holon run exited with non-zero status: $RUN_EXIT" >&2
+  exit "$RUN_EXIT"
+fi
+
+echo "[4/4] done"
+cat <<EOT
+Run succeeded.
+- out dir: $OUT_DIR
+- agent home: $AGENT_HOME
+- workspace: $WORKSPACE
+- ppt file: $PPT_PATH
+- run log: $RUN_LOG
+
+Collect evidence:
+  ./e2e-manual/run-pptx-remote-skill/collect.sh --out "$OUT_DIR/collected" --run-dir "$OUT_DIR"
+EOT


### PR DESCRIPTION
## Summary
- add a new manual E2E case `e2e-manual/run-pptx-remote-skill`
- validate `holon run` with local-built agent bundle + remote popular skill (`pptx`)
- cover auto-init `agent_home`, skill activation by `--skills`, and `.pptx` artifact generation
- improve test script robustness:
  - run timeout guard to avoid stuck runs
  - normalize agent bundle to absolute path
  - run command from `/tmp` to avoid accidental `.holon/config.yaml` coupling from shell CWD
  - fix collector to avoid output path override via sourced env

## Files
- `e2e-manual/README.md`
- `e2e-manual/run-pptx-remote-skill/CASE.md`
- `e2e-manual/run-pptx-remote-skill/run.sh`
- `e2e-manual/run-pptx-remote-skill/collect.sh`

## Validation
- executed `./e2e-manual/run-pptx-remote-skill/run.sh` successfully (multiple runs)
- generated ppt artifact, for example:
  - `/tmp/holon-run-pptx-workspace-20260215-141007/holon-run-e2e.pptx`
- collected evidence successfully:
  - `/tmp/holon-run-pptx-e2e-20260215-141007/collected`

## Notes
- tracked follow-up for run config scope mismatch in `#692`.
