### PR TITLE
feat: add TUI model picker

### DIFF
--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -1,13 +1,12 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
     auth::load_codex_cli_credential,
     config::{AppConfig, CredentialSource, ModelRef, RuntimeModelCatalog},
     context::ContextConfig,
-    model_catalog::ResolvedRuntimeModelPolicy,
+    types::ResolvedModelAvailability,
 };
 
 use super::{build_candidate, classify_provider_error, retry::provider_retry_policy_json};
@@ -59,28 +58,6 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
         "model_availability": model_availability,
         "providers": providers,
     })
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ResolvedModelAvailability {
-    pub model: String,
-    pub provider: String,
-    pub display_name: String,
-    pub metadata_source: String,
-    pub provider_configured: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_source: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transport: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub credential_source: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub credential_kind: Option<String>,
-    pub credential_configured: bool,
-    pub available: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub unavailable_reason: Option<String>,
-    pub policy: ResolvedRuntimeModelPolicy,
 }
 
 pub fn resolved_model_availability(config: &AppConfig) -> Vec<ResolvedModelAvailability> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -64,9 +64,9 @@ use crate::{
         ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerStatus,
         ExternalTriggerSummary, LoadedAgentsMd, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint, Priority, QueueEntryRecord,
-        QueueEntryStatus, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
-        SkillActivationSource, SkillActivationState, SkillsRuntimeView, TaskKind, TaskRecord,
-        TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
+        QueueEntryStatus, ResolvedModelAvailability, RuntimeFailurePhase, RuntimeFailureSummary,
+        RuntimePosture, SkillActivationSource, SkillActivationState, SkillsRuntimeView, TaskKind,
+        TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
         TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
         WaitingIntentSummary, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
@@ -134,6 +134,7 @@ struct RuntimeInner {
     provider: RwLock<Arc<dyn AgentProvider>>,
     provider_reconfig: Option<ProviderReconfigurator>,
     model_catalog: RuntimeModelCatalog,
+    model_availability: Vec<ResolvedModelAvailability>,
     base_context_config: ContextConfig,
     context_config: RwLock<ContextConfig>,
     callback_base_url: String,
@@ -204,6 +205,7 @@ impl RuntimeHandle {
             base_context_config,
             context_config,
             RuntimeModelCatalog::default(),
+            Vec::new(),
             None,
             None,
         )
@@ -231,6 +233,7 @@ impl RuntimeHandle {
             base_context_config,
             context_config,
             model_catalog,
+            Vec::new(),
             None,
             Some(host_bridge),
         )
@@ -247,6 +250,7 @@ impl RuntimeHandle {
         host_bridge: RuntimeHostBridge,
     ) -> Result<Self> {
         let model_catalog = RuntimeModelCatalog::from_config(&config);
+        let model_availability = crate::provider::resolved_model_availability(&config);
         let base_context_config = context_config.clone();
         let mut provider_config = config.clone();
         provider_config.runtime_max_output_tokens = model_catalog
@@ -266,6 +270,7 @@ impl RuntimeHandle {
             base_context_config,
             resolved_context_config,
             model_catalog,
+            model_availability,
             Some(ProviderReconfigurator { config }),
             Some(host_bridge),
         )
@@ -281,6 +286,7 @@ impl RuntimeHandle {
         base_context_config: ContextConfig,
         context_config: ContextConfig,
         model_catalog: RuntimeModelCatalog,
+        model_availability: Vec<ResolvedModelAvailability>,
         provider_reconfig: Option<ProviderReconfigurator>,
         host_bridge: Option<RuntimeHostBridge>,
     ) -> Result<Self> {
@@ -442,6 +448,7 @@ impl RuntimeHandle {
                 provider: RwLock::new(provider),
                 provider_reconfig,
                 model_catalog,
+                model_availability,
                 base_context_config,
                 context_config: RwLock::new(resolved_context_config),
                 callback_base_url,
@@ -523,6 +530,7 @@ impl RuntimeHandle {
             override_model: state.model_override.clone(),
             resolved_policy,
             available_models: self.inner.model_catalog.available_models(),
+            model_availability: self.inner.model_availability.clone(),
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -36,6 +36,7 @@ mod chat;
 mod composer;
 mod input;
 mod logging;
+mod model_picker;
 mod overlay;
 mod projection;
 mod render;
@@ -925,6 +926,7 @@ mod tests {
                     source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
                 },
                 available_models: Vec::new(),
+                model_availability: Vec::new(),
             },
             token_usage: AgentTokenUsageSummary {
                 total: TokenUsage::new(0, 0),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1291,6 +1291,27 @@ mod tests {
         assert_eq!(app.composer.as_str(), "");
     }
 
+    #[tokio::test]
+    async fn slash_model_opens_model_picker_overlay() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/model");
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .unwrap();
+        assert_eq!(
+            app.overlay,
+            OverlayState::ModelPicker {
+                filter: String::new(),
+                selected: 0
+            }
+        );
+        assert_eq!(app.composer.as_str(), "");
+    }
+
     #[test]
     fn centered_rect_rows_uses_fixed_height() {
         let area = Rect::new(0, 0, 100, 40);

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -5,6 +5,7 @@ enum SlashCommand {
     Help,
     Agents,
     Events,
+    Model,
     Tasks,
     Transcript,
     Refresh,
@@ -25,7 +26,7 @@ struct SlashCommandSpec {
     command: SlashCommand,
 }
 
-const SLASH_COMMAND_SPECS: [SlashCommandSpec; 8] = [
+const SLASH_COMMAND_SPECS: [SlashCommandSpec; 9] = [
     SlashCommandSpec {
         name: "/help",
         description: "show slash command help",
@@ -40,6 +41,11 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 8] = [
         name: "/events",
         description: "open raw events overlay",
         command: SlashCommand::Events,
+    },
+    SlashCommandSpec {
+        name: "/model",
+        description: "open selected agent model picker",
+        command: SlashCommand::Model,
     },
     SlashCommandSpec {
         name: "/tasks",
@@ -208,6 +214,13 @@ impl TuiApp {
                 };
                 self.status_line = "Opened raw events overlay".into();
             }
+            SlashCommand::Model => {
+                self.overlay = OverlayState::ModelPicker {
+                    filter: String::new(),
+                    selected: 0,
+                };
+                self.status_line = "Opened model picker".into();
+            }
             SlashCommand::Tasks => {
                 self.overlay = OverlayState::Tasks {
                     selected: 0,
@@ -320,6 +333,53 @@ impl TuiApp {
                             selected,
                             detail_scroll,
                         };
+                    }
+                }
+                Ok(())
+            }
+            OverlayState::ModelPicker {
+                mut filter,
+                mut selected,
+            } => {
+                match key.code {
+                    KeyCode::Esc => {}
+                    KeyCode::Enter => {
+                        self.apply_model_picker_selection(&filter, selected).await?;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        selected = selected.saturating_sub(1);
+                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        let max = crate::tui::model_picker::model_picker_rows(
+                            self.selected_agent_summary(),
+                            &filter,
+                        )
+                        .len()
+                        .saturating_sub(1);
+                        selected = (selected + 1).min(max);
+                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                    }
+                    KeyCode::Backspace => {
+                        filter.pop();
+                        selected = crate::tui::model_picker::clamp_model_picker_selection(
+                            self.selected_agent_summary(),
+                            &filter,
+                            selected,
+                        );
+                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                    }
+                    KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        filter.push(ch);
+                        selected = crate::tui::model_picker::clamp_model_picker_selection(
+                            self.selected_agent_summary(),
+                            &filter,
+                            selected,
+                        );
+                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                    }
+                    _ => {
+                        self.overlay = OverlayState::ModelPicker { filter, selected };
                     }
                 }
                 Ok(())
@@ -455,6 +515,36 @@ impl TuiApp {
         }
     }
 
+    async fn apply_model_picker_selection(&mut self, filter: &str, selected: usize) -> Result<()> {
+        let agent_id = self
+            .selected_agent_id()
+            .ok_or_else(|| anyhow!("no agent selected"))?
+            .to_string();
+        let choice = crate::tui::model_picker::selected_model_choice(
+            self.selected_agent_summary(),
+            filter,
+            selected,
+        )
+        .ok_or_else(|| anyhow!("no model selection available"))?;
+
+        match choice {
+            crate::tui::model_picker::ModelPickerChoice::InheritDefault => {
+                self.client.clear_agent_model_override(&agent_id).await?;
+                self.status_line =
+                    format!("Cleared model override for {agent_id}; inheriting runtime default");
+            }
+            crate::tui::model_picker::ModelPickerChoice::Model { model } => {
+                self.client
+                    .set_agent_model_override(&agent_id, model.clone())
+                    .await?;
+                self.status_line = format!("Set model override for {agent_id} to {model}");
+            }
+        }
+        self.overlay = OverlayState::None;
+        self.bootstrap_selected_agent().await?;
+        Ok(())
+    }
+
     fn selected_event_reverse_index(&self, selected_event_id: Option<&str>) -> Option<usize> {
         let projection = self.projection.as_ref()?;
         selected_event_id
@@ -557,6 +647,10 @@ mod tests {
         assert_eq!(
             parse_composer_submission("/refresh").unwrap(),
             Some(ComposerSubmission::Slash(SlashCommand::Refresh))
+        );
+        assert_eq!(
+            parse_composer_submission("/model").unwrap(),
+            Some(ComposerSubmission::Slash(SlashCommand::Model))
         );
         assert_eq!(
             parse_composer_submission("/clear-status").unwrap(),

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -1,0 +1,268 @@
+use crate::types::{AgentSummary, ResolvedModelAvailability};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ModelPickerChoice {
+    InheritDefault,
+    Model { model: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ModelPickerRow {
+    pub(super) choice: ModelPickerChoice,
+    pub(super) title: String,
+    pub(super) detail: String,
+    pub(super) searchable: String,
+    pub(super) available: bool,
+}
+
+pub(super) fn model_picker_rows(agent: Option<&AgentSummary>, filter: &str) -> Vec<ModelPickerRow> {
+    let Some(agent) = agent else {
+        return Vec::new();
+    };
+    let mut rows = vec![inherit_default_row(agent)];
+    rows.extend(
+        agent
+            .model
+            .model_availability
+            .iter()
+            .map(model_availability_row),
+    );
+
+    let query = filter.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return rows;
+    }
+    rows.into_iter()
+        .filter(|row| row.searchable.contains(&query))
+        .collect()
+}
+
+pub(super) fn selected_model_choice(
+    agent: Option<&AgentSummary>,
+    filter: &str,
+    selected: usize,
+) -> Option<ModelPickerChoice> {
+    model_picker_rows(agent, filter)
+        .into_iter()
+        .nth(selected)
+        .map(|row| row.choice)
+}
+
+pub(super) fn clamp_model_picker_selection(
+    agent: Option<&AgentSummary>,
+    filter: &str,
+    selected: usize,
+) -> usize {
+    let len = model_picker_rows(agent, filter).len();
+    if len == 0 {
+        0
+    } else {
+        selected.min(len - 1)
+    }
+}
+
+fn inherit_default_row(agent: &AgentSummary) -> ModelPickerRow {
+    let default_model = agent.model.runtime_default_model.as_string();
+    let current = agent.model.override_model.is_none();
+    let title = if current {
+        format!("inherit runtime default: {default_model} (current)")
+    } else {
+        format!("inherit runtime default: {default_model}")
+    };
+    ModelPickerRow {
+        choice: ModelPickerChoice::InheritDefault,
+        detail: "clear this agent's model override".into(),
+        searchable: format!("inherit default runtime {default_model}").to_ascii_lowercase(),
+        title,
+        available: true,
+    }
+}
+
+fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
+    let status = if entry.available {
+        "ready".to_string()
+    } else {
+        format!(
+            "unavailable: {}",
+            entry
+                .unavailable_reason
+                .as_deref()
+                .unwrap_or("provider unavailable")
+        )
+    };
+    let provider = entry
+        .provider_source
+        .as_deref()
+        .map(|source| format!("{} provider:{source}", entry.provider))
+        .unwrap_or_else(|| entry.provider.clone());
+    let transport = entry
+        .transport
+        .as_deref()
+        .map(|transport| format!(" transport:{transport}"))
+        .unwrap_or_default();
+    ModelPickerRow {
+        choice: ModelPickerChoice::Model {
+            model: entry.model.clone(),
+        },
+        title: format!("{}  {}", entry.model, entry.display_name),
+        detail: format!(
+            "{status}  {provider}{transport}  source:{}",
+            entry.metadata_source
+        ),
+        searchable: format!(
+            "{} {} {} {} {}",
+            entry.model, entry.display_name, entry.provider, entry.metadata_source, status
+        )
+        .to_ascii_lowercase(),
+        available: entry.available,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clamp_model_picker_selection, model_picker_rows, selected_model_choice};
+    use crate::system::{ExecutionProfile, ExecutionSnapshot};
+    use crate::{
+        config::{ModelRef, ProviderId},
+        model_catalog::{ModelCapabilityFlags, ModelMetadataSource, ResolvedRuntimeModelPolicy},
+        types::{
+            AgentIdentityView, AgentKind, AgentLifecycleHint, AgentModelSource, AgentModelState,
+            AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentSummary,
+            AgentTokenUsageSummary, AgentVisibility, ChildAgentSummary, ClosureDecision,
+            ClosureOutcome, LoadedAgentsMdView, ResolvedModelAvailability, RuntimePosture,
+            SkillsRuntimeView, TokenUsage, WaitingIntentSummary,
+        },
+    };
+
+    fn policy(model: &str, display_name: &str) -> ResolvedRuntimeModelPolicy {
+        ResolvedRuntimeModelPolicy {
+            model_ref: ModelRef::parse(model).unwrap(),
+            display_name: display_name.into(),
+            description: "test".into(),
+            context_window_tokens: Some(200_000),
+            effective_context_window_percent: 90,
+            prompt_budget_estimated_tokens: 180_000,
+            compaction_trigger_estimated_tokens: 180_000,
+            compaction_keep_recent_estimated_tokens: 68_400,
+            runtime_max_output_tokens: 32_000,
+            tool_output_truncation_estimated_tokens: 2_500,
+            max_output_tokens_upper_limit: Some(128_000),
+            capabilities: ModelCapabilityFlags::default(),
+            source: ModelMetadataSource::BuiltInCatalog,
+        }
+    }
+
+    fn availability(model: &str, display_name: &str, available: bool) -> ResolvedModelAvailability {
+        let model_ref = ModelRef::parse(model).unwrap();
+        ResolvedModelAvailability {
+            model: model.into(),
+            provider: model_ref.provider.as_str().into(),
+            display_name: display_name.into(),
+            metadata_source: "built_in_catalog".into(),
+            provider_configured: true,
+            provider_source: Some("built_in".into()),
+            transport: Some("chat_completions".into()),
+            credential_source: Some("env".into()),
+            credential_kind: Some("api_key".into()),
+            credential_configured: available,
+            available,
+            unavailable_reason: (!available).then_some("credential_missing".into()),
+            policy: policy(model, display_name),
+        }
+    }
+
+    fn summary() -> AgentSummary {
+        AgentSummary {
+            identity: AgentIdentityView {
+                agent_id: "default".into(),
+                kind: AgentKind::Default,
+                visibility: AgentVisibility::Public,
+                ownership: AgentOwnership::SelfOwned,
+                profile_preset: AgentProfilePreset::PublicNamed,
+                status: AgentRegistryStatus::Active,
+                is_default_agent: true,
+                parent_agent_id: None,
+                lineage_parent_agent_id: None,
+                delegated_from_task_id: None,
+            },
+            agent: AgentState::new("default"),
+            lifecycle: AgentLifecycleHint::default(),
+            model: AgentModelState {
+                source: AgentModelSource::RuntimeDefault,
+                runtime_default_model: ModelRef::new(ProviderId::openai(), "gpt-5.4"),
+                effective_model: ModelRef::new(ProviderId::openai(), "gpt-5.4"),
+                requested_model: Some(ModelRef::new(ProviderId::openai(), "gpt-5.4")),
+                active_model: Some(ModelRef::new(ProviderId::openai(), "gpt-5.4")),
+                fallback_active: false,
+                effective_fallback_models: Vec::new(),
+                override_model: None,
+                resolved_policy: policy("openai/gpt-5.4", "GPT-5.4"),
+                available_models: Vec::new(),
+                model_availability: vec![
+                    availability("openai/gpt-5.4", "GPT-5.4", true),
+                    availability("anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6", false),
+                ],
+            },
+            token_usage: AgentTokenUsageSummary {
+                total: TokenUsage::new(0, 0),
+                total_model_rounds: 0,
+                last_turn: None,
+            },
+            closure: ClosureDecision {
+                outcome: ClosureOutcome::Completed,
+                waiting_reason: None,
+                work_signal: None,
+                runtime_posture: RuntimePosture::Awake,
+                evidence: Vec::new(),
+            },
+            execution: ExecutionSnapshot {
+                profile: ExecutionProfile::default(),
+                policy: ExecutionProfile::default().policy_snapshot(),
+                attached_workspaces: Vec::new(),
+                workspace_id: None,
+                workspace_anchor: "/tmp".into(),
+                execution_root: "/tmp".into(),
+                cwd: "/tmp".into(),
+                execution_root_id: None,
+                projection_kind: None,
+                access_mode: None,
+                worktree_root: None,
+            },
+            active_workspace_occupancy: None,
+            loaded_agents_md: LoadedAgentsMdView::default(),
+            skills: SkillsRuntimeView::default(),
+            active_children: Vec::<ChildAgentSummary>::new(),
+            active_waiting_intents: Vec::<WaitingIntentSummary>::new(),
+            active_external_triggers: Vec::new(),
+            recent_operator_notifications: Vec::new(),
+            recent_brief_count: 0,
+            recent_event_count: 0,
+        }
+    }
+
+    #[test]
+    fn picker_rows_include_inherit_and_runtime_availability() {
+        let agent = summary();
+        let rows = model_picker_rows(Some(&agent), "");
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].title.contains("inherit runtime default"));
+        assert!(rows[1].title.contains("openai/gpt-5.4"));
+        assert!(!rows[2].available);
+        assert!(rows[2].detail.contains("credential_missing"));
+    }
+
+    #[test]
+    fn picker_rows_filter_by_model_and_label() {
+        let agent = summary();
+        let rows = model_picker_rows(Some(&agent), "sonnet");
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].title.contains("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn picker_selection_clamps_to_filtered_rows() {
+        let agent = summary();
+        assert_eq!(clamp_model_picker_selection(Some(&agent), "gpt", 10), 1);
+        assert!(selected_model_choice(Some(&agent), "", 1).is_some());
+    }
+}

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -19,22 +19,22 @@ pub(super) fn model_picker_rows(agent: Option<&AgentSummary>, filter: &str) -> V
     let Some(agent) = agent else {
         return Vec::new();
     };
-    let mut rows = vec![inherit_default_row(agent)];
-    rows.extend(
-        agent
-            .model
-            .model_availability
-            .iter()
-            .map(model_availability_row),
-    );
-
+    let inherit_row = inherit_default_row(agent);
     let query = filter.trim().to_ascii_lowercase();
+    let model_rows = agent
+        .model
+        .model_availability
+        .iter()
+        .map(model_availability_row);
     if query.is_empty() {
+        let mut rows = vec![inherit_row];
+        rows.extend(model_rows);
         return rows;
     }
-    rows.into_iter()
-        .filter(|row| row.searchable.contains(&query))
-        .collect()
+
+    let mut rows = vec![inherit_row];
+    rows.extend(model_rows.filter(|row| row.searchable.contains(&query)));
+    rows
 }
 
 pub(super) fn selected_model_choice(
@@ -255,8 +255,9 @@ mod tests {
     fn picker_rows_filter_by_model_and_label() {
         let agent = summary();
         let rows = model_picker_rows(Some(&agent), "sonnet");
-        assert_eq!(rows.len(), 1);
-        assert!(rows[0].title.contains("claude-sonnet-4-6"));
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].title.contains("inherit runtime default"));
+        assert!(rows[1].title.contains("claude-sonnet-4-6"));
     }
 
     #[test]

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -17,6 +17,10 @@ pub(super) enum OverlayState {
         selected: usize,
         detail_scroll: u16,
     },
+    ModelPicker {
+        filter: String,
+        selected: usize,
+    },
     DebugPromptInput {
         composer: ComposerState,
     },
@@ -43,6 +47,9 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
             selected,
             detail_scroll,
         } => draw_tasks_overlay(frame, app, *selected, *detail_scroll),
+        OverlayState::ModelPicker { filter, selected } => {
+            draw_model_picker_overlay(frame, app, filter, *selected)
+        }
         OverlayState::DebugPromptInput { composer } => draw_input_modal(
             frame,
             "Debug Prompt",
@@ -258,6 +265,62 @@ fn draw_tasks_overlay(frame: &mut Frame<'_>, app: &TuiApp, selected: usize, deta
     frame.render_widget(detail, layout[1]);
 }
 
+fn draw_model_picker_overlay(frame: &mut Frame<'_>, app: &TuiApp, filter: &str, selected: usize) {
+    let popup = centered_rect(92, 80, frame.area());
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(4),
+        ])
+        .split(popup);
+    frame.render_widget(Clear, popup);
+
+    let filter_text = if filter.is_empty() {
+        "Filter: ".to_string()
+    } else {
+        format!("Filter: {filter}")
+    };
+    let filter_widget =
+        Paragraph::new(filter_text).block(Block::default().title("Model").borders(Borders::ALL));
+    frame.render_widget(filter_widget, layout[0]);
+
+    let rows = crate::tui::model_picker::model_picker_rows(app.selected_agent_summary(), filter);
+    let items = if rows.is_empty() {
+        vec![ListItem::new(
+            "No runtime-provided model availability matches the filter",
+        )]
+    } else {
+        rows.iter()
+            .map(|row| {
+                let status = if row.available { " " } else { "!" };
+                ListItem::new(format!("{status} {}\n  {}", row.title, row.detail))
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut state = ListState::default();
+    if !rows.is_empty() {
+        state.select(Some(selected.min(rows.len().saturating_sub(1))));
+    }
+    let list = List::new(items)
+        .block(Block::default().title("Models").borders(Borders::ALL))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(list, layout[1], &mut state);
+
+    let current = app
+        .selected_agent_summary()
+        .map(render::render_model_status)
+        .unwrap_or_else(|| "model: <no agent selected>".into());
+    let help = Paragraph::new(format!(
+        "{current}\nType to filter, Backspace edits, Up/Down moves, Enter selects, Esc cancels"
+    ))
+    .block(Block::default().borders(Borders::ALL))
+    .wrap(Wrap { trim: false });
+    frame.render_widget(help, layout[2]);
+}
+
 fn draw_large_text_overlay(frame: &mut Frame<'_>, title: &str, text: &str, scroll: u16) {
     let popup = centered_rect(90, 80, frame.area());
     frame.render_widget(Clear, popup);
@@ -283,6 +346,7 @@ fn draw_help_overlay(frame: &mut Frame<'_>, scroll: u16) {
         "  /help show this help",
         "  /agents open agent picker/detail",
         "  /events open raw event inspector",
+        "  /model open model picker for the selected agent",
         "  /tasks open task overlay",
         "  /transcript open transcript overlay",
         "  /refresh re-bootstrap the selected agent from /state",

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1604,6 +1604,7 @@ mod tests {
                     source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
                 },
                 available_models: Vec::new(),
+                model_availability: Vec::new(),
             },
             token_usage: AgentTokenUsageSummary {
                 total: TokenUsage::new(0, 0),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -179,7 +179,7 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
             "Closure: {:?} / {:?}",
             agent.closure.outcome, agent.closure.runtime_posture
         ),
-        format!("Model: {}", render_model_status(agent)),
+        render_model_status(agent),
     ];
 
     lines.push(String::new());

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -115,6 +115,9 @@ fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
         OverlayState::Events { .. } => "Events: Up/Down, PgUp/PgDn, Home/End, Esc",
         OverlayState::Transcript { .. } => "Transcript: Up/Down, PgUp/PgDn, Home/End, Esc",
         OverlayState::Tasks { .. } => "Tasks: Up/Down, PgUp/PgDn, Home/End, Esc",
+        OverlayState::ModelPicker { .. } => {
+            "Model: type filter, Backspace edit, Up/Down move, Enter select, Esc cancel"
+        }
         OverlayState::DebugPromptInput { .. } => "Debug prompt: Enter confirm, Esc cancel",
         OverlayState::DebugPromptView { .. } => "Debug prompt: Up/Down, PgUp/PgDn, Home/End, Esc",
         OverlayState::HelpView { .. } => "Help: Up/Down, PgUp/PgDn, Home/End, Esc",
@@ -143,10 +146,14 @@ fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
             app.connection_label()
         )
     };
+    let model = app
+        .selected_agent_summary()
+        .map(render_model_status)
+        .unwrap_or_else(|| "model: <no agent selected>".into());
     let text = if app.status_line.trim().is_empty() {
-        format!("{help}\n{connection}")
+        format!("{help}\n{connection}  {model}")
     } else {
-        format!("{help}\n{connection}\n{}", app.status_line)
+        format!("{help}\n{connection}  {model}\n{}", app.status_line)
     };
     let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::TOP));
     frame.render_widget(paragraph, area);
@@ -172,6 +179,7 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
             "Closure: {:?} / {:?}",
             agent.closure.outcome, agent.closure.runtime_posture
         ),
+        format!("Model: {}", render_model_status(agent)),
     ];
 
     lines.push(String::new());
@@ -541,6 +549,30 @@ pub(super) fn render_task_detail(task: &TaskRecord) -> String {
     lines.join("\n")
 }
 
+pub(super) fn render_model_status(agent: &AgentSummary) -> String {
+    let model = agent
+        .model
+        .active_model
+        .as_ref()
+        .unwrap_or(&agent.model.effective_model);
+    if agent.model.fallback_active {
+        let requested = agent
+            .model
+            .requested_model
+            .as_ref()
+            .unwrap_or(&agent.model.effective_model);
+        return format!(
+            "model: {} (fallback from {})",
+            model.as_string(),
+            requested.as_string()
+        );
+    }
+    if agent.model.override_model.is_some() {
+        return format!("model: {} (agent override)", model.as_string());
+    }
+    format!("model: {}", model.as_string())
+}
+
 pub(super) fn render_summary(agent: &AgentSummary) -> String {
     let mut lines = vec![
         format!("Agent: {}", agent.identity.agent_id),
@@ -664,8 +696,8 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_activity_event, prompt_cursor_position, render_header, render_prompt_buffer,
-        render_prompt_text, render_summary, status_bar_height,
+        format_activity_event, prompt_cursor_position, render_header, render_model_status,
+        render_prompt_buffer, render_prompt_text, render_summary, status_bar_height,
     };
     use crate::system::{ExecutionProfile, ExecutionSnapshot};
     use crate::tui::projection::{ProjectionEventLane, ProjectionEventRecord};
@@ -736,6 +768,7 @@ mod tests {
                     source: crate::model_catalog::ModelMetadataSource::BuiltInCatalog,
                 },
                 available_models: Vec::new(),
+                model_availability: Vec::new(),
             },
             token_usage: AgentTokenUsageSummary {
                 total: TokenUsage::new(0, 0),
@@ -838,6 +871,38 @@ mod tests {
         assert!(rendered.contains("SpawnAgent returns `agent_id` only"));
         assert!(
             rendered.contains("child_1:AwakeRunning[private/parent_supervised (private_child)]")
+        );
+    }
+
+    #[test]
+    fn model_status_distinguishes_inherited_override_and_fallback() {
+        let inherited = sample_agent_summary();
+        assert_eq!(
+            render_model_status(&inherited),
+            "model: anthropic/claude-sonnet-4-6"
+        );
+
+        let mut overridden = sample_agent_summary();
+        overridden.model.override_model =
+            Some(crate::config::ModelRef::parse("openai/gpt-5.4").unwrap());
+        overridden.model.effective_model =
+            crate::config::ModelRef::parse("openai/gpt-5.4").unwrap();
+        overridden.model.active_model =
+            Some(crate::config::ModelRef::parse("openai/gpt-5.4").unwrap());
+        assert_eq!(
+            render_model_status(&overridden),
+            "model: openai/gpt-5.4 (agent override)"
+        );
+
+        let mut fallback = overridden;
+        fallback.model.requested_model =
+            Some(crate::config::ModelRef::parse("openai/gpt-5.4").unwrap());
+        fallback.model.active_model =
+            Some(crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap());
+        fallback.model.fallback_active = true;
+        assert_eq!(
+            render_model_status(&fallback),
+            "model: anthropic/claude-sonnet-4-6 (fallback from openai/gpt-5.4)"
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2579,6 +2579,30 @@ pub struct AgentModelState {
     pub resolved_policy: ResolvedRuntimeModelPolicy,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub available_models: Vec<BuiltInModelMetadata>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub model_availability: Vec<ResolvedModelAvailability>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedModelAvailability {
+    pub model: String,
+    pub provider: String,
+    pub display_name: String,
+    pub metadata_source: String,
+    pub provider_configured: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_kind: Option<String>,
+    pub credential_configured: bool,
+    pub available: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unavailable_reason: Option<String>,
+    pub policy: ResolvedRuntimeModelPolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- show the selected agent model in the TUI status/runtime state, including inherited, override, and fallback-active states
- add `/model` to open a filterable model picker sourced from the runtime resolved model availability surface
- apply selections through the agent-scoped control API, including an inherit/default option to clear overrides

Closes #775

## Verification

- cargo check
- cargo test tui:: --lib
- cargo test resolved_model_availability --lib
