### PR TITLE
serve: remove hardcoded prompt style and avoid pulling composed images

### DIFF
--- a/agents/claude/src/agent.ts
+++ b/agents/claude/src/agent.ts
@@ -1135,8 +1135,6 @@ async function runServeClaudeSession(
                   eventRaw,
                   "",
                   `Target session key: ${sessionKey}`,
-                  "Process this event. Decide actions autonomously and execute via available skills/tools.",
-                  "After actions complete, summarize what you decided and what changed.",
                 ].join("\n");
                 const turnResult = await runServeQueryTurn(
                   logger,
@@ -1209,9 +1207,6 @@ async function runServeClaudeSession(
     const turnPrompt = [
       "New event payload (JSON):",
       eventPayload,
-      "",
-      "Process this event. Decide actions autonomously and execute via available skills/tools.",
-      "After actions complete, summarize what you decided and what changed.",
     ].join("\n");
     const mainSession = await ensureSessionReady("main");
     const turnResult = await runServeQueryTurn(


### PR DESCRIPTION
## Summary
- remove hardcoded style-shaping text from serve turn prompt construction in `agents/claude/src/agent.ts`
- keep serve turn prompt focused on event payload/session context only
- refactor docker runtime image-availability checks via `ensureImagePresent`
- only pull images when `ImageInspect` returns not-found
- skip pull for local composed images (`holon-composed-*`) and return explicit error instead

## Why
- avoid template-like response shaping from runtime-level hardcoded prompt text
- prevent slow/failing remote pull attempts for deterministic local composed images during serve session startup/restart
- avoid masking non-not-found inspect errors as pull attempts

## Testing
- `npm --prefix agents/claude run build`
- `GOCACHE=$(pwd)/.gocache go test ./pkg/runtime/docker -run 'TestIsImageAlreadyExistsBuildError' -v`
