### PR TITLE
fix: improve TUI composer and active activity

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1789,6 +1789,119 @@ mod tests {
     }
 
     #[test]
+    fn chat_text_keeps_active_activity_after_brief_event() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+        snapshot.agent.agent.working_memory.current_working_memory =
+            crate::types::WorkingMemorySnapshot {
+                current_work_item_id: Some("work-1".into()),
+                delivery_target: Some("fix TUI active activity".into()),
+                work_summary: Some("Improve the Conversation working indicator".into()),
+                ..Default::default()
+            };
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-tool".into(),
+                event: "tool_executed".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-tool".into(),
+                    seq: 2,
+                    ts: Utc::now(),
+                    agent_id: "default".into(),
+                    event_type: "tool_executed".into(),
+                    payload: json!({
+                        "tool_name": "ExecCommand",
+                        "exec_command_cmd": "cargo test tui"
+                    }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-brief".into(),
+                event: "brief_created".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-brief".into(),
+                    seq: 3,
+                    ts: Utc::now(),
+                    agent_id: "default".into(),
+                    event_type: "brief_created".into(),
+                    payload: json!({
+                        "id": "brief-1",
+                        "agent_id": "default",
+                        "workspace_id": crate::types::AGENT_HOME_WORKSPACE_ID,
+                        "work_item_id": null,
+                        "kind": "result",
+                        "created_at": Utc::now(),
+                        "text": "Still working",
+                        "attachments": null,
+                        "related_message_id": null,
+                        "related_task_id": null
+                    }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.projection = Some(projection);
+
+        let rendered: String = build_chat_text(&collect_chat_items(&app))
+            .lines
+            .into_iter()
+            .flat_map(|line| line.spans.into_iter().map(|span| span.content))
+            .collect();
+        assert!(rendered.contains("Holon (working)"));
+        assert!(rendered.contains("Improve the Conversation working indicator"));
+        assert!(rendered.contains("Now: ExecCommand: cargo test tui"));
+    }
+
+    #[test]
+    fn chat_text_does_not_show_stale_activity_when_agent_is_idle() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeIdle;
+        snapshot.agent.agent.pending = 0;
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-tool".into(),
+                event: "tool_executed".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-tool".into(),
+                    seq: 2,
+                    ts: Utc::now(),
+                    agent_id: "default".into(),
+                    event_type: "tool_executed".into(),
+                    payload: json!({
+                        "tool_name": "ExecCommand",
+                        "exec_command_cmd": "cargo test stale"
+                    }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.projection = Some(projection);
+
+        let rendered: String = build_chat_text(&collect_chat_items(&app))
+            .lines
+            .into_iter()
+            .flat_map(|line| line.spans.into_iter().map(|span| span.content))
+            .collect();
+        assert!(!rendered.contains("Holon (working)"));
+        assert!(!rendered.contains("cargo test stale"));
+    }
+
+    #[test]
     fn collect_chat_items_orders_equal_timestamps_deterministically() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -17,7 +17,10 @@ use crate::{
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Local};
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    event::{
+        self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -75,6 +78,14 @@ pub async fn run_tui(config: AppConfig, no_alt_screen: bool) -> Result<()> {
     if alt_screen_enabled {
         execute!(stdout, EnterAlternateScreen)?;
         terminal_guard.alternate_screen_enabled = true;
+    }
+    if execute!(
+        stdout,
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    )
+    .is_ok()
+    {
+        terminal_guard.keyboard_enhancement_enabled = true;
     }
 
     let backend = CrosstermBackend::new(stdout);
@@ -771,6 +782,7 @@ fn is_cursor_too_old_error(err: &anyhow::Error) -> bool {
 struct TerminalCleanupGuard {
     raw_mode_enabled: bool,
     alternate_screen_enabled: bool,
+    keyboard_enhancement_enabled: bool,
 }
 
 impl TerminalCleanupGuard {
@@ -778,12 +790,17 @@ impl TerminalCleanupGuard {
         Self {
             raw_mode_enabled: false,
             alternate_screen_enabled: false,
+            keyboard_enhancement_enabled: false,
         }
     }
 }
 
 impl Drop for TerminalCleanupGuard {
     fn drop(&mut self) {
+        if self.keyboard_enhancement_enabled {
+            let mut stdout = io::stdout();
+            let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+        }
         if self.raw_mode_enabled {
             let _ = disable_raw_mode();
         }
@@ -1142,6 +1159,22 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(app.composer.as_str(), "h\ni");
+    }
+
+    #[tokio::test]
+    async fn shift_enter_adds_new_line_when_slash_menu_is_visible() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/de");
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT))
+            .await
+            .unwrap();
+
+        assert_eq!(app.composer.as_str(), "/de\n");
     }
 
     #[tokio::test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1442,6 +1442,47 @@ mod tests {
         assert_eq!(app.composer.as_str(), "");
     }
 
+    #[tokio::test]
+    async fn slash_menu_enter_runs_selected_prefix_command() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/mo");
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            app.overlay,
+            OverlayState::ModelPicker {
+                filter: String::new(),
+                selected: 0
+            }
+        );
+        assert_eq!(app.composer.as_str(), "");
+    }
+
+    #[tokio::test]
+    async fn slash_menu_enter_runs_selected_command_from_root_menu() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/");
+        app.slash_menu_selected = 1;
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .unwrap();
+
+        assert_eq!(app.overlay, OverlayState::Agents);
+        assert_eq!(app.composer.as_str(), "");
+    }
+
     #[test]
     fn centered_rect_rows_uses_fixed_height() {
         let area = Rect::new(0, 0, 100, 40);

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -132,8 +132,6 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
     }
 
     if let Some(projection) = app.projection.as_ref() {
-        let mut visible_event_ids = std::collections::HashSet::new();
-
         for event in projection.durable_conversation_events() {
             if !is_chat_visible_conversation_event(&event.kind) {
                 continue;
@@ -143,19 +141,6 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
                 role: CachedChatRole::System,
                 speaker: conversation_event_speaker(&event.kind),
                 body: conversation_event_body(event),
-            });
-            visible_event_ids.insert(event.id.as_str());
-        }
-
-        for event in projection.recent_activity_events() {
-            if visible_event_ids.contains(event.id.as_str()) {
-                continue;
-            }
-            items.push(CachedChatItem {
-                created_at: event.ts,
-                role: CachedChatRole::System,
-                speaker: conversation_event_speaker(&event.kind),
-                body: progress_event_body(event),
             });
         }
     }
