### PR TITLE
fix: harden ApplyPatch failure recovery

### DIFF
--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -2455,6 +2455,10 @@ function summarizeHolonToolExecutions(entries) {
 
 export function summarizeHolonTokenOptimization(events, toolExecutions = [], options = {}) {
   const toolSummaries = toolExecutions.map(summarizeToolPayloadSize);
+  const truncatedMutationToolCallRejections = events.filter((event) => {
+    const kind = event?.kind ?? event?.event ?? event?.type;
+    return kind === "truncated_mutation_tool_call_rejected";
+  }).length;
   let nextToolIndex = 0;
   let previousTool = null;
   const rounds = [];
@@ -2556,7 +2560,10 @@ export function summarizeHolonTokenOptimization(events, toolExecutions = [], opt
     }
   }
 
-  const summary = summarizeTokenOptimizationRounds(rounds);
+  const summary = {
+    ...summarizeTokenOptimizationRounds(rounds),
+    truncated_mutation_tool_call_rejections: truncatedMutationToolCallRejections
+  };
   return {
     schema_version: 1,
     generated_from: "holon_events",

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -980,6 +980,38 @@ test("summarizeHolonTokenOptimization reports OpenAI remote compaction", () => {
   assert.equal(diagnostics.summary.openai_remote_compaction_items, 2);
 });
 
+test("summarizeHolonTokenOptimization reports truncated mutation call rejections", () => {
+  const diagnostics = summarizeHolonTokenOptimization([
+    {
+      kind: "truncated_mutation_tool_call_rejected",
+      data: {
+        tool_name: "ApplyPatch",
+        tool_call_id: "patch-1",
+        stop_reason: "max_tokens"
+      }
+    },
+    {
+      kind: "provider_round_completed",
+      data: {
+        round: 1,
+        input_tokens: 500,
+        output_tokens: 50,
+        provider_attempt_timeline: {
+          attempts: [
+            {
+              provider: "openai",
+              model_ref: "openai/gpt-5.4",
+              outcome: "succeeded"
+            }
+          ]
+        }
+      }
+    }
+  ]);
+
+  assert.equal(diagnostics.summary.truncated_mutation_tool_call_rejections, 1);
+});
+
 test("summarizeHolonTokenOptimization reports Anthropic context management usage", () => {
   const diagnostics = summarizeHolonTokenOptimization([
     {

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -97,14 +97,14 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_apply_patch",
             PromptStability::Stable,
-            "Use ApplyPatch as the primary file-mutation tool. Use it for new files, whole-file replacement, small local edits, multi-hunk single-file changes, structural edits, and non-trivial refactors. Do not expect separate Write or Edit tools; express all file mutation as unified diff text. On providers that expose ApplyPatch as a freeform grammar tool, send the unified diff body directly and do not wrap it in JSON. On JSON/function fallback providers, ApplyPatch expects exactly `{\"patch\":\"--- a/path\\n+++ b/path\\n@@ -1,1 +1,1 @@\\n-old\\n+new\\n\"}`; do not use `input`. The model-visible ApplyPatch receipt is concise text with action markers like `A`, `M`, `D`, or `R`, while the canonical result still records structured changed-file metadata, `changed_paths`, `changed_file_count`, ignored metadata, diagnostics, and `summary_text`.".to_string(),
+            "Use ApplyPatch as the primary precise file-mutation tool. Use it for focused new files, small local edits, multi-hunk single-file changes, structural edits, and bounded refactors. For very large new files, generated files, whole-file rewrites, bulk deletes, or broad mechanical refactors, choose the lower-context path: split the change into smaller ApplyPatch calls, or use a carefully bounded ExecCommand/scripted rewrite when that avoids emitting a huge diff and is easier to verify. Do not expect separate Write or Edit tools; express ordinary file mutation as unified diff text. On providers that expose ApplyPatch as a freeform grammar tool, send the unified diff body directly and do not wrap it in JSON. On JSON/function fallback providers, ApplyPatch expects exactly `{\"patch\":\"--- a/path\\n+++ b/path\\n@@ -1,1 +1,1 @@\\n-old\\n+new\\n\"}`; do not use `input`. The model-visible ApplyPatch receipt is concise text with action markers like `A`, `M`, `D`, or `R`, while the canonical result still records structured changed-file metadata, `changed_paths`, `changed_file_count`, ignored metadata, diagnostics, and `summary_text`.".to_string(),
         ));
     }
     if names.contains(&"ApplyPatch") {
         sections.push(section(
             "tool_file_mutation",
             PromptStability::Stable,
-            "File mutation is workspace-scoped and centered on ApplyPatch. Use unified diff `---`/`+++` file headers and `@@` hunks for new files, deletes, precise edits, and renames. Prefer focused hunks with enough surrounding context to stay unambiguous. Include at least 3 context lines before and after each changed line, and expand to 5–10 lines when the file contains repeated structures or similar patterns. Blank lines within hunks must have a space prefix to be valid context lines. Avoid using ExecCommand with shell rewrite tricks like `sed -i` as the default editing path. After any file mutation, rely on the ApplyPatch receipt first, then run focused verification with ExecCommand when correctness matters. Do not use file mutation tools for broad exploration; inspect with shell-first read commands through ExecCommand instead.".to_string(),
+            "File mutation is workspace-scoped and centered on ApplyPatch. Use unified diff `---`/`+++` file headers and `@@` hunks for deletes, precise edits, and renames. Prefer focused hunks with enough surrounding context to stay unambiguous. Include at least 3 context lines before and after each changed line, and expand to 5–10 lines when the file contains repeated structures or similar patterns. Blank lines within hunks must have a space prefix to be valid context lines. Keep tool output bounded: do not paste enormous malformed patches, do not retry the same large failed patch unchanged, and split large refactors into smaller patch/application steps when that keeps failures recoverable. Avoid using ExecCommand with shell rewrite tricks like `sed -i` as the default editing path, but use a bounded script or heredoc when generating/replacing a large file is cheaper and safer than a huge diff. After any file mutation, rely on the ApplyPatch receipt first, then run focused verification with ExecCommand when correctness matters. Do not use file mutation tools for broad exploration; inspect with shell-first read commands through ExecCommand instead.".to_string(),
         ));
     }
     if names.contains(&"UseWorkspace") {
@@ -405,12 +405,18 @@ mod tests {
         assert!(apply_patch
             .content
             .contains("Do not expect separate Write or Edit tools"));
+        assert!(apply_patch.content.contains("lower-context path"));
+        assert!(apply_patch.content.contains("very large new files"));
         let section = sections
             .iter()
             .find(|s| s.name == "tool_file_mutation")
             .expect("file mutation section");
         assert!(section.content.contains("centered on ApplyPatch"));
         assert!(section.content.contains("sed -i"));
+        assert!(section
+            .content
+            .contains("do not retry the same large failed patch unchanged"));
+        assert!(section.content.contains("bounded script or heredoc"));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5170,6 +5170,7 @@ mod tests {
             .expect("tool result content");
         assert!(content.contains("ApplyPatch failed"));
         assert!(content.contains("truncated_mutation_tool_call"));
+        assert!(content.contains("max_tokens"));
         assert!(content.contains("retryable: true"));
         assert!(content.len() < 800);
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4331,6 +4331,10 @@ mod tests {
         calls: Mutex<usize>,
     }
 
+    struct MaxOutputMutationToolProvider {
+        calls: Mutex<usize>,
+    }
+
     #[async_trait]
     impl AgentProvider for TruncatingProvider {
         async fn complete_turn(
@@ -4660,6 +4664,61 @@ mod tests {
                     })
                 }
                 _ => anyhow::bail!("unexpected provider call after recovery text"),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AgentProvider for MaxOutputMutationToolProvider {
+        async fn complete_turn(
+            &self,
+            request: ProviderTurnRequest,
+        ) -> Result<ProviderTurnResponse> {
+            let mut calls = self.calls.lock().await;
+            *calls += 1;
+            match *calls {
+                1 => Ok(ProviderTurnResponse {
+                    blocks: vec![ModelBlock::ToolUse {
+                        id: "truncated-patch".into(),
+                        name: "ApplyPatch".into(),
+                        input: serde_json::json!({
+                            "patch": "--- /dev/null\n+++ b/app.txt\n@@ -0,0 +1 @@\n+should-not-be-written\n",
+                        }),
+                    }],
+                    stop_reason: Some("max_tokens".into()),
+                    input_tokens: 20,
+                    output_tokens: 10,
+                    cache_usage: None,
+                    request_diagnostics: None,
+                }),
+                2 => {
+                    assert!(
+                        request.conversation.iter().any(|message| matches!(
+                            message,
+                            ConversationMessage::UserToolResults(results)
+                                if results.iter().any(|result|
+                                    result.tool_use_id == "truncated-patch"
+                                        && result.is_error
+                                        && result
+                                            .error
+                                            .as_ref()
+                                            .is_some_and(|error| error.kind == "truncated_mutation_tool_call")
+                                )
+                        )),
+                        "continuation should receive a structured truncation error"
+                    );
+                    Ok(ProviderTurnResponse {
+                        blocks: vec![ModelBlock::Text {
+                            text: "Recovered after rejected truncated mutation.".into(),
+                        }],
+                        stop_reason: None,
+                        input_tokens: 15,
+                        output_tokens: 8,
+                        cache_usage: None,
+                        request_diagnostics: None,
+                    })
+                }
+                _ => panic!("provider should stop after recovery"),
             }
         }
     }
@@ -5032,6 +5091,87 @@ mod tests {
             tool_results.data["results"][0]["is_error"].as_bool(),
             Some(true)
         );
+    }
+
+    #[tokio::test]
+    async fn max_output_mutation_tool_call_is_rejected_without_side_effects() {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let provider = Arc::new(MaxOutputMutationToolProvider {
+            calls: Mutex::new(0),
+        });
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            provider.clone(),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+
+        let outcome = runtime
+            .run_agent_loop(
+                "default",
+                TrustLevel::TrustedOperator,
+                test_effective_prompt(),
+                LoopControlOptions {
+                    max_tool_rounds: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.terminal_kind, TurnTerminalKind::Completed);
+        assert_eq!(
+            outcome.final_text,
+            "Recovered after rejected truncated mutation."
+        );
+        assert_eq!(*provider.calls.lock().await, 2);
+        assert!(
+            !workspace.path().join("app.txt").exists(),
+            "ApplyPatch must not execute when the provider stopped at max_output_tokens"
+        );
+        assert_eq!(
+            runtime
+                .storage()
+                .read_recent_tool_executions(10)
+                .unwrap()
+                .len(),
+            0
+        );
+
+        let events = runtime.storage().read_recent_events(20).unwrap();
+        let rejection_event = events
+            .iter()
+            .find(|event| event.kind == "truncated_mutation_tool_call_rejected")
+            .expect("missing truncated_mutation_tool_call_rejected event");
+        assert_eq!(
+            rejection_event.data["tool_call_id"].as_str(),
+            Some("truncated-patch")
+        );
+        assert_eq!(
+            rejection_event.data["tool_name"].as_str(),
+            Some("ApplyPatch")
+        );
+        assert_eq!(
+            rejection_event.data["error_kind"].as_str(),
+            Some("truncated_mutation_tool_call")
+        );
+
+        let transcript = runtime.storage().read_recent_transcript(10).unwrap();
+        let tool_results = transcript
+            .iter()
+            .find(|entry| entry.kind == TranscriptEntryKind::ToolResults)
+            .expect("missing tool results transcript");
+        let content = tool_results.data["results"][0]["content"]
+            .as_str()
+            .expect("tool result content");
+        assert!(content.contains("ApplyPatch failed"));
+        assert!(content.contains("truncated_mutation_tool_call"));
+        assert!(content.contains("retryable: true"));
+        assert!(content.len() < 800);
     }
 
     #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1540,6 +1540,46 @@ impl RuntimeHandle {
                     tool_result_envelopes.push(tool_result_error_envelope(&tool_name, error));
                     continue;
                 }
+                if is_max_output_stop_reason(stop_reason.as_deref())
+                    && rejects_truncated_mutation_tool_call(&call.name)
+                {
+                    let error = ToolError::new(
+                        "truncated_mutation_tool_call",
+                        format!(
+                            "{tool_name} was not executed because the provider stopped with max_output_tokens; mutation tool arguments may be incomplete"
+                        ),
+                    )
+                    .with_details(serde_json::json!({
+                        "tool_name": tool_name.clone(),
+                        "stop_reason": stop_reason.clone(),
+                        "round": round,
+                    }))
+                    .with_recovery_hint(
+                        "retry the mutation as a complete, smaller tool call after inspecting any needed context",
+                    )
+                    .with_retryable(true);
+                    let result = crate::tool::ToolResult::error(&tool_name, error.clone());
+                    let result_content = crate::tool::tools::render_tool_result_for_model(&result)?;
+                    self.inner.storage.append_event(&AuditEvent::new(
+                        "truncated_mutation_tool_call_rejected",
+                        serde_json::json!({
+                            "tool_call_id": tool_call_id.clone(),
+                            "tool_name": tool_name.clone(),
+                            "stop_reason": stop_reason.clone(),
+                            "round": round,
+                            "error_kind": error.kind.clone(),
+                            "tool_error": error.clone(),
+                        }),
+                    ))?;
+                    tool_results.push(ToolResultBlock {
+                        tool_use_id: tool_call_id.clone(),
+                        content: result_content,
+                        is_error: true,
+                        error: Some(error.clone()),
+                    });
+                    tool_result_envelopes.push(result.envelope);
+                    continue;
+                }
                 match self
                     .inner
                     .tools
@@ -1673,6 +1713,13 @@ fn command_preview_field(call: &ToolCall) -> Option<String> {
         .then(|| call.input.get("cmd").and_then(Value::as_str))
         .flatten()
         .map(ToString::to_string)
+}
+
+fn rejects_truncated_mutation_tool_call(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "ApplyPatch" | "UpdateWorkItem" | "UpdateWorkPlan"
+    )
 }
 
 #[cfg(test)]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1543,10 +1543,11 @@ impl RuntimeHandle {
                 if is_max_output_stop_reason(stop_reason.as_deref())
                     && rejects_truncated_mutation_tool_call(&call.name)
                 {
+                    let stop_reason_label = stop_reason.as_deref().unwrap_or("an output limit");
                     let error = ToolError::new(
                         "truncated_mutation_tool_call",
                         format!(
-                            "{tool_name} was not executed because the provider stopped with max_output_tokens; mutation tool arguments may be incomplete"
+                            "{tool_name} was not executed because the provider stopped with {stop_reason_label}; mutation tool arguments may be incomplete"
                         ),
                     )
                     .with_details(serde_json::json!({

--- a/src/tool/tools/apply_patch_tool.rs
+++ b/src/tool/tools/apply_patch_tool.rs
@@ -8,9 +8,9 @@ use crate::{
     system::ExecutionScopeKind,
     tool::{
         apply_patch,
-        helpers::{invalid_tool_input, validate_non_empty},
+        helpers::{invalid_tool_input, truncate_text, validate_non_empty},
         spec::{ToolFreeformGrammar, ToolResultStatus},
-        ToolResult,
+        ToolError, ToolResult,
     },
     types::{ApplyPatchAction, ApplyPatchResult, ToolCapabilityFamily, TrustLevel},
 };
@@ -20,6 +20,8 @@ use crate::tool::{helpers::parse_tool_args, schema::tool_input_schema};
 
 pub(crate) const NAME: &str = "ApplyPatch";
 const APPLY_PATCH_LARK_GRAMMAR: &str = include_str!("apply_patch_tool.lark");
+const MODEL_ERROR_TEXT_LIMIT: usize = 700;
+const MODEL_ERROR_TOKEN_LIMIT: usize = 96;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -85,7 +87,7 @@ pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
         let error = result
             .tool_error()
             .ok_or_else(|| anyhow!("ApplyPatch error result missing tool error"))?;
-        return Ok(format!("ApplyPatch failed\n{}\n", error.render()));
+        return Ok(render_apply_patch_error_for_model(error));
     }
 
     let value = result
@@ -102,6 +104,59 @@ pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
         lines.extend(result.changed_files.iter().map(render_changed_file_receipt));
     }
     Ok(lines.join("\n"))
+}
+
+fn render_apply_patch_error_for_model(error: &ToolError) -> String {
+    let mut lines = vec![
+        "ApplyPatch failed".to_string(),
+        format!("- kind: {}", error.kind),
+        format!(
+            "- message: {}",
+            sanitize_model_visible_error_text(&error.message)
+        ),
+    ];
+    if let Some(recovery_hint) = error.recovery_hint.as_deref() {
+        lines.push(format!(
+            "- recovery_hint: {}",
+            sanitize_model_visible_error_text(recovery_hint)
+        ));
+    }
+    if error.details.is_some() {
+        lines.push(
+            "- details: omitted from model-visible receipt; inspect audit/tool records if exact parser details are needed"
+                .to_string(),
+        );
+    }
+    if error.retryable {
+        lines.push("- retryable: true".to_string());
+    }
+    lines.push(
+        "Use a smaller, valid unified diff or inspect the target file before retrying.".to_string(),
+    );
+    format!("{}\n", lines.join("\n"))
+}
+
+fn sanitize_model_visible_error_text(text: &str) -> String {
+    let mut sanitized = String::new();
+    let mut token_len = 0usize;
+    let mut omitting_token = false;
+    for ch in text.trim().chars() {
+        if ch.is_whitespace() {
+            token_len = 0;
+            omitting_token = false;
+            sanitized.push(ch);
+            continue;
+        }
+
+        token_len += 1;
+        if token_len <= MODEL_ERROR_TOKEN_LIMIT {
+            sanitized.push(ch);
+        } else if !omitting_token {
+            sanitized.push_str("[long token omitted]");
+            omitting_token = true;
+        }
+    }
+    truncate_text(&sanitized, MODEL_ERROR_TEXT_LIMIT)
 }
 
 fn extract_patch_input(input: &Value) -> Result<String> {
@@ -193,6 +248,32 @@ mod tests {
         let rendered = render_for_model(&result).unwrap();
         assert!(rendered.contains("ApplyPatch failed"));
         assert!(rendered.contains("patch exploded"));
+    }
+
+    #[test]
+    fn apply_patch_error_omits_large_details_from_model_receipt() {
+        let long_path = format!("src/{}.rs", "nested".repeat(600));
+        let invalid_fragment = format!("{} code to=functions.ApplyPatch", "***".repeat(2000));
+        let result = ToolResult::error(
+            NAME,
+            ToolError::new(
+                "invalid_patch_syntax",
+                format!("invalid patch near {}", "x".repeat(400)),
+            )
+            .with_details(json!({
+                "path": long_path,
+                "fragment": invalid_fragment,
+            }))
+            .with_recovery_hint(format!("inspect {}", "target".repeat(200))),
+        );
+
+        let rendered = render_for_model(&result).unwrap();
+        assert!(rendered.contains("ApplyPatch failed"));
+        assert!(rendered.contains("details: omitted"));
+        assert!(rendered.contains("[long token omitted]"));
+        assert!(!rendered.contains("code to=functions.ApplyPatch"));
+        assert!(!rendered.contains(&"nested".repeat(60)));
+        assert!(rendered.len() < 1_200);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #805.

## What changed

- Keep model-visible ApplyPatch failure receipts short by omitting structured parser/debug details and truncating long tokens in messages and recovery hints.
- Reject mutation tool calls when the provider stopped with `max_output_tokens`, before executing side-effecting tools such as ApplyPatch, UpdateWorkItem, and UpdateWorkPlan.
- Add an audit event, `truncated_mutation_tool_call_rejected`, so benchmark output can separate truncated mutation calls from normal failed patches.
- Update prompt guidance so ApplyPatch stays the primary precise edit tool while large/generated/whole-file changes can use lower-context bounded command paths.
- Surface truncated mutation rejections in benchmark token diagnostics.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib apply_patch`
- `cargo test --lib max_output_mutation_tool_call_is_rejected_without_side_effects`
- `cd benchmark && npm ci && npm test -- --runTestsByPath tests/manifest.test.mjs`

The runtime regression is the focused reproduction for a provider round that returns `stop_reason=max_tokens` together with an ApplyPatch call: the patch is rejected, no workspace file is created, no tool execution is recorded, and the model receives a retryable structured error.
