### PR TITLE
Implement OpenAI remote compaction boundary

### DIFF
--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -2544,6 +2544,7 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
         requestLoweringMode,
         requestDiagnostics
       ),
+      openai_remote_compaction: openaiRemoteCompactionDiagnostic(provider, requestDiagnostics),
       context_management: contextManagement,
       previous_tool: previousTool,
       anthropic_cache: anthropicCache,
@@ -2861,6 +2862,33 @@ function incrementalContinuationDiagnostic(provider, round, requestLoweringMode,
   return {
     status: "fallback_full_request",
     fallback_reason: "incremental_continuation_not_observed_in_provider_round"
+  };
+}
+
+function openaiRemoteCompactionDiagnostic(provider, requestDiagnostics) {
+  if (provider !== "openai" && provider !== "openai-codex") {
+    return null;
+  }
+  const compaction = requestDiagnostics?.openai_remote_compaction;
+  if (!compaction) {
+    return null;
+  }
+  return {
+    status: compaction.status ?? "unknown",
+    trigger_reason: compaction.trigger_reason ?? null,
+    input_items: numberOrNull(compaction.input_items),
+    output_items: numberOrNull(compaction.output_items),
+    compaction_items: numberOrNull(compaction.compaction_items),
+    latest_compaction_index: numberOrNull(compaction.latest_compaction_index),
+    encrypted_content_hashes: Array.isArray(compaction.encrypted_content_hashes)
+      ? compaction.encrypted_content_hashes
+      : [],
+    encrypted_content_bytes: Array.isArray(compaction.encrypted_content_bytes)
+      ? compaction.encrypted_content_bytes.map(numberOrNull)
+      : [],
+    request_shape_hash: compaction.request_shape_hash ?? null,
+    continuation_generation: numberOrNull(compaction.continuation_generation),
+    error: compaction.error ?? null
   };
 }
 
