### PR TITLE
Fix WorkItem plan contract and checkpoint invalidation semantics

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1521,7 +1521,7 @@ minimal shape is:
 - `created_at`
 - `items`
 
-Each plan item contains:
+Each persisted plan item contains:
 
 - `step`
 - `status`
@@ -1531,6 +1531,23 @@ The initial plan-step status set is:
 - `pending`
 - `in_progress`
 - `completed`
+
+Model-visible work-item tool results project the same checklist through the RFC
+tool vocabulary instead of exposing the persisted field names. `CreateWorkItem`,
+`UpdateWorkItem`, `GetWorkItem`, and `ListWorkItems(include_plan=true)` return
+plan items as:
+
+- `step`
+- `state`
+
+The model-visible plan-step state set is:
+
+- `pending`
+- `doing`
+- `done`
+
+Tool inputs use the same model-visible `state` vocabulary. The internal
+`status` values remain a storage detail.
 
 The runtime persists a `DeliverySummaryRecord` when `CompleteWorkItem` receives
 an explicit `result_summary`. It is associated with the completed work item and

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1616,6 +1616,14 @@ plan snapshots separately.
 These tools are part of the explicit adoption path for work items. They do not
 require runtime-side semantic resolution of arbitrary ingress into a work item.
 
+Work-plan updates are coordination state, not the artifact progress ledger.
+Prompt guidance should frame `UpdateWorkItem.plan` as bookkeeping after
+material progress such as a file mutation, verification result, blocker
+discovery, or completed inspection objective. A successful work-item mutation
+may invalidate turn-local checkpoint state because the runtime focus changed,
+but failed tool inputs and `ExecCommand` calls do not invalidate checkpoint
+anchors by command-name heuristics.
+
 ### Control-Plane Work-Item Enqueue
 
 The runtime also exposes a control-plane enqueue path for future work items:

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -260,7 +260,7 @@ fn build_system_sections(
         section(
             "work_item_first_execution",
             PromptStability::Stable,
-            "Treat task-like work as WorkItem-first by default. If the turn is more than a brief status answer, casual chat, or a narrow one-shot explanation, do not jump straight into execution when there is no current active work item anchor. First decide whether the delivery target is already clear enough to stabilize as a work item. If it is still ambiguous, proactively communicate with the operator to clarify the real delivery target, acceptance boundary, or priority before making high-commitment edits. Once the target is clear, create or refresh the active work item first, then record a work plan for genuine multi-step work, and only then begin commands, edits, waits, or task coordination. Prefer refreshing the current active work item over creating a new one unless the delivery target has actually changed.".to_string(),
+            "Treat task-like work as WorkItem-first by default. If the turn is more than a brief status answer, casual chat, or a narrow one-shot explanation, do not ignore the absence of a current active work item anchor. First decide whether the delivery target is already clear enough to stabilize as a work item. If it is still ambiguous, proactively communicate with the operator to clarify the real delivery target, acceptance boundary, or priority before making high-commitment edits. If a little local inspection is needed to make the target concrete, do that bounded inspection first, then create or refresh the active work item once the target is stable enough to name. Prefer refreshing the current active work item over creating a new one unless the delivery target has actually changed.".to_string(),
         ),
         section(
             "trust_boundary",
@@ -778,11 +778,14 @@ mod tests {
         assert!(section.content.contains("WorkItem-first"));
         assert!(section
             .content
-            .contains("no current active work item anchor"));
+            .contains("absence of a current active work item anchor"));
         assert!(section.content.contains("clarify the real delivery target"));
         assert!(section
             .content
-            .contains("create or refresh the active work item first"));
+            .contains("local inspection is needed to make the target concrete"));
+        assert!(section
+            .content
+            .contains("once the target is stable enough to name"));
         assert!(section.content.contains("brief status answer"));
     }
 

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -68,7 +68,7 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_work_item_write",
             PromptStability::Stable,