@@ -167,6 +152,10 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
             .then_with(|| left.speaker.cmp(&right.speaker))
             .then_with(|| left.body.cmp(&right.body))
     });
+    let fallback_ts = items.last().map(|item| item.created_at);
+    if let Some(active_item) = active_activity_item(app, fallback_ts) {
+        items.push(active_item);
+    }
     items
 }
 
@@ -277,6 +266,217 @@ fn chat_role_rank(role: CachedChatRole) -> u8 {
         CachedChatRole::Agent => 1,
         CachedChatRole::System => 2,
     }
+}
+
+fn active_activity_item(
+    app: &TuiApp,
+    fallback_ts: Option<DateTime<chrono::Utc>>,
+) -> Option<CachedChatItem> {
+    let projection = app.projection.as_ref();
+    let agent = projection
+        .map(|projection| &projection.agent)
+        .or_else(|| app.selected_agent_summary())?;
+    if !agent_has_active_activity(agent) {
+        return None;
+    }
+
+    let latest_activity = projection.and_then(latest_activity_event);
+    let latest_event_ts =
+        projection.and_then(|projection| projection.event_log().last().map(|event| event.ts));
+    let created_at = latest_event_ts
+        .or(agent.agent.last_brief_at)
+        .or_else(|| {
+            agent
+                .agent
+                .last_turn_terminal
+                .as_ref()
+                .map(|terminal| terminal.completed_at)
+        })
+        .or(fallback_ts)
+        .or_else(|| app.last_event_at.map(|ts| ts.with_timezone(&chrono::Utc)))
+        .unwrap_or_else(chrono::Utc::now);
+
+    Some(CachedChatItem {
+        created_at,
+        role: CachedChatRole::System,
+        speaker: active_activity_speaker(agent),
+        body: active_activity_body(
+            agent,
+            projection.map(|projection| projection.tasks.as_slice()),
+            latest_activity,
+        ),
+    })
+}
+
+fn agent_has_active_activity(agent: &AgentSummary) -> bool {
+    let active_parent = matches!(
+        agent.agent.status,
+        crate::types::AgentStatus::Booting
+            | crate::types::AgentStatus::AwakeRunning
+            | crate::types::AgentStatus::AwaitingTask
+    );
+    let active_child = agent.active_children.iter().any(|child| {
+        matches!(
+            child.status,
+            crate::types::AgentStatus::Booting
+                | crate::types::AgentStatus::AwakeRunning
+                | crate::types::AgentStatus::AwaitingTask
+        ) || child.pending > 0
+            || child.active_task_count > 0
+    });
+    active_parent || !agent.agent.active_task_ids.is_empty() || active_child
+}
+
+fn latest_activity_event(
+    projection: &crate::tui::projection::TuiProjection,
+) -> Option<&crate::tui::projection::ProjectionEventRecord> {
+    projection
+        .event_log()
+        .iter()
+        .rev()
+        .find(|event| crate::tui::projection::is_ephemeral_activity_kind(&event.kind))
+}
+
+fn active_activity_speaker(agent: &AgentSummary) -> String {
+    match agent.agent.status {
+        crate::types::AgentStatus::Booting => "Holon (starting)".into(),
+        crate::types::AgentStatus::AwaitingTask => "Holon (waiting)".into(),
+        crate::types::AgentStatus::AwakeRunning => "Holon (working)".into(),
+        _ if !agent.active_children.is_empty() => "Holon (delegating)".into(),
+        _ => "Holon (working)".into(),
+    }
+}
+
+fn active_activity_body(
+    agent: &AgentSummary,
+    tasks: Option<&[TaskRecord]>,
+    latest_activity: Option<&crate::tui::projection::ProjectionEventRecord>,
+) -> String {
+    let mut lines = Vec::new();
+    let memory = &agent.agent.working_memory.current_working_memory;
+
+    if let Some(summary) = non_empty(memory.work_summary.as_deref()) {
+        lines.push(format!("Working: {}", trim_activity_line(summary, 180)));
+    } else if let Some(task_summary) = active_task_summary(agent, tasks) {
+        lines.push(format!("Task: {}", trim_activity_line(&task_summary, 180)));
+    } else if let Some(child_summary) = active_child_summary(agent) {
+        lines.push(format!(
+            "Delegated: {}",
+            trim_activity_line(&child_summary, 180)
+        ));
+    } else {
+        lines.push(match agent.agent.status {
+            crate::types::AgentStatus::Booting => "Starting runtime".into(),
+            crate::types::AgentStatus::AwaitingTask => "Waiting for active task progress".into(),
+            crate::types::AgentStatus::AwakeRunning => "Working on the current turn".into(),
+            _ => "Work is still active".into(),
+        });
+    }
+
+    if let Some(target) = non_empty(memory.delivery_target.as_deref()) {
+        lines.push(format!("Target: {}", trim_activity_line(target, 160)));
+    }
+
+    if let Some(work_item_id) = non_empty(
+        memory
+            .current_work_item_id
+            .as_deref()
+            .or(agent.agent.current_work_item_id.as_deref())
+            .or(agent.agent.current_turn_work_item_id.as_deref()),
+    ) {
+        lines.push(format!("Work item: {work_item_id}"));
+    }
+
+    if let Some(event) = latest_activity {
+        lines.push(format!(
+            "Now: {}",
+            trim_activity_line(&progress_event_body(event), 180)
+        ));
+    }
+
+    if !agent.agent.active_task_ids.is_empty() || agent.agent.pending > 0 {
+        lines.push(format!(
+            "Queue: pending {}, active tasks {}",
+            agent.agent.pending,
+            agent.agent.active_task_ids.len()
+        ));
+    }
+
+    if !agent.active_children.is_empty() {
+        let children = agent
+            .active_children
+            .iter()
+            .take(2)
+            .map(|child| {
+                let mut description = format!(
+                    "{} {:?}",
+                    child.identity.agent_id, child.observability.phase
+                );
+                if let Some(summary) = child
+                    .observability
+                    .work_summary
+                    .as_deref()
+                    .or(child.observability.last_progress_brief.as_deref())
+                {
+                    description.push_str(": ");
+                    description.push_str(&trim_activity_line(summary, 100));
+                }
+                description
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        lines.push(format!("Children: {children}"));
+    }
+
+    if !memory.waiting_on.is_empty() {
+        lines.push(format!(
+            "Waiting on: {}",
+            memory
+                .waiting_on
+                .iter()
+                .take(2)
+                .map(|item| trim_activity_line(item, 80))
+                .collect::<Vec<_>>()
+                .join("; ")
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn active_task_summary(agent: &AgentSummary, tasks: Option<&[TaskRecord]>) -> Option<String> {
+    let tasks = tasks?;
+    agent.agent.active_task_ids.iter().find_map(|task_id| {
+        tasks
+            .iter()
+            .find(|task| task.id == *task_id)
+            .and_then(|task| task.summary.clone())
+    })
+}
+
+fn active_child_summary(agent: &AgentSummary) -> Option<String> {
+    agent.active_children.iter().find_map(|child| {
+        child
+            .observability
+            .work_summary
+            .clone()
+            .or_else(|| child.observability.last_progress_brief.clone())
+    })
+}
+
+fn trim_activity_line(input: &str, max_chars: usize) -> String {
+    trim_preview(&collapse_whitespace(input), max_chars)
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
 }
 
 pub(super) fn paragraph_max_scroll(text: &Text<'_>, area: Rect) -> u16 {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -668,12 +668,8 @@ impl TuiApp {
             }
             KeyCode::Enter => {
                 let selected = self.slash_menu_selected.min(specs.len().saturating_sub(1));
-                let command = specs[selected].name;
-                let selection = if self.composer.as_str().trim() == command {
-                    command.to_string()
-                } else {
-                    self.composer.as_str().to_string()
-                };
+                let selection =
+                    slash_menu_enter_submission(self.composer.as_str(), specs[selected]);
                 let selection = parse_composer_submission(&selection)?;
                 match selection {
                     Some(ComposerSubmission::Slash(command, args)) => {
@@ -816,6 +812,24 @@ impl TuiApp {
     }
 }
 
+fn slash_menu_enter_submission(buffer: &str, selected: SlashCommandSpec) -> String {
+    let trimmed = buffer.trim();
+    let Some((token, rest)) = trimmed.split_once(char::is_whitespace) else {
+        return selected.name.to_string();
+    };
+
+    if token == selected.name || slash_command_spec(token).is_none() {
+        let rest = rest.trim();
+        if rest.is_empty() {
+            selected.name.to_string()
+        } else {
+            format!("{} {rest}", selected.name)
+        }
+    } else {
+        trimmed.to_string()
+    }
+}
+
 enum BufferAction {
     Submit,
     Cancel,
@@ -919,8 +933,8 @@ impl TuiApp {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_composer_submission, slash_menu_specs, slash_prompt_lines, ComposerSubmission,
-        SlashCommand,
+        parse_composer_submission, slash_command_spec, slash_menu_enter_submission,
+        slash_menu_specs, slash_prompt_lines, ComposerSubmission, SlashCommand,
     };
     use crossterm::event::KeyCode;
 
@@ -1024,6 +1038,27 @@ mod tests {
     #[test]
     fn slash_menu_ignores_multiline_input() {
         assert!(slash_menu_specs("/mo\nextra").is_empty());
+    }
+
+    #[test]
+    fn slash_menu_enter_submission_uses_selected_command_for_prefix() {
+        let model = slash_command_spec("/model").expect("model command");
+        assert_eq!(slash_menu_enter_submission("/", model), "/model");
+        assert_eq!(slash_menu_enter_submission("/mo", model), "/model");
+        assert_eq!(slash_menu_enter_submission("   /mo  ", model), "/model");
+    }
+
+    #[test]
+    fn slash_menu_enter_submission_preserves_arguments_with_selected_command() {
+        let agent = slash_command_spec("/agent").expect("agent command");
+        assert_eq!(
+            slash_menu_enter_submission("/ag default", agent),
+            "/agent default"
+        );
+        assert_eq!(
+            slash_menu_enter_submission("   /agent default  ", agent),
+            "/agent default"
+        );
     }
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -628,6 +628,9 @@ impl TuiApp {
     }
 
     async fn handle_slash_menu_key(&mut self, key: KeyEvent) -> Result<bool> {
+        if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT) {
+            return Ok(false);
+        }
         if !self.is_slash_menu_visible() {
             return Ok(false);
         }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -7,7 +7,7 @@ use unicode_width::UnicodeWidthStr;
 pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     let area = frame.area();
     let slash_menu = slash_menu_lines(app);
-    let prompt_height = prompt_pane_height(app.composer.as_str(), slash_menu.len());
+    let prompt_height = prompt_pane_height(app.composer.as_str(), slash_menu.len(), area.width);
     let status_height = status_bar_height(&app.status_line);
     let outer = Layout::default()
         .direction(Direction::Vertical)
@@ -260,13 +260,14 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
     lines.join("\n")
 }
 
-fn prompt_pane_height(buffer: &str, slash_menu_rows: usize) -> u16 {
-    let mut prompt_lines = buffer.lines().count();
-    if buffer.is_empty() || buffer.ends_with('\n') {
-        prompt_lines += 1;
-    }
-    let prompt_lines = prompt_lines.max(1) as u16;
-    (prompt_lines + slash_menu_rows as u16 + 2).clamp(3, 12)
+fn prompt_pane_height(buffer: &str, slash_menu_rows: usize, pane_width: u16) -> u16 {
+    let input_width = pane_width.saturating_sub(2).max(1);
+    let prompt_rows = render_prompt_buffer(buffer)
+        .split('\n')
+        .map(|line| wrapped_prompt_rows(line, input_width))
+        .sum::<u16>()
+        .max(1);
+    (prompt_rows + slash_menu_rows as u16 + 2).clamp(3, 12)
 }
 
 fn status_bar_height(status_line: &str) -> u16 {
@@ -308,7 +309,11 @@ fn render_prompt_buffer(buffer: &str) -> String {
 fn render_prompt_text(buffer: &str, slash_menu: &[Line<'static>]) -> Text<'static> {
     if !slash_menu.is_empty() {
         let mut lines = slash_menu.to_vec();
-        lines.push(Line::from(render_prompt_buffer(buffer)));
+        lines.extend(
+            render_prompt_buffer(buffer)
+                .lines()
+                .map(|line| Line::from(line.to_string())),
+        );
         return Text::from(lines);
     }
 
@@ -813,8 +818,9 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        prompt_cursor_position, render_header, render_model_status, render_prompt_buffer,
-        render_prompt_text, render_summary, render_task_detail, status_bar_height,
+        prompt_cursor_position, prompt_pane_height, render_header, render_model_status,
+        render_prompt_buffer, render_prompt_text, render_summary, render_task_detail,
+        status_bar_height,
     };
     use crate::system::{ExecutionProfile, ExecutionSnapshot};
     use crate::types::{
@@ -962,6 +968,12 @@ mod tests {
     }
 
     #[test]
+    fn prompt_pane_height_accounts_for_soft_wrapped_lines() {
+        assert_eq!(prompt_pane_height("abcdefgh", 0, 10), 4);
+        assert_eq!(prompt_pane_height("abcdefghabcdefgh", 0, 10), 5);
+    }
+
+    #[test]
     fn empty_prompt_renders_dim_placeholder() {
         let rendered = render_prompt_text("", &[]);
         let line = rendered.lines.first().expect("placeholder line");
@@ -1086,6 +1098,32 @@ mod tests {
             .join("\n");
         assert!(joined.contains("/debug-prompt open debug prompt dialog"));
         assert!(joined.contains("> /de"));
+    }
+
+    #[test]
+    fn slash_menu_prompt_buffer_uses_real_text_lines() {
+        let rendered = render_prompt_text(
+            "/debug\nsecond",
+            &[Line::from("  /debug-prompt open debug prompt dialog")],
+        );
+        let joined = rendered
+            .lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            joined,
+            vec![
+                "  /debug-prompt open debug prompt dialog",
+                "> /debug",
+                "  second"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Keep Conversation durable history separate from live TUI activity by appending a synthetic active activity item only while the selected agent has active work.
- Show current work summary, delivery target, work item, active queue/children, and the latest tool/progress event in that active item.
- Preserve the earlier TUI input fixes for multiline wrapping, Shift+Enter newlines, and slash-menu selected command execution.

## Tests
- cargo test tui -- --nocapture
