### PR TITLE
feat: add work item query tools

### DIFF
--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -534,8 +534,10 @@ The proposed tool surface is:
 `CompleteWorkItem` marks a work item done and optionally records the completion
 summary.
 
-`GetWorkItem` and `ListWorkItems` provide explicit read access so the prompt
-projection does not become a hidden database query surface.
+`GetActiveWorkItem`, `GetWorkItem`, and `ListWorkItems` provide explicit read
+access so the prompt projection does not become a hidden database query surface.
+Agents should prefer these read tools before switching, completing, or expanding
+cross-turn work.
 
 There is no separate `UpdateWorkPlan` in this model. The current plan is
 exposed through the work-item tool surface and is updated by `UpdateWorkItem`
@@ -636,15 +638,25 @@ The initial `CompleteWorkItem` shape should be:
 
 The initial read shapes should be:
 
+- `GetActiveWorkItem(include_plan?)`
 - `GetWorkItem(work_item_id)`
 - `ListWorkItems(filter?, limit?)`
 
 Useful initial filters are:
 
+- current work item
 - all open work items
-- runnable open work items
+- queued open work items
 - blocked open work items
 - done work items
+
+The first rollout can expose this read surface before replacing the legacy
+write tools. During that transition, read results should translate the existing
+stored statuses into the target model:
+
+- `active`, `queued`, and `waiting` are presented as `open`
+- `completed` is presented as `done`
+- `current_work_item_id` is presented as focus, separate from lifecycle
 
 ### Work-plan update semantics
 

--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -639,8 +639,8 @@ The initial `CompleteWorkItem` shape should be:
 The initial read shapes should be:
 
 - `GetActiveWorkItem(include_plan?)`
-- `GetWorkItem(work_item_id)`
-- `ListWorkItems(filter?, limit?)`
+- `GetWorkItem(work_item_id, include_plan?)`
+- `ListWorkItems(filter?, limit?, include_plan?)`
 
 Useful initial filters are:
 

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -67,6 +67,16 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
             "Use UpdateWorkItem to explicitly create or refresh the current high-level work container once the message-driven turn has clarified what the delivery target really is. If the current task is not just a brief answer and there is no active work item yet, do not skip straight to execution: first clarify the delivery target with the operator if it is still ambiguous, otherwise create or refresh the active work item before doing commands or edits. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. Omit `id` when creating a new work item; include it when replacing the latest snapshot of an existing one. Prefer refreshing the current active work item instead of creating a new one unless the delivery target has actually changed. Use UpdateWorkPlan only when a work item already exists, and for genuine multi-step work default to updating the plan before execution. Always submit the full current checklist snapshot rather than patching individual steps. When an exploration or inspection step has served its objective, update the work plan before continuing. If the current step remains in_progress, record the specific blocker or missing fact in progress_note instead of silently widening exploration. Keep delivery_target stable, keep summary concise, and use progress_note only for the latest meaningful checkpoint or blocker.".to_string(),
         ));
     }
+    if names.contains(&"GetActiveWorkItem")
+        || names.contains(&"GetWorkItem")
+        || names.contains(&"ListWorkItems")
+    {
+        sections.push(section(
+            "tool_work_item_read",
+            PromptStability::Stable,
+            "Use GetActiveWorkItem to inspect the current work-item focus before relying on memory briefs. Use GetWorkItem when you already know the id and need its open/done state, focus flag, and optional plan. Use ListWorkItems for queue inspection with filters such as open, done, current, queued, and blocked. Treat current_work_item_id as focus, not lifecycle; open/done describes completion, while current/queued/blocked is the scheduling view. Read the work-item surface before switching, completing, or expanding cross-turn work so the next action is anchored to the right delivery target.".to_string(),
+        ));
+    }
     if names.contains(&"TaskList")
         || names.contains(&"TaskStatus")
         || names.contains(&"TaskInput")