-            "Use CreateWorkItem to create a new open delivery target, PickWorkItem to make an existing open item current, UpdateWorkItem to replace blocked_by and/or the full plan snapshot, and CompleteWorkItem only when the delivery target is actually done. If the current task is not just a brief answer and there is no current work item yet, first clarify the delivery target with the operator if it is still ambiguous; otherwise create and pick the work item before doing commands or edits. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, include or update the plan before execution and always submit the full current checklist snapshot rather than patching individual steps. When an exploration or inspection step has served its objective, update the work plan before continuing. If the current step remains doing, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Keep delivery_target stable and complete explicitly when done.".to_string(),
+            "Use CreateWorkItem to create a new open delivery target, PickWorkItem to make an existing open item current, UpdateWorkItem to replace blocked_by and/or the full plan snapshot, and CompleteWorkItem only when the delivery target is actually done. If the current task is not just a brief answer and there is no current work item yet, clarify the delivery target with the operator if it is still ambiguous; if bounded inspection is needed to make the target concrete, do that inspection before creating the work item. Once a delivery target is stable enough to name, create or pick the work item and keep that delivery_target stable instead of recreating work items to refine wording. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, maintain the full current checklist snapshot rather than patching individual steps. Update plan state after material progress such as a code change, verification result, blocker discovery, or completed inspection objective; if the next known action is a file mutation, use ApplyPatch first and update the plan afterward. Plan updates are coordination/bookkeeping and do not replace file mutation, verification, PR/issue updates, final delivery, or other artifact progress. If the current step remains doing, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Complete explicitly when done.".to_string(),
         ));
     }
     if names.contains(&"GetWorkItem") || names.contains(&"ListWorkItems") {
@@ -278,10 +278,17 @@ mod tests {
         assert!(section
             .content
             .contains("clarify the delivery target with the operator"));
-        assert!(section.content.contains("update the plan before execution"));
         assert!(section
             .content
-            .contains("exploration or inspection step has served its objective"));
+            .contains("bounded inspection is needed to make the target concrete"));
+        assert!(section.content.contains("keep that delivery_target stable"));
+        assert!(section
+            .content
+            .contains("Update plan state after material progress"));
+        assert!(section
+            .content
+            .contains("use ApplyPatch first and update the plan afterward"));
+        assert!(section.content.contains("coordination/bookkeeping"));
         assert!(section.content.contains("specific blocker or missing fact"));
         assert!(section
             .content

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -69,6 +69,11 @@ async fn work_item_query_tools_return_current_open_done_views() {
     assert_eq!(active_item["focus"].as_str(), Some("current"));
     assert_eq!(active_item["is_current"].as_bool(), Some(true));
     assert_eq!(active_item["plan"]["items"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        active_item["plan"]["items"][0]["state"].as_str(),
+        Some("doing")
+    );
+    assert!(active_item["plan"]["items"][0]["status"].is_null());
 
     let (list_result, _) = registry
         .execute(
@@ -136,6 +141,155 @@ async fn work_item_query_tools_return_current_open_done_views() {
         fallback_payload["work_items"][0]["id"].as_str(),
         Some(active.id.as_str())
     );
+}
+
+#[tokio::test]
+async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+
+    let (create_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "create".into(),
+                name: "CreateWorkItem".into(),
+                input: serde_json::json!({
+                    "delivery_target": "ship work item plan contract",
+                    "plan": [
+                        { "step": "inspect current contract", "state": "done" },
+                        { "step": "update tool shape", "state": "doing" },
+                        { "step": "verify regression", "state": "pending" }
+                    ]
+                }),
+            },
+        )
+        .await
+        .unwrap();
+    let create_payload = create_result.envelope.result.unwrap();
+    let work_item_id = create_payload["work_item"]["id"].as_str().unwrap();
+    assert_eq!(
+        create_payload["plan"]["items"][0]["state"].as_str(),
+        Some("done")
+    );
+    assert_eq!(
+        create_payload["plan"]["items"][1]["state"].as_str(),
+        Some("doing")
+    );
+    assert_eq!(
+        create_payload["plan"]["items"][2]["state"].as_str(),
+        Some("pending")
+    );
+    assert!(create_payload["plan"]["items"][0]["status"].is_null());
+
+    let (get_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "get".into(),
+                name: "GetWorkItem".into(),
+                input: serde_json::json!({
+                    "work_item_id": work_item_id,
+                    "include_plan": true
+                }),
+            },
+        )
+        .await
+        .unwrap();
+    let get_payload = get_result.envelope.result.unwrap();
+    assert_eq!(
+        get_payload["work_item"]["plan"]["items"][1]["state"].as_str(),
+        Some("doing")
+    );
+    assert!(get_payload["work_item"]["plan"]["items"][1]["status"].is_null());
+
+    let returned_items = get_payload["work_item"]["plan"]["items"].clone();
+    let (update_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "update".into(),
+                name: "UpdateWorkItem".into(),
+                input: serde_json::json!({
+                    "work_item_id": work_item_id,
+                    "plan": returned_items
+                }),
+            },
+        )
+        .await
+        .unwrap();
+    let update_payload = update_result.envelope.result.unwrap();
+    assert_eq!(
+        update_payload["plan"]["items"][1]["state"].as_str(),
+        Some("doing")
+    );
+    assert!(update_payload["plan"]["items"][1]["status"].is_null());
+}
+
+#[tokio::test]
+async fn update_work_item_old_plan_shape_returns_state_example_hint() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+
+    let error = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "bad-update".into(),
+                name: "UpdateWorkItem".into(),
+                input: serde_json::json!({
+                    "work_item_id": "item-1",
+                    "plan": [
+                        { "step": "inspect current handler", "status": "completed" }
+                    ]
+                }),
+            },
+        )
+        .await
+        .unwrap_err();
+    let tool_error = crate::tool::ToolError::from_anyhow(&error);
+    assert_eq!(tool_error.kind, "invalid_tool_input");
+    assert_eq!(
+        tool_error
+            .details
+            .as_ref()
+            .and_then(|details| details.get("parse_error"))
+            .and_then(serde_json::Value::as_str),
+        Some("unknown field `status`, expected `step` or `state`")
+    );
+    let recovery_hint = tool_error.recovery_hint.as_deref().unwrap_or_default();
+    assert!(recovery_hint.contains("\"state\":\"done\""));
+    assert!(recovery_hint.contains("pending, doing, or done"));
 }
 
 #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -56,7 +56,7 @@ Include:
 - the next goal-aligned action
 
 If continuing exploration, name the specific missing information and the next bounded command/query.
