### PR TITLE
fix(tools): harden Sleep and MemoryGet validation

### DIFF
--- a/docs/rfcs/agent-and-workspace-memory.md
+++ b/docs/rfcs/agent-and-workspace-memory.md
@@ -287,7 +287,9 @@ Phase 1 exposes this as `MemorySearch` and `MemoryGet`. `MemorySearch` returns
 enough provenance for follow-up (`kind`, `source_ref`, scope, workspace, source
 path, title, snippet, score, timestamp, and metadata). `MemoryGet(source_ref,
 max_chars?)` returns the same provenance plus bounded exact source text and a
-`truncated` flag.
+`truncated` flag. The `source_ref` is an opaque handle copied from
+`MemorySearch` results, not a file path, skill path, URL, or identifier the
+model should construct.
 
 ## Indexing Model
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -763,7 +763,8 @@ Delegation rules:
 - `public_named` requires an explicit `agent_id` and returns only `agent_id`
 - spawning a new `public_named` agent may record lineage provenance without
   placing that agent under parent supervision
-- `Sleep` is the public primitive for short session-local waiting
+- `Sleep` is the public primitive for resting; optional `duration_ms` is only
+  for positive short session-local wake delays
 - `exec_command` is the only public creation path for managed `command_task`
 - no separate public `CreateTask` tool remains
 - child agents are created with parent provenance
@@ -1428,7 +1429,9 @@ hard safety caps.
 memory. It searches curated memory and runtime evidence, not arbitrary project
 documents. `MemoryGet(source_ref, max_chars?)` is the matching exact expansion
 step: after search returns a provenance-bearing `source_ref`, the agent can
-fetch the bounded original source text without search-token expansion.
+fetch the bounded original source text without search-token expansion. The
+`source_ref` is an opaque handle copied from `MemorySearch` results; it is not a
+file path, skill path, URL, or model-constructible identifier.
 
 The runtime stores its derived memory index at
 `agent_home/.holon/indexes/memory.sqlite3`, with
@@ -1448,7 +1451,8 @@ index is disposable and rebuildable from stronger sources:
 
 `MemoryGet` returns the same provenance plus exact `content` and a `truncated`
 flag. The default content bound is 12,000 characters and the hard maximum is
-50,000 characters.
+50,000 characters. When `max_chars` is provided through the tool surface it
+must be between 1 and 50,000.
 
 Search is scoped to the active workspace by default, while agent-scoped memory
 is always available across workspaces. Callers may explicitly include all
@@ -1708,6 +1712,12 @@ The runtime should record:
 - when it went to sleep
 - why it slept
 - what wake condition is expected, if known
+
+Omitting `duration_ms` means ordinary indefinite rest until another wake signal
+arrives. A positive `duration_ms` requests a short session-local wake after the
+bounded delay. `duration_ms = 0` is tolerated as equivalent to omission for
+model-output compatibility, but the published tool schema and prompt direct
+models to omit it instead.
 
 ### Suggested Lifecycle
 

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -22,7 +22,7 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_sleep",
             PromptStability::Stable,
