### PR TITLE
Add Rust binary release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,156 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.asset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: holon-linux-amd64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            asset: holon-darwin-amd64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset: holon-darwin-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --locked --target "${{ matrix.target }}"
+
+      - name: Package release archive
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          tmpdir="$(mktemp -d)"
+          cp "target/${{ matrix.target }}/release/holon" "$tmpdir/holon"
+          tar -czf "dist/${{ matrix.asset }}.tar.gz" -C "$tmpdir" holon
+          shasum -a 256 "dist/${{ matrix.asset }}.tar.gz" > "dist/${{ matrix.asset }}.tar.gz.sha256"
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.asset }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist-artifacts
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Validate release version
+        run: |
+          set -euo pipefail
+          crate_version="$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$crate_version" != "$tag_version" ]; then
+            echo "Cargo.toml version ($crate_version) must match tag version ($tag_version)." >&2
+            exit 1
+          fi
+
+      - name: Prepare checksums and Homebrew formula
+        run: |
+          set -euo pipefail
+          (
+            cd dist-artifacts
+            rm -f ./*.sha256
+            shasum -a 256 ./*.tar.gz | sort -k2 > checksums.txt
+          )
+          scripts/generate-homebrew-formula.sh \
+            "$GITHUB_REF_NAME" \
+            dist-artifacts/checksums.txt \
+            homebrew-tap/Formula/holon.rb
+
+      - name: Upload Homebrew formula artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: homebrew-formula
+          path: homebrew-tap/Formula/holon.rb
+          if-no-files-found: error
+
+      - name: Prepare release notes
+        run: |
+          set -euo pipefail
+          cat > release-notes.md <<EOF
+          ## Install
+
+          Homebrew:
+
+          \`\`\`bash
+          brew tap holon-run/tap
+          brew install holon
+          \`\`\`
+
+          Direct binary:
+
+          \`\`\`bash
+          curl -L "https://github.com/holon-run/holon/releases/download/${GITHUB_REF_NAME}/holon-linux-amd64.tar.gz" | tar -xz
+          chmod +x holon
+          ./holon --help
+          \`\`\`
+
+          Replace \`holon-linux-amd64.tar.gz\` with \`holon-darwin-amd64.tar.gz\` or \`holon-darwin-arm64.tar.gz\` on macOS.
+          EOF
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md
+          files: |
+            dist-artifacts/*.tar.gz
+            dist-artifacts/checksums.txt
+
+      - name: Push Homebrew formula
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "HOMEBREW_TAP_TOKEN is not configured; formula was generated as an artifact only."
+            exit 0
+          fi
+
+          tap_dir="$(mktemp -d)"
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/holon-run/homebrew-tap.git" "$tap_dir"
+          mkdir -p "$tap_dir/Formula"
+          cp homebrew-tap/Formula/holon.rb "$tap_dir/Formula/holon.rb"
+
+          cd "$tap_dir"
+          git config user.name "holon-bot"
+          git config user.email "holon-bot@holon.run"
+          git add Formula/holon.rb
+          if git diff --staged --quiet; then
+            echo "Homebrew formula is already up to date."
+            exit 0
+          fi
+          git commit -m "Update Holon formula for ${GITHUB_REF_NAME}"
+          git push origin main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.1.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ The core problem it solves is not "talking to a model". The core problem is:
 `Holon` currently has two primary runtime entry points plus one operator
 lifecycle surface.
 
+## Install
+
+The main branch builds a Rust binary named `holon`.
+
+Build from source:
+
+```bash
+cargo install --path .
+holon --help
+```
+
+Released binaries are published as GitHub Release assets for Linux amd64,
+macOS amd64, and macOS arm64. Once a release is tagged, install with Homebrew:
+
+```bash
+brew tap holon-run/tap
+brew install holon
+```
+
 ### `holon run`
 
 This is the simplest way to use `Holon`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,26 @@
+# Release
+
+Holon releases are published from version tags.
+
+## Versioning
+
+Keep `Cargo.toml` aligned with the tag. For example, `v0.13.0` must be released
+from a commit whose crate version is `0.13.0`.
+
+## Publish
+
+```bash
+git tag v0.13.0
+git push origin v0.13.0
+```
+
+The release workflow builds and uploads:
+
+- `holon-linux-amd64.tar.gz`
+- `holon-darwin-amd64.tar.gz`
+- `holon-darwin-arm64.tar.gz`
+- `checksums.txt`
+
+The workflow also generates `Formula/holon.rb`. If `HOMEBREW_TAP_TOKEN` is
+configured, it pushes the formula to `holon-run/homebrew-tap`; otherwise the
+formula is available as a workflow artifact.

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <version-tag> <checksums-file> <output-file>" >&2
+  exit 2
+fi
+
+version="$1"
+checksums_file="$2"
+output_file="$3"
+
+if [[ "$version" != v*.*.* ]]; then
+  echo "version tag must look like vX.Y.Z: $version" >&2
+  exit 2
+fi
+
+if [ ! -f "$checksums_file" ]; then
+  echo "checksums file does not exist: $checksums_file" >&2
+  exit 2
+fi
+
+checksum_for() {
+  local asset="$1"
+  awk -v asset="$asset" '
+    {
+      file = $2
+      sub(/^.*\//, "", file)
+      if (file == asset) {
+        print $1
+        exit
+      }
+    }
+  ' "$checksums_file"
+}
+
+linux_amd64_sha="$(checksum_for holon-linux-amd64.tar.gz)"
+darwin_amd64_sha="$(checksum_for holon-darwin-amd64.tar.gz)"
+darwin_arm64_sha="$(checksum_for holon-darwin-arm64.tar.gz)"
+
+for required in linux_amd64_sha darwin_amd64_sha darwin_arm64_sha; do
+  if [ -z "${!required}" ]; then
+    echo "missing checksum: $required" >&2
+    exit 1
+  fi
+done
+
+version_no_v="${version#v}"
+mkdir -p "$(dirname "$output_file")"
+
+cat > "$output_file" <<EOF
+class Holon < Formula
+  desc "Headless, event-driven runtime for long-lived agents"
+  homepage "https://github.com/holon-run/holon"
+  version "$version_no_v"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/holon-run/holon/releases/download/$version/holon-darwin-arm64.tar.gz"
+      sha256 "$darwin_arm64_sha"
+    else
+      url "https://github.com/holon-run/holon/releases/download/$version/holon-darwin-amd64.tar.gz"
+      sha256 "$darwin_amd64_sha"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/holon-run/holon/releases/download/$version/holon-linux-amd64.tar.gz"
+      sha256 "$linux_amd64_sha"
+    else
+      odie "Holon does not publish a Linux ARM64 binary yet"
+    end
+  end
+
+  def install
+    bin.install "holon"
+  end
+
+  test do
+    assert_match "$version_no_v", shell_output("#{bin}/holon --version")
+  end
+end
+EOF

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use tracing_subscriber::EnvFilter;
 #[derive(Debug, Parser)]
 #[command(name = "holon")]
 #[command(about = "A headless, event-driven runtime for long-lived agents")]
+#[command(version)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
## Summary

- add a Rust binary release workflow for Linux amd64, macOS amd64, and macOS arm64 archives
- generate checksums and a Homebrew formula, with optional tap push through HOMEBREW_TAP_TOKEN
- document the release flow and align the Rust crate/CLI version with the next Holon release line

## Verification

- actionlint .github/workflows/release.yml
- scripts/generate-homebrew-formula.sh v0.13.0 <fake-checksums> <tmp-formula> && ruby -c <tmp-formula>
- cargo fmt --all -- --check
- cargo check --all-targets
- cargo run --quiet -- --version
- git diff --check
