### PR TITLE
fix(openai-codex): stabilize provider window compaction

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,7 @@ pub struct ProviderRuntimeConfig {
     pub credential: Option<String>,
     pub codex_home: Option<PathBuf>,
     pub originator: Option<String>,
+    pub reasoning_effort: Option<String>,
     pub context_management: AnthropicContextManagementConfig,
 }
 
@@ -238,6 +239,8 @@ pub struct ProviderConfigFile {
     pub transport: ProviderTransportKind,
     pub base_url: String,
     pub auth: ProviderAuthConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1421,6 +1424,12 @@ fn resolve_provider_registry(
 fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<ProviderRegistry> {
     let mut registry = ProviderRegistry::new();
     let openai_codex = ProviderId::openai_codex();
+    let openai_codex_reasoning_effort = env::var("HOLON_OPENAI_CODEX_REASONING_EFFORT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| Some("low".to_string()))
+        .map(|value| validate_openai_reasoning_effort(&value).map(|_| value))
+        .transpose()?;
     registry.insert(
         openai_codex.clone(),
         ProviderRuntimeConfig {
@@ -1442,6 +1451,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
                     .unwrap_or_else(|_| default_codex_home()),
             ),
             originator: Some("codex_cli_rs".into()),
+            reasoning_effort: openai_codex_reasoning_effort,
             context_management: Default::default(),
         },
     );
@@ -1465,6 +1475,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
             credential: env::var("OPENAI_API_KEY").ok(),
             codex_home: None,
             originator: None,
+            reasoning_effort: None,
             context_management: Default::default(),
         },
     );
@@ -1486,6 +1497,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
             credential: get_config_value("ANTHROPIC_AUTH_TOKEN", None, settings_env),
             codex_home: None,
             originator: None,
+            reasoning_effort: None,
             context_management: resolve_anthropic_context_management_config()?,
         },
     );
@@ -1789,6 +1801,7 @@ fn insert_builtin_http_provider(
             credential: credential.map(|resolution| resolution.value),
             codex_home: None,
             originator: None,
+            reasoning_effort: None,
             context_management: Default::default(),
         },
     );
@@ -1843,14 +1856,30 @@ fn materialize_provider_config(
         credential: None,
         codex_home: None,
         originator: None,
+        reasoning_effort: None,
         context_management: Default::default(),
     });
+    if let Some(reasoning_effort) = provider_config.reasoning_effort.as_deref() {
+        validate_openai_reasoning_effort(reasoning_effort)?;
+    }
     runtime.id = id;
     runtime.transport = provider_config.transport;
     runtime.base_url = provider_config.base_url;
     runtime.auth = provider_config.auth;
     runtime.credential = credential;
+    if provider_config.reasoning_effort.is_some() {
+        runtime.reasoning_effort = provider_config.reasoning_effort;
+    }
     Ok(runtime)
+}
+
+fn validate_openai_reasoning_effort(value: &str) -> Result<()> {
+    match value {
+        "low" | "medium" | "high" | "xhigh" => Ok(()),
+        _ => Err(anyhow!(
+            "OpenAI Codex reasoning_effort must be one of low, medium, high, xhigh"
+        )),
+    }
 }
 
 fn resolve_provider_credential(
@@ -1973,6 +2002,7 @@ pub fn provider_registry_for_tests(
             credential: None,
             codex_home: Some(codex_home),
             originator: Some("codex_cli_rs".into()),
+            reasoning_effort: Some("low".into()),
             context_management: Default::default(),
         },
     );
@@ -1993,6 +2023,7 @@ pub fn provider_registry_for_tests(
             credential: openai_key.map(ToString::to_string),
             codex_home: None,
             originator: None,
+            reasoning_effort: None,
             context_management: Default::default(),
         },
     );
@@ -2013,6 +2044,7 @@ pub fn provider_registry_for_tests(
             credential: anthropic_token.map(ToString::to_string),
             codex_home: None,
             originator: None,
+            reasoning_effort: None,
             context_management: Default::default(),
         },
     );
@@ -2802,6 +2834,7 @@ mod tests {
                     profile: None,
                     external: None,
                 },
+                reasoning_effort: None,
             },
             &settings_env,
             &CredentialStoreFile::default(),
@@ -2888,6 +2921,7 @@ mod tests {
                     profile: Some(" openrouter:default ".into()),
                     external: None,
                 },
+                reasoning_effort: None,
             },
             &settings_env,
             &credential_store,
@@ -2926,6 +2960,7 @@ mod tests {
                     profile: Some("openrouter:default".into()),
                     external: None,
                 },
+                reasoning_effort: None,
             },
         );
         save_persisted_config_at(&config_path, &config).unwrap();
@@ -3017,6 +3052,7 @@ mod tests {
                     profile: None,
                     external: Some("codex_cli".into()),
                 },