@@ -3270,6 +3298,11 @@ function summarizeTokenOptimizationRounds(rounds) {
   const contextManagementAppliedEditCounts = {};
   let contextManagementClearedInputTokens = 0;
   let contextManagementClearedToolUses = 0;
+  let openaiRemoteCompactionRounds = 0;
+  const openaiRemoteCompactionStatuses = {};
+  let openaiRemoteCompactionInputItems = 0;
+  let openaiRemoteCompactionOutputItems = 0;
+  let openaiRemoteCompactionItems = 0;
   let cacheMissWithContextManagementAppliedRounds = 0;
   let cacheRecoveredAfterContextManagementAppliedRounds = 0;
   let previousContextManagementAppliedMiss = false;
@@ -3308,6 +3341,15 @@ function summarizeTokenOptimizationRounds(rounds) {
       }
       contextManagementClearedInputTokens += round.context_management.cleared_input_tokens ?? 0;
       contextManagementClearedToolUses += round.context_management.cleared_tool_uses ?? 0;
+    }
+    if (round.openai_remote_compaction) {
+      openaiRemoteCompactionRounds += 1;
+      const status = round.openai_remote_compaction.status ?? "unknown";
+      openaiRemoteCompactionStatuses[status] =
+        (openaiRemoteCompactionStatuses[status] ?? 0) + 1;
+      openaiRemoteCompactionInputItems += round.openai_remote_compaction.input_items ?? 0;
+      openaiRemoteCompactionOutputItems += round.openai_remote_compaction.output_items ?? 0;
+      openaiRemoteCompactionItems += round.openai_remote_compaction.compaction_items ?? 0;
     }
     if (round.cache_break_classification) {
       cacheBreakClassificationCounts[round.cache_break_classification] =
@@ -3369,6 +3411,11 @@ function summarizeTokenOptimizationRounds(rounds) {
     context_management_applied_edit_counts: contextManagementAppliedEditCounts,
     context_management_cleared_input_tokens: contextManagementClearedInputTokens,
     context_management_cleared_tool_uses: contextManagementClearedToolUses,
+    openai_remote_compaction_rounds: openaiRemoteCompactionRounds,
+    openai_remote_compaction_statuses: openaiRemoteCompactionStatuses,
+    openai_remote_compaction_input_items: openaiRemoteCompactionInputItems,
+    openai_remote_compaction_output_items: openaiRemoteCompactionOutputItems,
+    openai_remote_compaction_items: openaiRemoteCompactionItems,
     cache_miss_with_context_management_applied_rounds: cacheMissWithContextManagementAppliedRounds,
     cache_recovered_after_context_management_applied_rounds:
       cacheRecoveredAfterContextManagementAppliedRounds,

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -923,6 +923,59 @@ test("summarizeHolonTokenOptimization reports OpenAI incremental continuation hi
   assert.deepEqual(diagnostics.summary.incremental_fallback_reasons, {});
 });
 
+test("summarizeHolonTokenOptimization reports OpenAI remote compaction", () => {
+  const diagnostics = summarizeHolonTokenOptimization(
+    [
+      {
+        kind: "provider_round_completed",
+        data: {
+          round: 3,
+          input_tokens: 900,
+          output_tokens: 80,
+          provider_request_diagnostics: {
+            request_lowering_mode: "provider_window_compacted",
+            openai_remote_compaction: {
+              status: "compacted",
+              trigger_reason: "provider_window_item_threshold",
+              input_items: 12,
+              output_items: 3,
+              compaction_items: 2,
+              latest_compaction_index: 2,
+              encrypted_content_hashes: ["hash-a", "hash-b"],
+              encrypted_content_bytes: [8, 9],
+              request_shape_hash: "shape-hash",
+              continuation_generation: 4
+            }
+          },
+          provider_attempt_timeline: {
+            attempts: [
+              {
+                provider: "openai",
+                model_ref: "openai/gpt-5.4",
+                outcome: "succeeded"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    [],
+    {
+      modelRef: "openai/gpt-5.4"
+    }
+  );
+
+  assert.equal(diagnostics.rounds[0].request_lowering_mode, "provider_window_compacted");
+  assert.equal(diagnostics.rounds[0].openai_remote_compaction.status, "compacted");
+  assert.equal(diagnostics.rounds[0].openai_remote_compaction.input_items, 12);
+  assert.equal(diagnostics.summary.request_lowering_modes.provider_window_compacted, 1);
+  assert.equal(diagnostics.summary.openai_remote_compaction_rounds, 1);
+  assert.equal(diagnostics.summary.openai_remote_compaction_statuses.compacted, 1);
+  assert.equal(diagnostics.summary.openai_remote_compaction_input_items, 12);
+  assert.equal(diagnostics.summary.openai_remote_compaction_output_items, 3);
+  assert.equal(diagnostics.summary.openai_remote_compaction_items, 2);
+});
+
 test("summarizeHolonTokenOptimization reports Anthropic context management usage", () => {
   const diagnostics = summarizeHolonTokenOptimization([
     {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -169,6 +169,24 @@ pub struct ProviderIncrementalContinuationDiagnostics {
     pub incremental_input_items: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_input_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_prefix_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_mismatch_index: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_item_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_item_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_item_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_item_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_shape_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -121,6 +121,8 @@ pub struct ProviderRequestDiagnostics {
     pub anthropic_context_management: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub incremental_continuation: Option<ProviderIncrementalContinuationDiagnostics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openai_remote_compaction: Option<ProviderOpenAiRemoteCompactionDiagnostics>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -187,6 +189,31 @@ pub struct ProviderIncrementalContinuationDiagnostics {
     pub current_item_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_shape_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderOpenAiRemoteCompactionDiagnostics {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compaction_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_compaction_index: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encrypted_content_hashes: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encrypted_content_bytes: Option<Vec<usize>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_shape_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -32,6 +32,7 @@ fn openai_text_response(response_id: &str, text: &str) -> Value {
         "usage": { "input_tokens": 2, "output_tokens": 1 },
         "output": [{
             "type": "message",
+            "role": "assistant",
             "content": [{ "type": "output_text", "text": text }]
         }]
     })
@@ -59,6 +60,21 @@ fn provider_large_window_continuation_with_prompt_frame() -> ProviderTurnRequest
             is_error: false,
             error: None,
         }]),
+    ]);
+    request
+}
+
+fn provider_large_window_paired_request_with_prompt_frame() -> ProviderTurnRequest {
+    provider_large_window_continuation_with_prompt_frame()
+}
+
+fn provider_large_window_paired_followup_with_prompt_frame() -> ProviderTurnRequest {
+    let mut request = provider_large_window_paired_request_with_prompt_frame();
+    request.conversation.extend([
+        ConversationMessage::AssistantBlocks(vec![ModelBlock::Text {
+            text: "ready".into(),
+        }]),
+        ConversationMessage::UserText("continue".into()),
     ]);
     request
 }
@@ -136,11 +152,11 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
                     async move {
                         captured.lock().unwrap().push(body);
                         let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-                        if attempt == 0 {
-                            Json(openai_tool_call_response("resp_1"))
-                        } else {
-                            Json(openai_text_response("resp_2", "done"))
-                        }
+                        let response = match attempt {
+                            0 => openai_text_response("resp_1", "ready"),
+                            _ => openai_text_response("resp_2", "done"),
+                        };
+                        Json(response)
                     }
                 }),
             )
@@ -172,11 +188,11 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let first = provider
-        .complete_turn(provider_large_window_request_with_prompt_frame())
+        .complete_turn(provider_large_window_paired_request_with_prompt_frame())
         .await
         .unwrap();
     let second = provider
-        .complete_turn(provider_large_window_continuation_with_prompt_frame())
+        .complete_turn(provider_large_window_paired_followup_with_prompt_frame())
         .await
         .unwrap();
 
@@ -186,7 +202,7 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
         .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
         .expect("remote compaction diagnostics");
     assert_eq!(remote_compaction.status, "compacted");
-    assert_eq!(remote_compaction.input_items, Some(9));
+    assert_eq!(remote_compaction.input_items, Some(11));
     assert_eq!(remote_compaction.output_items, Some(3));
     assert_eq!(remote_compaction.compaction_items, Some(2));
     assert_eq!(remote_compaction.latest_compaction_index, Some(2));
@@ -208,16 +224,65 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
     let replayed_input = response_bodies[1]["input"].as_array().unwrap();
     assert_eq!(replayed_input[0]["type"], json!("compaction"));
     assert_eq!(replayed_input[2]["type"], json!("compaction"));
-    assert_eq!(
-        replayed_input.last().unwrap()["type"],
-        json!("function_call_output")
-    );
+    assert_eq!(replayed_input.last().unwrap()["type"], json!("message"));
 
     let compact_bodies = compact_bodies.lock().unwrap();
     assert_eq!(compact_bodies.len(), 1);
-    assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 9);
+    assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 11);
     assert_eq!(compact_bodies[0]["tools"], json!([]));
     assert_eq!(compact_bodies[0]["parallel_tool_calls"], json!(false));
+}
+
+#[tokio::test]
+async fn openai_responses_skips_remote_compaction_for_unpaired_tool_call() {
+    let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let compact_bodies_for_server = compact_bodies.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(|Json(_body): Json<Value>| async {
+                    Json(openai_tool_call_response("resp_1"))
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(move |Json(body): Json<Value>| {
+                    let captured = compact_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        Json(json!({
+                            "output": [
+                                { "type": "compaction", "encrypted_content": "opaque" }
+                            ]
+                        }))
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let response = provider
+        .complete_turn(provider_large_window_request_with_prompt_frame())
+        .await
+        .unwrap();
+
+    let remote_compaction = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("remote compaction skip diagnostics");
+    assert_eq!(remote_compaction.status, "skipped_unpaired_tool_call");
+    assert_eq!(remote_compaction.input_items, Some(9));
+    assert!(compact_bodies.lock().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -236,11 +301,11 @@ async fn openai_responses_local_shape_change_does_not_rewrite_compacted_provider
                     async move {
                         captured.lock().unwrap().push(body);
                         let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-                        if attempt == 0 {
-                            Json(openai_tool_call_response("resp_1"))
-                        } else {
-                            Json(openai_text_response("resp_2", "done"))
-                        }
+                        let response = match attempt {
+                            0 => openai_text_response("resp_1", "ready"),
+                            _ => openai_text_response("resp_2", "done"),
+                        };
+                        Json(response)
                     }
                 }),
             )
@@ -266,10 +331,10 @@ async fn openai_responses_local_shape_change_does_not_rewrite_compacted_provider
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     provider
-        .complete_turn(provider_large_window_request_with_prompt_frame())
+        .complete_turn(provider_large_window_paired_request_with_prompt_frame())
         .await
         .unwrap();
-    let mut changed = provider_large_window_continuation_with_prompt_frame();
+    let mut changed = provider_large_window_paired_followup_with_prompt_frame();
     changed
         .prompt_frame
         .cache

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -326,6 +326,20 @@ async fn openai_responses_falls_back_when_conversation_is_not_append_only() {
             .and_then(|diagnostics| diagnostics.fallback_reason.as_deref()),
         Some("conversation_not_strict_append_only")
     );
+    let diagnostics = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.incremental_continuation.as_ref())
+        .expect("incremental continuation diagnostics");
+    assert_eq!(diagnostics.expected_prefix_items, Some(2));
+    assert_eq!(diagnostics.first_mismatch_index, Some(1));
+    assert_eq!(diagnostics.previous_item_type.as_deref(), Some("function_call"));
+    assert_eq!(diagnostics.current_item_type, None);
+    assert_eq!(diagnostics.previous_item_id.as_deref(), Some("exec-1"));
+    assert_eq!(diagnostics.current_item_id, None);
+    assert!(diagnostics.previous_item_hash.is_some());
+    assert!(diagnostics.current_item_hash.is_none());
+    assert!(diagnostics.request_shape_hash.is_some());
     let bodies = captured_bodies.lock().unwrap();
     assert_eq!(bodies.len(), 2);
     assert!(bodies[1].get("previous_response_id").is_none());

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -37,6 +37,32 @@ fn openai_text_response(response_id: &str, text: &str) -> Value {
     })
 }
 
+fn provider_large_window_request_with_prompt_frame() -> ProviderTurnRequest {
+    let mut request = provider_turn_request_with_prompt_frame();
+    request.conversation = (0..8)
+        .map(|index| ConversationMessage::UserText(format!("message {index}")))
+        .collect();
+    request
+}
+
+fn provider_large_window_continuation_with_prompt_frame() -> ProviderTurnRequest {
+    let mut request = provider_large_window_request_with_prompt_frame();
+    request.conversation.extend([
+        ConversationMessage::AssistantBlocks(vec![ModelBlock::ToolUse {
+            id: "exec-1".into(),
+            name: "ExecCommand".into(),
+            input: json!({ "cmd": "printf ok" }),
+        }]),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "exec-1".into(),
+            content: "ok".into(),
+            is_error: false,
+            error: None,
+        }]),
+    ]);
+    request
+}
+
 #[tokio::test]
 async fn openai_responses_uses_incremental_continuation_for_strict_append() {
     let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
@@ -90,6 +116,181 @@ async fn openai_responses_uses_incremental_continuation_for_strict_append() {
     assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
     assert_eq!(bodies[1]["input"].as_array().unwrap().len(), 1);
     assert_eq!(bodies[1]["input"][0]["type"], json!("function_call_output"));
+}
+
+#[tokio::test]
+async fn openai_responses_remote_compacts_provider_window_and_replays_compaction_items() {
+    let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let response_bodies_for_server = response_bodies.clone();
+    let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let compact_bodies_for_server = compact_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(move |Json(body): Json<Value>| {
+                    let captured = response_bodies_for_server.clone();
+                    let attempts = attempts_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            Json(openai_tool_call_response("resp_1"))
+                        } else {
+                            Json(openai_text_response("resp_2", "done"))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(move |Json(body): Json<Value>| {
+                    let captured = compact_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        Json(json!({
+                            "output": [
+                                { "type": "compaction", "encrypted_content": "opaque-1" },
+                                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "recent" }] },
+                                { "type": "compaction", "encrypted_content": "opaque-2" }
+                            ]
+                        }))
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let first = provider
+        .complete_turn(provider_large_window_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let second = provider
+        .complete_turn(provider_large_window_continuation_with_prompt_frame())
+        .await
+        .unwrap();
+
+    let remote_compaction = first
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("remote compaction diagnostics");
+    assert_eq!(remote_compaction.status, "compacted");
+    assert_eq!(remote_compaction.input_items, Some(9));
+    assert_eq!(remote_compaction.output_items, Some(3));
+    assert_eq!(remote_compaction.compaction_items, Some(2));
+    assert_eq!(remote_compaction.latest_compaction_index, Some(2));
+    assert_eq!(
+        remote_compaction.encrypted_content_bytes.as_deref(),
+        Some([8usize, 8usize].as_slice())
+    );
+
+    assert_eq!(
+        second
+            .request_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.request_lowering_mode.as_str()),
+        Some("provider_window_compacted")
+    );
+    let response_bodies = response_bodies.lock().unwrap();
+    assert_eq!(response_bodies.len(), 2);
+    assert!(response_bodies[1].get("previous_response_id").is_none());
+    let replayed_input = response_bodies[1]["input"].as_array().unwrap();
+    assert_eq!(replayed_input[0]["type"], json!("compaction"));
+    assert_eq!(replayed_input[2]["type"], json!("compaction"));
+    assert_eq!(
+        replayed_input.last().unwrap()["type"],
+        json!("function_call_output")
+    );
+
+    let compact_bodies = compact_bodies.lock().unwrap();
+    assert_eq!(compact_bodies.len(), 1);
+    assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 9);
+    assert_eq!(compact_bodies[0]["tools"], json!([]));
+    assert_eq!(compact_bodies[0]["parallel_tool_calls"], json!(false));
+}
+
+#[tokio::test]
+async fn openai_responses_local_shape_change_does_not_rewrite_compacted_provider_window() {
+    let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let response_bodies_for_server = response_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(move |Json(body): Json<Value>| {
+                    let captured = response_bodies_for_server.clone();
+                    let attempts = attempts_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            Json(openai_tool_call_response("resp_1"))
+                        } else {
+                            Json(openai_text_response("resp_2", "done"))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(|Json(_body): Json<Value>| async {
+                    Json(json!({
+                        "output": [
+                            { "type": "compaction", "encrypted_content": "opaque" }
+                        ]
+                    }))
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(provider_large_window_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let mut changed = provider_large_window_continuation_with_prompt_frame();
+    changed
+        .prompt_frame
+        .cache
+        .as_mut()
+        .expect("cache identity")
+        .compression_epoch += 1;
+    let response = provider.complete_turn(changed).await.unwrap();
+
+    assert_eq!(
+        response
+            .request_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.incremental_continuation.as_ref())
+            .and_then(|diagnostics| diagnostics.fallback_reason.as_deref()),
+        Some("request_shape_changed")
+    );
+    let response_bodies = response_bodies.lock().unwrap();
+    assert_eq!(response_bodies.len(), 2);
+    assert!(response_bodies[1].get("previous_response_id").is_none());
+    assert_eq!(response_bodies[1]["input"][0]["type"], json!("message"));
+    assert_ne!(response_bodies[1]["input"][0]["type"], json!("compaction"));
 }
 
 #[tokio::test]
@@ -333,7 +534,10 @@ async fn openai_responses_falls_back_when_conversation_is_not_append_only() {
         .expect("incremental continuation diagnostics");
     assert_eq!(diagnostics.expected_prefix_items, Some(2));
     assert_eq!(diagnostics.first_mismatch_index, Some(1));
-    assert_eq!(diagnostics.previous_item_type.as_deref(), Some("function_call"));
+    assert_eq!(
+        diagnostics.previous_item_type.as_deref(),
+        Some("function_call")
+    );
     assert_eq!(diagnostics.current_item_type, None);
     assert_eq!(diagnostics.previous_item_id.as_deref(), Some("exec-1"));
     assert_eq!(diagnostics.current_item_id, None);

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -286,6 +286,102 @@ async fn openai_responses_skips_remote_compaction_for_unpaired_tool_call() {
 }
 
 #[tokio::test]
+async fn openai_responses_remote_compacts_before_request_after_tool_output_pairs_call() {
+    let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let response_bodies_for_server = response_bodies.clone();
+    let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let compact_bodies_for_server = compact_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(move |Json(body): Json<Value>| {
+                    let captured = response_bodies_for_server.clone();
+                    let attempts = attempts_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        let response = match attempt {
+                            0 => openai_tool_call_response("resp_1"),
+                            _ => openai_text_response("resp_2", "done"),
+                        };
+                        Json(response)
+                    }
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(move |Json(body): Json<Value>| {
+                    let captured = compact_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        Json(json!({
+                            "output": [
+                                { "type": "compaction", "encrypted_content": "opaque" },
+                                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "recent" }] }
+                            ]
+                        }))
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let first = provider
+        .complete_turn(provider_large_window_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let second = provider
+        .complete_turn(provider_large_window_continuation_with_prompt_frame())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        first
+            .request_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+            .map(|diagnostics| diagnostics.status.as_str()),
+        Some("skipped_unpaired_tool_call")
+    );
+    let remote_compaction = second
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("pre-request remote compaction diagnostics");
+    assert_eq!(remote_compaction.status, "compacted");
+    assert_eq!(
+        remote_compaction.trigger_reason.as_deref(),
+        Some("provider_window_item_threshold_before_request")
+    );
+    assert_eq!(remote_compaction.input_items, Some(10));
+
+    let response_bodies = response_bodies.lock().unwrap();
+    assert_eq!(response_bodies.len(), 2);
+    assert!(response_bodies[1].get("previous_response_id").is_none());
+    let replayed_input = response_bodies[1]["input"].as_array().unwrap();
+    assert_eq!(replayed_input[0]["type"], json!("compaction"));
+    assert_eq!(
+        replayed_input.last().unwrap()["type"],
+        json!("function_call_output")
+    );
+
+    let compact_bodies = compact_bodies.lock().unwrap();
+    assert_eq!(compact_bodies.len(), 1);
+    assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 10);
+}
+
+#[tokio::test]
 async fn openai_responses_local_shape_change_does_not_rewrite_compacted_provider_window() {
     let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
     let response_bodies_for_server = response_bodies.clone();

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -285,6 +285,7 @@ impl AgentProvider for AnthropicProvider {
                 anthropic_cache: Some(cache_diagnostics),
                 anthropic_context_management: parsed.context_management,
                 incremental_continuation: None,
+                openai_remote_compaction: None,
             }),
         })
     }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -64,7 +64,8 @@ pub(crate) enum OpenAiResponsesTransportContract {
 
 #[derive(Debug, Default)]
 struct OpenAiContinuationState {
-    snapshots: HashMap<OpenAiContinuationScope, OpenAiContinuationSnapshot>,
+    windows: HashMap<OpenAiContinuationScope, OpenAiProviderWindow>,
+    next_generation: u64,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -74,11 +75,12 @@ struct OpenAiContinuationScope {
 }
 
 #[derive(Debug, Clone)]
-struct OpenAiContinuationSnapshot {
-    response_id: String,
+struct OpenAiProviderWindow {
+    response_id: Option<String>,
     request_shape: OpenAiRequestShape,
-    full_input: Vec<Value>,
-    response_output: Vec<Value>,
+    items: Vec<Value>,
+    latest_compaction_index: Option<usize>,
+    generation: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -577,7 +579,7 @@ fn plan_chat_completion_request(
     };
 
     let previous = lock_openai_continuation(continuation)
-        .snapshots
+        .windows
         .get(scope_ref)
         .cloned();
 
@@ -627,7 +629,7 @@ fn plan_chat_completion_request(
     }
 
     // Chat Completions continuation currently cannot safely reconstruct an
-    // assistant message from `previous.response_output` for prefix matching.
+    // assistant message from the provider window for prefix matching.
     // `full_messages` contains message objects, but `response_output` is not
     // guaranteed to store a comparable message value, so incremental
     // continuation would be unreliable here. Send the full request instead.
@@ -861,7 +863,7 @@ fn plan_openai_responses_request(
         });
     };
     let previous = lock_openai_continuation(continuation)
-        .snapshots
+        .windows
         .get(scope_ref)
         .cloned();
     let Some(previous) = previous else {
@@ -900,8 +902,23 @@ fn plan_openai_responses_request(
         });
     }
 
-    let mut expected_prefix = previous.full_input.clone();
-    expected_prefix.extend(previous.response_output.clone());
+    if previous.response_id.is_none() {
+        return Ok(OpenAiRequestPlan {
+            body,
+            scope,
+            full_input,
+            request_shape,
+            diagnostics: incremental_diagnostics(
+                "full_request",
+                "missing_response_id",
+                None,
+                full_input_items,
+                None,
+            ),
+        });
+    }
+
+    let expected_prefix = previous.items.clone();
     let mismatch = openai_continuation_mismatch_diagnostics(
         &expected_prefix,
         &full_input,
@@ -928,7 +945,8 @@ fn plan_openai_responses_request(
 
     let incremental_input = full_input[expected_prefix.len()..].to_vec();
     body["input"] = Value::Array(incremental_input.clone());
-    body["previous_response_id"] = Value::String(previous.response_id);
+    body["previous_response_id"] =
+        Value::String(previous.response_id.expect("response id checked above"));
     let request_shape_hash = request_shape_hash(&request_shape);
     Ok(OpenAiRequestPlan {
         body,
@@ -1040,6 +1058,16 @@ fn openai_item_hash(item: &Value) -> String {
     sha256_hex(canonical_json(item).as_bytes())
 }
 
+fn latest_openai_compaction_index(items: &[Value]) -> Option<usize> {
+    items
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(index, item)| {
+            (item.get("type").and_then(Value::as_str) == Some("compaction")).then_some(index)
+        })
+}
+
 fn request_shape_hash(request_shape: &OpenAiRequestShape) -> String {
     let value = json!({
         "wire_shape": request_shape.wire_shape,
@@ -1123,20 +1151,26 @@ fn update_openai_continuation(
     let Some(scope) = scope else {
         return;
     };
+    let mut state = lock_openai_continuation(continuation);
     let next = match (parsed.response_id.as_ref(), parsed.output_items.is_empty()) {
-        (Some(response_id), false) => Some(OpenAiContinuationSnapshot {
-            response_id: response_id.clone(),
-            request_shape,
-            full_input,
-            response_output: parsed.output_items.clone(),
-        }),
+        (Some(response_id), false) => {
+            state.next_generation = state.next_generation.saturating_add(1);
+            let mut items = full_input;
+            items.extend(parsed.output_items.clone());
+            Some(OpenAiProviderWindow {
+                response_id: Some(response_id.clone()),
+                request_shape,
+                latest_compaction_index: latest_openai_compaction_index(&items),
+                items,
+                generation: state.next_generation,
+            })
+        }
         _ => None,
     };
-    let mut state = lock_openai_continuation(continuation);
     if let Some(next) = next {
-        state.snapshots.insert(scope, next);
+        state.windows.insert(scope, next);
     } else {
-        state.snapshots.remove(&scope);
+        state.windows.remove(&scope);
     }
 }
 
@@ -1146,9 +1180,9 @@ fn invalidate_openai_continuation(
 ) {
     let mut state = lock_openai_continuation(continuation);
     if let Some(scope) = scope {
-        state.snapshots.remove(scope);
+        state.windows.remove(scope);
     } else {
-        state.snapshots.clear();
+        state.windows.clear();
     }
 }
 
@@ -2394,7 +2428,8 @@ fn unsupported_streaming_transport_error(provider_name: &str) -> anyhow::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::chat_completions_url;
+    use super::{chat_completions_url, latest_openai_compaction_index};
+    use serde_json::json;
 
     #[test]
     fn chat_completions_url_accepts_openai_compatible_base_urls() {
@@ -2422,5 +2457,17 @@ mod tests {
             chat_completions_url("https://proxy.example/chat/completions"),
             "https://proxy.example/chat/completions"
         );
+    }
+
+    #[test]
+    fn openai_provider_window_tracks_latest_compaction_item() {
+        let items = vec![
+            json!({ "type": "message", "role": "user" }),
+            json!({ "type": "compaction", "encrypted_content": "first" }),
+            json!({ "type": "message", "role": "user" }),
+            json!({ "type": "compaction", "encrypted_content": "second" }),
+        ];
+
+        assert_eq!(latest_openai_compaction_index(&items), Some(3));
     }
 }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -2,8 +2,9 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use reqwest::{Client, Response};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::{Arc, Mutex, MutexGuard},
 };
 
@@ -93,6 +94,19 @@ struct OpenAiRequestPlan {
     full_input: Vec<Value>,
     request_shape: OpenAiRequestShape,
     diagnostics: ProviderRequestDiagnostics,
+}
+
+#[derive(Debug, Clone, Default)]
+struct OpenAiContinuationMismatchDiagnostics {
+    expected_prefix_items: usize,
+    first_mismatch_index: Option<usize>,
+    previous_item_type: Option<String>,
+    current_item_type: Option<String>,
+    previous_item_id: Option<String>,
+    current_item_id: Option<String>,
+    previous_item_hash: Option<String>,
+    current_item_hash: Option<String>,
+    request_shape_hash: Option<String>,
 }
 
 #[derive(Debug)]
@@ -556,6 +570,7 @@ fn plan_chat_completion_request(
                     "missing_continuation_scope",
                     None,
                     full_message_count,
+                    None,
                 ),
             },
         ));
@@ -580,6 +595,7 @@ fn plan_chat_completion_request(
                     "not_applicable_initial_request",
                     None,
                     full_message_count,
+                    None,
                 ),
             },
         ));
@@ -588,6 +604,7 @@ fn plan_chat_completion_request(
     // Check if request shape changed
     if previous.request_shape != request_shape {
         // Request changed - send full request
+        let request_shape_hash = request_shape_hash(&request_shape);
         return Ok((
             full_body.clone(),
             OpenAiRequestPlan {
@@ -600,6 +617,10 @@ fn plan_chat_completion_request(
                     "request_shape_changed",
                     None,
                     full_message_count,
+                    Some(OpenAiContinuationMismatchDiagnostics {
+                        request_shape_hash: Some(request_shape_hash),
+                        ..OpenAiContinuationMismatchDiagnostics::default()
+                    }),
                 ),
             },
         ));
@@ -610,6 +631,7 @@ fn plan_chat_completion_request(
     // `full_messages` contains message objects, but `response_output` is not
     // guaranteed to store a comparable message value, so incremental
     // continuation would be unreliable here. Send the full request instead.
+    let request_shape_hash = request_shape_hash(&request_shape);
     return Ok((
         full_body.clone(),
         OpenAiRequestPlan {
@@ -622,6 +644,10 @@ fn plan_chat_completion_request(
                 "chat_completions_incremental_continuation_unsupported",
                 None,
                 full_message_count,
+                Some(OpenAiContinuationMismatchDiagnostics {
+                    request_shape_hash: Some(request_shape_hash),
+                    ..OpenAiContinuationMismatchDiagnostics::default()
+                }),
             ),
         },
     ));
@@ -830,6 +856,7 @@ fn plan_openai_responses_request(
                 "missing_continuation_scope",
                 None,
                 full_input_items,
+                None,
             ),
         });
     };
@@ -848,11 +875,13 @@ fn plan_openai_responses_request(
                 "not_applicable_initial_request",
                 None,
                 full_input_items,
+                None,
             ),
         });
     };
 
     if previous.request_shape != request_shape {
+        let request_shape_hash = request_shape_hash(&request_shape);
         return Ok(OpenAiRequestPlan {
             body,
             scope,
@@ -863,12 +892,21 @@ fn plan_openai_responses_request(
                 "request_shape_changed",
                 None,
                 full_input_items,
+                Some(OpenAiContinuationMismatchDiagnostics {
+                    request_shape_hash: Some(request_shape_hash),
+                    ..OpenAiContinuationMismatchDiagnostics::default()
+                }),
             ),
         });
     }
 
     let mut expected_prefix = previous.full_input.clone();
     expected_prefix.extend(previous.response_output.clone());
