### PR TITLE
fix: guard solve review publishing

### DIFF
--- a/skills/github-review/SKILL.md
+++ b/skills/github-review/SKILL.md
@@ -165,8 +165,21 @@ Short execution summary:
 ## Publishing Guardrails
 
 - Publish at most one review per execution round.
-- A successful primary publish is terminal; do not run alternate publish paths.
-- Before fallback publish, check whether an equivalent Holon review already exists for the same head SHA and skip if present.
+- Treat review/comment publishing as a single-shot external side effect: choose
+  one publish surface, either one PR review or one PR comment, not both.
+- Capture the target PR `headRefOid` before publishing and use it as the
+  deduplication key.
+- Before any publish or retry, check existing reviews/comments by Holon or the
+  current GitHub actor for the same head SHA. If an equivalent review/comment
+  already exists, skip publishing and record the existing URL/status.
+- A successful primary publish is terminal; immediately write the publish result
+  to `${GITHUB_OUTPUT_DIR}/review-publish.json` and do not run alternate publish
+  paths.
+- Before fallback publish, require both conditions: no local
+  `review-publish.json` success marker exists, and no equivalent Holon review or
+  comment exists for the same head SHA.
+- If a publish command result is ambiguous, verify existing reviews/comments for
+  the same head SHA before retrying. Do not retry blindly.
 
 ## Configuration
 

--- a/skills/github-review/SKILL.md
+++ b/skills/github-review/SKILL.md
@@ -79,6 +79,9 @@ Generate:
 - `${GITHUB_OUTPUT_DIR}/review.md`
 - `${GITHUB_OUTPUT_DIR}/review.json`
 - `${GITHUB_OUTPUT_DIR}/summary.md`
+- `${GITHUB_OUTPUT_DIR}/review-publish.json` after a successful publish, or when
+  publishing is skipped because an equivalent same-head review/comment already
+  exists
 - Optional `${GITHUB_OUTPUT_DIR}/manifest.json` (execution metadata)
 
 ### 3. Publish review

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -279,7 +279,27 @@ pub fn build_solve_prompt(
         "GitHub operating rules:\n- Use GITHUB_TOKEN or GH_TOKEN when publishing through gh.\n- The repository checkout is already prepared by the caller; do not clone by default.\n- If code changes are required, create or reuse an appropriate branch, commit intentionally, push, and create or update a PR yourself.\n- If this is a review-only task, publish one structured review or comment only when the requested skill workflow calls for it.\n- Prefer the github-issue-solve, github-pr-fix, github-review, and ghx skills when their descriptions match the target."
             .to_string(),
     );
+    if should_include_review_publish_guardrails(request, target) {
+        sections.push(
+            "Review publishing guardrails:\n- Treat PR review/comment publishing as a single-shot external side effect.\n- For a review-only goal, choose exactly one publish surface: one PR review or one PR comment, not both.\n- Before publishing, read the current PR head SHA and existing reviews/comments by Holon/Holonbot for that same head. If an equivalent review/comment already exists, do not publish again; record the existing URL/status in the output artifacts.\n- After any review/comment publish command succeeds, stop all other publish paths immediately. Do not run fallback `gh pr review`, `gh api .../reviews`, or issue-comment publish commands after a successful primary publish.\n- If a publish command result is ambiguous, verify existing reviews/comments for the same head SHA before retrying. Retry only when no Holon/Holonbot review or comment for that head exists."
+                .to_string(),
+        );
+    }
     sections.join("\n\n")
+}
+
+fn should_include_review_publish_guardrails(
+    request: &SolveRequest,
+    target: Option<&GitHubTarget>,
+) -> bool {
+    matches!(
+        target.map(|target| target.kind),
+        Some(GitHubTargetKind::PullRequest)
+    ) || request
+        .goal
+        .as_deref()
+        .map(|goal| goal.to_ascii_lowercase().contains("review"))
+        .unwrap_or(false)
 }
 
 fn default_goal(target: Option<&GitHubTarget>) -> String {
@@ -421,6 +441,22 @@ mod tests {
         assert!(prompt.contains("github-pr-fix"));
         assert!(prompt.contains("github-review"));
         assert!(prompt.contains("/tmp/out/manifest.json"));
+    }
+
+    #[test]
+    fn build_prompt_adds_review_publish_guardrails_for_review_goals() {
+        let mut request = request("https://github.com/holon-run/holon-test/pull/52");
+        request.goal = Some(
+            "Review the target pull request only. Publish one concise review or PR comment.".into(),
+        );
+        let target = parse_github_target(&request.target_ref, None).unwrap();
+        let prompt = build_solve_prompt(&request, target.as_ref(), Path::new("/tmp/out"));
+
+        assert!(prompt.contains("Review publishing guardrails"));
+        assert!(prompt.contains("single-shot external side effect"));
+        assert!(prompt.contains("one PR review or one PR comment, not both"));
+        assert!(prompt.contains("After any review/comment publish command succeeds"));
+        assert!(prompt.contains("verify existing reviews/comments for the same head SHA"));
     }
 
     #[test]

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -298,8 +298,18 @@ fn should_include_review_publish_guardrails(
     ) || request
         .goal
         .as_deref()
-        .map(|goal| goal.to_ascii_lowercase().contains("review"))
+        .map(goal_mentions_review)
         .unwrap_or(false)
+}
+
+fn goal_mentions_review(goal: &str) -> bool {
+    goal.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|token| {
+            matches!(
+                token.to_ascii_lowercase().as_str(),
+                "review" | "reviews" | "reviewing"
+            )
+        })
 }
 
 fn default_goal(target: Option<&GitHubTarget>) -> String {
@@ -445,7 +455,7 @@ mod tests {
 
     #[test]
     fn build_prompt_adds_review_publish_guardrails_for_review_goals() {
-        let mut request = request("https://github.com/holon-run/holon-test/pull/52");
+        let mut request = request("https://github.com/holon-run/holon-test/issues/52");
         request.goal = Some(
             "Review the target pull request only. Publish one concise review or PR comment.".into(),
         );
@@ -457,6 +467,16 @@ mod tests {
         assert!(prompt.contains("one PR review or one PR comment, not both"));
         assert!(prompt.contains("After any review/comment publish command succeeds"));
         assert!(prompt.contains("verify existing reviews/comments for the same head SHA"));
+    }
+
+    #[test]
+    fn review_publish_guardrails_do_not_match_preview_text() {
+        let mut request = request("https://github.com/holon-run/holon-test/issues/52");
+        request.goal = Some("Generate a preview artifact for the target issue.".into());
+        let target = parse_github_target(&request.target_ref, None).unwrap();
+        let prompt = build_solve_prompt(&request, target.as_ref(), Path::new("/tmp/out"));
+
+        assert!(!prompt.contains("Review publishing guardrails"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add explicit review publishing guardrails to `holon solve` prompts for PR/review-only goals
- strengthen the bundled `github-review` skill so review/comment publishing is single-shot, head-SHA deduped, and fallback-gated by a publish marker plus existing-review checks

Closes #783

## Verification

- cargo test solve::tests --lib
- cargo test agent_template::tests --lib
- cargo check