+                reasoning_effort: None,
             },
             &settings_env,
             &CredentialStoreFile::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1877,7 +1877,7 @@ fn validate_openai_reasoning_effort(value: &str) -> Result<()> {
     match value {
         "low" | "medium" | "high" | "xhigh" => Ok(()),
         _ => Err(anyhow!(
-            "OpenAI Codex reasoning_effort must be one of low, medium, high, xhigh"
+            "invalid OpenAI Codex reasoning_effort '{value}'; must be one of low, medium, high, xhigh"
         )),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -880,6 +880,7 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
                     profile: credential_profile.map(|value| value.trim().to_string()),
                     external: credential_external,
                 },
+                reasoning_effort: None,
             };
             validate_provider_config(&id, &provider_config)?;
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -120,6 +120,8 @@ pub struct ProviderRequestDiagnostics {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anthropic_context_management: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openai_request_controls: Option<ProviderOpenAiRequestControlsDiagnostics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub incremental_continuation: Option<ProviderIncrementalContinuationDiagnostics>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openai_remote_compaction: Option<ProviderOpenAiRemoteCompactionDiagnostics>,
@@ -189,6 +191,16 @@ pub struct ProviderIncrementalContinuationDiagnostics {
     pub current_item_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_shape_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderOpenAiRequestControlsDiagnostics {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    pub reasoning_sent: bool,
+    pub include_reasoning_encrypted_content: bool,
+    pub max_output_tokens_sent: bool,
+    pub max_output_tokens_unsupported: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -18,9 +18,11 @@ fn openai_tool_call_response(response_id: &str) -> Value {
         "usage": { "input_tokens": 3, "output_tokens": 2 },
         "output": [{
             "type": "function_call",
+            "id": "fc_non_persisted",
+            "status": "completed",
             "call_id": "exec-1",
             "name": "ExecCommand",
-            "arguments": "{\"cmd\":\"printf ok\"}"
+            "arguments": "{\n  \"cmd\": \"printf ok\"\n}"
         }]
     })
 }
@@ -32,6 +34,8 @@ fn openai_text_response(response_id: &str, text: &str) -> Value {
         "usage": { "input_tokens": 2, "output_tokens": 1 },
         "output": [{
             "type": "message",
+            "id": "msg_non_persisted",
+            "status": "completed",
             "role": "assistant",
             "content": [{ "type": "output_text", "text": text }]
         }]
@@ -42,7 +46,7 @@ fn openai_text_sse_response(response_id: &str, text: &str) -> String {
     format!(
         concat!(
             "event: response.completed\n",
-            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":2,\"output_tokens\":1}},\"output\":[{{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{{\"type\":\"output_text\",\"text\":\"{}\"}}]}}]}}}}\n\n"
+            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":2,\"output_tokens\":1}},\"output\":[{{\"type\":\"message\",\"id\":\"msg_non_persisted\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{{\"type\":\"output_text\",\"text\":\"{}\"}}]}}]}}}}\n\n"
         ),
         response_id, text
     )
@@ -217,9 +221,8 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
                         captured.lock().unwrap().push(body);
                         Json(json!({
                             "output": [
-                                { "type": "compaction", "encrypted_content": "opaque-1" },
                                 { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "recent" }] },
-                                { "type": "compaction", "encrypted_content": "opaque-2" }
+                                { "type": "compaction_summary", "encrypted_content": "opaque-2", "status": "completed" }
                             ]
                         }))
                     }
@@ -252,12 +255,12 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
         .expect("remote compaction diagnostics");
     assert_eq!(remote_compaction.status, "compacted");
     assert_eq!(remote_compaction.input_items, Some(11));
-    assert_eq!(remote_compaction.output_items, Some(3));
-    assert_eq!(remote_compaction.compaction_items, Some(2));
-    assert_eq!(remote_compaction.latest_compaction_index, Some(2));
+    assert_eq!(remote_compaction.output_items, Some(2));
+    assert_eq!(remote_compaction.compaction_items, Some(1));
+    assert_eq!(remote_compaction.latest_compaction_index, Some(1));
     assert_eq!(
         remote_compaction.encrypted_content_bytes.as_deref(),
-        Some([8usize, 8usize].as_slice())
+        Some([8usize].as_slice())
     );
 
     assert_eq!(
@@ -272,8 +275,8 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
     assert!(response_bodies[1].get("previous_response_id").is_none());
     let replayed_input = response_bodies[1]["input"].as_array().unwrap();
     assert_eq!(replayed_input[0]["type"], json!("compaction"));
-    assert_eq!(replayed_input[2]["type"], json!("compaction"));
     assert_eq!(replayed_input.last().unwrap()["type"], json!("message"));
+    assert!(!response_bodies[1].to_string().contains("recent"));
 
     let compact_bodies = compact_bodies.lock().unwrap();
     assert_eq!(compact_bodies.len(), 1);

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -1208,6 +1208,7 @@ fn build_provider_from_config_uses_custom_openai_responses_provider() {
             credential: Some("openrouter-key".into()),
             codex_home: None,
             originator: None,
+            reasoning_effort: None,
             context_management: Default::default(),
         },
     );