+    let mismatch = openai_continuation_mismatch_diagnostics(
+        &expected_prefix,
+        &full_input,
+        &request_shape,
+    );
     if expected_prefix.is_empty()
         || full_input.len() <= expected_prefix.len()
         || !full_input.starts_with(&expected_prefix)
@@ -883,6 +921,7 @@ fn plan_openai_responses_request(
                 "conversation_not_strict_append_only",
                 None,
                 full_input_items,
+                Some(mismatch),
             ),
         });
     }
@@ -890,6 +929,7 @@ fn plan_openai_responses_request(
     let incremental_input = full_input[expected_prefix.len()..].to_vec();
     body["input"] = Value::Array(incremental_input.clone());
     body["previous_response_id"] = Value::String(previous.response_id);
+    let request_shape_hash = request_shape_hash(&request_shape);
     Ok(OpenAiRequestPlan {
         body,
         scope,
@@ -904,6 +944,15 @@ fn plan_openai_responses_request(
                 fallback_reason: None,
                 incremental_input_items: Some(incremental_input.len()),
                 full_input_items: Some(full_input_items),
+                expected_prefix_items: Some(expected_prefix.len()),
+                first_mismatch_index: None,
+                previous_item_type: None,
+                current_item_type: None,
+                previous_item_id: None,
+                current_item_id: None,
+                previous_item_hash: None,
+                current_item_hash: None,
+                request_shape_hash: Some(request_shape_hash),
             }),
         },
     })
