### PR TITLE
ci: restore holon trigger and run reports

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -5,8 +5,9 @@ on:
     inputs:
       ref:
         description: GitHub issue or PR reference, such as owner/repo#123.
-        required: true
+        required: false
         type: string
+        default: ''
       repo:
         description: GitHub repository hint for shorthand refs such as #123.
         required: false
@@ -112,8 +113,168 @@ jobs:
             echo "home=$RUNNER_TEMP/holon/home"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Resolve Holon context
+        id: context
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_BASE: ${{ inputs.base }}
+          INPUT_GOAL: ${{ inputs.goal }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          ISSUE_IS_PR: ${{ github.event.issue.pull_request.url || '' }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          LABEL_NAME: ${{ github.event.label.name || '' }}
+          ASSIGNEE_LOGIN: ${{ github.event.assignee.login || '' }}
+          AUTO_REVIEW: ${{ vars.HOLON_AUTO_REVIEW || 'false' }}
+          AUTO_REVIEW_ON_PUSH: ${{ vars.HOLON_AUTO_REVIEW_ON_PUSH || 'false' }}
+        run: |
+          set -euo pipefail
+
+          should_run=false
+          reason="event not eligible"
+          ref=""
+          repo="$INPUT_REPO"
+          base="$INPUT_BASE"
+          goal="$INPUT_GOAL"
+
+          write_outputs() {
+            {
+              echo "should_run=$should_run"
+              echo "ref=$ref"
+              echo "repo=$repo"
+              echo "base=$base"
+              echo "reason=$reason"
+              echo "goal<<__HOLON_GOAL__"
+              if [ -n "$goal" ]; then
+                printf '%s\n' "$goal"
+              fi
+              echo "__HOLON_GOAL__"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          if [ -n "$INPUT_REF" ]; then
+            should_run=true
+            reason="explicit ref input"
+            ref="$INPUT_REF"
+            if [[ "$ref" =~ ^#[0-9]+$ ]] && [ -z "$repo" ]; then
+              repo="$REPO"
+            fi
+            write_outputs
+            exit 0
+          fi
+
+          if [ "$ACTOR" = "holonbot[bot]" ] || [ "$ACTOR" = "github-actions[bot]" ]; then
+            reason="skip bot actor: $ACTOR"
+            write_outputs
+            exit 0
+          fi
+
+          case "$EVENT_NAME:$EVENT_ACTION" in
+            issue_comment:created)
+              first_line="$(printf '%s\n' "$COMMENT_BODY" | sed -n '1s/^[[:space:]]*//;1s/[[:space:]]*$//;1p')"
+              permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || true)"
+              if [ "$permission" != "admin" ] && [ "$permission" != "maintain" ] && [ "$permission" != "write" ]; then
+                reason="insufficient permission for $ACTOR: ${permission:-none}"
+                write_outputs
+                exit 0
+              fi
+
+              if [ -n "$ISSUE_IS_PR" ]; then
+                ref="https://github.com/$REPO/pull/$ISSUE_NUMBER"
+                case "$first_line" in
+                  "@holonbot fix"|"@holonbot pr-fix")
+                    should_run=true
+                    reason="PR fix command"
+                    goal="${goal:-Fix the target pull request according to the latest requester comment. Push commits to the PR branch when changes are needed. Do not open another PR. Publish a concise completion summary and stop.}"
+                    ;;
+                  "@holonbot review")
+                    should_run=true
+                    reason="PR review command"
+                    goal="${goal:-Review the target pull request only. Publish exactly one structured review or PR comment. Do not edit files, push commits, open PRs, or close issues.}"
+                    ;;
+                  *)
+                    reason="unrecognized PR command: $first_line"
+                    ;;
+                esac
+              else
+                ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
+                case "$first_line" in
+                  "@holonbot fix"|"@holonbot solve")
+                    should_run=true
+                    reason="issue solve command"
+                    goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
+                    ;;
+                  *)
+                    reason="unrecognized issue command: $first_line"
+                    ;;
+                esac
+              fi
+              ;;
+            issues:labeled)
+              if [ "$LABEL_NAME" = "holon" ]; then
+                should_run=true
+                reason="issue labeled holon"
+                ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
+                goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
+              fi
+              ;;
+            issues:assigned)
+              if [ "$ASSIGNEE_LOGIN" = "holonbot" ] || [ "$ASSIGNEE_LOGIN" = "holonbot[bot]" ]; then
+                should_run=true
+                reason="issue assigned to holonbot"
+                ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
+                goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
+              fi
+              ;;
+            pull_request:labeled)
+              if [ "$LABEL_NAME" = "holon" ]; then
+                should_run=true
+                reason="PR labeled holon"
+              fi
+              ;;
+            pull_request:opened|pull_request:reopened|pull_request:ready_for_review)
+              if [ "$AUTO_REVIEW" = "true" ]; then
+                should_run=true
+                reason="auto review enabled"
+              fi
+              ;;
+            pull_request:synchronize)
+              if [ "$AUTO_REVIEW_ON_PUSH" = "true" ]; then
+                should_run=true
+                reason="auto review on push enabled"
+              fi
+              ;;
+          esac
+
+          if [ "$should_run" = "true" ] && [ -n "$PR_NUMBER" ]; then
+            ref="https://github.com/$REPO/pull/$PR_NUMBER"
+            is_cross_repo="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name != .base.repo.full_name' 2>/dev/null || echo "true")"
+            if [ "$is_cross_repo" = "true" ]; then
+              should_run=false
+              reason="skip cross-repo PR"
+              goal=""
+            else
+              goal="${goal:-Review the target pull request only. Publish exactly one structured review or PR comment. Do not edit files, push commits, open PRs, or close issues.}"
+            fi
+          fi
+
+          write_outputs
+
+      - name: Report skipped Holon run
+        if: steps.context.outputs.should_run != 'true'
+        shell: bash
+        run: |
+          echo "Holon skipped: ${{ steps.context.outputs.reason }}"
+
       - name: Checkout Holon source
