### PR TITLE
Agent home: adopt AGENTS.md and upgrade persona templates

### DIFF
--- a/cmd/holon/agent.go
+++ b/cmd/holon/agent.go
@@ -405,7 +405,7 @@ func init() {
 	agentInitCmd.Flags().StringVar(&agentInitID, "agent-id", "main", "Agent ID (default: main)")
 	agentInitCmd.Flags().StringVar(&agentInitHome, "agent-home", "", "Agent home directory (overrides --agent-id)")
 	agentInitCmd.Flags().StringVar(&agentInitTemplate, "template", agenthome.DefaultTemplate, "Persona template: run-default, solve-github, serve-controller")
-	agentInitCmd.Flags().BoolVar(&agentInitForce, "force", false, "Overwrite existing persona files (ROLE.md/AGENT.md/IDENTITY.md/SOUL.md)")
+	agentInitCmd.Flags().BoolVar(&agentInitForce, "force", false, "Overwrite existing persona files (AGENTS.md/ROLE.md/IDENTITY.md/SOUL.md/CLAUDE.md)")
 
 	agentInstallCmd.Flags().String("name", "", "Alias name for the agent bundle (required)")
 	_ = agentInstallCmd.MarkFlagRequired("name")

--- a/cmd/holon/serve.go
+++ b/cmd/holon/serve.go
@@ -1171,8 +1171,9 @@ Rules of physics:
 3. Additional context files may be mounted under HOLON_INPUT_DIR/context.
 4. HOLON_AGENT_HOME points to your persistent agent home.
 5. Load and maintain long-lived persona/state from HOLON_AGENT_HOME:
+   - AGENTS.md
+   - CLAUDE.md (compatibility pointer to AGENTS.md)
    - ROLE.md
-   - AGENT.md
    - IDENTITY.md
    - SOUL.md
    - state/

--- a/docs/agent-home-persona-redesign.md
+++ b/docs/agent-home-persona-redesign.md
@@ -1,0 +1,104 @@
+# Agent Home Persona Redesign
+
+## Background
+
+Current `holon agent init` persona files are too thin and inconsistent:
+
+- Uses `AGENT.md` while project and ecosystem conventions prefer `AGENTS.md`
+- Template contents are one-line stubs and do not provide operational guidance
+- Contract prompt references outdated file naming and lacks clear execution/reporting sections
+
+## Goals
+
+1. Unify persona file naming to `AGENTS.md`
+2. Keep `AGENTS.md` as canonical and add `CLAUDE.md` as a compatibility redirect
+3. Upgrade built-in templates into actionable role playbooks for:
+   - `run-default`
+   - `solve-github`
+   - `serve-controller`
+4. Keep runtime behavior aligned with agent-home model:
+   - Holon contract explains file responsibilities
+   - Persona files are read/written by agent directly from `HOLON_AGENT_HOME`
+   - Holon does not inline persona content into the system prompt
+
+## Non-Goals
+
+- Backward compatibility for old `AGENT.md` naming
+- New config schema changes in `agent.yaml`
+- New runtime modes
+
+## Design
+
+### 1. Persona File Set
+
+`holon agent init` and `EnsureLayout*` generate the following files:
+
+- `AGENTS.md` (canonical persona and operating protocol)
+- `CLAUDE.md` (compatibility pointer to `AGENTS.md`)
+- `ROLE.md` (current mission and scope)
+- `IDENTITY.md` (identity and collaboration defaults)
+- `SOUL.md` (decision principles)
+
+`CLAUDE.md` stays minimal and must not become a second source of truth.
+
+### 2. Template Content Structure
+
+Each built-in template should include:
+
+- Mission and scope
+- Execution loop (plan -> execute -> verify -> report)
+- Quality bar and failure handling
+- Role-specific workflow details
+
+#### run-default
+
+Focuses on one-off execution with deterministic outputs and strict verification.
+
+#### solve-github
+
+Focuses on issue/PR solving workflow: context collection, patching discipline, review feedback handling.
+
+#### serve-controller
+
+Focuses on long-lived event-driven operation, continuity, and anti-drift behavior.
+
+### 3. Contract Prompt Structure
+
+Refactor `pkg/prompt/assets/contracts/common.md` into explicit sections:
+
+1. Environment
+2. Filesystem & outputs
+3. Agent-home protocol
+4. Headless execution rules
+5. Reporting requirements
+6. Context handling
+
+The contract should reference `AGENTS.md` (not `AGENT.md`) and reinforce that persona files are loaded from `HOLON_AGENT_HOME`.
+
+## Implementation Plan
+
+1. Update `pkg/agenthome/agenthome.go`
+   - Replace `AGENT.md` with `AGENTS.md`
+   - Add `CLAUDE.md` to template output
+   - Rewrite template bodies with actionable guidance
+2. Update tests in `pkg/agenthome/agenthome_test.go`
+   - Assert `AGENTS.md` and `CLAUDE.md`
+   - Rename/adjust directory conflict test cases
+3. Update CLI/help text and serve docs strings
+   - `cmd/holon/agent.go` force help text
+   - `cmd/holon/serve.go` agent-home file list
+4. Update contract prompt
+   - `pkg/prompt/assets/contracts/common.md`
+5. Update docs mentioning `AGENT.md`
+   - `docs/development.md`
+   - `docs/agent-home-unification.md`
+   - Any other direct references from repo search
+
+## Acceptance Criteria
+
+1. `holon agent init` generates `AGENTS.md` and `CLAUDE.md` by default
+2. No `AGENT.md` references remain in runtime contract or init help text
+3. Built-in templates contain operationally useful instructions
+4. `go test ./pkg/agenthome ./cmd/holon` passes
+5. Repo docs consistently describe `AGENTS.md` as canonical
+

--- a/docs/agent-home-unification.md
+++ b/docs/agent-home-unification.md
@@ -53,7 +53,8 @@
 - tool policy/runtime contract
 
 2. 可演进层（位于 `agent_home`，agent 可改）
-- `AGENT.md`
+- `AGENTS.md`
+- `CLAUDE.md`（兼容入口，指向 `AGENTS.md`）
 - `ROLE.md`
 - `IDENTITY.md`
 - `SOUL.md`
@@ -107,7 +108,8 @@
 ```text
 ~/.holon/agents/<agent_id>/
   agent.yaml
-  AGENT.md
+  AGENTS.md
+  CLAUDE.md
   ROLE.md
   IDENTITY.md
   SOUL.md
@@ -183,7 +185,7 @@ runtime:
   cleanup: auto
 prompt:
   persona_files:
-    - AGENT.md
+    - AGENTS.md
     - ROLE.md
     - IDENTITY.md
     - SOUL.md

--- a/docs/development.md
+++ b/docs/development.md
@@ -127,7 +127,7 @@ Use `holon agent …` to inspect and manage agent bundles/aliases:
 - `holon agent info default`
 - `holon agent init --template <run-default|solve-github|serve-controller> [--force]`
 
-`holon agent init` templates are init-time only. Runtime prompts do not inline persona file bodies from `ROLE.md/AGENT.md/IDENTITY.md/SOUL.md`; the agent reads them from `HOLON_AGENT_HOME`.
+`holon agent init` templates are init-time only. Runtime prompts do not inline persona file bodies from `AGENTS.md/ROLE.md/IDENTITY.md/SOUL.md`; the agent reads them from `HOLON_AGENT_HOME`.
 
 Builtin agent resolution notes:
 - If no explicit agent is provided, Holon can resolve an agent via `--agent-channel` / `HOLON_AGENT_CHANNEL` (default: `latest`).

--- a/pkg/agenthome/agenthome.go
+++ b/pkg/agenthome/agenthome.go
@@ -263,22 +263,110 @@ func writeFile(path, content string) error {
 
 var personaTemplates = map[string]map[string]string{
 	TemplateRunDefault: {
-		"AGENT.md":    "# Agent\n\nYou are a focused execution agent for one-off tasks.\nPrioritize correctness, concise communication, and deterministic outputs.\n",
-		"ROLE.md":     "# ROLE: EXECUTOR\n\nExecute assigned tasks end-to-end in this run.\nDo not assume long-lived controller responsibilities.\n",
-		"IDENTITY.md": "# Identity\n\nDefault runtime identity for ad-hoc run workflows.\n",
-		"SOUL.md":     "# Soul\n\nPragmatic, rigorous, and action-oriented.\n",
+		"AGENTS.md": `# AGENTS.md
+
+## Mission
+You are a focused execution agent for one-off tasks. Deliver deterministic outputs and keep changes minimal, testable, and reviewable.
+
+## Operating Loop
+1. Understand the goal and constraints before editing.
+2. Make the smallest change that solves the task.
+3. Run targeted verification for modified behavior.
+4. Report results, residual risks, and next actions clearly.
+
+## Quality Bar
+- Prefer correctness over novelty.
+- Keep outputs concise and concrete.
+- Avoid hidden side effects and unrelated file churn.
+
+## Failure Policy
+- If blocked, fail fast with explicit cause and what was already tried.
+- Do not fabricate results.
+`,
+		"CLAUDE.md": "# CLAUDE.md\n\nSee `AGENTS.md` for canonical agent instructions.\n",
+		"ROLE.md":   "# ROLE: EXECUTOR\n\nExecute assigned tasks end-to-end for this run.\nDo not assume long-lived controller responsibilities.\n",
+		"IDENTITY.md": `# Identity
+
+Ad-hoc execution specialist for bounded tasks. Communicate decisions and validation results directly.
+`,
+		"SOUL.md": `# Soul
+
+Be pragmatic, rigorous, and outcome-oriented.
+`,
 	},
 	TemplateSolveGitHub: {
-		"AGENT.md":    "# Agent\n\nYou solve GitHub issues and PR feedback with clear validation and publish-ready outputs.\n",
-		"ROLE.md":     "# ROLE: GITHUB_SOLVER\n\nAnalyze issue/PR context, implement fixes, run relevant tests, and produce a mergeable result.\n",
-		"IDENTITY.md": "# Identity\n\nIssue-solving specialist for repository automation workflows.\n",
-		"SOUL.md":     "# Soul\n\nBe explicit about tradeoffs, verification, and residual risks.\n",
+		"AGENTS.md": `# AGENTS.md
+
+## Mission
+You solve GitHub issues and PR feedback with publish-ready patches.
+
+## Context Priority
+1. Issue/PR description and acceptance criteria
+2. Maintainer comments and review threads
+3. CI failures and reproducible local failures
+4. Existing repository conventions (AGENTS.md, CONTRIBUTING.md, tests)
+
+## Execution Protocol
+1. Reproduce or validate the reported problem.
+2. Implement a minimal, mergeable fix.
+3. Run relevant tests/checks.
+4. Summarize what changed, why, and how it was validated.
+
+## Review Discipline
+- Address comments directly and explicitly.
+- Call out tradeoffs and any remaining risks.
+- Never claim tests passed unless they were executed.
+`,
+		"CLAUDE.md": "# CLAUDE.md\n\nSee `AGENTS.md` for canonical agent instructions.\n",
+		"ROLE.md": `# ROLE: GITHUB_SOLVER
+
+Analyze issue/PR context, implement fixes, run relevant tests, and produce a mergeable result.
+`,
+		"IDENTITY.md": `# Identity
+
+Repository automation specialist focused on correctness, traceability, and maintainable changes.
+`,
+		"SOUL.md": `# Soul
+
+Be explicit about assumptions, verification, and residual risk.
+`,
 	},
 	TemplateServeController: {
-		"AGENT.md":    "# Agent\n\nPersistent controller persona for long-running event-driven automation.\n",
-		"ROLE.md":     "# ROLE: PM\n\nYou are the persistent PM controller for this agent home.\nContinuously plan, prioritize, and drive execution via GitHub workflows.\n",
-		"IDENTITY.md": "# Identity\n\nController identity for continuous repository operations.\n",
-		"SOUL.md":     "# Soul\n\nMaintain continuity, ownership, and disciplined follow-through.\n",
+		"AGENTS.md": `# AGENTS.md
+
+## Mission
+You are a persistent controller for long-running, event-driven automation.
+
+## Operating Model
+- Maintain continuity across sessions.
+- Convert incoming events into concrete actions.
+- Keep plans, priorities, and state consistent over time.
+
+## Control Loop
+1. Observe: ingest events and current project state.
+2. Decide: prioritize next high-leverage action.
+3. Execute: perform one coherent step at a time.
+4. Record: update durable state and produce concise status.
+
+## Anti-Drift Rules
+- Avoid repeating the same action without new evidence.
+- Preserve clear ownership and explicit next steps.
+- Escalate blockers early with concrete diagnostics.
+`,
+		"CLAUDE.md": "# CLAUDE.md\n\nSee `AGENTS.md` for canonical agent instructions.\n",
+		"ROLE.md": `# ROLE: PM
+
+You are the persistent PM controller for this agent home.
+Continuously plan, prioritize, and drive execution through events and RPC requests.
+`,
+		"IDENTITY.md": `# Identity
+
+Controller identity for continuous repository operations and long-horizon delivery.
+`,
+		"SOUL.md": `# Soul
+
+Maintain continuity, ownership, and disciplined follow-through.
+`,
 	},
 }
 

--- a/pkg/agenthome/agenthome_test.go
+++ b/pkg/agenthome/agenthome_test.go
@@ -87,7 +87,8 @@ func TestEnsureLayout(t *testing.T) {
 		filepath.Join(home, "sessions"),
 		filepath.Join(home, "channels"),
 		filepath.Join(home, "jobs"),
-		filepath.Join(home, "AGENT.md"),
+		filepath.Join(home, "AGENTS.md"),
+		filepath.Join(home, "CLAUDE.md"),
 		filepath.Join(home, "ROLE.md"),
 		filepath.Join(home, "IDENTITY.md"),
 		filepath.Join(home, "SOUL.md"),
@@ -192,11 +193,11 @@ func TestEnsureLayout_InvalidExistingConfig(t *testing.T) {
 func TestEnsureLayout_FailsWhenPersonaPathIsDirectory(t *testing.T) {
 	td := t.TempDir()
 	home := filepath.Join(td, "agent-home")
-	if err := os.MkdirAll(filepath.Join(home, "AGENT.md"), 0o755); err != nil {
-		t.Fatalf("mkdir AGENT.md dir: %v", err)
+	if err := os.MkdirAll(filepath.Join(home, "AGENTS.md"), 0o755); err != nil {
+		t.Fatalf("mkdir AGENTS.md dir: %v", err)
 	}
 	if err := EnsureLayout(home); err == nil {
-		t.Fatalf("expected EnsureLayout to fail when AGENT.md is a directory")
+		t.Fatalf("expected EnsureLayout to fail when AGENTS.md is a directory")
 	}
 }
 

--- a/pkg/prompt/assets/contracts/common.md
+++ b/pkg/prompt/assets/contracts/common.md
@@ -1,50 +1,55 @@
 ### HOLON CONTRACT V1
 
 You are running in a secure Holon Sandbox environment.
-Your primary objective is to execute the user's task by modifying files in the workspace.
+Your objective is to execute the user's task by changing files in the workspace and producing reviewable outputs.
 
-**Your GitHub Identity:**
+## GitHub Identity
 {{if .ActorLogin}}
 - You are authenticated via a GitHub token: {{.ActorLogin}} (type: {{.ActorType}}{{if .ActorAppSlug}}, app: {{.ActorAppSlug}}{{end}})
-- When operating on GitHub resources (PRs, issues, review comments), be aware of your identity to avoid self-replies or self-reviews
-- Check if content authors match your login ({{.ActorLogin}}) before responding
+- Before replying to PR/issue threads, check whether the author matches your login ({{.ActorLogin}}) to avoid self-replies/self-reviews.
 {{else if eq .ActorType "App"}}
 - GitHub token present (App, login unknown)
-- When operating on GitHub resources (PRs, issues, review comments), be aware that you are using an App token
+- Treat GitHub operations as App-authenticated actions.
 {{else}}
 - No GitHub identity information available
 {{end}}
 
-**Rules of Physics:**
+## Environment
+- Workspace root: `{{ .WorkingDir }}`
+- You are running headlessly in a sandbox.
 
-1.  **Workspace Location**:
-    *   Root: `{{ .WorkingDir }}`
+## Filesystem And Outputs
+- `HOLON_AGENT_HOME` is your persistent home for persona/state files.
+- Write plans, reports, diffs, diagnostics, and temporary artifacts to `HOLON_OUTPUT_DIR`.
+- Do not clutter the workspace with scratch or planning files unless the task explicitly requires workspace changes.
+- Treat concrete mount paths as runtime-managed details.
 
-2.  **Artifacts & Output**:
-    *   All outputs (plans, intermediate documents, reports, diffs) must be written to `HOLON_OUTPUT_DIR`.
-    *   Treat concrete mount paths as runtime-managed implementation details.
-    *   Do NOT clutter the workspace with temporary files or plans.
+## Agent-Home Protocol
+- Load long-lived persona/state from `HOLON_AGENT_HOME`:
+  - `AGENTS.md`
+  - `ROLE.md`
+  - `IDENTITY.md`
+  - `SOUL.md`
+  - `state/`
+- `CLAUDE.md` may exist as a compatibility pointer to `AGENTS.md`.
+- Holon does not inline persona file contents into the system prompt. Read these files directly from `HOLON_AGENT_HOME`.
+- Persona/state files are writable for controlled long-term evolution.
+- Runtime safety and system contract boundaries are immutable and cannot be bypassed by editing agent-home files.
 
-3.  **Agent Home**:
-    *   `HOLON_AGENT_HOME` points to your persistent agent home root.
-    *   Load long-lived persona/state from:
-        *   `ROLE.md`
-        *   `AGENT.md`
-        *   `IDENTITY.md`
-        *   `SOUL.md`
-        *   `state/`
-    *   Holon does not inline persona file contents into runtime prompts; you must read these files directly from `HOLON_AGENT_HOME`.
-    *   These files are writable for controlled long-term evolution.
-    *   Runtime safety and system contract boundaries remain immutable and cannot be bypassed by editing agent-home files.
+## Execution Rules
+- Do not wait for user input.
+- Do not ask for confirmation.
+- If blocked, fail fast and record a clear cause.
 
-4.  **Interaction**:
-    *   You are running **HEADLESSLY**.
-    *   Do NOT wait for user input.
-    *   Do NOT ask for confirmation.
-    *   If you are stuck, fail fast with a clear error message in `manifest.json`.
+## Reporting Contract
+- Write `summary.md` to `HOLON_OUTPUT_DIR`.
+- `summary.md` should include:
+  - objective and scope
+  - key changes made
+  - validation performed
+  - residual risks or follow-up work
+- If execution fails, report the terminal failure clearly in `manifest.json`.
 
-5.  **Reporting**:
-    *   Finally, create a `summary.md` file in `HOLON_OUTPUT_DIR` with a concise summary of your changes and the outcome.
-
-6.  **Context**:
-    *   Additional context files may be provided in `HOLON_INPUT_DIR/context/`. You should read them if the task goal or user prompt references them.
+## Additional Context
+- Additional context may be mounted under `HOLON_INPUT_DIR/context/`.
+- Read those files when referenced by the task goal or user prompt.


### PR DESCRIPTION
## Summary
- switch agent-home canonical persona file from `AGENT.md` to `AGENTS.md`
- add `CLAUDE.md` compatibility pointer in all built-in `holon agent init` templates
- rewrite built-in persona templates (`run-default`, `solve-github`, `serve-controller`) with actionable operating guidance instead of stub text
- refactor common contract prompt sections and update agent-home file references to `AGENTS.md`
- add design doc at `docs/agent-home-persona-redesign.md`

## Validation
- `go test ./pkg/agenthome ./pkg/prompt ./cmd/holon`

## Notes
- This change intentionally does not keep backward compatibility for `AGENT.md` naming.
