### PR TITLE
fix(runtime): extract workspace binding and execution snapshot boundary

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,6 +9,7 @@ mod message_dispatch;
 mod operator;
 mod operator_dispatch;
 mod provider_turn;
+mod workspace;
 mod subagent;
 mod task_state_reducer;
 mod tasks;
@@ -166,23 +167,11 @@ impl RuntimeHandle {
         projection_kind: WorkspaceProjectionKind,
         execution_root: &Path,
     ) -> Result<String> {
-        Ok(match projection_kind {
-            WorkspaceProjectionKind::CanonicalRoot => {
-                format!("canonical_root:{workspace_id}")
-            }
-            WorkspaceProjectionKind::GitWorktreeRoot => format!(
-                "git_worktree_root:{workspace_id}:{}",
-                crate::system::workspace::normalize_path(execution_root)?.display()
-            ),
-        })
+        workspace::build_execution_root_id(workspace_id, projection_kind, execution_root)
     }
 
     fn agent_home_workspace_entry(data_dir: &Path) -> WorkspaceEntry {
-        WorkspaceEntry::new(
-            AGENT_HOME_WORKSPACE_ID,
-            data_dir.to_path_buf(),
-            Some("AgentHome".into()),
-        )
+        workspace::agent_home_workspace_entry(data_dir)
     }
 
     pub fn new(
@@ -649,122 +638,20 @@ impl RuntimeHandle {
         self.workspace_view_from_state(&guard.state)
     }
 
-    fn detached_execution_root(&self) -> PathBuf {
-        self.inner.storage.data_dir().to_path_buf()
-    }
-
     pub(crate) fn workspace_view_for_root(
         &self,
         execution_root: PathBuf,
         cwd: PathBuf,
         worktree_root: Option<PathBuf>,
     ) -> Result<WorkspaceView> {
-        let state = self
-            .inner
-            .storage
-            .read_agent()?
-            .ok_or_else(|| anyhow!("agent state not found"))?;
-        let workspace_id = state
-            .active_workspace_entry
-            .as_ref()
-            .map(|entry| entry.workspace_id.clone());
-        let workspace_anchor = state
-            .active_workspace_entry
-            .as_ref()
-            .map(|entry| entry.workspace_anchor.clone())
-            .unwrap_or_else(|| self.detached_execution_root());
-        let execution_root_id = state
-            .active_workspace_entry
-            .as_ref()
-            .map(|entry| entry.execution_root_id.clone());
-        let access_mode = state
-            .active_workspace_entry
-            .as_ref()
-            .map(|entry| entry.access_mode);
-        WorkspaceView::new(
-            workspace_id,
-            workspace_anchor,
-            execution_root,
-            cwd,
-            execution_root_id,
-            access_mode,
-            worktree_root,
-        )
+        workspace::workspace_view_for_root(&self.inner.storage, execution_root, cwd, worktree_root)
     }
 
     fn workspace_view_from_state(&self, state: &AgentState) -> Result<WorkspaceView> {
-        if let Some(entry) = state.active_workspace_entry.as_ref() {
-            let worktree_root = (entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot)
-                .then(|| entry.execution_root.clone());
-            return WorkspaceView::new(
-                Some(entry.workspace_id.clone()),
-                entry.workspace_anchor.clone(),
-                entry.execution_root.clone(),
-                entry.cwd.clone(),
-                Some(entry.execution_root_id.clone()),
-                Some(entry.access_mode),
-                worktree_root,
-            );
-        }
-
-        // If no active_workspace_entry is set, use detached execution root
-        let execution_root = self.detached_execution_root();
-        WorkspaceView::new(
-            None,
-            execution_root.clone(),
-            execution_root.clone(),
-            execution_root.clone(),
-            None,
-            Some(WorkspaceAccessMode::ExclusiveWrite),
-            None,
+        workspace::workspace_view_from_state(
+            state,
+            self.inner.storage.data_dir().to_path_buf(),
         )
-    }
-
-    /// Load all attached workspace (id, path) pairs from storage.
-    fn load_attached_workspace_entries(&self) -> Result<Vec<(String, PathBuf)>> {
-        let entries = self.inner.storage.latest_workspace_entries()?;
-        Ok(entries
-            .into_iter()
-            .map(|entry| (entry.workspace_id, entry.workspace_anchor))
-            .collect())
-    }
-
-    fn load_attached_workspace_entries_for(
-        &self,
-        attached_workspace_ids: &[String],
-        workspace: &WorkspaceView,
-    ) -> Result<Vec<(String, PathBuf)>> {
-        let known_entries = self
-            .load_attached_workspace_entries()?
-            .into_iter()
-            .collect::<std::collections::HashMap<_, _>>();
-        let active_workspace_id = workspace.workspace_id().map(ToString::to_string);
-        let mut ordered_ids = Vec::new();
-
-        if let Some(active_id) = active_workspace_id.as_ref() {
-            if attached_workspace_ids.is_empty()
-                || attached_workspace_ids.iter().any(|id| id == active_id)
-            {
-                ordered_ids.push(active_id.clone());
-            }
-        }
-
-        for workspace_id in attached_workspace_ids {
-            if !ordered_ids.iter().any(|id| id == workspace_id) {
-                ordered_ids.push(workspace_id.clone());
-            }
-        }
-
-        let mut resolved = Vec::new();
-        for workspace_id in ordered_ids {
-            if let Some(anchor) = known_entries.get(&workspace_id) {
-                resolved.push((workspace_id, anchor.clone()));
-            } else if active_workspace_id.as_deref() == Some(workspace_id.as_str()) {
-                resolved.push((workspace_id, workspace.workspace_anchor().to_path_buf()));
-            }
-        }
-
-        Ok(resolved)
     }
 
     fn execution_snapshot_for_view(
@@ -773,61 +660,15 @@ impl RuntimeHandle {
         workspace: &WorkspaceView,
         attached_workspace_ids: &[String],
     ) -> ExecutionSnapshot {
-        let attached_workspaces = self
-            .load_attached_workspace_entries_for(attached_workspace_ids, workspace)
-            .unwrap_or_else(|_| {
-                workspace
-                    .workspace_id()
-                    .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
-                    .into_iter()
-                    .collect()
-            });
-
-        ExecutionSnapshot {
-            policy: profile.policy_snapshot(),
-            profile,
-            attached_workspaces,
-            workspace_id: workspace.workspace_id().map(ToString::to_string),
-            workspace_anchor: workspace.workspace_anchor().to_path_buf(),
-            execution_root: workspace.execution_root().to_path_buf(),
-            cwd: workspace.cwd().to_path_buf(),
-            execution_root_id: workspace.execution_root_id().map(ToString::to_string),
-            projection_kind: if workspace.worktree_root().is_some() {
-                Some(WorkspaceProjectionKind::GitWorktreeRoot)
-            } else {
-                Some(WorkspaceProjectionKind::CanonicalRoot)
-            },
-            access_mode: workspace.access_mode(),
-            worktree_root: workspace.worktree_root().map(|path| path.to_path_buf()),
-        }
+        workspace::execution_snapshot_for_view(profile, workspace, attached_workspace_ids, &self.inner.storage)
     }
 
     fn workspace_anchor_for_state_ref<'a>(&self, state: &'a AgentState) -> Option<&'a Path> {
-        state
-            .active_workspace_entry
-            .as_ref()
-            .map(|entry| entry.workspace_anchor.as_path())
+        workspace::workspace_anchor_for_state_ref(state)
     }
 
     fn execution_root_sync(&self) -> PathBuf {
-        self.inner
-            .storage
-            .read_agent()
-            .ok()
-            .flatten()
-            .and_then(|state| {
-                state
-                    .active_workspace_entry
-                    .as_ref()
-                    .map(|entry| entry.execution_root.clone())
-                    .or_else(|| {
-                        state
-                            .worktree_session
-                            .as_ref()
-                            .map(|worktree| worktree.worktree_path.clone())
-                    })
-            })
-            .unwrap_or_else(|| self.detached_execution_root())
+        workspace::execution_root_sync(&self.inner.storage)
     }
 
     pub(crate) async fn effective_execution(
@@ -839,22 +680,13 @@ impl RuntimeHandle {
         let attached_workspace_ids = guard.state.attached_workspaces.clone();
         drop(guard);
         let workspace = self.workspace_view().await?;
-        let attached_workspaces = self
-            .load_attached_workspace_entries_for(&attached_workspace_ids, &workspace)
-            .unwrap_or_else(|_| {
-                workspace
-                    .workspace_id()
-                    .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
-                    .into_iter()
-                    .collect()
-            });
-
-        Ok(EffectiveExecution {
+        Ok(workspace::build_effective_execution(
+            &self.inner.storage,
+            scope,
             profile,
             workspace,
-            scope,
-            attached_workspaces,
-        })
+            &attached_workspace_ids,
+        ))
     }
 
     pub(crate) async fn effective_execution_for_workspace(
@@ -866,21 +698,13 @@ impl RuntimeHandle {
         let profile = guard.state.execution_profile.clone();
         let attached_workspace_ids = guard.state.attached_workspaces.clone();
         drop(guard);
-        let attached_workspaces = self
-            .load_attached_workspace_entries_for(&attached_workspace_ids, &workspace)
-            .unwrap_or_else(|_| {
-                workspace
-                    .workspace_id()
-                    .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
-                    .into_iter()
-                    .collect()
-            });
-        Ok(EffectiveExecution {
+        Ok(workspace::build_effective_execution(
+            &self.inner.storage,
+            scope,
             profile,
             workspace,
-            scope,
-            attached_workspaces,
-        })
+            &attached_workspace_ids,
+        ))
     }
 
     pub async fn execution_snapshot(&self) -> Result<ExecutionSnapshot> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,13 +9,13 @@ mod message_dispatch;
 mod operator;
 mod operator_dispatch;
 mod provider_turn;
-mod workspace;
 mod subagent;
 mod task_state_reducer;
 mod tasks;
 #[cfg(test)]
 mod test_util;
 mod turn;
+mod workspace;
 mod worktree;
 
 use std::{
@@ -648,10 +648,7 @@ impl RuntimeHandle {
     }
 
     fn workspace_view_from_state(&self, state: &AgentState) -> Result<WorkspaceView> {
-        workspace::workspace_view_from_state(
-            state,
-            self.inner.storage.data_dir().to_path_buf(),
-        )
+        workspace::workspace_view_from_state(state, self.inner.storage.data_dir().to_path_buf())
     }
 
     fn execution_snapshot_for_view(
@@ -660,7 +657,12 @@ impl RuntimeHandle {
         workspace: &WorkspaceView,
         attached_workspace_ids: &[String],
     ) -> ExecutionSnapshot {
-        workspace::execution_snapshot_for_view(profile, workspace, attached_workspace_ids, &self.inner.storage)
+        workspace::execution_snapshot_for_view(
+            profile,
+            workspace,
+            attached_workspace_ids,
+            &self.inner.storage,
+        )
     }
 
     fn workspace_anchor_for_state_ref<'a>(&self, state: &'a AgentState) -> Option<&'a Path> {

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -1,12 +1,15 @@
-use std::{collections::HashMap, path::{Path, PathBuf}};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{anyhow, Result};
 
 use crate::{
     storage::AppStorage,
     system::{
-        EffectiveExecution, ExecutionProfile, ExecutionScopeKind, ExecutionSnapshot, WorkspaceAccessMode,
-        WorkspaceProjectionKind, WorkspaceView,
+        EffectiveExecution, ExecutionProfile, ExecutionScopeKind, ExecutionSnapshot,
+        WorkspaceAccessMode, WorkspaceProjectionKind, WorkspaceView,
     },
     types::{AgentState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID},
 };
@@ -159,14 +162,15 @@ pub(crate) fn execution_snapshot_for_view(
     attached_workspace_ids: &[String],
     storage: &AppStorage,
 ) -> ExecutionSnapshot {
-    let attached_workspaces = load_attached_workspace_entries_for(storage, attached_workspace_ids, workspace)
-        .unwrap_or_else(|_| {
-            workspace
-                .workspace_id()
-                .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
-                .into_iter()
-                .collect()
-        });
+    let attached_workspaces =
+        load_attached_workspace_entries_for(storage, attached_workspace_ids, workspace)
+            .unwrap_or_else(|_| {
+                workspace
+                    .workspace_id()
+                    .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
+                    .into_iter()
+                    .collect()
+            });
 
     ExecutionSnapshot {
         policy: profile.policy_snapshot(),
@@ -194,14 +198,15 @@ pub(crate) fn build_effective_execution(
     workspace: WorkspaceView,
     attached_workspace_ids: &[String],
 ) -> EffectiveExecution {
-    let attached_workspaces = load_attached_workspace_entries_for(storage, attached_workspace_ids, &workspace)
-        .unwrap_or_else(|_| {
-            workspace
-                .workspace_id()
-                .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
-                .into_iter()
-                .collect()
-        });
+    let attached_workspaces =
+        load_attached_workspace_entries_for(storage, attached_workspace_ids, &workspace)
+            .unwrap_or_else(|_| {
+                workspace
+                    .workspace_id()
+                    .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
+                    .into_iter()
+                    .collect()
+            });
 
     EffectiveExecution {
         profile,

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -1,0 +1,239 @@
+use std::{collections::HashMap, path::{Path, PathBuf}};
+
+use anyhow::{anyhow, Result};
+
+use crate::{
+    storage::AppStorage,
+    system::{
+        EffectiveExecution, ExecutionProfile, ExecutionScopeKind, ExecutionSnapshot, WorkspaceAccessMode,
+        WorkspaceProjectionKind, WorkspaceView,
+    },
+    types::{AgentState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID},
+};
+
+pub(crate) fn build_execution_root_id(
+    workspace_id: &str,
+    projection_kind: WorkspaceProjectionKind,
+    execution_root: &Path,
+) -> Result<String> {
+    Ok(match projection_kind {
+        WorkspaceProjectionKind::CanonicalRoot => {
+            format!("canonical_root:{workspace_id}")
+        }
+        WorkspaceProjectionKind::GitWorktreeRoot => format!(
+            "git_worktree_root:{workspace_id}:{}",
+            crate::system::workspace::normalize_path(execution_root)?.display()
+        ),
+    })
+}
+
+pub(crate) fn agent_home_workspace_entry(data_dir: &Path) -> WorkspaceEntry {
+    WorkspaceEntry::new(
+        AGENT_HOME_WORKSPACE_ID,
+        data_dir.to_path_buf(),
+        Some("AgentHome".into()),
+    )
+}
+
+pub(crate) fn detached_execution_root(storage: &AppStorage) -> PathBuf {
+    storage.data_dir().to_path_buf()
+}
+
+pub(crate) fn workspace_view_from_state(
+    state: &AgentState,
+    detached_execution_root: PathBuf,
+) -> Result<WorkspaceView> {
+    if let Some(entry) = state.active_workspace_entry.as_ref() {
+        let worktree_root = (entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot)
+            .then(|| entry.execution_root.clone());
+        return WorkspaceView::new(
+            Some(entry.workspace_id.clone()),
+            entry.workspace_anchor.clone(),
+            entry.execution_root.clone(),
+            entry.cwd.clone(),
+            Some(entry.execution_root_id.clone()),
+            Some(entry.access_mode),
+            worktree_root,
+        );
+    }
+
+    let execution_root = detached_execution_root;
+    WorkspaceView::new(
+        None,
+        execution_root.clone(),
+        execution_root.clone(),
+        execution_root.clone(),
+        None,
+        Some(WorkspaceAccessMode::ExclusiveWrite),
+        None,
+    )
+}
+
+pub(crate) fn workspace_view_for_root(
+    storage: &AppStorage,
+    execution_root: PathBuf,
+    cwd: PathBuf,
+    worktree_root: Option<PathBuf>,
+) -> Result<WorkspaceView> {
+    let state = storage
+        .read_agent()?
+        .ok_or_else(|| anyhow!("agent state not found"))?;
+    let workspace_id = state
+        .active_workspace_entry
+        .as_ref()
+        .map(|entry| entry.workspace_id.clone());
+    let workspace_anchor = state
+        .active_workspace_entry
+        .as_ref()
+        .map(|entry| entry.workspace_anchor.clone())
+        .unwrap_or_else(|| detached_execution_root(storage));
+    let execution_root_id = state
+        .active_workspace_entry
+        .as_ref()
+        .map(|entry| entry.execution_root_id.clone());
+    let access_mode = state
+        .active_workspace_entry
+        .as_ref()
+        .map(|entry| entry.access_mode);
+    WorkspaceView::new(
+        workspace_id,
+        workspace_anchor,
+        execution_root,
+        cwd,
+        execution_root_id,
+        access_mode,
+        worktree_root,
+    )
+}
+
+pub(crate) fn load_attached_workspace_entries(
+    storage: &AppStorage,
+) -> Result<Vec<(String, PathBuf)>> {
+    let entries = storage.latest_workspace_entries()?;
+    Ok(entries
+        .into_iter()
+        .map(|entry| (entry.workspace_id, entry.workspace_anchor))
+        .collect())
+}
+
+pub(crate) fn load_attached_workspace_entries_for(
+    storage: &AppStorage,
+    attached_workspace_ids: &[String],
+    workspace: &WorkspaceView,
+) -> Result<Vec<(String, PathBuf)>> {
+    let known_entries = load_attached_workspace_entries(storage)?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+    let active_workspace_id = workspace.workspace_id().map(ToString::to_string);
+    let mut ordered_ids = Vec::new();
+
+    if let Some(active_id) = active_workspace_id.as_ref() {
+        if attached_workspace_ids.is_empty()
+            || attached_workspace_ids.iter().any(|id| id == active_id)
+        {
+            ordered_ids.push(active_id.clone());
+        }
+    }
+
+    for workspace_id in attached_workspace_ids {
+        if !ordered_ids.iter().any(|id| id == workspace_id) {
+            ordered_ids.push(workspace_id.clone());
+        }
+    }
+
+    let mut resolved = Vec::new();
+    for workspace_id in ordered_ids {
+        if let Some(anchor) = known_entries.get(&workspace_id) {
+            resolved.push((workspace_id, anchor.clone()));
+        } else if active_workspace_id.as_deref() == Some(workspace_id.as_str()) {
+            resolved.push((workspace_id, workspace.workspace_anchor().to_path_buf()));
+        }
+    }
+
+    Ok(resolved)
+}
+
+pub(crate) fn execution_snapshot_for_view(
+    profile: ExecutionProfile,
+    workspace: &WorkspaceView,
+    attached_workspace_ids: &[String],
+    storage: &AppStorage,
+) -> ExecutionSnapshot {
+    let attached_workspaces = load_attached_workspace_entries_for(storage, attached_workspace_ids, workspace)
+        .unwrap_or_else(|_| {
+            workspace
+                .workspace_id()
+                .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
+                .into_iter()
+                .collect()
+        });
+
+    ExecutionSnapshot {
+        policy: profile.policy_snapshot(),
+        profile,
+        attached_workspaces,
+        workspace_id: workspace.workspace_id().map(ToString::to_string),
+        workspace_anchor: workspace.workspace_anchor().to_path_buf(),
+        execution_root: workspace.execution_root().to_path_buf(),
+        cwd: workspace.cwd().to_path_buf(),
+        execution_root_id: workspace.execution_root_id().map(ToString::to_string),
+        projection_kind: if workspace.worktree_root().is_some() {
+            Some(WorkspaceProjectionKind::GitWorktreeRoot)
+        } else {
+            Some(WorkspaceProjectionKind::CanonicalRoot)
+        },
+        access_mode: workspace.access_mode(),
+        worktree_root: workspace.worktree_root().map(|path| path.to_path_buf()),
+    }
+}
+
+pub(crate) fn build_effective_execution(
+    storage: &AppStorage,
+    scope: ExecutionScopeKind,
+    profile: ExecutionProfile,
+    workspace: WorkspaceView,
+    attached_workspace_ids: &[String],
+) -> EffectiveExecution {
+    let attached_workspaces = load_attached_workspace_entries_for(storage, attached_workspace_ids, &workspace)
+        .unwrap_or_else(|_| {
+            workspace
+                .workspace_id()
+                .map(|id| (id.to_string(), workspace.workspace_anchor().to_path_buf()))
+                .into_iter()
+                .collect()
+        });
+
+    EffectiveExecution {
+        profile,
+        workspace,
+        scope,
+        attached_workspaces,
+    }
+}
+
+pub(crate) fn workspace_anchor_for_state_ref<'a>(state: &'a AgentState) -> Option<&'a Path> {
+    state
+        .active_workspace_entry
+        .as_ref()
+        .map(|entry| entry.workspace_anchor.as_path())
+}
+
+pub(crate) fn execution_root_sync(storage: &AppStorage) -> PathBuf {
+    storage
+        .read_agent()
+        .ok()
+        .flatten()
+        .and_then(|state| {
+            state
+                .active_workspace_entry
+                .as_ref()
+                .map(|entry| entry.execution_root.clone())
+                .or_else(|| {
+                    state
+                        .worktree_session
+                        .as_ref()
+                        .map(|worktree| worktree.worktree_path.clone())
+                })
+        })
+        .unwrap_or_else(|| detached_execution_root(storage))
+}


### PR DESCRIPTION
## Summary
- Extracted workspace binding / execution snapshot logic from `src/runtime.rs` into new coordinator module `src/runtime/workspace.rs`.
- Runtime now delegates: execution-root-id creation, workspace view construction, workspace attachment loading, execution snapshot assembly, and effective execution assembly to the new module.
- Kept behavior unchanged; no tool semantics, policy changes, or public API changes.

## Changes
- Added: `src/runtime/workspace.rs` with existing workspace logic moved from runtime impl.
- Updated: `src/runtime.rs` to call through workspace coordinator and removed unused passthrough wrappers.

## Verification
- `cargo test use_workspace`
- `cargo test workspace`
- `cargo test runtime`

## Notes
- No new tests were added; existing workspace/runtime/use_workspace tests pass as-is.
- Issue: #788
