### PR TITLE
fix(openai): stabilize responses append matching

### DIFF
--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -2985,7 +2985,9 @@ function incrementalContinuationDiagnostic(provider, round, requestLoweringMode,
       incremental_input_items: numberOrNull(
         requestDiagnostics.incremental_continuation.incremental_input_items
       ),
-      full_input_items: numberOrNull(requestDiagnostics.incremental_continuation.full_input_items)
+      full_input_items: numberOrNull(requestDiagnostics.incremental_continuation.full_input_items),
+      first_mismatch_path: requestDiagnostics.incremental_continuation.first_mismatch_path ?? null,
+      mismatch_kind: requestDiagnostics.incremental_continuation.mismatch_kind ?? null
     };
   }
   if (round <= 1) {
@@ -3446,6 +3448,7 @@ function summarizeTokenOptimizationRounds(rounds) {
   let openaiRemoteCompactionInputItems = 0;
   let openaiRemoteCompactionOutputItems = 0;
   let openaiRemoteCompactionItems = 0;
+  const incrementalMismatchKinds = {};
   let cacheMissWithContextManagementAppliedRounds = 0;
   let cacheRecoveredAfterContextManagementAppliedRounds = 0;
   let previousContextManagementAppliedMiss = false;
@@ -3468,6 +3471,10 @@ function summarizeTokenOptimizationRounds(rounds) {
     const reason = round.incremental_continuation?.fallback_reason;
     if (reason) {
       incrementalFallbackReasons[reason] = (incrementalFallbackReasons[reason] ?? 0) + 1;
+    }
+    const mismatchKind = round.incremental_continuation?.mismatch_kind;
+    if (mismatchKind) {
+      incrementalMismatchKinds[mismatchKind] = (incrementalMismatchKinds[mismatchKind] ?? 0) + 1;
     }
     if (round.context_management?.status === "enabled") {
       contextManagementEnabledRounds += 1;
@@ -3547,6 +3554,7 @@ function summarizeTokenOptimizationRounds(rounds) {
     cache_creation_input_tokens: cacheCreationInputTokens,
     high_input_zero_cache_read_rounds: highInputZeroCacheReadRounds,
     incremental_fallback_reasons: incrementalFallbackReasons,
+    incremental_mismatch_kinds: incrementalMismatchKinds,
     context_management_enabled_rounds: contextManagementEnabledRounds,
     context_management_eligible_tool_result_bytes: contextManagementEligibleToolResultBytes,
     context_management_eligible_tool_result_count: contextManagementEligibleToolResultCount,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -191,6 +191,10 @@ pub struct ProviderIncrementalContinuationDiagnostics {
     pub current_item_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_shape_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_mismatch_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mismatch_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -42,6 +42,27 @@ fn openai_text_response(response_id: &str, text: &str) -> Value {
     })
 }
 
+fn openai_text_response_with_provider_metadata(response_id: &str, text: &str) -> Value {
+    json!({
+        "id": response_id,
+        "status": "completed",
+        "usage": { "input_tokens": 2, "output_tokens": 1 },
+        "output": [{
+            "type": "message",
+            "id": "msg_non_persisted",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{
+                "type": "output_text",
+                "text": text,
+                "annotations": [{ "type": "file_citation", "index": 0 }],
+                "metadata": { "provider_only": true },
+                "status": "completed"
+            }]
+        }]
+    })
+}
+
 fn openai_text_sse_response(response_id: &str, text: &str) -> String {
     format!(
         concat!(
@@ -132,6 +153,17 @@ fn provider_large_window_paired_followup_with_prompt_frame() -> ProviderTurnRequ
     request
 }
 
+fn provider_text_followup_with_prompt_frame(previous_text: &str) -> ProviderTurnRequest {
+    let mut request = provider_turn_request_with_prompt_frame();
+    request.conversation.extend([
+        ConversationMessage::AssistantBlocks(vec![ModelBlock::Text {
+            text: previous_text.into(),
+        }]),
+        ConversationMessage::UserText("continue".into()),
+    ]);
+    request
+}
+
 #[tokio::test]
 async fn openai_responses_uses_incremental_continuation_for_strict_append() {
     let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
@@ -188,6 +220,137 @@ async fn openai_responses_uses_incremental_continuation_for_strict_append() {
 }
 
 #[tokio::test]
+async fn openai_responses_uses_incremental_continuation_when_text_output_has_provider_metadata() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Json(openai_text_response_with_provider_metadata(
+                        "resp_1", "ready",
+                    ))
+                } else {
+                    Json(openai_text_response("resp_2", "done"))
+                }
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let response = provider
+        .complete_turn(provider_text_followup_with_prompt_frame("ready"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response
+            .request_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.request_lowering_mode.as_str()),
+        Some("incremental_continuation")
+    );
+    let diagnostics = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.incremental_continuation.as_ref())
+        .expect("incremental diagnostics");
+    assert_eq!(diagnostics.status, "hit");
+    assert_eq!(diagnostics.fallback_reason, None);
+    assert_eq!(diagnostics.incremental_input_items, Some(1));
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 2);
+    assert_eq!(bodies[1]["previous_response_id"], json!("resp_1"));
+    assert_eq!(bodies[1]["input"].as_array().unwrap().len(), 1);
+    assert_eq!(bodies[1]["input"][0]["role"], json!("user"));
+}
+
+#[tokio::test]
+async fn openai_codex_append_match_replays_provider_window_without_previous_response_id() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/codex/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                let response = if attempt == 0 {
+                    openai_text_sse_response("resp_1", "ready")
+                } else {
+                    openai_text_sse_response("resp_2", "done")
+                };
+                ([("content-type", "text/event-stream")], response)
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let response = provider
+        .complete_turn(provider_text_followup_with_prompt_frame("ready"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response
+            .request_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.request_lowering_mode.as_str()),
+        Some("provider_window_replay")
+    );
+    let diagnostics = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.incremental_continuation.as_ref())
+        .expect("incremental diagnostics");
+    assert_eq!(diagnostics.status, "hit");
+    assert_eq!(diagnostics.fallback_reason, None);
+    assert_eq!(diagnostics.incremental_input_items, Some(1));
+    let bodies = captured_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 2);
+    assert!(bodies[1].get("previous_response_id").is_none());
+    let input = bodies[1]["input"].as_array().unwrap();
+    assert_eq!(input.len(), 3);
+    assert_eq!(input[1]["role"], json!("assistant"));
+    assert_eq!(input[2]["role"], json!("user"));
+}
+
+#[tokio::test]
 async fn openai_responses_remote_compacts_provider_window_and_replays_compaction_items() {
     let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
     let response_bodies_for_server = response_bodies.clone();
@@ -206,7 +369,7 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
                         captured.lock().unwrap().push(body);
                         let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                         let response = match attempt {
-                            0 => openai_text_response("resp_1", "ready"),
+                            0 => openai_text_response_with_provider_metadata("resp_1", "ready"),
                             _ => openai_text_response("resp_2", "done"),
                         };
                         Json(response)
@@ -1307,8 +1470,76 @@ async fn openai_responses_falls_back_when_conversation_is_not_append_only() {
     assert!(diagnostics.previous_item_hash.is_some());
     assert!(diagnostics.current_item_hash.is_none());
     assert!(diagnostics.request_shape_hash.is_some());
+    assert_eq!(diagnostics.first_mismatch_path.as_deref(), Some("/1"));
+    assert_eq!(
+        diagnostics.mismatch_kind.as_deref(),
+        Some("length_mismatch")
+    );
     let bodies = captured_bodies.lock().unwrap();
     assert_eq!(bodies.len(), 2);
+    assert!(bodies[1].get("previous_response_id").is_none());
+}
+
+#[tokio::test]
+async fn openai_responses_reports_semantic_mismatch_path_for_changed_assistant_text() {
+    let captured_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured_for_server = captured_bodies.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_server = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/responses",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured_for_server.clone();
+            let attempts = attempts_for_server.clone();
+            async move {
+                captured.lock().unwrap().push(body);
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Json(openai_text_response("resp_1", "ready"))
+                } else {
+                    Json(openai_text_response("resp_2", "done"))
+                }
+            }
+        }),
+    ))
+    .await;
+    let mut fixture = test_config("openai/gpt-5.4", &[], Some("openai-key"), None, false);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai())
+        .unwrap()
+        .base_url = base_url;
+    let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    provider
+        .complete_turn(provider_turn_request_with_prompt_frame())
+        .await
+        .unwrap();
+    let response = provider
+        .complete_turn(provider_text_followup_with_prompt_frame("changed"))
+        .await
+        .unwrap();
+
+    let diagnostics = response
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.incremental_continuation.as_ref())
+        .expect("incremental continuation diagnostics");
+    assert_eq!(
+        diagnostics.fallback_reason.as_deref(),
+        Some("conversation_not_strict_append_only")
+    );
+    assert_eq!(diagnostics.first_mismatch_index, Some(1));
+    assert_eq!(
+        diagnostics.first_mismatch_path.as_deref(),
+        Some("/1/content/0/text")
+    );
+    assert_eq!(
+        diagnostics.mismatch_kind.as_deref(),
+        Some("semantic_mismatch")
+    );
+    let bodies = captured_bodies.lock().unwrap();
     assert!(bodies[1].get("previous_response_id").is_none());
 }
 

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1427,12 +1427,10 @@ fn openai_append_match_output_items(output_items: &[Value]) -> Vec<Value> {
 }
 
 fn openai_append_match_output_item(item: &Value) -> Option<Value> {
-    match item.get("type").and_then(Value::as_str) {
-        Some("message" | "function_call" | "custom_tool_call") => {
-            Some(canonicalize_openai_append_match_item(item))
-        }
-        Some("reasoning") => None,
-        _ => Some(canonicalize_openai_append_match_item(item)),
+    if matches!(item.get("type").and_then(Value::as_str), Some("reasoning")) {
+        None
+    } else {
+        Some(canonicalize_openai_append_match_item(item))
     }
 }
 

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -133,7 +133,7 @@ struct OpenAiRequestShape {
 struct OpenAiRequestPlan {
     body: Value,
     scope: Option<OpenAiContinuationScope>,
-    full_input: Vec<Value>,
+    append_match_input: Vec<Value>,
     provider_input: Vec<Value>,
     request_shape: OpenAiRequestShape,
     diagnostics: ProviderRequestDiagnostics,
@@ -150,6 +150,8 @@ struct OpenAiContinuationMismatchDiagnostics {
     previous_item_hash: Option<String>,
     current_item_hash: Option<String>,
     request_shape_hash: Option<String>,
+    first_mismatch_path: Option<String>,
+    mismatch_kind: Option<String>,
 }
 
 #[derive(Debug)]
@@ -296,7 +298,7 @@ impl AgentProvider for OpenAiProvider {
             ToolSchemaContract::Relaxed,
             None,
         )?;
-        let mut plan = plan_openai_responses_request(body, &request, &self.continuation)?;
+        let mut plan = plan_openai_responses_request(body, &request, &self.continuation, true)?;
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
@@ -335,7 +337,7 @@ impl AgentProvider for OpenAiProvider {
             &self.continuation,
             plan_scope.clone(),
             plan_request_shape.clone(),
-            plan.full_input,
+            plan.append_match_input,
             plan.provider_input,
             &parsed,
         );
@@ -379,7 +381,7 @@ impl AgentProvider for OpenAiCodexProvider {
             ToolSchemaContract::Relaxed,
             self.reasoning_effort.as_deref(),
         )?;
-        let mut plan = plan_openai_responses_request(body, &request, &self.continuation)?;
+        let mut plan = plan_openai_responses_request(body, &request, &self.continuation, false)?;
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
@@ -422,7 +424,7 @@ impl AgentProvider for OpenAiCodexProvider {
             &self.continuation,
             plan_scope.clone(),
             plan_request_shape.clone(),
-            plan.full_input,
+            plan.append_match_input,
             plan.provider_input,
             &parsed,
         );
@@ -491,7 +493,7 @@ impl AgentProvider for OpenAiChatCompletionsProvider {
             &self.continuation,
             plan.scope,
             plan.request_shape,
-            plan.full_input,
+            plan.append_match_input,
             plan.provider_input,
             &parsed,
         );
@@ -632,7 +634,7 @@ fn plan_chat_completion_request(
             OpenAiRequestPlan {
                 body: full_body,
                 scope,
-                full_input: full_messages.clone(),
+                append_match_input: full_messages.clone(),
                 provider_input: full_messages,
                 request_shape,
                 diagnostics: incremental_diagnostics(
@@ -659,7 +661,7 @@ fn plan_chat_completion_request(
             OpenAiRequestPlan {
                 body: full_body,
                 scope,
-                full_input: full_messages.clone(),
+                append_match_input: full_messages.clone(),
                 provider_input: full_messages,
                 request_shape,
                 diagnostics: incremental_diagnostics(
@@ -683,7 +685,7 @@ fn plan_chat_completion_request(
             OpenAiRequestPlan {
                 body: full_body,
                 scope,
-                full_input: full_messages.clone(),
+                append_match_input: full_messages.clone(),
                 provider_input: full_messages,
                 request_shape,
                 diagnostics: incremental_diagnostics(
@@ -712,7 +714,7 @@ fn plan_chat_completion_request(
         OpenAiRequestPlan {
             body: full_body,
             scope,
-            full_input: full_messages.clone(),
+            append_match_input: full_messages.clone(),
             provider_input: full_messages,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -934,6 +936,7 @@ fn plan_openai_responses_request(
     mut body: Value,
     request: &ProviderTurnRequest,
     continuation: &Arc<Mutex<OpenAiContinuationState>>,
+    allow_previous_response_id: bool,
 ) -> Result<OpenAiRequestPlan> {
     let full_input = body
         .get("input")
@@ -946,6 +949,7 @@ fn plan_openai_responses_request(
             )
         })?;
     let full_input_items = full_input.len();
+    let append_match_input = openai_append_match_input_items(&full_input);
     let request_shape = request_shape_without_input(&body, request);
     let scope = continuation_scope(request);
     let request_controls = Some(openai_request_controls_diagnostics(&body));
@@ -953,7 +957,7 @@ fn plan_openai_responses_request(
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input: full_input.clone(),
+            append_match_input,
             provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -974,7 +978,7 @@ fn plan_openai_responses_request(
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input: full_input.clone(),
+            append_match_input,
             provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -993,7 +997,7 @@ fn plan_openai_responses_request(
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input: full_input.clone(),
+            append_match_input,
             provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -1011,16 +1015,19 @@ fn plan_openai_responses_request(
     }
 
     let expected_prefix = previous.append_match_items.clone();
-    let mismatch =
-        openai_continuation_mismatch_diagnostics(&expected_prefix, &full_input, &request_shape);
+    let mismatch = openai_continuation_mismatch_diagnostics(
+        &expected_prefix,
+        &append_match_input,
+        &request_shape,
+    );
     if expected_prefix.is_empty()
-        || full_input.len() <= expected_prefix.len()
-        || !full_input.starts_with(&expected_prefix)
+        || append_match_input.len() <= expected_prefix.len()
+        || !append_match_input.starts_with(&expected_prefix)
     {
         return Ok(OpenAiRequestPlan {
             body,
             scope,
-            full_input: full_input.clone(),
+            append_match_input,
             provider_input: full_input,
             request_shape,
             diagnostics: incremental_diagnostics(
@@ -1035,8 +1042,12 @@ fn plan_openai_responses_request(
     }
 
     let incremental_input = full_input[expected_prefix.len()..].to_vec();
-    let has_response_id = previous.response_id.is_some();
-    let provider_input = if let Some(response_id) = previous.response_id {
+    let response_id = allow_previous_response_id
+        .then(|| previous.response_id.clone())
+        .flatten();
+    let has_response_id = response_id.is_some();
+    let replay_is_compacted = previous.latest_compaction_index.is_some();
+    let provider_input = if let Some(response_id) = response_id {
         body["input"] = Value::Array(incremental_input.clone());
         body["previous_response_id"] = Value::String(response_id);
         incremental_input.clone()
@@ -1050,15 +1061,14 @@ fn plan_openai_responses_request(
     Ok(OpenAiRequestPlan {
         body,
         scope,
-        full_input,
+        append_match_input,
         provider_input,
         request_shape,
         diagnostics: ProviderRequestDiagnostics {
-            request_lowering_mode: if has_response_id {
-                "incremental_continuation".into()
-            } else {
-                "provider_window_compacted".into()
-            },
+            request_lowering_mode: openai_append_match_lowering_mode(
+                has_response_id,
+                replay_is_compacted,
+            ),
             anthropic_cache: None,
             anthropic_context_management: None,
             openai_request_controls: request_controls,
@@ -1077,9 +1087,21 @@ fn plan_openai_responses_request(
                 previous_item_hash: None,
                 current_item_hash: None,
                 request_shape_hash: Some(request_shape_hash),
+                first_mismatch_path: None,
+                mismatch_kind: None,
             }),
         },
     })
+}
+
+fn openai_append_match_lowering_mode(has_response_id: bool, replay_is_compacted: bool) -> String {
+    if has_response_id {
+        "incremental_continuation".into()
+    } else if replay_is_compacted {
+        "provider_window_compacted".into()
+    } else {
+        "provider_window_replay".into()
+    }
 }
 
 fn continuation_scope(request: &ProviderTurnRequest) -> Option<OpenAiContinuationScope> {
@@ -1120,6 +1142,14 @@ fn openai_continuation_mismatch_diagnostics(
         });
     let previous = first_mismatch_index.and_then(|index| expected_prefix.get(index));
     let current = first_mismatch_index.and_then(|index| full_input.get(index));
+    let item_path = match (first_mismatch_index, previous, current) {
+        (Some(index), Some(previous), Some(current)) => {
+            let suffix = first_json_mismatch_path(previous, current).unwrap_or_default();
+            Some(format!("/{index}{suffix}"))
+        }
+        (Some(index), _, _) => Some(format!("/{index}")),
+        _ => None,
+    };
     OpenAiContinuationMismatchDiagnostics {
         expected_prefix_items: expected_prefix.len(),
         first_mismatch_index,
@@ -1130,6 +1160,93 @@ fn openai_continuation_mismatch_diagnostics(
         previous_item_hash: previous.map(openai_item_hash),
         current_item_hash: current.map(openai_item_hash),
         request_shape_hash: Some(request_shape_hash(request_shape)),
+        first_mismatch_path: item_path.clone(),
+        mismatch_kind: Some(openai_mismatch_kind(
+            previous,
+            current,
+            item_path.as_deref(),
+        )),
+    }
+}
+
+fn first_json_mismatch_path(previous: &Value, current: &Value) -> Option<String> {
+    if previous == current {
+        return None;
+    }
+    match (previous, current) {
+        (Value::Array(previous), Value::Array(current)) => {
+            let shared = previous.len().min(current.len());
+            for index in 0..shared {
+                if let Some(path) = first_json_mismatch_path(&previous[index], &current[index]) {
+                    return Some(format!("/{index}{path}"));
+                }
+            }
+            Some(format!("/{shared}"))
+        }
+        (Value::Object(previous), Value::Object(current)) => {
+            let keys = previous
+                .keys()
+                .chain(current.keys())
+                .collect::<std::collections::BTreeSet<_>>();
+            for key in keys {
+                match (previous.get(key), current.get(key)) {
+                    (Some(previous), Some(current)) => {
+                        if let Some(path) = first_json_mismatch_path(previous, current) {
+                            return Some(format!("/{}{}", json_pointer_escape(key), path));
+                        }
+                    }
+                    _ => return Some(format!("/{}", json_pointer_escape(key))),
+                }
+            }
+            Some(String::new())
+        }
+        _ => Some(String::new()),
+    }
+}
+
+fn json_pointer_escape(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
+}
+
+fn openai_mismatch_kind(
+    previous: Option<&Value>,
+    current: Option<&Value>,
+    path: Option<&str>,
+) -> String {
+    let Some(previous) = previous else {
+        return "length_mismatch".into();
+    };
+    let Some(current) = current else {
+        return "length_mismatch".into();
+    };
+    let previous_type = openai_item_type(previous);
+    let current_type = openai_item_type(current);
+    if previous_type != current_type {
+        return "semantic_mismatch".into();
+    }
+    let path = path.unwrap_or_default();
+    if path.contains("/id")
+        || path.contains("/status")
+        || path.contains("/metadata")
+        || path.contains("/annotations")
+        || path.contains("/logprobs")
+    {
+        return "provider_metadata_only".into();
+    }
+    match previous_type.as_str() {
+        "message" => {
+            if previous.get("role").and_then(Value::as_str) == Some("assistant")
+                && path.contains("/content")
+                && !path.ends_with("/text")
+            {
+                "assistant_text_shape".into()
+            } else {
+                "semantic_mismatch".into()
+            }
+        }
+        "function_call" | "custom_tool_call" => "tool_call_shape".into(),
+        "function_call_output" | "custom_tool_call_output" => "tool_result_shape".into(),
+        _ => "semantic_mismatch".into(),
     }
 }
 
@@ -1251,6 +1368,8 @@ fn incremental_diagnostics(
             previous_item_hash: mismatch.previous_item_hash,
             current_item_hash: mismatch.current_item_hash,
             request_shape_hash: mismatch.request_shape_hash,
+            first_mismatch_path: mismatch.first_mismatch_path,
+            mismatch_kind: mismatch.mismatch_kind,
         }),
     }
 }
@@ -1259,7 +1378,7 @@ fn update_openai_continuation(
     continuation: &Arc<Mutex<OpenAiContinuationState>>,
     scope: Option<OpenAiContinuationScope>,
     request_shape: OpenAiRequestShape,
-    full_input: Vec<Value>,
+    append_match_input: Vec<Value>,
     provider_input: Vec<Value>,
     parsed: &ParsedOpenAiResponse,
 ) {
@@ -1280,7 +1399,7 @@ fn update_openai_continuation(
                     .iter()
                     .map(canonicalize_openai_provider_item),
             );
-            let mut append_match_items = full_input;
+            let mut append_match_items = append_match_input;
             append_match_items.extend(openai_append_match_output_items(&parsed.output_items));
             Some(OpenAiProviderWindow {
                 response_id: Some(response_id.clone()),
@@ -1310,10 +1429,10 @@ fn openai_append_match_output_items(output_items: &[Value]) -> Vec<Value> {
 fn openai_append_match_output_item(item: &Value) -> Option<Value> {
     match item.get("type").and_then(Value::as_str) {
         Some("message" | "function_call" | "custom_tool_call") => {
-            Some(canonicalize_openai_provider_item(item))
+            Some(canonicalize_openai_append_match_item(item))
         }
         Some("reasoning") => None,
-        _ => Some(canonicalize_openai_provider_item(item)),
+        _ => Some(canonicalize_openai_append_match_item(item)),
     }
 }
 
@@ -1547,7 +1666,7 @@ async fn maybe_compact_openai_request_plan(
         request_shape: plan.request_shape.clone(),
         latest_compaction_index: latest_openai_compaction_index(&compactable_items),
         items: compactable_items,
-        append_match_items: plan.full_input.clone(),
+        append_match_items: plan.append_match_input.clone(),
         generation: previous.generation,
     };
     let candidate = match openai_provider_window_compaction_candidate(&compactable_window) {
@@ -1978,9 +2097,16 @@ fn sanitize_openai_store_false_compact_items(items: &[Value]) -> Vec<Value> {
         .collect()
 }
 
-// Provider windows are replayed into future OpenAI requests and compared
-// against locally rebuilt input for append-only continuation. Normalize
-// provider-only transport fields so equivalent conversation items stay stable.
+fn openai_append_match_input_items(items: &[Value]) -> Vec<Value> {
+    items
+        .iter()
+        .map(canonicalize_openai_append_match_item)
+        .collect()
+}
+
+// Provider windows are replayed into future OpenAI requests and compact calls.
+// Keep their wire shape close to OpenAI's item contract while stripping fields
+// that are not accepted on replay.
 fn canonicalize_openai_provider_item(item: &Value) -> Value {
     let mut item = openai_without_provider_item_id(item);
     let Some(object) = item.as_object_mut() else {
@@ -2006,6 +2132,128 @@ fn canonicalize_openai_provider_item(item: &Value) -> Value {
         }
     }
     item
+}
+
+// Append matching compares provider outputs against Holon-rebuilt input. Use a
+// semantic form that preserves item order and conversational meaning while
+// ignoring provider-only metadata and nested text decorations.
+fn canonicalize_openai_append_match_item(item: &Value) -> Value {
+    let item = openai_without_provider_item_id(item);
+    let Some(object) = item.as_object() else {
+        return item;
+    };
+    match object.get("type").and_then(Value::as_str) {
+        Some("message") => canonicalize_openai_append_match_message(object),
+        Some("function_call") => canonicalize_openai_append_match_function_call(object),
+        Some("custom_tool_call") => canonicalize_openai_append_match_custom_tool_call(object),
+        Some("function_call_output" | "custom_tool_call_output") => json!({
+            "type": object.get("type").cloned().unwrap_or(Value::Null),
+            "call_id": object.get("call_id").cloned().unwrap_or(Value::Null),
+            "output": object.get("output").cloned().unwrap_or(Value::Null),
+        }),
+        Some("compaction_summary") => {
+            let mut canonical = json!({ "type": "compaction" });
+            if let Some(encrypted_content) = object.get("encrypted_content") {
+                canonical["encrypted_content"] = encrypted_content.clone();
+            }
+            canonical
+        }
+        Some("compaction") => {
+            let mut canonical = json!({ "type": "compaction" });
+            if let Some(encrypted_content) = object.get("encrypted_content") {
+                canonical["encrypted_content"] = encrypted_content.clone();
+            }
+            canonical
+        }
+        Some(_) | None => canonicalize_openai_provider_item(&item),
+    }
+}
+
+fn canonicalize_openai_append_match_message(object: &serde_json::Map<String, Value>) -> Value {
+    let role = object
+        .get("role")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let content = object
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| canonicalize_openai_append_match_content_item(role, item))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    json!({
+        "type": "message",
+        "role": role,
+        "content": content,
+    })
+}
+
+fn canonicalize_openai_append_match_content_item(role: &str, item: &Value) -> Value {
+    let Some(object) = item.as_object() else {
+        return item.clone();
+    };
+    let item_type = object.get("type").and_then(Value::as_str);
+    if matches!(
+        item_type,
+        Some("output_text" | "input_text" | "text" | "message_text")
+    ) {
+        let normalized_type = if role == "assistant" {
+            "output_text"
+        } else {
+            "input_text"
+        };
+        return json!({
+            "type": normalized_type,
+            "text": object.get("text").cloned().unwrap_or(Value::String(String::new())),
+        });
+    }
+    let mut canonical = serde_json::Map::new();
+    if let Some(item_type) = object.get("type") {
+        canonical.insert("type".into(), item_type.clone());
+    }
+    for key in ["text", "image_url", "file_id", "filename"] {
+        if let Some(value) = object.get(key) {
+            canonical.insert(key.into(), value.clone());
+        }
+    }
+    Value::Object(canonical)
+}
+
+fn canonicalize_openai_append_match_function_call(
+    object: &serde_json::Map<String, Value>,
+) -> Value {
+    let arguments = object
+        .get("arguments")
+        .and_then(Value::as_str)
+        .map(canonicalize_openai_arguments_string)
+        .map(Value::String)
+        .unwrap_or_else(|| object.get("arguments").cloned().unwrap_or(Value::Null));
+    json!({
+        "type": "function_call",
+        "call_id": object.get("call_id").cloned().unwrap_or(Value::Null),
+        "name": object.get("name").cloned().unwrap_or(Value::Null),
+        "arguments": arguments,
+    })
+}
+
+fn canonicalize_openai_append_match_custom_tool_call(
+    object: &serde_json::Map<String, Value>,
+) -> Value {
+    json!({
+        "type": "custom_tool_call",
+        "call_id": object.get("call_id").cloned().unwrap_or(Value::Null),
+        "name": object.get("name").cloned().unwrap_or(Value::Null),
+        "input": object.get("input").cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn canonicalize_openai_arguments_string(arguments: &str) -> String {
+    serde_json::from_str::<Value>(arguments)
+        .map(|parsed| canonical_json(&parsed))
+        .unwrap_or_else(|_| arguments.to_string())
 }
 
 fn openai_without_provider_item_id(item: &Value) -> Value {

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -55,7 +55,19 @@ fn live_append_match_prompt_frame() -> ProviderPromptFrame {
     )
 }
 
-fn text_response(blocks: &[ModelBlock]) -> String {
+fn assistant_text_blocks(blocks: &[ModelBlock]) -> Vec<ModelBlock> {
+    blocks
+        .iter()
+        .filter(|block| matches!(block, ModelBlock::Text { .. }))
+        .cloned()
+        .collect()
+}
+
+fn assistant_response(blocks: &[ModelBlock]) -> ConversationMessage {
+    ConversationMessage::AssistantBlocks(assistant_text_blocks(blocks))
+}
+
+fn response_text(blocks: &[ModelBlock]) -> String {
     blocks
         .iter()
         .filter_map(|block| match block {
@@ -99,7 +111,7 @@ async fn live_openai_codex_replays_provider_window_after_append_match() -> Resul
             tools: vec![],
         })
         .await?;
-    let first_text = text_response(&first.blocks);
+    let first_text = response_text(&first.blocks);
     assert!(
         !first_text.trim().is_empty(),
         "expected text output from first live Codex response"
@@ -110,7 +122,7 @@ async fn live_openai_codex_replays_provider_window_after_append_match() -> Resul
             prompt_frame: frame,
             conversation: vec![
                 ConversationMessage::UserText("Reply with exactly READY.".into()),
-                ConversationMessage::AssistantBlocks(vec![ModelBlock::Text { text: first_text }]),
+                assistant_response(&first.blocks),
                 ConversationMessage::UserText("Reply with exactly DONE.".into()),
             ],
             tools: vec![],

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use holon::{
     config::AppConfig,
+    prompt::PromptStability,
     provider::{
-        AgentProvider, ConversationMessage, ModelBlock, OpenAiCodexProvider, ProviderTurnRequest,
+        AgentProvider, ConversationMessage, ModelBlock, OpenAiCodexProvider, PromptContentBlock,
+        ProviderPromptCache, ProviderPromptFrame, ProviderTurnRequest,
     },
     tool::ToolSpec,
 };
@@ -31,6 +33,39 @@ fn probe_tool_spec() -> ToolSpec {
     }
 }
 
+fn live_append_match_prompt_frame() -> ProviderPromptFrame {
+    ProviderPromptFrame::structured(
+        "Reply briefly and follow the user's exact formatting requirements.",
+        vec![PromptContentBlock {
+            text: "stable live append-match probe system block".into(),
+            stability: PromptStability::Stable,
+            cache_breakpoint: true,
+        }],
+        vec![PromptContentBlock {
+            text: "agent-scoped live append-match probe context".into(),
+            stability: PromptStability::AgentScoped,
+            cache_breakpoint: true,
+        }],
+        Some(ProviderPromptCache {
+            agent_id: "live-openai-codex-append-match".into(),
+            prompt_cache_key: "live-openai-codex-append-match".into(),
+            working_memory_revision: 1,
+            compression_epoch: 0,
+        }),
+    )
+}
+
+fn text_response(blocks: &[ModelBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ModelBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
 #[tokio::test]
 #[ignore = "requires real Codex auth state and network access"]
 async fn live_openai_codex_provider_returns_real_response() -> Result<()> {
@@ -46,6 +81,57 @@ async fn live_openai_codex_provider_returns_real_response() -> Result<()> {
         ))
         .await?;
     assert!(!output.blocks.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires real Codex auth state and network access"]
+async fn live_openai_codex_replays_provider_window_after_append_match() -> Result<()> {
+    let config = live_config()?;
+    let provider = OpenAiCodexProvider::from_config(&config, &live_openai_codex_model())?;
+    let frame = live_append_match_prompt_frame();
+    let first = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: frame.clone(),
+            conversation: vec![ConversationMessage::UserText(
+                "Reply with exactly READY.".into(),
+            )],
+            tools: vec![],
+        })
+        .await?;
+    let first_text = text_response(&first.blocks);
+    assert!(
+        !first_text.trim().is_empty(),
+        "expected text output from first live Codex response"
+    );
+
+    let second = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: frame,
+            conversation: vec![
+                ConversationMessage::UserText("Reply with exactly READY.".into()),
+                ConversationMessage::AssistantBlocks(vec![ModelBlock::Text { text: first_text }]),
+                ConversationMessage::UserText("Reply with exactly DONE.".into()),
+            ],
+            tools: vec![],
+        })
+        .await?;
+
+    let diagnostics = second
+        .request_diagnostics
+        .as_ref()
+        .expect("request diagnostics");
+    assert_eq!(
+        diagnostics.request_lowering_mode.as_str(),
+        "provider_window_replay"
+    );
+    let incremental = diagnostics
+        .incremental_continuation
+        .as_ref()
+        .expect("incremental continuation diagnostics");
+    assert_eq!(incremental.status, "hit");
+    assert_eq!(incremental.fallback_reason, None);
+    assert_eq!(incremental.incremental_input_items, Some(1));
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #834

## Summary
- split OpenAI provider replay windows from semantic append-match ledgers so provider-returned metadata does not break continuation matching
- canonicalize Responses message/tool items before append matching and report first mismatch path/kind when fallback is required
- keep standard OpenAI on `previous_response_id` after append-match hits while making OpenAI Codex replay the provider window because the Codex backend rejects `previous_response_id`
- surface mismatch kind summaries in benchmark token optimization diagnostics

## Tests
- `cargo fmt --check`
- `cargo test --lib provider::tests::openai_responses -- --test-threads=1`
- `npm test` in `benchmark/`
- `cargo test --all-targets -- --test-threads=1`
- `cargo test --test live_codex live_openai_codex_replays_provider_window_after_append_match -- --ignored --exact --nocapture`