-        if: inputs.build_from_source
+        if: inputs.build_from_source && steps.context.outputs.should_run == 'true'
         shell: bash
         env:
           HOLON_REPOSITORY: ${{ inputs.holon_repository }}
@@ -130,11 +291,11 @@ jobs:
           echo "HOLON_SOURCE_DIR=$src_dir" >> "$GITHUB_ENV"
 
       - name: Set up Rust
-        if: inputs.build_from_source
+        if: inputs.build_from_source && steps.context.outputs.should_run == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Holon from source
-        if: inputs.build_from_source
+        if: inputs.build_from_source && steps.context.outputs.should_run == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -144,7 +305,7 @@ jobs:
           chmod +x "$RUNNER_TEMP/holon/bin/holon"
 
       - name: Download Holon binary
-        if: ${{ !inputs.build_from_source }}
+        if: ${{ !inputs.build_from_source && steps.context.outputs.should_run == 'true' }}
         shell: bash
         env:
           INPUT_VERSION: ${{ inputs.version }}
@@ -184,6 +345,7 @@ jobs:
 
       - name: Resolve GitHub token
         id: github-token
+        if: steps.context.outputs.should_run == 'true'
         shell: bash
         env:
           HOLON_GITHUB_TOKEN_INPUT: ${{ secrets.holon_github_token }}
@@ -255,13 +417,14 @@ jobs:
 
       - name: Run Holon solve
         id: run
+        if: steps.context.outputs.should_run == 'true'
         shell: bash
         env:
-          INPUT_REF: ${{ inputs.ref }}
-          INPUT_REPO: ${{ inputs.repo }}
-          INPUT_BASE: ${{ inputs.base }}
-          INPUT_GOAL: ${{ inputs.goal }}
-          INPUT_MODEL: ${{ inputs.model }}
+          INPUT_REF: ${{ steps.context.outputs.ref }}
+          INPUT_REPO: ${{ steps.context.outputs.repo }}
+          INPUT_BASE: ${{ steps.context.outputs.base }}
+          INPUT_GOAL: ${{ steps.context.outputs.goal }}
+          INPUT_MODEL: ${{ inputs.model || vars.HOLON_MODEL || '' }}
           ANTHROPIC_AUTH_TOKEN_INPUT: ${{ secrets.anthropic_auth_token || secrets.anthropic_api_key }}
           ANTHROPIC_BASE_URL_INPUT: ${{ secrets.anthropic_base_url || 'https://api.anthropic.com' }}
           OPENAI_API_KEY_INPUT: ${{ secrets.openai_api_key }}