-            "Use Sleep when the current task is complete and no immediate follow-up remains. Do not idle-spin by avoiding Sleep once the agent can safely rest. Emit a delivery-ready completion summary in a text block before calling Sleep. The Sleep reason should be a concise label referencing the preceding summary. When calling Sleep, always provide `reason`. Optionally add a short positive `duration_ms` only when you intentionally want a session-local wake after a bounded delay. Do not use `duration_ms` as a durable timer or scheduling substitute, and do not expect a task handle from Sleep. Never use Sleep with a vague reason like 'done' or 'completed'.".to_string(),
+            "Use Sleep when the current task is complete and no immediate follow-up remains. Do not idle-spin by avoiding Sleep once the agent can safely rest. Emit a delivery-ready completion summary in a text block before calling Sleep. The Sleep reason should be a concise label referencing the preceding summary. When calling Sleep, always provide `reason`. Omit `duration_ms` for ordinary indefinite rest. Optionally add a short positive `duration_ms` only when you intentionally want a session-local wake after a bounded delay; never set it to 0. Do not use `duration_ms` as a durable timer or scheduling substitute, and do not expect a task handle from Sleep. Never use Sleep with a vague reason like 'done' or 'completed'.".to_string(),
         ));
     }
     if names.contains(&"SpawnAgent") {

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -419,6 +419,23 @@ fn openai_request_payload_validates_full_tool_matrix_in_strict_mode() {
         .collect::<Vec<_>>();
     assert!(duration_types.contains(&"integer"));
     assert!(duration_types.contains(&"null"));
+    assert_eq!(
+        sleep["parameters"]["properties"]["duration_ms"]["minimum"],
+        Value::from(1.0)
+    );
+
+    let memory_get = emitted_tools
+        .iter()
+        .find(|tool| tool["name"] == "MemoryGet")
+        .expect("MemoryGet tool should be present");
+    assert_eq!(
+        memory_get["parameters"]["properties"]["max_chars"]["minimum"],
+        Value::from(1.0)
+    );
+    assert_eq!(
+        memory_get["parameters"]["properties"]["max_chars"]["maximum"],
+        Value::from(50000.0)
+    );
 }
 
 #[test]

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -608,10 +608,15 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
             _ => None,
         })
     {
-        assert!(checkpoint.contains("current user goal"));
-        assert!(checkpoint.contains("what remains unknown"));
-        assert!(checkpoint.contains("next goal-aligned action"));
-        assert!(checkpoint.contains("Do not assume the task requires code changes"));
+        if checkpoint.contains("delta progress checkpoint request") {
+            assert!(checkpoint.contains("Base checkpoint preview"));
+            assert!(checkpoint.contains("whether the next bounded action changed"));
+        } else {
+            assert!(checkpoint.contains("current user goal"));
+            assert!(checkpoint.contains("what remains unknown"));
+            assert!(checkpoint.contains("next goal-aligned action"));
+            assert!(checkpoint.contains("Do not assume the task requires code changes"));
+        }
         assert!(!checkpoint.contains("start editing"));
         assert!(!checkpoint.contains("begin implementation"));
     }

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -712,5 +712,37 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(duration_types.contains(&"integer"));
         assert!(duration_types.contains(&"null"));
+        assert_eq!(duration_ms["minimum"], Value::from(1.0));
+    }
+
+    #[test]
+    fn memory_get_schema_bounds_max_chars_in_final_emitted_shape() {
+        let registry = ToolRegistry::new(PathBuf::from("."));
+        let memory_get = registry
+            .tool_specs()
+            .unwrap()
+            .into_iter()
+            .find(|spec| spec.name == "MemoryGet")
+            .expect("MemoryGet should be present");
+        let final_schema =
+            emitted_tool_json_schema(&memory_get.input_schema, ToolSchemaContract::Strict)
+                .expect("memory get schema");
+        let max_chars = &final_schema["properties"]["max_chars"];
+
+        assert!(final_schema["required"]
+            .as_array()
+            .expect("required should be an array")
+            .iter()
+            .any(|value| value == "max_chars"));
+        let max_chars_types = max_chars["type"]
+            .as_array()
+            .expect("max_chars type should be an array")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+        assert!(max_chars_types.contains(&"integer"));
+        assert!(max_chars_types.contains(&"null"));
+        assert_eq!(max_chars["minimum"], Value::from(1.0));
+        assert_eq!(max_chars["maximum"], Value::from(50000.0));
     }
 }

--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -382,15 +382,7 @@ pub(crate) fn extract_sleep_duration_ms(input: &Value) -> Result<Option<u64>> {
         ));
     };
     if duration_ms == 0 {
-        return Err(invalid_tool_input(
-            "Sleep",
-            "Sleep `duration_ms` must be greater than zero",
-            json!({
-                "field": "duration_ms",
-                "validation_error": "must be greater than zero",
-            }),
-            "provide a positive integer millisecond delay, or omit `duration_ms` for ordinary terminal rest",
-        ));
+        return Ok(None);
     }
     Ok(Some(duration_ms))
 }