@@ -275,6 +285,32 @@ mod tests {
         assert!(section
             .content
             .contains("instead of silently widening exploration"));
+    }
+
+    #[test]
+    fn test_work_item_read_section_emitted_when_available() {
+        let tools = vec![
+            ToolSpec {
+                name: "GetActiveWorkItem".into(),
+                description: String::new(),
+                input_schema: json!({}),
+                freeform_grammar: None,
+            },
+            ToolSpec {
+                name: "ListWorkItems".into(),
+                description: String::new(),
+                input_schema: json!({}),
+                freeform_grammar: None,
+            },
+        ];
+        let sections = tool_sections(&tools);
+        let section = sections
+            .iter()
+            .find(|s| s.name == "tool_work_item_read")
+            .expect("work item read section");
+        assert!(section.content.contains("current_work_item_id as focus"));
+        assert!(section.content.contains("open/done"));
+        assert!(section.content.contains("before relying on memory briefs"));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1845,6 +1845,30 @@ mod tests {
         let done_payload = done_result.envelope.result.unwrap();
         assert_eq!(done_payload["work_item"]["state"].as_str(), Some("done"));
         assert_eq!(done_payload["work_item"]["focus"].as_str(), Some("done"));
+
+        bind_turn_to_work_item(&runtime, completed.id.as_str()).await;
+        let (fallback_result, _) = registry
+            .execute(
+                &runtime,
+                "default",
+                &TrustLevel::TrustedOperator,
+                &crate::tool::ToolCall {
+                    id: "fallback-active".into(),
+                    name: "GetActiveWorkItem".into(),
+                    input: serde_json::json!({}),
+                },
+            )
+            .await
+            .unwrap();
+        let fallback_payload = fallback_result.envelope.result.unwrap();
+        assert_eq!(
+            fallback_payload["context"]["current_work_item_id"].as_str(),
+            Some(active.id.as_str())
+        );
+        assert_eq!(
+            fallback_payload["work_item"]["id"].as_str(),
+            Some(active.id.as_str())
+        );
     }
 
     async fn mark_blocking_task(runtime: &RuntimeHandle, task_id: &str) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1707,6 +1707,146 @@ mod tests {
         updated.id
     }
 
+    #[tokio::test]
+    async fn work_item_query_tools_return_current_open_done_views() {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(StubProvider::new("done")),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+
+        let active = runtime
+            .update_work_item(
+                None,
+                "finish active delivery".into(),
+                WorkItemStatus::Active,
+                Some("active summary".into()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        runtime
+            .update_work_plan(
+                active.id.clone(),
+                vec![crate::types::WorkPlanItem {
+                    step: "inspect query surface".into(),
+                    status: crate::types::WorkPlanStepStatus::InProgress,
+                }],
+            )
+            .await
+            .unwrap();
+        let queued = runtime
+            .update_work_item(
+                None,
+                "queued delivery".into(),
+                WorkItemStatus::Queued,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let completed = runtime
+            .update_work_item(
+                None,
+                "completed delivery".into(),
+                WorkItemStatus::Completed,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        bind_turn_to_work_item(&runtime, &active.id).await;
+
+        let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+        let (active_result, _) = registry
+            .execute(
+                &runtime,
+                "default",
+                &TrustLevel::TrustedOperator,
+                &crate::tool::ToolCall {
+                    id: "active".into(),
+                    name: "GetActiveWorkItem".into(),
+                    input: serde_json::json!({"include_plan": true}),
+                },
+            )
+            .await
+            .unwrap();
+        let active_payload = active_result.envelope.result.unwrap();
+        assert_eq!(
+            active_payload["context"]["current_work_item_id"].as_str(),
+            Some(active.id.as_str())
+        );
+        assert_eq!(active_payload["work_item"]["state"].as_str(), Some("open"));
+        assert_eq!(
+            active_payload["work_item"]["focus"].as_str(),
+            Some("current")
+        );
+        assert_eq!(
+            active_payload["work_item"]["is_current"].as_bool(),
+            Some(true)
+        );
+        assert_eq!(
+            active_payload["work_item"]["plan"]["items"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let (list_result, _) = registry
+            .execute(
+                &runtime,
+                "default",
+                &TrustLevel::TrustedOperator,
+                &crate::tool::ToolCall {
+                    id: "list".into(),
+                    name: "ListWorkItems".into(),
+                    input: serde_json::json!({"filter": "open", "limit": 10}),
+                },
+            )
+            .await
+            .unwrap();
+        let list_payload = list_result.envelope.result.unwrap();
+        let items = list_payload["work_items"].as_array().unwrap();
+        assert_eq!(list_payload["total_matching"].as_u64(), Some(2));
+        assert!(items
+            .iter()
+            .any(|item| item["id"].as_str() == Some(active.id.as_str())));
+        assert!(items
+            .iter()
+            .any(|item| item["id"].as_str() == Some(queued.id.as_str())));
+        assert!(!items
+            .iter()
+            .any(|item| item["id"].as_str() == Some(completed.id.as_str())));
+
+        let (done_result, _) = registry
+            .execute(
+                &runtime,
+                "default",
+                &TrustLevel::TrustedOperator,
+                &crate::tool::ToolCall {
+                    id: "done".into(),
+                    name: "GetWorkItem".into(),
+                    input: serde_json::json!({"work_item_id": completed.id}),
+                },
+            )
+            .await
+            .unwrap();
+        let done_payload = done_result.envelope.result.unwrap();
+        assert_eq!(done_payload["work_item"]["state"].as_str(), Some("done"));
+        assert_eq!(done_payload["work_item"]["focus"].as_str(), Some("done"));
+    }
+
     async fn mark_blocking_task(runtime: &RuntimeHandle, task_id: &str) {
         runtime
             .inner

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -324,6 +324,9 @@ mod tests {
             "SpawnAgent",
             "TaskInput",
             "TaskOutput",
+            "GetActiveWorkItem",
+            "GetWorkItem",
+            "ListWorkItems",
             "UpdateWorkItem",
             "MemorySearch",
             "MemoryGet",
@@ -521,6 +524,9 @@ mod tests {
 
         assert!(names.iter().any(|name| name == "TaskOutput"));
         assert!(names.iter().any(|name| name == "TaskInput"));
+        assert!(names.iter().any(|name| name == "GetActiveWorkItem"));
+        assert!(names.iter().any(|name| name == "GetWorkItem"));
+        assert!(names.iter().any(|name| name == "ListWorkItems"));
         assert!(names.iter().any(|name| name == "UpdateWorkItem"));
         assert!(names.iter().any(|name| name == "MemorySearch"));
         assert!(names.iter().any(|name| name == "MemoryGet"));
@@ -550,6 +556,12 @@ mod tests {
         );
         assert_eq!(family_for("MemorySearch"), ToolCapabilityFamily::CoreAgent);
         assert_eq!(family_for("MemoryGet"), ToolCapabilityFamily::CoreAgent);
+        assert_eq!(
+            family_for("GetActiveWorkItem"),
+            ToolCapabilityFamily::CoreAgent
+        );
+        assert_eq!(family_for("GetWorkItem"), ToolCapabilityFamily::CoreAgent);
+        assert_eq!(family_for("ListWorkItems"), ToolCapabilityFamily::CoreAgent);
         assert_eq!(
             family_for("SpawnAgent"),
             ToolCapabilityFamily::AgentCreation

--- a/src/tool/tools/get_active_work_item.rs
+++ b/src/tool/tools/get_active_work_item.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    runtime::RuntimeHandle,
+    tool::spec::typed_spec,
+    types::{ToolCapabilityFamily, TrustLevel},
+};
+
+use super::{
+    serialize_success,
+    work_item_query::{
+        latest_current_record, query_context, view_for_record, WorkItemQueryContext, WorkItemView,
+    },
+    BuiltinToolDefinition,
+};
+use crate::tool::helpers::parse_tool_args;
+
+pub(crate) const NAME: &str = "GetActiveWorkItem";
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GetActiveWorkItemArgs {
+    #[serde(default)]
+    pub(crate) include_plan: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct GetActiveWorkItemResult {
+    pub(crate) context: WorkItemQueryContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) work_item: Option<WorkItemView>,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::CoreAgent,
+        spec: typed_spec::<GetActiveWorkItemArgs>(
+            NAME,
+            "Read the agent's current work-item focus. The result is empty when no open current work item exists.",
+        )?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    _agent_id: &str,
+    _trust: &TrustLevel,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: GetActiveWorkItemArgs = parse_tool_args(NAME, input)?;
+    let context = query_context(runtime).await?;
+    let work_item = match latest_current_record(runtime, &context).await? {
+        Some(record) => Some(view_for_record(runtime, &context, record, args.include_plan).await?),
+        None => None,
+    };
+    serialize_success(NAME, &GetActiveWorkItemResult { context, work_item })
+}

--- a/src/tool/tools/get_work_item.rs
+++ b/src/tool/tools/get_work_item.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    runtime::RuntimeHandle,
+    tool::spec::typed_spec,
+    types::{ToolCapabilityFamily, TrustLevel},
+};
+
+use super::{
+    serialize_success,
+    work_item_query::{query_context, view_for_record, WorkItemQueryContext, WorkItemView},
+    BuiltinToolDefinition,
+};
+use crate::tool::helpers::{parse_tool_args, validate_non_empty};
+
+pub(crate) const NAME: &str = "GetWorkItem";
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GetWorkItemArgs {
+    pub(crate) work_item_id: String,
+    #[serde(default)]
+    pub(crate) include_plan: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct GetWorkItemResult {
+    pub(crate) context: WorkItemQueryContext,
+    pub(crate) work_item: WorkItemView,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::CoreAgent,
+        spec: typed_spec::<GetWorkItemArgs>(
+            NAME,
+            "Read one work item by id, including its open/done lifecycle view, current focus flag, and optional latest plan snapshot.",
+        )?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    _agent_id: &str,
+    _trust: &TrustLevel,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: GetWorkItemArgs = parse_tool_args(NAME, input)?;
+    let work_item_id = validate_non_empty(args.work_item_id, NAME, "work_item_id")?;
+    let record = runtime
+        .latest_work_item(&work_item_id)
+        .await?
+        .ok_or_else(|| {
+            crate::tool::ToolError::new(
+                "unknown_work_item",
+                format!("unknown work item {work_item_id}"),
+            )
+        })?;
+    let context = query_context(runtime).await?;
+    let work_item = view_for_record(runtime, &context, record, args.include_plan).await?;
+    serialize_success(NAME, &GetWorkItemResult { context, work_item })
+}

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -1,0 +1,127 @@
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    runtime::RuntimeHandle,
+    tool::spec::typed_spec,
+    types::{ToolCapabilityFamily, TrustLevel, WorkItemStatus},
+};
+
+use super::{
+    serialize_success,
+    work_item_query::{
+        lifecycle_view, query_context, view_for_record, WorkItemFocusView, WorkItemLifecycleView,
+        WorkItemQueryContext, WorkItemView,
+    },
+    BuiltinToolDefinition,
+};
+use crate::tool::helpers::parse_tool_args;
+
+pub(crate) const NAME: &str = "ListWorkItems";
+const DEFAULT_LIMIT: usize = 20;
+const MAX_LIMIT: usize = 100;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub(crate) enum ListWorkItemsFilter {
+    All,
+    Open,
+    Done,
+    Current,
+    Queued,
+    Blocked,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ListWorkItemsArgs {
+    #[serde(default)]
+    pub(crate) filter: Option<ListWorkItemsFilter>,
+    #[serde(default)]
+    pub(crate) limit: Option<usize>,
+    #[serde(default)]
+    pub(crate) include_plan: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ListWorkItemsResult {
+    pub(crate) context: WorkItemQueryContext,
+    pub(crate) filter: ListWorkItemsFilter,
+    pub(crate) returned: usize,
+    pub(crate) total_matching: usize,
+    pub(crate) limit: usize,
+    pub(crate) work_items: Vec<WorkItemView>,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::CoreAgent,
+        spec: typed_spec::<ListWorkItemsArgs>(
+            NAME,
+            "List recent work items with explicit current, open, done, queued, and blocked views. Use this before relying on memory briefs for work-item focus.",
+        )?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    _agent_id: &str,
+    _trust: &TrustLevel,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: ListWorkItemsArgs = parse_tool_args(NAME, input)?;
+    let filter = args.filter.unwrap_or(ListWorkItemsFilter::All);
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let context = query_context(runtime).await?;
+    let mut records = runtime.latest_work_items().await?;
+    records.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    let matching = records
+        .into_iter()
+        .filter(|record| matches_filter(record, &context, &filter))
+        .collect::<Vec<_>>();
+    let total_matching = matching.len();
+    let selected = matching.into_iter().take(limit).collect::<Vec<_>>();
+    let mut work_items = Vec::with_capacity(selected.len());
+    for record in selected {
+        work_items.push(view_for_record(runtime, &context, record, args.include_plan).await?);
+    }
+    serialize_success(
+        NAME,
+        &ListWorkItemsResult {
+            context,
+            filter,
+            returned: work_items.len(),
+            total_matching,
+            limit,
+            work_items,
+        },
+    )
+}
+
+fn matches_filter(
+    record: &crate::types::WorkItemRecord,
+    context: &WorkItemQueryContext,
+    filter: &ListWorkItemsFilter,
+) -> bool {
+    let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
+        && record.status != WorkItemStatus::Completed;
+    match filter {
+        ListWorkItemsFilter::All => true,
+        ListWorkItemsFilter::Open => lifecycle_view(&record.status) == WorkItemLifecycleView::Open,
+        ListWorkItemsFilter::Done => lifecycle_view(&record.status) == WorkItemLifecycleView::Done,
+        ListWorkItemsFilter::Current => is_current,
+        ListWorkItemsFilter::Queued => {
+            !is_current
+                && super::work_item_query::focus_view(&record.status, is_current)
+                    == WorkItemFocusView::Queued
+        }
+        ListWorkItemsFilter::Blocked => {
+            !is_current
+                && super::work_item_query::focus_view(&record.status, is_current)
+                    == WorkItemFocusView::Blocked
+        }
+    }
+}

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -15,6 +15,9 @@ pub(crate) mod create_external_trigger;
 pub(crate) mod enqueue;
 pub(crate) mod exec_command;
 pub(crate) mod exec_command_batch;
+pub(crate) mod get_active_work_item;
+pub(crate) mod get_work_item;
+pub(crate) mod list_work_items;
 pub(crate) mod memory_get;
 pub(crate) mod memory_search;
 pub(crate) mod notify_operator;
@@ -28,6 +31,7 @@ pub(crate) mod task_stop;
 pub(crate) mod update_work_item;
 pub(crate) mod update_work_plan;
 pub(crate) mod use_workspace;
+pub(crate) mod work_item_query;
 
 pub(crate) struct BuiltinToolDefinition {
     pub(crate) family: ToolCapabilityFamily,
@@ -46,6 +50,9 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         task_input::definition()?,
         task_output::definition()?,
         task_stop::definition()?,
+        get_active_work_item::definition()?,
+        get_work_item::definition()?,
+        list_work_items::definition()?,
         update_work_item::definition()?,
         memory_search::definition()?,
         memory_get::definition()?,
@@ -78,6 +85,13 @@ pub(crate) async fn execute_builtin_tool(
         task_input::NAME => task_input::execute(runtime, agent_id, trust, &call.input).await,
         task_output::NAME => task_output::execute(runtime, agent_id, trust, &call.input).await,
         task_stop::NAME => task_stop::execute(runtime, agent_id, trust, &call.input).await,
+        get_active_work_item::NAME => {
+            get_active_work_item::execute(runtime, agent_id, trust, &call.input).await
+        }
+        get_work_item::NAME => get_work_item::execute(runtime, agent_id, trust, &call.input).await,
+        list_work_items::NAME => {
+            list_work_items::execute(runtime, agent_id, trust, &call.input).await
+        }
         update_work_item::NAME => {
             update_work_item::execute(runtime, agent_id, trust, &call.input).await
         }

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -53,17 +53,22 @@ pub(crate) struct WorkItemQueryContext {
 
 pub(crate) async fn query_context(runtime: &RuntimeHandle) -> Result<WorkItemQueryContext> {
     let state = runtime.agent_state().await?;
-    let current_work_item_id = if state.current_turn_work_item_id.is_some() {
-        state.current_turn_work_item_id
-    } else {
-        runtime
-            .latest_work_items()
-            .await?
-            .into_iter()
-            .filter(|item| item.status == WorkItemStatus::Active)
-            .max_by(|left, right| left.updated_at.cmp(&right.updated_at))
-            .map(|item| item.id)
-    };
+    if let Some(bound_id) = state.current_turn_work_item_id.as_deref() {
+        if let Some(record) = runtime.latest_work_item(bound_id).await? {
+            if record.status != WorkItemStatus::Completed {
+                return Ok(WorkItemQueryContext {
+                    current_work_item_id: Some(record.id),
+                });
+            }
+        }
+    }
+    let current_work_item_id = runtime
+        .latest_work_items()
+        .await?
+        .into_iter()
+        .filter(|item| item.status == WorkItemStatus::Active)
+        .max_by(|left, right| left.updated_at.cmp(&right.updated_at))
+        .map(|item| item.id);
     Ok(WorkItemQueryContext {
         current_work_item_id,
     })

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -1,0 +1,139 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    runtime::RuntimeHandle,
+    types::{WorkItemRecord, WorkItemStatus, WorkPlanSnapshot},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WorkItemLifecycleView {
+    Open,
+    Done,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WorkItemFocusView {
+    Current,
+    Queued,
+    Blocked,
+    Done,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct WorkItemView {
+    pub(crate) id: String,
+    pub(crate) agent_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) delivery_target: String,
+    pub(crate) state: WorkItemLifecycleView,
+    pub(crate) focus: WorkItemFocusView,
+    pub(crate) legacy_status: WorkItemStatus,
+    pub(crate) is_current: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) parent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) progress_note: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) plan: Option<WorkPlanSnapshot>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct WorkItemQueryContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) current_work_item_id: Option<String>,
+}
+
+pub(crate) async fn query_context(runtime: &RuntimeHandle) -> Result<WorkItemQueryContext> {
+    let state = runtime.agent_state().await?;
+    let current_work_item_id = if state.current_turn_work_item_id.is_some() {
+        state.current_turn_work_item_id
+    } else {
+        runtime
+            .latest_work_items()
+            .await?
+            .into_iter()
+            .filter(|item| item.status == WorkItemStatus::Active)
+            .max_by(|left, right| left.updated_at.cmp(&right.updated_at))
+            .map(|item| item.id)
+    };
+    Ok(WorkItemQueryContext {
+        current_work_item_id,
+    })
+}
+
+pub(crate) async fn view_for_record(
+    runtime: &RuntimeHandle,
+    context: &WorkItemQueryContext,
+    record: WorkItemRecord,
+    include_plan: bool,
+) -> Result<WorkItemView> {
+    let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
+        && record.status != WorkItemStatus::Completed;
+    let legacy_status = record.status.clone();
+    let plan = if include_plan {
+        runtime.latest_work_plan(&record.id).await?
+    } else {
+        None
+    };
+    Ok(WorkItemView {
+        id: record.id,
+        agent_id: record.agent_id,
+        workspace_id: record.workspace_id,
+        delivery_target: record.delivery_target,
+        state: lifecycle_view(&legacy_status),
+        focus: focus_view(&legacy_status, is_current),
+        legacy_status,
+        is_current,
+        parent_id: record.parent_id,
+        summary: record.summary,
+        progress_note: record.progress_note,
+        plan,
+        created_at: record.created_at,
+        updated_at: record.updated_at,
+    })
+}
+
+pub(crate) async fn latest_current_record(
+    runtime: &RuntimeHandle,
+    context: &WorkItemQueryContext,
+) -> Result<Option<WorkItemRecord>> {
+    if let Some(current_work_item_id) = context.current_work_item_id.as_deref() {
+        if let Some(record) = runtime.latest_work_item(current_work_item_id).await? {
+            if record.status != WorkItemStatus::Completed {
+                return Ok(Some(record));
+            }
+        }
+    }
+    Ok(None)
+}
+
+pub(crate) fn lifecycle_view(status: &WorkItemStatus) -> WorkItemLifecycleView {
+    match status {
+        &WorkItemStatus::Completed => WorkItemLifecycleView::Done,
+        &WorkItemStatus::Active | &WorkItemStatus::Queued | &WorkItemStatus::Waiting => {
+            WorkItemLifecycleView::Open
+        }
+    }
+}
+
+pub(crate) fn focus_view(status: &WorkItemStatus, is_current: bool) -> WorkItemFocusView {
+    if *status == WorkItemStatus::Completed {
+        return WorkItemFocusView::Done;
+    }
+    if is_current {
+        return WorkItemFocusView::Current;
+    }
+    match status {
+        &WorkItemStatus::Waiting => WorkItemFocusView::Blocked,
+        &WorkItemStatus::Active | &WorkItemStatus::Queued => WorkItemFocusView::Queued,
+        &WorkItemStatus::Completed => WorkItemFocusView::Done,
+    }
+}


### PR DESCRIPTION
Addresses the first low-risk slice of #800.

## What changed

- Added `GetActiveWorkItem`, `GetWorkItem`, and `ListWorkItems` as read-only work-item tools.
- The read surface returns `open`/`done` lifecycle, current/queued/blocked/done focus, `current_work_item_id` context, legacy status, and optional latest plan snapshots.
- Added prompt guidance so agents inspect work-item focus before relying on memory briefs or changing cross-turn work.
- Updated the work-item RFC to document the query-first rollout and legacy-status translation during the transition.

## Scope note

This PR intentionally does not replace the legacy write tools, remove `UpdateWorkPlan`, add dependency/blocker graph fields, or implement SpawnAgent delegation metadata. Those are higher-risk follow-up slices from #800.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib work_item`
- `cargo test --lib stable_tool_specs`
- `cargo test --lib emitted_tool_schemas_remain_strict_for_all_exposed_tools`