@@ -932,12 +981,116 @@ fn request_shape_without_input(body: &Value, request: &ProviderTurnRequest) -> O
     }
 }
 
+fn openai_continuation_mismatch_diagnostics(
+    expected_prefix: &[Value],
+    full_input: &[Value],
+    request_shape: &OpenAiRequestShape,
+) -> OpenAiContinuationMismatchDiagnostics {
+    let first_mismatch_index = expected_prefix
+        .iter()
+        .zip(full_input.iter())
+        .position(|(previous, current)| previous != current)
+        .or_else(|| {
+            (expected_prefix.len() != full_input.len())
+                .then_some(expected_prefix.len().min(full_input.len()))
+        });
+    let previous = first_mismatch_index.and_then(|index| expected_prefix.get(index));
+    let current = first_mismatch_index.and_then(|index| full_input.get(index));
+    OpenAiContinuationMismatchDiagnostics {
+        expected_prefix_items: expected_prefix.len(),
+        first_mismatch_index,
+        previous_item_type: previous.map(openai_item_type),
+        current_item_type: current.map(openai_item_type),
+        previous_item_id: previous.and_then(openai_item_stable_id),
+        current_item_id: current.and_then(openai_item_stable_id),
+        previous_item_hash: previous.map(openai_item_hash),
+        current_item_hash: current.map(openai_item_hash),
+        request_shape_hash: Some(request_shape_hash(request_shape)),
+    }
+}
+
+fn openai_item_type(item: &Value) -> String {
+    item.get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| match item {
+            Value::Object(_) => "object",
+            Value::Array(_) => "array",
+            Value::String(_) => "string",
+            Value::Number(_) => "number",
+            Value::Bool(_) => "bool",
+            Value::Null => "null",
+        })
+        .to_string()
+}
+
+fn openai_item_stable_id(item: &Value) -> Option<String> {
+    if let Some(id) = ["id", "call_id"]
+        .into_iter()
+        .find_map(|key| item.get(key).and_then(Value::as_str))
+    {
+        return Some(id.to_string());
+    }
+    item.get("role").and_then(Value::as_str).map(|role| {
+        let item_type = openai_item_type(item);
+        format!("{item_type}:{role}")
+    })
+}
+
+fn openai_item_hash(item: &Value) -> String {
+    sha256_hex(canonical_json(item).as_bytes())
+}
+
+fn request_shape_hash(request_shape: &OpenAiRequestShape) -> String {
+    let value = json!({
+        "wire_shape": request_shape.wire_shape,
+        "prompt_frame": request_shape.prompt_frame,
+    });
+    sha256_hex(canonical_json(&value).as_bytes())
+}
+
+fn canonical_json(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => serde_json::to_string(value).unwrap_or_else(|_| "\"\"".into()),
+        Value::Array(values) => {
+            let items = values.iter().map(canonical_json).collect::<Vec<_>>();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(map) => {
+            let ordered = map
+                .iter()
+                .map(|(key, value)| (key, value))
+                .collect::<BTreeMap<_, _>>();
+            let items = ordered
+                .into_iter()
+                .map(|(key, value)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(key).unwrap_or_else(|_| "\"\"".into()),
+                        canonical_json(value)
+                    )
+                })
+                .collect::<Vec<_>>();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{:02x}", byte)).collect()
+}
+
 fn incremental_diagnostics(
     request_lowering_mode: &str,
     fallback_reason: &str,
     incremental_input_items: Option<usize>,
     full_input_items: usize,
+    mismatch: Option<OpenAiContinuationMismatchDiagnostics>,
 ) -> ProviderRequestDiagnostics {
+    let mismatch = mismatch.unwrap_or_default();
     ProviderRequestDiagnostics {
         request_lowering_mode: request_lowering_mode.into(),
         anthropic_cache: None,
@@ -947,6 +1100,15 @@ fn incremental_diagnostics(
             fallback_reason: Some(fallback_reason.into()),
             incremental_input_items,
             full_input_items: Some(full_input_items),
+            expected_prefix_items: Some(mismatch.expected_prefix_items),
+            first_mismatch_index: mismatch.first_mismatch_index,
+            previous_item_type: mismatch.previous_item_type,
+            current_item_type: mismatch.current_item_type,
+            previous_item_id: mismatch.previous_item_id,
+            current_item_id: mismatch.current_item_id,
+            previous_item_hash: mismatch.previous_item_hash,
+            current_item_hash: mismatch.current_item_hash,
+            request_shape_hash: mismatch.request_shape_hash,
         }),
     }
 }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -4,7 +4,7 @@ use reqwest::{Client, Response};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, Mutex, MutexGuard},
 };
 