@@ -498,16 +490,12 @@ mod tests {
     }
 
     #[test]
-    fn sleep_duration_rejects_zero_delay() {
-        let err = extract_sleep_duration_ms(&json!({
+    fn sleep_duration_treats_zero_as_omitted() {
+        let duration_ms = extract_sleep_duration_ms(&json!({
             "reason": "pause",
             "duration_ms": 0,
         }))
-        .unwrap_err();
-        let tool_error = err
-            .downcast_ref::<crate::tool::ToolError>()
-            .expect("tool error");
-        assert_eq!(tool_error.kind, "invalid_tool_input");
-        assert!(tool_error.message.contains("greater than zero"));
+        .unwrap();
+        assert_eq!(duration_ms, None);
     }
 }

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 
 use crate::{
     runtime::RuntimeHandle,
-    tool::{spec::typed_spec, ToolError},
+    tool::{helpers::invalid_tool_input, spec::typed_spec, ToolError},
     types::{ToolCapabilityFamily, TrustLevel},
 };
 
@@ -13,11 +13,20 @@ use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
 pub(crate) const NAME: &str = "MemoryGet";
+const MAX_CHARS_MAX: usize = 50_000;
+const ALLOWED_SOURCE_REF_PREFIXES: &[&str] = &[
+    "agent_memory:",
+    "workspace_profile:",
+    "brief:",
+    "episode:",
+    "work_item:",
+];
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct MemoryGetArgs {
     pub(crate) source_ref: String,
+    #[schemars(range(min = 1, max = 50000))]
     pub(crate) max_chars: Option<usize>,
 }
 
@@ -31,7 +40,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<MemoryGetArgs>(
             NAME,
-            "Fetch exact bounded Holon memory content by a source_ref returned from MemorySearch.",
+            "Fetch exact bounded Holon memory content by a source_ref copied verbatim from MemorySearch.results[].source_ref. Do not invent source_ref values or use MemoryGet for skill paths, file paths, or URLs.",
         )?,
     })
 }
