### PR TITLE
serve: decouple RPC readiness from startup bootstrap

### DIFF
--- a/agents/claude/src/agent.ts
+++ b/agents/claude/src/agent.ts
@@ -1044,7 +1044,7 @@ async function runServeClaudeSession(
   const bootstrapPrompt = [
     "You are running in persistent controller session mode.",
     "On startup, proactively check for unfinished work and continue autonomously when appropriate.",
-    "Do not block RPC handling while doing this work.",
+    "Complete this autonomous work efficiently while remaining responsive to new instructions.",
     "",
     "### System Instructions",
     systemInstruction,
@@ -1054,7 +1054,7 @@ async function runServeClaudeSession(
     "",
     "Acknowledge briefly, then proceed with autonomous work if needed.",
   ].join("\n");
-  let startupBootstrapState: "idle" | "running" | "completed" | "failed" = "idle";
+  let startupBootstrapState: "idle" | "running" | "completed" | "failed" = "running";
   let startupBootstrapError = "";
 
   try {

--- a/cmd/holon/serve.go
+++ b/cmd/holon/serve.go
@@ -1645,6 +1645,9 @@ func (h *cliControllerHandler) logControllerDoneIfAvailableLocked(reason string)
 	}
 	select {
 	case waitErr := <-h.controllerDone:
+		if waitErr == nil {
+			return
+		}
 		containerID := ""
 		if h.controllerSession != nil {
 			containerID = h.controllerSession.ContainerID


### PR DESCRIPTION
## Summary
- decouple serve RPC readiness from startup autonomous bootstrap work in controller agent
- keep `main` session initialized at startup while ensuring RPC socket is available immediately
- add startup bootstrap observability to `/health` (`bootstrap_state`, `bootstrap_error`)
- improve controller restart diagnostics by logging completed `Wait` result before reconnect reset
- ensure exited session containers are removed even when they exit non-zero, and enrich exit errors with inspect state (`oom_killed`, `state_error`, `finished_at`)

## Root cause
`holon serve` waited for an initial Claude turn during startup before opening the RPC socket. If that turn exceeded warmup timeout, serve failed with `controller rpc not ready: context deadline exceeded`.

## Behavior changes
- RPC health endpoint now comes up independently of startup autonomous work.
- Startup autonomous work runs in background and no longer blocks runtime warmup.
- Container cleanup is more reliable for failed sessions, reducing exited-container accumulation.
- Reconnect path emits better logs for why previous controller session ended.

## Validation
- `npm run -s build` (under `agents/claude`)
- `go test ./cmd/holon ./pkg/runtime/docker`