@@ -1234,8 +1234,23 @@ async fn maybe_compact_openai_provider_window(
         let state = lock_openai_continuation(continuation);
         state.windows.get(scope).cloned()
     }?;
-    if !should_compact_openai_provider_window(&window) {
-        return None;
+    if let Some(skip_reason) = openai_provider_window_compaction_skip_reason(&window) {
+        if skip_reason == "below_item_threshold" {
+            return None;
+        }
+        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+            status: format!("skipped_{skip_reason}"),
+            trigger_reason: Some("provider_window_item_threshold".into()),
+            input_items: Some(window.items.len()),
+            output_items: None,
+            compaction_items: None,
+            latest_compaction_index: window.latest_compaction_index,
+            encrypted_content_hashes: None,
+            encrypted_content_bytes: None,
+            request_shape_hash: Some(request_shape_hash(request_shape)),
+            continuation_generation: Some(window.generation),
+            error: None,
+        });
     }
 
     let input_items = window.items.len();
@@ -1299,6 +1314,25 @@ async fn maybe_compact_openai_provider_window(
     let output_items = compacted.len();
     let generation = {
         let mut state = lock_openai_continuation(continuation);
+        let current_generation = state.windows.get(scope).map(|current| current.generation);
+        if current_generation != Some(window.generation) {
+            return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                status: "stale_generation".into(),
+                trigger_reason: Some("provider_window_item_threshold".into()),
+                input_items: Some(input_items),
+                output_items: Some(output_items),
+                compaction_items: Some(compaction_items),
+                latest_compaction_index,
+                encrypted_content_hashes: Some(encrypted_content_hashes),
+                encrypted_content_bytes: Some(encrypted_content_bytes),
+                request_shape_hash: Some(request_shape_hash),
+                continuation_generation: current_generation,
+                error: Some(format!(
+                    "OpenAI provider window advanced while compact request was in flight; captured generation {}",
+                    window.generation
+                )),
+            });
+        }
         state.next_generation = state.next_generation.saturating_add(1);
         let generation = state.next_generation;
         state.windows.insert(
@@ -1330,12 +1364,51 @@ async fn maybe_compact_openai_provider_window(
     })
 }
 
