### PR TITLE
fix: show progress events in Conversation

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1612,7 +1612,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_text_includes_durable_projection_system_events() {
+    fn chat_text_excludes_internal_projection_events_and_provider_text() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(
             client,
@@ -1645,6 +1645,21 @@ mod tests {
             },
             &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
         );
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-provider".into(),
+                event: "provider_round_completed".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-provider".into(),
+                    seq: 3,
+                    ts: Utc::now(),
+                    agent_id: "default".into(),
+                    event_type: "provider_round_completed".into(),
+                    payload: json!({ "round": 1, "text_preview": "hidden provider partial" }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
         app.projection = Some(projection);
 
         let rendered: String = build_chat_text(&collect_chat_items(&app))
@@ -1652,8 +1667,9 @@ mod tests {
             .into_iter()
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
-        assert!(rendered.contains("System (work)"));
-        assert!(rendered.contains("prepare rollout plan"));
+        assert!(!rendered.contains("System (work)"));
+        assert!(!rendered.contains("prepare rollout plan"));
+        assert!(!rendered.contains("hidden provider partial"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -60,12 +60,6 @@ const BRIEF_LIMIT: usize = 24;
 const TRANSCRIPT_LIMIT: usize = 40;
 const TASK_LIMIT: usize = 40;
 
-#[derive(Debug, Clone)]
-pub(crate) struct CachedActivityText {
-    agent_id: String,
-    text: String,
-}
-
 pub async fn run_tui(config: AppConfig, no_alt_screen: bool) -> Result<()> {
     let client = LocalClient::new(config.clone())?;
     let log_writer = TuiLogWriter::new(config.agent_root_dir())?;
@@ -164,7 +158,6 @@ struct TuiApp {
     pub(crate) status_line: String,
     should_quit: bool,
     chat_text_cache: RefCell<Option<CachedChatText>>,
-    pub(crate) activity_text_cache: RefCell<Option<CachedActivityText>>,
     log_writer: TuiLogWriter,
 }
 
@@ -226,7 +219,6 @@ impl TuiApp {
             status_line: "Connecting to local Holon runtime...".into(),
             should_quit: false,
             chat_text_cache: RefCell::new(None),
-            activity_text_cache: RefCell::new(None),
             log_writer,
         }
     }
@@ -361,7 +353,6 @@ impl TuiApp {
         self.transcript.clear();
         self.tasks.clear();
         self.projection = None;
-        self.activity_text_cache.borrow_mut().take();
         self.last_refresh_at = None;
         self.last_event_at = None;
         self.refresh_deadline = None;
@@ -405,7 +396,6 @@ impl TuiApp {
 
         self.stop_stream_task();
         self.selected_agent = target_index;
-        self.activity_text_cache.borrow_mut().take();
         self.projection = Some(projection);
         self.apply_projection_view();
         self.last_refresh_at = Some(Local::now());

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -132,6 +132,8 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
     }
 
     if let Some(projection) = app.projection.as_ref() {
+        let mut visible_event_ids = std::collections::HashSet::new();
+
         for event in projection.durable_conversation_events() {
             if !is_chat_visible_conversation_event(&event.kind) {
                 continue;
@@ -141,6 +143,19 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
                 role: CachedChatRole::System,
                 speaker: conversation_event_speaker(&event.kind),
                 body: conversation_event_body(event),
+            });
+            visible_event_ids.insert(event.id.as_str());
+        }
+
+        for event in projection.recent_activity_events() {
+            if visible_event_ids.contains(event.id.as_str()) {
+                continue;
+            }
+            items.push(CachedChatItem {
+                created_at: event.ts,
+                role: CachedChatRole::System,
+                speaker: conversation_event_speaker(&event.kind),
+                body: progress_event_body(event),
             });
         }
     }
@@ -347,6 +362,29 @@ pub(super) fn conversation_event_body(
     format!("{prefix}{}", event.summary)
 }
 
+fn progress_event_body(event: &crate::tui::projection::ProjectionEventRecord) -> String {
+    if event.kind == "tool_executed" || event.kind == "tool_execution_failed" {
+        return event
+            .payload
+            .get("tool_name")
+            .and_then(serde_json::Value::as_str)
+            .map(|tool_name| {
+                if tool_name == "ExecCommand" {
+                    event
+                        .payload
+                        .get("exec_command_cmd")
+                        .and_then(serde_json::Value::as_str)
+                        .map(|cmd| format!("ExecCommand: {cmd}"))
+                        .unwrap_or_else(|| event.summary.clone())
+                } else {
+                    event.summary.clone()
+                }
+            })
+            .unwrap_or_else(|| event.summary.clone());
+    }
+    conversation_event_body(event)
+}
+
 fn render_brief_body(brief: &BriefRecord) -> String {
     if let Some(task_id) = brief.related_task_id.as_deref() {
         let preview = brief
@@ -380,4 +418,47 @@ fn trim_preview(input: &str, max_chars: usize) -> String {
         .collect::<String>();
     trimmed.push('…');
     trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::progress_event_body;
+    use crate::tui::projection::{ProjectionEventLane, ProjectionEventRecord};
+    use chrono::Utc;
+    use serde_json::json;
+
+    #[test]
+    fn progress_event_body_shows_full_exec_command() {
+        let event = ProjectionEventRecord {
+            id: "evt-1".into(),
+            seq: 1,
+            ts: Utc::now(),
+            lane: ProjectionEventLane::Debug,
+            kind: "tool_executed".into(),
+            summary: "tool executed: ExecCommand".into(),
+            payload: json!({
+                "tool_name": "ExecCommand",
+                "exec_command_cmd": "git status --short --branch"
+            }),
+        };
+        let rendered = progress_event_body(&event);
+        assert_eq!(rendered, "ExecCommand: git status --short --branch");
+    }
+
+    #[test]
+    fn progress_event_body_uses_summary_for_non_command_tools() {
+        let event = ProjectionEventRecord {
+            id: "evt-2".into(),
+            seq: 2,
+            ts: Utc::now(),
+            lane: ProjectionEventLane::Debug,
+            kind: "tool_executed".into(),
+            summary: "tool executed: Sleep".into(),
+            payload: json!({
+                "tool_name": "Sleep"
+            }),
+        };
+        let rendered = progress_event_body(&event);
+        assert_eq!(rendered, "tool executed: Sleep");
+    }
 }

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -171,14 +171,7 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
 }
 
 pub(super) fn is_chat_visible_conversation_event(kind: &str) -> bool {
-    !matches!(
-        kind,
-        "message_enqueued"
-            | "brief_created"
-            | "task_created"
-            | "task_status_updated"
-            | "task_result_received"
-    )
+    matches!(kind, "operator_notification_requested" | "runtime_error")
 }
 
 pub(super) fn build_chat_text(items: &[CachedChatItem]) -> Text<'static> {
@@ -374,7 +367,13 @@ fn progress_event_body(event: &crate::tui::projection::ProjectionEventRecord) ->
                         .payload
                         .get("exec_command_cmd")
                         .and_then(serde_json::Value::as_str)
-                        .map(|cmd| format!("ExecCommand: {cmd}"))
+                        .map(|cmd| {
+                            if event.kind == "tool_execution_failed" {
+                                format!("ExecCommand failed: {cmd}")
+                            } else {
+                                format!("ExecCommand: {cmd}")
+                            }
+                        })
                         .unwrap_or_else(|| event.summary.clone())
                 } else {
                     event.summary.clone()
@@ -422,7 +421,7 @@ fn trim_preview(input: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::progress_event_body;
+    use super::{is_chat_visible_conversation_event, progress_event_body};
     use crate::tui::projection::{ProjectionEventLane, ProjectionEventRecord};
     use chrono::Utc;
     use serde_json::json;
@@ -446,6 +445,26 @@ mod tests {
     }
 
     #[test]
+    fn progress_event_body_marks_failed_exec_command() {
+        let event = ProjectionEventRecord {
+            id: "evt-2".into(),
+            seq: 2,
+            ts: Utc::now(),
+            lane: ProjectionEventLane::Debug,
+            kind: "tool_execution_failed".into(),
+            summary: "tool execution failed: ExecCommand".into(),
+            payload: json!({
+                "tool_name": "ExecCommand",
+                "exec_command_cmd": "cargo test tui"
+            }),
+        };
+
+        let rendered = progress_event_body(&event);
+
+        assert_eq!(rendered, "ExecCommand failed: cargo test tui");
+    }
+
+    #[test]
     fn progress_event_body_uses_summary_for_non_command_tools() {
         let event = ProjectionEventRecord {
             id: "evt-2".into(),
@@ -460,5 +479,26 @@ mod tests {
         };
         let rendered = progress_event_body(&event);
         assert_eq!(rendered, "tool executed: Sleep");
+    }
+
+    #[test]
+    fn chat_visible_conversation_events_are_user_facing_only() {
+        assert!(is_chat_visible_conversation_event(
+            "operator_notification_requested"
+        ));
+        assert!(is_chat_visible_conversation_event("runtime_error"));
+
+        assert!(!is_chat_visible_conversation_event("work_item_written"));
+        assert!(!is_chat_visible_conversation_event(
+            "waiting_intent_created"
+        ));
+        assert!(!is_chat_visible_conversation_event(
+            "waiting_intent_cancelled"
+        ));
+        assert!(!is_chat_visible_conversation_event("callback_delivered"));
+        assert!(!is_chat_visible_conversation_event("workspace_attached"));
+        assert!(!is_chat_visible_conversation_event(
+            "provider_round_completed"
+        ));
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -215,12 +215,10 @@ impl TuiApp {
             SlashCommand::Help => {
                 self.overlay = OverlayState::HelpView { scroll: 0 };
                 self.status_line = "Opened slash command help".into();
-                self.cache_activity_message("Opened slash command help");
             }
             SlashCommand::Agents => {
                 self.overlay = OverlayState::Agents;
                 self.status_line = "Opened agents overlay".into();
-                self.cache_activity_message("Opened agents overlay");
             }
             SlashCommand::Events => {
                 self.overlay = OverlayState::Events {
@@ -228,7 +226,6 @@ impl TuiApp {
                     detail_scroll: 0,
                 };
                 self.status_line = "Opened raw events overlay".into();
-                self.cache_activity_message("Opened raw events overlay");
             }
             SlashCommand::Model => {
                 self.overlay = OverlayState::ModelPicker {
@@ -236,7 +233,6 @@ impl TuiApp {
                     selected: 0,
                 };
                 self.status_line = "Opened model picker".into();
-                self.cache_activity_message("Opened model picker");
             }
             SlashCommand::Tasks => {
                 self.overlay = OverlayState::Tasks {
@@ -244,17 +240,14 @@ impl TuiApp {
                     detail_scroll: 0,
                 };
                 self.status_line = "Opened tasks overlay".into();
-                self.cache_activity_message("Opened tasks overlay");
             }
             SlashCommand::Transcript => {
                 self.overlay = OverlayState::Transcript { scroll: 0 };
                 self.status_line = "Opened transcript overlay".into();
-                self.cache_activity_message("Opened transcript overlay");
             }
             SlashCommand::Refresh => {
                 self.overlay = OverlayState::None;
                 self.status_line = "Refreshing selected agent from /state".into();
-                self.cache_activity_message("Refreshing selected agent from /state");
                 self.bootstrap_selected_agent().await?;
             }
             SlashCommand::ClearStatus => {
@@ -266,7 +259,6 @@ impl TuiApp {
                     composer: ComposerState::new(),
                 };
                 self.status_line = "Opened debug prompt dialog".into();
-                self.cache_activity_message("Opened debug prompt dialog");
             }
         }
         Ok(())
@@ -669,16 +661,12 @@ impl TuiApp {
                 self.client.clear_agent_model_override(&agent_id).await?;
                 self.status_line =
                     format!("Cleared model override for {agent_id}; inheriting runtime default");
-                let msg = self.status_line.clone();
-                self.cache_activity_message(&msg);
             }
             crate::tui::model_picker::ModelPickerChoice::Model { model } => {
                 self.client
                     .set_agent_model_override(&agent_id, model.clone())
                     .await?;
                 self.status_line = format!("Set model override for {agent_id} to {model}");
-                let msg = self.status_line.clone();
-                self.cache_activity_message(&msg);
             }
         }
         self.overlay = OverlayState::None;
@@ -704,17 +692,6 @@ impl TuiApp {
             .as_ref()
             .and_then(|projection| projection.event_log().iter().rev().nth(index))
             .map(|event| event.id.clone())
-    }
-
-    /// Cache a UI feedback message in the activity text cache so it persists
-    /// in the Logs panel even after the status_line is cleared.
-    fn cache_activity_message(&mut self, message: &str) {
-        if let Some(projection) = &self.projection {
-            *self.activity_text_cache.borrow_mut() = Some(CachedActivityText {
-                agent_id: projection.agent.identity.agent_id.clone(),
-                text: message.to_string(),
-            });
-        }
     }
 }
 

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -666,9 +666,7 @@ pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
 pub(crate) fn is_ephemeral_activity_kind(kind: &str) -> bool {
     matches!(
         kind,
-        "provider_round_completed"
-            | "text_only_round_observed"
-            | "tool_executed"
+        "tool_executed"
             | "tool_execution_failed"
             | "skill_activated"
             | "system_tick_emitted"
@@ -982,7 +980,7 @@ mod tests {
     }
 
     #[test]
-    fn projection_marks_transcript_stale_for_round_events() {
+    fn projection_logs_provider_rounds_without_recent_activity() {
         let mut projection = TuiProjection::from_snapshot(sample_snapshot());
 
         projection.apply_event(
@@ -993,12 +991,10 @@ mod tests {
             &test_log_writer(),
         );
 
-        assert!(projection
-            .stale_slices
-            .contains(&ProjectionSlice::TranscriptTail));
+        assert!(projection.recent_activity_events().is_empty());
         assert_eq!(
             projection.event_log().last().map(|event| event.lane),
-            Some(ProjectionEventLane::Debug)
+            Some(ProjectionEventLane::State)
         );
         assert_eq!(
             projection
@@ -1026,9 +1022,11 @@ mod tests {
         );
 
         let activity = projection.recent_activity_events();
-        assert_eq!(activity.len(), 2);
-        assert_eq!(activity[0].kind, "provider_round_completed");
-        assert_eq!(activity[1].kind, "tool_executed");
+        assert_eq!(activity.len(), 1);
+        assert_eq!(activity[0].kind, "tool_executed");
+        assert!(!activity.iter().any(|event| {
+            event.summary.contains("partial") || event.payload.get("text_preview").is_some()
+        }));
 
         projection.apply_event(
             sample_event(

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -13,7 +13,6 @@ pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
         .constraints([
             Constraint::Length(2),
             Constraint::Min(0),
-            Constraint::Length(4),
             Constraint::Length(prompt_height),
             Constraint::Length(status_height),
         ])
@@ -21,9 +20,8 @@ pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
 
     draw_header(frame, outer[0], app);
     draw_main_panels(frame, outer[1], app);
-    draw_activity_pane(frame, outer[2], app);
-    draw_prompt_pane(frame, outer[3], app, &slash_menu);
-    draw_status_bar(frame, outer[4], app);
+    draw_prompt_pane(frame, outer[2], app, &slash_menu);
+    draw_status_bar(frame, outer[3], app);
     draw_overlay(frame, app);
 }
 
@@ -73,13 +71,6 @@ fn draw_runtime_state(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
                 .title("Runtime State")
                 .borders(Borders::ALL),
         )
-        .wrap(Wrap { trim: false });
-    frame.render_widget(paragraph, area);
-}
-
-fn draw_activity_pane(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
-    let paragraph = Paragraph::new(render_activity_text(app))
-        .block(Block::default().title("Logs").borders(Borders::ALL))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }
@@ -266,67 +257,6 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
     lines.join("\n")
 }
 
-fn render_activity_text(app: &TuiApp) -> String {
-    let Some(projection) = app.projection.as_ref() else {
-        return render_status_line_or_default(app, "Bootstrapping snapshot and stream...");
-    };
-    let agent_id = projection.agent.identity.agent_id.as_str();
-    let events = projection.recent_log_events(4);
-    if events.is_empty() {
-        let cached = app.activity_text_cache.borrow();
-        if let Some(cached) = cached.as_ref().filter(|c| c.agent_id == agent_id) {
-            return cached.text.clone();
-        }
-        // Show "No in-flight activity" only when turn has ended.
-        if projection.session.current_run_id.is_none() {
-            return "No in-flight activity.".into();
-        }
-        return String::new();
-    }
-
-    let mut text_parts = Vec::new();
-
-    // Prepend status line message if it exists (for UI feedback like "Opened help")
-    if !app.status_line.trim().is_empty() {
-        text_parts.push(app.status_line.trim().to_string());
-    }
-
-    let event_text = events
-        .into_iter()
-        .map(|event| format_activity_event(event))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    if !event_text.is_empty() {
-        text_parts.push(event_text);
-    }
-
-    let text = text_parts.join("\n");
-    if !text.is_empty() {
-        *app.activity_text_cache.borrow_mut() = Some(super::CachedActivityText {
-            agent_id: agent_id.to_string(),
-            text: text.clone(),
-        });
-        text
-    } else {
-        // Borrow cache once and reuse for both checks to avoid duplication
-        let cached = app.activity_text_cache.borrow();
-        cached
-            .as_ref()
-            .filter(|c| c.agent_id == agent_id && !c.text.is_empty())
-            .map(|c| c.text.clone())
-            .unwrap_or_default()
-    }
-}
-
-fn render_status_line_or_default(app: &TuiApp, default: &str) -> String {
-    if app.status_line.is_empty() {
-        default.to_string()
-    } else {
-        app.status_line.clone()
-    }
-}
-
 fn prompt_pane_height(buffer: &str, slash_menu_rows: usize) -> u16 {
     let mut prompt_lines = buffer.lines().count();
     if buffer.is_empty() || buffer.ends_with('\n') {
@@ -481,36 +411,6 @@ fn wrapped_prompt_rows(line: &str, visible_line_width: u16) -> u16 {
 
 fn display_width(text: &str) -> u16 {
     UnicodeWidthStr::width(text).min(u16::MAX as usize) as u16
-}
-
-fn format_activity_event(event: &crate::tui::projection::ProjectionEventRecord) -> String {
-    let detail = if event.kind == "tool_executed" || event.kind == "tool_execution_failed" {
-        event
-            .payload
-            .get("tool_name")
-            .and_then(Value::as_str)
-            .map(|tool_name| {
-                if tool_name == "ExecCommand" {
-                    event
-                        .payload
-                        .get("exec_command_cmd")
-                        .and_then(Value::as_str)
-                        .map(|cmd| format!("ExecCommand: {cmd}"))
-                        .unwrap_or_else(|| event.summary.clone())
-                } else {
-                    event.summary.clone()
-                }
-            })
-            .unwrap_or_else(|| event.summary.clone())
-    } else {
-        event.summary.clone()
-    };
-
-    format!(
-        "[{}] {}",
-        event.ts.with_timezone(&Local).format("%H:%M:%S"),
-        detail
-    )
 }
 
 pub(super) fn render_header(agent: &AgentSummary) -> String {
@@ -761,17 +661,10 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_activity_event, prompt_cursor_position, render_activity_text, render_header,
-        render_model_status, render_prompt_buffer, render_prompt_text, render_summary,
-        status_bar_height,
+        prompt_cursor_position, render_header, render_model_status, render_prompt_buffer,
+        render_prompt_text, render_summary, status_bar_height,
     };
-    use crate::client::{
-        AgentStateSnapshot, LocalClient, StateSessionSnapshot, StateWorkspaceSnapshot,
-    };
-    use crate::config::{AltScreenMode, AppConfig};
     use crate::system::{ExecutionProfile, ExecutionSnapshot};
-    use crate::tui::logging::TuiLogWriter;
-    use crate::tui::projection::{ProjectionEventLane, ProjectionEventRecord, TuiProjection};
     use crate::types::{
         AgentIdentityView, AgentKind, AgentLifecycleHint, AgentModelSource, AgentModelState,
         AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentSummary,
@@ -779,84 +672,8 @@ mod tests {
         ChildAgentSummary, ClosureDecision, ClosureOutcome, LoadedAgentsMdView, RuntimePosture,
         SkillsRuntimeView, TokenUsage,
     };
-    use chrono::Utc;
     use ratatui::prelude::{Line, Rect};
-    use serde_json::json;
-    use std::collections::HashMap;
     use std::path::PathBuf;
-
-    use super::super::{CachedActivityText, TuiApp};
-
-    fn test_config() -> AppConfig {
-        let temp = tempfile::tempdir().unwrap().keep();
-        AppConfig {
-            default_agent_id: "default".into(),
-            http_addr: "127.0.0.1:0".into(),
-            callback_base_url: "http://127.0.0.1:0".into(),
-            home_dir: temp.clone(),
-            data_dir: temp.clone(),
-            socket_path: temp.join("run").join("holon.sock"),
-            workspace_dir: temp.join("workspace"),
-            context_window_messages: 8,
-            context_window_briefs: 8,
-            compaction_trigger_messages: 10,
-            compaction_keep_recent_messages: 4,
-            prompt_budget_estimated_tokens: 4096,
-            compaction_trigger_estimated_tokens: 2048,
-            compaction_keep_recent_estimated_tokens: 768,
-            recent_episode_candidates: 12,
-            max_relevant_episodes: 3,
-            control_token: Some("secret".into()),
-            control_auth_mode: crate::config::ControlAuthMode::Auto,
-            config_file_path: temp.join("config.json"),
-            stored_config: Default::default(),
-            default_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
-            fallback_models: Vec::new(),
-            runtime_max_output_tokens: 8192,
-            default_tool_output_tokens: crate::tool::helpers::DEFAULT_TOOL_OUTPUT_TOKENS as u32,
-            max_tool_output_tokens: crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32,
-            disable_provider_fallback: false,
-            tui_alternate_screen: AltScreenMode::Auto,
-            validated_model_overrides: HashMap::new(),
-            validated_unknown_model_fallback: None,
-            providers: crate::config::provider_registry_for_tests(
-                None,
-                Some("dummy"),
-                temp.join(".codex"),
-            ),
-        }
-    }
-
-    fn sample_app() -> TuiApp {
-        TuiApp::new(
-            LocalClient::new(test_config()).unwrap(),
-            TuiLogWriter::new_temp().unwrap(),
-        )
-    }
-
-    fn sample_projection(current_run_id: Option<&str>) -> TuiProjection {
-        TuiProjection::from_snapshot(AgentStateSnapshot {
-            agent: sample_agent_summary(),
-            session: StateSessionSnapshot {
-                current_run_id: current_run_id.map(str::to_string),
-                pending_count: usize::from(current_run_id.is_some()),
-                last_turn: None,
-            },
-            tasks: Vec::new(),
-            transcript_tail: Vec::new(),
-            briefs_tail: Vec::new(),
-            timers: Vec::new(),
-            work_items: Vec::new(),
-            work_plan: None,
-            waiting_intents: Vec::new(),
-            external_triggers: Vec::new(),
-            operator_notifications: Vec::new(),
-            workspace: StateWorkspaceSnapshot::default(),
-            execution: None,
-            brief: None,
-            cursor: Some("cursor-1".into()),
-        })
-    }
 
     fn sample_agent_summary() -> AgentSummary {
         let mut state = AgentState::new("default");
@@ -1052,53 +869,6 @@ mod tests {
     }
 
     #[test]
-    fn activity_empty_projection_uses_status_line() {
-        let mut app = sample_app();
-        app.status_line = "Bootstrapping agent".into();
-
-        assert_eq!(render_activity_text(&app), "Bootstrapping agent");
-    }
-
-    #[test]
-    fn activity_empty_projection_uses_default_when_status_empty() {
-        let mut app = sample_app();
-        app.status_line.clear();
-
-        assert_eq!(
-            render_activity_text(&app),
-            "Bootstrapping snapshot and stream..."
-        );
-    }
-
-    #[test]
-    fn activity_empty_events_active_run_uses_agent_cache() {
-        let mut app = sample_app();
-        app.projection = Some(sample_projection(Some("run-1")));
-        *app.activity_text_cache.borrow_mut() = Some(CachedActivityText {
-            agent_id: "default".into(),
-            text: "tool running".into(),
-        });
-
-        assert_eq!(render_activity_text(&app), "tool running");
-    }
-
-    #[test]
-    fn activity_empty_events_active_run_without_cache_is_empty() {
-        let mut app = sample_app();
-        app.projection = Some(sample_projection(Some("run-1")));
-
-        assert_eq!(render_activity_text(&app), "");
-    }
-
-    #[test]
-    fn activity_empty_events_ended_run_reports_no_inflight_activity() {
-        let mut app = sample_app();
-        app.projection = Some(sample_projection(None));
-
-        assert_eq!(render_activity_text(&app), "No in-flight activity.");
-    }
-
-    #[test]
     fn prompt_cursor_tracks_multiline_end_position() {
         let area = Rect::new(10, 5, 40, 6);
         assert_eq!(
@@ -1174,43 +944,6 @@ mod tests {
     fn empty_status_line_uses_compact_status_bar_height() {
         assert_eq!(status_bar_height(""), 3);
         assert_eq!(status_bar_height("Action failed"), 4);
-    }
-
-    #[test]
-    fn activity_shows_full_exec_command() {
-        let event = ProjectionEventRecord {
-            id: "evt-1".into(),
-            seq: 1,
-            ts: Utc::now(),
-            lane: ProjectionEventLane::Debug,
-            kind: "tool_executed".into(),
-            summary: "tool executed: ExecCommand".into(),
-            payload: json!({
-                "tool_name": "ExecCommand",
-                "exec_command_cmd": "git status --short --branch"
-            }),
-        };
-
-        let rendered = format_activity_event(&event);
-        assert!(rendered.contains("ExecCommand: git status --short --branch"));
-    }
-
-    #[test]
-    fn activity_uses_summary_for_non_command_tools() {
-        let event = ProjectionEventRecord {
-            id: "evt-2".into(),
-            seq: 2,
-            ts: Utc::now(),
-            lane: ProjectionEventLane::Debug,
-            kind: "tool_executed".into(),
-            summary: "tool executed: read_file".into(),
-            payload: json!({
-                "tool_name": "read_file"
-            }),
-        };
-
-        let rendered = format_activity_event(&event);
-        assert!(rendered.contains("tool executed: read_file"));
     }
 }
 


### PR DESCRIPTION
Closes #838

## Summary
- Move recent ephemeral agent activity into the Conversation pane.
- Remove the separate empty Logs pane/activity cache path from the TUI layout.
- Format ExecCommand progress rows with the actual command text and avoid duplicating durable events.

## Verification
- cargo fmt --all
- cargo test progress_event_body --all
- cargo test tui --all
