### PR TITLE
Fix OpenAI Codex compact routing and recovery

### DIFF
--- a/docs/implementation-decisions/026-openai-codex-transport-contract.md
+++ b/docs/implementation-decisions/026-openai-codex-transport-contract.md
@@ -10,3 +10,10 @@ Reason:
 - the Codex backend requires `stream=true`
 - Holon must reconstruct terminal output from streamed events and classify
   explicit terminal failures rather than pretending the provider is available
+
+Endpoint boundary:
+
+- `openai-codex` treats `/backend-api/codex` as the ChatGPT-backed Responses
+  API base
+- legacy configs that still point at `/backend-api` are normalized before
+  constructing `/responses` and `/responses/compact`

--- a/docs/implementation-decisions/052-turn-local-compaction-remains-request-projection.md
+++ b/docs/implementation-decisions/052-turn-local-compaction-remains-request-projection.md
@@ -1,0 +1,16 @@
+# Turn-Local Compaction Remains Request Projection
+
+Decision:
+
+- keep turn-local compaction as an in-memory provider request projection, not a
+  durable replacement history checkpoint
+
+Reason:
+
+- `maybe_compact_agent` owns durable cross-turn message compaction
+- OpenAI remote compaction owns opaque provider-window replacement state
+- turn-local compaction only keeps one runtime turn below the provider prompt
+  budget by projecting older completed rounds into deterministic recaps
+
+This preserves Holon's readable runtime state as the semantic source of truth
+while avoiding a third durable compaction format inside the same fix.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -69,3 +69,4 @@ Current decision notes:
 - [049 Anthropic Cache Break Classification](./049-anthropic-cache-break-classification.md)
 - [050 Anthropic Claude CLI-Like Cache Lowering](./050-anthropic-claude-cli-like-cache-lowering.md)
 - [051 Runtime Config Provider Credentials](./051-runtime-config-provider-credentials.md)
+- [052 Turn-Local Compaction Remains Request Projection](./052-turn-local-compaction-remains-request-projection.md)