-fn should_compact_openai_provider_window(window: &OpenAiProviderWindow) -> bool {
+fn openai_provider_window_compaction_skip_reason(
+    window: &OpenAiProviderWindow,
+) -> Option<&'static str> {
     let since_latest_compaction = window
         .latest_compaction_index
         .map(|index| window.items.len().saturating_sub(index + 1))
         .unwrap_or(window.items.len());
-    since_latest_compaction >= OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS
+    if since_latest_compaction < OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS {
+        return Some("below_item_threshold");
+    }
+    if has_unpaired_openai_tool_call(&window.items) {
+        return Some("unpaired_tool_call");
+    }
+    None
+}
+
+fn has_unpaired_openai_tool_call(items: &[Value]) -> bool {
+    let mut function_calls = HashSet::new();
+    let mut custom_tool_calls = HashSet::new();
+    let mut function_outputs = HashSet::new();
+    let mut custom_tool_outputs = HashSet::new();
+
+    for item in items {
+        let Some(call_id) = item.get("call_id").and_then(Value::as_str) else {
+            continue;
+        };
+        match item.get("type").and_then(Value::as_str) {
+            Some("function_call") => {
+                function_calls.insert(call_id.to_string());
+            }
+            Some("custom_tool_call") => {
+                custom_tool_calls.insert(call_id.to_string());
+            }
+            Some("function_call_output") => {
+                function_outputs.insert(call_id.to_string());
+            }
+            Some("custom_tool_call_output") => {
+                custom_tool_outputs.insert(call_id.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    !function_calls.is_subset(&function_outputs)
+        || !custom_tool_calls.is_subset(&custom_tool_outputs)
 }
 
 fn build_openai_compact_request_body(request_shape: &OpenAiRequestShape, items: &[Value]) -> Value {

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -258,18 +258,32 @@ impl AgentProvider for OpenAiProvider {
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Relaxed,
         )?;
-        let plan = plan_openai_responses_request(body, &request, &self.continuation)?;
+        let mut plan = plan_openai_responses_request(body, &request, &self.continuation)?;
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
+        let headers = self
+            .api_key
+            .as_ref()
+            .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
+            .unwrap_or_default();
+        if let Some(remote_compaction) = maybe_compact_openai_request_plan(
+            &self.continuation,
+            &mut plan,
+            &self.client,
+            format!("{}/responses/compact", self.base_url),
+            headers.clone(),
+        )
+        .await
+        {
+            sent_diagnostics.openai_remote_compaction = Some(remote_compaction);
+            sent_diagnostics.request_lowering_mode = plan.diagnostics.request_lowering_mode.clone();
+        }
         let parsed = match send_openai_responses_request(
             &self.client,
             format!("{}/responses", self.base_url),
             plan.body,
-            self.api_key
-                .as_ref()
-                .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
-                .unwrap_or_default(),
+            headers.clone(),
         )
         .await
         {
@@ -287,18 +301,17 @@ impl AgentProvider for OpenAiProvider {
             plan.provider_input,
             &parsed,
         );
-        sent_diagnostics.openai_remote_compaction = maybe_compact_openai_provider_window(
-            &self.continuation,
-            plan_scope.as_ref(),
-            &plan_request_shape,
-            &self.client,
-            format!("{}/responses/compact", self.base_url),
-            self.api_key
-                .as_ref()
-                .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
-                .unwrap_or_default(),
-        )
-        .await;
+        if sent_diagnostics.openai_remote_compaction.is_none() {
+            sent_diagnostics.openai_remote_compaction = maybe_compact_openai_provider_window(
+                &self.continuation,
+                plan_scope.as_ref(),
+                &plan_request_shape,
+                &self.client,
+                format!("{}/responses/compact", self.base_url),
+                headers,
+            )
+            .await;
+        }
         Ok(parsed.response.with_request_diagnostics(sent_diagnostics))
     }
 
@@ -327,23 +340,36 @@ impl AgentProvider for OpenAiCodexProvider {
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
         )?;
-        let plan = plan_openai_responses_request(body, &request, &self.continuation)?;
+        let mut plan = plan_openai_responses_request(body, &request, &self.continuation)?;
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
+        let headers = vec![
+            (
+                "authorization",
+                format!("Bearer {}", credential.access_token),
+            ),
+            ("chatgpt-account-id", credential.account_id.clone()),
+            ("OpenAI-Beta", "responses=experimental".to_string()),
+            ("originator", self.originator.clone()),
+        ];
+        if let Some(remote_compaction) = maybe_compact_openai_request_plan(
+            &self.continuation,
+            &mut plan,
+            &self.client,
+            format!("{}/responses/compact", self.base_url),
+            headers.clone(),
+        )
+        .await
+        {
+            sent_diagnostics.openai_remote_compaction = Some(remote_compaction);
+            sent_diagnostics.request_lowering_mode = plan.diagnostics.request_lowering_mode.clone();
+        }
         let parsed = match send_openai_responses_streaming_request(
             &self.client,
             format!("{}/codex/responses", self.base_url),
             plan.body,
-            vec![
-                (
-                    "authorization",
-                    format!("Bearer {}", credential.access_token),
-                ),
-                ("chatgpt-account-id", credential.account_id.clone()),
-                ("OpenAI-Beta", "responses=experimental".to_string()),
-                ("originator", self.originator.clone()),
-            ],
+            headers.clone(),
         )
         .await
         {
@@ -361,23 +387,17 @@ impl AgentProvider for OpenAiCodexProvider {
             plan.provider_input,
             &parsed,
         );
-        sent_diagnostics.openai_remote_compaction = maybe_compact_openai_provider_window(
-            &self.continuation,
-            plan_scope.as_ref(),
-            &plan_request_shape,
-            &self.client,
-            format!("{}/responses/compact", self.base_url),
-            vec![
-                (
-                    "authorization",
-                    format!("Bearer {}", credential.access_token),
-                ),
-                ("chatgpt-account-id", credential.account_id),
-                ("OpenAI-Beta", "responses=experimental".to_string()),
-                ("originator", self.originator.clone()),
-            ],
-        )
-        .await;
+        if sent_diagnostics.openai_remote_compaction.is_none() {
+            sent_diagnostics.openai_remote_compaction = maybe_compact_openai_provider_window(
+                &self.continuation,
+                plan_scope.as_ref(),
+                &plan_request_shape,
+                &self.client,
+                format!("{}/responses/compact", self.base_url),
+                headers,
+            )
+            .await;
+        }
         Ok(parsed.response.with_request_diagnostics(sent_diagnostics))
     }
 
@@ -1360,6 +1380,159 @@ async fn maybe_compact_openai_provider_window(
         encrypted_content_bytes: Some(encrypted_content_bytes),
         request_shape_hash: Some(request_shape_hash),
         continuation_generation: Some(generation),
+        error: None,
+    })
+}
+
+async fn maybe_compact_openai_request_plan(
+    continuation: &Arc<Mutex<OpenAiContinuationState>>,
+    plan: &mut OpenAiRequestPlan,
+    client: &Client,
+    compact_url: String,
+    headers: Vec<(&str, String)>,
+) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
+    if plan.diagnostics.request_lowering_mode != "incremental_continuation" {
+        return None;
+    }
+    let scope = plan.scope.as_ref()?;
+    let previous = {
+        let state = lock_openai_continuation(continuation);
+        state.windows.get(scope).cloned()
+    }?;
+    previous.response_id.as_ref()?;
+
+    let mut compactable_items = previous.items.clone();
+    compactable_items.extend(plan.provider_input.clone());
+    let compactable_window = OpenAiProviderWindow {
+        response_id: None,
+        request_shape: plan.request_shape.clone(),
+        latest_compaction_index: latest_openai_compaction_index(&compactable_items),
+        items: compactable_items,
+        append_match_items: plan.full_input.clone(),
+        generation: previous.generation,
+    };
+    if let Some(skip_reason) = openai_provider_window_compaction_skip_reason(&compactable_window) {
+        if skip_reason == "below_item_threshold" {
+            return None;
+        }
+        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+            status: format!("skipped_{skip_reason}"),
+            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            input_items: Some(compactable_window.items.len()),
+            output_items: None,
+            compaction_items: None,
+            latest_compaction_index: compactable_window.latest_compaction_index,
+            encrypted_content_hashes: None,
+            encrypted_content_bytes: None,
+            request_shape_hash: Some(request_shape_hash(&plan.request_shape)),
+            continuation_generation: Some(previous.generation),
+            error: None,
+        });
+    }
+
+    let input_items = compactable_window.items.len();
+    let request_shape_hash = request_shape_hash(&plan.request_shape);
+    let compact_body =
+        build_openai_compact_request_body(&plan.request_shape, &compactable_window.items);
+    let compacted =
+        match send_openai_compact_request(client, compact_url, compact_body, headers).await {
+            Ok(compacted) => compacted,
+            Err(error) => {
+                return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                    status: "failed".into(),
+                    trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+                    input_items: Some(input_items),
+                    output_items: None,
+                    compaction_items: None,
+                    latest_compaction_index: compactable_window.latest_compaction_index,
+                    encrypted_content_hashes: None,
+                    encrypted_content_bytes: None,
+                    request_shape_hash: Some(request_shape_hash),
+                    continuation_generation: Some(previous.generation),
+                    error: Some(error.to_string()),
+                });
+            }
+        };
+    if compacted.is_empty() {
+        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+            status: "rejected_empty_output".into(),
+            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            input_items: Some(input_items),
+            output_items: Some(0),
+            compaction_items: Some(0),
+            latest_compaction_index: compactable_window.latest_compaction_index,
+            encrypted_content_hashes: Some(Vec::new()),
+            encrypted_content_bytes: Some(Vec::new()),
+            request_shape_hash: Some(request_shape_hash),
+            continuation_generation: Some(previous.generation),
+            error: Some("OpenAI compact response returned an empty output window".into()),
+        });
+    }
+
+    let latest_compaction_index = latest_openai_compaction_index(&compacted);
+    let encrypted_content_hashes = openai_compaction_encrypted_content_hashes(&compacted);
+    let encrypted_content_bytes = openai_compaction_encrypted_content_bytes(&compacted);
+    let compaction_items = encrypted_content_hashes.len();
+    if compaction_items == 0 {
+        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+            status: "rejected_missing_compaction_item".into(),
+            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            input_items: Some(input_items),
+            output_items: Some(compacted.len()),
+            compaction_items: Some(0),
+            latest_compaction_index: None,
+            encrypted_content_hashes: Some(Vec::new()),
+            encrypted_content_bytes: Some(Vec::new()),
+            request_shape_hash: Some(request_shape_hash),
+            continuation_generation: Some(previous.generation),
+            error: Some("OpenAI compact response did not include a compaction item".into()),
+        });
+    }
+
+    let current_generation = {
+        let state = lock_openai_continuation(continuation);
+        state.windows.get(scope).map(|current| current.generation)
+    };
+    if current_generation != Some(previous.generation) {
+        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+            status: "stale_generation".into(),
+            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            input_items: Some(input_items),
+            output_items: Some(compacted.len()),
+            compaction_items: Some(compaction_items),
+            latest_compaction_index,
+            encrypted_content_hashes: Some(encrypted_content_hashes),
+            encrypted_content_bytes: Some(encrypted_content_bytes),
+            request_shape_hash: Some(request_shape_hash),
+            continuation_generation: current_generation,
+            error: Some(format!(
+                "OpenAI provider window advanced while compact request was in flight; captured generation {}",
+                previous.generation
+            )),
+        });
+    }
+
+    let output_items = compacted.len();
+    let mut provider_input = compacted;
+    provider_input.extend(plan.provider_input.clone());
+    plan.body["input"] = Value::Array(provider_input.clone());
+    if let Some(object) = plan.body.as_object_mut() {
+        object.remove("previous_response_id");
+    }
+    plan.provider_input = provider_input;
+    plan.diagnostics.request_lowering_mode = "provider_window_compacted".into();
+
+    Some(ProviderOpenAiRemoteCompactionDiagnostics {
+        status: "compacted".into(),
+        trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+        input_items: Some(input_items),
+        output_items: Some(output_items),
+        compaction_items: Some(compaction_items),
+        latest_compaction_index,
+        encrypted_content_hashes: Some(encrypted_content_hashes),
+        encrypted_content_bytes: Some(encrypted_content_bytes),
+        request_shape_hash: Some(request_shape_hash),
+        continuation_generation: Some(previous.generation),
         error: None,
     })
 }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -13,8 +13,9 @@ use crate::{
     config::{AppConfig, CredentialKind, CredentialSource, ProviderId, ProviderRuntimeConfig},
     provider::{
         emitted_tool_json_schema, AgentProvider, ConversationMessage, ModelBlock,
-        ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics, ProviderPromptFrame,
-        ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse, ToolSchemaContract,
+        ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
+        ProviderOpenAiRemoteCompactionDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
+        ProviderTurnRequest, ProviderTurnResponse, ToolSchemaContract,
     },
 };
 
@@ -62,6 +63,8 @@ pub(crate) enum OpenAiResponsesTransportContract {
     ChatCompletions,
 }
 
