### PR TITLE
docs: clarify v0.13 release boundary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,14 @@ jobs:
         run: |
           set -euo pipefail
           cat > release-notes.md <<EOF
+          ## Runtime line
+
+          Holon ${GITHUB_REF_NAME} is part of the Rust runtime line. The Rust runtime is now the main \`holon\` binary.
+
+          This line is intentionally breaking relative to the old Go-line releases. If you need the old Go implementation, stay on \`v0.12.0\`.
+
+          Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
+
           ## Install
 
           Homebrew:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The core question Holon explores is:
 
 ## Install
 
-Build from source:
+Build the current checkout from source:
 
 ```bash
 cargo install --path .
@@ -61,6 +61,10 @@ macOS amd64, and macOS arm64. Once a release is tagged, install with Homebrew:
 brew tap holon-run/tap
 brew install holon
 ```
+
+The command examples below assume `holon` is installed on `PATH`. When working
+directly from a source checkout, run `cargo install --path .` first so the
+quickstart matches the released binary surface.
 
 ## Core Commands
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -38,6 +38,18 @@ The workflow also generates `Formula/holon.rb`. If `HOMEBREW_TAP_TOKEN` is
 configured, it pushes the formula to `holon-run/homebrew-tap`; otherwise the
 formula is available as a workflow artifact.
 
-Before pushing the tag, run the release tracker verification checklist and make
-sure the README quickstart still uses installed `holon ...` commands rather
-than `cargo run -- ...` commands.
+## Pre-Tag Checklist
+
+Before pushing the tag, verify:
+
+- `Cargo.toml` and `Cargo.lock` are aligned with the tag version
+- release notes call out the Rust runtime line and Go-line fallback boundary
+- release notes state that `v0.12.0` remains the fallback tag for old Go
+  behavior
+- supported binary assets are Linux amd64, macOS amd64, and macOS arm64
+- `checksums.txt` will be included with the release assets
+- `Formula/holon.rb` will be generated, and either pushed to
+  `holon-run/homebrew-tap` or retained as a workflow artifact when
+  `HOMEBREW_TAP_TOKEN` is not configured
+- the README quickstart uses installed `holon ...` commands rather than
+  `cargo run -- ...` commands

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,19 @@
 
 Holon releases are published from version tags.
 
+## Line Boundary
+
+`v0.13.0` is the first public Rust runtime release after the old Go mainline.
+It is intentionally breaking relative to the Go-line releases. Users who need
+the old Go implementation should stay on `v0.12.0`.
+
+Release notes for `v0.13.0` and later must make this boundary explicit:
+
+- the Rust runtime is now the main `holon` binary
+- `v0.13.0` is intentionally breaking relative to Go-line releases
+- `v0.12.0` remains the fallback tag for old Go behavior
+- supported binary assets are Linux amd64, macOS amd64, and macOS arm64
+
 ## Versioning
 
 Keep `Cargo.toml` aligned with the tag. For example, `v0.13.0` must be released
@@ -24,3 +37,7 @@ The release workflow builds and uploads:
 The workflow also generates `Formula/holon.rb`. If `HOMEBREW_TAP_TOKEN` is
 configured, it pushes the formula to `holon-run/homebrew-tap`; otherwise the
 formula is available as a workflow artifact.
+
+Before pushing the tag, run the release tracker verification checklist and make
+sure the README quickstart still uses installed `holon ...` commands rather
+than `cargo run -- ...` commands.


### PR DESCRIPTION
## Summary

- Clarify that README quickstart examples use installed `holon ...` commands and that source checkout users should run `cargo install --path .` first.
- Document the `v0.13.0` Rust runtime line boundary in `docs/release.md`, including the `v0.12.0` Go-line fallback.
- Add the same Rust-line and supported-asset wording to the generated release notes template in `.github/workflows/release.yml`.

## Verification

- `git diff --check`
- `actionlint .github/workflows/release.yml`
- `cargo run --quiet -- --version` -> `holon 0.13.0`

Refs #773.
