### PR TITLE
feat: add TUI slash command menu

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1315,6 +1315,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn slash_menu_cursor_movement_preserves_dismissal() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/mo");
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .await
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE))
+            .await
+            .unwrap();
+
+        assert_eq!(app.composer.as_str(), "/mo");
+        assert_eq!(app.slash_menu_dismissed_for.as_deref(), Some("/mo"));
+    }
+
+    #[tokio::test]
     async fn slash_debug_prompt_opens_overlay() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -156,6 +156,8 @@ struct TuiApp {
     chat_scroll: ChatScrollState,
     chat_max_scroll: u16,
     composer: ComposerState,
+    slash_menu_selected: usize,
+    slash_menu_dismissed_for: Option<String>,
     overlay: OverlayState,
     last_refresh_at: Option<DateTime<Local>>,
     last_event_at: Option<DateTime<Local>>,
@@ -216,6 +218,8 @@ impl TuiApp {
             chat_scroll: ChatScrollState::new(),
             chat_max_scroll: 0,
             composer: ComposerState::new(),
+            slash_menu_selected: 0,
+            slash_menu_dismissed_for: None,
             overlay: OverlayState::None,
             last_refresh_at: None,
             last_event_at: None,
@@ -1269,6 +1273,45 @@ mod tests {
             .unwrap();
         assert_eq!(app.overlay, OverlayState::None);
         assert_eq!(app.composer.as_str(), "draft:");
+    }
+
+    #[tokio::test]
+    async fn slash_menu_navigation_and_tab_complete_selected_command() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/");
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+            .await
+            .unwrap();
+        assert_eq!(app.slash_menu_selected, 1);
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .await
+            .unwrap();
+        assert_eq!(app.composer.as_str(), "/agents");
+        assert_eq!(app.overlay, OverlayState::None);
+    }
+
+    #[tokio::test]
+    async fn slash_menu_esc_dismisses_without_clearing_prompt() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/mo");
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .await
+            .unwrap();
+
+        assert_eq!(app.composer.as_str(), "/mo");
+        assert_eq!(app.overlay, OverlayState::None);
+        assert_eq!(app.slash_menu_dismissed_for.as_deref(), Some("/mo"));
     }
 
     #[tokio::test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1315,6 +1315,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn slash_menu_esc_dismisses_unknown_command_without_clearing_prompt() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/unknown");
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .await
+            .unwrap();
+
+        assert_eq!(app.composer.as_str(), "/unknown");
+        assert_eq!(app.overlay, OverlayState::None);
+        assert_eq!(app.slash_menu_dismissed_for.as_deref(), Some("/unknown"));
+    }
+
+    #[tokio::test]
     async fn slash_menu_cursor_movement_preserves_dismissal() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -20,9 +20,9 @@ enum ComposerSubmission {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct SlashCommandSpec {
-    name: &'static str,
-    description: &'static str,
+pub(super) struct SlashCommandSpec {
+    pub(super) name: &'static str,
+    pub(super) description: &'static str,
     command: SlashCommand,
 }
 
@@ -81,6 +81,21 @@ fn slash_command_spec(command: &str) -> Option<SlashCommandSpec> {
         .find(|spec| spec.name == command)
 }
 
+pub(super) fn slash_menu_specs(buffer: &str) -> Vec<SlashCommandSpec> {
+    let trimmed = buffer.trim_start();
+    if !trimmed.starts_with('/') || trimmed.starts_with("//") || buffer.contains('\n') {
+        return Vec::new();
+    }
+
+    let token = trimmed.split_whitespace().next().unwrap_or("/");
+    let query = token.trim_start_matches('/');
+    SLASH_COMMAND_SPECS
+        .iter()
+        .filter(|spec| query.is_empty() || spec.name[1..].starts_with(query))
+        .copied()
+        .collect()
+}
+
 fn parse_composer_submission(buffer: &str) -> Result<Option<ComposerSubmission>> {
     let text = buffer.trim().to_string();
     if text.is_empty() {
@@ -116,21 +131,19 @@ fn parse_composer_submission(buffer: &str) -> Result<Option<ComposerSubmission>>
     Ok(Some(ComposerSubmission::Slash(slash_command)))
 }
 
-pub(super) fn slash_prompt_lines(buffer: &str) -> Option<Vec<String>> {
-    let trimmed = buffer.trim_start();
-    if !trimmed.starts_with('/') || trimmed.starts_with("//") || buffer.contains('\n') {
+#[cfg(test)]
+fn slash_prompt_lines(buffer: &str) -> Option<Vec<String>> {
+    if buffer.trim_start().starts_with("//") || buffer.contains('\n') {
         return None;
     }
 
-    let token = trimmed.split_whitespace().next().unwrap_or("/");
-    let query = token.trim_start_matches('/');
-    let matches = SLASH_COMMAND_SPECS
-        .iter()
-        .filter(|spec| query.is_empty() || spec.name[1..].starts_with(query))
-        .copied()
-        .collect::<Vec<_>>();
+    let token = buffer.trim_start().split_whitespace().next().unwrap_or("/");
+    let matches = slash_menu_specs(buffer);
 
     if matches.is_empty() {
+        if !token.starts_with('/') {
+            return None;
+        }
         return Some(vec![format!(
             "Slash: no command matches {token}. Use /help for the full list."
         )]);
@@ -439,6 +452,10 @@ impl TuiApp {
     }
 
     async fn handle_main_key(&mut self, key: KeyEvent) -> Result<()> {
+        if self.handle_slash_menu_key(key).await? {
+            return Ok(());
+        }
+
         if key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
                 KeyCode::Char('a') => {
@@ -484,15 +501,92 @@ impl TuiApp {
             }
             KeyCode::Esc => {
                 self.composer.clear();
+                self.slash_menu_selected = 0;
+                self.slash_menu_dismissed_for = None;
             }
             _ => match edit_buffer(key, &mut self.composer) {
                 Some(BufferAction::Submit) => self.submit_prompt_buffer().await?,
-                Some(BufferAction::Cancel) => self.composer.clear(),
-                None => {}
+                Some(BufferAction::Cancel) => {
+                    self.composer.clear();
+                    self.slash_menu_selected = 0;
+                    self.slash_menu_dismissed_for = None;
+                }
+                None => self.sync_slash_menu_after_edit(),
             },
         }
 
         Ok(())
+    }
+
+    async fn handle_slash_menu_key(&mut self, key: KeyEvent) -> Result<bool> {
+        let specs = self.active_slash_menu_specs();
+        if specs.is_empty() {
+            return Ok(false);
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                self.slash_menu_dismissed_for = Some(self.composer.as_str().to_string());
+                self.slash_menu_selected = 0;
+                Ok(true)
+            }
+            KeyCode::Up | KeyCode::Char('p')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    || matches!(key.code, KeyCode::Up) =>
+            {
+                self.slash_menu_selected = self.slash_menu_selected.saturating_sub(1);
+                Ok(true)
+            }
+            KeyCode::Down | KeyCode::Char('n')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    || matches!(key.code, KeyCode::Down) =>
+            {
+                self.slash_menu_selected =
+                    (self.slash_menu_selected + 1).min(specs.len().saturating_sub(1));
+                Ok(true)
+            }
+            KeyCode::Tab => {
+                let selected = self.slash_menu_selected.min(specs.len().saturating_sub(1));
+                self.composer = ComposerState::from(specs[selected].name);
+                self.slash_menu_selected = selected;
+                self.slash_menu_dismissed_for = None;
+                Ok(true)
+            }
+            KeyCode::Enter => {
+                let selected = self.slash_menu_selected.min(specs.len().saturating_sub(1));
+                let command = specs[selected].command;
+                self.execute_slash_command(command).await?;
+                self.composer.clear();
+                self.slash_menu_selected = 0;
+                self.slash_menu_dismissed_for = None;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn active_slash_menu_specs(&self) -> Vec<SlashCommandSpec> {
+        if self.overlay != OverlayState::None {
+            return Vec::new();
+        }
+        if self
+            .slash_menu_dismissed_for
+            .as_deref()
+            .is_some_and(|dismissed| dismissed == self.composer.as_str())
+        {
+            return Vec::new();
+        }
+        slash_menu_specs(self.composer.as_str())
+    }
+
+    fn sync_slash_menu_after_edit(&mut self) {
+        self.slash_menu_dismissed_for = None;
+        let len = slash_menu_specs(self.composer.as_str()).len();
+        if len == 0 {
+            self.slash_menu_selected = 0;
+        } else {
+            self.slash_menu_selected = self.slash_menu_selected.min(len - 1);
+        }
     }
 
     async fn handle_agents_overlay_key(&mut self, key: KeyEvent) -> Result<()> {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -504,15 +504,18 @@ impl TuiApp {
                 self.slash_menu_selected = 0;
                 self.slash_menu_dismissed_for = None;
             }
-            _ => match edit_buffer(key, &mut self.composer) {
-                Some(BufferAction::Submit) => self.submit_prompt_buffer().await?,
-                Some(BufferAction::Cancel) => {
-                    self.composer.clear();
-                    self.slash_menu_selected = 0;
-                    self.slash_menu_dismissed_for = None;
+            _ => {
+                let before = self.composer.as_str().to_string();
+                match edit_buffer(key, &mut self.composer) {
+                    Some(BufferAction::Submit) => self.submit_prompt_buffer().await?,
+                    Some(BufferAction::Cancel) => {
+                        self.composer.clear();
+                        self.slash_menu_selected = 0;
+                        self.slash_menu_dismissed_for = None;
+                    }
+                    None => self.sync_slash_menu_after_edit(before != self.composer.as_str()),
                 }
-                None => self.sync_slash_menu_after_edit(),
-            },
+            }
         }
 
         Ok(())
@@ -579,8 +582,10 @@ impl TuiApp {
         slash_menu_specs(self.composer.as_str())
     }
 
-    fn sync_slash_menu_after_edit(&mut self) {
-        self.slash_menu_dismissed_for = None;
+    fn sync_slash_menu_after_edit(&mut self, buffer_changed: bool) {
+        if buffer_changed {
+            self.slash_menu_dismissed_for = None;
+        }
         let len = slash_menu_specs(self.composer.as_str()).len();
         if len == 0 {
             self.slash_menu_selected = 0;

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -719,7 +719,10 @@ fn adjust_scroll_for_key(scroll: u16, code: KeyCode) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_composer_submission, slash_prompt_lines, ComposerSubmission, SlashCommand};
+    use super::{
+        parse_composer_submission, slash_menu_specs, slash_prompt_lines, ComposerSubmission,
+        SlashCommand,
+    };
 
     #[test]
     fn parses_plain_chat_submission() {
@@ -797,6 +800,11 @@ mod tests {
     #[test]
     fn slash_prompt_ignores_escaped_slash_chat() {
         assert!(slash_prompt_lines("//hello").is_none());
+    }
+
+    #[test]
+    fn slash_menu_ignores_multiline_input() {
+        assert!(slash_menu_specs("/mo\nextra").is_empty());
     }
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -522,10 +522,11 @@ impl TuiApp {
     }
 
     async fn handle_slash_menu_key(&mut self, key: KeyEvent) -> Result<bool> {
-        let specs = self.active_slash_menu_specs();
-        if specs.is_empty() {
+        if !self.is_slash_menu_visible() {
             return Ok(false);
         }
+
+        let specs = self.active_slash_menu_specs();
 
         match key.code {
             KeyCode::Esc => {
@@ -533,6 +534,7 @@ impl TuiApp {
                 self.slash_menu_selected = 0;
                 Ok(true)
             }
+            _ if specs.is_empty() => Ok(false),
             KeyCode::Up | KeyCode::Char('p')
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     || matches!(key.code, KeyCode::Up) =>
@@ -568,15 +570,26 @@ impl TuiApp {
         }
     }
 
-    fn active_slash_menu_specs(&self) -> Vec<SlashCommandSpec> {
+    fn is_slash_menu_visible(&self) -> bool {
         if self.overlay != OverlayState::None {
-            return Vec::new();
+            return false;
         }
         if self
             .slash_menu_dismissed_for
             .as_deref()
             .is_some_and(|dismissed| dismissed == self.composer.as_str())
         {
+            return false;
+        }
+
+        let buffer = self.composer.as_str();
+        !buffer.contains('\n')
+            && buffer.trim_start().starts_with('/')
+            && !buffer.trim_start().starts_with("//")
+    }
+
+    fn active_slash_menu_specs(&self) -> Vec<SlashCommandSpec> {
+        if !self.is_slash_menu_visible() {
             return Vec::new();
         }
         slash_menu_specs(self.composer.as_str())

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,12 +1,12 @@
 use super::overlay::draw_overlay;
 use super::*;
-use crate::tui::input::slash_prompt_lines;
+use crate::tui::input::slash_menu_specs;
 use unicode_width::UnicodeWidthStr;
 
 pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     let area = frame.area();
-    let slash_hint = slash_prompt_lines(app.composer.as_str());
-    let prompt_height = prompt_pane_height(app.composer.as_str(), slash_hint.as_deref());
+    let slash_menu = slash_menu_lines(app);
+    let prompt_height = prompt_pane_height(app.composer.as_str(), slash_menu.len());
     let status_height = status_bar_height(&app.status_line);
     let outer = Layout::default()
         .direction(Direction::Vertical)
@@ -22,7 +22,7 @@ pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     draw_header(frame, outer[0], app);
     draw_main_panels(frame, outer[1], app);
     draw_activity_pane(frame, outer[2], app);
-    draw_prompt_pane(frame, outer[3], app, slash_hint.as_deref());
+    draw_prompt_pane(frame, outer[3], app, &slash_menu);
     draw_status_bar(frame, outer[4], app);
     draw_overlay(frame, app);
 }
@@ -84,13 +84,8 @@ fn draw_activity_pane(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
     frame.render_widget(paragraph, area);
 }
 
-fn draw_prompt_pane(
-    frame: &mut Frame<'_>,
-    area: Rect,
-    app: &TuiApp,
-    slash_hint: Option<&[String]>,
-) {
-    let paragraph = Paragraph::new(render_prompt_text(app.composer.as_str(), slash_hint))
+fn draw_prompt_pane(frame: &mut Frame<'_>, area: Rect, app: &TuiApp, slash_menu: &[Line<'static>]) {
+    let paragraph = Paragraph::new(render_prompt_text(app.composer.as_str(), slash_menu))
         .block(Block::default().borders(Borders::ALL))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
@@ -100,7 +95,7 @@ fn draw_prompt_pane(
             area,
             app.composer.as_str(),
             app.composer.cursor(),
-            slash_hint.map(|lines| lines.len() as u16).unwrap_or(0),
+            slash_menu.len() as u16,
         );
         frame.set_cursor_position(ratatui::layout::Position { x, y });
     }
@@ -108,6 +103,9 @@ fn draw_prompt_pane(
 
 fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
     let help = match app.overlay {
+        OverlayState::None if !slash_menu_lines(app).is_empty() => {
+            "Slash: Up/Down select  Tab complete  Enter run  Esc close"
+        }
         OverlayState::None => {
             "/help commands  Left/Right/Home/End edit  Up/Down scroll  Ctrl+A agents  Ctrl+E events  Ctrl+J tasks  Ctrl+C quit"
         }
@@ -312,14 +310,13 @@ fn render_activity_text(app: &TuiApp) -> String {
     }
 }
 
-fn prompt_pane_height(buffer: &str, slash_hint: Option<&[String]>) -> u16 {
+fn prompt_pane_height(buffer: &str, slash_menu_rows: usize) -> u16 {
     let mut prompt_lines = buffer.lines().count();
     if buffer.is_empty() || buffer.ends_with('\n') {
         prompt_lines += 1;
     }
     let prompt_lines = prompt_lines.max(1) as u16;
-    let slash_hint_lines = slash_hint.map(|lines| lines.len() as u16).unwrap_or(0);
-    (prompt_lines + slash_hint_lines + 2).clamp(3, 11)
+    (prompt_lines + slash_menu_rows as u16 + 2).clamp(3, 12)
 }
 
 fn status_bar_height(status_line: &str) -> u16 {
@@ -358,12 +355,11 @@ fn render_prompt_buffer(buffer: &str) -> String {
     rendered
 }
 
-fn render_prompt_text(buffer: &str, slash_hint: Option<&[String]>) -> Text<'static> {
-    if let Some(lines) = slash_hint.filter(|lines| !lines.is_empty()) {
-        let mut rendered = lines.join("\n");
-        rendered.push('\n');
-        rendered.push_str(&render_prompt_buffer(buffer));
-        return Text::from(rendered);
+fn render_prompt_text(buffer: &str, slash_menu: &[Line<'static>]) -> Text<'static> {
+    if !slash_menu.is_empty() {
+        let mut lines = slash_menu.to_vec();
+        lines.push(Line::from(render_prompt_buffer(buffer)));
+        return Text::from(lines);
     }
 
     if !buffer.is_empty() {
@@ -377,6 +373,55 @@ fn render_prompt_text(buffer: &str, slash_hint: Option<&[String]>) -> Text<'stat
             Style::default().add_modifier(Modifier::DIM),
         ),
     ]))
+}
+
+fn slash_menu_lines(app: &TuiApp) -> Vec<Line<'static>> {
+    if app.overlay != OverlayState::None {
+        return Vec::new();
+    }
+    if app
+        .slash_menu_dismissed_for
+        .as_deref()
+        .is_some_and(|dismissed| dismissed == app.composer.as_str())
+    {
+        return Vec::new();
+    }
+
+    let buffer = app.composer.as_str();
+    if !buffer.trim_start().starts_with('/') || buffer.trim_start().starts_with("//") {
+        return Vec::new();
+    }
+    let specs = slash_menu_specs(buffer);
+    if specs.is_empty() {
+        let token = buffer.trim_start().split_whitespace().next().unwrap_or("/");
+        return vec![Line::from(vec![
+            Span::styled("  ", Style::default().add_modifier(Modifier::DIM)),
+            Span::styled(
+                format!("no command matches {token}"),
+                Style::default().add_modifier(Modifier::DIM),
+            ),
+        ])];
+    }
+
+    specs
+        .iter()
+        .take(8)
+        .enumerate()
+        .map(|(index, spec)| {
+            let selected = index == app.slash_menu_selected.min(specs.len().saturating_sub(1));
+            let style = if selected {
+                Style::default().add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default()
+            };
+            let prefix = if selected { "> " } else { "  " };
+            Line::from(vec![
+                Span::styled(prefix, style),
+                Span::styled(format!("{:<14}", spec.name), style),
+                Span::styled(spec.description, style.add_modifier(Modifier::DIM)),
+            ])
+        })
+        .collect()
 }
 
 fn prompt_cursor_position(area: Rect, buffer: &str, cursor: usize, hint_rows: u16) -> (u16, u16) {
@@ -709,7 +754,7 @@ mod tests {
         SkillsRuntimeView, TokenUsage,
     };
     use chrono::Utc;
-    use ratatui::prelude::Rect;
+    use ratatui::prelude::{Line, Rect};
     use serde_json::json;
     use std::path::PathBuf;
 
@@ -847,7 +892,7 @@ mod tests {
 
     #[test]
     fn empty_prompt_renders_dim_placeholder() {
-        let rendered = render_prompt_text("", None);
+        let rendered = render_prompt_text("", &[]);
         let line = rendered.lines.first().expect("placeholder line");
         let text: String = line
             .spans
@@ -949,13 +994,13 @@ mod tests {
     }
 
     #[test]
-    fn slash_hint_renders_above_prompt_buffer() {
+    fn slash_menu_renders_above_prompt_buffer() {
         let rendered = render_prompt_text(
             "/de",
-            Some(&[
-                "Slash: >/debug-prompt".to_string(),
-                "Best: /debug-prompt open debug prompt dialog".to_string(),
-            ]),
+            &[
+                Line::from("  /debug-prompt open debug prompt dialog"),
+                Line::from("  /help         show slash command help"),
+            ],
         );
         let joined = rendered
             .lines
@@ -968,12 +1013,12 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(joined.contains("Slash: >/debug-prompt"));
+        assert!(joined.contains("/debug-prompt open debug prompt dialog"));
         assert!(joined.contains("> /de"));
     }
 
     #[test]
-    fn prompt_cursor_offsets_for_slash_hint_rows() {
+    fn prompt_cursor_offsets_for_slash_menu_rows() {
         let area = Rect::new(10, 5, 20, 8);
         assert_eq!(prompt_cursor_position(area, "/de", 3, 2), (16, 9));
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -388,7 +388,10 @@ fn slash_menu_lines(app: &TuiApp) -> Vec<Line<'static>> {
     }
 
     let buffer = app.composer.as_str();
-    if !buffer.trim_start().starts_with('/') || buffer.trim_start().starts_with("//") {
+    if buffer.contains('\n')
+        || !buffer.trim_start().starts_with('/')
+        || buffer.trim_start().starts_with("//")
+    {
         return Vec::new();
     }
     let specs = slash_menu_specs(buffer);


### PR DESCRIPTION
## Summary
- add an interactive slash command menu in `holon tui` when the composer starts with `/`
- support Up/Down and Ctrl+P/Ctrl+N navigation, Tab completion, Enter execution, and Esc dismissal without clearing the prompt
- keep the existing `/model` model picker as an overlay while making slash command discovery selectable

## Verification
- `cargo fmt --all -- --check`
- `cargo test tui:: --lib`
- `cargo test --all-targets -- --test-threads=1`