+const OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS: usize = 8;
+
 #[derive(Debug, Default)]
 struct OpenAiContinuationState {
     windows: HashMap<OpenAiContinuationScope, OpenAiProviderWindow>,
@@ -79,6 +82,7 @@ struct OpenAiProviderWindow {
     response_id: Option<String>,
     request_shape: OpenAiRequestShape,
     items: Vec<Value>,
+    append_match_items: Vec<Value>,
     latest_compaction_index: Option<usize>,
     generation: u64,
 }
@@ -94,6 +98,7 @@ struct OpenAiRequestPlan {
     body: Value,
     scope: Option<OpenAiContinuationScope>,
     full_input: Vec<Value>,
+    provider_input: Vec<Value>,
     request_shape: OpenAiRequestShape,
     diagnostics: ProviderRequestDiagnostics,
 }
@@ -254,7 +259,9 @@ impl AgentProvider for OpenAiProvider {
             ToolSchemaContract::Relaxed,
         )?;
         let plan = plan_openai_responses_request(body, &request, &self.continuation)?;
-        let sent_diagnostics = plan.diagnostics.clone();
+        let mut sent_diagnostics = plan.diagnostics.clone();
+        let plan_scope = plan.scope.clone();
+        let plan_request_shape = plan.request_shape.clone();
         let parsed = match send_openai_responses_request(
             &self.client,
             format!("{}/responses", self.base_url),
@@ -274,11 +281,24 @@ impl AgentProvider for OpenAiProvider {
         };
         update_openai_continuation(
             &self.continuation,
-            plan.scope,
-            plan.request_shape,
+            plan_scope.clone(),
+            plan_request_shape.clone(),
             plan.full_input,
+            plan.provider_input,
             &parsed,
         );
+        sent_diagnostics.openai_remote_compaction = maybe_compact_openai_provider_window(
+            &self.continuation,
+            plan_scope.as_ref(),
+            &plan_request_shape,
+            &self.client,
+            format!("{}/responses/compact", self.base_url),
+            self.api_key
+                .as_ref()
+                .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
+                .unwrap_or_default(),
+        )
+        .await;
         Ok(parsed.response.with_request_diagnostics(sent_diagnostics))
     }
 
@@ -308,7 +328,9 @@ impl AgentProvider for OpenAiCodexProvider {
             ToolSchemaContract::Relaxed,
         )?;
         let plan = plan_openai_responses_request(body, &request, &self.continuation)?;
-        let sent_diagnostics = plan.diagnostics.clone();
+        let mut sent_diagnostics = plan.diagnostics.clone();
+        let plan_scope = plan.scope.clone();
+        let plan_request_shape = plan.request_shape.clone();
         let parsed = match send_openai_responses_streaming_request(
             &self.client,
             format!("{}/codex/responses", self.base_url),
@@ -318,7 +340,7 @@ impl AgentProvider for OpenAiCodexProvider {
                     "authorization",
                     format!("Bearer {}", credential.access_token),
                 ),
-                ("chatgpt-account-id", credential.account_id),
+                ("chatgpt-account-id", credential.account_id.clone()),
                 ("OpenAI-Beta", "responses=experimental".to_string()),
                 ("originator", self.originator.clone()),
             ],
@@ -333,11 +355,29 @@ impl AgentProvider for OpenAiCodexProvider {
         };
         update_openai_continuation(
             &self.continuation,
-            plan.scope,
-            plan.request_shape,
+            plan_scope.clone(),
+            plan_request_shape.clone(),
             plan.full_input,
+            plan.provider_input,
             &parsed,
         );
+        sent_diagnostics.openai_remote_compaction = maybe_compact_openai_provider_window(
+            &self.continuation,
+            plan_scope.as_ref(),
+            &plan_request_shape,
+            &self.client,
+            format!("{}/responses/compact", self.base_url),
+            vec![
+                (
+                    "authorization",
+                    format!("Bearer {}", credential.access_token),
+                ),
+                ("chatgpt-account-id", credential.account_id),
+                ("OpenAI-Beta", "responses=experimental".to_string()),
+                ("originator", self.originator.clone()),
+            ],
+        )
+        .await;
         Ok(parsed.response.with_request_diagnostics(sent_diagnostics))
     }
 
@@ -393,6 +433,7 @@ impl AgentProvider for OpenAiChatCompletionsProvider {
             plan.scope,
             plan.request_shape,
             plan.full_input,
+            plan.provider_input,
             &parsed,
         );
 
