### PR TITLE
feat: restore Holon solve workflow surface

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -1,0 +1,201 @@
+name: Holon Solve
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: GitHub issue or PR reference, such as owner/repo#123.
+        required: true
+        type: string
+      base:
+        description: Base branch hint.
+        required: false
+        type: string
+        default: ''
+      goal:
+        description: Explicit solve goal.
+        required: false
+        type: string
+        default: ''
+      model:
+        description: Holon model ref.
+        required: false
+        type: string
+        default: ''
+      version:
+        description: Holon version to download when build_from_source is false.
+        required: false
+        type: string
+        default: latest
+      build_from_source:
+        description: Build Holon from source.
+        required: false
+        type: boolean
+        default: true
+      holon_repository:
+        description: Holon repository for source builds.
+        required: false
+        type: string
+        default: holon-run/holon
+      holon_ref:
+        description: Optional Holon git ref for source builds.
+        required: false
+        type: string
+        default: ''
+      runs_on:
+        description: Runner label.
+        required: false
+        type: string
+        default: ubuntu-latest
+    secrets:
+      anthropic_auth_token:
+        required: false
+      anthropic_api_key:
+        required: false
+      openai_api_key:
+        required: false
+      holon_github_token:
+        required: false
+      anthropic_base_url:
+        required: false
+      openai_base_url:
+        required: false
+
+jobs:
+  solve:
+    runs-on: ${{ inputs.runs_on }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare Holon directories
+        id: dirs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/holon/input" "$RUNNER_TEMP/holon/output" "$RUNNER_TEMP/holon/home"
+          {
+            echo "input=$RUNNER_TEMP/holon/input"
+            echo "output=$RUNNER_TEMP/holon/output"
+            echo "home=$RUNNER_TEMP/holon/home"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Holon source
+        if: inputs.build_from_source
+        shell: bash
+        env:
+          HOLON_REPOSITORY: ${{ inputs.holon_repository }}
+          HOLON_REF: ${{ inputs.holon_ref }}
+        run: |
+          set -euo pipefail
+          src_dir="$RUNNER_TEMP/holon-source"
+          rm -rf "$src_dir"
+          git clone --depth 1 "https://github.com/${HOLON_REPOSITORY}.git" "$src_dir"
+          if [ -n "$HOLON_REF" ]; then
+            git -C "$src_dir" fetch --depth 1 origin "$HOLON_REF"
+            git -C "$src_dir" checkout FETCH_HEAD
+          fi
+          echo "HOLON_SOURCE_DIR=$src_dir" >> "$GITHUB_ENV"
+
+      - name: Set up Rust
+        if: inputs.build_from_source
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Holon from source
+        if: inputs.build_from_source
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release --locked --manifest-path "$HOLON_SOURCE_DIR/Cargo.toml"
+          mkdir -p "$RUNNER_TEMP/holon/bin"
+          cp "$HOLON_SOURCE_DIR/target/release/holon" "$RUNNER_TEMP/holon/bin/holon"
+          chmod +x "$RUNNER_TEMP/holon/bin/holon"
+
+      - name: Download Holon binary
+        if: ${{ !inputs.build_from_source }}
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m)"
+          case "$arch" in
+            x86_64) arch=amd64 ;;
+            arm64|aarch64) arch=arm64 ;;
+          esac
+          release_path=latest/download
+          if [ "$INPUT_VERSION" != "latest" ]; then
+            release_path="download/$INPUT_VERSION"
+          fi
+          mkdir -p "$RUNNER_TEMP/holon/bin"
+          curl -fsSL "https://github.com/holon-run/holon/releases/$release_path/holon-$platform-$arch.tar.gz" |
+            tar -xz -C "$RUNNER_TEMP/holon/bin"
+          chmod +x "$RUNNER_TEMP/holon/bin/holon"
+
+      - name: Run Holon solve
+        shell: bash
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_BASE: ${{ inputs.base }}
+          INPUT_GOAL: ${{ inputs.goal }}
+          INPUT_MODEL: ${{ inputs.model }}
+          ANTHROPIC_AUTH_TOKEN_INPUT: ${{ secrets.anthropic_auth_token || secrets.anthropic_api_key }}
+          ANTHROPIC_BASE_URL_INPUT: ${{ secrets.anthropic_base_url || 'https://api.anthropic.com' }}
+          OPENAI_API_KEY_INPUT: ${{ secrets.openai_api_key }}
+          OPENAI_BASE_URL_INPUT: ${{ secrets.openai_base_url }}
+          GITHUB_TOKEN_INPUT: ${{ secrets.holon_github_token || github.token }}
+        run: |
+          set -euo pipefail
+          export PATH="$RUNNER_TEMP/holon/bin:$PATH"
+          export GITHUB_TOKEN="$GITHUB_TOKEN_INPUT"
+          export GH_TOKEN="$GITHUB_TOKEN_INPUT"
+          if [ -n "$ANTHROPIC_AUTH_TOKEN_INPUT" ]; then
+            export ANTHROPIC_AUTH_TOKEN="$ANTHROPIC_AUTH_TOKEN_INPUT"
+          fi
+          if [ -n "$ANTHROPIC_BASE_URL_INPUT" ]; then
+            export ANTHROPIC_BASE_URL="$ANTHROPIC_BASE_URL_INPUT"
+          fi
+          if [ -n "$OPENAI_API_KEY_INPUT" ]; then
+            export OPENAI_API_KEY="$OPENAI_API_KEY_INPUT"
+          fi
+          if [ -n "$OPENAI_BASE_URL_INPUT" ]; then
+            export OPENAI_BASE_URL="$OPENAI_BASE_URL_INPUT"
+          fi
+
+          args=("$INPUT_REF" --home "${{ steps.dirs.outputs.home }}" --workspace "${{ github.workspace }}" --input "${{ steps.dirs.outputs.input }}" --output "${{ steps.dirs.outputs.output }}" --json)
+          if [ -n "$INPUT_BASE" ]; then
+            args+=(--base "$INPUT_BASE")
+          fi
+          if [ -n "$INPUT_GOAL" ]; then
+            args+=(--goal "$INPUT_GOAL")
+          fi
+          if [ -n "$INPUT_MODEL" ]; then
+            args+=(--model "$INPUT_MODEL")
+          fi
+          holon solve "${args[@]}"
+
+      - name: Add Holon summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="${{ steps.dirs.outputs.output }}"
+          if [ -f "$output/summary.md" ]; then
+            cat "$output/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload Holon artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: holon-solve-output
+          path: ${{ steps.dirs.outputs.output }}/
+          retention-days: 7

