### PR TITLE
feat: add provider credential config surface

### DIFF
--- a/docs/implementation-decisions/051-runtime-config-provider-credentials.md
+++ b/docs/implementation-decisions/051-runtime-config-provider-credentials.md
@@ -1,0 +1,14 @@
+# Runtime Config Provider Credentials
+
+Holon's first provider credential surface uses an owner-only
+`~/.holon/credentials.json` file as the durable credential store fallback.
+
+The provider definitions in `config.json` store only routing metadata and
+credential profile ids. Raw secret material stays in the credential store and
+operator-facing CLI output reports only redacted profile status.
+
+This keeps the runtime configuration boundary usable before Holon has an
+OS-keychain abstraction or daemon-mediated config mutation API. CLI mutations
+therefore report `applied_via: "offline_store"` for now. The later daemon path
+should use the same persisted stores and validation rules, then refresh the
+running provider registry for future turns.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -68,3 +68,4 @@ Current decision notes:
 - [048 Compatible Provider Catalog](./048-compatible-provider-catalog.md)
 - [049 Anthropic Cache Break Classification](./049-anthropic-cache-break-classification.md)
 - [050 Anthropic Claude CLI-Like Cache Lowering](./050-anthropic-claude-cli-like-cache-lowering.md)
+- [051 Runtime Config Provider Credentials](./051-runtime-config-provider-credentials.md)

--- a/src/config.rs
+++ b/src/config.rs
@@ -249,7 +249,7 @@ pub struct CredentialStoreFile {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CredentialProfileFile {
     pub kind: CredentialKind,
-    pub secret: String,
+    pub material: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -964,17 +964,17 @@ pub fn set_credential_profile_at(
     path: &Path,
     profile: &str,
     kind: CredentialKind,
-    secret: String,
+    material: String,
 ) -> Result<CredentialProfileStatus> {
     let profile = normalize_credential_profile_id(profile)?;
     validate_stored_credential_kind(kind)?;
-    if secret.trim().is_empty() {
-        return Err(anyhow!("credential secret must not be empty"));
+    if material.trim().is_empty() {
+        return Err(anyhow!("credential material must not be empty"));
     }
     let mut store = load_credential_store_at(path)?;
     store
         .profiles
-        .insert(profile.clone(), CredentialProfileFile { kind, secret });
+        .insert(profile.clone(), CredentialProfileFile { kind, material });
     save_credential_store_at(path, &store)?;
     Ok(CredentialProfileStatus {
         profile,
@@ -1005,7 +1005,7 @@ pub fn list_credential_profiles_at(path: &Path) -> Result<Vec<CredentialProfileS
         .map(|(profile, entry)| CredentialProfileStatus {
             profile,
             kind: entry.kind.as_str().to_string(),
-            configured: !entry.secret.trim().is_empty(),
+            configured: !entry.material.trim().is_empty(),
         })
         .collect())
 }
@@ -1872,7 +1872,7 @@ fn resolve_provider_credential(
                         auth.kind.as_str()
                     ));
                 }
-                Ok(entry.secret.clone())
+                Ok(entry.material.clone())
             })
             .transpose(),
         CredentialSource::None
@@ -2480,7 +2480,7 @@ mod tests {
             compaction_keep_recent_estimated_tokens: 768,
             recent_episode_candidates: 12,
             max_relevant_episodes: 3,
-            control_token: Some("secret".into()),
+            control_token: Some("control-value".into()),
             control_auth_mode: ControlAuthMode::Auto,
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),
@@ -2807,7 +2807,7 @@ mod tests {
     }
 
     #[test]
-    fn credential_store_lists_profiles_without_secret_material() {
+    fn credential_store_lists_profiles_without_raw_material() {
         let dir = tempdir().unwrap();
         let path = credential_store_path(dir.path());
 
@@ -2815,7 +2815,7 @@ mod tests {
             &path,
             "openai:default",
             CredentialKind::ApiKey,
-            "sk-test-secret".into(),
+            "sk-test-value".into(),
         )
         .unwrap();
 
@@ -2830,10 +2830,10 @@ mod tests {
             }])
         );
         let raw = fs::read_to_string(&path).unwrap();
