### PR TITLE
fix: close Agents overlay after Enter confirmation

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1236,6 +1236,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn agent_overlay_enter_keeps_open_on_failed_switch() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.agents = vec![sample_agent_summary("alpha"), sample_agent_summary("beta")];
+        app.selected_agent = 1;
+        app.overlay = OverlayState::Agents;
+        app.connection_state = TuiConnectionState::Streaming;
+
+        let err = app
+            .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .unwrap_err();
+
+        assert_eq!(app.overlay, OverlayState::Agents);
+        assert_eq!(
+            app.status_line,
+            format!("Failed to switch to agent beta: {err}")
+        );
+    }
+
+    #[tokio::test]
     async fn esc_closes_active_overlay_before_touching_prompt() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -627,7 +627,8 @@ impl TuiApp {
                     }
                     Err(err) => {
                         if !agent_id.is_empty() {
-                            self.status_line = format!("Failed to switch to agent {agent_id}: {err}");
+                            self.status_line =
+                                format!("Failed to switch to agent {agent_id}: {err}");
                         }
                         self.overlay = OverlayState::Agents;
                         Err(err)

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -618,6 +618,22 @@ impl TuiApp {
     async fn handle_agents_overlay_key(&mut self, key: KeyEvent) -> Result<()> {
         match key.code {
             KeyCode::Esc => Ok(()),
+            KeyCode::Enter => {
+                let agent_id = self.selected_agent_id().unwrap_or("").to_string();
+                match self.bootstrap_agent_index(self.selected_agent).await {
+                    Ok(()) => {
+                        self.overlay = OverlayState::None;
+                        Ok(())
+                    }
+                    Err(err) => {
+                        if !agent_id.is_empty() {
+                            self.status_line = format!("Failed to switch to agent {agent_id}: {err}");
+                        }
+                        self.overlay = OverlayState::Agents;
+                        Err(err)
+                    }
+                }
+            }
             KeyCode::Up | KeyCode::Char('k') => {
                 self.move_agent_selection(-1).await?;
                 self.overlay = OverlayState::Agents;


### PR DESCRIPTION
## Summary

- Bind `Enter` in the Agents overlay to confirm the current selection and perform an agent bootstrap.
- Keep overlay open and preserve explicit failure status feedback when switch fails.
- Close overlay automatically after a successful switch.
- Keep navigation behavior unchanged.
- Add regression test for Enter failure handling in overlay mode.

Closes #839
