### PR TITLE
feat: expose active model attempts

### DIFF
--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -11,9 +11,11 @@ use super::{
         classify_provider_error, format_provider_failure, provider_max_attempts,
         provider_retry_backoff, RetryDisposition,
     },
-    AgentProvider, ProviderAttemptOutcome, ProviderAttemptRecord, ProviderAttemptTimeline,
-    ProviderContextManagementPolicy, ProviderTurnRequest, ProviderTurnResponse,
+    AgentProvider, PromptContentBlock, ProviderAttemptOutcome, ProviderAttemptRecord,
+    ProviderAttemptTimeline, ProviderContextManagementPolicy, ProviderTurnRequest,
+    ProviderTurnResponse,
 };
+use crate::prompt::PromptStability;
 
 #[derive(Clone)]
 pub(super) struct FallbackProvider {
@@ -24,8 +26,9 @@ pub(super) struct FallbackProvider {
 mod tests {
     use std::sync::Arc;
 
-    use anyhow::Result;
+    use anyhow::{anyhow, Result};
     use async_trait::async_trait;
+    use tokio::sync::Mutex;
 
     use super::*;
     use crate::provider::{ModelBlock, ProviderCacheUsage};
@@ -33,6 +36,13 @@ mod tests {
     #[derive(Clone)]
     struct PolicyProvider {
         policy: Option<ProviderContextManagementPolicy>,
+    }
+
+    #[derive(Clone)]
+    struct RecordingProvider {
+        name: &'static str,
+        fail: bool,
+        prompts: Arc<Mutex<Vec<String>>>,
     }
 
     #[async_trait]
@@ -59,6 +69,33 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl AgentProvider for RecordingProvider {
+        async fn complete_turn(
+            &self,
+            request: ProviderTurnRequest,
+        ) -> Result<ProviderTurnResponse> {
+            self.prompts.lock().await.push(format!(
+                "{}:{}",
+                self.name, request.prompt_frame.system_prompt
+            ));
+            if self.fail {
+                return Err(anyhow!("forced provider failure"));
+            }
+            Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text { text: "ok".into() }],
+                stop_reason: None,
+                input_tokens: 1,
+                output_tokens: 1,
+                cache_usage: Some(ProviderCacheUsage {
+                    read_input_tokens: 0,
+                    creation_input_tokens: 0,
+                }),
+                request_diagnostics: None,
+            })
+        }
+    }
+
     fn policy(trigger_input_tokens: u32) -> ProviderContextManagementPolicy {
         ProviderContextManagementPolicy {
             provider: "anthropic".into(),
@@ -79,6 +116,18 @@ mod tests {
         }
     }
 
+    fn recording_candidate(
+        model_ref: &str,
+        provider_name: &str,
+        provider: RecordingProvider,
+    ) -> ProviderCandidate {
+        ProviderCandidate {
+            model_ref: model_ref.into(),
+            provider_name: provider_name.into(),
+            provider: Arc::new(provider),
+        }
+    }
+
     #[test]
     fn context_management_policy_requires_full_policy_match() {
         let provider = FallbackProvider {
@@ -89,6 +138,93 @@ mod tests {
         };
 
         assert_eq!(provider.context_management_policy(), None);
+    }
+
+    #[tokio::test]
+    async fn model_visible_hint_marks_normal_attempt_with_active_model_only() {
+        let prompts = Arc::new(Mutex::new(Vec::new()));
+        let provider = FallbackProvider {
+            candidates: vec![recording_candidate(
+                "openai/gpt-5.4",
+                "openai",
+                RecordingProvider {
+                    name: "primary",
+                    fail: false,
+                    prompts: prompts.clone(),
+                },
+            )],
+        };
+
+        let (_response, timeline) = provider
+            .complete_turn_with_diagnostics(ProviderTurnRequest::plain(
+                "base",
+                Vec::new(),
+                Vec::new(),
+            ))
+            .await
+            .expect("provider should succeed");
+
+        let recorded = prompts.lock().await;
+        assert_eq!(recorded.len(), 1);
+        assert!(recorded[0].contains("Runtime: active_model=openai/gpt-5.4"));
+        assert!(!recorded[0].contains("requested_model="));
+        let timeline = timeline.expect("timeline");
+        assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
+        assert_eq!(timeline.active_model_ref.as_deref(), Some("openai/gpt-5.4"));
+    }
+
+    #[tokio::test]
+    async fn model_visible_hint_marks_fallback_attempt_with_requested_model() {
+        let prompts = Arc::new(Mutex::new(Vec::new()));
+        let provider = FallbackProvider {
+            candidates: vec![
+                recording_candidate(
+                    "openai/gpt-5.4",
+                    "openai",
+                    RecordingProvider {
+                        name: "primary",
+                        fail: true,
+                        prompts: prompts.clone(),
+                    },
+                ),
+                recording_candidate(
+                    "anthropic/claude-sonnet-4-6",
+                    "anthropic",
+                    RecordingProvider {
+                        name: "fallback",
+                        fail: false,
+                        prompts: prompts.clone(),
+                    },
+                ),
+            ],
+        };
+
+        let (_response, timeline) = provider
+            .complete_turn_with_diagnostics(ProviderTurnRequest::plain(
+                "base",
+                Vec::new(),
+                Vec::new(),
+            ))
+            .await
+            .expect("fallback provider should succeed");
+
+        let recorded = prompts.lock().await;
+        assert_eq!(recorded.len(), 2);
+        assert!(recorded[0].contains("Runtime: active_model=openai/gpt-5.4"));
+        assert!(!recorded[0].contains("requested_model="));
+        assert!(recorded[1].contains(
+            "Runtime: active_model=anthropic/claude-sonnet-4-6 requested_model=openai/gpt-5.4"
+        ));
+        let timeline = timeline.expect("timeline");
+        assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
+        assert_eq!(
+            timeline.active_model_ref.as_deref(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(
+            timeline.winning_model_ref.as_deref(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
     }
 }
 
@@ -103,13 +239,20 @@ impl AgentProvider for FallbackProvider {
         &self,
         request: ProviderTurnRequest,
     ) -> Result<(ProviderTurnResponse, Option<ProviderAttemptTimeline>)> {
+        let requested_model_ref = self
+            .candidates
+            .first()
+            .map(|candidate| candidate.model_ref.clone())
+            .unwrap_or_default();
         let mut errors = Vec::new();
         let mut timeline = Vec::new();
         for (candidate_index, candidate) in self.candidates.iter().enumerate() {
             let max_attempts = provider_max_attempts();
             let mut last_error = None;
             for attempt in 1..=max_attempts {
-                match candidate.provider.complete_turn(request.clone()).await {
+                let attempt_request =
+                    request_for_model_attempt(&request, &requested_model_ref, &candidate.model_ref);
+                match candidate.provider.complete_turn(attempt_request).await {
                     Ok(response) => {
                         timeline.push(ProviderAttemptRecord {
                             provider: candidate.provider_name.clone(),
@@ -130,6 +273,8 @@ impl AgentProvider for FallbackProvider {
                         let diagnostics = ProviderAttemptTimeline {
                             aggregated_token_usage: aggregate_attempt_token_usage(&timeline),
                             attempts: timeline,
+                            requested_model_ref: requested_model_ref.clone(),
+                            active_model_ref: Some(candidate.model_ref.clone()),
                             winning_model_ref: Some(candidate.model_ref.clone()),
                         };
                         return Ok((response, Some(diagnostics)));
@@ -210,6 +355,8 @@ impl AgentProvider for FallbackProvider {
             ProviderAttemptTimeline {
                 aggregated_token_usage: aggregate_attempt_token_usage(&timeline),
                 attempts: timeline,
+                requested_model_ref,
+                active_model_ref: None,
                 winning_model_ref: None,
             },
             source,
@@ -249,5 +396,33 @@ impl AgentProvider for FallbackProvider {
             }
         }
         Some(first)
+    }
+}
+
+fn request_for_model_attempt(
+    request: &ProviderTurnRequest,
+    requested_model_ref: &str,
+    active_model_ref: &str,
+) -> ProviderTurnRequest {
+    let mut request = request.clone();
+    let hint = runtime_model_hint(requested_model_ref, active_model_ref);
+
+    if !request.prompt_frame.system_prompt.trim().is_empty() {
+        request.prompt_frame.system_prompt.push_str("\n\n");
+    }
+    request.prompt_frame.system_prompt.push_str(&hint);
+    request.prompt_frame.system_blocks.push(PromptContentBlock {
+        text: hint,
+        stability: PromptStability::TurnScoped,
+        cache_breakpoint: false,
+    });
+    request
+}
+
+fn runtime_model_hint(requested_model_ref: &str, active_model_ref: &str) -> String {
+    if requested_model_ref == active_model_ref || requested_model_ref.is_empty() {
+        format!("Runtime: active_model={active_model_ref}")
+    } else {
+        format!("Runtime: active_model={active_model_ref} requested_model={requested_model_ref}")
     }
 }

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -31,7 +31,7 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
-    use crate::provider::{ModelBlock, ProviderCacheUsage};
+    use crate::provider::{ModelBlock, ProviderCacheUsage, ProviderPromptFrame};
 
     #[derive(Clone)]
     struct PolicyProvider {
@@ -43,6 +43,7 @@ mod tests {
         name: &'static str,
         fail: bool,
         prompts: Arc<Mutex<Vec<String>>>,
+        system_blocks: Arc<Mutex<Vec<Vec<PromptContentBlock>>>>,
     }
 
     #[async_trait]
@@ -79,6 +80,10 @@ mod tests {
                 "{}:{}",
                 self.name, request.prompt_frame.system_prompt
             ));
+            self.system_blocks
+                .lock()
+                .await
+                .push(request.prompt_frame.system_blocks.clone());
             if self.fail {
                 return Err(anyhow!("forced provider failure"));
             }
@@ -143,6 +148,7 @@ mod tests {
     #[tokio::test]
     async fn model_visible_hint_marks_normal_attempt_with_active_model_only() {
         let prompts = Arc::new(Mutex::new(Vec::new()));
+        let system_blocks = Arc::new(Mutex::new(Vec::new()));
         let provider = FallbackProvider {
             candidates: vec![recording_candidate(
                 "openai/gpt-5.4",
@@ -151,6 +157,7 @@ mod tests {
                     name: "primary",
                     fail: false,
                     prompts: prompts.clone(),
+                    system_blocks: system_blocks.clone(),
                 },
             )],
         };
@@ -168,6 +175,7 @@ mod tests {
         assert_eq!(recorded.len(), 1);
         assert!(recorded[0].contains("Runtime: active_model=openai/gpt-5.4"));
         assert!(!recorded[0].contains("requested_model="));
+        assert!(system_blocks.lock().await[0].is_empty());
         let timeline = timeline.expect("timeline");
         assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
         assert_eq!(timeline.active_model_ref.as_deref(), Some("openai/gpt-5.4"));
@@ -176,6 +184,7 @@ mod tests {
     #[tokio::test]
     async fn model_visible_hint_marks_fallback_attempt_with_requested_model() {
         let prompts = Arc::new(Mutex::new(Vec::new()));
+        let system_blocks = Arc::new(Mutex::new(Vec::new()));
         let provider = FallbackProvider {
             candidates: vec![
                 recording_candidate(
@@ -185,6 +194,7 @@ mod tests {
                         name: "primary",
                         fail: true,
                         prompts: prompts.clone(),
+                        system_blocks: system_blocks.clone(),
                     },
                 ),
                 recording_candidate(
@@ -194,6 +204,7 @@ mod tests {
                         name: "fallback",
                         fail: false,
                         prompts: prompts.clone(),
+                        system_blocks: system_blocks.clone(),
                     },
                 ),
             ],
@@ -215,6 +226,7 @@ mod tests {
         assert!(recorded[1].contains(
             "Runtime: active_model=anthropic/claude-sonnet-4-6 requested_model=openai/gpt-5.4"
         ));
+        assert!(system_blocks.lock().await[0].is_empty());
         let timeline = timeline.expect("timeline");
         assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
         assert_eq!(
@@ -225,6 +237,51 @@ mod tests {
             timeline.winning_model_ref.as_deref(),
             Some("anthropic/claude-sonnet-4-6")
         );
+    }
+
+    #[tokio::test]
+    async fn model_visible_hint_preserves_structured_system_shape_and_marks_cache_breakpoint() {
+        let prompts = Arc::new(Mutex::new(Vec::new()));
+        let system_blocks = Arc::new(Mutex::new(Vec::new()));
+        let provider = FallbackProvider {
+            candidates: vec![recording_candidate(
+                "openai/gpt-5.4",
+                "openai",
+                RecordingProvider {
+                    name: "primary",
+                    fail: false,
+                    prompts: prompts.clone(),
+                    system_blocks: system_blocks.clone(),
+                },
+            )],
+        };
+
+        let request = ProviderTurnRequest {
+            prompt_frame: ProviderPromptFrame::structured(
+                "base",
+                vec![PromptContentBlock {
+                    text: "existing".into(),
+                    stability: PromptStability::Stable,
+                    cache_breakpoint: false,
+                }],
+                Vec::new(),
+                None,
+            ),
+            conversation: Vec::new(),
+            tools: Vec::new(),
+        };
+
+        provider
+            .complete_turn_with_diagnostics(request)
+            .await
+            .expect("provider should succeed");
+
+        let recorded_blocks = system_blocks.lock().await;
+        assert_eq!(recorded_blocks[0].len(), 2);
+        let hint = recorded_blocks[0].last().expect("runtime hint block");
+        assert_eq!(hint.text, "Runtime: active_model=openai/gpt-5.4");
+        assert_eq!(hint.stability, PromptStability::TurnScoped);
+        assert!(hint.cache_breakpoint);
     }
 }
 
@@ -411,11 +468,13 @@ fn request_for_model_attempt(
         request.prompt_frame.system_prompt.push_str("\n\n");
     }
     request.prompt_frame.system_prompt.push_str(&hint);
-    request.prompt_frame.system_blocks.push(PromptContentBlock {
-        text: hint,
-        stability: PromptStability::TurnScoped,
-        cache_breakpoint: false,
-    });
+    if !request.prompt_frame.system_blocks.is_empty() {
+        request.prompt_frame.system_blocks.push(PromptContentBlock {
+            text: hint,
+            stability: PromptStability::TurnScoped,
+            cache_breakpoint: true,
+        });
+    }
     request
 }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -314,6 +314,10 @@ pub struct ProviderAttemptRecord {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderAttemptTimeline {
     pub attempts: Vec<ProviderAttemptRecord>,
+    #[serde(default)]
+    pub requested_model_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_model_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub winning_model_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -493,6 +493,13 @@ impl RuntimeHandle {
             .inner
             .model_catalog
             .effective_model(state.model_override.as_ref());
+        let active_model = state
+            .last_requested_model
+            .as_ref()
+            .filter(|requested| *requested == &effective_model)
+            .and_then(|_| state.last_active_model.clone())
+            .unwrap_or_else(|| effective_model.clone());
+        let fallback_active = active_model != effective_model;
         let effective_chain = self
             .inner
             .model_catalog
@@ -508,7 +515,10 @@ impl RuntimeHandle {
                 crate::types::AgentModelSource::RuntimeDefault
             },
             runtime_default_model: self.inner.model_catalog.default_model.clone(),
-            effective_model,
+            effective_model: effective_model.clone(),
+            requested_model: Some(effective_model),
+            active_model: Some(active_model),
+            fallback_active,
             effective_fallback_models: effective_chain.into_iter().skip(1).collect(),
             override_model: state.model_override.clone(),
             resolved_policy,
@@ -4579,6 +4589,8 @@ mod tests {
                         },
                     ],
                     aggregated_token_usage: Some(TokenUsage::new(12, 6)),
+                    requested_model_ref: "openai/gpt-5.4".into(),
+                    active_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
                     winning_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
                 }),
             ))
@@ -4855,6 +4867,8 @@ mod tests {
                         }),
                     }],
                     aggregated_token_usage: None,
+                    requested_model_ref: "openai/gpt-5.4".into(),
+                    active_model_ref: None,
                     winning_model_ref: None,
                 },
                 anyhow!("bad request"),
@@ -4885,6 +4899,8 @@ mod tests {
                         transport_diagnostics: None,
                     }],
                     aggregated_token_usage: Some(TokenUsage::new(125_166, 0)),
+                    requested_model_ref: "openai-codex/gpt-5.3-codex-spark".into(),
+                    active_model_ref: None,
                     winning_model_ref: None,
                 },
                 anyhow!("context_length_exceeded: input too long"),
@@ -5609,6 +5625,26 @@ mod tests {
             Some("anthropic/claude-sonnet-4-6")
         );
         assert_eq!(
+            timeline["requested_model_ref"].as_str(),
+            Some("openai/gpt-5.4")
+        );
+        assert_eq!(
+            timeline["active_model_ref"].as_str(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(
+            assistant_round.data["requested_model"].as_str(),
+            Some("openai/gpt-5.4")
+        );
+        assert_eq!(
+            assistant_round.data["active_model"].as_str(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(
+            assistant_round.data["fallback_active"].as_bool(),
+            Some(true)
+        );
+        assert_eq!(
             assistant_round.data["token_usage"]["total_tokens"].as_u64(),
             Some(18)
         );
@@ -5634,6 +5670,15 @@ mod tests {
                 .len(),
             2
         );
+        assert_eq!(
+            provider_event.data["requested_model"].as_str(),
+            Some("openai/gpt-5.4")
+        );
+        assert_eq!(
+            provider_event.data["active_model"].as_str(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(provider_event.data["fallback_active"].as_bool(), Some(true));
     }
 
     #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -4,11 +4,12 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::{
+    config::ModelRef,
     prompt::EffectivePrompt,
     provider::{
         provider_attempt_timeline, provider_error_is_context_length_exceeded, AgentProvider,
-        ConversationMessage, ModelBlock, PromptContentBlock, ProviderPromptFrame,
-        ProviderTurnRequest, ToolResultBlock,
+        ConversationMessage, ModelBlock, PromptContentBlock, ProviderAttemptTimeline,
+        ProviderPromptFrame, ProviderTurnRequest, ToolResultBlock,
     },
     runtime::provider_turn::{
         build_continuation_request, build_provider_prompt_frame, build_provider_turn_request,
@@ -255,6 +256,39 @@ fn estimate_prompt_frame_tokens(prompt_frame: &ProviderPromptFrame) -> usize {
         estimate_text_tokens(&prompt_frame.system_prompt)
     } else {
         structured_tokens
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ProviderAttemptModelState {
+    requested_model: Option<ModelRef>,
+    active_model: Option<ModelRef>,
+    fallback_active: bool,
+}
+
+fn provider_attempt_model_state(
+    timeline: Option<&ProviderAttemptTimeline>,
+) -> ProviderAttemptModelState {
+    let Some(timeline) = timeline else {
+        return ProviderAttemptModelState::default();
+    };
+    let requested_model = (!timeline.requested_model_ref.is_empty())
+        .then(|| ModelRef::parse(&timeline.requested_model_ref).ok())
+        .flatten();
+    let active_model = timeline
+        .active_model_ref
+        .as_deref()
+        .or(timeline.winning_model_ref.as_deref())
+        .and_then(|model| ModelRef::parse(model).ok());
+    let fallback_active = requested_model
+        .as_ref()
+        .zip(active_model.as_ref())
+        .is_some_and(|(requested, active)| requested != active);
+
+    ProviderAttemptModelState {
+        requested_model,
+        active_model,
+        fallback_active,
     }
 }
 
@@ -1190,6 +1224,7 @@ impl RuntimeHandle {
             let stop_reason = response.stop_reason.clone();
             let cache_usage = response.cache_usage.clone();
             let request_diagnostics = response.request_diagnostics.clone();
+            let model_attempt_state = provider_attempt_model_state(attempt_timeline.as_ref());
 
             {
                 let mut guard = self.inner.agent.lock().await;
@@ -1200,6 +1235,8 @@ impl RuntimeHandle {
                     response.input_tokens,
                     response.output_tokens,
                 ));
+                guard.state.last_requested_model = model_attempt_state.requested_model.clone();
+                guard.state.last_active_model = model_attempt_state.active_model.clone();
                 self.inner.storage.write_agent(&guard.state)?;
             }
 
@@ -1279,6 +1316,9 @@ impl RuntimeHandle {
                     "prompt_cache_key": effective_prompt.cache_identity.prompt_cache_key.clone(),
                     "working_memory_revision": effective_prompt.cache_identity.working_memory_revision,
                     "compression_epoch": effective_prompt.cache_identity.compression_epoch,
+                    "requested_model": model_attempt_state.requested_model.clone(),
+                    "active_model": model_attempt_state.active_model.clone(),
+                    "fallback_active": model_attempt_state.fallback_active,
                     "context_management": context_management,
                     "provider_request_diagnostics": request_diagnostics.clone(),
                     "provider_attempt_timeline": attempt_timeline,
@@ -1370,6 +1410,9 @@ impl RuntimeHandle {
                             "prompt_cache_key": effective_prompt.cache_identity.prompt_cache_key.clone(),
                             "working_memory_revision": effective_prompt.cache_identity.working_memory_revision,
                             "compression_epoch": effective_prompt.cache_identity.compression_epoch,
+                            "requested_model": model_attempt_state.requested_model,
+                            "active_model": model_attempt_state.active_model,
+                            "fallback_active": model_attempt_state.fallback_active,
                             "context_management": context_management,
                             "provider_request_diagnostics": request_diagnostics,
                             "provider_attempt_timeline": attempt_timeline,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -891,6 +891,13 @@ mod tests {
             model: AgentModelState {
                 effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
                     .unwrap(),
+                requested_model: Some(
+                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                ),
+                active_model: Some(
+                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                ),
+                fallback_active: false,
                 runtime_default_model: crate::config::ModelRef::parse(
                     "anthropic/claude-sonnet-4-6",
                 )

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1570,6 +1570,13 @@ mod tests {
             model: AgentModelState {
                 effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
                     .unwrap(),
+                requested_model: Some(
+                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                ),
+                active_model: Some(
+                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                ),
+                fallback_active: false,
                 runtime_default_model: crate::config::ModelRef::parse(
                     "anthropic/claude-sonnet-4-6",
                 )

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -702,6 +702,13 @@ mod tests {
             model: AgentModelState {
                 effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
                     .unwrap(),
+                requested_model: Some(
+                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                ),
+                active_model: Some(
+                    crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+                ),
+                fallback_active: false,
                 runtime_default_model: crate::config::ModelRef::parse(
                     "anthropic/claude-sonnet-4-6",
                 )

--- a/src/types.rs
+++ b/src/types.rs
@@ -1255,6 +1255,10 @@ pub struct AgentState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_override: Option<ModelRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_requested_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_active_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_turn_terminal: Option<TurnTerminalRecord>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_runtime_failure: Option<RuntimeFailureSummary>,
@@ -1321,6 +1325,8 @@ impl AgentState {
             active_skills: Vec::new(),
             last_continuation: None,
             model_override: None,
+            last_requested_model: None,
+            last_active_model: None,
             last_turn_terminal: None,
             last_runtime_failure: None,
         }
@@ -2559,6 +2565,12 @@ pub struct AgentModelState {
     pub source: AgentModelSource,
     pub runtime_default_model: ModelRef,
     pub effective_model: ModelRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_model: Option<ModelRef>,
+    #[serde(default)]
+    pub fallback_active: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub effective_fallback_models: Vec<ModelRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- inject a model-visible runtime hint for each provider attempt with `active_model`, adding `requested_model` only when fallback changes the attempted model
- persist requested/active model refs in provider attempt timelines, provider round events, assistant transcript entries, and agent model status
- add regression coverage for normal and fallback prompt hints plus runtime event/transcript model state

Closes #774

## Verification
- `cargo test provider::fallback -- --nocapture`
- `cargo test runtime_persists_provider_attempt_timeline_on_successful_round -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check`