--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -7,6 +7,11 @@ on:
         description: GitHub issue or PR reference, such as owner/repo#123.
         required: true
         type: string
+      repo:
+        description: GitHub repository hint for shorthand refs such as #123.
+        required: false
+        type: string
+        default: ''
       base:
         description: Base branch hint.
         required: false
@@ -68,7 +73,6 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -131,6 +135,14 @@ jobs:
             x86_64) arch=amd64 ;;
             arm64|aarch64) arch=arm64 ;;
           esac
+          if [ "$platform" != "linux" ] && [ "$platform" != "darwin" ]; then
+            echo "::error::Unsupported platform for Holon binary download: $platform"
+            exit 1
+          fi
+          if [ "$platform" = "linux" ] && [ "$arch" != "amd64" ]; then
+            echo "::error::Linux release assets currently support amd64 only. Set inputs.build_from_source=true or use a linux/amd64 runner."
+            exit 1
+          fi
           release_path=latest/download
           if [ "$INPUT_VERSION" != "latest" ]; then
             release_path="download/$INPUT_VERSION"
@@ -144,6 +156,7 @@ jobs:
         shell: bash
         env:
           INPUT_REF: ${{ inputs.ref }}
+          INPUT_REPO: ${{ inputs.repo }}
           INPUT_BASE: ${{ inputs.base }}
           INPUT_GOAL: ${{ inputs.goal }}
           INPUT_MODEL: ${{ inputs.model }}
@@ -171,6 +184,9 @@ jobs:
           fi
 
           args=("$INPUT_REF" --home "${{ steps.dirs.outputs.home }}" --workspace "${{ github.workspace }}" --input "${{ steps.dirs.outputs.input }}" --output "${{ steps.dirs.outputs.output }}" --json)