@@ -1250,6 +1251,7 @@ fn build_candidate_accepts_openai_responses_without_auth() {
             credential: None,
             codex_home: None,
             originator: None,
+            reasoning_effort: None,
             context_management: Default::default(),
         },
     );

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -234,6 +234,7 @@ fn openai_responses_request_sets_store_false() {
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
+        None,
     )
     .unwrap();
     assert_eq!(body["store"], Value::Bool(false));
@@ -249,6 +250,7 @@ fn openai_responses_request_lowers_prompt_frame_to_full_request_with_cache_key()
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
+        None,
     )
     .unwrap();
 
@@ -269,6 +271,7 @@ fn build_openai_standard_request_includes_max_output_tokens() {
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
+        None,
     )
     .unwrap();
 
@@ -285,6 +288,7 @@ fn build_openai_codex_streaming_request_omits_max_output_tokens() {
         &request,
         OpenAiResponsesTransportContract::CodexStreaming,
         ToolSchemaContract::Relaxed,
+        None,
     )
     .unwrap();
 
@@ -293,6 +297,25 @@ fn build_openai_codex_streaming_request_omits_max_output_tokens() {
     assert!(body.get("reasoning").is_some());
     assert_eq!(body["reasoning"], Value::Null);
     assert_eq!(body["include"], json!([]));
+}
+
+#[test]
+fn build_openai_codex_streaming_request_sends_supported_reasoning_effort() {
+    let request = provider_turn_request();
+    let body = build_openai_responses_request(
+        "gpt-5.4",
+        256,
+        &request,
+        OpenAiResponsesTransportContract::CodexStreaming,
+        ToolSchemaContract::Relaxed,
+        Some("low"),
+    )
+    .unwrap();
+
+    assert_eq!(body["stream"], Value::Bool(true));
+    assert!(body.get("max_output_tokens").is_none());
+    assert_eq!(body["reasoning"], json!({ "effort": "low" }));
+    assert_eq!(body["include"], json!(["reasoning.encrypted_content"]));
 }
 
 #[test]
@@ -305,6 +328,7 @@ fn openai_request_uses_custom_tool_shape_for_apply_patch() {
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
+        None,
     )
     .unwrap();
 
@@ -338,6 +362,7 @@ fn openai_request_payload_validates_full_tool_matrix_in_strict_mode() {
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Strict,
+        None,
     )
     .unwrap();
 
@@ -406,6 +431,7 @@ fn openai_codex_request_payload_validates_full_tool_matrix_in_strict_mode() {
         &request,
         OpenAiResponsesTransportContract::CodexStreaming,
         ToolSchemaContract::Strict,
+        Some("low"),
     )
     .unwrap();
 

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -284,6 +284,7 @@ impl AgentProvider for AnthropicProvider {
                 request_lowering_mode: request_lowering_mode.to_string(),
                 anthropic_cache: Some(cache_diagnostics),
                 anthropic_context_management: parsed.context_management,
+                openai_request_controls: None,
                 incremental_continuation: None,
                 openai_remote_compaction: None,
             }),

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -14,8 +14,9 @@ use crate::{
     provider::{
         emitted_tool_json_schema, AgentProvider, ConversationMessage, ModelBlock,
         ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
-        ProviderOpenAiRemoteCompactionDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
-        ProviderTurnRequest, ProviderTurnResponse, ToolSchemaContract,
+        ProviderOpenAiRemoteCompactionDiagnostics, ProviderOpenAiRequestControlsDiagnostics,
+        ProviderPromptFrame, ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
+        ToolSchemaContract,
     },
 };
 
@@ -44,6 +45,7 @@ pub struct OpenAiCodexProvider {
     originator: String,
     model: String,
     max_output_tokens: u32,
+    reasoning_effort: Option<String>,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
 }
 
@@ -232,6 +234,7 @@ impl OpenAiCodexProvider {
                 .unwrap_or_else(|| "codex_cli_rs".into()),
             model: model.to_string(),
             max_output_tokens,
+            reasoning_effort: provider_config.reasoning_effort.clone(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
     }
@@ -291,6 +294,7 @@ impl AgentProvider for OpenAiProvider {
             &request,
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Relaxed,
+            None,
         )?;
         let mut plan = plan_openai_responses_request(body, &request, &self.continuation)?;
         let mut sent_diagnostics = plan.diagnostics.clone();
@@ -373,6 +377,7 @@ impl AgentProvider for OpenAiCodexProvider {
             &request,
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
+            self.reasoning_effort.as_deref(),
         )?;
         let mut plan = plan_openai_responses_request(body, &request, &self.continuation)?;
         let mut sent_diagnostics = plan.diagnostics.clone();
@@ -636,6 +641,7 @@ fn plan_chat_completion_request(
                     None,
                     full_message_count,
                     None,
+                    None,
                 ),
             },
         ));