--- a/docs/rfcs/extensible-model-provider-configuration.md
+++ b/docs/rfcs/extensible-model-provider-configuration.md
@@ -109,7 +109,7 @@ The persisted runtime config should evolve toward this shape:
   "providers": {
     "openai-codex": {
       "transport": "openai_codex_responses",
-      "base_url": "https://chatgpt.com/backend-api",
+      "base_url": "https://chatgpt.com/backend-api/codex",
       "auth": {
         "source": "external_cli",
         "kind": "session_token",

--- a/docs/rfcs/openai-remote-compaction.md
+++ b/docs/rfcs/openai-remote-compaction.md
@@ -22,6 +22,13 @@ OpenAI Responses exposes remote compaction through:
 - standalone `POST /v1/responses/compact`
 - server-side compaction through `/v1/responses` `context_management`
 
+For ChatGPT/Codex-authenticated backend routes, Holon treats
+`https://chatgpt.com/backend-api/codex` as the provider API base. The
+corresponding standalone compact route is therefore
+`/backend-api/codex/responses/compact`. Older Holon configs that use
+`/backend-api` remain accepted by normalizing the API base before endpoint
+construction.
+
 The compacted item returned by OpenAI includes encrypted provider state. Holon
 can store and replay that item, but cannot inspect its semantic contents.
 
@@ -133,6 +140,12 @@ Holon should avoid compaction churn by following these rules:
 
 Remote compaction should therefore be a threshold crossing event, not a routine
 per-round rewrite.
+
+If the compact route returns a permanent endpoint capability failure such as
+404, 405, 410, or 501, Holon should negative-cache that endpoint for the current
+provider session. Later rounds should emit `skipped_unsupported_endpoint`
+diagnostics instead of repeating the same known-bad compact request. Transient
+transport, rate-limit, and server failures should not populate this cache.
 
 ## 6. Multiple Compaction Items
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1427,7 +1427,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
             id: openai_codex,
             transport: ProviderTransportKind::OpenAiCodexResponses,
             base_url: env::var("HOLON_OPENAI_CODEX_BASE_URL")
-                .unwrap_or_else(|_| "https://chatgpt.com/backend-api".to_string()),
+                .unwrap_or_else(|_| "https://chatgpt.com/backend-api/codex".to_string()),
             auth: ProviderAuthConfig {
                 source: CredentialSource::ExternalCli,
                 kind: CredentialKind::SessionToken,
@@ -1962,7 +1962,7 @@ pub fn provider_registry_for_tests(
         ProviderRuntimeConfig {
             id: openai_codex,
             transport: ProviderTransportKind::OpenAiCodexResponses,
-            base_url: "https://chatgpt.com/backend-api".into(),
+            base_url: "https://chatgpt.com/backend-api/codex".into(),
             auth: ProviderAuthConfig {
                 source: CredentialSource::ExternalCli,
                 kind: CredentialKind::SessionToken,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -197,6 +197,10 @@ pub struct ProviderOpenAiRemoteCompactionDiagnostics {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trigger_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_items: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_items: Option<usize>,

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -38,6 +38,16 @@ fn openai_text_response(response_id: &str, text: &str) -> Value {
     })
 }
 
+fn openai_text_sse_response(response_id: &str, text: &str) -> String {
+    format!(
+        concat!(
+            "event: response.completed\n",
+            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":2,\"output_tokens\":1}},\"output\":[{{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{{\"type\":\"output_text\",\"text\":\"{}\"}}]}}]}}}}\n\n"
+        ),
+        response_id, text
+    )
+}
+
 fn provider_large_window_request_with_prompt_frame() -> ProviderTurnRequest {
     let mut request = provider_turn_request_with_prompt_frame();
     request.conversation = (0..8)
@@ -231,6 +241,232 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
     assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 11);
     assert_eq!(compact_bodies[0]["tools"], json!([]));
     assert_eq!(compact_bodies[0]["parallel_tool_calls"], json!(false));
+}
+
+#[tokio::test]
+async fn openai_codex_remote_compact_uses_codex_backend_route_for_legacy_base_url() {
+    let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let response_bodies_for_server = response_bodies.clone();
+    let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let compact_bodies_for_server = compact_bodies.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/codex/responses",
+                post(move |Json(body): Json<Value>| {
+                    let captured = response_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        (
+                            [("content-type", "text/event-stream")],
+                            openai_text_sse_response("resp_1", "ready"),
+                        )
+                    }
+                }),
+            )
+            .route(
+                "/codex/responses/compact",
+                post(move |Json(body): Json<Value>| {
+                    let captured = compact_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        Json(json!({
+                            "output": [
+                                { "type": "compaction", "encrypted_content": "opaque" }
+                            ]
+                        }))
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let response = provider
+        .complete_turn(provider_large_window_paired_request_with_prompt_frame())
+        .await
+        .unwrap();
+
+    assert_eq!(response_bodies.lock().unwrap().len(), 1);
+    assert_eq!(compact_bodies.lock().unwrap().len(), 1);
+    let remote_compaction = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("remote compaction diagnostics");
+    assert_eq!(remote_compaction.status, "compacted");
+    assert_eq!(
+        remote_compaction.endpoint_kind.as_deref(),
+        Some("responses_compact")
+    );
+}
+
+#[tokio::test]
+async fn openai_codex_remote_compact_does_not_double_codex_path_for_new_base_url() {
+    let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let compact_bodies_for_server = compact_bodies.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/codex/responses",
+                post(|Json(_body): Json<Value>| async {
+                    (
+                        [("content-type", "text/event-stream")],
+                        openai_text_sse_response("resp_1", "ready"),
+                    )
+                }),
+            )
+            .route(
+                "/codex/responses/compact",
+                post(move |Json(body): Json<Value>| {
+                    let captured = compact_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        Json(json!({
+                            "output": [
+                                { "type": "compaction", "encrypted_content": "opaque" }
+                            ]
+                        }))
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = format!("{base_url}/codex");
+    let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(provider_large_window_paired_request_with_prompt_frame())
+        .await
+        .unwrap();
+
+    assert_eq!(compact_bodies.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn openai_responses_caches_unsupported_remote_compact_endpoint() {
+    let compact_attempts = Arc::new(AtomicUsize::new(0));
+    let compact_attempts_for_server = compact_attempts.clone();
+    let response_attempts = Arc::new(AtomicUsize::new(0));
+    let response_attempts_for_server = response_attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(move |Json(_body): Json<Value>| {
+                    let attempts = response_attempts_for_server.clone();
+                    async move {
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            Json(openai_text_response("resp_1", "ready"))
+                        } else {
+                            Json(openai_text_response("resp_2", "done"))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(move |Json(_body): Json<Value>| {
+                    let attempts = compact_attempts_for_server.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        (
+                            StatusCode::NOT_FOUND,
+                            Json(json!({ "detail": "Not Found" })),
+                        )
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let first = provider
+        .complete_turn(provider_large_window_paired_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let second = provider
+        .complete_turn(provider_large_window_paired_followup_with_prompt_frame())
+        .await
+        .unwrap();
+
+    let first_compaction = first
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("first remote compaction diagnostics");
+    assert_eq!(first_compaction.status, "unsupported_endpoint");
+    assert_eq!(first_compaction.http_status, Some(404));
+
+    let second_compaction = second
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("second remote compaction diagnostics");
+    assert_eq!(second_compaction.status, "skipped_unsupported_endpoint");
+    assert_eq!(second_compaction.http_status, Some(404));
+    assert_eq!(compact_attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn openai_codex_streaming_incomplete_max_output_tokens_returns_recoverable_response() {
+    let base_url = spawn_test_server(Router::new().route(
+        "/codex/responses",
+        post(|Json(_body): Json<Value>| async {
+            (
+                [("content-type", "text/event-stream")],
+                concat!(
+                    "event: response.output_item.done\n",
+                    "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"partial report\"}]}}\n\n",
+                    "event: response.incomplete\n",
+                    "data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"usage\":{\"input_tokens\":5,\"output_tokens\":3}}}\n\n"
+                ),
+            )
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let response = provider
+        .complete_turn(provider_turn_request())
+        .await
+        .unwrap();
+
+    assert_eq!(response.stop_reason.as_deref(), Some("max_output_tokens"));
+    assert_eq!(response.input_tokens, 5);
+    assert_eq!(response.output_tokens, 3);
+    assert!(matches!(
+        &response.blocks[0],
+        ModelBlock::Text { text } if text == "partial report"
+    ));
 }
 
 #[tokio::test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -22,7 +22,8 @@ use crate::{
 use super::build_http_client;
 use crate::provider::retry::{
     classify_reqwest_transport_error, classify_status_error, invalid_response_error,
-    provider_transport_error, ProviderFailureClassification, ProviderFailureKind, RetryDisposition,
+    provider_transport_error, ProviderFailureClassification, ProviderFailureKind,
+    ProviderTransportError, RetryDisposition,
 };
 
 #[derive(Clone)]
@@ -63,11 +64,38 @@ pub(crate) enum OpenAiResponsesTransportContract {
 }
 
 const OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS: usize = 8;
+const OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND: &str = "responses_compact";
 
 #[derive(Debug, Default)]
 struct OpenAiContinuationState {
     windows: HashMap<OpenAiContinuationScope, OpenAiProviderWindow>,
+    unsupported_compact_endpoints: HashMap<String, u16>,
     next_generation: u64,
+}
+
+fn openai_responses_url(base_url: &str) -> String {
+    format!("{}/responses", base_url.trim_end_matches('/'))
+}
+
+fn openai_responses_compact_url(base_url: &str) -> String {
+    format!("{}/responses/compact", base_url.trim_end_matches('/'))
+}
+
+fn openai_codex_api_base_url(base_url: &str) -> String {
+    let base_url = base_url.trim_end_matches('/');
+    if base_url.ends_with("/codex") {
+        base_url.to_string()
+    } else {
+        format!("{base_url}/codex")
+    }
+}
+
+fn openai_codex_responses_url(base_url: &str) -> String {
+    format!("{}/responses", openai_codex_api_base_url(base_url))
+}
+
+fn openai_codex_responses_compact_url(base_url: &str) -> String {
+    format!("{}/responses/compact", openai_codex_api_base_url(base_url))
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -270,7 +298,7 @@ impl AgentProvider for OpenAiProvider {
             &self.continuation,
             &mut plan,
             &self.client,
-            format!("{}/responses/compact", self.base_url),
+            openai_responses_compact_url(&self.base_url),
             headers.clone(),
         )
         .await
@@ -280,7 +308,7 @@ impl AgentProvider for OpenAiProvider {
         }
         let parsed = match send_openai_responses_request(
             &self.client,
-            format!("{}/responses", self.base_url),
+            openai_responses_url(&self.base_url),
             plan.body,
             headers.clone(),
         )
@@ -306,7 +334,7 @@ impl AgentProvider for OpenAiProvider {
                 plan_scope.as_ref(),
                 &plan_request_shape,
                 &self.client,
-                format!("{}/responses/compact", self.base_url),
+                openai_responses_compact_url(&self.base_url),
                 headers,
             )
             .await;
@@ -356,7 +384,7 @@ impl AgentProvider for OpenAiCodexProvider {
             &self.continuation,
             &mut plan,
             &self.client,
-            format!("{}/responses/compact", self.base_url),
+            openai_codex_responses_compact_url(&self.base_url),
             headers.clone(),
         )
         .await
@@ -366,7 +394,7 @@ impl AgentProvider for OpenAiCodexProvider {
         }
         let parsed = match send_openai_responses_streaming_request(
             &self.client,
-            format!("{}/codex/responses", self.base_url),
+            openai_codex_responses_url(&self.base_url),
             plan.body,
             headers.clone(),
         )
@@ -392,7 +420,7 @@ impl AgentProvider for OpenAiCodexProvider {
                 plan_scope.as_ref(),
                 &plan_request_shape,
                 &self.client,
-                format!("{}/responses/compact", self.base_url),
+                openai_codex_responses_compact_url(&self.base_url),
                 headers,
             )
             .await;
@@ -1222,6 +1250,8 @@ async fn maybe_compact_openai_provider_window(
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: format!("skipped_{skip_reason}"),
             trigger_reason: Some("provider_window_item_threshold".into()),
+            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+            http_status: None,
             input_items: Some(window.items.len()),
             output_items: None,
             compaction_items: None,
@@ -1236,14 +1266,42 @@ async fn maybe_compact_openai_provider_window(
 
     let input_items = window.items.len();
     let request_shape_hash = request_shape_hash(request_shape);
+    if let Some(http_status) = compact_endpoint_unsupported_status(continuation, &compact_url) {
+        return Some(openai_compact_unsupported_diagnostics(
+            "skipped_unsupported_endpoint",
+            "provider_window_item_threshold",
+            input_items,
+            window.latest_compaction_index,
+            Some(request_shape_hash),
+            Some(window.generation),
+            http_status,
+            None,
+        ));
+    }
     let compact_body = build_openai_compact_request_body(request_shape, &window.items);
     let compacted =
-        match send_openai_compact_request(client, compact_url, compact_body, headers).await {
+        match send_openai_compact_request(client, compact_url.clone(), compact_body, headers).await
+        {
             Ok(compacted) => compacted,
             Err(error) => {
+                if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
+                    mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
+                    return Some(openai_compact_unsupported_diagnostics(
+                        "unsupported_endpoint",
+                        "provider_window_item_threshold",
+                        input_items,
+                        window.latest_compaction_index,
+                        Some(request_shape_hash),
+                        Some(window.generation),
+                        http_status,
+                        Some(error.to_string()),
+                    ));
+                }
                 return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                     status: "failed".into(),
                     trigger_reason: Some("provider_window_item_threshold".into()),
+                    endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                    http_status: error_status(&error),
                     input_items: Some(input_items),
                     output_items: None,
                     compaction_items: None,
@@ -1260,6 +1318,8 @@ async fn maybe_compact_openai_provider_window(
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_empty_output".into(),
             trigger_reason: Some("provider_window_item_threshold".into()),
+            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+            http_status: None,
             input_items: Some(input_items),
             output_items: Some(0),
             compaction_items: Some(0),
@@ -1280,6 +1340,8 @@ async fn maybe_compact_openai_provider_window(
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_missing_compaction_item".into(),
             trigger_reason: Some("provider_window_item_threshold".into()),
+            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+            http_status: None,
             input_items: Some(input_items),
             output_items: Some(compacted.len()),
             compaction_items: Some(0),
@@ -1300,6 +1362,8 @@ async fn maybe_compact_openai_provider_window(
             return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                 status: "stale_generation".into(),
                 trigger_reason: Some("provider_window_item_threshold".into()),
+                endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                http_status: None,
                 input_items: Some(input_items),
                 output_items: Some(output_items),
                 compaction_items: Some(compaction_items),
@@ -1333,6 +1397,8 @@ async fn maybe_compact_openai_provider_window(
     Some(ProviderOpenAiRemoteCompactionDiagnostics {
         status: "compacted".into(),
         trigger_reason: Some("provider_window_item_threshold".into()),
+        endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+        http_status: None,
         input_items: Some(input_items),
         output_items: Some(output_items),
         compaction_items: Some(compaction_items),
@@ -1379,6 +1445,8 @@ async fn maybe_compact_openai_request_plan(
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: format!("skipped_{skip_reason}"),
             trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+            http_status: None,
             input_items: Some(compactable_window.items.len()),
             output_items: None,
             compaction_items: None,
@@ -1393,15 +1461,43 @@ async fn maybe_compact_openai_request_plan(
 
     let input_items = compactable_window.items.len();
     let request_shape_hash = request_shape_hash(&plan.request_shape);
+    if let Some(http_status) = compact_endpoint_unsupported_status(continuation, &compact_url) {
+        return Some(openai_compact_unsupported_diagnostics(
+            "skipped_unsupported_endpoint",
+            "provider_window_item_threshold_before_request",
+            input_items,
+            compactable_window.latest_compaction_index,
+            Some(request_shape_hash),
+            Some(previous.generation),
+            http_status,
+            None,
+        ));
+    }
     let compact_body =
         build_openai_compact_request_body(&plan.request_shape, &compactable_window.items);
     let compacted =
-        match send_openai_compact_request(client, compact_url, compact_body, headers).await {
+        match send_openai_compact_request(client, compact_url.clone(), compact_body, headers).await
+        {
             Ok(compacted) => compacted,
             Err(error) => {
+                if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
+                    mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
+                    return Some(openai_compact_unsupported_diagnostics(
+                        "unsupported_endpoint",
+                        "provider_window_item_threshold_before_request",
+                        input_items,
+                        compactable_window.latest_compaction_index,
+                        Some(request_shape_hash),
+                        Some(previous.generation),
+                        http_status,
+                        Some(error.to_string()),
+                    ));
+                }
                 return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                     status: "failed".into(),
                     trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+                    endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                    http_status: error_status(&error),
                     input_items: Some(input_items),
                     output_items: None,
                     compaction_items: None,
@@ -1418,6 +1514,8 @@ async fn maybe_compact_openai_request_plan(
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_empty_output".into(),
             trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+            http_status: None,
             input_items: Some(input_items),
             output_items: Some(0),
             compaction_items: Some(0),
@@ -1438,6 +1536,8 @@ async fn maybe_compact_openai_request_plan(
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_missing_compaction_item".into(),
             trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+            http_status: None,
             input_items: Some(input_items),
             output_items: Some(compacted.len()),
             compaction_items: Some(0),
@@ -1458,6 +1558,8 @@ async fn maybe_compact_openai_request_plan(
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "stale_generation".into(),
             trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+            http_status: None,
             input_items: Some(input_items),
             output_items: Some(compacted.len()),
             compaction_items: Some(compaction_items),
@@ -1486,6 +1588,8 @@ async fn maybe_compact_openai_request_plan(
     Some(ProviderOpenAiRemoteCompactionDiagnostics {
         status: "compacted".into(),
         trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+        endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+        http_status: None,
         input_items: Some(input_items),
         output_items: Some(output_items),
         compaction_items: Some(compaction_items),
@@ -1496,6 +1600,69 @@ async fn maybe_compact_openai_request_plan(
         continuation_generation: Some(previous.generation),
         error: None,
     })
+}
+
+fn compact_endpoint_unsupported_status(
+    continuation: &Arc<Mutex<OpenAiContinuationState>>,
+    compact_url: &str,
+) -> Option<u16> {
+    let state = lock_openai_continuation(continuation);
+    state
+        .unsupported_compact_endpoints
+        .get(compact_url)
+        .copied()
+}
+
+fn mark_compact_endpoint_unsupported(
+    continuation: &Arc<Mutex<OpenAiContinuationState>>,
+    compact_url: &str,
+    http_status: u16,
+) {
+    let mut state = lock_openai_continuation(continuation);
+    state
+        .unsupported_compact_endpoints
+        .insert(compact_url.to_string(), http_status);
+}
+
+fn unsupported_compact_endpoint_status(error: &anyhow::Error) -> Option<u16> {
+    let status = error_status(error)?;
+    match status {
+        404 | 405 | 410 | 501 => Some(status),
+        _ => None,
+    }
+}
+
+fn error_status(error: &anyhow::Error) -> Option<u16> {
+    error
+        .downcast_ref::<ProviderTransportError>()
+        .and_then(|error| error.status)
+}
+
+fn openai_compact_unsupported_diagnostics(
+    status: &str,
+    trigger_reason: &str,
+    input_items: usize,
+    latest_compaction_index: Option<usize>,
+    request_shape_hash: Option<String>,
+    continuation_generation: Option<u64>,
+    http_status: u16,
+    error: Option<String>,
+) -> ProviderOpenAiRemoteCompactionDiagnostics {
+    ProviderOpenAiRemoteCompactionDiagnostics {
+        status: status.into(),
+        trigger_reason: Some(trigger_reason.into()),
+        endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+        http_status: Some(http_status),
+        input_items: Some(input_items),
+        output_items: None,
+        compaction_items: None,
+        latest_compaction_index,
+        encrypted_content_hashes: None,
+        encrypted_content_bytes: None,
+        request_shape_hash,
+        continuation_generation,
+        error,
+    }
 }
 
 fn openai_provider_window_compaction_skip_reason(
@@ -2510,6 +2677,9 @@ async fn read_openai_streaming_response(response: Response) -> Result<Value> {
                         item,
                         MAX_STREAMED_OUTPUT_ITEMS,
                     )?,
+                    StreamingSseEvent::Incomplete(response) => {
+                        return recover_openai_incomplete_response(response, &streamed_output_items)
+                    }
                     StreamingSseEvent::Done => return Err(early_done_protocol_violation_error()),
                     StreamingSseEvent::Terminal(response) => {
                         return Ok(finalize_openai_terminal_response(
@@ -2536,6 +2706,9 @@ async fn read_openai_streaming_response(response: Response) -> Result<Value> {
         StreamingSseEvent::Continue => {}
         StreamingSseEvent::OutputItem(item) => {
             push_streamed_output_item(&mut streamed_output_items, item, MAX_STREAMED_OUTPUT_ITEMS)?
+        }
+        StreamingSseEvent::Incomplete(response) => {
+            return recover_openai_incomplete_response(response, &streamed_output_items)
         }
         StreamingSseEvent::Done => return Err(early_done_protocol_violation_error()),
         StreamingSseEvent::Terminal(response) => {
@@ -2572,6 +2745,7 @@ fn early_done_protocol_violation_error() -> anyhow::Error {
 enum StreamingSseEvent {
     Continue,
     OutputItem(Value),
+    Incomplete(Value),
     Done,
     Terminal(Value),
 }
@@ -2642,13 +2816,34 @@ fn consume_openai_sse_event(data_lines: &mut Vec<String>) -> Result<StreamingSse
                 Some(response),
             ));
         }
-        if event_type == "response.incomplete" || matches!(status, Some("incomplete" | "cancelled"))
-        {
+        if event_type == "response.incomplete" || status == Some("incomplete") {
+            if openai_incomplete_reason(response) == Some("max_output_tokens") {
+                return Ok(StreamingSseEvent::Incomplete(response.clone()));
+            }
+            return Err(classify_openai_incomplete_response(response));
+        }
+        if status == Some("cancelled") {
             return Err(classify_openai_incomplete_response(response));
         }
     }
 
     Ok(StreamingSseEvent::Continue)
+}
+
+fn recover_openai_incomplete_response(
+    response: Value,
+    streamed_output_items: &[Value],
+) -> Result<Value> {
+    let response = finalize_openai_terminal_response(response, streamed_output_items);
+    let has_output = response
+        .get("output")
+        .and_then(Value::as_array)
+        .is_some_and(|output| !output.is_empty());
+    if has_output {
+        Ok(response)
+    } else {
+        Err(classify_openai_incomplete_response(&response))
+    }
 }
 
 fn finalize_openai_terminal_response(
@@ -2718,10 +2913,7 @@ fn classify_openai_streaming_error(
 }
 
 fn classify_openai_incomplete_response(response: &Value) -> anyhow::Error {
-    let reason = response
-        .get("incomplete_details")
-        .and_then(|details| details.get("reason"))
-        .and_then(Value::as_str)
+    let reason = openai_incomplete_reason(response)
         .or_else(|| response.get("status").and_then(Value::as_str))
         .unwrap_or("unknown");
     provider_transport_error(
@@ -2733,6 +2925,13 @@ fn classify_openai_incomplete_response(response: &Value) -> anyhow::Error {
         None,
         format!("OpenAI-style streaming response did not complete successfully: {reason}"),
     )
+}
+
+fn openai_incomplete_reason(response: &Value) -> Option<&str> {
+    response
+        .get("incomplete_details")
+        .and_then(|details| details.get("reason"))
+        .and_then(Value::as_str)
 }
 
 #[allow(dead_code)]
@@ -2869,9 +3068,16 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
         response: ProviderTurnResponse {
             blocks,
             stop_reason: response
-                .get("status")
+                .get("incomplete_details")
+                .and_then(|details| details.get("reason"))
                 .and_then(Value::as_str)
                 .map(str::to_string)
+                .or_else(|| {
+                    response
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
                 .or_else(|| {
                     response
                         .get("stop_reason")

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1430,7 +1430,7 @@ fn combine_text_history(history: &[String], text_blocks: &[String]) -> Vec<Strin
 fn is_max_output_stop_reason(stop_reason: Option<&str>) -> bool {
     matches!(
         stop_reason,
-        Some("max_tokens") | Some("model_context_window_exceeded")
+        Some("max_tokens") | Some("max_output_tokens") | Some("model_context_window_exceeded")
     )
 }
 
@@ -1468,6 +1468,11 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
+
+    #[test]
+    fn openai_max_output_tokens_stop_reason_triggers_recovery() {
+        assert!(is_max_output_stop_reason(Some("max_output_tokens")));
+    }
 
     fn context_config() -> ContextConfig {
         ContextConfig {

--- a/tests/live_openai_codex_compact.rs
+++ b/tests/live_openai_codex_compact.rs
@@ -1,0 +1,67 @@
+use anyhow::{anyhow, Result};
+use holon::{
+    config::{AppConfig, ProviderId},
+    provider::{AgentProvider, ConversationMessage, OpenAiCodexProvider, ProviderTurnRequest},
+};
+
+fn live_config() -> Result<AppConfig> {
+    AppConfig::load()
+}
+
+fn live_openai_codex_model() -> String {
+    std::env::var("HOLON_LIVE_OPENAI_CODEX_MODEL").unwrap_or_else(|_| "gpt-5.3-codex-spark".into())
+}
+
+fn codex_compact_route(base_url: &str) -> String {
+    let base_url = base_url.trim_end_matches('/');
+    let api_base = if base_url.ends_with("/codex") {
+        base_url.to_string()
+    } else {
+        format!("{base_url}/codex")
+    };
+    format!("{api_base}/responses/compact")
+}
+
+#[tokio::test]
+#[ignore = "requires Codex CLI ChatGPT auth and network access"]
+async fn live_openai_codex_remote_compact_route_probe() -> Result<()> {
+    let config = live_config()?;
+    let provider_config = config
+        .providers
+        .get(&ProviderId::openai_codex())
+        .ok_or_else(|| anyhow!("missing openai-codex provider config"))?;
+    let route = codex_compact_route(&provider_config.base_url);
+    let provider = OpenAiCodexProvider::from_config(&config, &live_openai_codex_model())?;
+    let output = provider
+        .complete_turn(ProviderTurnRequest::plain(
+            "Reply briefly. Do not include private information.",
+            (0..8)
+                .map(|index| ConversationMessage::UserText(format!("compact probe item {index}")))
+                .collect(),
+            vec![],
+        ))
+        .await?;
+
+    let diagnostics = output
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .ok_or_else(|| anyhow!("remote compact was not attempted for route {route}"))?;
+
+    eprintln!(
+        "openai-codex compact route probe: route={route}, status={}, http_status_class={}, input_items={:?}, output_items={:?}, compaction_items={:?}",
+        diagnostics.status,
+        diagnostics
+            .http_status
+            .map(|status| format!("{}xx", status / 100))
+            .unwrap_or_else(|| "none".into()),
+        diagnostics.input_items,
+        diagnostics.output_items,
+        diagnostics.compaction_items
+    );
+
+    if diagnostics.http_status == Some(404) {
+        anyhow::bail!("openai-codex compact route returned 404: {route}");
+    }
+    Ok(())
+}

--- a/tests/live_openai_codex_compact.rs
+++ b/tests/live_openai_codex_compact.rs
@@ -1,7 +1,10 @@
 use anyhow::{anyhow, Result};
 use holon::{
     config::{AppConfig, ProviderId},
-    provider::{AgentProvider, ConversationMessage, OpenAiCodexProvider, ProviderTurnRequest},
+    provider::{
+        AgentProvider, ConversationMessage, OpenAiCodexProvider, ProviderPromptCache,
+        ProviderPromptFrame, ProviderTurnRequest,
+    },
 };
 
 fn live_config() -> Result<AppConfig> {
@@ -33,13 +36,23 @@ async fn live_openai_codex_remote_compact_route_probe() -> Result<()> {
     let route = codex_compact_route(&provider_config.base_url);
     let provider = OpenAiCodexProvider::from_config(&config, &live_openai_codex_model())?;
     let output = provider
-        .complete_turn(ProviderTurnRequest::plain(
-            "Reply briefly. Do not include private information.",
-            (0..8)
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: ProviderPromptFrame::structured(
+                "Reply briefly. Do not include private information.",
+                Vec::new(),
+                Vec::new(),
+                Some(ProviderPromptCache {
+                    agent_id: "live-openai-codex-compact-probe".into(),
+                    prompt_cache_key: "live-openai-codex-compact-probe".into(),
+                    working_memory_revision: 0,
+                    compression_epoch: 0,
+                }),
+            ),
+            conversation: (0..8)
                 .map(|index| ConversationMessage::UserText(format!("compact probe item {index}")))
                 .collect(),
-            vec![],
-        ))
+            tools: vec![],
+        })
         .await?;
 
     let diagnostics = output


### PR DESCRIPTION
## Summary

- normalize `openai-codex` Responses routes around the ChatGPT Codex API base (`/backend-api/codex`) while keeping legacy `/backend-api` overrides working
- add permanent unsupported compact endpoint diagnostics and session-local negative caching for 404/405/410/501 compact failures
- treat streamed `response.incomplete` with `incomplete_details.reason=max_output_tokens` as recoverable when output items were already streamed, so runtime recovery can run
- document that turn-local compaction remains request projection, separate from durable message compaction and OpenAI remote compaction
- add an ignored live Codex compact probe for the real route without logging credentials or transcript content

Fixes #796.

## Verification

- `cargo fmt --all`
- `cargo test openai_responses --lib`
- `cargo test openai --lib`
- `cargo test openai_max_output_tokens_stop_reason_triggers_recovery --lib`
- `cargo test materialize_provider_config_preserves_builtin_runtime_fields --lib`
- `cargo test --test live_openai_codex_compact --no-run`
- `cargo fmt --all -- --check && cargo test --lib`

The live probe is ignored by default and was compiled but not executed locally because it requires a live ChatGPT/Codex session.
