### PR TITLE
Improve ApplyPatch prompt and diagnostics

### DIFF
--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -17,6 +17,9 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         .iter()
         .map(|tool| tool.name.as_str())
         .collect::<Vec<_>>();
+    let apply_patch_tool = available_tools
+        .iter()
+        .find(|tool| tool.name == "ApplyPatch");
 
     if names.contains(&"Sleep") {
         sections.push(section(
@@ -104,18 +107,23 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
             "Use ExecCommandBatch when several bounded shell commands should run before the next decision and do not require interactive input, background task management, or command-task continuation. Each item uses restricted ExecCommand startup fields: `cmd`, optional `workdir`, `shell`, `login`, `yield_time_ms`, and `max_output_tokens`. Do not pass `tty`, `accepts_input`, or `continue_on_result`; call ExecCommand directly for interactive, tty, or long-running supervised commands. ExecCommandBatch runs items sequentially and returns one grouped receipt with per-item status, output previews, truncation flags, command previews, and errors. Use it instead of unstructured shell separator scripts when item boundaries matter, but keep each item command compact and artifact-oriented. Do not use it for edits, arbitrary nested tools, installs, or commands whose later items depend on earlier output unless you intentionally set `stop_on_error` for a bounded sequence.".to_string(),
         ));
     }
