### PR TITLE
fix(openai-codex): harden streaming retry and remote compact

### DIFF
--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -2876,6 +2876,8 @@ function openaiRemoteCompactionDiagnostic(provider, requestDiagnostics) {
   return {
     status: compaction.status ?? "unknown",
     trigger_reason: compaction.trigger_reason ?? null,
+    endpoint_kind: compaction.endpoint_kind ?? null,
+    http_status: compaction.http_status == null ? null : numberOrNull(compaction.http_status),
     input_items: numberOrNull(compaction.input_items),
     output_items: numberOrNull(compaction.output_items),
     compaction_items: numberOrNull(compaction.compaction_items),

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -937,6 +937,8 @@ test("summarizeHolonTokenOptimization reports OpenAI remote compaction", () => {
             openai_remote_compaction: {
               status: "compacted",
               trigger_reason: "provider_window_item_threshold",
+              endpoint_kind: "responses_compact",
+              http_status: null,
               input_items: 12,
               output_items: 3,
               compaction_items: 2,
@@ -967,6 +969,8 @@ test("summarizeHolonTokenOptimization reports OpenAI remote compaction", () => {
 
   assert.equal(diagnostics.rounds[0].request_lowering_mode, "provider_window_compacted");
   assert.equal(diagnostics.rounds[0].openai_remote_compaction.status, "compacted");
+  assert.equal(diagnostics.rounds[0].openai_remote_compaction.endpoint_kind, "responses_compact");
+  assert.equal(diagnostics.rounds[0].openai_remote_compaction.http_status, null);
   assert.equal(diagnostics.rounds[0].openai_remote_compaction.input_items, 12);
   assert.equal(diagnostics.summary.request_lowering_modes.provider_window_compacted, 1);
   assert.equal(diagnostics.summary.openai_remote_compaction_rounds, 1);

--- a/docs/rfcs/openai-remote-compaction.md
+++ b/docs/rfcs/openai-remote-compaction.md
@@ -147,6 +147,12 @@ provider session. Later rounds should emit `skipped_unsupported_endpoint`
 diagnostics instead of repeating the same known-bad compact request. Transient
 transport, rate-limit, and server failures should not populate this cache.
 
+Not every 404 from the compact route is an endpoint capability failure. When
+OpenAI reports that request items are not persisted, Holon should classify the
+compact request as invalid provider input instead of negative-caching the
+endpoint. This is especially important for `store=false` usage, where response
+output item ids can be provider-local and unavailable to a later compact call.
+
 ## 6. Multiple Compaction Items
 
 Holon must not assume there is only one encrypted compaction item.
@@ -247,6 +253,18 @@ Suggested non-triggers:
 - after every local semantic compaction
 - while a tool call and its output are not paired yet
 - when request shape changed for unrelated reasons
+
+The "tool call and its output are not paired yet" rule applies to the compacted
+span, not necessarily to the whole provider window. If the latest provider
+window has a complete prefix followed by an unpaired tool call, Holon may compact
+the complete prefix and retain the unpaired tail verbatim for the next request.
+Holon must not compact across an unpaired `function_call` or `custom_tool_call`.
+
+When building compact input for stateless `store=false` sessions, Holon should
+strip provider-generated top-level item ids from compact input. Stable tool
+pairing identity must be preserved through `call_id`; if a provider emits a tool
+call item with only `id`, Holon may copy that value into `call_id` before
+removing the top-level `id`.
 
 ## 9. Benchmark Expectations
 

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -135,12 +135,18 @@ pub(crate) fn classify_reqwest_transport_error(
     error: reqwest::Error,
 ) -> anyhow::Error {
     let status = error.status().map(|status| status.as_u16());
+    let source_chain = error_chain_messages(&error);
     let classification = if error.is_timeout() {
         ProviderFailureClassification {
             kind: ProviderFailureKind::Timeout,
             disposition: RetryDisposition::Retryable,
         }
     } else if error.is_connect() {
+        ProviderFailureClassification {
+            kind: ProviderFailureKind::Connection,
+            disposition: RetryDisposition::Retryable,
+        }
+    } else if is_retryable_response_body_read_interruption(stage, &error, &source_chain) {
         ProviderFailureClassification {
             kind: ProviderFailureKind::Connection,
             disposition: RetryDisposition::Retryable,
@@ -155,10 +161,42 @@ pub(crate) fn classify_reqwest_transport_error(
         classification,
         status,
         Some(reqwest_transport_diagnostics(
-            stage, provider, model_ref, url, &error,
+            stage,
+            provider,
+            model_ref,
+            url,
+            &error,
+            source_chain,
         )),
         format!("{context}: {error}"),
     )
+}
+
+fn is_retryable_response_body_read_interruption(
+    stage: &str,
+    error: &reqwest::Error,
+    source_chain: &[String],
+) -> bool {
+    if !matches!(stage, "response_body" | "streaming_response_body") {
+        return false;
+    }
+    if !(error.is_body() || error.is_decode()) {
+        return false;
+    }
+
+    source_chain.iter().any(|message| {
+        let message = message.to_ascii_lowercase();
+        message.contains("unexpected eof")
+            || message.contains("end of file")
+            || message.contains("connection reset")
+            || message.contains("connection closed")
+            || message.contains("connection aborted")
+            || message.contains("broken pipe")
+            || message.contains("incomplete message")
+            || message.contains("error reading a body from connection")
+            || message.contains("chunk size")
+            || message.contains("request or response body error")
+    })
 }
 
 pub(crate) fn classify_status_error(
@@ -217,6 +255,7 @@ fn reqwest_transport_diagnostics(
     model_ref: Option<&str>,
     url: Option<&str>,
     error: &reqwest::Error,
+    source_chain: Vec<String>,
 ) -> ProviderTransportDiagnostics {
     ProviderTransportDiagnostics {
         stage: stage.to_string(),
@@ -235,7 +274,7 @@ fn reqwest_transport_diagnostics(
             is_redirect: error.is_redirect(),
             status: error.status().map(|status| status.as_u16()),
         }),
-        source_chain: error_chain_messages(error),
+        source_chain,
     }
 }
 

--- a/src/provider/tests/mod.rs
+++ b/src/provider/tests/mod.rs
@@ -14,10 +14,10 @@ use super::{
     build_candidate, build_openai_input, build_openai_responses_request,
     build_provider_from_config, emitted_tool_json_schema, parse_openai_response,
     provider_attempt_timeline, provider_doctor, provider_max_attempts,
-    provider_transport_diagnostics, validate_emitted_tool_schema, AgentProvider, AnthropicProvider,
-    ConversationMessage, ModelBlock, OpenAiCodexProvider, OpenAiProvider, PromptContentBlock,
-    ProviderAttemptOutcome, ProviderPromptCache, ProviderPromptCapability, ProviderPromptFrame,
-    ProviderTurnRequest, ToolResultBlock, ToolSchemaContract,
+    validate_emitted_tool_schema, AgentProvider, AnthropicProvider, ConversationMessage,
+    ModelBlock, OpenAiCodexProvider, OpenAiProvider, PromptContentBlock, ProviderAttemptOutcome,
+    ProviderPromptCache, ProviderPromptCapability, ProviderPromptFrame, ProviderTurnRequest,
+    ToolResultBlock, ToolSchemaContract,
 };
 
 mod anthropic_messages;

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -48,11 +48,50 @@ fn openai_text_sse_response(response_id: &str, text: &str) -> String {
     )
 }
 
+fn openai_reasoning_and_tool_call_sse_response(response_id: &str) -> String {
+    format!(
+        concat!(
+            "event: response.completed\n",
+            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":10,\"output_tokens\":4}},\"output\":[",
+            "{{\"type\":\"reasoning\",\"id\":\"rs_non_persisted\",\"encrypted_content\":\"opaque-reasoning\"}},",
+            "{{\"type\":\"function_call\",\"id\":\"fc_non_persisted\",\"call_id\":\"exec-1\",\"name\":\"ExecCommand\",\"arguments\":\"{{\\\"cmd\\\":\\\"printf ok\\\"}}\"}}",
+            "]}}}}\n\n"
+        ),
+        response_id
+    )
+}
+
 fn provider_large_window_request_with_prompt_frame() -> ProviderTurnRequest {
     let mut request = provider_turn_request_with_prompt_frame();
     request.conversation = (0..8)
         .map(|index| ConversationMessage::UserText(format!("message {index}")))
         .collect();
+    request
+}
+
+fn provider_nearly_large_window_request_with_prompt_frame() -> ProviderTurnRequest {
+    let mut request = provider_turn_request_with_prompt_frame();
+    request.conversation = (0..7)
+        .map(|index| ConversationMessage::UserText(format!("message {index}")))
+        .collect();
+    request
+}
+
+fn provider_nearly_large_window_continuation_with_prompt_frame() -> ProviderTurnRequest {
+    let mut request = provider_nearly_large_window_request_with_prompt_frame();
+    request.conversation.extend([
+        ConversationMessage::AssistantBlocks(vec![ModelBlock::ToolUse {
+            id: "exec-1".into(),
+            name: "ExecCommand".into(),
+            input: json!({ "cmd": "printf ok" }),
+        }]),
+        ConversationMessage::UserToolResults(vec![ToolResultBlock {
+            tool_use_id: "exec-1".into(),
+            content: "ok".into(),
+            is_error: false,
+            error: None,
+        }]),
+    ]);
     request
 }
 
@@ -357,6 +396,94 @@ async fn openai_codex_remote_compact_does_not_double_codex_path_for_new_base_url
 }
 
 #[tokio::test]
+async fn openai_codex_remote_compact_sanitizes_ids_and_retains_unpaired_tail() {
+    let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let response_bodies_for_server = response_bodies.clone();
+    let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let compact_bodies_for_server = compact_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/codex/responses",
+                post(move |Json(body): Json<Value>| {
+                    let captured = response_bodies_for_server.clone();
+                    let attempts = attempts_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        let response = if attempt == 0 {
+                            openai_reasoning_and_tool_call_sse_response("resp_1")
+                        } else {
+                            openai_text_sse_response("resp_2", "done")
+                        };
+                        ([("content-type", "text/event-stream")], response)
+                    }
+                }),
+            )
+            .route(
+                "/codex/responses/compact",
+                post(move |Json(body): Json<Value>| {
+                    let captured = compact_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        Json(json!({
+                            "output": [
+                                { "type": "compaction", "encrypted_content": "opaque-compact" }
+                            ]
+                        }))
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let first = provider
+        .complete_turn(provider_large_window_request_with_prompt_frame())
+        .await
+        .unwrap();
+    provider
+        .complete_turn(provider_large_window_continuation_with_prompt_frame())
+        .await
+        .unwrap();
+
+    let remote_compaction = first
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("remote compaction diagnostics");
+    assert_eq!(remote_compaction.status, "compacted");
+    assert_eq!(remote_compaction.input_items, Some(9));
+
+    let compact_bodies = compact_bodies.lock().unwrap();
+    assert_eq!(compact_bodies.len(), 1);
+    let compact_input = compact_bodies[0]["input"].as_array().unwrap();
+    assert_eq!(compact_input.len(), 9);
+    assert!(compact_bodies[0].to_string().contains("opaque-reasoning"));
+    assert!(!compact_bodies[0].to_string().contains("rs_non_persisted"));
+    assert!(!compact_bodies[0].to_string().contains("fc_non_persisted"));
+    assert!(!compact_bodies[0].to_string().contains("exec-1"));
+
+    let response_bodies = response_bodies.lock().unwrap();
+    assert_eq!(response_bodies.len(), 2);
+    let second_input = response_bodies[1]["input"].as_array().unwrap();
+    assert_eq!(second_input[0]["type"], json!("compaction"));
+    assert_eq!(second_input[1]["type"], json!("function_call"));
+    assert_eq!(second_input[2]["type"], json!("function_call_output"));
+    assert_eq!(second_input[1]["call_id"], json!("exec-1"));
+    assert_eq!(second_input[2]["call_id"], json!("exec-1"));
+}
+
+#[tokio::test]
 async fn openai_responses_caches_unsupported_remote_compact_endpoint() {
     let compact_attempts = Arc::new(AtomicUsize::new(0));
     let compact_attempts_for_server = compact_attempts.clone();
@@ -430,6 +557,80 @@ async fn openai_responses_caches_unsupported_remote_compact_endpoint() {
 }
 
 #[tokio::test]
+async fn openai_responses_reports_non_persisted_compact_item_ids_without_endpoint_cache() {
+    let compact_attempts = Arc::new(AtomicUsize::new(0));
+    let compact_attempts_for_server = compact_attempts.clone();
+    let response_attempts = Arc::new(AtomicUsize::new(0));
+    let response_attempts_for_server = response_attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(move |Json(_body): Json<Value>| {
+                    let attempts = response_attempts_for_server.clone();
+                    async move {
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            Json(openai_text_response("resp_1", "ready"))
+                        } else {
+                            Json(openai_text_response("resp_2", "done"))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(move |Json(_body): Json<Value>| {
+                    let attempts = compact_attempts_for_server.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        (
+                            StatusCode::NOT_FOUND,
+                            Json(json!({
+                                "error": {
+                                    "message": "Item with id 'rs_missing' not found. Items are not persisted when `store` is set to false. Try again with `store` set to true, or remove this item from your input.",
+                                    "type": "invalid_request_error",
+                                    "param": "input",
+                                    "code": null
+                                }
+                            })),
+                        )
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let first = provider
+        .complete_turn(provider_large_window_paired_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let second = provider
+        .complete_turn(provider_large_window_paired_followup_with_prompt_frame())
+        .await
+        .unwrap();
+
+    for response in [first, second] {
+        let compaction = response
+            .request_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+            .expect("remote compaction diagnostics");
+        assert_eq!(compaction.status, "invalid_non_persisted_item_id");
+        assert_eq!(compaction.http_status, Some(404));
+    }
+    assert_eq!(compact_attempts.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
 async fn openai_codex_streaming_incomplete_max_output_tokens_returns_recoverable_response() {
     let base_url = spawn_test_server(Router::new().route(
         "/codex/responses",
@@ -470,7 +671,59 @@ async fn openai_codex_streaming_incomplete_max_output_tokens_returns_recoverable
 }
 
 #[tokio::test]
-async fn openai_responses_skips_remote_compaction_for_unpaired_tool_call() {
+async fn openai_codex_retries_streaming_body_read_interruptions() {
+    let interrupted = b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n20\r\nevent: response.created\n".to_vec();
+    let body = openai_text_sse_response("resp_ok", "retry ok");
+    let complete = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .into_bytes();
+    let base_url = spawn_raw_http_server_bytes_sequence(vec![interrupted, complete]).await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = base_url;
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+
+    let (response, diagnostics) = provider
+        .complete_turn_with_diagnostics(provider_turn_request())
+        .await
+        .expect("stream body interruption should retry and recover");
+
+    assert!(matches!(
+        &response.blocks[0],
+        ModelBlock::Text { text } if text == "retry ok"
+    ));
+    let timeline = diagnostics.expect("missing attempt timeline");
+    assert_eq!(timeline.attempts.len(), 2);
+    assert_eq!(
+        timeline.attempts[0].failure_kind.as_deref(),
+        Some("connection")
+    );
+    assert_eq!(
+        timeline.attempts[0].disposition.as_deref(),
+        Some("retryable")
+    );
+    assert_eq!(
+        timeline.attempts[0]
+            .transport_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.stage.as_str()),
+        Some("streaming_response_body")
+    );
+    assert_eq!(
+        timeline.attempts[1].outcome,
+        ProviderAttemptOutcome::Succeeded
+    );
+}
+
+#[tokio::test]
+async fn openai_responses_compacts_safe_prefix_before_unpaired_tool_call() {
     let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
     let compact_bodies_for_server = compact_bodies.clone();
     let base_url = spawn_test_server(
@@ -515,14 +768,115 @@ async fn openai_responses_skips_remote_compaction_for_unpaired_tool_call() {
         .request_diagnostics
         .as_ref()
         .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
-        .expect("remote compaction skip diagnostics");
-    assert_eq!(remote_compaction.status, "skipped_unpaired_tool_call");
-    assert_eq!(remote_compaction.input_items, Some(9));
-    assert!(compact_bodies.lock().unwrap().is_empty());
+        .expect("remote compaction diagnostics");
+    assert_eq!(remote_compaction.status, "compacted");
+    assert_eq!(remote_compaction.input_items, Some(8));
+    let compact_bodies = compact_bodies.lock().unwrap();
+    assert_eq!(compact_bodies.len(), 1);
+    assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 8);
+    assert!(compact_bodies[0].to_string().contains("message 7"));
+    assert!(!compact_bodies[0].to_string().contains("exec-1"));
 }
 
 #[tokio::test]
-async fn openai_responses_remote_compacts_before_request_after_tool_output_pairs_call() {
+async fn openai_responses_skips_remote_compaction_when_safe_prefix_is_below_threshold() {
+    let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let response_bodies_for_server = response_bodies.clone();
+    let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let compact_bodies_for_server = compact_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/responses",
+                post(move |Json(body): Json<Value>| {
+                    let captured = response_bodies_for_server.clone();
+                    let attempts = attempts_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        let response = match attempt {
+                            0 => openai_tool_call_response("resp_1"),
+                            _ => openai_text_response("resp_2", "done"),
+                        };
+                        Json(response)
+                    }
+                }),
+            )
+            .route(
+                "/responses/compact",
+                post(move |Json(body): Json<Value>| {
+                    let captured = compact_bodies_for_server.clone();
+                    async move {
+                        captured.lock().unwrap().push(body);
+                        Json(json!({
+                            "output": [
+                                { "type": "compaction", "encrypted_content": "opaque" }
+                            ]
+                        }))
+                    }
+                }),
+            ),
+    )
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let response = provider
+        .complete_turn(provider_nearly_large_window_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let second = provider
+        .complete_turn(provider_nearly_large_window_continuation_with_prompt_frame())
+        .await
+        .unwrap();
+
+    let remote_compaction = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("remote compaction skip diagnostics");
+    assert_eq!(remote_compaction.status, "skipped_unpaired_tool_call");
+    assert_eq!(remote_compaction.input_items, Some(8));
+
+    let second_compaction = second
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+        .expect("pre-request remote compaction diagnostics");
+    assert_eq!(second_compaction.status, "compacted");
+    assert_eq!(
+        second_compaction.trigger_reason.as_deref(),
+        Some("provider_window_item_threshold_before_request")
+    );
+    assert_eq!(second_compaction.input_items, Some(9));
+
+    let response_bodies = response_bodies.lock().unwrap();
+    assert_eq!(response_bodies.len(), 2);
+    assert!(response_bodies[1].get("previous_response_id").is_none());
+    let second_input = response_bodies[1]["input"].as_array().unwrap();
+    assert_eq!(second_input.len(), 1);
+    assert_eq!(second_input[0]["type"], json!("compaction"));
+
+    let compact_bodies = compact_bodies.lock().unwrap();
+    assert_eq!(compact_bodies.len(), 1);
+    let compact_input = compact_bodies[0]["input"].as_array().unwrap();
+    assert_eq!(compact_input.len(), 9);
+    assert_eq!(
+        compact_input.last().unwrap()["type"],
+        json!("function_call_output")
+    );
+}
+
+#[tokio::test]
+async fn openai_responses_replays_compacted_prefix_with_retained_tool_tail() {
     let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
     let response_bodies_for_server = response_bodies.clone();
     let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
@@ -582,39 +936,48 @@ async fn openai_responses_remote_compacts_before_request_after_tool_output_pairs
         .await
         .unwrap();
 
-    assert_eq!(
-        first
-            .request_diagnostics
-            .as_ref()
-            .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
-            .map(|diagnostics| diagnostics.status.as_str()),
-        Some("skipped_unpaired_tool_call")
-    );
-    let remote_compaction = second
+    let first_compaction = first
         .request_diagnostics
         .as_ref()
         .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
-        .expect("pre-request remote compaction diagnostics");
-    assert_eq!(remote_compaction.status, "compacted");
+        .expect("post-response remote compaction diagnostics");
+    assert_eq!(first_compaction.status, "compacted");
     assert_eq!(
-        remote_compaction.trigger_reason.as_deref(),
-        Some("provider_window_item_threshold_before_request")
+        first_compaction.trigger_reason.as_deref(),
+        Some("provider_window_item_threshold")
     );
-    assert_eq!(remote_compaction.input_items, Some(10));
+    assert_eq!(first_compaction.input_items, Some(8));
+
+    assert!(
+        second
+            .request_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+            .is_none(),
+        "the second request should replay the compacted prefix and retained tool tail without another compact pass"
+    );
 
     let response_bodies = response_bodies.lock().unwrap();
     assert_eq!(response_bodies.len(), 2);
     assert!(response_bodies[1].get("previous_response_id").is_none());
     let replayed_input = response_bodies[1]["input"].as_array().unwrap();
     assert_eq!(replayed_input[0]["type"], json!("compaction"));
-    assert_eq!(
-        replayed_input.last().unwrap()["type"],
-        json!("function_call_output")
-    );
+    assert!(!response_bodies[1].to_string().contains("message 0"));
+    let tool_pair_index = replayed_input
+        .windows(2)
+        .position(|items| {
+            items[0]["type"] == json!("function_call")
+                && items[1]["type"] == json!("function_call_output")
+                && items[0]["call_id"] == json!("exec-1")
+                && items[1]["call_id"] == json!("exec-1")
+        })
+        .expect("retained tool call should be followed by its tool output");
+    assert!(tool_pair_index > 0);
 
     let compact_bodies = compact_bodies.lock().unwrap();
     assert_eq!(compact_bodies.len(), 1);
-    assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 10);
+    assert_eq!(compact_bodies[0]["input"].as_array().unwrap().len(), 8);
+    assert!(!compact_bodies[0].to_string().contains("exec-1"));
 }
 
 #[tokio::test]

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -863,9 +863,10 @@ async fn openai_provider_fails_fast_on_contract_errors() {
 }
 
 #[tokio::test]
-async fn openai_provider_preserves_structured_unknown_transport_diagnostics() {
-    let response = b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 100\r\nconnection: close\r\n\r\n{\"id\":\"resp_partial\"";
-    let base_url = spawn_raw_http_server(response).await;
+async fn openai_provider_retries_response_body_read_interruptions() {
+    let interrupted = b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 100\r\nconnection: close\r\n\r\n{\"id\":\"resp_partial\"";
+    let complete = b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{\"id\":\"resp_ok\",\"status\":\"completed\",\"usage\":{\"input_tokens\":2,\"output_tokens\":1},\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"retry ok\"}]}]}";
+    let base_url = spawn_raw_http_server_sequence(vec![interrupted, complete]).await;
 
     let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
     fixture
@@ -874,39 +875,29 @@ async fn openai_provider_preserves_structured_unknown_transport_diagnostics() {
         .get_mut(&ProviderId::openai())
         .unwrap()
         .base_url = base_url;
-    fixture
-        .config
-        .stored_config
-        .runtime
-        .disable_provider_fallback = Some(true);
-    fixture.config.disable_provider_fallback = true;
-
     let provider = build_provider_from_config(&fixture.config).unwrap();
-    let error = provider
-        .complete_turn(provider_turn_request())
+    let (response, diagnostics) = provider
+        .complete_turn_with_diagnostics(provider_turn_request())
         .await
-        .err()
-        .expect("truncated response body should fail");
+        .expect("truncated response body should retry and recover");
 
-    assert!(error.to_string().contains("fail_fast (unknown)"));
-    let diagnostics =
-        provider_transport_diagnostics(&error).expect("missing structured transport diagnostics");
-    assert_eq!(diagnostics.stage, "response_body");
-    assert_eq!(diagnostics.provider.as_deref(), Some("openai"));
-    assert_eq!(diagnostics.model_ref.as_deref(), Some("openai/gpt-5.4"));
-    assert!(diagnostics
-        .url
-        .as_deref()
-        .unwrap_or_default()
-        .ends_with("/responses"));
-    assert!(diagnostics.reqwest.is_some());
-    assert!(!diagnostics.source_chain.is_empty());
-
-    let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
-    assert_eq!(timeline.attempts.len(), 1);
+    assert!(matches!(
+        &response.blocks[0],
+        ModelBlock::Text { text } if text == "retry ok"
+    ));
+    let timeline = diagnostics.expect("missing attempt timeline");
+    assert_eq!(timeline.attempts.len(), 2);
     assert_eq!(
         timeline.attempts[0].failure_kind.as_deref(),
-        Some("unknown")
+        Some("connection")
+    );
+    assert_eq!(
+        timeline.attempts[0].disposition.as_deref(),
+        Some("retryable")
+    );
+    assert_eq!(
+        timeline.attempts[0].outcome,
+        ProviderAttemptOutcome::Retrying
     );
     assert_eq!(
         timeline.attempts[0]
@@ -914,6 +905,10 @@ async fn openai_provider_preserves_structured_unknown_transport_diagnostics() {
             .as_ref()
             .map(|diag| diag.stage.as_str()),
         Some("response_body")
+    );
+    assert_eq!(
+        timeline.attempts[1].outcome,
+        ProviderAttemptOutcome::Succeeded
     );
 }
 

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -30,13 +30,30 @@ pub async fn spawn_test_server(router: Router) -> String {
     format!("http://{}", addr)
 }
 
+#[allow(dead_code)]
 pub async fn spawn_raw_http_server(response: &'static [u8]) -> String {
+    spawn_raw_http_server_sequence(vec![response]).await
+}
+
+pub async fn spawn_raw_http_server_sequence(responses: Vec<&'static [u8]>) -> String {
+    spawn_raw_http_server_bytes_sequence(
+        responses
+            .into_iter()
+            .map(|response| response.to_vec())
+            .collect(),
+    )
+    .await
+}
+
+pub async fn spawn_raw_http_server_bytes_sequence(responses: Vec<Vec<u8>>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
-        let (mut stream, _) = listener.accept().await.unwrap();
-        drain_http_request(&mut stream).await;
-        stream.write_all(response).await.unwrap();
+        for response in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            drain_http_request(&mut stream).await;
+            stream.write_all(&response).await.unwrap();
+        }
     });
     format!("http://{}", addr)
 }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1753,9 +1753,7 @@ fn openai_provider_window_compaction_candidate(
 
     let boundary =
         latest_complete_openai_tool_call_boundary(&window.items).ok_or("unpaired_tool_call")?;
-    if boundary == 0 {
-        return Err("unpaired_tool_call");
-    }
+    debug_assert!(boundary > 0);
 
     let compact_items = window.items[..boundary].to_vec();
     if items_since_latest_openai_compaction(&compact_items) < OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -114,6 +114,13 @@ struct OpenAiProviderWindow {
     generation: u64,
 }
 
+#[derive(Debug, Clone)]
+struct OpenAiCompactionCandidate {
+    items: Vec<Value>,
+    retained_tail: Vec<Value>,
+    latest_compaction_index: Option<usize>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct OpenAiRequestShape {
     wire_shape: Value,
@@ -1209,7 +1216,7 @@ fn update_openai_continuation(
             let mut items = provider_input;
             items.extend(parsed.output_items.clone());
             let mut append_match_items = full_input;
-            append_match_items.extend(parsed.output_items.clone());
+            append_match_items.extend(openai_append_match_output_items(&parsed.output_items));
             Some(OpenAiProviderWindow {
                 response_id: Some(response_id.clone()),
                 request_shape,
@@ -1228,6 +1235,23 @@ fn update_openai_continuation(
     }
 }
 
+fn openai_append_match_output_items(output_items: &[Value]) -> Vec<Value> {
+    output_items
+        .iter()
+        .filter_map(openai_append_match_output_item)
+        .collect()
+}
+
+fn openai_append_match_output_item(item: &Value) -> Option<Value> {
+    match item.get("type").and_then(Value::as_str) {
+        Some("message" | "function_call" | "custom_tool_call") => {
+            Some(openai_without_provider_item_id(item))
+        }
+        Some("reasoning") => None,
+        _ => Some(openai_without_provider_item_id(item)),
+    }
+}
+
 async fn maybe_compact_openai_provider_window(
     continuation: &Arc<Mutex<OpenAiContinuationState>>,
     scope: Option<&OpenAiContinuationScope>,
@@ -1243,54 +1267,74 @@ async fn maybe_compact_openai_provider_window(
         let state = lock_openai_continuation(continuation);
         state.windows.get(scope).cloned()
     }?;
-    if let Some(skip_reason) = openai_provider_window_compaction_skip_reason(&window) {
-        if skip_reason == "below_item_threshold" {
-            return None;
+    let candidate = match openai_provider_window_compaction_candidate(&window) {
+        Ok(candidate) => candidate,
+        Err(skip_reason) => {
+            if skip_reason == "below_item_threshold" {
+                return None;
+            }
+            return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                status: format!("skipped_{skip_reason}"),
+                trigger_reason: Some("provider_window_item_threshold".into()),
+                endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                http_status: None,
+                input_items: Some(window.items.len()),
+                output_items: None,
+                compaction_items: None,
+                latest_compaction_index: window.latest_compaction_index,
+                encrypted_content_hashes: None,
+                encrypted_content_bytes: None,
+                request_shape_hash: Some(request_shape_hash(request_shape)),
+                continuation_generation: Some(window.generation),
+                error: None,
+            });
         }
-        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
-            status: format!("skipped_{skip_reason}"),
-            trigger_reason: Some("provider_window_item_threshold".into()),
-            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
-            http_status: None,
-            input_items: Some(window.items.len()),
-            output_items: None,
-            compaction_items: None,
-            latest_compaction_index: window.latest_compaction_index,
-            encrypted_content_hashes: None,
-            encrypted_content_bytes: None,
-            request_shape_hash: Some(request_shape_hash(request_shape)),
-            continuation_generation: Some(window.generation),
-            error: None,
-        });
-    }
+    };
 
-    let input_items = window.items.len();
+    let input_items = candidate.items.len();
     let request_shape_hash = request_shape_hash(request_shape);
     if let Some(http_status) = compact_endpoint_unsupported_status(continuation, &compact_url) {
         return Some(openai_compact_unsupported_diagnostics(
             "skipped_unsupported_endpoint",
             "provider_window_item_threshold",
             input_items,
-            window.latest_compaction_index,
+            candidate.latest_compaction_index,
             Some(request_shape_hash),
             Some(window.generation),
             http_status,
             None,
         ));
     }
-    let compact_body = build_openai_compact_request_body(request_shape, &window.items);
+    let compact_body = build_openai_compact_request_body(request_shape, &candidate.items);
     let compacted =
         match send_openai_compact_request(client, compact_url.clone(), compact_body, headers).await
         {
             Ok(compacted) => compacted,
             Err(error) => {
+                if is_non_persisted_compact_item_id_error(&error) {
+                    return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                        status: "invalid_non_persisted_item_id".into(),
+                        trigger_reason: Some("provider_window_item_threshold".into()),
+                        endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                        http_status: error_status(&error),
+                        input_items: Some(input_items),
+                        output_items: None,
+                        compaction_items: None,
+                        latest_compaction_index: candidate.latest_compaction_index,
+                        encrypted_content_hashes: None,
+                        encrypted_content_bytes: None,
+                        request_shape_hash: Some(request_shape_hash),
+                        continuation_generation: Some(window.generation),
+                        error: Some(error.to_string()),
+                    });
+                }
                 if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
                     mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
                     return Some(openai_compact_unsupported_diagnostics(
                         "unsupported_endpoint",
                         "provider_window_item_threshold",
                         input_items,
-                        window.latest_compaction_index,
+                        candidate.latest_compaction_index,
                         Some(request_shape_hash),
                         Some(window.generation),
                         http_status,
@@ -1305,7 +1349,7 @@ async fn maybe_compact_openai_provider_window(
                     input_items: Some(input_items),
                     output_items: None,
                     compaction_items: None,
-                    latest_compaction_index: window.latest_compaction_index,
+                    latest_compaction_index: candidate.latest_compaction_index,
                     encrypted_content_hashes: None,
                     encrypted_content_bytes: None,
                     request_shape_hash: Some(request_shape_hash),
@@ -1323,7 +1367,7 @@ async fn maybe_compact_openai_provider_window(
             input_items: Some(input_items),
             output_items: Some(0),
             compaction_items: Some(0),
-            latest_compaction_index: window.latest_compaction_index,
+            latest_compaction_index: candidate.latest_compaction_index,
             encrypted_content_hashes: Some(Vec::new()),
             encrypted_content_bytes: Some(Vec::new()),
             request_shape_hash: Some(request_shape_hash),
@@ -1380,12 +1424,15 @@ async fn maybe_compact_openai_provider_window(
         }
         state.next_generation = state.next_generation.saturating_add(1);
         let generation = state.next_generation;
+        let mut items = compacted;
+        items.extend(candidate.retained_tail.clone());
+        let latest_compaction_index = latest_openai_compaction_index(&items);
         state.windows.insert(
             scope.clone(),
             OpenAiProviderWindow {
                 response_id: None,
                 request_shape: request_shape.clone(),
-                items: compacted,
+                items,
                 append_match_items: window.append_match_items,
                 latest_compaction_index,
                 generation,
@@ -1438,55 +1485,76 @@ async fn maybe_compact_openai_request_plan(
         append_match_items: plan.full_input.clone(),
         generation: previous.generation,
     };
-    if let Some(skip_reason) = openai_provider_window_compaction_skip_reason(&compactable_window) {
-        if skip_reason == "below_item_threshold" {
-            return None;
+    let candidate = match openai_provider_window_compaction_candidate(&compactable_window) {
+        Ok(candidate) => candidate,
+        Err(skip_reason) => {
+            if skip_reason == "below_item_threshold" {
+                return None;
+            }
+            return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                status: format!("skipped_{skip_reason}"),
+                trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+                endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                http_status: None,
+                input_items: Some(compactable_window.items.len()),
+                output_items: None,
+                compaction_items: None,
+                latest_compaction_index: compactable_window.latest_compaction_index,
+                encrypted_content_hashes: None,
+                encrypted_content_bytes: None,
+                request_shape_hash: Some(request_shape_hash(&plan.request_shape)),
+                continuation_generation: Some(previous.generation),
+                error: None,
+            });
         }
-        return Some(ProviderOpenAiRemoteCompactionDiagnostics {
-            status: format!("skipped_{skip_reason}"),
-            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
-            endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
-            http_status: None,
-            input_items: Some(compactable_window.items.len()),
-            output_items: None,
-            compaction_items: None,
-            latest_compaction_index: compactable_window.latest_compaction_index,
-            encrypted_content_hashes: None,
-            encrypted_content_bytes: None,
-            request_shape_hash: Some(request_shape_hash(&plan.request_shape)),
-            continuation_generation: Some(previous.generation),
-            error: None,
-        });
-    }
+    };
 
-    let input_items = compactable_window.items.len();
+    let input_items = candidate.items.len();
     let request_shape_hash = request_shape_hash(&plan.request_shape);
     if let Some(http_status) = compact_endpoint_unsupported_status(continuation, &compact_url) {
         return Some(openai_compact_unsupported_diagnostics(
             "skipped_unsupported_endpoint",
             "provider_window_item_threshold_before_request",
             input_items,
-            compactable_window.latest_compaction_index,
+            candidate.latest_compaction_index,
             Some(request_shape_hash),
             Some(previous.generation),
             http_status,
             None,
         ));
     }
-    let compact_body =
-        build_openai_compact_request_body(&plan.request_shape, &compactable_window.items);
+    let compact_body = build_openai_compact_request_body(&plan.request_shape, &candidate.items);
     let compacted =
         match send_openai_compact_request(client, compact_url.clone(), compact_body, headers).await
         {
             Ok(compacted) => compacted,
             Err(error) => {
+                if is_non_persisted_compact_item_id_error(&error) {
+                    return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                        status: "invalid_non_persisted_item_id".into(),
+                        trigger_reason: Some(
+                            "provider_window_item_threshold_before_request".into(),
+                        ),
+                        endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                        http_status: error_status(&error),
+                        input_items: Some(input_items),
+                        output_items: None,
+                        compaction_items: None,
+                        latest_compaction_index: candidate.latest_compaction_index,
+                        encrypted_content_hashes: None,
+                        encrypted_content_bytes: None,
+                        request_shape_hash: Some(request_shape_hash),
+                        continuation_generation: Some(previous.generation),
+                        error: Some(error.to_string()),
+                    });
+                }
                 if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
                     mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
                     return Some(openai_compact_unsupported_diagnostics(
                         "unsupported_endpoint",
                         "provider_window_item_threshold_before_request",
                         input_items,
-                        compactable_window.latest_compaction_index,
+                        candidate.latest_compaction_index,
                         Some(request_shape_hash),
                         Some(previous.generation),
                         http_status,
@@ -1501,7 +1569,7 @@ async fn maybe_compact_openai_request_plan(
                     input_items: Some(input_items),
                     output_items: None,
                     compaction_items: None,
-                    latest_compaction_index: compactable_window.latest_compaction_index,
+                    latest_compaction_index: candidate.latest_compaction_index,
                     encrypted_content_hashes: None,
                     encrypted_content_bytes: None,
                     request_shape_hash: Some(request_shape_hash),
@@ -1519,7 +1587,7 @@ async fn maybe_compact_openai_request_plan(
             input_items: Some(input_items),
             output_items: Some(0),
             compaction_items: Some(0),
-            latest_compaction_index: compactable_window.latest_compaction_index,
+            latest_compaction_index: candidate.latest_compaction_index,
             encrypted_content_hashes: Some(Vec::new()),
             encrypted_content_bytes: Some(Vec::new()),
             request_shape_hash: Some(request_shape_hash),
@@ -1577,7 +1645,7 @@ async fn maybe_compact_openai_request_plan(
 
     let output_items = compacted.len();
     let mut provider_input = compacted;
-    provider_input.extend(plan.provider_input.clone());
+    provider_input.extend(candidate.retained_tail.clone());
     plan.body["input"] = Value::Array(provider_input.clone());
     if let Some(object) = plan.body.as_object_mut() {
         object.remove("previous_response_id");
@@ -1625,11 +1693,21 @@ fn mark_compact_endpoint_unsupported(
 }
 
 fn unsupported_compact_endpoint_status(error: &anyhow::Error) -> Option<u16> {
+    if is_non_persisted_compact_item_id_error(error) {
+        return None;
+    }
     let status = error_status(error)?;
     match status {
         404 | 405 | 410 | 501 => Some(status),
         _ => None,
     }
+}
+
+fn is_non_persisted_compact_item_id_error(error: &anyhow::Error) -> bool {
+    error_status(error) == Some(404)
+        && error
+            .to_string()
+            .contains("Items are not persisted when `store` is set to false")
 }
 
 fn error_status(error: &anyhow::Error) -> Option<u16> {
@@ -1665,20 +1743,96 @@ fn openai_compact_unsupported_diagnostics(
     }
 }
 
-fn openai_provider_window_compaction_skip_reason(
+fn openai_provider_window_compaction_candidate(
     window: &OpenAiProviderWindow,
-) -> Option<&'static str> {
-    let since_latest_compaction = window
-        .latest_compaction_index
-        .map(|index| window.items.len().saturating_sub(index + 1))
-        .unwrap_or(window.items.len());
-    if since_latest_compaction < OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS {
-        return Some("below_item_threshold");
+) -> std::result::Result<OpenAiCompactionCandidate, &'static str> {
+    if items_since_latest_openai_compaction(&window.items) < OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS
+    {
+        return Err("below_item_threshold");
     }
-    if has_unpaired_openai_tool_call(&window.items) {
-        return Some("unpaired_tool_call");
+
+    let boundary =
+        latest_complete_openai_tool_call_boundary(&window.items).ok_or("unpaired_tool_call")?;
+    if boundary == 0 {
+        return Err("unpaired_tool_call");
     }
-    None
+
+    let compact_items = window.items[..boundary].to_vec();
+    if items_since_latest_openai_compaction(&compact_items) < OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS
+    {
+        return Err("unpaired_tool_call");
+    }
+    if has_unpaired_openai_tool_call(&compact_items) {
+        return Err("unpaired_tool_call");
+    }
+
+    Ok(OpenAiCompactionCandidate {
+        latest_compaction_index: latest_openai_compaction_index(&compact_items),
+        items: compact_items,
+        retained_tail: window.items[boundary..].to_vec(),
+    })
+}
+
+fn items_since_latest_openai_compaction(items: &[Value]) -> usize {
+    latest_openai_compaction_index(items)
+        .map(|index| items.len().saturating_sub(index + 1))
+        .unwrap_or(items.len())
+}
+
+fn latest_complete_openai_tool_call_boundary(items: &[Value]) -> Option<usize> {
+    let mut function_calls = HashSet::new();
+    let mut custom_tool_calls = HashSet::new();
+    let mut function_outputs = HashSet::new();
+    let mut custom_tool_outputs = HashSet::new();
+    let mut latest_complete_boundary = None;
+
+    for (index, item) in items.iter().enumerate() {
+        let Some(call_id) = item.get("call_id").and_then(Value::as_str) else {
+            if openai_tool_call_sets_are_complete(
+                &function_calls,
+                &function_outputs,
+                &custom_tool_calls,
+                &custom_tool_outputs,
+            ) {
+                latest_complete_boundary = Some(index + 1);
+            }
+            continue;
+        };
+        match item.get("type").and_then(Value::as_str) {
+            Some("function_call") => {
+                function_calls.insert(call_id.to_string());
+            }
+            Some("custom_tool_call") => {
+                custom_tool_calls.insert(call_id.to_string());
+            }
+            Some("function_call_output") => {
+                function_outputs.insert(call_id.to_string());
+            }
+            Some("custom_tool_call_output") => {
+                custom_tool_outputs.insert(call_id.to_string());
+            }
+            _ => {}
+        }
+        if openai_tool_call_sets_are_complete(
+            &function_calls,
+            &function_outputs,
+            &custom_tool_calls,
+            &custom_tool_outputs,
+        ) {
+            latest_complete_boundary = Some(index + 1);
+        }
+    }
+
+    latest_complete_boundary
+}
+
+fn openai_tool_call_sets_are_complete(
+    function_calls: &HashSet<String>,
+    function_outputs: &HashSet<String>,
+    custom_tool_calls: &HashSet<String>,
+    custom_tool_outputs: &HashSet<String>,
+) -> bool {
+    function_calls.is_subset(function_outputs) && custom_tool_calls.is_subset(custom_tool_outputs)
 }
 
 fn has_unpaired_openai_tool_call(items: &[Value]) -> bool {
@@ -1708,14 +1862,19 @@ fn has_unpaired_openai_tool_call(items: &[Value]) -> bool {
         }
     }
 
-    !function_calls.is_subset(&function_outputs)
-        || !custom_tool_calls.is_subset(&custom_tool_outputs)
+    !openai_tool_call_sets_are_complete(
+        &function_calls,
+        &function_outputs,
+        &custom_tool_calls,
+        &custom_tool_outputs,
+    )
 }
 
 fn build_openai_compact_request_body(request_shape: &OpenAiRequestShape, items: &[Value]) -> Value {
+    let compact_items = sanitize_openai_store_false_compact_items(items);
     let mut body = json!({
         "model": request_shape.wire_shape.get("model").cloned().unwrap_or(Value::Null),
-        "input": items,
+        "input": compact_items,
         "instructions": request_shape
             .wire_shape
             .get("instructions")
@@ -1741,6 +1900,31 @@ fn build_openai_compact_request_body(request_shape: &OpenAiRequestShape, items: 
         body["text"] = text.clone();
     }
     body
+}
+
+fn sanitize_openai_store_false_compact_items(items: &[Value]) -> Vec<Value> {
+    items.iter().map(openai_without_provider_item_id).collect()
+}
+
+fn openai_without_provider_item_id(item: &Value) -> Value {
+    let mut item = item.clone();
+    let Some(object) = item.as_object_mut() else {
+        return item;
+    };
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    if let Some(id) = id.as_deref() {
+        match object.get("type").and_then(Value::as_str) {
+            Some("function_call" | "custom_tool_call") if !object.contains_key("call_id") => {
+                object.insert("call_id".into(), Value::String(id.to_string()));
+            }
+            _ => {}
+        }
+    }
+    object.remove("id");
+    item
 }
 
 fn openai_compaction_encrypted_content_hashes(items: &[Value]) -> Vec<String> {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -281,7 +281,8 @@ fn render_activity_text(app: &TuiApp) -> String {
             return "No in-flight activity.".into();
         }
         // During active turn, show the last cached text for this agent or empty
-        return app.activity_text_cache
+        return app
+            .activity_text_cache
             .borrow()
             .as_ref()
             .filter(|c| c.agent_id == agent_id)
@@ -291,9 +292,7 @@ fn render_activity_text(app: &TuiApp) -> String {
 
     let text = events
         .into_iter()
-        .map(|event| {
-            format_activity_event(event)
-        })
+        .map(|event| format_activity_event(event))
         .collect::<Vec<_>>()
         .join("\n");
     if !text.is_empty() {


### PR DESCRIPTION
## Summary

Closes #803.

This hardens the OpenAI/OpenAI Codex recovery path exposed by the latest benchmark run:

- classify interrupted `response_body` and `streaming_response_body` reads as retryable connection failures for all providers, not only `openai-codex`
- compact only safe OpenAI provider-window prefixes before unpaired tool calls, then retain the unpaired tail for the next request
- sanitize `store=false` compact input by dropping provider-generated item ids while preserving stable `call_id` pairing
- split invalid non-persisted compact item id failures from true unsupported endpoint diagnostics
- surface compact `endpoint_kind` and `http_status` in benchmark token diagnostics
- update the RFC with the compact boundary and `store=false` input rules

## Tests

- `cargo fmt --all -- --check`
- `cargo test openai_responses --lib`
- `cargo test routing_auth_doctor --lib`
- `cargo test --lib`
- `npm test` in `benchmark/`

Notes: `cargo test --lib` still reports pre-existing warnings for an unused `IntoResponse` import in `anthropic_messages.rs` and unused chat-completions stream helpers.