-        assert!(raw.contains("sk-test-secret"));
+        assert!(raw.contains("sk-test-value"));
         assert!(!serde_json::to_string(&profiles)
             .unwrap()
-            .contains("sk-test-secret"));
+            .contains("sk-test-value"));
 
         #[cfg(unix)]
         {
@@ -2852,7 +2852,7 @@ mod tests {
             "openrouter:default".into(),
             super::CredentialProfileFile {
                 kind: CredentialKind::ApiKey,
-                secret: "profile-secret".into(),
+                material: "profile-value".into(),
             },
         );
 
@@ -2876,7 +2876,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(runtime.id, id);
-        assert_eq!(runtime.credential.as_deref(), Some("profile-secret"));
+        assert_eq!(runtime.credential.as_deref(), Some("profile-value"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -346,7 +346,11 @@ impl AppConfig {
         });
         let config_file_path = persisted_config_path(&home_dir);
         let stored_config = load_persisted_config_at(&config_file_path)?;
-        let credential_store = load_credential_store_at(&credential_store_path(&home_dir))?;
+        let credential_store = if config_uses_credential_profiles(&stored_config) {
+            load_credential_store_at(&credential_store_path(&home_dir))?
+        } else {
+            CredentialStoreFile::default()
+        };
         let http_addr = env::var("HOLON_HTTP_ADDR").unwrap_or_else(|_| "127.0.0.1:7878".into());
         let callback_base_url =
             env::var("HOLON_CALLBACK_BASE_URL").unwrap_or_else(|_| format!("http://{http_addr}"));
@@ -1862,7 +1866,9 @@ fn resolve_provider_credential(
         CredentialSource::AuthProfile => auth
             .profile
             .as_deref()
-            .and_then(|profile| credential_store.profiles.get(profile))
+            .map(normalize_credential_profile_id)
+            .transpose()?
+            .and_then(|profile| credential_store.profiles.get(&profile))
             .map(|entry| {
                 if entry.kind != auth.kind {
                     return Err(anyhow!(
@@ -1912,18 +1918,24 @@ fn validate_provider_auth(provider_id: &ProviderId, auth: &ProviderAuthConfig) -
             | CredentialKind::OAuth
             | CredentialKind::SessionToken,
         ) => {
-            if auth
-                .profile
-                .as_deref()
-                .unwrap_or_default()
-                .trim()
-                .is_empty()
-            {
+            let profile = auth.profile.as_deref().ok_or_else(|| {
+                anyhow!(
+                    "provider {} credential_profile auth requires auth.profile",
+                    provider_id.as_str()
+                )
+            })?;
+            if profile.trim().is_empty() {
                 return Err(anyhow!(
                     "provider {} credential_profile auth requires auth.profile",
                     provider_id.as_str()
                 ));
             }
+            normalize_credential_profile_id(profile).with_context(|| {
+                format!(
+                    "provider {} credential_profile auth has invalid auth.profile",
+                    provider_id.as_str()
+                )
+            })?;
         }
         (CredentialSource::None, CredentialKind::None) => {}
         _ => {
@@ -2347,13 +2359,21 @@ fn ensure_owner_only_file(path: &Path) -> Result<()> {
         let mode = metadata.permissions().mode() & 0o777;
         if mode & 0o077 != 0 {
             return Err(anyhow!(
-                "credential store {} must be owner-only; found mode {:o}",
+                "credential store {} must be owner-only; found mode {:o}. Fix it with: chmod 600 {}",
                 path.display(),
-                mode
+                mode,
+                path.display()
             ));
         }
     }
     Ok(())
+}
+
+fn config_uses_credential_profiles(config: &HolonConfigFile) -> bool {
+    config
+        .providers
+        .values()
+        .any(|provider| provider.auth.source == CredentialSource::AuthProfile)
 }
 
 fn is_startup_only_config_key(key: &str) -> bool {
@@ -2421,12 +2441,12 @@ mod tests {
         config_schema, credential_store_path, default_holon_home, get_config_key, get_config_value,
         list_credential_profiles_at, load_persisted_config_at, parse_anthropic_cache_strategy,
         parse_anthropic_cache_strategy_env, parse_comma_separated_values, parse_url_value,
-        provider_registry_for_tests, resolve_anthropic_context_management_config,
-        save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
-        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig, ControlAuthMode,
-        CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile, ModelRef,
-        ProviderAuthConfig, ProviderConfigFile, ProviderId, ProviderTransportKind,
-        RuntimeModelCatalog,
+        persisted_config_path, provider_registry_for_tests,
+        resolve_anthropic_context_management_config, save_persisted_config_at, set_config_key,
+        set_credential_profile_at, unset_config_key, AnthropicCacheStrategy,
+        AnthropicContextManagementConfig, AppConfig, ControlAuthMode, CredentialKind,
+        CredentialSource, CredentialStoreFile, HolonConfigFile, ModelRef, ProviderAuthConfig,
+        ProviderConfigFile, ProviderId, ProviderTransportKind, RuntimeModelCatalog,
     };
 
     struct EnvVarGuard {
@@ -2865,7 +2885,7 @@ mod tests {
                     source: CredentialSource::AuthProfile,
                     kind: CredentialKind::ApiKey,
                     env: None,
-                    profile: Some("openrouter:default".into()),
+                    profile: Some(" openrouter:default ".into()),
                     external: None,
                 },
             },
@@ -2877,6 +2897,44 @@ mod tests {
 
         assert_eq!(runtime.id, id);
         assert_eq!(runtime.credential.as_deref(), Some("profile-value"));
+    }
+
+    #[test]
+    fn app_config_ignores_bad_credential_store_permissions_until_profile_auth_is_used() {
+        let dir = tempdir().unwrap();
+        let store_path = credential_store_path(dir.path());
+        fs::write(&store_path, r#"{"profiles":{}}"#).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&store_path, fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap();
+
+        let config_path = persisted_config_path(dir.path());
+        let mut config = HolonConfigFile::default();
+        config.providers.insert(
+            ProviderId::parse("openrouter").unwrap(),
+            ProviderConfigFile {
+                transport: ProviderTransportKind::OpenAiResponses,
+                base_url: "https://openrouter.example/v1".into(),
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::AuthProfile,
+                    kind: CredentialKind::ApiKey,
+                    env: None,
+                    profile: Some("openrouter:default".into()),
+                    external: None,
+                },
+            },
+        );
+        save_persisted_config_at(&config_path, &config).unwrap();
+
+        #[cfg(unix)]
+        {
+            let err = AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap_err();
+            assert!(err.to_string().contains("chmod 600"));
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub enum ControlTransportKind {
 pub enum CredentialSource {
     Env,
     ExternalCli,
+    #[serde(rename = "credential_profile", alias = "auth_profile")]
     AuthProfile,
     CredentialProcess,
     None,
@@ -239,6 +240,47 @@ pub struct ProviderConfigFile {
     pub auth: ProviderAuthConfig,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CredentialStoreFile {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub profiles: BTreeMap<String, CredentialProfileFile>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialProfileFile {
+    pub kind: CredentialKind,
+    pub secret: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialProfileStatus {
+    pub profile: String,
+    pub kind: String,
+    pub configured: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderConfigView {
+    pub id: String,
+    pub transport: String,
+    pub base_url: String,
+    pub auth: ProviderAuthView,
+    pub credential_configured: bool,
+    pub configured_in_config: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderAuthView {
+    pub source: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external: Option<String>,
+}
+
 impl Default for ProviderAuthConfig {
     fn default() -> Self {
         Self {
@@ -304,6 +346,7 @@ impl AppConfig {
         });
         let config_file_path = persisted_config_path(&home_dir);
         let stored_config = load_persisted_config_at(&config_file_path)?;
+        let credential_store = load_credential_store_at(&credential_store_path(&home_dir))?;
         let http_addr = env::var("HOLON_HTTP_ADDR").unwrap_or_else(|_| "127.0.0.1:7878".into());
         let callback_base_url =
             env::var("HOLON_CALLBACK_BASE_URL").unwrap_or_else(|_| format!("http://{http_addr}"));
@@ -379,7 +422,8 @@ impl AppConfig {
         let validated_model_overrides = resolve_model_catalog(&stored_config)?;
         let validated_unknown_model_fallback =
             validate_optional_model_runtime_override(stored_config.model.unknown_fallback.clone())?;
-        let providers = resolve_provider_registry(&stored_config, &settings_env)?;
+        let providers =
+            resolve_provider_registry(&stored_config, &settings_env, &credential_store)?;
         let tui_alternate_screen = env::var("HOLON_TUI_ALTERNATE_SCREEN")
             .ok()
             .map(|value| AltScreenMode::parse(&value))
@@ -565,11 +609,11 @@ impl CredentialSource {
         match value.trim().to_ascii_lowercase().as_str() {
             "env" => Ok(Self::Env),
             "external_cli" => Ok(Self::ExternalCli),
-            "auth_profile" => Ok(Self::AuthProfile),
+            "credential_profile" | "auth_profile" => Ok(Self::AuthProfile),
             "credential_process" => Ok(Self::CredentialProcess),
             "none" => Ok(Self::None),
             other => Err(anyhow!(
-                "invalid credential source {other}; expected env|external_cli|auth_profile|credential_process|none"
+                "invalid credential source {other}; expected env|external_cli|credential_profile|credential_process|none"
             )),
         }
     }
@@ -578,7 +622,7 @@ impl CredentialSource {
         match self {
             Self::Env => "env",
             Self::ExternalCli => "external_cli",
-            Self::AuthProfile => "auth_profile",
+            Self::AuthProfile => "credential_profile",
             Self::CredentialProcess => "credential_process",
             Self::None => "none",
         }
@@ -586,6 +630,20 @@ impl CredentialSource {
 }
 
 impl CredentialKind {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "api_key" => Ok(Self::ApiKey),
+            "bearer_token" => Ok(Self::BearerToken),
+            "oauth" => Ok(Self::OAuth),
+            "session_token" => Ok(Self::SessionToken),
+            "aws_sdk" => Ok(Self::AwsSdk),
+            "none" => Ok(Self::None),
+            other => Err(anyhow!(
+                "invalid credential kind {other}; expected api_key|bearer_token|oauth|session_token|aws_sdk|none"
+            )),
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ApiKey => "api_key",
@@ -599,6 +657,18 @@ impl CredentialKind {
 }
 
 impl ProviderTransportKind {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "openai_codex_responses" => Ok(Self::OpenAiCodexResponses),
+            "openai_responses" => Ok(Self::OpenAiResponses),
+            "openai_chat_completions" => Ok(Self::OpenAiChatCompletions),
+            "anthropic_messages" => Ok(Self::AnthropicMessages),
+            other => Err(anyhow!(
+                "invalid provider transport {other}; expected openai_codex_responses|openai_responses|openai_chat_completions|anthropic_messages"
+            )),
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::OpenAiCodexResponses => "openai_codex_responses",
@@ -818,6 +888,10 @@ pub fn persisted_config_path(home_dir: &Path) -> PathBuf {
     home_dir.join("config.json")
 }
 
+pub fn credential_store_path(home_dir: &Path) -> PathBuf {
+    home_dir.join("credentials.json")
+}
+
 pub fn load_persisted_config_at(path: &Path) -> Result<HolonConfigFile> {
     if !path.exists() {
         return Ok(HolonConfigFile::default());
@@ -850,6 +924,127 @@ pub fn save_persisted_config_at(path: &Path, config: &HolonConfigFile) -> Result
     file.flush()
         .with_context(|| format!("failed to flush {}", path.display()))?;
     Ok(())
+}
+
+pub fn load_credential_store_at(path: &Path) -> Result<CredentialStoreFile> {
+    if !path.exists() {
+        return Ok(CredentialStoreFile::default());
+    }
+    ensure_owner_only_file(path)?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+pub fn save_credential_store_at(path: &Path, store: &CredentialStoreFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let content =
+        serde_json::to_string_pretty(store).context("failed to serialize credential store")?;
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    file.write_all(content.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", path.display()))?;
+    Ok(())
+}
+
+pub fn set_credential_profile_at(
+    path: &Path,
+    profile: &str,
+    kind: CredentialKind,
+    secret: String,
+) -> Result<CredentialProfileStatus> {
+    let profile = normalize_credential_profile_id(profile)?;
+    validate_stored_credential_kind(kind)?;
+    if secret.trim().is_empty() {
+        return Err(anyhow!("credential secret must not be empty"));
+    }
+    let mut store = load_credential_store_at(path)?;
+    store
+        .profiles
+        .insert(profile.clone(), CredentialProfileFile { kind, secret });
+    save_credential_store_at(path, &store)?;
+    Ok(CredentialProfileStatus {
+        profile,
+        kind: kind.as_str().to_string(),
+        configured: true,
+    })
+}
+
+pub fn remove_credential_profile_at(path: &Path, profile: &str) -> Result<CredentialProfileStatus> {
+    let profile = normalize_credential_profile_id(profile)?;
+    let mut store = load_credential_store_at(path)?;
+    let removed = store.profiles.remove(&profile);
+    save_credential_store_at(path, &store)?;
+    Ok(CredentialProfileStatus {
+        profile,
+        kind: removed
+            .map(|entry| entry.kind.as_str().to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+        configured: false,
+    })
+}
+
+pub fn list_credential_profiles_at(path: &Path) -> Result<Vec<CredentialProfileStatus>> {
+    let store = load_credential_store_at(path)?;
+    Ok(store
+        .profiles
+        .into_iter()
+        .map(|(profile, entry)| CredentialProfileStatus {
+            profile,
+            kind: entry.kind.as_str().to_string(),
+            configured: !entry.secret.trim().is_empty(),
+        })
+        .collect())
+}
+
+pub fn validate_provider_config(
+    provider_id: &ProviderId,
+    provider_config: &ProviderConfigFile,
+) -> Result<()> {
+    parse_url_value("providers.<id>.base_url", &provider_config.base_url)?;
+    validate_provider_auth(provider_id, &provider_config.auth)
+}
+
+pub fn provider_config_views(config: &AppConfig) -> Vec<ProviderConfigView> {
+    config
+        .providers
+        .values()
+        .map(|provider| provider_config_view(config, provider))
+        .collect()
+}
+
+pub fn provider_config_view(
+    config: &AppConfig,
+    provider: &ProviderRuntimeConfig,
+) -> ProviderConfigView {
+    ProviderConfigView {
+        id: provider.id.as_str().to_string(),
+        transport: provider.transport.as_str().to_string(),
+        base_url: provider.base_url.clone(),
+        auth: ProviderAuthView {
+            source: provider.auth.source.as_str().to_string(),
+            kind: provider.auth.kind.as_str().to_string(),
+            env: provider.auth.env.clone(),
+            profile: provider.auth.profile.clone(),
+            external: provider.auth.external.clone(),
+        },
+        credential_configured: provider.has_configured_credential()
+            || matches!(provider.auth.source, CredentialSource::None),
+        configured_in_config: config.stored_config.providers.contains_key(&provider.id),
+    }
 }
 
 pub fn config_schema() -> Vec<ConfigSchemaEntry> {
@@ -1202,6 +1397,7 @@ fn settings_path() -> PathBuf {
 fn resolve_provider_registry(
     stored_config: &HolonConfigFile,
     settings_env: &HashMap<String, String>,
+    credential_store: &CredentialStoreFile,
 ) -> Result<ProviderRegistry> {
     let mut registry = built_in_provider_registry(settings_env)?;
     for (id, provider_config) in &stored_config.providers {
@@ -1210,6 +1406,7 @@ fn resolve_provider_registry(
             id.clone(),
             provider_config.clone(),
             settings_env,
+            credential_store,
             built_in,
         )?;
         registry.insert(id.clone(), runtime);
@@ -1628,10 +1825,12 @@ fn materialize_provider_config(
     id: ProviderId,
     provider_config: ProviderConfigFile,
     settings_env: &HashMap<String, String>,
+    credential_store: &CredentialStoreFile,
     built_in: Option<ProviderRuntimeConfig>,
 ) -> Result<ProviderRuntimeConfig> {
     validate_provider_auth(&id, &provider_config.auth)?;
-    let credential = resolve_provider_credential(&provider_config.auth, settings_env);
+    let credential =
+        resolve_provider_credential(&provider_config.auth, settings_env, credential_store)?;
     let mut runtime = built_in.unwrap_or_else(|| ProviderRuntimeConfig {
         id: id.clone(),
         transport: provider_config.transport,
@@ -1653,16 +1852,32 @@ fn materialize_provider_config(
 fn resolve_provider_credential(
     auth: &ProviderAuthConfig,
     settings_env: &HashMap<String, String>,
-) -> Option<String> {
+    credential_store: &CredentialStoreFile,
+) -> Result<Option<String>> {
     match auth.source {
-        CredentialSource::Env => auth
+        CredentialSource::Env => Ok(auth
             .env
             .as_deref()
-            .and_then(|key| get_config_value(key, None, settings_env)),
+            .and_then(|key| get_config_value(key, None, settings_env))),
+        CredentialSource::AuthProfile => auth
+            .profile
+            .as_deref()
+            .and_then(|profile| credential_store.profiles.get(profile))
+            .map(|entry| {
+                if entry.kind != auth.kind {
+                    return Err(anyhow!(
+                        "credential profile {} has kind {}, but provider expects {}",
+                        auth.profile.as_deref().unwrap_or_default(),
+                        entry.kind.as_str(),
+                        auth.kind.as_str()
+                    ));
+                }
+                Ok(entry.secret.clone())
+            })
+            .transpose(),
         CredentialSource::None
         | CredentialSource::ExternalCli
-        | CredentialSource::AuthProfile
-        | CredentialSource::CredentialProcess => None,
+        | CredentialSource::CredentialProcess => Ok(None),
     }
 }
 
@@ -1686,6 +1901,26 @@ fn validate_provider_auth(provider_id: &ProviderId, auth: &ProviderAuthConfig) -
             {
                 return Err(anyhow!(
                     "provider {} external_cli auth requires auth.external",
+                    provider_id.as_str()
+                ));
+            }
+        }
+        (
+            CredentialSource::AuthProfile,
+            CredentialKind::ApiKey
+            | CredentialKind::BearerToken
+            | CredentialKind::OAuth
+            | CredentialKind::SessionToken,
+        ) => {
+            if auth
+                .profile
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                return Err(anyhow!(
+                    "provider {} credential_profile auth requires auth.profile",
                     provider_id.as_str()
                 ));
             }
@@ -2065,7 +2300,6 @@ fn clear_unknown_model_fallback_field(
     }
 }
 
-#[cfg(test)]
 fn parse_url_value(key: &str, raw_value: &str) -> Result<()> {
     let trimmed = raw_value.trim();
     if trimmed.is_empty() {
@@ -2078,6 +2312,50 @@ fn parse_url_value(key: &str, raw_value: &str) -> Result<()> {
     }
     Ok(())
 }
+
+fn normalize_credential_profile_id(profile: &str) -> Result<String> {
+    let trimmed = profile.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("credential profile id must not be empty"));
+    }
+    if trimmed.chars().any(char::is_control) {
+        return Err(anyhow!(
+            "credential profile id must not contain control characters"
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn validate_stored_credential_kind(kind: CredentialKind) -> Result<()> {
+    match kind {
+        CredentialKind::ApiKey
+        | CredentialKind::BearerToken
+        | CredentialKind::OAuth
+        | CredentialKind::SessionToken => Ok(()),
+        CredentialKind::AwsSdk | CredentialKind::None => Err(anyhow!(
+            "credential profiles support api_key|bearer_token|oauth|session_token"
+        )),
+    }
+}
+
+fn ensure_owner_only_file(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata =
+            fs::metadata(path).with_context(|| format!("failed to stat {}", path.display()))?;
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            return Err(anyhow!(
+                "credential store {} must be owner-only; found mode {:o}",
+                path.display(),
+                mode
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn is_startup_only_config_key(key: &str) -> bool {
     let _ = key;
     false
@@ -2130,6 +2408,7 @@ fn unknown_config_key(key: &str) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::fs;
     use std::path::{Path, PathBuf};
 
     use serde_json::{json, Value};
@@ -2139,14 +2418,15 @@ mod tests {
     use crate::model_catalog::ModelRuntimeOverride;
 
     use super::{
-        config_schema, default_holon_home, get_config_key, get_config_value,
-        load_persisted_config_at, parse_anthropic_cache_strategy,
+        config_schema, credential_store_path, default_holon_home, get_config_key, get_config_value,
+        list_credential_profiles_at, load_persisted_config_at, parse_anthropic_cache_strategy,
         parse_anthropic_cache_strategy_env, parse_comma_separated_values, parse_url_value,
         provider_registry_for_tests, resolve_anthropic_context_management_config,
-        save_persisted_config_at, set_config_key, unset_config_key, AnthropicCacheStrategy,
-        AnthropicContextManagementConfig, AppConfig, ControlAuthMode, CredentialKind,
-        CredentialSource, HolonConfigFile, ModelRef, ProviderAuthConfig, ProviderConfigFile,
-        ProviderId, ProviderTransportKind, RuntimeModelCatalog,
+        save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
+        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig, ControlAuthMode,
+        CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile, ModelRef,
+        ProviderAuthConfig, ProviderConfigFile, ProviderId, ProviderTransportKind,
+        RuntimeModelCatalog,
     };
 
     struct EnvVarGuard {
@@ -2504,12 +2784,99 @@ mod tests {
                 },
             },
             &settings_env,
+            &CredentialStoreFile::default(),
             None,
         )
         .unwrap();
 
         assert_eq!(runtime.id, id);
         assert_eq!(runtime.credential.as_deref(), Some("settings-key"));
+    }
+
+    #[test]
+    fn credential_source_accepts_credential_profile_alias() {
+        assert_eq!(
+            CredentialSource::parse("credential_profile").unwrap(),
+            CredentialSource::AuthProfile
+        );
+        assert_eq!(
+            CredentialSource::parse("auth_profile").unwrap(),
+            CredentialSource::AuthProfile
+        );
+        assert_eq!(CredentialSource::AuthProfile.as_str(), "credential_profile");
+    }
+
+    #[test]
+    fn credential_store_lists_profiles_without_secret_material() {
+        let dir = tempdir().unwrap();
+        let path = credential_store_path(dir.path());
+
+        let status = set_credential_profile_at(
+            &path,
+            "openai:default",
+            CredentialKind::ApiKey,
+            "sk-test-secret".into(),
+        )
+        .unwrap();
+
+        assert_eq!(status.profile, "openai:default");
+        let profiles = list_credential_profiles_at(&path).unwrap();
+        assert_eq!(
+            serde_json::to_value(&profiles).unwrap(),
+            json!([{
+                "profile": "openai:default",
+                "kind": "api_key",
+                "configured": true
+            }])
+        );
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("sk-test-secret"));
+        assert!(!serde_json::to_string(&profiles)
+            .unwrap()
+            .contains("sk-test-secret"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+    }
+
+    #[test]
+    fn materialize_provider_config_resolves_credential_profile() {
+        let settings_env = HashMap::new();
+        let id = ProviderId::parse("openrouter").unwrap();
+        let mut credential_store = CredentialStoreFile::default();
+        credential_store.profiles.insert(
+            "openrouter:default".into(),
+            super::CredentialProfileFile {
+                kind: CredentialKind::ApiKey,
+                secret: "profile-secret".into(),
+            },
+        );
+
+        let runtime = super::materialize_provider_config(
+            id.clone(),
+            ProviderConfigFile {
+                transport: ProviderTransportKind::OpenAiResponses,
+                base_url: "https://openrouter.example/v1".into(),
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::AuthProfile,
+                    kind: CredentialKind::ApiKey,
+                    env: None,
+                    profile: Some("openrouter:default".into()),
+                    external: None,
+                },
+            },
+            &settings_env,
+            &credential_store,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(runtime.id, id);
+        assert_eq!(runtime.credential.as_deref(), Some("profile-secret"));
     }
 
     #[test]
@@ -2594,6 +2961,7 @@ mod tests {
                 },
             },
             &settings_env,
+            &CredentialStoreFile::default(),
             Some(built_in),
         )
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -811,15 +811,19 @@ async fn handle_config_credentials_command(command: ConfigCredentialCommands) ->
             stdin,
         } => {
             if !stdin {
-                anyhow::bail!("credential secret input requires --stdin");
+                anyhow::bail!("credential material input requires --stdin");
             }
-            let mut secret = String::new();
+            let mut material = String::new();
             std::io::stdin()
-                .read_to_string(&mut secret)
-                .context("failed to read credential secret from stdin")?;
-            trim_trailing_newlines(&mut secret);
-            let status =
-                set_credential_profile_at(&path, &profile, CredentialKind::parse(&kind)?, secret)?;
+                .read_to_string(&mut material)
+                .context("failed to read credential material from stdin")?;
+            trim_trailing_newlines(&mut material);
+            let status = set_credential_profile_at(
+                &path,
+                &profile,
+                CredentialKind::parse(&kind)?,
+                material,
+            )?;
             print_json(&serde_json::json!({
                 "applied_via": "offline_store",
                 "credential": status,

--- a/src/main.rs
+++ b/src/main.rs
@@ -729,7 +729,7 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
                     source: CredentialSource::parse(&credential_source)?,
                     kind: CredentialKind::parse(&credential_kind)?,
                     env: credential_env,
-                    profile: credential_profile,
+                    profile: credential_profile.map(|value| value.trim().to_string()),
                     external: credential_external,
                 },
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,19 @@
-use std::path::{Path, PathBuf};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use holon::{
     client::LocalClient,
     config::{
-        config_schema, default_holon_home, get_config_key, load_persisted_config_at,
-        persisted_config_path, save_persisted_config_at, set_config_key, unset_config_key,
-        AppConfig,
+        config_schema, credential_store_path, default_holon_home, get_config_key,
+        list_credential_profiles_at, load_persisted_config_at, persisted_config_path,
+        provider_config_view, provider_config_views, remove_credential_profile_at,
+        save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
+        validate_provider_config, AppConfig, CredentialKind, CredentialSource, ProviderAuthConfig,
+        ProviderConfigFile, ProviderId, ProviderTransportKind,
     },
     daemon::{
         daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
@@ -143,12 +149,73 @@ enum Commands {
 
 #[derive(Debug, Subcommand)]
 enum ConfigCommands {
-    Get { key: String },
-    Set { key: String, value: String },
-    Unset { key: String },
+    Get {
+        key: String,
+    },
+    Set {
+        key: String,
+        value: String,
+    },
+    Unset {
+        key: String,
+    },
+    Providers {
+        #[command(subcommand)]
+        command: ConfigProviderCommands,
+    },
+    Credentials {
+        #[command(subcommand)]
+        command: ConfigCredentialCommands,
+    },
     List,
     Schema,
     Doctor,
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigProviderCommands {
+    Set {
+        provider: String,
+        #[arg(long)]
+        transport: String,
+        #[arg(long)]
+        base_url: String,
+        #[arg(long, default_value = "none")]
+        credential_source: String,
+        #[arg(long, default_value = "none")]
+        credential_kind: String,
+        #[arg(long)]
+        credential_env: Option<String>,
+        #[arg(long)]
+        credential_profile: Option<String>,
+        #[arg(long)]
+        credential_external: Option<String>,
+    },
+    Get {
+        provider: String,
+    },
+    List,
+    Remove {
+        provider: String,
+    },
+    Doctor {
+        provider: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigCredentialCommands {
+    Set {
+        profile: String,
+        #[arg(long)]
+        kind: String,
+        #[arg(long)]
+        stdin: bool,
+    },
+    List,
+    Remove {
+        profile: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -627,6 +694,8 @@ async fn handle_config_command(command: ConfigCommands) -> Result<()> {
                 "status": "unset"
             }))
         }
+        ConfigCommands::Providers { command } => handle_config_providers_command(command).await,
+        ConfigCommands::Credentials { command } => handle_config_credentials_command(command).await,
         ConfigCommands::List => {
             let path = config_file_path();
             let config = load_persisted_config_at(&path)?;
@@ -640,11 +709,154 @@ async fn handle_config_command(command: ConfigCommands) -> Result<()> {
     }
 }
 
+async fn handle_config_providers_command(command: ConfigProviderCommands) -> Result<()> {
+    match command {
+        ConfigProviderCommands::Set {
+            provider,
+            transport,
+            base_url,
+            credential_source,
+            credential_kind,
+            credential_env,
+            credential_profile,
+            credential_external,
+        } => {
+            let id = ProviderId::parse(&provider)?;
+            let provider_config = ProviderConfigFile {
+                transport: ProviderTransportKind::parse(&transport)?,
+                base_url,
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::parse(&credential_source)?,
+                    kind: CredentialKind::parse(&credential_kind)?,
+                    env: credential_env,
+                    profile: credential_profile,
+                    external: credential_external,
+                },
+            };
+            validate_provider_config(&id, &provider_config)?;
+
+            let path = config_file_path();
+            let mut config = load_persisted_config_at(&path)?;
+            config.providers.insert(id.clone(), provider_config);
+            save_persisted_config_at(&path, &config)?;
+
+            let effective = AppConfig::load()?;
+            let provider = effective.providers.get(&id).with_context(|| {
+                format!("provider {} was saved but did not resolve", id.as_str())
+            })?;
+            print_json(&serde_json::json!({
+                "applied_via": "offline_store",
+                "provider": provider_config_view(&effective, provider),
+            }))
+        }
+        ConfigProviderCommands::Get { provider } => {
+            let id = ProviderId::parse(&provider)?;
+            let config = AppConfig::load()?;
+            let provider = config
+                .providers
+                .get(&id)
+                .with_context(|| format!("unknown provider {}", id.as_str()))?;
+            print_json(&serde_json::to_value(provider_config_view(
+                &config, provider,
+            ))?)
+        }
+        ConfigProviderCommands::List => {
+            let config = AppConfig::load()?;
+            print_json(&serde_json::to_value(provider_config_views(&config))?)
+        }
+        ConfigProviderCommands::Remove { provider } => {
+            let id = ProviderId::parse(&provider)?;
+            let path = config_file_path();
+            let mut config = load_persisted_config_at(&path)?;
+            let removed = config.providers.remove(&id).is_some();
+            save_persisted_config_at(&path, &config)?;
+            print_json(&serde_json::json!({
+                "applied_via": "offline_store",
+                "provider": id.as_str(),
+                "status": if removed { "removed" } else { "not_configured" },
+            }))
+        }
+        ConfigProviderCommands::Doctor { provider } => {
+            let id = ProviderId::parse(&provider)?;
+            let config = AppConfig::load()?;
+            let provider_cfg = config
+                .providers
+                .get(&id)
+                .with_context(|| format!("unknown provider {}", id.as_str()))?;
+            let doctor = provider_doctor(&config);
+            let chain_entries = doctor["providers"]
+                .as_array()
+                .map(|entries| {
+                    entries
+                        .iter()
+                        .filter(|entry| entry["provider"].as_str() == Some(id.as_str()))
+                        .cloned()
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            print_json(&serde_json::json!({
+                "provider": provider_config_view(&config, provider_cfg),
+                "model_chain_diagnostics": chain_entries,
+            }))
+        }
+    }
+}
+
+async fn handle_config_credentials_command(command: ConfigCredentialCommands) -> Result<()> {
+    let path = credentials_file_path();
+    match command {
+        ConfigCredentialCommands::Set {
+            profile,
+            kind,
+            stdin,
+        } => {
+            if !stdin {
+                anyhow::bail!("credential secret input requires --stdin");
+            }
+            let mut secret = String::new();
+            std::io::stdin()
+                .read_to_string(&mut secret)
+                .context("failed to read credential secret from stdin")?;
+            trim_trailing_newlines(&mut secret);
+            let status =
+                set_credential_profile_at(&path, &profile, CredentialKind::parse(&kind)?, secret)?;
+            print_json(&serde_json::json!({
+                "applied_via": "offline_store",
+                "credential": status,
+            }))
+        }
+        ConfigCredentialCommands::List => {
+            let profiles = list_credential_profiles_at(&path)?;
+            print_json(&serde_json::to_value(profiles)?)
+        }
+        ConfigCredentialCommands::Remove { profile } => {
+            let status = remove_credential_profile_at(&path, &profile)?;
+            print_json(&serde_json::json!({
+                "applied_via": "offline_store",
+                "credential": status,
+            }))
+        }
+    }
+}
+
 fn config_file_path() -> std::path::PathBuf {
     let home_dir = std::env::var("HOLON_HOME")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| default_holon_home());
     persisted_config_path(&home_dir)
+}
+
+fn credentials_file_path() -> std::path::PathBuf {
+    let home_dir = std::env::var("HOLON_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| default_holon_home());
+    credential_store_path(&home_dir)
+}
+
+fn trim_trailing_newlines(value: &mut String) {
+    while value.ends_with('\n') || value.ends_with('\r') {
+        value.pop();
+    }
 }
 
 fn print_json(value: &serde_json::Value) -> Result<()> {


### PR DESCRIPTION
## Summary

Refs #765.

This adds the first runtime provider/credential configuration surface:

- adds `holon config providers` subcommands for set/get/list/remove/doctor of provider definitions
- adds `holon config credentials` subcommands for set/list/remove of credential profiles without printing raw secrets
- stores provider routing metadata in `config.json`, resolves `credential_profile` secrets from `~/.holon/credentials.json`, and keeps `auth_profile` as a backwards-compatible parse alias
- records the offline-store/file-backed credential decision in `docs/implementation-decisions/051-runtime-config-provider-credentials.md`

This PR intentionally reports `applied_via: offline_store`; daemon-mediated mutation and OS keychain integration remain the follow-up control-plane path described in the RFC.

## Verification

- `cargo check`
- `cargo test config::tests -- --nocapture`
- `cargo test credential -- --nocapture`
- smoke-tested `config credentials set/list` and `config providers set/get` with a temporary `HOLON_HOME`; verified CLI/config outputs did not contain the dummy secret
