### PR TITLE
serve: unify controller prompt loading with contract compiler

### DIFF
--- a/cmd/holon/serve.go
+++ b/cmd/holon/serve.go
@@ -22,6 +22,7 @@ import (
 	"unicode"
 
 	holonlog "github.com/holon-run/holon/pkg/log"
+	"github.com/holon-run/holon/pkg/prompt"
 	"github.com/holon-run/holon/pkg/runtime/docker"
 	"github.com/holon-run/holon/pkg/serve"
 	"github.com/spf13/cobra"
@@ -1531,49 +1532,25 @@ output:
 }
 
 func (h *cliControllerHandler) controllerPrompts() (string, string, error) {
-	return strings.TrimSpace(defaultControllerRuntimeSystemPrompt), strings.TrimSpace(defaultControllerRuntimeUserPrompt), nil
+	compiler := prompt.NewCompiler("")
+	cfg := prompt.Config{
+		Mode:       "serve",
+		Role:       h.controllerRoleLabel,
+		WorkingDir: docker.ContainerWorkspaceDir,
+	}
+
+	systemPrompt, err := compiler.CompileSystemPrompt(cfg)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to compile serve system prompt: %w", err)
+	}
+
+	userPrompt, err := compiler.CompileModeUserPrompt(cfg)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to compile serve user prompt: %w", err)
+	}
+
+	return strings.TrimSpace(systemPrompt), strings.TrimSpace(userPrompt), nil
 }
