### PR TITLE
tui: support multiline input in serve UI

### DIFF
--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -183,8 +183,8 @@ func NewApp(client *RPCClient) *App {
 	input.SetWidth(80)
 	input.Focus()
 	input.KeyMap.InsertNewline = key.NewBinding(
-		key.WithKeys("ctrl+j"),
-		key.WithHelp("ctrl+j", "newline"),
+		key.WithKeys("enter", "ctrl+j"),
+		key.WithHelp("enter/ctrl+j", "newline"),
 	)
 
 	conversation := viewport.New(80, 16)
@@ -371,7 +371,7 @@ func (a *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return a, a.prevFocus()
 		}
 		return a, nil
-	case "enter":
+	case "ctrl+s":
 		if a.activeDrawer == drawerNone && a.focus == focusInput && strings.TrimSpace(a.input.Value()) != "" && !a.sending {
 			return a, a.sendMessage()
 		}
@@ -769,7 +769,7 @@ func (a *App) renderHelp() string {
 		return helpStyle.Render(help)
 	}
 
-	help := fmt.Sprintf("Keys: [Tab] Focus | [Enter] Send%s | [Ctrl+J] Newline | [Ctrl+U] Clear | [A/L] Drawer (conversation focus) | [Ctrl+P] Pause | [Ctrl+R] Resume | [Ctrl+L] Refresh | [Ctrl+A] Auto-Refresh\nScroll: [↑/↓] Line | [PgUp/PgDn] Page | [q] Quit", inputState)
+	help := fmt.Sprintf("Keys: [Tab] Focus | [Ctrl+S] Send%s | [Enter/Ctrl+J] Newline | [Ctrl+U] Clear | [A/L] Drawer (conversation focus) | [Ctrl+P] Pause | [Ctrl+R] Resume | [Ctrl+L] Refresh | [Ctrl+A] Auto-Refresh\nScroll: [↑/↓] Line | [PgUp/PgDn] Page | [q] Quit", inputState)
 	return helpStyle.Render(help)
 }
 

--- a/pkg/tui/app_test.go
+++ b/pkg/tui/app_test.go
@@ -149,19 +149,35 @@ func TestAppInputCtrlJInsertsNewline(t *testing.T) {
 	}
 }
 
-func TestAppEnterStartsSend(t *testing.T) {
+func TestAppCtrlSStartsSend(t *testing.T) {
 	app := NewApp(NewRPCClient("http://127.0.0.1:8080/rpc"))
 	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	app = model.(*App)
 
 	app.input.SetValue("hello")
-	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model, cmd := app.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
 	app = model.(*App)
 	if cmd == nil {
 		t.Fatalf("expected send command to be returned")
 	}
 	if !app.sending {
-		t.Fatalf("expected sending=true after enter")
+		t.Fatalf("expected sending=true after ctrl+s")
+	}
+}
+
+func TestAppEnterInsertsNewline(t *testing.T) {
+	app := NewApp(NewRPCClient("http://127.0.0.1:8080/rpc"))
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = model.(*App)
+
+	app.input.SetValue("hello")
+	model, _ = app.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	app = model.(*App)
+	if got := app.input.Value(); !strings.Contains(got, "\n") {
+		t.Fatalf("input value = %q, want newline inserted", got)
+	}
+	if app.sending {
+		t.Fatalf("expected sending=false after enter")
 	}
 }
 


### PR DESCRIPTION
## Summary
- enable multiline input in `holon serve` TUI input box
- map `Enter`/`Ctrl+J` to newline insertion in the textarea
- move message send action from `Enter` to `Ctrl+S`
- update help text and input behavior tests accordingly

## Testing
- `GOCACHE=$(pwd)/.gocache go test ./pkg/tui -run 'Test(App|Drawer|Conversation|DefaultView|SystemNotification|AssistantItemCreated|TurnAggregation|StreamError|ReconnectDelay|TUISmoke_InputDeletion)' -v`

## Notes
- Full `go test ./pkg/tui` includes a smoke test that binds a local port; this is blocked in the current sandbox environment.