-If the current plan step is complete, update the work plan before proceeding.
+If the current plan step became complete through material progress, update the work plan after that progress is recorded.
 This is not a request to finish the task; after the checkpoint, continue with the next goal-aligned action when useful.
 Do not assume the task requires code changes unless the user goal does.";
 
@@ -566,51 +566,23 @@ fn build_compacted_round_recap(rounds: &[TurnRoundRecord], recap_budget: usize) 
     recap
 }
 
-fn exec_command_changes_checkpoint_anchor(command: &str) -> bool {
-    let command = command.trim_start();
-    let lower = command.to_ascii_lowercase();
-    let mut segments = lower
-        .split(['&', ';', '\n'])
-        .map(str::trim)
-        .filter(|segment| !segment.is_empty());
-    segments.any(|segment| {
-        segment.starts_with("cargo test")
-            || segment.starts_with("cargo nextest")
-            || segment.starts_with("cargo fmt")
-            || segment.starts_with("cargo clippy")
-            || segment.starts_with("make test")
-            || segment.starts_with("make check")
-            || segment.starts_with("npm test")
-            || segment.starts_with("npm run test")
-            || segment.starts_with("npm run lint")
-            || segment.starts_with("npm run format")
-            || segment.starts_with("pnpm test")
-            || segment.starts_with("yarn test")
-            || segment.starts_with("pytest")
-            || segment.starts_with("uv run pytest")
-            || segment.starts_with("go test")
-            || segment.starts_with("git commit")
-    })
+fn tool_result_invalidates_checkpoint_anchor(envelope: &ToolResultEnvelope) -> bool {
+    envelope.status == ToolResultStatus::Success
+        && matches!(
+            envelope.tool_name.as_str(),
+            "CreateWorkItem"
+                | "PickWorkItem"
+                | "UpdateWorkItem"
+                | "CompleteWorkItem"
+                | "ApplyPatch"
+        )
 }
 
-fn tool_call_changes_checkpoint_anchor(call: &ToolCall) -> bool {
-    match call.name.as_str() {
-        "CreateWorkItem" | "PickWorkItem" | "UpdateWorkItem" | "CompleteWorkItem"
-        | "ApplyPatch" => true,
-        "ExecCommand" => call
-            .input
-            .get("cmd")
-            .and_then(Value::as_str)
-            .is_some_and(exec_command_changes_checkpoint_anchor),
-        _ => false,
-    }
-}
-
-fn round_changes_checkpoint_anchor(round: &TurnRoundRecord) -> bool {
+fn round_invalidates_checkpoint_anchor(round: &TurnRoundRecord) -> bool {
     round
-        .tool_calls
+        .tool_result_envelopes
         .iter()
-        .any(tool_call_changes_checkpoint_anchor)
+        .any(tool_result_invalidates_checkpoint_anchor)
 }
 
 fn build_delta_checkpoint_prompt(previous_round: usize, previous_checkpoint: &str) -> String {
@@ -1701,7 +1673,7 @@ impl RuntimeHandle {
                 tool_result_envelopes,
                 follow_up_user_texts: Vec::new(),
             };
-            if round_changes_checkpoint_anchor(&round_record) {
+            if round_invalidates_checkpoint_anchor(&round_record) {
                 checkpoint_state.anchor_generation =
                     checkpoint_state.anchor_generation.saturating_add(1);
             }
@@ -1844,6 +1816,24 @@ mod tests {
             tool_result_envelopes: Vec::new(),
             follow_up_user_texts: Vec::new(),
         }
+    }
+
+    fn fixture_round_with_tool_result(
+        round: usize,
+        text: &str,
+        tool_name: &str,
+        input: Value,
+        status: ToolResultStatus,
+    ) -> TurnRoundRecord {
+        let mut record = fixture_round_with_tool(round, text, tool_name, input);
+        record.tool_result_envelopes = vec![ToolResultEnvelope {
+            tool_name: tool_name.to_string(),
+            status,
+            summary_text: None,
+            result: None,
+            error: None,
+        }];
+        record
     }
 
     fn checkpoint_state_with_latest(
@@ -2850,37 +2840,60 @@ mod tests {
     }
 
     #[test]
-    fn round_changes_checkpoint_anchor_for_mutation_and_verifier_tools_only() {
-        assert!(round_changes_checkpoint_anchor(&fixture_round_with_tool(
-            1,
-            "patch",
-            "ApplyPatch",
-            serde_json::json!({ "patch": "--- a/app.txt\n+++ b/app.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n" }),
-        )));
-        assert!(round_changes_checkpoint_anchor(&fixture_round_with_tool(
-            2,
-            "plan",
-            "UpdateWorkItem",
-            serde_json::json!({ "work_item_id": "item-1", "plan": [] }),
-        )));
-        assert!(round_changes_checkpoint_anchor(&fixture_round_with_tool(
-            3,
-            "complete work item",
-            "CompleteWorkItem",
-            serde_json::json!({ "work_item_id": "item-1" }),
-        )));
-        assert!(round_changes_checkpoint_anchor(&fixture_round_with_tool(
-            4,
-            "verify",
-            "ExecCommand",
-            serde_json::json!({ "cmd": "cargo test --test runtime_compaction" }),
-        )));
-        assert!(!round_changes_checkpoint_anchor(&fixture_round_with_tool(
-            5,
-            "read",
-            "ExecCommand",
-            serde_json::json!({ "cmd": "sed -n '1,40p' src/runtime/turn.rs" }),
-        )));
+    fn round_invalidates_checkpoint_anchor_for_successful_state_mutation_tools_only() {
+        assert!(round_invalidates_checkpoint_anchor(
+            &fixture_round_with_tool_result(
+                1,
+                "patch",
+                "ApplyPatch",
+                serde_json::json!({ "patch": "--- a/app.txt\n+++ b/app.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n" }),
+                ToolResultStatus::Success,
+            )
+        ));
+        assert!(round_invalidates_checkpoint_anchor(
+            &fixture_round_with_tool_result(
+                2,
+                "plan",
+                "UpdateWorkItem",
+                serde_json::json!({ "work_item_id": "item-1", "plan": [] }),
+                ToolResultStatus::Success,
+            )
+        ));
+        assert!(round_invalidates_checkpoint_anchor(
+            &fixture_round_with_tool_result(
+                3,
+                "complete work item",
+                "CompleteWorkItem",
+                serde_json::json!({ "work_item_id": "item-1" }),
+                ToolResultStatus::Success,
+            )
+        ));
+        assert!(!round_invalidates_checkpoint_anchor(
+            &fixture_round_with_tool_result(
+                4,
+                "verify",
+                "ExecCommand",
+                serde_json::json!({ "cmd": "cargo test --test runtime_compaction" }),
+                ToolResultStatus::Success,
+            )
+        ));
+        assert!(!round_invalidates_checkpoint_anchor(
+            &fixture_round_with_tool_result(
+                5,
+                "failed plan",
+                "UpdateWorkItem",
+                serde_json::json!({ "work_item_id": "item-1", "plan": [] }),
+                ToolResultStatus::Error,
+            )
+        ));
+        assert!(!round_invalidates_checkpoint_anchor(
+            &fixture_round_with_tool(
+                6,
+                "call without result",
+                "ApplyPatch",
+                serde_json::json!({})
+            )
+        ));
     }
 
     #[test]

--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -20,6 +20,22 @@ pub(crate) fn parse_tool_args<T>(tool_name: &str, input: &Value) -> Result<T>
 where
     T: DeserializeOwned,
 {
+    parse_tool_args_with_recovery_hint(
+        tool_name,
+        input,
+        format!("provide input for {tool_name} that matches the published tool schema"),
+    )
+}
+
+pub(crate) fn parse_tool_args_with_recovery_hint<T>(
+    tool_name: &str,
+    input: &Value,
+    recovery_hint: impl Into<String>,
+) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let recovery_hint = recovery_hint.into();
     serde_json::from_value(input.clone()).map_err(|error| {
         anyhow::Error::from(
             ToolError::new(
@@ -30,9 +46,7 @@ where
                 "tool_name": tool_name,
                 "parse_error": error.to_string(),
             }))
-            .with_recovery_hint(format!(
-                "provide input for {tool_name} that matches the published tool schema"
-            )),
+            .with_recovery_hint(recovery_hint),
         )
     })
 }

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -46,11 +46,5 @@ pub(crate) async fn execute(
             normalize_optional_non_empty(args.result_summary),
         )
         .await?;
-    serialize_success(
-        NAME,
-        &WorkItemMutationResult {
-            work_item,
-            plan: None,
-        },
-    )
+    serialize_success(NAME, &WorkItemMutationResult::new(work_item, None))
 }

--- a/src/tool/tools/create_work_item.rs
+++ b/src/tool/tools/create_work_item.rs
@@ -5,14 +5,16 @@ use serde_json::Value;
 
 use crate::{
     runtime::RuntimeHandle,
-    tool::helpers::{parse_tool_args, validate_non_empty},
+    tool::helpers::validate_non_empty,
     tool::spec::typed_spec,
     types::{ToolCapabilityFamily, TrustLevel},
 };
 
 use super::{
     serialize_success,
-    work_item_action::{convert_plan, WorkItemMutationResult, WorkPlanItemArgs},
+    work_item_action::{
+        convert_plan, parse_work_item_action_args, WorkItemMutationResult, WorkPlanItemArgs,
+    },
     BuiltinToolDefinition,
 };
 
@@ -42,9 +44,9 @@ pub(crate) async fn execute(
     _trust: &TrustLevel,
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
-    let args: CreateWorkItemArgs = parse_tool_args(NAME, input)?;
+    let args: CreateWorkItemArgs = parse_work_item_action_args(NAME, input)?;
     let delivery_target = validate_non_empty(args.delivery_target, NAME, "delivery_target")?;
     let plan = args.plan.map(|plan| convert_plan(NAME, plan)).transpose()?;
     let (work_item, plan) = runtime.create_work_item(delivery_target, plan).await?;
-    serialize_success(NAME, &WorkItemMutationResult { work_item, plan })
+    serialize_success(NAME, &WorkItemMutationResult::new(work_item, plan))
 }

--- a/src/tool/tools/update_work_item.rs
+++ b/src/tool/tools/update_work_item.rs
@@ -5,14 +5,16 @@ use serde_json::Value;
 
 use crate::{
     runtime::RuntimeHandle,
-    tool::helpers::{normalize_optional_non_empty, parse_tool_args, validate_non_empty},
+    tool::helpers::{normalize_optional_non_empty, validate_non_empty},
     tool::spec::typed_spec,
     types::{ToolCapabilityFamily, TrustLevel},
 };
 
 use super::{
     serialize_success,
-    work_item_action::{convert_plan, WorkItemMutationResult, WorkPlanItemArgs},
+    work_item_action::{
+        convert_plan, parse_work_item_action_args, WorkItemMutationResult, WorkPlanItemArgs,
+    },
     BuiltinToolDefinition,
 };
 
@@ -44,7 +46,7 @@ pub(crate) async fn execute(
     _trust: &TrustLevel,
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
-    let args: UpdateWorkItemArgs = parse_tool_args(NAME, input)?;
+    let args: UpdateWorkItemArgs = parse_work_item_action_args(NAME, input)?;
     let work_item_id = validate_non_empty(args.work_item_id, NAME, "work_item_id")?;
     let blocked_by = args
         .blocked_by
@@ -53,5 +55,5 @@ pub(crate) async fn execute(
     let (work_item, plan) = runtime
         .update_work_item_fields(work_item_id, blocked_by, plan)
         .await?;
-    serialize_success(NAME, &WorkItemMutationResult { work_item, plan })
+    serialize_success(NAME, &WorkItemMutationResult::new(work_item, plan))
 }

--- a/src/tool/tools/work_item_action.rs
+++ b/src/tool/tools/work_item_action.rs
@@ -1,9 +1,10 @@
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    tool::helpers::validate_non_empty,
+    tool::helpers::{parse_tool_args_with_recovery_hint, validate_non_empty},
     types::{WorkItemRecord, WorkPlanItem, WorkPlanSnapshot, WorkPlanStepStatus},
 };
 
@@ -43,9 +44,76 @@ pub(crate) fn convert_plan(
         .collect()
 }
 
+pub(crate) fn parse_work_item_action_args<T>(
+    tool_name: &str,
+    input: &serde_json::Value,
+) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    parse_tool_args_with_recovery_hint(tool_name, input, work_plan_recovery_hint())
+}
+
+fn work_plan_recovery_hint() -> &'static str {
+    "use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WorkPlanStepStateView {
+    Pending,
+    Doing,
+    Done,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct WorkPlanItemView {
+    pub(crate) step: String,
+    pub(crate) state: WorkPlanStepStateView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct WorkPlanView {
+    pub(crate) work_item_id: String,
+    pub(crate) agent_id: String,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) items: Vec<WorkPlanItemView>,
+}
+
+impl From<WorkPlanSnapshot> for WorkPlanView {
+    fn from(snapshot: WorkPlanSnapshot) -> Self {
+        Self {
+            work_item_id: snapshot.work_item_id,
+            agent_id: snapshot.agent_id,
+            created_at: snapshot.created_at,
+            items: snapshot
+                .items
+                .into_iter()
+                .map(|item| WorkPlanItemView {
+                    step: item.step,
+                    state: match item.status {
+                        WorkPlanStepStatus::Pending => WorkPlanStepStateView::Pending,
+                        WorkPlanStepStatus::InProgress => WorkPlanStepStateView::Doing,
+                        WorkPlanStepStatus::Completed => WorkPlanStepStateView::Done,
+                    },
+                })
+                .collect(),
+        }
+    }
+}
+
 #[derive(Serialize)]
 pub(crate) struct WorkItemMutationResult {
     pub(crate) work_item: WorkItemRecord,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) plan: Option<WorkPlanSnapshot>,