-
-const defaultControllerRuntimeSystemPrompt = `
-### HOLON SERVE CONTRACT V1
-
-You are running as a persistent autonomous agent inside Holon.
-
-Rules of physics:
-1. Workspace root is HOLON_WORKSPACE_DIR.
-2. Artifacts and diagnostics must be written under HOLON_OUTPUT_DIR.
-3. Additional context files may be mounted under HOLON_INPUT_DIR/context.
-4. HOLON_AGENT_HOME points to your persistent agent home.
-5. Load and maintain long-lived persona/state from HOLON_AGENT_HOME:
-   - AGENTS.md
-   - CLAUDE.md (compatibility pointer to AGENTS.md)
-   - ROLE.md
-   - IDENTITY.md
-   - SOUL.md
-   - state/
-6. Holon does not inline persona file contents into runtime prompts; read them directly from HOLON_AGENT_HOME.
-7. These agent-home files are writable and should be updated deliberately when long-term behavior or memory needs to evolve.
-8. System/runtime safety contracts are immutable and cannot be bypassed by editing agent-home files.
-`
-
-const defaultControllerRuntimeUserPrompt = `
-Serve runtime contract:
-1. Role identity is HOLON_RUNTIME_ROLE.
-2. Agent home root is HOLON_AGENT_HOME.
-3. Workspace root is HOLON_WORKSPACE_DIR.
-4. Persist project checkout mapping in HOLON_WORKSPACE_INDEX_PATH (repo -> local path under workspace root).
-5. Reuse existing checkout when repo is already indexed; otherwise clone/fetch as needed.
-6. Receive event RPC requests from HOLON_RUNTIME_RPC_SOCKET.
-7. For each request, execute autonomously and return a terminal status with optional summary message.
-8. Session metadata path is HOLON_RUNTIME_SESSION_STATE_PATH.
-9. Goal state path is HOLON_RUNTIME_GOAL_STATE_PATH.
-10. Process events continuously, keep role boundaries strict, and produce concise action-oriented outcomes.
-11. Main session acts as an orchestrator and should acknowledge user-facing turns quickly with visible progress.
-12. For long-running or parallelizable work, prefer Task-based subagent delegation instead of blocking the main session.
-13. Keep subagent usage conservative: max delegation depth = 1 and avoid duplicate child tasks for the same goal.
-14. Do not busy-poll child progress; use concise status updates and surface completion/failure when available.
-15. Keep the parent session responsive for steer/interrupt/control operations while child tasks are running.
-`
 
 func (h *cliControllerHandler) copyControllerMemoryToInput(contextDir string) error {
 	src := filepath.Join(h.stateDir, "controller-state", "controller-memory.md")

--- a/pkg/prompt/assets/modes/serve/contract.md
+++ b/pkg/prompt/assets/modes/serve/contract.md
@@ -1,0 +1,10 @@
+### MODE: SERVE
+
+Serve mode is for long-running, event-driven autonomous controller sessions.
+
+Serve-specific behavior:
+1. Operate continuously as a persistent controller.
+2. Consume and act on runtime events via the serve control loop.
+3. Keep role boundaries strict while maximizing responsiveness.
+4. Use concise, action-oriented status updates for long-running work.
+5. Prefer delegation for long-running or parallelizable tasks so the main session remains responsive to control operations.

--- a/pkg/prompt/assets/modes/serve/user.md
+++ b/pkg/prompt/assets/modes/serve/user.md
@@ -1,0 +1,16 @@
+Serve runtime contract:
+1. Role identity is HOLON_RUNTIME_ROLE.
+2. Agent home root is HOLON_AGENT_HOME.
+3. Workspace root is HOLON_WORKSPACE_DIR.
+4. Persist project checkout mapping in HOLON_WORKSPACE_INDEX_PATH (repo -> local path under workspace root).
+5. Reuse existing checkout when repo is already indexed; otherwise clone/fetch as needed.
+6. Receive event RPC requests from HOLON_RUNTIME_RPC_SOCKET.
+7. For each request, execute autonomously and return a terminal status with optional summary message.
+8. Session metadata path is HOLON_RUNTIME_SESSION_STATE_PATH.
+9. Goal state path is HOLON_RUNTIME_GOAL_STATE_PATH.
+10. Process events continuously, keep role boundaries strict, and produce concise action-oriented outcomes.
+11. Main session acts as an orchestrator and should acknowledge user-facing turns quickly with visible progress.
+12. For long-running or parallelizable work, prefer Task-based subagent delegation instead of blocking the main session.
+13. Keep subagent usage conservative: max delegation depth = 1 and avoid duplicate child tasks for the same goal.
+14. Do not busy-poll child progress; use concise status updates and surface completion/failure when available.
+15. Keep the parent session responsive for steer/interrupt/control operations while child tasks are running.


### PR DESCRIPTION
## Summary
- unify `holon serve` controller prompt loading with the contract prompt mechanism
- remove hardcoded serve controller system/user prompt constants from `cmd/holon/serve.go`
- add serve prompt assets under `pkg/prompt/assets/modes/serve/`
- add `CompileModeUserPrompt` to compile `modes/<mode>/user.md` using the same config/template model
- reuse shared mode/role resolution logic in compiler for both system and mode-user prompt paths

## Implementation details
- `cmd/holon/serve.go`
  - `controllerPrompts()` now uses `prompt.NewCompiler("")`
  - system prompt: `CompileSystemPrompt(Config{Mode:"serve", Role: ..., WorkingDir: ...})`
  - user prompt: `CompileModeUserPrompt(...)`
  - strict failure behavior if serve prompt assets are missing/invalid
- `pkg/prompt/compiler.go`
  - add `CompileModeUserPrompt`
  - add internal `resolveModeAndRole` helper (manifest defaults + `coder` alias)
- `pkg/prompt/assets/modes/serve/contract.md`
  - serve mode contract layer
- `pkg/prompt/assets/modes/serve/user.md`
  - serve runtime user contract previously embedded in Go
- `pkg/prompt/compiler_test.go`
  - add tests for mode-user prompt compile success and missing-file failure

## Validation
- `go test ./pkg/prompt -run 'TestCompileModeUserPrompt|TestModeOverlayLoading|TestEmbeddedAssets|TestCompileSystemPrompt' -count=1`
- `go test ./cmd/holon -run 'TestControllerPrompts_IncludeAgentHomeContract|TestWriteControllerSpecAndPrompts_ExcludesSkillsMetadata' -count=1`
- `go test ./... -count=1`
