### PR TITLE
provider: expose fallback attempt timeline for diagnostics (issue #833)

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -142,6 +142,8 @@ type ProviderAttemptRecord = {
 
 type ProviderAttemptTimeline = {
   attempts: ProviderAttemptRecord[]
+  requested_model_ref: string
+  active_model_ref?: string
   winning_model_ref?: string
   aggregated_token_usage?: TokenUsage
 }
@@ -162,8 +164,8 @@ Phase-1 visibility rules:
   - `provider_round_completed`
   - `terminal_delivery_round_completed`
   - `runtime_error`
-   - transcript `AssistantRound` entries
-   - transcript `RuntimeFailure` entries
+  - transcript `AssistantRound` entries
+  - transcript `RuntimeFailure` entries
 - this issue does not define any TUI presentation; future surfaces should
   consume the same contract
 

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -249,6 +249,19 @@ pub(crate) fn invalid_response_error(
     )
 }
 
+fn sanitize_transport_url(raw: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(raw) else {
+        return raw.to_string();
+    };
+
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+
+    url.to_string()
+}
+
 fn reqwest_transport_diagnostics(
     stage: &str,
     provider: &str,
@@ -262,8 +275,8 @@ fn reqwest_transport_diagnostics(
         provider: Some(provider.to_string()),
         model_ref: model_ref.map(ToString::to_string),
         url: url
-            .map(ToString::to_string)
-            .or_else(|| error.url().map(|url| url.to_string())),
+            .or_else(|| error.url().map(reqwest::Url::as_str))
+            .map(sanitize_transport_url),
         status: error.status().map(|status| status.as_u16()),
         reqwest: Some(ReqwestTransportDiagnostics {
             is_timeout: error.is_timeout(),
@@ -311,5 +324,18 @@ pub(crate) fn format_provider_failure(
             "{model_ref}: fail_fast ({kind}{status}): {error}",
             kind = classification.kind.as_str()
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn transport_url_sanitizer_removes_credentials_query_and_fragment() {
+        assert_eq!(
+            super::sanitize_transport_url(
+                "https://user:secret@example.com/v1/responses?api_key=token#frag"
+            ),
+            "https://example.com/v1/responses"
+        );
     }
 }

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -1019,6 +1019,103 @@ async fn provider_fallback_continues_after_retry_exhaustion() {
 }
 
 #[tokio::test]
+async fn provider_fallback_continues_immediately_after_fail_fast_error() {
+    let openai_attempts = Arc::new(AtomicUsize::new(0));
+    let openai_server_attempts = openai_attempts.clone();
+    let openai_base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move || {
+            let attempts = openai_server_attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                (axum::http::StatusCode::BAD_REQUEST, "bad request").into_response()
+            }
+        }),
+    ))
+    .await;
+
+    let anthropic_attempts = Arc::new(AtomicUsize::new(0));
+    let anthropic_server_attempts = anthropic_attempts.clone();
+    let anthropic_base_url = spawn_test_server(
+        Router::new()
+            .route(
+                "/v1/messages",
+                post(move |State(attempts): State<Arc<AtomicUsize>>| async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Json(json!({
+                        "content": [{ "type": "text", "text": "anthropic fallback" }],
+                        "stop_reason": "end_turn",
+                        "usage": { "input_tokens": 4, "output_tokens": 2 }
+                    }))
+                }),
+            )
+            .with_state(anthropic_server_attempts),
+    )
+    .await;
+
+    let mut fixture = test_config(
+        "openai/gpt-5.4",
+        &["anthropic/claude-sonnet-4-6"],
+        Some("openai-key"),
+        Some("anthropic-token"),
+        false,
+    );
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = openai_base_url;
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::anthropic())
+        .unwrap()
+        .base_url = anthropic_base_url;
+
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+    let (response, diagnostics) = provider
+        .complete_turn_with_diagnostics(provider_turn_request())
+        .await
+        .unwrap();
+
+    assert_eq!(openai_attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(anthropic_attempts.load(Ordering::SeqCst), 1);
+    let timeline = diagnostics.expect("missing attempt timeline");
+    assert_eq!(timeline.attempts.len(), 2);
+    assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
+    assert_eq!(
+        timeline.active_model_ref.as_deref(),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert_eq!(
+        timeline.winning_model_ref.as_deref(),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert_eq!(
+        timeline.attempts[0].outcome,
+        ProviderAttemptOutcome::FailFastAborted
+    );
+    assert_eq!(
+        timeline.attempts[0].failure_kind.as_deref(),
+        Some("contract_error")
+    );
+    assert_eq!(
+        timeline.attempts[0].disposition.as_deref(),
+        Some("fail_fast")
+    );
+    assert!(timeline.attempts[0].advanced_to_fallback);
+    assert_eq!(timeline.attempts[0].attempt, 1);
+    assert_eq!(
+        timeline.attempts[1].outcome,
+        ProviderAttemptOutcome::Succeeded
+    );
+    assert!(
+        matches!(&response.blocks[0], ModelBlock::Text { text } if text == "anthropic fallback")
+    );
+}
+
+#[tokio::test]
 async fn provider_fallback_can_be_disabled_for_retry_exhaustion() {
     let openai_attempts = Arc::new(AtomicUsize::new(0));
     let openai_server_attempts = openai_attempts.clone();


### PR DESCRIPTION
## What changed

- docs/runtime-spec.md: Align the ProviderAttemptTimeline contract to include `requested_model_ref` and `active_model_ref` fields that the runtime already emits in `provider_round_completed` and transcript events.

- src/provider/retry.rs: Add `sanitize_transport_url` to strip credentials, query, and fragment from transport diagnostic URLs at construction time, ensuring that all structured timeline surfaces (not just failure artifacts) do not leak secrets. Add a small unit test `transport_url_sanitizer_removes_credentials_query_and_fragment`.

- src/provider/tests/routing_auth_doctor.rs: Add a focused provider integration test `provider_fallback_continues_immediately_after_fail_fast_error` that verifies a fail-fast error (e.g., 400 contract error) on the primary provider advances to the next configured provider and that the timeline records the correct `requested_model_ref`, `active_model_ref`, `winning_model_ref`, attempt outcomes, and `advanced_to_fallback` flag.

## Why

Issue #833 requested structured fallback attempt timelines so operators/agents can distinguish immediate fail-fast fallback from retry-then-fallback, and see the final winning provider/model. The existing runtime already records and persists these timelines in audit and transcript events; this PR adds test coverage and doc alignment to confirm the behavior. The URL sanitizer is a small privacy hardening to prevent credential/query/fragment leakage in structured diagnostics.

## Verification

- New test `provider_fallback_continues_immediately_after_fail_fast_error` passes, covering fail-fast-to-fallback with full timeline checks.
- Existing tests for retry-then-fallback and successful rounds continue to pass.
- Unit test `transport_url_sanitizer_removes_credentials_query_and_fragment` verifies the sanitizer strips `user:secret`, query, and fragment from URLs.
- No changes to provider execution logic or retry/fallback policy.

## Notes

No PM/architecture review required: this is minimal observability hardening and test coverage for behavior already implemented and surfaced in runtime events. The runtime contract was implicitly present; we merely align the spec and cover the missing fail-fast-to-fallback path with a test.