-    if names.contains(&"ApplyPatch") {
+    if let Some(apply_patch_tool) = apply_patch_tool {
+        let invocation_contract = if apply_patch_tool.freeform_grammar.is_some() {
+            "Current ApplyPatch surface is a freeform grammar tool: send the unified diff body directly. Do not wrap it in JSON, and do not use `patch` or `input` fields."
+        } else {
+            "Current ApplyPatch surface is a JSON/function tool: call it with exactly `{\"patch\":\"--- a/path\\n+++ b/path\\n@@ -1,1 +1,1 @@\\n-old\\n+new\\n\"}`. Do not use `input`, and do not send a raw freeform diff body."
+        };
         sections.push(section(
             "tool_apply_patch",
             PromptStability::Stable,
-            "Use ApplyPatch as the primary precise file-mutation tool. Use it for focused new files, small local edits, multi-hunk single-file changes, structural edits, and bounded refactors. For very large new files, generated files, whole-file rewrites, bulk deletes, or broad mechanical refactors, choose the lower-context path: split the change into smaller ApplyPatch calls, or use a carefully bounded ExecCommand/scripted rewrite when that avoids emitting a huge diff and is easier to verify. Do not expect separate Write or Edit tools; express ordinary file mutation as unified diff text. On providers that expose ApplyPatch as a freeform grammar tool, send the unified diff body directly and do not wrap it in JSON. On JSON/function fallback providers, ApplyPatch expects exactly `{\"patch\":\"--- a/path\\n+++ b/path\\n@@ -1,1 +1,1 @@\\n-old\\n+new\\n\"}`; do not use `input`. The model-visible ApplyPatch receipt is concise text with action markers like `A`, `M`, `D`, or `R`, while the canonical result still records structured changed-file metadata, `changed_paths`, `changed_file_count`, ignored metadata, diagnostics, and `summary_text`.".to_string(),
+            format!("Use ApplyPatch as the primary precise file-mutation tool. Use it for focused new files, small local edits, multi-hunk single-file changes, structural edits, and bounded refactors. For very large new files, generated files, whole-file rewrites, bulk deletes, or broad mechanical refactors, choose the lower-context path: split the change into smaller ApplyPatch calls, or use a carefully bounded ExecCommand/scripted rewrite when that avoids emitting a huge diff and is easier to verify. Do not expect separate Write or Edit tools; express ordinary file mutation as unified diff text. {invocation_contract} The model-visible ApplyPatch receipt is concise text with action markers like `A`, `M`, `D`, or `R`; if it says success with diagnostics, treat the target file as potentially different from your intended mental model. The canonical result still records structured changed-file metadata, `changed_paths`, `changed_file_count`, ignored metadata, diagnostics, and `summary_text`."),
         ));
     }
     if names.contains(&"ApplyPatch") {
         sections.push(section(
             "tool_file_mutation",
             PromptStability::Stable,
-            "File mutation is workspace-scoped and centered on ApplyPatch. Use unified diff `---`/`+++` file headers and `@@` hunks for deletes, precise edits, and renames. Prefer focused hunks with enough surrounding context to stay unambiguous. Include at least 3 context lines before and after each changed line, and expand to 5–10 lines when the file contains repeated structures or similar patterns. Blank lines within hunks must have a space prefix to be valid context lines. Keep tool output bounded: do not paste enormous malformed patches, do not retry the same large failed patch unchanged, and split large refactors into smaller patch/application steps when that keeps failures recoverable. Avoid using ExecCommand with shell rewrite tricks like `sed -i` as the default editing path, but use a bounded script or heredoc when generating/replacing a large file is cheaper and safer than a huge diff. After any file mutation, rely on the ApplyPatch receipt first, then run focused verification with ExecCommand when correctness matters. Do not use file mutation tools for broad exploration; inspect with shell-first read commands through ExecCommand instead.".to_string(),
+            "File mutation is workspace-scoped and centered on ApplyPatch. Use unified diff `---`/`+++` file headers and `@@` hunks for deletes, precise edits, and renames. Prefer focused hunks with enough surrounding context to stay unambiguous. Include at least 3 context lines before and after each changed line, and expand to 5–10 lines when the file contains repeated structures or similar patterns. Blank lines within hunks must have a space prefix to be valid context lines. Keep tool output bounded: do not paste enormous malformed patches, do not retry the same large failed patch unchanged, and split large refactors into smaller patch/application steps when that keeps failures recoverable. Avoid using ExecCommand with shell rewrite tricks like `sed -i` as the default editing path, but use a bounded script or heredoc when generating/replacing a large file is cheaper and safer than a huge diff. After a clean file mutation, rely on the ApplyPatch receipt first, then run focused verification with ExecCommand when correctness matters. If ApplyPatch reports diagnostics, warnings, partial application, context mismatch, or any non-clean receipt, inspect the exact affected region before continuing edits to that file and do not retry the same diagnostic-producing patch unchanged. Do not use file mutation tools for broad exploration; inspect with shell-first read commands through ExecCommand instead.".to_string(),
         ));
     }
     if names.contains(&"UseWorkspace") {
@@ -451,6 +459,16 @@ mod tests {
             .contains("Do not expect separate Write or Edit tools"));
         assert!(apply_patch.content.contains("lower-context path"));
         assert!(apply_patch.content.contains("very large new files"));
+        assert!(apply_patch.content.contains("success with diagnostics"));
+        assert!(apply_patch
+            .content
+            .contains("Current ApplyPatch surface is a JSON/function tool"));
+        assert!(apply_patch
+            .content
+            .contains("do not send a raw freeform diff body"));
+        assert!(!apply_patch
+            .content
+            .contains("Current ApplyPatch surface is a freeform grammar tool"));
         let section = sections
             .iter()
             .find(|s| s.name == "tool_file_mutation")
@@ -461,6 +479,41 @@ mod tests {
             .content
             .contains("do not retry the same large failed patch unchanged"));
         assert!(section.content.contains("bounded script or heredoc"));
+        assert!(section.content.contains("non-clean receipt"));
+        assert!(section
+            .content
+            .contains("inspect the exact affected region"));
+    }
+
+    #[test]
+    fn test_apply_patch_section_uses_freeform_invocation_when_grammar_is_available() {
+        let tools = vec![ToolSpec {
+            name: "ApplyPatch".into(),
+            description: String::new(),
+            input_schema: json!({}),
+            freeform_grammar: Some(crate::tool::spec::ToolFreeformGrammar {
+                syntax: "lark".into(),
+                definition: "start: /.+/".into(),
+            }),
+        }];
+        let sections = tool_sections(&tools);
+        let apply_patch = sections
+            .iter()
+            .find(|s| s.name == "tool_apply_patch")
+            .expect("apply patch section");
+
+        assert!(apply_patch
+            .content
+            .contains("Current ApplyPatch surface is a freeform grammar tool"));
+        assert!(apply_patch
+            .content
+            .contains("send the unified diff body directly"));
+        assert!(apply_patch
+            .content
+            .contains("do not use `patch` or `input` fields"));
+        assert!(!apply_patch
+            .content
+            .contains("Current ApplyPatch surface is a JSON/function tool"));
     }
 
     #[test]

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -443,6 +443,14 @@ impl AgentProvider for FallbackProvider {
         capabilities
     }
 
+    fn supports_freeform_grammar_tools(&self) -> bool {
+        !self.candidates.is_empty()
+            && self
+                .candidates
+                .iter()
+                .all(|candidate| candidate.provider.supports_freeform_grammar_tools())
+    }
+
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {
         let mut candidates = self.candidates.iter();
         let first = candidates.next()?.provider.context_management_policy()?;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -294,6 +294,25 @@ pub trait AgentProvider: Send + Sync {
         vec![ProviderPromptCapability::FullRequestOnly]
     }
 
+    fn supports_freeform_grammar_tools(&self) -> bool {
+        false
+    }
+
+    fn prompt_tool_specs(&self, tools: &[ToolSpec]) -> Vec<ToolSpec> {
+        if self.supports_freeform_grammar_tools() {
+            return tools.to_vec();
+        }
+
+        tools
+            .iter()
+            .cloned()
+            .map(|mut tool| {
+                tool.freeform_grammar = None;
+                tool
+            })
+            .collect()
+    }
+
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {
         None
     }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -367,6 +367,10 @@ impl AgentProvider for OpenAiProvider {
             crate::provider::ProviderPromptCapability::IncrementalResponses,
         ]
     }
+
+    fn supports_freeform_grammar_tools(&self) -> bool {
+        true
+    }
 }
 
 #[async_trait]
