### PR TITLE
workflow: unify agent resolution for source builds

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -1185,65 +1185,6 @@ jobs:
           fi
           docker info
 
-      - name: Setup Node (for local agent bundle)
-        if: steps.gate.outputs.should_run == 'true' && inputs.build_from_source == true && inputs.agent == ''
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Build local agent bundle
-        id: local-agent
-        if: steps.gate.outputs.should_run == 'true' && inputs.build_from_source == true && inputs.agent == ''
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ ! -d "agents/claude" ]; then
-            echo "::error::agents/claude directory not found"
-            exit 1
-          fi
-
-          if [ ! -f "agents/claude/package.json" ]; then
-            echo "::error::agents/claude/package.json not found"
-            exit 1
-          fi
-
-          cd agents/claude
-          npm ci
-          npm run bundle
-
-          BUNDLE_REL="$(ls -t dist/agent-bundles/*.tar.gz | head -n 1)"
-          if [ -z "$BUNDLE_REL" ]; then
-            echo "::error::Failed to find built agent bundle under agents/claude/dist/agent-bundles"
-            exit 1
-          fi
-
-          BUNDLE_ABS="${{ github.workspace }}/agents/claude/$BUNDLE_REL"
-          echo "agent_ref=$BUNDLE_ABS" >> "$GITHUB_OUTPUT"
-          echo "✅ Built local agent bundle: $BUNDLE_ABS"
-
-      - name: Resolve agent input
-        id: agent
-        if: steps.gate.outputs.should_run == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          AGENT_INPUT='${{ inputs.agent }}'
-          LOCAL_AGENT='${{ steps.local-agent.outputs.agent_ref }}'
-
-          if [ -n "$AGENT_INPUT" ]; then
-            echo "agent_ref=$AGENT_INPUT" >> "$GITHUB_OUTPUT"
-            echo "Using explicit agent input: $AGENT_INPUT"
-          elif [ -n "$LOCAL_AGENT" ]; then
-            echo "agent_ref=$LOCAL_AGENT" >> "$GITHUB_OUTPUT"
-            echo "Using local source-built agent bundle: $LOCAL_AGENT"
-          else
-            # Keep empty to trigger composite action fallback (no --agent flag).
-            echo "agent_ref=" >> "$GITHUB_OUTPUT"
-            echo "Using action default agent resolution (channel latest)"
-          fi
-
       - name: Run Holon
         id: run
         if: steps.gate.outputs.should_run == 'true'
@@ -1253,7 +1194,7 @@ jobs:
         with:
           ref: "${{ github.repository }}#${{ steps.ctx.outputs.issue_number }}"
           base: ${{ steps.base.outputs.base }}
-          agent: ${{ steps.agent.outputs.agent_ref }}
+          agent: ${{ inputs.agent }}
           anthropic_auth_token: ${{ secrets.anthropic_auth_token || secrets.anthropic_api_key }}
           anthropic_base_url: ${{ secrets.anthropic_base_url || 'https://api.anthropic.com' }}
           github_token: ${{ secrets.holon_github_token }}

--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,12 @@ runs:
         cache: true
         cache-dependency-path: ${{ runner.temp }}/holon-source/go.sum
 
+    - name: Setup Node (for source-built agent bundle)
+      if: inputs.build_from_source == 'true' && inputs.agent == ''
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
     - name: Build from source (if enabled)
       if: inputs.build_from_source == 'true'
       shell: bash
@@ -277,6 +283,37 @@ runs:
           echo "   Consider specifying output_dir to enable artifact uploads"
         fi
 
+        # Resolve agent reference in one place:
+        # 1) explicit inputs.agent
+        # 2) source-built local bundle (when build_from_source=true)
+        # 3) empty => holon default agent resolution
+        AGENT_REF="${{ inputs.agent }}"
+        if [ -z "$AGENT_REF" ] && [ "${{ inputs.build_from_source }}" = "true" ]; then
+          HOLON_SRC_DIR="${{ runner.temp }}/holon-source"
+          AGENT_SRC_DIR="$HOLON_SRC_DIR/agents/claude"
+          if [ ! -d "$AGENT_SRC_DIR" ]; then
+            echo "::error::expected agent source directory not found: $AGENT_SRC_DIR"
+            exit 1
+          fi
+          if [ ! -f "$AGENT_SRC_DIR/package.json" ]; then
+            echo "::error::expected agent package.json not found: $AGENT_SRC_DIR/package.json"
+            exit 1
+          fi
+
+          pushd "$AGENT_SRC_DIR" >/dev/null
+          npm ci
+          npm run bundle
+          BUNDLE_REL="$(ls -t dist/agent-bundles/*.tar.gz | head -n 1)"
+          popd >/dev/null
+
+          if [ -z "$BUNDLE_REL" ]; then
+            echo "::error::failed to find built agent bundle under $AGENT_SRC_DIR/dist/agent-bundles"
+            exit 1
+          fi
+          AGENT_REF="$AGENT_SRC_DIR/$BUNDLE_REL"
+          echo "Using source-built agent bundle: $AGENT_REF"
+        fi
+
         # Build solve command arguments
         SOLVE_ARGS=()
         if [ -n "${{ inputs.repo }}" ]; then
@@ -285,8 +322,8 @@ runs:
         if [ -n "${{ inputs.base }}" ]; then
           SOLVE_ARGS+=(--base "${{ inputs.base }}")
         fi
-        if [ -n "${{ inputs.agent }}" ]; then
-          SOLVE_ARGS+=(--agent "${{ inputs.agent }}")
+        if [ -n "$AGENT_REF" ]; then
+          SOLVE_ARGS+=(--agent "$AGENT_REF")
         fi
         if [ -n "${{ inputs.role }}" ]; then
           SOLVE_ARGS+=(--role "${{ inputs.role }}")


### PR DESCRIPTION
## Summary
- move agent resolution/build logic to `action.yml` only
- remove duplicated local bundle build path from reusable workflow `holon-solve.yml`
- make `build_from_source: true` work for third-party repos that do not contain `agents/claude`

## Root Cause
`holon-solve.yml` tried to build `agents/claude` from the target repository workspace when:
- `build_from_source == true`
- `inputs.agent == ''`

This assumption is only valid in the holon repo itself, and fails in third-party repos.

## Changes
- `action.yml`
  - add `Setup Node (for source-built agent bundle)` when `build_from_source == 'true' && inputs.agent == ''`
  - in `Run Holon Solve`, resolve `AGENT_REF` with precedence:
    1. explicit `inputs.agent`
    2. source-built bundle from `${{ runner.temp }}/holon-source/agents/claude`
    3. empty (fallback to holon default resolution)
  - pass resolved `AGENT_REF` to `holon solve --agent ...` when non-empty
- `.github/workflows/holon-solve.yml`
  - remove local `agents/claude` setup/build/resolve steps
  - pass `inputs.agent` directly to composite action

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); YAML.load_file(".github/workflows/holon-solve.yml"); puts "yaml ok"'`
- `git diff --check`

## Expected Behavior After Fix
- third-party repos can set `build_from_source: true` without requiring a local `agents/claude` directory
- agent resolution behavior is centralized in `action.yml`, reducing drift and duplicated logic