+          if [ -n "$INPUT_REPO" ]; then
+            args+=(--repo "$INPUT_REPO")
+          fi
           if [ -n "$INPUT_BASE" ]; then
             args+=(--base "$INPUT_BASE")
           fi

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,235 @@
+name: Holon Solve
+description: Run the Rust Holon GitHub solve preset against a checked-out repository.
+branding:
+  icon: cpu
+  color: blue
+
+inputs:
+  ref:
+    description: GitHub issue or PR reference, such as owner/repo#123.
+    required: true
+  repo:
+    description: Repository hint for numeric refs.
+    required: false
+    default: ''
+  base:
+    description: Base branch hint.
+    required: false
+    default: ''
+  goal:
+    description: Explicit solve goal.
+    required: false
+    default: ''
+  role:
+    description: Optional role hint.
+    required: false
+    default: ''
+  model:
+    description: Holon model ref, such as openai/gpt-5.4 or anthropic/claude-sonnet-4-6.
+    required: false
+    default: ''
+  max_turns:
+    description: Maximum foreground model turns.
+    required: false
+    default: '12'
+  anthropic_auth_token:
+    description: Anthropic Auth Token.
+    required: false
+  anthropic_api_key:
+    description: Legacy alias for anthropic_auth_token.
+    required: false
+    deprecationMessage: Use anthropic_auth_token instead.
+  anthropic_base_url:
+    description: Anthropic Base URL.
+    required: false
+    default: https://api.anthropic.com
+  openai_api_key:
+    description: OpenAI API key.
+    required: false
+  openai_base_url:
+    description: OpenAI Base URL.
+    required: false
+    default: ''
+  github_token:
+    description: GitHub token. Defaults to github.token.
+    required: false
+    default: ''
+  version:
+    description: Holon release version to download when build_from_source is false.
+    required: false
+    default: latest
+  build_from_source:
+    description: Build Holon from source before running.
+    required: false
+    default: 'true'
+  holon_repository:
+    description: Holon repository for source builds.
+    required: false
+    default: holon-run/holon
+  holon_ref:
+    description: Optional Holon git ref for source builds.
+    required: false
+    default: ''
+  workspace:
+    description: Checked-out repository path. Defaults to GITHUB_WORKSPACE.
+    required: false
+    default: ''
+  cwd:
+    description: Working directory for the solve run. Defaults to workspace.
+    required: false
+    default: ''
+  input_dir:
+    description: Input context directory.
+    required: false
+    default: ''
+  output_dir:
+    description: Output artifact directory.
+    required: false
+    default: ''
+  state_dir:
+    description: Holon home directory for runtime state.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Holon source
+      if: inputs.build_from_source == 'true'
+      shell: bash
+      env:
+        HOLON_REPOSITORY: ${{ inputs.holon_repository }}
+        HOLON_REF: ${{ inputs.holon_ref }}
+      run: |
+        set -euo pipefail
+        src_dir="$RUNNER_TEMP/holon-source"
+        rm -rf "$src_dir"
+        git clone --depth 1 "https://github.com/${HOLON_REPOSITORY}.git" "$src_dir"
+        if [ -n "$HOLON_REF" ]; then
+          git -C "$src_dir" fetch --depth 1 origin "$HOLON_REF"
+          git -C "$src_dir" checkout FETCH_HEAD
+        fi
+        echo "HOLON_SOURCE_DIR=$src_dir" >> "$GITHUB_ENV"
+
+    - name: Set up Rust
+      if: inputs.build_from_source == 'true'
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Build Holon from source
+      if: inputs.build_from_source == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cargo build --release --locked --manifest-path "$HOLON_SOURCE_DIR/Cargo.toml"
+        mkdir -p "$RUNNER_TEMP/holon/bin"
+        cp "$HOLON_SOURCE_DIR/target/release/holon" "$RUNNER_TEMP/holon/bin/holon"
+        chmod +x "$RUNNER_TEMP/holon/bin/holon"
+
+    - name: Download Holon binary
+      if: inputs.build_from_source != 'true'
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64) arch=amd64 ;;
+          arm64|aarch64) arch=arm64 ;;
+        esac
+        if [ "$platform" != "linux" ] && [ "$platform" != "darwin" ]; then
+          echo "::error::Unsupported platform: $platform"
+          exit 1
+        fi
+        if [ "$platform" = "linux" ] && [ "$arch" != "amd64" ]; then
+          echo "::error::Linux release assets currently support amd64 only."
+          exit 1
+        fi
+        release_path=latest/download
+        if [ "$INPUT_VERSION" != "latest" ]; then
+          release_path="download/$INPUT_VERSION"
+        fi
+        mkdir -p "$RUNNER_TEMP/holon/bin"
+        curl -fsSL "https://github.com/holon-run/holon/releases/$release_path/holon-$platform-$arch.tar.gz" |
+          tar -xz -C "$RUNNER_TEMP/holon/bin"
+        chmod +x "$RUNNER_TEMP/holon/bin/holon"
+
+    - name: Run Holon solve
+      shell: bash
+      env:
+        INPUT_REF: ${{ inputs.ref }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_GOAL: ${{ inputs.goal }}
+        INPUT_ROLE: ${{ inputs.role }}
+        INPUT_MODEL: ${{ inputs.model }}
+        INPUT_MAX_TURNS: ${{ inputs.max_turns }}
+        INPUT_WORKSPACE: ${{ inputs.workspace }}
+        INPUT_CWD: ${{ inputs.cwd }}
+        INPUT_INPUT_DIR: ${{ inputs.input_dir }}
+        INPUT_OUTPUT_DIR: ${{ inputs.output_dir }}
+        INPUT_STATE_DIR: ${{ inputs.state_dir }}
+        ANTHROPIC_AUTH_TOKEN_INPUT: ${{ inputs.anthropic_auth_token || inputs.anthropic_api_key }}
+        ANTHROPIC_BASE_URL_INPUT: ${{ inputs.anthropic_base_url }}
+        OPENAI_API_KEY_INPUT: ${{ inputs.openai_api_key }}
+        OPENAI_BASE_URL_INPUT: ${{ inputs.openai_base_url }}
+        GITHUB_TOKEN_INPUT: ${{ inputs.github_token || github.token }}
+      run: |
+        set -euo pipefail
+        export PATH="$RUNNER_TEMP/holon/bin:$PATH"
+        export GITHUB_TOKEN="$GITHUB_TOKEN_INPUT"
+        export GH_TOKEN="$GITHUB_TOKEN_INPUT"
+        if [ -n "$ANTHROPIC_AUTH_TOKEN_INPUT" ]; then
+          export ANTHROPIC_AUTH_TOKEN="$ANTHROPIC_AUTH_TOKEN_INPUT"
+        fi
+        if [ -n "$ANTHROPIC_BASE_URL_INPUT" ]; then
+          export ANTHROPIC_BASE_URL="$ANTHROPIC_BASE_URL_INPUT"
+        fi
+        if [ -n "$OPENAI_API_KEY_INPUT" ]; then
+          export OPENAI_API_KEY="$OPENAI_API_KEY_INPUT"
+        fi
+        if [ -n "$OPENAI_BASE_URL_INPUT" ]; then
+          export OPENAI_BASE_URL="$OPENAI_BASE_URL_INPUT"
+        fi
+
+        workspace="$INPUT_WORKSPACE"
+        if [ -z "$workspace" ]; then
+          workspace="${GITHUB_WORKSPACE:-$PWD}"
+        fi
+        cwd="$INPUT_CWD"
+        if [ -z "$cwd" ]; then
+          cwd="$workspace"
+        fi
+        input_dir="$INPUT_INPUT_DIR"
+        if [ -z "$input_dir" ]; then
+          input_dir="$RUNNER_TEMP/holon/input"
+        fi
+        output_dir="$INPUT_OUTPUT_DIR"
+        if [ -z "$output_dir" ]; then
+          output_dir="$RUNNER_TEMP/holon/output"
+        fi
+        state_dir="$INPUT_STATE_DIR"
+        if [ -z "$state_dir" ]; then
+          state_dir="$RUNNER_TEMP/holon/home"
+        fi
+        mkdir -p "$input_dir" "$output_dir" "$state_dir"
+
+        args=("$INPUT_REF" --home "$state_dir" --workspace "$workspace" --cwd "$cwd" --input "$input_dir" --output "$output_dir" --max-turns "$INPUT_MAX_TURNS" --json)
+        if [ -n "$INPUT_REPO" ]; then
+          args+=(--repo "$INPUT_REPO")
+        fi
+        if [ -n "$INPUT_BASE" ]; then
+          args+=(--base "$INPUT_BASE")
+        fi
+        if [ -n "$INPUT_GOAL" ]; then
+          args+=(--goal "$INPUT_GOAL")
+        fi
+        if [ -n "$INPUT_ROLE" ]; then
+          args+=(--role "$INPUT_ROLE")
+        fi
+        if [ -n "$INPUT_MODEL" ]; then
+          args+=(--model "$INPUT_MODEL")
+        fi
+
+        holon solve "${args[@]}"

--- a/builtin_templates/holon-github-solve/AGENTS.md
+++ b/builtin_templates/holon-github-solve/AGENTS.md
@@ -1,0 +1,22 @@
+# Holon GitHub Solve Agent
+
+You are a GitHub task agent created by `holon solve`.
+
+## Responsibilities
+
+- interpret the target issue or pull request from the solve prompt
+- collect current GitHub context with `gh` when needed
+- choose the matching GitHub skill workflow
+- implement, review, comment, or publish exactly as the target requires
+- write completion artifacts under `GITHUB_OUTPUT_DIR`
+
+## Operating Rules
+
+- Assume the caller has already checked out the repository.
+- Do not clone a fresh copy of the repository unless the prompt explicitly asks.
+- Use `GITHUB_TOKEN` or `GH_TOKEN` for GitHub operations.
+- For issue implementation, prefer `github-issue-solve`.
+- For pull request remediation, prefer `github-pr-fix`.
+- For review-only tasks, prefer `github-review`.
+- Use `ghx` guidance for raw GitHub CLI and API commands.
+- Do not report success until required publish actions are complete.

--- a/builtin_templates/holon-github-solve/skills.json
+++ b/builtin_templates/holon-github-solve/skills.json
@@ -1,0 +1,20 @@
+{
+  "skill_refs": [
+    {
+      "kind": "builtin",
+      "name": "github-issue-solve"
+    },
+    {
+      "kind": "builtin",
+      "name": "github-pr-fix"
+    },
+    {
+      "kind": "builtin",
+      "name": "github-review"
+    },
+    {
+      "kind": "builtin",
+      "name": "ghx"
+    }
+  ]
+}

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -53,6 +53,14 @@ const BUILTIN_TEMPLATES: &[BuiltinTemplate] = &[
         agents_md: include_str!("../builtin_templates/holon-release/AGENTS.md"),
         skills_json: None,
     },
+    BuiltinTemplate {
+        template_id: "holon-github-solve",
+        version: 1,
+        agents_md: include_str!("../builtin_templates/holon-github-solve/AGENTS.md"),
+        skills_json: Some(include_str!(
+            "../builtin_templates/holon-github-solve/skills.json"
+        )),
+    },
 ];
 
 struct BuiltinTemplate {
@@ -107,7 +115,32 @@ struct TemplateSkillsManifest {
 enum TemplateSkillRef {
     Local { path: PathBuf },
     Github { package: String },
+    Builtin { name: String },
 }
+
+struct BuiltinSkill {
+    name: &'static str,
+    skill_md: &'static str,
+}
+
+const BUILTIN_SKILLS: &[BuiltinSkill] = &[
+    BuiltinSkill {
+        name: "ghx",
+        skill_md: include_str!("../skills/ghx/SKILL.md"),
+    },
+    BuiltinSkill {
+        name: "github-issue-solve",
+        skill_md: include_str!("../skills/github-issue-solve/SKILL.md"),
+    },
+    BuiltinSkill {
+        name: "github-pr-fix",
+        skill_md: include_str!("../skills/github-pr-fix/SKILL.md"),
+    },
+    BuiltinSkill {
+        name: "github-review",
+        skill_md: include_str!("../skills/github-review/SKILL.md"),
+    },
+];
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -426,10 +459,18 @@ fn parse_skill_refs(path: PathBuf) -> Result<Vec<TemplateSkillRef>> {
     let manifest: TemplateSkillsManifest = serde_json::from_str(&content)
         .with_context(|| format!("failed to parse {}", path.display()))?;
     for skill_ref in &manifest.skill_refs {
-        if let TemplateSkillRef::Github { package } = skill_ref {
-            bail!(
-                "github skill refs are not supported in phase 1; use local skill refs instead: {package}"
-            );
+        match skill_ref {
+            TemplateSkillRef::Github { package } => {
+                bail!(
+                    "github skill refs are not supported in phase 1; use local or builtin skill refs instead: {package}"
+                );
+            }
+            TemplateSkillRef::Builtin { name } => {
+                if builtin_skill(name).is_none() {
+                    bail!("unknown builtin skill ref: {name}");
+                }
+            }
+            TemplateSkillRef::Local { .. } => {}
         }
     }
     Ok(manifest.skill_refs)
@@ -740,10 +781,32 @@ async fn materialize_skill_ref(
 ) -> Result<PathBuf> {
     match skill_ref {
         TemplateSkillRef::Local { path } => materialize_local_skill_ref(skills_root, path),
+        TemplateSkillRef::Builtin { name } => materialize_builtin_skill_ref(skills_root, name),
         TemplateSkillRef::Github { package } => bail!(
-            "github skill refs are not supported in phase 1; use local skill refs instead: {package}"
+            "github skill refs are not supported in phase 1; use local or builtin skill refs instead: {package}"
         ),
     }
+}
+
+fn builtin_skill(name: &str) -> Option<&'static BuiltinSkill> {
+    BUILTIN_SKILLS.iter().find(|skill| skill.name == name)
+}
+
+fn materialize_builtin_skill_ref(skills_root: &Path, name: &str) -> Result<PathBuf> {
+    let skill = builtin_skill(name).ok_or_else(|| anyhow!("unknown builtin skill ref: {name}"))?;
+    fs::create_dir_all(skills_root)
+        .with_context(|| format!("failed to create {}", skills_root.display()))?;
+    let destination = skills_root.join(skill.name);
+    if destination.exists() {
+        bail!(
+            "template skill destination {} already exists",
+            destination.display()
+        );
+    }
+    fs::create_dir_all(&destination)
+        .with_context(|| format!("failed to create {}", destination.display()))?;
+    write_file_atomically(&destination.join("SKILL.md"), skill.skill_md.as_bytes())?;
+    Ok(destination)
 }
 
 fn materialize_local_skill_ref(skills_root: &Path, path: &Path) -> Result<PathBuf> {
@@ -949,6 +1012,30 @@ mod tests {
         };
 
         assert!(builtin_template_is_managed(&template_dir, &state).unwrap());
+    }
+
+    #[tokio::test]
+    async fn github_solve_template_materializes_builtin_skills() {
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let home = tempdir().unwrap();
+        let _guard = EnvGuard::set("HOME", home.path().display().to_string());
+        seed_builtin_templates().unwrap();
+
+        let agent_home = home.path().join("agent");
+        initialize_agent_home_from_template(&agent_home, "holon-github-solve")
+            .await
+            .unwrap();
+
+        let agents_md = fs::read_to_string(agent_home.join("AGENTS.md")).unwrap();
+        assert!(agents_md.contains("Holon GitHub Solve Agent"));
+        assert!(agent_home
+            .join("skills/github-issue-solve/SKILL.md")
+            .is_file());
+        assert!(agent_home.join("skills/github-pr-fix/SKILL.md").is_file());
+        assert!(agent_home.join("skills/github-review/SKILL.md").is_file());
+        assert!(agent_home.join("skills/ghx/SKILL.md").is_file());
     }
 
     #[tokio::test]

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -121,24 +121,48 @@ enum TemplateSkillRef {
 struct BuiltinSkill {
     name: &'static str,
     skill_md: &'static str,
+    files: &'static [BuiltinSkillFile],
+}
+
+struct BuiltinSkillFile {
+    path: &'static str,
+    content: &'static str,
 }
 
 const BUILTIN_SKILLS: &[BuiltinSkill] = &[
     BuiltinSkill {
         name: "ghx",
         skill_md: include_str!("../skills/ghx/SKILL.md"),
+        files: &[],
     },
     BuiltinSkill {
         name: "github-issue-solve",
         skill_md: include_str!("../skills/github-issue-solve/SKILL.md"),
+        files: &[BuiltinSkillFile {
+            path: "references/issue-solve-workflow.md",
+            content: include_str!(
+                "../skills/github-issue-solve/references/issue-solve-workflow.md"
+            ),
+        }],
     },
     BuiltinSkill {
         name: "github-pr-fix",
         skill_md: include_str!("../skills/github-pr-fix/SKILL.md"),
+        files: &[
+            BuiltinSkillFile {
+                path: "references/diagnostics.md",
+                content: include_str!("../skills/github-pr-fix/references/diagnostics.md"),
+            },
+            BuiltinSkillFile {
+                path: "references/pr-fix-workflow.md",
+                content: include_str!("../skills/github-pr-fix/references/pr-fix-workflow.md"),
+            },
+        ],
     },
     BuiltinSkill {
         name: "github-review",
         skill_md: include_str!("../skills/github-review/SKILL.md"),
+        files: &[],
     },
 ];
 
@@ -806,6 +830,9 @@ fn materialize_builtin_skill_ref(skills_root: &Path, name: &str) -> Result<PathB
     fs::create_dir_all(&destination)
         .with_context(|| format!("failed to create {}", destination.display()))?;
     write_file_atomically(&destination.join("SKILL.md"), skill.skill_md.as_bytes())?;
+    for file in skill.files {
+        write_file_atomically(&destination.join(file.path), file.content.as_bytes())?;
+    }
     Ok(destination)
 }
 
@@ -1033,7 +1060,16 @@ mod tests {
         assert!(agent_home
             .join("skills/github-issue-solve/SKILL.md")
             .is_file());
+        assert!(agent_home
+            .join("skills/github-issue-solve/references/issue-solve-workflow.md")
+            .is_file());
         assert!(agent_home.join("skills/github-pr-fix/SKILL.md").is_file());
+        assert!(agent_home
+            .join("skills/github-pr-fix/references/diagnostics.md")
+            .is_file());
+        assert!(agent_home
+            .join("skills/github-pr-fix/references/pr-fix-workflow.md")
+            .is_file());
         assert!(agent_home.join("skills/github-review/SKILL.md").is_file());
         assert!(agent_home.join("skills/ghx/SKILL.md").is_file());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod queue;
 pub mod run_once;
 pub mod runtime;
 pub mod skills;
+pub mod solve;
 pub mod storage;
 pub mod system;
 pub mod tool;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use holon::{
     http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
     provider::provider_doctor,
     run_once::{run_once, RunOnceRequest},
+    solve::{run_solve, SolveRequest},
     tui::run_tui,
     types::{ControlAction, TrustLevel},
 };
@@ -126,6 +127,42 @@ enum Commands {
         workspace_root: Option<PathBuf>,
         #[arg(long)]
         cwd: Option<PathBuf>,
+    },
+    Solve {
+        #[arg(value_name = "REF")]
+        target_ref: String,
+        #[arg(long)]
+        repo: Option<String>,
+        #[arg(long)]
+        base: Option<String>,
+        #[arg(long)]
+        goal: Option<String>,
+        #[arg(long)]
+        role: Option<String>,
+        #[arg(long)]
+        agent: Option<String>,
+        #[arg(long)]
+        template: Option<String>,
+        #[arg(long)]
+        model: Option<String>,
+        #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+        max_turns: Option<u64>,
+        #[arg(long, default_value = "trusted-operator")]
+        trust: TrustLevel,
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        home: Option<PathBuf>,
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        #[arg(long)]
+        workspace_root: Option<PathBuf>,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        #[arg(long)]
+        input: Option<PathBuf>,
+        #[arg(long)]
+        output: Option<PathBuf>,
     },
     Workspace {
         #[command(subcommand)]
@@ -257,6 +294,45 @@ async fn main() -> Result<()> {
             )
             .await
         }
+        Commands::Solve {
+            target_ref,
+            repo,
+            base,
+            goal,
+            role,
+            agent,
+            template,
+            model,
+            max_turns,
+            trust,
+            json,
+            home,
+            workspace,
+            workspace_root,
+            cwd,
+            input,
+            output,
+        } => {
+            run_solve_command(
+                target_ref,
+                repo,
+                base,
+                goal,
+                role,
+                agent,
+                template,
+                model,
+                max_turns,
+                trust,
+                json,
+                home,
+                workspace.or(workspace_root),
+                cwd,
+                input,
+                output,
+            )
+            .await
+        }
         command => run_runtime_command(command).await,
     }
 }
@@ -358,6 +434,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         Commands::Workspace { command } => handle_workspace_command(&config, command).await,
         Commands::Tui { no_alt_screen } => run_tui(config, no_alt_screen).await,
         Commands::Run { .. } => unreachable!("run command is handled separately"),
+        Commands::Solve { .. } => unreachable!("solve command is handled separately"),
         Commands::Debug { command } => handle_debug_command(config, command).await,
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
     }
@@ -389,6 +466,58 @@ async fn run_one_shot(
             wait_for_tasks: !no_wait_for_tasks,
             workspace_root,
             cwd,
+        },
+    )
+    .await?;
+
+    if json {
+        print_json(&serde_json::to_value(&response)?)?;
+    } else {
+        println!("{}", response.render_text());
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_solve_command(
+    target_ref: String,
+    repo: Option<String>,
+    base: Option<String>,
+    goal: Option<String>,
+    role: Option<String>,
+    agent: Option<String>,
+    template: Option<String>,
+    model: Option<String>,
+    max_turns: Option<u64>,
+    trust: TrustLevel,
+    json: bool,
+    home: Option<PathBuf>,
+    workspace_root: Option<PathBuf>,
+    cwd: Option<PathBuf>,
+    input_dir: Option<PathBuf>,
+    output_dir: Option<PathBuf>,
+) -> Result<()> {
+    if let Some(model) = model.as_deref().filter(|model| !model.trim().is_empty()) {
+        std::env::set_var("HOLON_MODEL", model);
+    }
+    let config = AppConfig::load_with_home(home)?;
+    let response = run_solve(
+        config,
+        SolveRequest {
+            target_ref,
+            repo,
+            base,
+            goal,
+            role,
+            agent_id: agent,
+            template,
+            max_turns,
+            trust,
+            json,
+            workspace_root,
+            cwd,
+            input_dir,
+            output_dir,
         },
     )
     .await?;

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -92,7 +92,7 @@ pub async fn run_solve(config: AppConfig, request: SolveRequest) -> Result<RunOn
 
     let response = match run_once(config.clone(), run_request.clone()).await {
         Ok(response) => response,
-        Err(err) if err.to_string().contains("already exists") => {
+        Err(err) if is_agent_template_already_initialized_error(&err) => {
             let retry = RunOnceRequest {
                 create_agent: false,
                 template: None,
@@ -105,6 +105,15 @@ pub async fn run_solve(config: AppConfig, request: SolveRequest) -> Result<RunOn
 
     write_run_artifacts(&output_dir, &request, target.as_ref(), &response)?;
     Ok(response)
+}
+
+fn is_agent_template_already_initialized_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        let message = cause.to_string();
+        message.contains(
+            "already exists; template initialization only applies when creating a new agent",
+        )
+    })
 }
 
 fn prepare_output_dir(output_dir: Option<&Path>) -> Result<PathBuf> {
@@ -412,5 +421,16 @@ mod tests {
         assert!(prompt.contains("github-pr-fix"));
         assert!(prompt.contains("github-review"));
         assert!(prompt.contains("/tmp/out/manifest.json"));
+    }
+
+    #[test]
+    fn agent_template_retry_only_matches_specific_create_agent_error() {
+        let expected = anyhow!(
+            "agent github-solve already exists; template initialization only applies when creating a new agent"
+        );
+        assert!(is_agent_template_already_initialized_error(&expected));
+
+        let unrelated = anyhow!("target file already exists: README.md");
+        assert!(!is_agent_template_already_initialized_error(&unrelated));
     }
 }

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -1,0 +1,416 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+
+use crate::{
+    config::AppConfig,
+    run_once::{run_once, RunFinalStatus, RunOnceRequest, RunOnceResponse},
+    types::TrustLevel,
+};
+
+pub const DEFAULT_SOLVE_AGENT_ID: &str = "github-solve";
+pub const DEFAULT_SOLVE_TEMPLATE_ID: &str = "holon-github-solve";
+
+#[derive(Debug, Clone)]
+pub struct SolveRequest {
+    pub target_ref: String,
+    pub repo: Option<String>,
+    pub base: Option<String>,
+    pub goal: Option<String>,
+    pub role: Option<String>,
+    pub agent_id: Option<String>,
+    pub template: Option<String>,
+    pub max_turns: Option<u64>,
+    pub trust: TrustLevel,
+    pub json: bool,
+    pub workspace_root: Option<PathBuf>,
+    pub cwd: Option<PathBuf>,
+    pub input_dir: Option<PathBuf>,
+    pub output_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GitHubTarget {
+    pub repo: String,
+    pub number: u64,
+    pub kind: GitHubTargetKind,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GitHubTargetKind {
+    IssueOrPullRequest,
+    Issue,
+    PullRequest,
+}
+
+#[derive(Debug, Serialize)]
+struct SolveManifest<'a> {
+    provider: &'static str,
+    status: &'a str,
+    outcome: &'a str,
+    target_ref: &'a str,
+    target: Option<&'a GitHubTarget>,
+    run_json: Option<String>,
+    summary: Option<String>,
+}
+
+pub async fn run_solve(config: AppConfig, request: SolveRequest) -> Result<RunOnceResponse> {
+    let output_dir = prepare_output_dir(request.output_dir.as_deref())?;
+    let input_dir = prepare_input_dir(request.input_dir.as_deref(), &output_dir)?;
+    export_solve_env(&input_dir, &output_dir);
+
+    let target = parse_github_target(&request.target_ref, request.repo.as_deref())?;
+    write_input_metadata(&input_dir, &request, target.as_ref())?;
+
+    let prompt = build_solve_prompt(&request, target.as_ref(), &output_dir);
+    let agent_id = request
+        .agent_id
+        .clone()
+        .unwrap_or_else(|| DEFAULT_SOLVE_AGENT_ID.to_string());
+    let template = request
+        .template
+        .clone()
+        .unwrap_or_else(|| DEFAULT_SOLVE_TEMPLATE_ID.to_string());
+
+    let run_request = RunOnceRequest {
+        text: prompt,
+        trust: request.trust.clone(),
+        agent_id: Some(agent_id.clone()),
+        create_agent: true,
+        template: Some(template),
+        max_turns: request.max_turns,
+        wait_for_tasks: true,
+        workspace_root: request.workspace_root.clone(),
+        cwd: request.cwd.clone(),
+    };
+
+    let response = match run_once(config.clone(), run_request.clone()).await {
+        Ok(response) => response,
+        Err(err) if err.to_string().contains("already exists") => {
+            let retry = RunOnceRequest {
+                create_agent: false,
+                template: None,
+                ..run_request
+            };
+            run_once(config, retry).await?
+        }
+        Err(err) => return Err(err),
+    };
+
+    write_run_artifacts(&output_dir, &request, target.as_ref(), &response)?;
+    Ok(response)
+}
+
+fn prepare_output_dir(output_dir: Option<&Path>) -> Result<PathBuf> {
+    let path = output_dir.map(Path::to_path_buf).unwrap_or_else(|| {
+        std::env::temp_dir().join(format!("holon-output-{}", uuid::Uuid::new_v4()))
+    });
+    fs::create_dir_all(&path)
+        .with_context(|| format!("failed to create output directory {}", path.display()))?;
+    Ok(path)
+}
+
+fn prepare_input_dir(input_dir: Option<&Path>, output_dir: &Path) -> Result<PathBuf> {
+    let path = input_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| output_dir.join("github-context"));
+    fs::create_dir_all(&path)
+        .with_context(|| format!("failed to create input directory {}", path.display()))?;
+    Ok(path)
+}
+
+fn export_solve_env(input_dir: &Path, output_dir: &Path) {
+    std::env::set_var("GITHUB_INPUT_DIR", input_dir);
+    std::env::set_var("GITHUB_CONTEXT_DIR", input_dir);
+    std::env::set_var("GITHUB_OUTPUT_DIR", output_dir);
+}
+
+pub fn parse_github_target(
+    target_ref: &str,
+    repo_hint: Option<&str>,
+) -> Result<Option<GitHubTarget>> {
+    let trimmed = target_ref.trim();
+    if trimmed.is_empty() {
+        bail!("solve ref must not be empty");
+    }
+
+    if let Some((repo, number, kind)) = parse_github_url(trimmed)? {
+        return Ok(Some(GitHubTarget {
+            repo: repo.clone(),
+            number,
+            kind,
+            url: target_url(&repo, number, kind),
+        }));
+    }
+
+    if let Some(number) = trimmed.strip_prefix('#') {
+        let repo = repo_hint.ok_or_else(|| anyhow!("numeric ref requires --repo"))?;
+        validate_repo(repo)?;
+        let number = parse_number(number)?;
+        return Ok(Some(GitHubTarget {
+            repo: repo.to_string(),
+            number,
+            kind: GitHubTargetKind::IssueOrPullRequest,
+            url: target_url(repo, number, GitHubTargetKind::IssueOrPullRequest),
+        }));
+    }
+
+    if let Some((repo, number)) = trimmed.split_once('#') {
+        let repo = repo.trim();
+        validate_repo(repo)?;
+        let number = parse_number(number)?;
+        return Ok(Some(GitHubTarget {
+            repo: repo.to_string(),
+            number,
+            kind: GitHubTargetKind::IssueOrPullRequest,
+            url: target_url(repo, number, GitHubTargetKind::IssueOrPullRequest),
+        }));
+    }
+
+    Ok(None)
+}
+
+fn parse_github_url(raw: &str) -> Result<Option<(String, u64, GitHubTargetKind)>> {
+    let Ok(url) = reqwest::Url::parse(raw) else {
+        return Ok(None);
+    };
+    if url.host_str() != Some("github.com") {
+        return Ok(None);
+    }
+    let segments = url
+        .path_segments()
+        .map(|segments| segments.collect::<Vec<_>>())
+        .unwrap_or_default();
+    if segments.len() < 4 {
+        return Ok(None);
+    }
+    let repo = format!("{}/{}", segments[0], segments[1]);
+    validate_repo(&repo)?;
+    let kind = match segments[2] {
+        "issues" => GitHubTargetKind::Issue,
+        "pull" => GitHubTargetKind::PullRequest,
+        _ => return Ok(None),
+    };
+    Ok(Some((repo, parse_number(segments[3])?, kind)))
+}
+
+fn validate_repo(repo: &str) -> Result<()> {
+    let parts = repo.split('/').collect::<Vec<_>>();
+    if parts.len() != 2 || parts.iter().any(|part| part.trim().is_empty()) {
+        bail!("repo must be in owner/repo format: {repo}");
+    }
+    Ok(())
+}
+
+fn parse_number(raw: &str) -> Result<u64> {
+    raw.trim()
+        .parse::<u64>()
+        .with_context(|| format!("invalid GitHub issue/PR number: {raw}"))
+}
+
+fn target_url(repo: &str, number: u64, kind: GitHubTargetKind) -> String {
+    let path = match kind {
+        GitHubTargetKind::IssueOrPullRequest | GitHubTargetKind::Issue => "issues",
+        GitHubTargetKind::PullRequest => "pull",
+    };
+    format!("https://github.com/{repo}/{path}/{number}")
+}
+
+pub fn build_solve_prompt(
+    request: &SolveRequest,
+    target: Option<&GitHubTarget>,
+    output_dir: &Path,
+) -> String {
+    let mut sections = Vec::new();
+    sections.push(
+        "You are running Holon solve, a GitHub task preset built on top of holon run.".to_string(),
+    );
+
+    match target {
+        Some(target) => {
+            sections.push(format!(
+                "Target: {} #{} ({})\nURL: {}",
+                target.repo,
+                target.number,
+                match target.kind {
+                    GitHubTargetKind::IssueOrPullRequest => "issue_or_pull_request",
+                    GitHubTargetKind::Issue => "issue",
+                    GitHubTargetKind::PullRequest => "pull_request",
+                },
+                target.url
+            ));
+        }
+        None => sections.push(format!("Target ref: {}", request.target_ref)),
+    }
+
+    if let Some(base) = request.base.as_deref().filter(|value| !value.is_empty()) {
+        sections.push(format!("Base branch hint: {base}"));
+    }
+    if let Some(role) = request.role.as_deref().filter(|value| !value.is_empty()) {
+        sections.push(format!("Role hint: {role}"));
+    }
+    if let Some(goal) = request.goal.as_deref().filter(|value| !value.is_empty()) {
+        sections.push(format!("User goal:\n{goal}"));
+    } else {
+        sections.push(default_goal(target));
+    }
+
+    sections.push(format!(
+        "Output contract:\n- Write a concise human summary to {}/summary.md.\n- Write machine-readable execution status to {}/manifest.json.\n- Include any PR URL, comment URL, branch, commit SHA, verification commands, and residual blockers when available.",
+        output_dir.display(),
+        output_dir.display()
+    ));
+    sections.push(
+        "GitHub operating rules:\n- Use GITHUB_TOKEN or GH_TOKEN when publishing through gh.\n- The repository checkout is already prepared by the caller; do not clone by default.\n- If code changes are required, create or reuse an appropriate branch, commit intentionally, push, and create or update a PR yourself.\n- If this is a review-only task, publish one structured review or comment only when the requested skill workflow calls for it.\n- Prefer the github-issue-solve, github-pr-fix, github-review, and ghx skills when their descriptions match the target."
+            .to_string(),
+    );
+    sections.join("\n\n")
+}
+
+fn default_goal(target: Option<&GitHubTarget>) -> String {
+    match target.map(|target| target.kind) {
+        Some(GitHubTargetKind::PullRequest) => {
+            "Default goal: fix or review the target pull request according to the trigger context.".to_string()
+        }
+        Some(GitHubTargetKind::Issue) => {
+            "Default goal: solve the target issue end to end and publish the result.".to_string()
+        }
+        _ => {
+            "Default goal: inspect the target, determine whether it is an issue or pull request, then choose the appropriate GitHub skill workflow.".to_string()
+        }
+    }
+}
+
+fn write_input_metadata(
+    input_dir: &Path,
+    request: &SolveRequest,
+    target: Option<&GitHubTarget>,
+) -> Result<()> {
+    #[derive(Serialize)]
+    struct InputMetadata<'a> {
+        target_ref: &'a str,
+        target: Option<&'a GitHubTarget>,
+        repo_hint: Option<&'a str>,
+        base: Option<&'a str>,
+        role: Option<&'a str>,
+        goal: Option<&'a str>,
+    }
+
+    let metadata = InputMetadata {
+        target_ref: &request.target_ref,
+        target,
+        repo_hint: request.repo.as_deref(),
+        base: request.base.as_deref(),
+        role: request.role.as_deref(),
+        goal: request.goal.as_deref(),
+    };
+    let content = serde_json::to_vec_pretty(&metadata)?;
+    fs::write(input_dir.join("solve.json"), content)
+        .with_context(|| format!("failed to write {}", input_dir.join("solve.json").display()))
+}
+
+fn write_run_artifacts(
+    output_dir: &Path,
+    request: &SolveRequest,
+    target: Option<&GitHubTarget>,
+    response: &RunOnceResponse,
+) -> Result<()> {
+    let run_json_path = output_dir.join("run.json");
+    fs::write(&run_json_path, serde_json::to_vec_pretty(response)?)
+        .with_context(|| format!("failed to write {}", run_json_path.display()))?;
+
+    let summary_path = output_dir.join("summary.md");
+    if !summary_path.exists() {
+        fs::write(&summary_path, response.render_text())
+            .with_context(|| format!("failed to write {}", summary_path.display()))?;
+    }
+
+    let manifest_path = output_dir.join("manifest.json");
+    if !manifest_path.exists() {
+        let status = match response.final_status {
+            RunFinalStatus::Completed => "completed",
+            RunFinalStatus::Waiting => "waiting",
+            RunFinalStatus::Failed => "failed",
+            RunFinalStatus::MaxTurnsExceeded => "max_turns_exceeded",
+        };
+        let outcome = if response.final_status == RunFinalStatus::Completed {
+            "success"
+        } else {
+            "incomplete"
+        };
+        let manifest = SolveManifest {
+            provider: "holon-solve",
+            status,
+            outcome,
+            target_ref: &request.target_ref,
+            target,
+            run_json: Some(run_json_path.display().to_string()),
+            summary: Some(summary_path.display().to_string()),
+        };
+        fs::write(&manifest_path, serde_json::to_vec_pretty(&manifest)?)
+            .with_context(|| format!("failed to write {}", manifest_path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(target_ref: &str) -> SolveRequest {
+        SolveRequest {
+            target_ref: target_ref.to_string(),
+            repo: None,
+            base: Some("main".into()),
+            goal: None,
+            role: None,
+            agent_id: None,
+            template: None,
+            max_turns: Some(1),
+            trust: TrustLevel::TrustedOperator,
+            json: true,
+            workspace_root: None,
+            cwd: None,
+            input_dir: None,
+            output_dir: None,
+        }
+    }
+
+    #[test]
+    fn parse_owner_repo_number_ref() {
+        let target = parse_github_target("holon-run/holon#123", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(target.repo, "holon-run/holon");
+        assert_eq!(target.number, 123);
+        assert_eq!(target.kind, GitHubTargetKind::IssueOrPullRequest);
+    }
+
+    #[test]
+    fn parse_github_pull_url() {
+        let target = parse_github_target("https://github.com/holon-run/holon/pull/753", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(target.repo, "holon-run/holon");
+        assert_eq!(target.number, 753);
+        assert_eq!(target.kind, GitHubTargetKind::PullRequest);
+        assert_eq!(target.url, "https://github.com/holon-run/holon/pull/753");
+    }
+
+    #[test]
+    fn build_prompt_contains_github_skill_contract() {
+        let request = request("holon-run/holon#123");
+        let target = parse_github_target(&request.target_ref, None).unwrap();
+        let prompt = build_solve_prompt(&request, target.as_ref(), Path::new("/tmp/out"));
+        assert!(prompt.contains("github-issue-solve"));
+        assert!(prompt.contains("github-pr-fix"));
+        assert!(prompt.contains("github-review"));
+        assert!(prompt.contains("/tmp/out/manifest.json"));
+    }
+}


### PR DESCRIPTION
## Summary

- add a Rust `holon solve` GitHub preset built on top of `holon run`
- add the `holon-github-solve` builtin agent template with GitHub solve/review/fix skills
- restore the public action and reusable `holon-solve.yml` workflow around the Rust binary and external checkout

## Verification

- `cargo check -q`
- `cargo fmt --all -- --check`
- `cargo test -q solve::tests`
- `cargo test -q github_solve_template_materializes_builtin_skills`
- `actionlint .github/workflows/holon-solve.yml`
- `cargo run -q -- solve --help`