+    pub(crate) plan: Option<WorkPlanView>,
+}
+
+impl WorkItemMutationResult {
+    pub(crate) fn new(work_item: WorkItemRecord, plan: Option<WorkPlanSnapshot>) -> Self {
+        Self {
+            work_item,
+            plan: plan.map(Into::into),
+        }
+    }
 }

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     runtime::RuntimeHandle,
-    types::{WorkItemRecord, WorkItemState, WorkPlanSnapshot},
+    types::{WorkItemRecord, WorkItemState},
 };
+
+use super::work_item_action::WorkPlanView;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -35,7 +37,7 @@ pub(crate) struct WorkItemView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) blocked_by: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) plan: Option<WorkPlanSnapshot>,
+    pub(crate) plan: Option<WorkPlanView>,
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) updated_at: DateTime<Utc>,
 }
@@ -79,7 +81,7 @@ pub(crate) async fn view_for_record(
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
     let plan = if include_plan {
-        runtime.latest_work_plan(&record.id).await?
+        runtime.latest_work_plan(&record.id).await?.map(Into::into)
     } else {
         None
     };


### PR DESCRIPTION
## Summary

- Fix WorkItem plan tool results to use the RFC/model-facing `state` vocabulary (`pending`, `doing`, `done`) while keeping internal persisted plan `status` as storage detail.
- Add specific invalid-input recovery hints for old plan shapes such as `status: completed`.
- Update WorkItem prompt guidance so plan updates are bookkeeping after material progress, not a substitute for file mutation or verification.
- Change turn-local checkpoint anchor invalidation to depend on successful state-mutating tool results only; `ExecCommand` and failed tool inputs no longer invalidate anchors by command-name heuristics.

Fixes #844
Fixes #845

## Verification

- `cargo fmt --check`
- `cargo test runtime::tests::work_items --lib -- --test-threads=1`
- `cargo test runtime::turn --lib -- --test-threads=1`
- `cargo test prompt::tools --lib -- --test-threads=1`
- `cargo test prompt::tests::system_prompt_includes_work_item_first_execution_rules --lib -- --test-threads=1`
