### PR TITLE
fix: address TUI active activity review feedback

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1902,6 +1902,82 @@ mod tests {
     }
 
     #[test]
+    fn chat_text_shows_pending_queue_as_active_activity() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeIdle;
+        snapshot.agent.agent.pending = 1;
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let rendered: String = build_chat_text(&collect_chat_items(&app))
+            .lines
+            .into_iter()
+            .flat_map(|line| line.spans.into_iter().map(|span| span.content))
+            .collect();
+
+        assert!(rendered.contains("Holon (queued)"));
+        assert!(rendered.contains("Queued work is waiting to run"));
+        assert!(rendered.contains("Queue: pending 1, active tasks 0"));
+    }
+
+    #[test]
+    fn active_activity_timestamp_does_not_sort_before_tail_history() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let ts = Utc::now();
+        app.briefs = vec![BriefRecord {
+            id: "brief-latest".into(),
+            agent_id: "default".into(),
+            workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
+            work_item_id: None,
+            kind: BriefKind::Result,
+            created_at: ts + chrono::Duration::seconds(10),
+            text: "Latest durable response".into(),
+            attachments: None,
+            related_message_id: None,
+            related_task_id: None,
+        }];
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-tool".into(),
+                event: "tool_executed".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-tool".into(),
+                    seq: 2,
+                    ts,
+                    agent_id: "default".into(),
+                    event_type: "tool_executed".into(),
+                    payload: json!({
+                        "tool_name": "ExecCommand",
+                        "exec_command_cmd": "cargo test tui"
+                    }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.projection = Some(projection);
+
+        let items = collect_chat_items(&app);
+        let active_item = items.last().expect("active activity item");
+        let previous_item = items
+            .get(items.len().saturating_sub(2))
+            .expect("durable item before active activity");
+
+        assert_eq!(active_item.speaker, "Holon (working)");
+        assert!(active_item.created_at >= previous_item.created_at);
+    }
+
+    #[test]
     fn collect_chat_items_orders_equal_timestamps_deterministically() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -283,18 +283,21 @@ fn active_activity_item(
     let latest_activity = projection.and_then(latest_activity_event);
     let latest_event_ts =
         projection.and_then(|projection| projection.event_log().last().map(|event| event.ts));
-    let created_at = latest_event_ts
-        .or(agent.agent.last_brief_at)
-        .or_else(|| {
-            agent
-                .agent
-                .last_turn_terminal
-                .as_ref()
-                .map(|terminal| terminal.completed_at)
-        })
-        .or(fallback_ts)
-        .or_else(|| app.last_event_at.map(|ts| ts.with_timezone(&chrono::Utc)))
-        .unwrap_or_else(chrono::Utc::now);
+    let created_at = [
+        latest_event_ts,
+        agent.agent.last_brief_at,
+        agent
+            .agent
+            .last_turn_terminal
+            .as_ref()
+            .map(|terminal| terminal.completed_at),
+        fallback_ts,
+        app.last_event_at.map(|ts| ts.with_timezone(&chrono::Utc)),
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or_else(chrono::Utc::now);
 
     Some(CachedChatItem {
         created_at,
@@ -324,7 +327,10 @@ fn agent_has_active_activity(agent: &AgentSummary) -> bool {
         ) || child.pending > 0
             || child.active_task_count > 0
     });
-    active_parent || !agent.agent.active_task_ids.is_empty() || active_child
+    active_parent
+        || agent.agent.pending > 0
+        || !agent.agent.active_task_ids.is_empty()
+        || active_child
 }
 
 fn latest_activity_event(
@@ -342,6 +348,7 @@ fn active_activity_speaker(agent: &AgentSummary) -> String {
         crate::types::AgentStatus::Booting => "Holon (starting)".into(),
         crate::types::AgentStatus::AwaitingTask => "Holon (waiting)".into(),
         crate::types::AgentStatus::AwakeRunning => "Holon (working)".into(),
+        crate::types::AgentStatus::AwakeIdle if agent.agent.pending > 0 => "Holon (queued)".into(),
         _ if !agent.active_children.is_empty() => "Holon (delegating)".into(),
         _ => "Holon (working)".into(),
     }
@@ -369,6 +376,9 @@ fn active_activity_body(
             crate::types::AgentStatus::Booting => "Starting runtime".into(),
             crate::types::AgentStatus::AwaitingTask => "Waiting for active task progress".into(),
             crate::types::AgentStatus::AwakeRunning => "Working on the current turn".into(),
+            crate::types::AgentStatus::AwakeIdle if agent.agent.pending > 0 => {
+                "Queued work is waiting to run".into()
+            }
             _ => "Work is still active".into(),
         });
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -261,13 +261,22 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
 }
 
 fn prompt_pane_height(buffer: &str, slash_menu_rows: usize, pane_width: u16) -> u16 {
+    const MAX_PROMPT_PANE_HEIGHT: u16 = 12;
+
     let input_width = pane_width.saturating_sub(2).max(1);
-    let prompt_rows = render_prompt_buffer(buffer)
-        .split('\n')
-        .map(|line| wrapped_prompt_rows(line, input_width))
-        .sum::<u16>()
-        .max(1);
-    (prompt_rows + slash_menu_rows as u16 + 2).clamp(3, 12)
+    let mut prompt_rows = 0u32;
+    for line in render_prompt_buffer(buffer).split('\n') {
+        prompt_rows = prompt_rows.saturating_add(u32::from(wrapped_prompt_rows(line, input_width)));
+        if prompt_rows >= u32::from(MAX_PROMPT_PANE_HEIGHT) {
+            break;
+        }
+    }
+    let slash_menu_rows = slash_menu_rows.min(usize::from(MAX_PROMPT_PANE_HEIGHT)) as u32;
+    let pane_rows = prompt_rows
+        .max(1)
+        .saturating_add(slash_menu_rows)
+        .saturating_add(2);
+    pane_rows.clamp(3, u32::from(MAX_PROMPT_PANE_HEIGHT)) as u16
 }
 
 fn status_bar_height(status_line: &str) -> u16 {
@@ -412,9 +421,10 @@ fn prompt_cursor_position(area: Rect, buffer: &str, cursor: usize, hint_rows: u1
 }
 
 fn wrapped_prompt_rows(line: &str, visible_line_width: u16) -> u16 {
-    let line_width = display_width(line);
-    let rows = (line_width + visible_line_width.saturating_sub(1)) / visible_line_width;
-    rows.max(1)
+    let line_width = u32::from(display_width(line));
+    let visible_line_width = u32::from(visible_line_width.max(1));
+    let rows = line_width.saturating_add(visible_line_width.saturating_sub(1)) / visible_line_width;
+    rows.max(1).min(u32::from(u16::MAX)) as u16
 }
 
 fn display_width(text: &str) -> u16 {
@@ -971,6 +981,13 @@ mod tests {
     fn prompt_pane_height_accounts_for_soft_wrapped_lines() {
         assert_eq!(prompt_pane_height("abcdefgh", 0, 10), 4);
         assert_eq!(prompt_pane_height("abcdefghabcdefgh", 0, 10), 5);
+    }
+
+    #[test]
+    fn prompt_pane_height_saturates_for_large_pastes() {
+        let buffer = "abcdefghij\n".repeat(70_000);
+        assert_eq!(prompt_pane_height(&buffer, usize::MAX, 4), 12);
+        assert_eq!(prompt_pane_height(&"a".repeat(70_000), 0, 4), 12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Address Copilot review feedback from merged PR #854.
- Keep the synthetic active activity timestamp consistent with tail placement by using the max candidate timestamp.
- Treat pending queued work as visible active activity, including an explicit queued state label.
- Make prompt height and wrap-row calculations saturating for very large pasted input.

## Tests
- cargo test tui -- --nocapture