@@ -453,6 +457,10 @@ impl AgentProvider for OpenAiCodexProvider {
             crate::provider::ProviderPromptCapability::PromptCacheKey,
             crate::provider::ProviderPromptCapability::IncrementalResponses,
         ]
+    }
+
+    fn supports_freeform_grammar_tools(&self) -> bool {
+        true
     }
 }
 

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -30,6 +30,8 @@ impl RuntimeHandle {
             let state = guard.state.clone();
             drop(guard);
             let available_tools = self.filtered_tool_specs(&identity)?;
+            let provider = self.current_provider().await;
+            let prompt_tools = provider.prompt_tool_specs(&available_tools);
             let workspace = self.workspace_view_from_state(&state)?;
             let execution = self.execution_snapshot_for_view(
                 state.execution_profile.clone(),
@@ -49,7 +51,7 @@ impl RuntimeHandle {
                 &identity,
                 loaded_agents_md,
                 &skills,
-                &available_tools,
+                &prompt_tools,
                 continuation_resolution,
             )?
         };
@@ -131,6 +133,8 @@ impl RuntimeHandle {
             .map(|trigger| resolve_continuation(&prior_closure, &trigger));
         let identity = self.agent_identity_view().await?;
         let available_tools = self.filtered_tool_specs(&identity)?;
+        let provider = self.current_provider().await;
+        let prompt_tools = provider.prompt_tool_specs(&available_tools);
         let execution = self.execution_snapshot().await?;
         let loaded_agents_md = self.loaded_agents_md_for_state(&agent)?;
         let skills = self.skills_runtime_view_for_state(&agent, &identity)?;
@@ -145,7 +149,7 @@ impl RuntimeHandle {
             &identity,
             loaded_agents_md,
             &skills,
-            &available_tools,
+            &prompt_tools,
             continuation.as_ref(),
         )
     }

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -1,6 +1,28 @@
 use super::super::*;
 use super::support::*;
 
+struct FreeformPromptProvider;
+
+#[async_trait]
+impl AgentProvider for FreeformPromptProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        Ok(ProviderTurnResponse {
+            blocks: vec![ModelBlock::Text {
+                text: "done".into(),
+            }],
+            stop_reason: Some("stop".into()),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_usage: None,
+            request_diagnostics: None,
+        })
+    }
+
+    fn supports_freeform_grammar_tools(&self) -> bool {
+        true
+    }
+}
+
 #[tokio::test]
 async fn agent_summary_reports_agents_md_sources_without_content() {
     let dir = tempdir().unwrap();
@@ -123,6 +145,62 @@ async fn detached_agent_does_not_load_workspace_agents_md() {
 
     let loaded = runtime.loaded_agents_md().await.unwrap();
     assert!(loaded.workspace_source.is_none());
+}
+
+#[tokio::test]
+async fn preview_prompt_lowers_apply_patch_contract_for_json_tool_providers() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let preview = runtime
+        .preview_prompt("edit a file".into(), TrustLevel::TrustedOperator)
+        .await
+        .unwrap();
+
+    assert!(preview
+        .rendered_system_prompt
+        .contains("Current ApplyPatch surface is a JSON/function tool"));
+    assert!(!preview
+        .rendered_system_prompt
+        .contains("Current ApplyPatch surface is a freeform grammar tool"));
+}
+
+#[tokio::test]
+async fn preview_prompt_keeps_apply_patch_contract_for_freeform_tool_providers() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(FreeformPromptProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let preview = runtime
+        .preview_prompt("edit a file".into(), TrustLevel::TrustedOperator)
+        .await
+        .unwrap();
+
+    assert!(preview
+        .rendered_system_prompt
+        .contains("Current ApplyPatch surface is a freeform grammar tool"));
+    assert!(!preview
+        .rendered_system_prompt
+        .contains("Current ApplyPatch surface is a JSON/function tool"));
 }
 
 #[tokio::test]