@@ -661,6 +667,7 @@ fn plan_chat_completion_request(
                     "not_applicable_initial_request",
                     None,
                     full_message_count,
+                    None,
                     None,
                 ),
             },
@@ -688,6 +695,7 @@ fn plan_chat_completion_request(
                         request_shape_hash: Some(request_shape_hash),
                         ..OpenAiContinuationMismatchDiagnostics::default()
                     }),
+                    None,
                 ),
             },
         ));
@@ -716,6 +724,7 @@ fn plan_chat_completion_request(
                     request_shape_hash: Some(request_shape_hash),
                     ..OpenAiContinuationMismatchDiagnostics::default()
                 }),
+                None,
             ),
         },
     ));
@@ -837,6 +846,7 @@ pub(crate) fn build_openai_responses_request(
     request: &ProviderTurnRequest,
     contract: OpenAiResponsesTransportContract,
     tool_schema_contract: ToolSchemaContract,
+    reasoning_effort: Option<&str>,
 ) -> Result<Value> {
     let tools = request
         .tools
@@ -883,11 +893,41 @@ pub(crate) fn build_openai_responses_request(
         }
         OpenAiResponsesTransportContract::CodexStreaming => {
             body["stream"] = Value::Bool(true);
-            body["reasoning"] = Value::Null;
-            body["include"] = Value::Array(Vec::new());
+            if let Some(reasoning_effort) = reasoning_effort {
+                body["reasoning"] = json!({ "effort": reasoning_effort });
+                body["include"] = json!(["reasoning.encrypted_content"]);
+            } else {
+                body["reasoning"] = Value::Null;
+                body["include"] = Value::Array(Vec::new());
+            }
         }
     }
     Ok(body)
+}
+
+fn openai_request_controls_diagnostics(body: &Value) -> ProviderOpenAiRequestControlsDiagnostics {
+    let reasoning_effort = body
+        .get("reasoning")
+        .and_then(|reasoning| reasoning.get("effort"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let include_reasoning_encrypted_content = body
+        .get("include")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| item.as_str() == Some("reasoning.encrypted_content"))
+        });
+    let max_output_tokens_sent = body.get("max_output_tokens").is_some();
+    let codex_streaming = body.get("stream").and_then(Value::as_bool) == Some(true);
+    ProviderOpenAiRequestControlsDiagnostics {
+        reasoning_sent: reasoning_effort.is_some(),
+        reasoning_effort,
+        include_reasoning_encrypted_content,
+        max_output_tokens_sent,
+        max_output_tokens_unsupported: codex_streaming,
+    }
 }
 
 fn plan_openai_responses_request(
@@ -908,6 +948,7 @@ fn plan_openai_responses_request(
     let full_input_items = full_input.len();
     let request_shape = request_shape_without_input(&body, request);
     let scope = continuation_scope(request);
+    let request_controls = Some(openai_request_controls_diagnostics(&body));
     let Some(scope_ref) = scope.as_ref() else {
         return Ok(OpenAiRequestPlan {
             body,
@@ -921,6 +962,7 @@ fn plan_openai_responses_request(
                 None,
                 full_input_items,
                 None,
+                request_controls,
             ),
         });
     };
@@ -941,6 +983,7 @@ fn plan_openai_responses_request(
                 None,
                 full_input_items,
                 None,
+                request_controls,
             ),
         });
     };
@@ -962,6 +1005,7 @@ fn plan_openai_responses_request(
                     request_shape_hash: Some(request_shape_hash),
                     ..OpenAiContinuationMismatchDiagnostics::default()
                 }),
+                request_controls,
             ),
         });
     }
@@ -985,6 +1029,7 @@ fn plan_openai_responses_request(
                 None,
                 full_input_items,
                 Some(mismatch),
+                request_controls,
             ),
         });
     }
@@ -1016,6 +1061,7 @@ fn plan_openai_responses_request(
             },
             anthropic_cache: None,
             anthropic_context_management: None,