@@ -43,17 +52,186 @@ pub(crate) async fn execute(
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
     let args: MemoryGetArgs = parse_tool_args(NAME, input)?;
-    let source_ref = validate_non_empty(args.source_ref, NAME, "source_ref")?;
-    let Some(memory) = runtime.get_memory(&source_ref, args.max_chars).await? else {
+    let source_ref = validate_source_ref(args.source_ref)?;
+    let max_chars = validate_max_chars(args.max_chars)?;
+    let Some(memory) = runtime.get_memory(&source_ref, max_chars).await? else {
         return Err(ToolError::new(
             "memory_source_not_found",
             format!("memory source `{source_ref}` was not found"),
         )
-        .with_details(json!({ "source_ref": source_ref }))
+        .with_details(json!({
+            "source_ref": source_ref,
+            "allowed_source_ref_prefixes": ALLOWED_SOURCE_REF_PREFIXES,
+            "reason": "source_ref was syntactically valid but is not present in the current visible memory index",
+        }))
         .with_recovery_hint(
-            "call MemorySearch first and pass one of its returned source_ref values",
+            "call MemorySearch again and pass one of its returned source_ref values verbatim",
         )
         .into());
     };
     serialize_success(NAME, &MemoryGetResponse { memory })
+}
+
+fn validate_source_ref(source_ref: String) -> Result<String> {
+    let source_ref = validate_non_empty(source_ref, NAME, "source_ref")?;
+    if source_ref.chars().any(char::is_whitespace) {
+        return Err(invalid_tool_input(
+            NAME,
+            "MemoryGet `source_ref` must be a single opaque handle without whitespace",
+            json!({
+                "field": "source_ref",
+                "source_ref": source_ref,
+                "validation_error": "must not contain whitespace",
+            }),
+            "copy a source_ref exactly from MemorySearch.results[].source_ref; do not paste snippets or paths",
+        ));
+    }
+
+    let Some((prefix, suffix)) = source_ref.split_once(':') else {
+        return Err(invalid_source_ref_error(
+            &source_ref,
+            "missing source_ref prefix",
+        ));
+    };
+    if suffix.is_empty() {
+        return Err(invalid_source_ref_error(
+            &source_ref,
+            "missing source_ref identifier",
+        ));
+    }
+
+    let prefix = format!("{prefix}:");
+    if !ALLOWED_SOURCE_REF_PREFIXES.contains(&prefix.as_str()) {
+        return Err(invalid_source_ref_error(
+            &source_ref,
+            "unsupported source_ref prefix",
+        ));
+    }
+
+    Ok(source_ref)
+}
+
+fn validate_max_chars(max_chars: Option<usize>) -> Result<Option<usize>> {
+    let Some(max_chars) = max_chars else {
+        return Ok(None);
+    };
+    if !(1..=MAX_CHARS_MAX).contains(&max_chars) {
+        return Err(invalid_tool_input(
+            NAME,
+            "MemoryGet `max_chars` must be between 1 and 50000 when provided",
+            json!({
+                "field": "max_chars",
+                "max_chars": max_chars,
+                "validation_error": "out of range",
+                "minimum": 1,
+                "maximum": MAX_CHARS_MAX,
+            }),
+            "omit `max_chars` for the default bound, or provide an integer from 1 through 50000",
+        ));
+    }
+    Ok(Some(max_chars))
+}
+
+fn invalid_source_ref_error(source_ref: &str, validation_error: &'static str) -> anyhow::Error {
+    invalid_tool_input(
+        NAME,
+        "MemoryGet `source_ref` must be copied from MemorySearch results",
+        json!({
+            "field": "source_ref",
+            "source_ref": source_ref,
+            "validation_error": validation_error,
+            "allowed_source_ref_prefixes": ALLOWED_SOURCE_REF_PREFIXES,
+        }),
+        "call MemorySearch first and copy one returned source_ref verbatim; use ExecCommand for workspace files or skill docs instead of MemoryGet",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_error(error: anyhow::Error) -> crate::tool::ToolError {
+        error
+            .downcast_ref::<crate::tool::ToolError>()
+            .expect("tool error")
+            .clone()
+    }
+
+    #[test]
+    fn source_ref_accepts_known_memory_prefixes() {
+        for source_ref in [
+            "agent_memory:self",
+            "workspace_profile:ws-123",
+            "brief:abc",
+            "episode:ep_123",
+            "work_item:work_123",
+        ] {
+            assert_eq!(
+                validate_source_ref(source_ref.to_string()).unwrap(),
+                source_ref
+            );
+        }
+    }
+
+    #[test]
+    fn source_ref_rejects_paths_and_unknown_prefixes() {
+        for source_ref in [
+            "/Users/jolestar/.agents/skills/agentinbox/SKILL.md",
+            "skill:/Users/jolestar/.agents/skills/agentinbox/SKILL.md",
+            "skill.md:/Users/jolestar/.agents/skills/agentinbox/SKILL.md",
+            "agentinbox:///SKILL.md",
+            "memory:invalid-ref-123",
+        ] {
+            let error = tool_error(validate_source_ref(source_ref.to_string()).unwrap_err());
+            assert_eq!(error.kind, "invalid_tool_input");
+            assert_eq!(
+                error.recovery_hint.as_deref(),
+                Some("call MemorySearch first and copy one returned source_ref verbatim; use ExecCommand for workspace files or skill docs instead of MemoryGet")
+            );
+        }
+    }
+
+    #[test]
+    fn source_ref_rejects_empty_suffix_and_whitespace() {
+        let empty_suffix = tool_error(validate_source_ref("brief:".to_string()).unwrap_err());
+        assert_eq!(empty_suffix.kind, "invalid_tool_input");
+        assert!(empty_suffix
+            .details
+            .as_ref()
+            .and_then(|details| details.get("validation_error"))
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("missing")));
+
+        let whitespace = tool_error(validate_source_ref("brief:abc def".to_string()).unwrap_err());
+        assert_eq!(whitespace.kind, "invalid_tool_input");
+        assert!(whitespace
+            .details
+            .as_ref()
+            .and_then(|details| details.get("validation_error"))
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("whitespace")));
+    }
+
+    #[test]
+    fn max_chars_accepts_omitted_and_bounded_values() {
+        assert_eq!(validate_max_chars(None).unwrap(), None);
+        assert_eq!(validate_max_chars(Some(1)).unwrap(), Some(1));
+        assert_eq!(
+            validate_max_chars(Some(MAX_CHARS_MAX)).unwrap(),
+            Some(MAX_CHARS_MAX)
+        );
+    }
+
+    #[test]
+    fn max_chars_rejects_zero_and_oversized_values() {
+        for max_chars in [0, MAX_CHARS_MAX + 1] {
+            let error = tool_error(validate_max_chars(Some(max_chars)).unwrap_err());
+            assert_eq!(error.kind, "invalid_tool_input");
+            assert!(error
+                .details
+                .as_ref()
+                .and_then(|details| details.get("maximum"))
+                .is_some());
+        }
+    }
 }