@@ -319,6 +482,100 @@ jobs:
             echo "summary=" >> "$GITHUB_OUTPUT"
           fi
           echo "result=${{ steps.run.outcome }}" >> "$GITHUB_OUTPUT"
+
+      - name: Post Holon run report
+        if: always() && steps.run.outcome != 'skipped'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          HOLON_OUTPUT_DIR: ${{ steps.dirs.outputs.output }}
+          HOLON_TARGET_REF: ${{ steps.context.outputs.ref }}
+          HOLON_REPOSITORY: ${{ steps.context.outputs.repo || github.repository }}
+        run: |
+          set -euo pipefail
+
+          script="$RUNNER_TEMP/holon-post-run-report.sh"
+          cat >"$script" <<'SCRIPT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          output_dir="${HOLON_OUTPUT_DIR:?HOLON_OUTPUT_DIR is required}"
+          target_ref="${HOLON_TARGET_REF:-}"
+          repo_hint="${HOLON_REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+          run_json="$output_dir/run.json"
+          summary_md="$output_dir/summary.md"
+          manifest_json="$output_dir/manifest.json"
+
+          if [ ! -f "$run_json" ]; then
+            echo "Skipping Holon run report: missing $run_json"
+            exit 0
+          fi
+
+          pr_url=""
+          if [[ "$target_ref" =~ ^https://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+            pr_url="https://github.com/${BASH_REMATCH[1]}/pull/${BASH_REMATCH[2]}"
+          elif [[ "$target_ref" =~ ^([^#[:space:]]+/[^#[:space:]]+)#([0-9]+)$ ]]; then
+            candidate_repo="${BASH_REMATCH[1]}"
+            candidate_number="${BASH_REMATCH[2]}"
+            if gh pr view "$candidate_number" --repo "$candidate_repo" --json url >/tmp/holon-pr-view.json 2>/dev/null; then
+              pr_url="$(jq -r '.url // empty' /tmp/holon-pr-view.json)"
+            fi
+          elif [[ "$target_ref" =~ ^#([0-9]+)$ ]] && [ -n "$repo_hint" ]; then
+            candidate_number="${BASH_REMATCH[1]}"
+            if gh pr view "$candidate_number" --repo "$repo_hint" --json url >/tmp/holon-pr-view.json 2>/dev/null; then
+              pr_url="$(jq -r '.url // empty' /tmp/holon-pr-view.json)"
+            fi
+          fi
+
+          if [ -z "$pr_url" ]; then
+            pr_url="$(
+              {
+                [ -f "$summary_md" ] && grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$summary_md" || true
+                [ -f "$manifest_json" ] && grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$manifest_json" || true
+                grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$run_json" || true
+              } | head -n1
+            )"
+          fi
+
+          if [[ ! "$pr_url" =~ ^https://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+            echo "Skipping Holon run report: no PR URL found."
+            exit 0
+          fi
+
+          target_repo="${BASH_REMATCH[1]}"
+          target_pr="${BASH_REMATCH[2]}"
+
+          input_tokens="$(jq -r '.token_usage.input_tokens // .input_tokens // 0' "$run_json")"
+          output_tokens="$(jq -r '.token_usage.output_tokens // .output_tokens // 0' "$run_json")"
+          total_tokens="$(jq -r '.token_usage.total_tokens // ((.input_tokens // 0) + (.output_tokens // 0))' "$run_json")"
+          model_rounds="$(jq -r '.model_rounds // 0' "$run_json")"
+          tool_calls="$(jq -r '.tool_calls // 0' "$run_json")"
+          cache_read="$(jq -r '.provider_cache_usage.read_input_tokens // 0' "$run_json")"
+          cache_created="$(jq -r '.provider_cache_usage.creation_input_tokens // 0' "$run_json")"
+          cacheable="$(jq -r '.provider_cache_usage.cacheable_input_tokens // 0' "$run_json")"
+          hit_rate="$(jq -r 'if (.provider_cache_usage.hit_rate // null) == null then "n/a" else ((.provider_cache_usage.hit_rate * 10000 | round) / 100 | tostring) + "%" end' "$run_json")"
+          final_status="$(jq -r '.final_status // "unknown"' "$run_json")"
+          report_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$repo_hint}/actions/runs/${GITHUB_RUN_ID:-}"
+
+          report_file="$(mktemp)"
+          cat >"$report_file" <<EOF
+          ## Holon Run Report
+
+          - Result: \`$final_status\`
+          - Target: $target_ref
+          - Workflow run: $report_url
+          - Token usage: input $input_tokens, output $output_tokens, total $total_tokens
+          - Provider cache: read $cache_read, created $cache_created, cacheable $cacheable, hit rate $hit_rate
+          - Model rounds: $model_rounds
+          - Tool calls: $tool_calls
+          EOF
+
+          gh api "repos/$target_repo/issues/$target_pr/comments" -X POST -F body=@"$report_file" >/dev/null
+          rm -f "$report_file"
+          echo "Posted Holon run report to $pr_url"
+          SCRIPT
+
+          bash "$script"
 
       - name: Upload Holon artifact
         if: always()

--- a/.github/workflows/holon-trigger.yml
+++ b/.github/workflows/holon-trigger.yml
@@ -1,0 +1,31 @@
+name: Holon Trigger
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [labeled, assigned]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: read
+  id-token: write
+
+concurrency:
+  group: holon-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  holon:
+    name: Run Holon
+    uses: ./.github/workflows/holon-solve.yml
+    secrets:
+      anthropic_auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+      anthropic_base_url: ${{ secrets.ANTHROPIC_BASE_URL }}
+      openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+      openai_base_url: ${{ secrets.OPENAI_BASE_URL }}
+      holon_github_token: ${{ secrets.HOLON_GITHUB_TOKEN }}

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -12,12 +12,13 @@ use crate::{
     config::AppConfig,
     host::RuntimeHost,
     ingress::InboundRequest,
+    provider::ProviderCacheUsage,
     runtime::RuntimeHandle,
     storage::PollActivityMarker,
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
-        AdmissionContext, AgentStatus, ClosureOutcome, ControlAction, FailureArtifact, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+        AdmissionContext, AgentStatus, AuditEvent, ClosureOutcome, ControlAction, FailureArtifact,
+        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
         TaskOutputSnapshot, TaskRecord, TaskStatus, TokenUsage, ToolExecutionRecord,
         ToolExecutionStatus, TrustLevel, WaitingReason,
     },
@@ -69,6 +70,15 @@ pub struct RunWorktreeSummary {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct RunProviderCacheUsage {
+    pub read_input_tokens: u64,
+    pub creation_input_tokens: u64,
+    pub cacheable_input_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hit_rate: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct RunOnceResponse {
     pub agent_id: String,
     pub final_status: RunFinalStatus,
@@ -87,6 +97,8 @@ pub struct RunOnceResponse {
     pub token_usage: TokenUsage,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_cache_usage: Option<RunProviderCacheUsage>,
     pub model_rounds: u64,
     pub tool_calls: usize,
     pub shell_commands: usize,
@@ -136,6 +148,17 @@ impl RunOnceResponse {
                 self.token_usage.input_tokens,
                 self.token_usage.output_tokens,
                 self.token_usage.total_tokens
+            ));
+        }
+
+        if let Some(cache_usage) = self.provider_cache_usage.as_ref() {
+            let hit_rate = cache_usage
+                .hit_rate
+                .map(|value| format!("{:.1}%", value * 100.0))
+                .unwrap_or_else(|| "n/a".to_string());
+            sections.push(format!(
+                "Provider cache: read {}, created {}, hit rate {}",
+                cache_usage.read_input_tokens, cache_usage.creation_input_tokens, hit_rate
             ));
         }
 
@@ -457,6 +480,7 @@ struct RunView {
     new_tasks: Vec<TaskRecord>,
     new_tools: Vec<ToolExecutionRecord>,
     new_messages: Vec<MessageEnvelope>,
+    new_events: Vec<AuditEvent>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -566,10 +590,16 @@ fn collect_run_view(runtime: &RuntimeHandle, baseline: &RunBaseline) -> Result<R
         .into_iter()
         .filter(|message| !baseline.message_ids.contains(&message.id))
         .collect::<Vec<_>>();
+    let new_events = runtime
+        .all_events()?
+        .into_iter()
+        .filter(|event| !baseline.event_ids.contains(&event.id))
+        .collect::<Vec<_>>();
     Ok(RunView {
         new_tasks,
         new_tools,
         new_messages,
+        new_events,
     })
 }
 
@@ -689,6 +719,7 @@ async fn build_response(
             .total_output_tokens
             .saturating_sub(baseline.total_output_tokens),
     );
+    let provider_cache_usage = aggregate_provider_cache_usage(&view.new_events);
     let failure_artifact = if final_status == RunFinalStatus::Failed {
         final_state
             .last_runtime_failure
@@ -736,6 +767,7 @@ async fn build_response(
         changed_files,
         input_tokens: token_usage.input_tokens,
         output_tokens: token_usage.output_tokens,
+        provider_cache_usage,
         token_usage,
         model_rounds: final_state
             .total_model_rounds
@@ -754,6 +786,59 @@ async fn build_response(
             .count()
             + batched_exec_command_items(&view.new_tools),
         batched_exec_command_items: batched_exec_command_items(&view.new_tools),
+    })
+}
+
+fn aggregate_provider_cache_usage(events: &[AuditEvent]) -> Option<RunProviderCacheUsage> {
+    let mut usage = ProviderCacheUsage {
+        read_input_tokens: 0,
+        creation_input_tokens: 0,
+    };
+    let mut saw_usage = false;
+
+    for event in events
+        .iter()
+        .filter(|event| event.kind == "provider_round_completed")
+    {
+        let Some(cache_usage) = event.data.get("provider_cache_usage") else {
+            continue;
+        };
+        if cache_usage.is_null() {
+            continue;
+        }
+        let read_input_tokens = cache_usage
+            .get("read_input_tokens")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0);
+        let creation_input_tokens = cache_usage
+            .get("creation_input_tokens")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0);
+        saw_usage = true;
+        usage.read_input_tokens = usage.read_input_tokens.saturating_add(read_input_tokens);
+        usage.creation_input_tokens = usage
+            .creation_input_tokens
+            .saturating_add(creation_input_tokens);
+    }
+
+    if !saw_usage {
+        return None;
+    }
+
+    let cacheable_input_tokens = usage
+        .read_input_tokens
+        .saturating_add(usage.creation_input_tokens);
+    let hit_rate = if cacheable_input_tokens == 0 {
+        None
+    } else {
+        Some(usage.read_input_tokens as f64 / cacheable_input_tokens as f64)
+    };
+
+    Some(RunProviderCacheUsage {
+        read_input_tokens: usage.read_input_tokens,
+        creation_input_tokens: usage.creation_input_tokens,
+        cacheable_input_tokens,
+        hit_rate,
     })
 }
 
@@ -1151,5 +1236,37 @@ mod tests {
         };
 
         assert_eq!(batched_exec_command_items(&[tool]), 3);
+    }
+
+    #[test]
+    fn aggregate_provider_cache_usage_sums_round_cache_tokens() {
+        let events = vec![
+            AuditEvent::new(
+                "provider_round_completed",
+                json!({
+                    "provider_cache_usage": {
+                        "read_input_tokens": 300,
+                        "creation_input_tokens": 100
+                    }
+                }),
+            ),
+            AuditEvent::new(
+                "provider_round_completed",
+                json!({
+                    "provider_cache_usage": {
+                        "read_input_tokens": 200,
+                        "creation_input_tokens": 400
+                    }
+                }),
+            ),
+            AuditEvent::new("state_changed", json!({})),
+        ];
+
+        let usage = aggregate_provider_cache_usage(&events).expect("cache usage");
+
+        assert_eq!(usage.read_input_tokens, 500);
+        assert_eq!(usage.creation_input_tokens, 500);
+        assert_eq!(usage.cacheable_input_tokens, 1000);
+        assert_eq!(usage.hit_rate, Some(0.5));
     }
 }


### PR DESCRIPTION
## Summary
- restore a thin `holon-trigger.yml` that only declares GitHub events, permissions, concurrency, and reusable workflow secrets
- move trigger context resolution into `holon-solve.yml`, including command/label/assignment handling and PR review auto-run gates
- add a centralized Holon run report comment for PR-backed runs, with token usage and provider cache stats from `run.json`
- expose aggregate provider cache usage from `holon run`/`holon solve` output

## Validation
- `cargo fmt --all -- --check`
- `cargo test -q aggregate_provider_cache_usage_sums_round_cache_tokens`
- `cargo check -q`
- `actionlint .github/workflows/holon-solve.yml .github/workflows/holon-trigger.yml`
- `git diff --check`
- `bash -n` on extracted `Resolve Holon context` and `Post Holon run report` shell blocks