+            openai_request_controls: request_controls,
             openai_remote_compaction: None,
             incremental_continuation: Some(ProviderIncrementalContinuationDiagnostics {
                 status: "hit".into(),
@@ -1119,9 +1165,18 @@ fn openai_item_hash(item: &Value) -> String {
 }
 
 fn latest_openai_compaction_index(items: &[Value]) -> Option<usize> {
-    items.iter().enumerate().rev().find_map(|(index, item)| {
-        (item.get("type").and_then(Value::as_str) == Some("compaction")).then_some(index)
-    })
+    items
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(index, item)| openai_is_compaction_item(item).then_some(index))
+}
+
+fn openai_is_compaction_item(item: &Value) -> bool {
+    matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("compaction" | "compaction_summary")
+    )
 }
 
 fn request_shape_hash(request_shape: &OpenAiRequestShape) -> String {
@@ -1173,12 +1228,14 @@ fn incremental_diagnostics(
     incremental_input_items: Option<usize>,
     full_input_items: usize,
     mismatch: Option<OpenAiContinuationMismatchDiagnostics>,
+    openai_request_controls: Option<ProviderOpenAiRequestControlsDiagnostics>,
 ) -> ProviderRequestDiagnostics {
     let mismatch = mismatch.unwrap_or_default();
     ProviderRequestDiagnostics {
         request_lowering_mode: request_lowering_mode.into(),
         anthropic_cache: None,
         anthropic_context_management: None,
+        openai_request_controls,
         openai_remote_compaction: None,
         incremental_continuation: Some(ProviderIncrementalContinuationDiagnostics {
             status: "fallback_full_request".into(),
@@ -1213,8 +1270,16 @@ fn update_openai_continuation(
     let next = match (parsed.response_id.as_ref(), parsed.output_items.is_empty()) {
         (Some(response_id), false) => {
             state.next_generation = state.next_generation.saturating_add(1);
-            let mut items = provider_input;
-            items.extend(parsed.output_items.clone());
+            let mut items = provider_input
+                .into_iter()
+                .map(|item| canonicalize_openai_provider_item(&item))
+                .collect::<Vec<_>>();
+            items.extend(
+                parsed
+                    .output_items
+                    .iter()
+                    .map(canonicalize_openai_provider_item),
+            );
             let mut append_match_items = full_input;
             append_match_items.extend(openai_append_match_output_items(&parsed.output_items));
             Some(OpenAiProviderWindow {
@@ -1245,10 +1310,10 @@ fn openai_append_match_output_items(output_items: &[Value]) -> Vec<Value> {
 fn openai_append_match_output_item(item: &Value) -> Option<Value> {
     match item.get("type").and_then(Value::as_str) {
         Some("message" | "function_call" | "custom_tool_call") => {
-            Some(openai_without_provider_item_id(item))
+            Some(canonicalize_openai_provider_item(item))
         }
         Some("reasoning") => None,
-        _ => Some(openai_without_provider_item_id(item)),
+        _ => Some(canonicalize_openai_provider_item(item)),
     }
 }
 
@@ -1424,7 +1489,7 @@ async fn maybe_compact_openai_provider_window(
         }
         state.next_generation = state.next_generation.saturating_add(1);
         let generation = state.next_generation;
-        let mut items = compacted;
+        let mut items = openai_compacted_replay_items(&compacted);
         items.extend(candidate.retained_tail.clone());
         let latest_compaction_index = latest_openai_compaction_index(&items);
         state.windows.insert(
@@ -1644,7 +1709,7 @@ async fn maybe_compact_openai_request_plan(
     }
 
     let output_items = compacted.len();
-    let mut provider_input = compacted;
+    let mut provider_input = openai_compacted_replay_items(&compacted);
     provider_input.extend(candidate.retained_tail.clone());
     plan.body["input"] = Value::Array(provider_input.clone());
     if let Some(object) = plan.body.as_object_mut() {
@@ -1769,6 +1834,12 @@ fn openai_provider_window_compaction_candidate(
         items: compact_items,
         retained_tail: window.items[boundary..].to_vec(),
     })
+}
+
+fn openai_compacted_replay_items(compacted: &[Value]) -> Vec<Value> {
+    latest_openai_compaction_index(compacted)
+        .map(|index| compacted[index..].to_vec())
+        .unwrap_or_else(|| compacted.to_vec())
 }
 
 fn items_since_latest_openai_compaction(items: &[Value]) -> usize {
@@ -1901,7 +1972,37 @@ fn build_openai_compact_request_body(request_shape: &OpenAiRequestShape, items: 
 }
 
 fn sanitize_openai_store_false_compact_items(items: &[Value]) -> Vec<Value> {
-    items.iter().map(openai_without_provider_item_id).collect()
+    items
+        .iter()
+        .map(canonicalize_openai_provider_item)
+        .collect()
+}
+
+fn canonicalize_openai_provider_item(item: &Value) -> Value {
+    let mut item = openai_without_provider_item_id(item);
+    let Some(object) = item.as_object_mut() else {
+        return item;
+    };
+    if object.get("type").and_then(Value::as_str) == Some("compaction_summary") {
+        object.insert("type".into(), Value::String("compaction".into()));
+    }
+    if matches!(
+        object.get("type").and_then(Value::as_str),
+        Some("message" | "function_call" | "custom_tool_call" | "reasoning" | "compaction")
+    ) {
+        object.remove("status");
+    }
+    if object.get("type").and_then(Value::as_str) == Some("function_call") {
+        if let Some(arguments) = object.get("arguments").and_then(Value::as_str) {
+            if let Ok(parsed_arguments) = serde_json::from_str::<Value>(arguments) {
+                object.insert(
+                    "arguments".into(),
+                    Value::String(canonical_json(&parsed_arguments)),
+                );
+            }
+        }
+    }
+    item
 }
 
 fn openai_without_provider_item_id(item: &Value) -> Value {
@@ -1928,7 +2029,7 @@ fn openai_without_provider_item_id(item: &Value) -> Value {
 fn openai_compaction_encrypted_content_hashes(items: &[Value]) -> Vec<String> {
     items
         .iter()
-        .filter(|item| item.get("type").and_then(Value::as_str) == Some("compaction"))
+        .filter(|item| openai_is_compaction_item(item))
         .filter_map(|item| item.get("encrypted_content").and_then(Value::as_str))
         .map(|content| sha256_hex(content.as_bytes()))
         .collect()
@@ -1937,7 +2038,7 @@ fn openai_compaction_encrypted_content_hashes(items: &[Value]) -> Vec<String> {
 fn openai_compaction_encrypted_content_bytes(items: &[Value]) -> Vec<usize> {
     items
         .iter()
-        .filter(|item| item.get("type").and_then(Value::as_str) == Some("compaction"))
+        .filter(|item| openai_is_compaction_item(item))
         .filter_map(|item| item.get("encrypted_content").and_then(Value::as_str))
         .map(str::len)
         .collect()
@@ -2003,8 +2104,7 @@ pub(crate) fn build_openai_input(conversation: &[ConversationMessage]) -> Result
                                     "type": "function_call",
                                     "call_id": id,
                                     "name": name,
-                                    "arguments": serde_json::to_string(input)
-                                        .context("failed to serialize tool call arguments")?,
+                                    "arguments": canonical_json(input),
                                 }));
                             }
                         }
@@ -2778,7 +2878,7 @@ async fn send_openai_compact_request(
     })?;
     let parsed: Value = serde_json::from_str(&response_body)
         .map_err(|error| invalid_response_error("invalid OpenAI compact JSON", error))?;
-    parsed
+    let output = parsed
         .get("output")
         .and_then(Value::as_array)
         .cloned()
@@ -2787,7 +2887,11 @@ async fn send_openai_compact_request(
                 "OpenAI compact response did not contain output array",
                 "missing output array",
             )
-        })
+        })?;
+    Ok(output
+        .into_iter()
+        .map(|item| canonicalize_openai_provider_item(&item))
+        .collect())
 }
 
 async fn send_openai_responses_streaming_request(
@@ -3135,7 +3239,10 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
                 "missing output array",
             )
         })?;
-    let output_items = output.clone();
+    let output_items = output
+        .iter()
+        .map(canonicalize_openai_provider_item)
+        .collect::<Vec<_>>();
     let mut blocks = Vec::new();
 
     for item in output {

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1978,6 +1978,9 @@ fn sanitize_openai_store_false_compact_items(items: &[Value]) -> Vec<Value> {
         .collect()
 }
 
+// Provider windows are replayed into future OpenAI requests and compared
+// against locally rebuilt input for append-only continuation. Normalize
+// provider-only transport fields so equivalent conversation items stay stable.
 fn canonicalize_openai_provider_item(item: &Value) -> Value {
     let mut item = openai_without_provider_item_id(item);
     let Some(object) = item.as_object_mut() else {

--- a/tests/live_openai_codex_compact.rs
+++ b/tests/live_openai_codex_compact.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path, process::Command};
+use std::{fs, path::Path, process::Command, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
 use base64::Engine;
@@ -113,7 +113,10 @@ async fn live_openai_codex_request_control_probe() -> Result<()> {
         .ok_or_else(|| anyhow!("missing openai-codex provider config"))?;
     let credential = load_live_codex_credential(provider_config)?;
     let route = codex_responses_route(&provider_config.base_url);
-    let client = Client::new();
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("failed to build Codex probe HTTP client")?;
 
     let default =
         post_codex_probe(&client, &route, &credential, codex_probe_body(None, false)).await?;

--- a/tests/live_openai_codex_compact.rs
+++ b/tests/live_openai_codex_compact.rs
@@ -1,11 +1,18 @@
-use anyhow::{anyhow, Result};
+use std::{fs, path::Path, process::Command};
+
+use anyhow::{anyhow, Context, Result};
+use base64::Engine;
 use holon::{
-    config::{AppConfig, ProviderId},
+    config::{AppConfig, ProviderId, ProviderRuntimeConfig},
     provider::{
         AgentProvider, ConversationMessage, OpenAiCodexProvider, ProviderPromptCache,
         ProviderPromptFrame, ProviderTurnRequest,
     },
 };
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 fn live_config() -> Result<AppConfig> {
     AppConfig::load()
@@ -23,6 +30,16 @@ fn codex_compact_route(base_url: &str) -> String {
         format!("{base_url}/codex")
     };
     format!("{api_base}/responses/compact")
+}
+
+fn codex_responses_route(base_url: &str) -> String {
+    let base_url = base_url.trim_end_matches('/');
+    let api_base = if base_url.ends_with("/codex") {
+        base_url.to_string()
+    } else {
+        format!("{base_url}/codex")
+    };
+    format!("{api_base}/responses")
 }
 
 #[tokio::test]
@@ -76,5 +93,272 @@ async fn live_openai_codex_remote_compact_route_probe() -> Result<()> {
     if diagnostics.http_status == Some(404) {
         anyhow::bail!("openai-codex compact route returned 404: {route}");
     }
+    if diagnostics.status != "compacted" || diagnostics.compaction_items.unwrap_or(0) == 0 {
+        anyhow::bail!(
+            "openai-codex compact route did not return a usable compaction item: status={}, compaction_items={:?}",
+            diagnostics.status,
+            diagnostics.compaction_items
+        );
+    }
     Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires Codex CLI ChatGPT auth and network access"]
+async fn live_openai_codex_request_control_probe() -> Result<()> {
+    let config = live_config()?;
+    let provider_config = config
+        .providers
+        .get(&ProviderId::openai_codex())
+        .ok_or_else(|| anyhow!("missing openai-codex provider config"))?;
+    let credential = load_live_codex_credential(provider_config)?;
+    let route = codex_responses_route(&provider_config.base_url);
+    let client = Client::new();
+
+    let default =
+        post_codex_probe(&client, &route, &credential, codex_probe_body(None, false)).await?;
+    eprintln!(
+        "openai-codex request controls: default status={}, body_hint={}",
+        default.status,
+        body_hint(&default.body)
+    );
+    assert!(
+        (200..300).contains(&default.status),
+        "default request should be accepted: {}",
+        body_hint(&default.body)
+    );
+
+    let low = post_codex_probe(
+        &client,
+        &route,
+        &credential,
+        codex_probe_body(Some("low"), false),
+    )
+    .await?;
+    eprintln!(
+        "openai-codex request controls: reasoning_low status={}, body_hint={}",
+        low.status,
+        body_hint(&low.body)
+    );
+    assert!(
+        (200..300).contains(&low.status),
+        "reasoning effort low should be accepted: {}",
+        body_hint(&low.body)
+    );
+
+    let max_output = post_codex_probe(
+        &client,
+        &route,
+        &credential,
+        codex_probe_body(Some("low"), true),
+    )
+    .await?;
+    eprintln!(
+        "openai-codex request controls: max_output_tokens status={}, body_hint={}",
+        max_output.status,
+        body_hint(&max_output.body)
+    );
+    assert_eq!(
+        max_output.status, 400,
+        "max_output_tokens should remain unsupported by the Codex backend"
+    );
+    assert!(
+        max_output.body.contains("max_output_tokens")
+            || max_output.body.contains("Unsupported parameter"),
+        "unexpected max_output_tokens error body: {}",
+        body_hint(&max_output.body)
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthDotJson {
+    tokens: Option<TokenData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenData {
+    access_token: String,
+    account_id: Option<String>,
+    id_token: Option<Value>,
+}
+
+#[derive(Debug)]
+struct LiveCodexCredential {
+    access_token: String,
+    account_id: String,
+}
+
+#[derive(Debug)]
+struct ProbeResponse {
+    status: u16,
+    body: String,
+}
+
+fn load_live_codex_credential(
+    provider_config: &ProviderRuntimeConfig,
+) -> Result<LiveCodexCredential> {
+    let codex_home = provider_config
+        .codex_home
+        .as_deref()
+        .ok_or_else(|| anyhow!("missing codex_home for OpenAI Codex provider"))?;
+    let codex_home = codex_home
+        .canonicalize()
+        .unwrap_or_else(|_| codex_home.to_path_buf());
+    let auth = load_live_codex_auth_from_file(&codex_home).or_else(|file_error| {
+        load_live_codex_auth_from_keychain(&codex_home).with_context(|| {
+            format!("failed to load Codex auth from auth.json or keychain: {file_error}")
+        })
+    })?;
+    let tokens = auth
+        .tokens
+        .ok_or_else(|| anyhow!("Codex auth record did not contain OAuth tokens"))?;
+    let account_id = tokens
+        .account_id
+        .or_else(|| {
+            tokens
+                .id_token
+                .as_ref()
+                .and_then(extract_account_id_from_id_token)
+        })
+        .or_else(|| extract_account_id_from_access_token(&tokens.access_token))
+        .ok_or_else(|| anyhow!("failed to resolve Codex account id from stored credentials"))?;
+    Ok(LiveCodexCredential {
+        access_token: tokens.access_token,
+        account_id,
+    })
+}
+
+fn load_live_codex_auth_from_file(codex_home: &Path) -> Result<AuthDotJson> {
+    let path = codex_home.join("auth.json");
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn load_live_codex_auth_from_keychain(codex_home: &Path) -> Result<AuthDotJson> {
+    if !cfg!(target_os = "macos") {
+        anyhow::bail!("Codex keychain auth fallback is only available on macOS");
+    }
+    let output = Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Codex Auth",
+            "-a",
+            &compute_codex_keychain_account(codex_home),
+            "-w",
+        ])
+        .output()
+        .context("failed to invoke macOS security tool")?;
+    if !output.status.success() {
+        anyhow::bail!("macOS keychain does not contain a Codex Auth entry");
+    }
+    let secret = String::from_utf8(output.stdout).context("Codex keychain entry was not UTF-8")?;
+    serde_json::from_str(secret.trim()).context("failed to parse Codex keychain auth record")
+}
+
+fn compute_codex_keychain_account(codex_home: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(codex_home.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let hex = format!("{digest:x}");
+    format!("cli|{}", &hex[..16])
+}
+
+fn codex_probe_body(reasoning_effort: Option<&str>, include_max_output_tokens: bool) -> Value {
+    let mut body = json!({
+        "model": live_openai_codex_model(),
+        "instructions": "Reply with exactly one short sentence.",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{ "type": "input_text", "text": "Say compact probe ok." }]
+        }],
+        "tools": [],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false,
+        "store": false,
+        "stream": true,
+        "reasoning": Value::Null,
+        "include": [],
+    });
+    if let Some(reasoning_effort) = reasoning_effort {
+        body["reasoning"] = json!({ "effort": reasoning_effort });
+        body["include"] = json!(["reasoning.encrypted_content"]);
+    }
+    if include_max_output_tokens {
+        body["max_output_tokens"] = json!(32);
+    }
+    body
+}
+
+async fn post_codex_probe(
+    client: &Client,
+    route: &str,
+    credential: &LiveCodexCredential,
+    body: Value,
+) -> Result<ProbeResponse> {
+    let response = client
+        .post(route)
+        .header("content-type", "application/json")
+        .header(
+            "authorization",
+            format!("Bearer {}", credential.access_token),
+        )
+        .header("chatgpt-account-id", &credential.account_id)
+        .header("OpenAI-Beta", "responses=experimental")
+        .header("originator", "codex_cli_rs")
+        .json(&body)
+        .send()
+        .await
+        .context("failed to send Codex probe request")?;
+    let status = response.status().as_u16();
+    let body = response
+        .text()
+        .await
+        .context("failed to read Codex probe response")?;
+    Ok(ProbeResponse { status, body })
+}
+
+fn extract_account_id_from_access_token(token: &str) -> Option<String> {
+    let payload = decode_jwt_payload(token)?;
+    extract_account_id_from_payload(&payload)
+}
+
+fn extract_account_id_from_id_token(id_token: &Value) -> Option<String> {
+    match id_token {
+        Value::String(jwt) => {
+            decode_jwt_payload(jwt).and_then(|payload| extract_account_id_from_payload(&payload))
+        }
+        Value::Object(payload) => extract_account_id_from_payload(&Value::Object(payload.clone())),
+        _ => None,
+    }
+}
+
+fn decode_jwt_payload(token: &str) -> Option<Value> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload.as_bytes())
+        .ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+fn extract_account_id_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("account_id")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("chatgpt_account_id").and_then(Value::as_str))
+        .or_else(|| {
+            payload
+                .get("https://api.openai.com/auth")
+                .and_then(|value| value.get("chatgpt_account_id"))
+                .and_then(Value::as_str)
+        })
+        .map(ToString::to_string)
+}
+
+fn body_hint(body: &str) -> String {
+    body.chars().take(240).collect()
 }


### PR DESCRIPTION
## Summary

- Fixes #818.
- Canonicalizes OpenAI/Codex provider-window items before append-only matching and compact replay, including provider-only `id`/`status`, canonical function-call arguments, and `compaction_summary` compact responses.
- Sends supported Codex `reasoning.effort` (default `low`, configurable via provider config or `HOLON_OPENAI_CODEX_REASONING_EFFORT`) with `reasoning.encrypted_content`, while keeping unsupported `max_output_tokens` out of Codex requests.
- Adds request-control diagnostics plus live Codex probes for remote compact and backend request-control behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib provider::tests::tool_schema -- --test-threads=1`
- `cargo test --lib provider::tests::openai_responses -- --test-threads=1`
- `cargo test --lib config::tests -- --test-threads=1`
- `cargo test --test live_openai_codex_compact -- --ignored --nocapture --test-threads=1`
- `cargo test --all-targets -- --test-threads=1`

Benchmark rerun is intentionally deferred until after merge.