--- a/src/tool/tools/memory_search.rs
+++ b/src/tool/tools/memory_search.rs
@@ -34,7 +34,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<MemorySearchArgs>(
             NAME,
-            "Search Holon memory sources, including agent memory markdown and runtime evidence. Normal workspace markdown is not included.",
+            "Search Holon memory sources, including agent memory markdown and runtime evidence. Normal workspace markdown is not included. Each result includes an opaque source_ref that can be copied verbatim to MemoryGet.",
         )?,
     })
 }

--- a/src/tool/tools/sleep.rs
+++ b/src/tool/tools/sleep.rs
@@ -18,6 +18,7 @@ pub(crate) const NAME: &str = "Sleep";
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub(crate) struct SleepArgs {
     pub(crate) reason: Option<String>,
+    #[schemars(range(min = 1))]
     pub(crate) duration_ms: Option<u64>,
 }
 
@@ -26,7 +27,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<SleepArgs>(
             NAME,
-            "Mark the current loop as done so the agent can sleep when no other work remains, or wake again after a short session-local `duration_ms` delay.",
+            "Mark the current loop as done so the agent can sleep when no other work remains. Omit `duration_ms` for ordinary rest, or provide a positive short session-local delay to wake again.",
         )?,
     })
 }


### PR DESCRIPTION
## Summary

Fixes #817 by tightening the tool contract around Sleep and MemoryGet while keeping model-output recovery tolerant where it matters.

- Treat `Sleep({ duration_ms: 0 })` as omitted at runtime, while emitting a schema minimum of `1` and prompting models to omit the field for ordinary indefinite rest.
- Validate `MemoryGet.source_ref` as an opaque handle copied from `MemorySearch` results, rejecting paths, URLs, unknown prefixes, whitespace, and empty identifiers with recovery guidance.
- Bound `MemoryGet.max_chars` to `1..=50000` in both emitted schema and runtime validation.
- Clarify the Sleep and memory-source contracts in runtime docs/RFC text.

## Verification

- `cargo fmt`
- `cargo test --lib tool::tools::memory_get -- --test-threads=1`
- `cargo test --lib tool::helpers::tests::sleep_duration -- --test-threads=1`
- `cargo test --lib tool::dispatch::tests:: -- --test-threads=1`
- `cargo test --lib provider::tests::tool_schema::openai_request_payload_validates_full_tool_matrix_in_strict_mode -- --test-threads=1`
- `cargo check --all-targets` (passes with existing warnings)
- `git diff --check`