--- a/src/tool/tools/apply_patch_tool.rs
+++ b/src/tool/tools/apply_patch_tool.rs
@@ -12,7 +12,9 @@ use crate::{
         spec::{ToolFreeformGrammar, ToolResultStatus},
         ToolError, ToolResult,
     },
-    types::{ApplyPatchAction, ApplyPatchResult, ToolCapabilityFamily, TrustLevel},
+    types::{
+        ApplyPatchAction, ApplyPatchDiagnostic, ApplyPatchResult, ToolCapabilityFamily, TrustLevel,
+    },
 };
 
 use super::{serialize_success, BuiltinToolDefinition};
@@ -22,6 +24,8 @@ pub(crate) const NAME: &str = "ApplyPatch";
 const APPLY_PATCH_LARK_GRAMMAR: &str = include_str!("apply_patch_tool.lark");
 const MODEL_ERROR_TEXT_LIMIT: usize = 700;
 const MODEL_ERROR_TOKEN_LIMIT: usize = 96;
+const MODEL_DIAGNOSTIC_LIMIT: usize = 8;
+const SUMMARY_DIAGNOSTIC_LIMIT: usize = 3;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -34,7 +38,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::LocalEnvironment,
         spec: crate::tool::ToolSpec {
             name: NAME.to_string(),
-            description: "Apply a unified diff patch across one or more files. On providers that expose custom/freeform tools, send the unified diff body directly rather than wrapping it in JSON. On JSON fallback providers, ApplyPatch expects exactly {\"patch\":\"--- a/path\\n+++ b/path\\n@@ -1,1 +1,1 @@\\n-old\\n+new\\n\"}. Do not use \"input\" or the old *** Begin Patch format.".to_string(),
+            description: "Apply a unified diff patch across one or more files. Follow the invocation shape exposed by the current tool surface, and do not use the old *** Begin Patch format.".to_string(),
             input_schema: tool_input_schema::<ApplyPatchArgs>()?,
             freeform_grammar: Some(ToolFreeformGrammar {
                 syntax: "lark".to_string(),
@@ -56,7 +60,7 @@ pub(crate) async fn execute(
         .await?;
     let outcome =
         apply_patch::apply_patch(execution.workspace.execution_root(), &patch_input).await?;
-    let summary_text = if outcome.changed_files.is_empty() {
+    let mut summary_text = if outcome.changed_files.is_empty() {
         "patched no files".to_string()
     } else {
         format!(
@@ -69,6 +73,9 @@ pub(crate) async fn execute(
                 .join(", ")
         )
     };
+    if !outcome.diagnostics.is_empty() {
+        summary_text.push_str(&render_diagnostics_summary(&outcome.diagnostics));
+    }
     serialize_success(
         NAME,
         &ApplyPatchResult {
@@ -97,11 +104,36 @@ pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
         .ok_or_else(|| anyhow!("ApplyPatch result missing payload"))?;
     let result: ApplyPatchResult = serde_json::from_value(value)?;
 
-    let mut lines = vec!["Success. Updated the following files:".to_string()];
+    let mut lines = if result.diagnostics.is_empty() {
+        vec!["Success. Updated the following files:".to_string()]
+    } else {
+        vec!["Success with diagnostics. Updated the following files:".to_string()]
+    };
     if result.changed_files.is_empty() {
         lines.push("(no file changes recorded)".to_string());
     } else {
         lines.extend(result.changed_files.iter().map(render_changed_file_receipt));
+    }
+    if !result.diagnostics.is_empty() {
+        lines.push(String::new());
+        lines.push("Diagnostics:".to_string());
+        lines.extend(
+            result
+                .diagnostics
+                .iter()
+                .take(MODEL_DIAGNOSTIC_LIMIT)
+                .map(render_diagnostic_for_model),
+        );
+        if result.diagnostics.len() > MODEL_DIAGNOSTIC_LIMIT {
+            lines.push(format!(
+                "- omitted {} additional diagnostics",
+                result.diagnostics.len() - MODEL_DIAGNOSTIC_LIMIT
+            ));
+        }
+        lines.push(
+            "Inspect the affected target region before applying another patch to the same file."
+                .to_string(),
+        );
     }
     Ok(lines.join("\n"))
 }
@@ -192,6 +224,44 @@ fn render_changed_file_receipt(file: &crate::types::ApplyPatchChangedFile) -> St
     }
 }
 
+fn render_diagnostic_for_model(diagnostic: &ApplyPatchDiagnostic) -> String {
+    let path = if diagnostic.path.trim().is_empty() {
+        "unknown path".to_string()
+    } else {
+        sanitize_model_visible_error_text(&diagnostic.path)
+    };
+    format!(
+        "- {} on {}: {}",
+        diagnostic.kind,
+        path,
+        sanitize_model_visible_error_text(&diagnostic.message)
+    )
+}
+
+fn render_diagnostics_summary(diagnostics: &[ApplyPatchDiagnostic]) -> String {
+    let mut parts = diagnostics
+        .iter()
+        .take(SUMMARY_DIAGNOSTIC_LIMIT)
+        .map(render_diagnostic_summary)
+        .collect::<Vec<_>>();
+    if diagnostics.len() > SUMMARY_DIAGNOSTIC_LIMIT {
+        parts.push(format!(
+            "+{} more",
+            diagnostics.len() - SUMMARY_DIAGNOSTIC_LIMIT
+        ));
+    }
+    format!(" (diagnostics: {})", parts.join(", "))
+}
+
+fn render_diagnostic_summary(diagnostic: &ApplyPatchDiagnostic) -> String {
+    let path = if diagnostic.path.trim().is_empty() {
+        "unknown path".to_string()
+    } else {
+        diagnostic.path.clone()
+    };
+    sanitize_model_visible_error_text(&format!("{} on {}", diagnostic.kind, path))
+}
+
 fn render_changed_file_summary(file: &crate::types::ApplyPatchChangedFile) -> String {
     match file.action {
         ApplyPatchAction::Move => format!(
@@ -240,6 +310,85 @@ mod tests {
         assert!(rendered.contains("Success. Updated the following files:"));
         assert!(rendered.contains("M src/lib.rs"));
         assert!(rendered.contains("A README.md"));
+    }
+
+    #[test]
+    fn apply_patch_renders_diagnostics_in_model_receipt() {
+        let result = serialize_success(
+            NAME,
+            &ApplyPatchResult {
+                changed_files: vec![crate::types::ApplyPatchChangedFile {
+                    action: ApplyPatchAction::Modify,
+                    path: "src/lib.rs".into(),
+                    from_path: None,
+                }],
+                changed_file_count: 1,
+                changed_paths: vec!["src/lib.rs".into()],
+                ignored_metadata: Vec::new(),
+                diagnostics: vec![ApplyPatchDiagnostic {
+                    path: "src/lib.rs".into(),
+                    kind: "hunk_count_mismatch".into(),
+                    message: "hunk header declared -1,1 +1,1 but body counted -1,20 +1,30".into(),
+                }],
+                summary_text: Some("patched M:src/lib.rs".into()),
+            },
+        )
+        .unwrap();
+
+        let rendered = render_for_model(&result).unwrap();
+        assert!(rendered.contains("Success with diagnostics"));
+        assert!(rendered.contains("M src/lib.rs"));
+        assert!(rendered.contains("Diagnostics:"));
+        assert!(rendered.contains("hunk_count_mismatch"));
+        assert!(rendered.contains("Inspect the affected target region"));
+    }
+
+    #[test]
+    fn apply_patch_renders_bounded_diagnostics_in_model_receipt() {
+        let diagnostics = (0..(MODEL_DIAGNOSTIC_LIMIT + 2))
+            .map(|idx| ApplyPatchDiagnostic {
+                path: format!("src/lib{idx}.rs"),
+                kind: "hunk_count_mismatch".into(),
+                message: format!("diagnostic {idx}"),
+            })
+            .collect::<Vec<_>>();
+        let result = serialize_success(
+            NAME,
+            &ApplyPatchResult {
+                changed_files: vec![crate::types::ApplyPatchChangedFile {
+                    action: ApplyPatchAction::Modify,
+                    path: "src/lib.rs".into(),
+                    from_path: None,
+                }],
+                changed_file_count: 1,
+                changed_paths: vec!["src/lib.rs".into()],
+                ignored_metadata: Vec::new(),
+                diagnostics,
+                summary_text: Some("patched M:src/lib.rs".into()),
+            },
+        )
+        .unwrap();
+
+        let rendered = render_for_model(&result).unwrap();
+        assert!(rendered.contains("diagnostic 7"));
+        assert!(!rendered.contains("diagnostic 8"));
+        assert!(rendered.contains("- omitted 2 additional diagnostics"));
+    }
+
+    #[test]
+    fn apply_patch_diagnostics_summary_is_bounded() {
+        let diagnostics = (0..(SUMMARY_DIAGNOSTIC_LIMIT + 2))
+            .map(|idx| ApplyPatchDiagnostic {
+                path: format!("src/lib{idx}.rs"),
+                kind: "hunk_count_mismatch".into(),
+                message: format!("diagnostic {idx}"),
+            })
+            .collect::<Vec<_>>();
+
+        let summary = render_diagnostics_summary(&diagnostics);
+        assert!(summary.contains("diagnostics: hunk_count_mismatch on src/lib0.rs"));
+        assert!(summary.contains("+2 more"));
+        assert!(!summary.contains("src/lib3.rs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- expose ApplyPatch diagnostics in model-visible success receipts and bounded compact summaries
- inject the ApplyPatch invocation contract from provider-aware prompt tool specs, so JSON/function transports do not receive freeform instructions
- cap model-visible diagnostic lines to avoid large malformed patches inflating the transcript

## Verification

- cargo fmt --check
- cargo test preview_prompt_lowers_apply_patch_contract_for_json_tool_providers --quiet
- cargo test preview_prompt_keeps_apply_patch_contract_for_freeform_tool_providers --quiet
- cargo test test_apply_patch_section_mentions_retired_write_and_edit_surface --quiet
- cargo test test_apply_patch_section_uses_freeform_invocation_when_grammar_is_available --quiet
- cargo test apply_patch_renders_diagnostics_in_model_receipt --quiet
- cargo test apply_patch_renders_bounded_diagnostics_in_model_receipt --quiet
- cargo test apply_patch_diagnostics_summary_is_bounded --quiet