@@ -565,7 +606,8 @@ fn plan_chat_completion_request(
             OpenAiRequestPlan {
                 body: full_body,
                 scope,
-                full_input: full_messages,
+                full_input: full_messages.clone(),
+                provider_input: full_messages,
                 request_shape,
                 diagnostics: incremental_diagnostics(
                     "full_request",
@@ -590,7 +632,8 @@ fn plan_chat_completion_request(
             OpenAiRequestPlan {
                 body: full_body,
                 scope,
-                full_input: full_messages,
+                full_input: full_messages.clone(),
+                provider_input: full_messages,
                 request_shape,
                 diagnostics: incremental_diagnostics(
                     "full_request",
@@ -612,7 +655,8 @@ fn plan_chat_completion_request(
             OpenAiRequestPlan {
                 body: full_body,
                 scope,
-                full_input: full_messages,
+                full_input: full_messages.clone(),
+                provider_input: full_messages,
                 request_shape,
                 diagnostics: incremental_diagnostics(
                     "full_request",
@@ -639,7 +683,8 @@ fn plan_chat_completion_request(
         OpenAiRequestPlan {
             body: full_body,
             scope,
-            full_input: full_messages,
+            full_input: full_messages.clone(),
+            provider_input: full_messages,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -851,7 +896,8 @@ fn plan_openai_responses_request(
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input,
+            full_input: full_input.clone(),
+            provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -870,7 +916,8 @@ fn plan_openai_responses_request(
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input,
+            full_input: full_input.clone(),
+            provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -887,7 +934,8 @@ fn plan_openai_responses_request(
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input,
+            full_input: full_input.clone(),
+            provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -902,28 +950,9 @@ fn plan_openai_responses_request(
         });
     }
 
-    if previous.response_id.is_none() {
-        return Ok(OpenAiRequestPlan {
-            body,
-            scope,
-            full_input,
-            request_shape,
-            diagnostics: incremental_diagnostics(
-                "full_request",
-                "missing_response_id",
-                None,
-                full_input_items,
-                None,
-            ),
-        });
-    }
-
-    let expected_prefix = previous.items.clone();
-    let mismatch = openai_continuation_mismatch_diagnostics(
-        &expected_prefix,
-        &full_input,
-        &request_shape,
-    );
+    let expected_prefix = previous.append_match_items.clone();
+    let mismatch =
+        openai_continuation_mismatch_diagnostics(&expected_prefix, &full_input, &request_shape);
     if expected_prefix.is_empty()
         || full_input.len() <= expected_prefix.len()
         || !full_input.starts_with(&expected_prefix)
@@ -931,7 +960,8 @@ fn plan_openai_responses_request(
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input,
+            full_input: full_input.clone(),
+            provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
                 "full_request",
@@ -944,19 +974,33 @@ fn plan_openai_responses_request(
     }
 
     let incremental_input = full_input[expected_prefix.len()..].to_vec();
-    body["input"] = Value::Array(incremental_input.clone());
-    body["previous_response_id"] =
-        Value::String(previous.response_id.expect("response id checked above"));
+    let has_response_id = previous.response_id.is_some();
+    let provider_input = if let Some(response_id) = previous.response_id {
+        body["input"] = Value::Array(incremental_input.clone());
+        body["previous_response_id"] = Value::String(response_id);
+        incremental_input.clone()
+    } else {
+        let mut provider_input = previous.items.clone();
+        provider_input.extend(incremental_input.clone());
+        body["input"] = Value::Array(provider_input.clone());
+        provider_input
+    };
     let request_shape_hash = request_shape_hash(&request_shape);
     Ok(OpenAiRequestPlan {
         body,
         scope,
         full_input,
+        provider_input,
         request_shape,
         diagnostics: ProviderRequestDiagnostics {
-            request_lowering_mode: "incremental_continuation".into(),
+            request_lowering_mode: if has_response_id {
+                "incremental_continuation".into()
+            } else {
+                "provider_window_compacted".into()
+            },
             anthropic_cache: None,
             anthropic_context_management: None,
+            openai_remote_compaction: None,
             incremental_continuation: Some(ProviderIncrementalContinuationDiagnostics {
                 status: "hit".into(),
                 fallback_reason: None,
@@ -1059,13 +1103,9 @@ fn openai_item_hash(item: &Value) -> String {
 }
 
 fn latest_openai_compaction_index(items: &[Value]) -> Option<usize> {
-    items
-        .iter()
-        .enumerate()
-        .rev()
-        .find_map(|(index, item)| {
-            (item.get("type").and_then(Value::as_str) == Some("compaction")).then_some(index)
-        })
+    items.iter().enumerate().rev().find_map(|(index, item)| {
+        (item.get("type").and_then(Value::as_str) == Some("compaction")).then_some(index)
+    })
 }
 
 fn request_shape_hash(request_shape: &OpenAiRequestShape) -> String {
@@ -1123,6 +1163,7 @@ fn incremental_diagnostics(
         request_lowering_mode: request_lowering_mode.into(),
         anthropic_cache: None,
         anthropic_context_management: None,
+        openai_remote_compaction: None,
         incremental_continuation: Some(ProviderIncrementalContinuationDiagnostics {
             status: "fallback_full_request".into(),
             fallback_reason: Some(fallback_reason.into()),
@@ -1146,6 +1187,7 @@ fn update_openai_continuation(
     scope: Option<OpenAiContinuationScope>,
     request_shape: OpenAiRequestShape,
     full_input: Vec<Value>,
+    provider_input: Vec<Value>,
     parsed: &ParsedOpenAiResponse,
 ) {
     let Some(scope) = scope else {
@@ -1155,13 +1197,16 @@ fn update_openai_continuation(
     let next = match (parsed.response_id.as_ref(), parsed.output_items.is_empty()) {
         (Some(response_id), false) => {
             state.next_generation = state.next_generation.saturating_add(1);
-            let mut items = full_input;
+            let mut items = provider_input;
             items.extend(parsed.output_items.clone());
+            let mut append_match_items = full_input;
+            append_match_items.extend(parsed.output_items.clone());
             Some(OpenAiProviderWindow {
                 response_id: Some(response_id.clone()),
                 request_shape,
                 latest_compaction_index: latest_openai_compaction_index(&items),
                 items,
+                append_match_items,
                 generation: state.next_generation,
             })
         }
@@ -1172,6 +1217,174 @@ fn update_openai_continuation(
     } else {
         state.windows.remove(&scope);
     }
+}
+
+async fn maybe_compact_openai_provider_window(
+    continuation: &Arc<Mutex<OpenAiContinuationState>>,
+    scope: Option<&OpenAiContinuationScope>,
+    request_shape: &OpenAiRequestShape,
+    client: &Client,
+    compact_url: String,
+    headers: Vec<(&str, String)>,
+) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
+    let Some(scope) = scope else {
+        return None;
+    };
+    let window = {
+        let state = lock_openai_continuation(continuation);
+        state.windows.get(scope).cloned()
+    }?;
+    if !should_compact_openai_provider_window(&window) {
+        return None;
+    }
+
+    let input_items = window.items.len();
+    let request_shape_hash = request_shape_hash(request_shape);
+    let compact_body = build_openai_compact_request_body(request_shape, &window.items);
+    let compacted =
+        match send_openai_compact_request(client, compact_url, compact_body, headers).await {
+            Ok(compacted) => compacted,
+            Err(error) => {
+                return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                    status: "failed".into(),
+                    trigger_reason: Some("provider_window_item_threshold".into()),
+                    input_items: Some(input_items),
+                    output_items: None,
+                    compaction_items: None,
+                    latest_compaction_index: window.latest_compaction_index,
+                    encrypted_content_hashes: None,
+                    encrypted_content_bytes: None,
+                    request_shape_hash: Some(request_shape_hash),
+                    continuation_generation: Some(window.generation),
+                    error: Some(error.to_string()),
+                });
+            }
+        };
+    if compacted.is_empty() {
+        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+            status: "rejected_empty_output".into(),
+            trigger_reason: Some("provider_window_item_threshold".into()),
+            input_items: Some(input_items),
+            output_items: Some(0),
+            compaction_items: Some(0),
+            latest_compaction_index: window.latest_compaction_index,
+            encrypted_content_hashes: Some(Vec::new()),
+            encrypted_content_bytes: Some(Vec::new()),
+            request_shape_hash: Some(request_shape_hash),
+            continuation_generation: Some(window.generation),
+            error: Some("OpenAI compact response returned an empty output window".into()),
+        });
+    }
+
+    let latest_compaction_index = latest_openai_compaction_index(&compacted);
+    let encrypted_content_hashes = openai_compaction_encrypted_content_hashes(&compacted);
+    let encrypted_content_bytes = openai_compaction_encrypted_content_bytes(&compacted);
+    let compaction_items = encrypted_content_hashes.len();
+    if compaction_items == 0 {
+        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+            status: "rejected_missing_compaction_item".into(),
+            trigger_reason: Some("provider_window_item_threshold".into()),
+            input_items: Some(input_items),
+            output_items: Some(compacted.len()),
+            compaction_items: Some(0),
+            latest_compaction_index: None,
+            encrypted_content_hashes: Some(Vec::new()),
+            encrypted_content_bytes: Some(Vec::new()),
+            request_shape_hash: Some(request_shape_hash),
+            continuation_generation: Some(window.generation),
+            error: Some("OpenAI compact response did not include a compaction item".into()),
+        });
+    }
+
+    let output_items = compacted.len();
+    let generation = {
+        let mut state = lock_openai_continuation(continuation);
+        state.next_generation = state.next_generation.saturating_add(1);
+        let generation = state.next_generation;
+        state.windows.insert(
+            scope.clone(),
+            OpenAiProviderWindow {
+                response_id: None,
+                request_shape: request_shape.clone(),
+                items: compacted,
+                append_match_items: window.append_match_items,
+                latest_compaction_index,
+                generation,
+            },
+        );
+        generation
+    };
+
+    Some(ProviderOpenAiRemoteCompactionDiagnostics {
+        status: "compacted".into(),
+        trigger_reason: Some("provider_window_item_threshold".into()),
+        input_items: Some(input_items),
+        output_items: Some(output_items),
+        compaction_items: Some(compaction_items),
+        latest_compaction_index,
+        encrypted_content_hashes: Some(encrypted_content_hashes),
+        encrypted_content_bytes: Some(encrypted_content_bytes),
+        request_shape_hash: Some(request_shape_hash),
+        continuation_generation: Some(generation),
+        error: None,
+    })
+}
+
+fn should_compact_openai_provider_window(window: &OpenAiProviderWindow) -> bool {
+    let since_latest_compaction = window
+        .latest_compaction_index
+        .map(|index| window.items.len().saturating_sub(index + 1))
+        .unwrap_or(window.items.len());
+    since_latest_compaction >= OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS
+}
+
+fn build_openai_compact_request_body(request_shape: &OpenAiRequestShape, items: &[Value]) -> Value {
+    let mut body = json!({
+        "model": request_shape.wire_shape.get("model").cloned().unwrap_or(Value::Null),
+        "input": items,
+        "instructions": request_shape
+            .wire_shape
+            .get("instructions")
+            .cloned()
+            .unwrap_or_else(|| Value::String(request_shape.prompt_frame.system_prompt.clone())),
+        "tools": request_shape
+            .wire_shape
+            .get("tools")
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new())),
+        "parallel_tool_calls": request_shape
+            .wire_shape
+            .get("parallel_tool_calls")
+            .cloned()
+            .unwrap_or(Value::Bool(false)),
+    });
+    if let Some(reasoning) = request_shape.wire_shape.get("reasoning") {
+        if !reasoning.is_null() {
+            body["reasoning"] = reasoning.clone();
+        }
+    }
+    if let Some(text) = request_shape.wire_shape.get("text") {
+        body["text"] = text.clone();
+    }
+    body
+}
+
+fn openai_compaction_encrypted_content_hashes(items: &[Value]) -> Vec<String> {
+    items
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("compaction"))
+        .filter_map(|item| item.get("encrypted_content").and_then(Value::as_str))
+        .map(|content| sha256_hex(content.as_bytes()))
+        .collect()
+}
+
+fn openai_compaction_encrypted_content_bytes(items: &[Value]) -> Vec<usize> {
+    items
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("compaction"))
+        .filter_map(|item| item.get("encrypted_content").and_then(Value::as_str))
+        .map(str::len)
+        .collect()
 }
 
 fn invalidate_openai_continuation(
@@ -1958,6 +2171,62 @@ async fn send_openai_responses_request(
     let parsed: Value = serde_json::from_str(&body)
         .map_err(|error| invalid_response_error("invalid OpenAI-style JSON", error))?;
     parse_openai_response_with_transport_state(parsed)
+}
+
+async fn send_openai_compact_request(
+    client: &Client,
+    url: String,
+    body: Value,
+    headers: Vec<(&str, String)>,
+) -> Result<Vec<Value>> {
+    let mut request = client.post(&url).header("content-type", "application/json");
+    for (name, value) in headers {
+        request = request.header(name, value);
+    }
+
+    let response = request.json(&body).send().await.map_err(|error| {
+        classify_reqwest_transport_error(
+            "OpenAI compact request failed",
+            "request_send",
+            "openai",
+            Some(&provider_model_ref("openai", &body)),
+            Some(url.as_str()),
+            error,
+        )
+    })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(classify_status_error(
+            "OpenAI compact request failed",
+            status,
+            body,
+        ));
+    }
+
+    let response_body = response.text().await.map_err(|error| {
+        classify_reqwest_transport_error(
+            "OpenAI compact response body failed",
+            "response_body",
+            "openai",
+            Some(&provider_model_ref("openai", &body)),
+            Some(url.as_str()),
+            error,
+        )
+    })?;
+    let parsed: Value = serde_json::from_str(&response_body)
+        .map_err(|error| invalid_response_error("invalid OpenAI compact JSON", error))?;
+    parsed
+        .get("output")
+        .and_then(Value::as_array)
+        .cloned()
+        .ok_or_else(|| {
+            invalid_response_error(
+                "OpenAI compact response did not contain output array",
+                "missing output array",
+            )
+        })
 }
 
 async fn send_openai_responses_streaming_request(


### PR DESCRIPTION
## Summary

Closes #791.

Implements the OpenAI remote compaction boundary described by `docs/rfcs/openai-remote-compaction.md`:

- adds secret-safe diagnostics for `conversation_not_strict_append_only` continuation misses
- stores OpenAI continuation as a provider-shaped window with separate semantic append-match state
- gates standalone `/responses/compact` on stable provider windows so unpaired `function_call` / `custom_tool_call` items are skipped instead of compacted
- compacts before the next request after a tool output pairs the prior tool call, then replays returned `type: "compaction"` items opaquely without parsing encrypted content as Holon memory
- guards both pre-request and post-response compaction against stale provider-window generations
- exposes remote compaction metadata in provider diagnostics and benchmark token-optimization summaries

## Notes

The compacted OpenAI window remains transport-local provider state. Holon local semantic memory, working memory, turn-local compaction, and audit logs remain the readable resume source.

The targeted #787 rerun now shows the unsafe boundary explicitly as `skipped_unpaired_tool_call`; the live path did not produce actual `compacted` rounds yet. The unit coverage exercises the paired tool-output pre-request compaction path, while the live benchmark evidence below is best read as a regression/diagnostic check rather than proof that #787 is already using compacted replay.

## Verification

- `cargo fmt --all -- --check`
- `cargo test openai_responses --lib`
- `cargo test openai --lib`
- `cargo test --lib`
- `cd benchmark && npm test`

## #787 targeted benchmark

Baseline artifact: `.benchmark-results/openai-live-refresh-2026-04-30-0787-spark/summary.json`

- baseline Holon: `input_tokens=5,774,216`, `model_rounds=102`, `full_request=102`, `conversation_not_strict_append_only=99`
- PR rerun label `openai-remote-compaction-pr792-holon-openai-r2`: `input_tokens=2,670,614`, `model_rounds=71`, `full_request=71`, `conversation_not_strict_append_only=69`, `openai_remote_compaction_statuses.skipped_unpaired_tool_call=66`, `compacted=0`