### PR TITLE
Refine WorkItem parse recovery hints

### DIFF
--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -279,17 +279,59 @@ async fn update_work_item_old_plan_shape_returns_state_example_hint() {
         .unwrap_err();
     let tool_error = crate::tool::ToolError::from_anyhow(&error);
     assert_eq!(tool_error.kind, "invalid_tool_input");
-    assert_eq!(
-        tool_error
-            .details
-            .as_ref()
-            .and_then(|details| details.get("parse_error"))
-            .and_then(serde_json::Value::as_str),
-        Some("unknown field `status`, expected `step` or `state`")
-    );
+    let parse_error = tool_error
+        .details
+        .as_ref()
+        .and_then(|details| details.get("parse_error"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    assert!(parse_error.contains("unknown field `status`"));
+    assert!(parse_error.contains("state"));
     let recovery_hint = tool_error.recovery_hint.as_deref().unwrap_or_default();
+    assert!(recovery_hint.contains("work_item_id"));
     assert!(recovery_hint.contains("\"state\":\"done\""));
     assert!(recovery_hint.contains("pending, doing, or done"));
+}
+
+#[tokio::test]
+async fn update_work_item_missing_id_returns_top_level_field_hint() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+
+    let error = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "missing-id".into(),
+                name: "UpdateWorkItem".into(),
+                input: serde_json::json!({
+                    "plan": [
+                        { "step": "inspect current handler", "state": "done" }
+                    ]
+                }),
+            },
+        )
+        .await
+        .unwrap_err();
+    let tool_error = crate::tool::ToolError::from_anyhow(&error);
+    assert_eq!(tool_error.kind, "invalid_tool_input");
+    let recovery_hint = tool_error.recovery_hint.as_deref().unwrap_or_default();
+    assert!(recovery_hint.contains("UpdateWorkItem schema"));
+    assert!(recovery_hint.contains("work_item_id"));
+    assert!(recovery_hint.contains("\"state\":\"done\""));
 }
 
 #[tokio::test]

--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -20,22 +20,20 @@ pub(crate) fn parse_tool_args<T>(tool_name: &str, input: &Value) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    parse_tool_args_with_recovery_hint(
-        tool_name,
-        input,
-        format!("provide input for {tool_name} that matches the published tool schema"),
-    )
+    parse_tool_args_with_recovery_hint(tool_name, input, || {
+        format!("provide input for {tool_name} that matches the published tool schema")
+    })
 }
 
-pub(crate) fn parse_tool_args_with_recovery_hint<T>(
+pub(crate) fn parse_tool_args_with_recovery_hint<T, F>(
     tool_name: &str,
     input: &Value,
-    recovery_hint: impl Into<String>,
+    recovery_hint: F,
 ) -> Result<T>
 where
     T: DeserializeOwned,
+    F: FnOnce() -> String,
 {
-    let recovery_hint = recovery_hint.into();
     serde_json::from_value(input.clone()).map_err(|error| {
         anyhow::Error::from(
             ToolError::new(
@@ -46,7 +44,7 @@ where
                 "tool_name": tool_name,
                 "parse_error": error.to_string(),
             }))
-            .with_recovery_hint(recovery_hint),
+            .with_recovery_hint(recovery_hint()),
         )
     })
 }

--- a/src/tool/tools/work_item_action.rs
+++ b/src/tool/tools/work_item_action.rs
@@ -51,11 +51,23 @@ pub(crate) fn parse_work_item_action_args<T>(
 where
     T: serde::de::DeserializeOwned,
 {
-    parse_tool_args_with_recovery_hint(tool_name, input, work_plan_recovery_hint())
+    parse_tool_args_with_recovery_hint(tool_name, input, || {
+        work_item_action_recovery_hint(tool_name).to_string()
+    })
 }
 
-fn work_plan_recovery_hint() -> &'static str {
-    "use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
+fn work_item_action_recovery_hint(tool_name: &str) -> &'static str {
+    match tool_name {
+        "CreateWorkItem" => {
+            "ensure the JSON matches the CreateWorkItem schema, including required top-level field \"delivery_target\"; use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
+        }
+        "UpdateWorkItem" => {
+            "ensure the JSON matches the UpdateWorkItem schema, including required top-level field \"work_item_id\"; use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
+        }
+        _ => {
+            "ensure the JSON matches the tool schema exactly; use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Follow up on Copilot review comments from #847.
- Make `parse_tool_args_with_recovery_hint` construct recovery hints only on the error path.
- Make WorkItem action parse hints include the required top-level field for CreateWorkItem / UpdateWorkItem.
- Loosen the old plan-shape regression test so it does not depend on the exact serde parse-error string, and add coverage for missing `work_item_id` recovery guidance.

Follow-up to #847.

## Verification

- `cargo fmt --check`
- `cargo test runtime::tests::work_items --lib -- --test-threads=1`
