### PR TITLE
Improve TUI conversation activity rendering

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -406,7 +406,7 @@ impl TuiApp {
         };
         let mut projection = TuiProjection::from_snapshot(snapshot);
         if !switching_agents {
-            if let Some(previous) = self.projection.as_ref() {
+            if let Some(previous) = self.projection.as_mut() {
                 projection.inherit_recent_event_logs_from(previous);
             }
         }
@@ -1955,7 +1955,7 @@ mod tests {
             &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
         );
         let mut refreshed_projection = TuiProjection::from_snapshot(snapshot);
-        refreshed_projection.inherit_recent_event_logs_from(&previous_projection);
+        refreshed_projection.inherit_recent_event_logs_from(&mut previous_projection);
         app.projection = Some(refreshed_projection);
 
         let rendered: String = build_chat_text(&collect_chat_items(&app))
@@ -2092,6 +2092,45 @@ mod tests {
             }
             other => panic!("expected active activity item, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn active_activity_cells_stay_stable_without_new_events() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+        snapshot.agent.agent.working_memory.current_working_memory =
+            crate::types::WorkingMemorySnapshot {
+                work_summary: Some("Keep cache stable while working".into()),
+                ..Default::default()
+            };
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let first_items = collect_chat_items(&app);
+        let second_items = collect_chat_items(&app);
+        assert_eq!(first_items, second_items);
+
+        let _ = chat_text(&app);
+        let cached_cells = app
+            .chat_text_cache
+            .borrow()
+            .as_ref()
+            .expect("active activity should be cached")
+            .cells
+            .clone();
+        let _ = chat_text(&app);
+        assert_eq!(
+            cached_cells,
+            app.chat_text_cache
+                .borrow()
+                .as_ref()
+                .expect("active activity should remain cached")
+                .cells
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -9,7 +9,7 @@ use crate::{
     client::{AgentStreamEvent, EventStreamRequest, LocalClient, LocalEventStream, LocalHttpError},
     config::{AltScreenMode, AppConfig},
     system::{workspace_access_mode_label, workspace_projection_label},
-    tui_markdown::render_markdown_text,
+    tui_markdown::{render_markdown_text, render_markdown_text_spaced},
     types::{
         AgentSummary, BriefRecord, TaskRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
     },
@@ -45,8 +45,10 @@ mod projection;
 mod render;
 
 #[cfg(test)]
-use chat::{build_chat_text, collect_chat_items, is_operator_origin_value};
-use chat::{chat_text, paragraph_max_scroll, CachedChatText, ChatScrollState};
+use chat::{
+    build_chat_text, chat_text, collect_chat_items, is_operator_origin_value, ConversationCell,
+};
+use chat::{chat_text_for_width, paragraph_max_scroll, CachedChatText, ChatScrollState};
 use composer::ComposerState;
 use logging::TuiLogWriter;
 #[cfg(test)]
@@ -827,7 +829,8 @@ mod tests {
         build_chat_text, centered_rect_rows, chat_text, collect_chat_items,
         determine_alt_screen_mode_for_terminal, is_cursor_too_old_error, is_operator_origin_value,
         paragraph_max_scroll, projection::TuiProjection, AgentListChange, ChatScrollState,
-        ComposerState, OverlayState, TuiApp, TuiConnectionState, TuiRuntimeMessage,
+        ComposerState, ConversationCell, OverlayState, TuiApp, TuiConnectionState,
+        TuiRuntimeMessage,
     };
     use crate::{
         client::{
@@ -2030,8 +2033,17 @@ mod tests {
             .get(items.len().saturating_sub(2))
             .expect("durable item before active activity");
 
-        assert!(active_item.speaker.starts_with("Holon (working)"));
-        assert!(active_item.created_at >= previous_item.created_at);
+        match active_item {
+            ConversationCell::ActiveActivity {
+                speaker,
+                created_at,
+                ..
+            } => {
+                assert!(speaker.starts_with("Holon (working)"));
+                assert!(*created_at >= previous_item.created_at());
+            }
+            other => panic!("expected active activity item, got {other:?}"),
+        }
     }
 
     #[test]
@@ -2071,8 +2083,8 @@ mod tests {
         }];
 
         let items = collect_chat_items(&app);
-        assert_eq!(items[0].speaker, "You");
-        assert_eq!(items[1].speaker, "Holon");
+        assert!(matches!(items[0], ConversationCell::UserMessage { .. }));
+        assert!(matches!(items[1], ConversationCell::AssistantMarkdown(_)));
     }
 
     #[test]
@@ -2238,7 +2250,7 @@ mod tests {
         {
             let cache_ref = app.chat_text_cache.borrow();
             let cached = cache_ref.as_ref().expect("chat text should be cached");
-            assert_eq!(cached.items, collect_chat_items(&app));
+            assert_eq!(cached.cells, collect_chat_items(&app));
         }
 
         app.briefs = vec![BriefRecord {
@@ -2264,7 +2276,7 @@ mod tests {
 
         let cache_ref = app.chat_text_cache.borrow();
         let cached = cache_ref.as_ref().expect("chat text should be recached");
-        assert_eq!(cached.items, collect_chat_items(&app));
+        assert_eq!(cached.cells, collect_chat_items(&app));
 
         drop(cache_ref);
         app.briefs.clear();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1686,7 +1686,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_text_excludes_internal_projection_events_and_provider_text() {
+    fn chat_text_shows_active_assistant_preview_without_durable_system_event() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(
             client,
@@ -1742,8 +1742,8 @@ mod tests {
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
         assert!(!rendered.contains("System (work)"));
-        assert!(!rendered.contains("prepare rollout plan"));
-        assert!(!rendered.contains("hidden provider partial"));
+        assert!(rendered.contains("Assistant hidden provider partial"));
+        assert!(rendered.contains("Action    prepare rollout plan [Open]"));
     }
 
     #[test]
@@ -1856,9 +1856,10 @@ mod tests {
             .into_iter()
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
-        assert!(rendered.contains("Holon (working)"));
-        assert!(rendered.contains("Improve the Conversation working indicator"));
-        assert!(rendered.contains("Now: ExecCommand: cargo test tui"));
+        assert!(rendered.contains("Holon (working"));
+        assert!(rendered.contains("Current   Improve the Conversation working indicator"));
+        assert!(rendered.contains("Assistant ..."));
+        assert!(rendered.contains("Action    Still working"));
     }
 
     #[test]
@@ -1919,9 +1920,11 @@ mod tests {
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
 
-        assert!(rendered.contains("Holon (queued)"));
-        assert!(rendered.contains("Queued work is waiting to run"));
-        assert!(rendered.contains("Queue: pending 1, active tasks 0"));
+        assert!(rendered.contains("Holon (queued"));
+        assert!(rendered.contains("Current   Queued work is waiting to run"));
+        assert!(rendered.contains("Assistant ..."));
+        assert!(rendered.contains("Action    Waiting for activity"));
+        assert!(!rendered.contains("Queue: pending 1, active tasks 0"));
     }
 
     #[test]
@@ -1973,7 +1976,7 @@ mod tests {
             .get(items.len().saturating_sub(2))
             .expect("durable item before active activity");
 
-        assert_eq!(active_item.speaker, "Holon (working)");
+        assert!(active_item.speaker.starts_with("Holon (working)"));
         assert!(active_item.created_at >= previous_item.created_at);
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -402,7 +402,12 @@ impl TuiApp {
                 return Err(err);
             }
         };
-        let projection = TuiProjection::from_snapshot(snapshot);
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+        if !switching_agents {
+            if let Some(previous) = self.projection.as_ref() {
+                projection.inherit_recent_event_logs_from(previous);
+            }
+        }
         let cursor = projection.cursor.clone();
 
         self.stop_stream_task();
@@ -1862,6 +1867,53 @@ mod tests {
         assert!(rendered.contains("Current   Improve the Conversation working indicator"));
         assert!(rendered.contains("Assistant ..."));
         assert!(rendered.contains("Action    Still working"));
+    }
+
+    #[test]
+    fn chat_text_keeps_active_action_after_snapshot_refresh() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("default", "evt-refresh");
+        snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+        snapshot.agent.agent.working_memory.current_working_memory =
+            crate::types::WorkingMemorySnapshot {
+                work_summary: Some("Keep the active action stable".into()),
+                ..Default::default()
+            };
+        let mut previous_projection =
+            TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
+        previous_projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-tool".into(),
+                event: "tool_executed".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-tool".into(),
+                    seq: 2,
+                    ts: Utc::now(),
+                    agent_id: "default".into(),
+                    event_type: "tool_executed".into(),
+                    payload: json!({
+                        "tool_name": "ExecCommand",
+                        "exec_command_cmd": "cargo test tui"
+                    }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut refreshed_projection = TuiProjection::from_snapshot(snapshot);
+        refreshed_projection.inherit_recent_event_logs_from(&previous_projection);
+        app.projection = Some(refreshed_projection);
+
+        let rendered: String = build_chat_text(&collect_chat_items(&app))
+            .lines
+            .into_iter()
+            .flat_map(|line| line.spans.into_iter().map(|span| span.content))
+            .collect();
+        assert!(rendered.contains("Action    ExecCommand: cargo test tui"));
+        assert!(!rendered.contains("Action    Waiting for activity"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1060,9 +1060,9 @@ mod tests {
             .into_iter()
             .map(|line| line.spans.into_iter().map(|span| span.content).collect())
             .collect();
-        assert!(lines.iter().any(|line| line.contains("You")));
+        assert!(lines.iter().any(|line| line.contains("› ")));
         assert!(lines.iter().any(|line| line.contains("Fix the failing CI")));
-        assert!(lines.iter().any(|line| line.contains("Holon")));
+        assert!(lines.iter().any(|line| line.contains("• ")));
         assert!(lines
             .iter()
             .any(|line| line.contains("I started a worktree task.")));
@@ -1093,7 +1093,9 @@ mod tests {
             .into_iter()
             .map(|line| line.spans.into_iter().map(|span| span.content).collect())
             .collect();
-        assert!(lines.iter().any(|line| line.contains("Holon  First line")));
+        assert!(lines
+            .iter()
+            .any(|line| line.contains("• ") && line.contains("First line")));
         assert!(lines.iter().any(|line| line.contains("Second line")));
     }
 
@@ -1856,7 +1858,7 @@ mod tests {
             .into_iter()
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
-        assert!(rendered.contains("Holon (working"));
+        assert!(rendered.contains("Working"));
         assert!(rendered.contains("Current   Improve the Conversation working indicator"));
         assert!(rendered.contains("Assistant ..."));
         assert!(rendered.contains("Action    Still working"));
@@ -1920,7 +1922,7 @@ mod tests {
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
 
-        assert!(rendered.contains("Holon (queued"));
+        assert!(rendered.contains("Queued"));
         assert!(rendered.contains("Current   Queued work is waiting to run"));
         assert!(rendered.contains("Assistant ..."));
         assert!(rendered.contains("Action    Waiting for activity"));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1623,6 +1623,54 @@ mod tests {
     }
 
     #[test]
+    fn chat_text_keeps_markdown_block_separator_unindented() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.briefs = vec![BriefRecord {
+            id: "brief-1".into(),
+            agent_id: "default".into(),
+            workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
+            work_item_id: None,
+            kind: BriefKind::Result,
+            created_at: Utc::now(),
+            text: "### Title\n\nBody".into(),
+            attachments: None,
+            related_message_id: None,
+            related_task_id: None,
+        }];
+
+        let lines = build_chat_text(&collect_chat_items(&app)).lines;
+        let title_index = lines
+            .iter()
+            .position(|line| {
+                let rendered_line: String = line
+                    .spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect();
+                rendered_line.contains("### Title")
+            })
+            .expect("heading should render");
+        let blank_line = lines
+            .get(title_index + 1)
+            .expect("markdown block separator should render");
+        assert!(blank_line.spans.is_empty());
+
+        let body_line = lines
+            .get(title_index + 2)
+            .expect("heading body should render");
+        let rendered_body: String = body_line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(rendered_body.ends_with("Body"));
+    }
+
+    #[test]
     fn chat_text_skips_ack_briefs() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -197,22 +197,19 @@ pub(super) fn chat_text(app: &TuiApp) -> Text<'static> {
 }
 
 fn append_chat_item(target: &mut Text<'static>, item: &CachedChatItem) {
+    if active_activity_status_label(&item.speaker).is_some() {
+        append_active_activity_item(target, item);
+        return;
+    }
+
     let body = render_markdown_text(&item.body);
     let body_lines = body.lines;
-    let prefix = chat_prefix_text(item);
-    let continuation_indent = " ".repeat(prefix.chars().count());
+    let prefix = chat_prefix_spans(item);
+    let continuation_indent = chat_continuation_indent(item);
 
     if let Some((first, rest)) = body_lines.split_first() {
-        let mut spans = Vec::with_capacity(first.spans.len() + 3);
-        spans.push(Span::styled(
-            chat_timestamp(item),
-            Style::default().add_modifier(Modifier::DIM),
-        ));
-        spans.push(Span::styled(
-            item.speaker.clone(),
-            chat_speaker_style(item.role),
-        ));
-        spans.push(Span::raw("  "));
+        let mut spans = Vec::with_capacity(prefix.len() + first.spans.len());
+        spans.extend(prefix);
         spans.extend(first.spans.clone());
         target.lines.push(Line::from(spans).style(first.style));
 
@@ -223,40 +220,85 @@ fn append_chat_item(target: &mut Text<'static>, item: &CachedChatItem) {
             target.lines.push(Line::from(spans).style(line.style));
         }
     } else {
-        target.lines.push(Line::from(vec![
-            Span::styled(
-                chat_timestamp(item),
-                Style::default().add_modifier(Modifier::DIM),
-            ),
-            Span::styled(item.speaker.clone(), chat_speaker_style(item.role)),
-        ]));
+        target.lines.push(Line::from(prefix));
     }
-
-    // Add extra spacing between messages for better readability.
-    // Two blank lines makes message separation more visually distinct.
-    target.lines.push(Line::from(""));
-    target.lines.push(Line::from(""));
 }
 
-fn chat_prefix_text(item: &CachedChatItem) -> String {
-    format!("{}{}  ", chat_timestamp(item), item.speaker)
+fn append_active_activity_item(target: &mut Text<'static>, item: &CachedChatItem) {
+    let status = active_activity_status_label(&item.speaker).unwrap_or("Working");
+    let marker = active_activity_display_marker(&item.speaker);
+    target.lines.push(Line::from(vec![
+        Span::styled(marker, Style::default().add_modifier(Modifier::DIM)),
+        Span::raw(" "),
+        Span::styled(status, Style::default().add_modifier(Modifier::BOLD)),
+    ]));
+
+    let body = render_markdown_text(&item.body);
+    for line in body.lines {
+        let mut spans = Vec::with_capacity(line.spans.len() + 1);
+        spans.push(Span::raw("  "));
+        spans.extend(line.spans);
+        target.lines.push(Line::from(spans).style(line.style));
+    }
+}
+
+fn chat_prefix_spans(item: &CachedChatItem) -> Vec<Span<'static>> {
+    let (marker, marker_style) = match item.role {
+        CachedChatRole::Operator => ("› ", Style::default().add_modifier(Modifier::BOLD)),
+        CachedChatRole::Agent => ("• ", Style::default().add_modifier(Modifier::DIM)),
+        CachedChatRole::System => (
+            "! ",
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::DIM),
+        ),
+    };
+
+    vec![
+        Span::styled(marker, marker_style),
+        Span::styled(
+            chat_timestamp(item),
+            Style::default().add_modifier(Modifier::DIM),
+        ),
+        Span::raw(" "),
+    ]
+}
+
+fn chat_continuation_indent(item: &CachedChatItem) -> String {
+    let prefix_width = 2 + chat_timestamp(item).chars().count() + 1;
+    " ".repeat(prefix_width)
 }
 
 fn chat_timestamp(item: &CachedChatItem) -> String {
-    format!(
-        "[{}] ",
-        item.created_at.with_timezone(&Local).format("%H:%M")
-    )
+    item.created_at
+        .with_timezone(&Local)
+        .format("%H:%M")
+        .to_string()
 }
 
-fn chat_speaker_style(role: CachedChatRole) -> Style {
-    match role {
-        CachedChatRole::Operator | CachedChatRole::Agent => {
-            Style::default().add_modifier(Modifier::BOLD)
-        }
-        CachedChatRole::System => Style::default()
-            .add_modifier(Modifier::BOLD)
-            .add_modifier(Modifier::DIM),
+fn active_activity_status_label(speaker: &str) -> Option<&'static str> {
+    if speaker.starts_with("Holon (working)") {
+        Some("Working")
+    } else if speaker.starts_with("Holon (queued)") {
+        Some("Queued")
+    } else if speaker.starts_with("Holon (starting)") {
+        Some("Starting")
+    } else if speaker.starts_with("Holon (waiting)") {
+        Some("Waiting")
+    } else if speaker.starts_with("Holon (delegating)") {
+        Some("Delegating")
+    } else {
+        None
+    }
+}
+
+fn active_activity_display_marker(speaker: &str) -> &'static str {
+    match speaker.rsplit_once(' ').map(|(_, marker)| marker) {
+        Some("-") => "-",
+        Some("\\") => "\\",
+        Some("|") => "|",
+        Some("/") => "/",
+        _ => "◦",
     }
 }
 

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -75,21 +75,40 @@ pub(super) enum CachedChatRole {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct CachedChatItem {
-    pub(super) created_at: DateTime<chrono::Utc>,
-    pub(super) role: CachedChatRole,
-    pub(super) speaker: String,
-    pub(super) body: String,
+pub(super) struct AssistantMarkdownCell {
+    created_at: DateTime<chrono::Utc>,
+    agent_id: String,
+    markdown: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum ConversationCell {
+    UserMessage {
+        created_at: DateTime<chrono::Utc>,
+        body: String,
+    },
+    AssistantMarkdown(AssistantMarkdownCell),
+    ActiveActivity {
+        created_at: DateTime<chrono::Utc>,
+        speaker: String,
+        body: String,
+    },
+    SystemNotice {
+        created_at: DateTime<chrono::Utc>,
+        speaker: String,
+        body: String,
+    },
 }
 
 #[derive(Clone)]
 pub(super) struct CachedChatText {
-    pub(super) items: Vec<CachedChatItem>,
+    pub(super) cells: Vec<ConversationCell>,
+    pub(super) width: u16,
     pub(super) text: Text<'static>,
 }
 
-pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
-    let mut items = Vec::new();
+pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
+    let mut cells = Vec::new();
 
     for entry in &app.transcript {
         if entry.kind != TranscriptEntryKind::IncomingMessage {
@@ -107,10 +126,8 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
             .get("body")
             .and_then(render_message_body_value)
             .unwrap_or_else(|| compact_json(&entry.data));
-        items.push(CachedChatItem {
+        cells.push(ConversationCell::UserMessage {
             created_at: entry.created_at,
-            role: CachedChatRole::Operator,
-            speaker: "You".to_string(),
             body,
         });
     }
@@ -119,16 +136,15 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
         if matches!(brief.kind, crate::types::BriefKind::Ack) {
             continue;
         }
-        items.push(CachedChatItem {
+        cells.push(ConversationCell::AssistantMarkdown(AssistantMarkdownCell {
             created_at: brief.created_at,
-            role: CachedChatRole::Agent,
-            speaker: match brief.kind {
+            agent_id: match brief.kind {
                 crate::types::BriefKind::Result => "Holon".to_string(),
                 crate::types::BriefKind::Failure => "Holon (failed)".to_string(),
                 crate::types::BriefKind::Ack => unreachable!("ack briefs are filtered above"),
             },
-            body: render_brief_body(brief),
-        });
+            markdown: render_brief_body(brief),
+        }));
     }
 
     if let Some(projection) = app.projection.as_ref() {
@@ -136,37 +152,114 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<CachedChatItem> {
             if !is_chat_visible_conversation_event(&event.kind) {
                 continue;
             }
-            items.push(CachedChatItem {
+            cells.push(ConversationCell::SystemNotice {
                 created_at: event.ts,
-                role: CachedChatRole::System,
                 speaker: conversation_event_speaker(&event.kind),
                 body: conversation_event_body(event),
             });
         }
     }
 
-    items.sort_by(|left, right| {
-        left.created_at
-            .cmp(&right.created_at)
-            .then_with(|| chat_role_rank(left.role).cmp(&chat_role_rank(right.role)))
-            .then_with(|| left.speaker.cmp(&right.speaker))
-            .then_with(|| left.body.cmp(&right.body))
+    cells.sort_by(|left, right| {
+        left.created_at()
+            .cmp(&right.created_at())
+            .then_with(|| chat_role_rank(left.role()).cmp(&chat_role_rank(right.role())))
+            .then_with(|| left.sort_speaker().cmp(right.sort_speaker()))
+            .then_with(|| left.sort_body().cmp(right.sort_body()))
     });
-    let fallback_ts = items.last().map(|item| item.created_at);
+    let fallback_ts = cells.last().map(ConversationCell::created_at);
     if let Some(active_item) = active_activity_item(app, fallback_ts) {
-        items.push(active_item);
+        cells.push(active_item);
     }
-    items
+    cells
 }
 
 pub(super) fn is_chat_visible_conversation_event(kind: &str) -> bool {
     matches!(kind, "operator_notification_requested" | "runtime_error")
 }
 
-pub(super) fn build_chat_text(items: &[CachedChatItem]) -> Text<'static> {
+impl ConversationCell {
+    pub(super) fn created_at(&self) -> DateTime<chrono::Utc> {
+        match self {
+            Self::UserMessage { created_at, .. }
+            | Self::ActiveActivity { created_at, .. }
+            | Self::SystemNotice { created_at, .. } => *created_at,
+            Self::AssistantMarkdown(cell) => cell.created_at,
+        }
+    }
+
+    fn role(&self) -> CachedChatRole {
+        match self {
+            Self::UserMessage { .. } => CachedChatRole::Operator,
+            Self::AssistantMarkdown(_) => CachedChatRole::Agent,
+            Self::ActiveActivity { .. } | Self::SystemNotice { .. } => CachedChatRole::System,
+        }
+    }
+
+    fn sort_speaker(&self) -> &str {
+        match self {
+            Self::UserMessage { .. } => "You",
+            Self::AssistantMarkdown(cell) => &cell.agent_id,
+            Self::ActiveActivity { speaker, .. } | Self::SystemNotice { speaker, .. } => speaker,
+        }
+    }
+
+    fn sort_body(&self) -> &str {
+        match self {
+            Self::UserMessage { body, .. }
+            | Self::ActiveActivity { body, .. }
+            | Self::SystemNotice { body, .. } => body,
+            Self::AssistantMarkdown(cell) => &cell.markdown,
+        }
+    }
+
+    fn render_lines(&self, width: u16) -> Vec<Line<'static>> {
+        match self {
+            Self::UserMessage { created_at, body } => render_prefixed_markdown_lines(
+                *created_at,
+                body,
+                CachedChatRole::Operator,
+                width,
+                false,
+            ),
+            Self::AssistantMarkdown(cell) => cell.render_lines(width),
+            Self::ActiveActivity { speaker, body, .. } => {
+                render_active_activity_lines(speaker, body)
+            }
+            Self::SystemNotice {
+                created_at, body, ..
+            } => render_prefixed_markdown_lines(
+                *created_at,
+                body,
+                CachedChatRole::System,
+                width,
+                false,
+            ),
+        }
+    }
+}
+
+impl AssistantMarkdownCell {
+    fn render_lines(&self, width: u16) -> Vec<Line<'static>> {
+        render_prefixed_markdown_lines(
+            self.created_at,
+            &self.markdown,
+            CachedChatRole::Agent,
+            width,
+            true,
+        )
+    }
+}
+
+#[cfg(test)]
+pub(super) fn build_chat_text(items: &[ConversationCell]) -> Text<'static> {
+    build_chat_text_for_width(items, u16::MAX)
+}
+
+pub(super) fn build_chat_text_for_width(items: &[ConversationCell], width: u16) -> Text<'static> {
     let mut text = Text::default();
     for (index, item) in items.iter().enumerate() {
-        append_chat_item(&mut text, item);
+        text.lines.extend(item.render_lines(width));
         if index + 1 < items.len() {
             text.lines.push(Line::default());
         }
@@ -175,7 +268,12 @@ pub(super) fn build_chat_text(items: &[CachedChatItem]) -> Text<'static> {
     text
 }
 
+#[cfg(test)]
 pub(super) fn chat_text(app: &TuiApp) -> Text<'static> {
+    chat_text_for_width(app, u16::MAX)
+}
+
+pub(super) fn chat_text_for_width(app: &TuiApp, width: u16) -> Text<'static> {
     let items = collect_chat_items(app);
     if items.is_empty() {
         *app.chat_text_cache.borrow_mut() = None;
@@ -183,67 +281,79 @@ pub(super) fn chat_text(app: &TuiApp) -> Text<'static> {
     }
 
     if let Some(cached) = app.chat_text_cache.borrow().as_ref() {
-        if cached.items == items {
+        if cached.cells == items && cached.width == width {
             return cached.text.clone();
         }
     }
 
-    let text = build_chat_text(&items);
+    let text = build_chat_text_for_width(&items, width);
     *app.chat_text_cache.borrow_mut() = Some(CachedChatText {
-        items,
+        cells: items,
+        width,
         text: text.clone(),
     });
     text
 }
 
-fn append_chat_item(target: &mut Text<'static>, item: &CachedChatItem) {
-    if active_activity_status_label(&item.speaker).is_some() {
-        append_active_activity_item(target, item);
-        return;
-    }
-
-    let body = render_markdown_text(&item.body);
+fn render_prefixed_markdown_lines(
+    created_at: DateTime<chrono::Utc>,
+    body: &str,
+    role: CachedChatRole,
+    width: u16,
+    spaced_markdown: bool,
+) -> Vec<Line<'static>> {
+    let body = if spaced_markdown && width >= 48 {
+        render_markdown_text_spaced(body)
+    } else {
+        render_markdown_text(body)
+    };
     let body_lines = body.lines;
-    let prefix = chat_prefix_spans(item);
-    let continuation_indent = chat_continuation_indent(item);
+    let prefix = chat_prefix_spans(created_at, role);
+    let continuation_indent = chat_continuation_indent(created_at);
+    let mut lines = Vec::new();
 
     if let Some((first, rest)) = body_lines.split_first() {
         let mut spans = Vec::with_capacity(prefix.len() + first.spans.len());
         spans.extend(prefix);
         spans.extend(first.spans.clone());
-        target.lines.push(Line::from(spans).style(first.style));
+        lines.push(Line::from(spans).style(first.style));
 
         for line in rest {
             let mut spans = Vec::with_capacity(line.spans.len() + 1);
             spans.push(Span::raw(continuation_indent.clone()));
             spans.extend(line.spans.clone());
-            target.lines.push(Line::from(spans).style(line.style));
+            lines.push(Line::from(spans).style(line.style));
         }
     } else {
-        target.lines.push(Line::from(prefix));
+        lines.push(Line::from(prefix));
     }
+    lines
 }
 
-fn append_active_activity_item(target: &mut Text<'static>, item: &CachedChatItem) {
-    let status = active_activity_status_label(&item.speaker).unwrap_or("Working");
-    let marker = active_activity_display_marker(&item.speaker);
-    target.lines.push(Line::from(vec![
+fn render_active_activity_lines(speaker: &str, body: &str) -> Vec<Line<'static>> {
+    let status = active_activity_status_label(speaker).unwrap_or("Working");
+    let marker = active_activity_display_marker(speaker);
+    let mut lines = vec![Line::from(vec![
         Span::styled(marker, Style::default().add_modifier(Modifier::DIM)),
         Span::raw(" "),
         Span::styled(status, Style::default().add_modifier(Modifier::BOLD)),
-    ]));
+    ])];
 
-    let body = render_markdown_text(&item.body);
+    let body = render_markdown_text(body);
     for line in body.lines {
         let mut spans = Vec::with_capacity(line.spans.len() + 1);
         spans.push(Span::raw("  "));
         spans.extend(line.spans);
-        target.lines.push(Line::from(spans).style(line.style));
+        lines.push(Line::from(spans).style(line.style));
     }
+    lines
 }
 
-fn chat_prefix_spans(item: &CachedChatItem) -> Vec<Span<'static>> {
-    let (marker, marker_style) = match item.role {
+fn chat_prefix_spans(
+    created_at: DateTime<chrono::Utc>,
+    role: CachedChatRole,
+) -> Vec<Span<'static>> {
+    let (marker, marker_style) = match role {
         CachedChatRole::Operator => ("› ", Style::default().add_modifier(Modifier::BOLD)),
         CachedChatRole::Agent => ("• ", Style::default().add_modifier(Modifier::DIM)),
         CachedChatRole::System => (
@@ -257,23 +367,20 @@ fn chat_prefix_spans(item: &CachedChatItem) -> Vec<Span<'static>> {
     vec![
         Span::styled(marker, marker_style),
         Span::styled(
-            chat_timestamp(item),
+            chat_timestamp(created_at),
             Style::default().add_modifier(Modifier::DIM),
         ),
         Span::raw(" "),
     ]
 }
 
-fn chat_continuation_indent(item: &CachedChatItem) -> String {
-    let prefix_width = 2 + chat_timestamp(item).chars().count() + 1;
+fn chat_continuation_indent(created_at: DateTime<chrono::Utc>) -> String {
+    let prefix_width = 2 + chat_timestamp(created_at).chars().count() + 1;
     " ".repeat(prefix_width)
 }
 
-fn chat_timestamp(item: &CachedChatItem) -> String {
-    item.created_at
-        .with_timezone(&Local)
-        .format("%H:%M")
-        .to_string()
+fn chat_timestamp(created_at: DateTime<chrono::Utc>) -> String {
+    created_at.with_timezone(&Local).format("%H:%M").to_string()
 }
 
 fn active_activity_status_label(speaker: &str) -> Option<&'static str> {
@@ -313,7 +420,7 @@ fn chat_role_rank(role: CachedChatRole) -> u8 {
 fn active_activity_item(
     app: &TuiApp,
     fallback_ts: Option<DateTime<chrono::Utc>>,
-) -> Option<CachedChatItem> {
+) -> Option<ConversationCell> {
     let projection = app.projection.as_ref();
     let agent = projection
         .map(|projection| &projection.agent)
@@ -342,9 +449,8 @@ fn active_activity_item(
     .max()
     .unwrap_or_else(chrono::Utc::now);
 
-    Some(CachedChatItem {
+    Some(ConversationCell::ActiveActivity {
         created_at,
-        role: CachedChatRole::System,
         speaker: active_activity_speaker(agent),
         body: active_activity_body(
             agent,

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -280,7 +280,8 @@ fn active_activity_item(
         return None;
     }
 
-    let latest_activity = projection.and_then(latest_activity_event);
+    let latest_action = projection.and_then(latest_action_event);
+    let latest_assistant = latest_assistant_message(app, projection);
     let latest_event_ts =
         projection.and_then(|projection| projection.event_log().last().map(|event| event.ts));
     let created_at = [
@@ -306,7 +307,8 @@ fn active_activity_item(
         body: active_activity_body(
             agent,
             projection.map(|projection| projection.tasks.as_slice()),
-            latest_activity,
+            latest_assistant.as_deref(),
+            latest_action,
         ),
     })
 }
@@ -333,46 +335,148 @@ fn agent_has_active_activity(agent: &AgentSummary) -> bool {
         || active_child
 }
 
-fn latest_activity_event(
+fn latest_action_event(
     projection: &crate::tui::projection::TuiProjection,
 ) -> Option<&crate::tui::projection::ProjectionEventRecord> {
     projection
         .event_log()
         .iter()
         .rev()
-        .find(|event| crate::tui::projection::is_ephemeral_activity_kind(&event.kind))
+        .find(|event| is_active_action_event_kind(&event.kind))
+}
+
+fn is_active_action_event_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "tool_executed"
+            | "tool_execution_failed"
+            | "task_created"
+            | "task_status_updated"
+            | "task_result_received"
+            | "work_item_written"
+            | "waiting_intent_created"
+            | "waiting_intent_cancelled"
+            | "callback_delivered"
+            | "operator_notification_requested"
+            | "workspace_entered"
+            | "workspace_exited"
+            | "workspace_detached"
+            | "worktree_entered"
+            | "worktree_exited"
+            | "worktree_auto_cleaned_up"
+            | "worktree_auto_cleanup_failed"
+            | "task_worktree_branch_cleanup_retained"
+            | "skill_activated"
+            | "system_tick_emitted"
+            | "message_admitted"
+            | "message_processing_started"
+            | "control_applied"
+            | "brief_created"
+            | "turn_terminal"
+            | "runtime_error"
+            | "max_output_tokens_recovery"
+            | "turn_local_checkpoint_recorded"
+    )
+}
+
+fn latest_assistant_message(
+    app: &TuiApp,
+    projection: Option<&crate::tui::projection::TuiProjection>,
+) -> Option<String> {
+    projection
+        .and_then(|projection| {
+            projection
+                .event_log()
+                .iter()
+                .rev()
+                .find_map(assistant_message_from_event)
+        })
+        .or_else(|| {
+            app.transcript
+                .iter()
+                .rev()
+                .find_map(assistant_message_from_transcript)
+        })
+}
+
+fn assistant_message_from_event(
+    event: &crate::tui::projection::ProjectionEventRecord,
+) -> Option<String> {
+    if event.kind != "provider_round_completed" && event.kind != "text_only_round_observed" {
+        return None;
+    }
+    event.payload.get("text_preview").and_then(non_empty_value)
+}
+
+fn assistant_message_from_transcript(entry: &TranscriptEntry) -> Option<String> {
+    if !matches!(
+        entry.kind,
+        TranscriptEntryKind::AssistantRound | TranscriptEntryKind::SubagentAssistantRound
+    ) {
+        return None;
+    }
+    let blocks = entry.data.get("blocks")?.as_array()?;
+    let text = blocks
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .filter_map(|text| non_empty(Some(text)).map(ToString::to_string))
+        .collect::<Vec<_>>()
+        .join(" ");
+    non_empty(Some(&text)).map(ToString::to_string)
 }
 
 fn active_activity_speaker(agent: &AgentSummary) -> String {
-    match agent.agent.status {
+    let state: String = match agent.agent.status {
         crate::types::AgentStatus::Booting => "Holon (starting)".into(),
         crate::types::AgentStatus::AwaitingTask => "Holon (waiting)".into(),
         crate::types::AgentStatus::AwakeRunning => "Holon (working)".into(),
         crate::types::AgentStatus::AwakeIdle if agent.agent.pending > 0 => "Holon (queued)".into(),
         _ if !agent.active_children.is_empty() => "Holon (delegating)".into(),
         _ => "Holon (working)".into(),
+    };
+    format!("{state} {}", active_activity_spinner())
+}
+
+fn active_activity_spinner() -> &'static str {
+    match (Local::now().timestamp_millis() / 250).rem_euclid(4) {
+        0 => "-",
+        1 => "\\",
+        2 => "|",
+        _ => "/",
     }
 }
 
 fn active_activity_body(
     agent: &AgentSummary,
     tasks: Option<&[TaskRecord]>,
-    latest_activity: Option<&crate::tui::projection::ProjectionEventRecord>,
+    latest_assistant: Option<&str>,
+    latest_action: Option<&crate::tui::projection::ProjectionEventRecord>,
 ) -> String {
-    let mut lines = Vec::new();
+    let current = current_activity_summary(agent, tasks);
+    let assistant = latest_assistant
+        .map(|text| trim_activity_line(text, 120))
+        .unwrap_or_else(|| "...".into());
+    let action = latest_action
+        .map(|event| trim_activity_line(&action_event_body(event), 120))
+        .unwrap_or_else(|| "Waiting for activity".into());
+
+    [
+        format!("Current   {}", trim_activity_line(&current, 120)),
+        format!("Assistant {}", assistant),
+        format!("Action    {}", action),
+    ]
+    .join("\n")
+}
+
+fn current_activity_summary(agent: &AgentSummary, tasks: Option<&[TaskRecord]>) -> String {
     let memory = &agent.agent.working_memory.current_working_memory;
 
-    if let Some(summary) = non_empty(memory.work_summary.as_deref()) {
-        lines.push(format!("Working: {}", trim_activity_line(summary, 180)));
-    } else if let Some(task_summary) = active_task_summary(agent, tasks) {
-        lines.push(format!("Task: {}", trim_activity_line(&task_summary, 180)));
-    } else if let Some(child_summary) = active_child_summary(agent) {
-        lines.push(format!(
-            "Delegated: {}",
-            trim_activity_line(&child_summary, 180)
-        ));
-    } else {
-        lines.push(match agent.agent.status {
+    non_empty(memory.work_summary.as_deref())
+        .map(ToString::to_string)
+        .or_else(|| active_task_summary(agent, tasks))
+        .or_else(|| active_child_summary(agent))
+        .unwrap_or_else(|| match agent.agent.status {
             crate::types::AgentStatus::Booting => "Starting runtime".into(),
             crate::types::AgentStatus::AwaitingTask => "Waiting for active task progress".into(),
             crate::types::AgentStatus::AwakeRunning => "Working on the current turn".into(),
@@ -380,78 +484,15 @@ fn active_activity_body(
                 "Queued work is waiting to run".into()
             }
             _ => "Work is still active".into(),
-        });
-    }
+        })
+}
 
-    if let Some(target) = non_empty(memory.delivery_target.as_deref()) {
-        lines.push(format!("Target: {}", trim_activity_line(target, 160)));
+fn action_event_body(event: &crate::tui::projection::ProjectionEventRecord) -> String {
+    if event.kind == "tool_executed" || event.kind == "tool_execution_failed" {
+        progress_event_body(event)
+    } else {
+        event.summary.clone()
     }
-
-    if let Some(work_item_id) = non_empty(
-        memory
-            .current_work_item_id
-            .as_deref()
-            .or(agent.agent.current_work_item_id.as_deref())
-            .or(agent.agent.current_turn_work_item_id.as_deref()),
-    ) {
-        lines.push(format!("Work item: {work_item_id}"));
-    }
-
-    if let Some(event) = latest_activity {
-        lines.push(format!(
-            "Now: {}",
-            trim_activity_line(&progress_event_body(event), 180)
-        ));
-    }
-
-    if !agent.agent.active_task_ids.is_empty() || agent.agent.pending > 0 {
-        lines.push(format!(
-            "Queue: pending {}, active tasks {}",
-            agent.agent.pending,
-            agent.agent.active_task_ids.len()
-        ));
-    }
-
-    if !agent.active_children.is_empty() {
-        let children = agent
-            .active_children
-            .iter()
-            .take(2)
-            .map(|child| {
-                let mut description = format!(
-                    "{} {:?}",
-                    child.identity.agent_id, child.observability.phase
-                );
-                if let Some(summary) = child
-                    .observability
-                    .work_summary
-                    .as_deref()
-                    .or(child.observability.last_progress_brief.as_deref())
-                {
-                    description.push_str(": ");
-                    description.push_str(&trim_activity_line(summary, 100));
-                }
-                description
-            })
-            .collect::<Vec<_>>()
-            .join("; ");
-        lines.push(format!("Children: {children}"));
-    }
-
-    if !memory.waiting_on.is_empty() {
-        lines.push(format!(
-            "Waiting on: {}",
-            memory
-                .waiting_on
-                .iter()
-                .take(2)
-                .map(|item| trim_activity_line(item, 80))
-                .collect::<Vec<_>>()
-                .join("; ")
-        ));
-    }
-
-    lines.join("\n")
 }
 
 fn active_task_summary(agent: &AgentSummary, tasks: Option<&[TaskRecord]>) -> Option<String> {
@@ -487,6 +528,13 @@ fn non_empty(value: Option<&str>) -> Option<&str> {
             Some(trimmed)
         }
     })
+}
+
+fn non_empty_value(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .and_then(|text| non_empty(Some(text)))
+        .map(ToString::to_string)
 }
 
 pub(super) fn paragraph_max_scroll(text: &Text<'_>, area: Rect) -> u16 {

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -319,6 +319,11 @@ fn render_prefixed_markdown_lines(
         lines.push(Line::from(spans).style(first.style));
 
         for line in rest {
+            if line.spans.iter().all(|span| span.content.is_empty()) {
+                lines.push(Line::default());
+                continue;
+            }
+
             let mut spans = Vec::with_capacity(line.spans.len() + 1);
             spans.push(Span::raw(continuation_indent.clone()));
             spans.extend(line.spans.clone());

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -282,7 +282,7 @@ pub(super) fn chat_text_for_width(app: &TuiApp, width: u16) -> Text<'static> {
 
     if let Some(cached) = app.chat_text_cache.borrow().as_ref() {
         if cached.cells == items && cached.width == width {
-            return cached.text.clone();
+            return refresh_active_activity_marker(cached.text.clone());
         }
     }
 
@@ -337,9 +337,11 @@ fn render_prefixed_markdown_lines(
 
 fn render_active_activity_lines(speaker: &str, body: &str) -> Vec<Line<'static>> {
     let status = active_activity_status_label(speaker).unwrap_or("Working");
-    let marker = active_activity_display_marker(speaker);
     let mut lines = vec![Line::from(vec![
-        Span::styled(marker, Style::default().add_modifier(Modifier::DIM)),
+        Span::styled(
+            active_activity_spinner(),
+            Style::default().add_modifier(Modifier::DIM),
+        ),
         Span::raw(" "),
         Span::styled(status, Style::default().add_modifier(Modifier::BOLD)),
     ])];
@@ -352,6 +354,27 @@ fn render_active_activity_lines(speaker: &str, body: &str) -> Vec<Line<'static>>
         lines.push(Line::from(spans).style(line.style));
     }
     lines
+}
+
+fn refresh_active_activity_marker(mut text: Text<'static>) -> Text<'static> {
+    for line in &mut text.lines {
+        let is_active_activity_header = line.spans.len() >= 3
+            && line.spans.get(1).is_some_and(|span| span.content == " ")
+            && line.spans.get(2).is_some_and(|span| {
+                matches!(
+                    span.content.as_ref(),
+                    "Working" | "Queued" | "Starting" | "Waiting" | "Delegating"
+                )
+            });
+        if is_active_activity_header {
+            line.spans[0] = Span::styled(
+                active_activity_spinner(),
+                Style::default().add_modifier(Modifier::DIM),
+            );
+            break;
+        }
+    }
+    text
 }
 
 fn chat_prefix_spans(
@@ -404,16 +427,6 @@ fn active_activity_status_label(speaker: &str) -> Option<&'static str> {
     }
 }
 
-fn active_activity_display_marker(speaker: &str) -> &'static str {
-    match speaker.rsplit_once(' ').map(|(_, marker)| marker) {
-        Some("-") => "-",
-        Some("\\") => "\\",
-        Some("|") => "|",
-        Some("/") => "/",
-        _ => "◦",
-    }
-}
-
 fn chat_role_rank(role: CachedChatRole) -> u8 {
     match role {
         CachedChatRole::Operator => 0,
@@ -452,7 +465,7 @@ fn active_activity_item(
     .into_iter()
     .flatten()
     .max()
-    .unwrap_or_else(chrono::Utc::now);
+    .unwrap_or_else(stable_active_activity_timestamp);
 
     Some(ConversationCell::ActiveActivity {
         created_at,
@@ -464,6 +477,10 @@ fn active_activity_item(
             latest_action,
         ),
     })
+}
+
+fn stable_active_activity_timestamp() -> DateTime<chrono::Utc> {
+    DateTime::<chrono::Utc>::from(std::time::SystemTime::UNIX_EPOCH)
 }
 
 fn agent_has_active_activity(agent: &AgentSummary) -> bool {
@@ -580,15 +597,14 @@ fn assistant_message_from_transcript(entry: &TranscriptEntry) -> Option<String> 
 }
 
 fn active_activity_speaker(agent: &AgentSummary) -> String {
-    let state: String = match agent.agent.status {
+    match agent.agent.status {
         crate::types::AgentStatus::Booting => "Holon (starting)".into(),
         crate::types::AgentStatus::AwaitingTask => "Holon (waiting)".into(),
         crate::types::AgentStatus::AwakeRunning => "Holon (working)".into(),
         crate::types::AgentStatus::AwakeIdle if agent.agent.pending > 0 => "Holon (queued)".into(),
         _ if !agent.active_children.is_empty() => "Holon (delegating)".into(),
         _ => "Holon (working)".into(),
-    };
-    format!("{state} {}", active_activity_spinner())
+    }
 }
 
 fn active_activity_spinner() -> &'static str {

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -113,6 +113,11 @@ impl TuiProjection {
         *self = Self::from_snapshot(snapshot);
     }
 
+    pub(crate) fn inherit_recent_event_logs_from(&mut self, previous: &Self) {
+        self.event_log = previous.event_log.clone();
+        self.durable_conversation_log = previous.durable_conversation_log.clone();
+    }
+
     pub(crate) fn apply_event(&mut self, event: AgentStreamEvent, log_writer: &TuiLogWriter) {
         let record = ProjectionEventRecord {
             id: event.id.clone(),

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::BTreeSet,
+    mem,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -113,9 +114,12 @@ impl TuiProjection {
         *self = Self::from_snapshot(snapshot);
     }
 
-    pub(crate) fn inherit_recent_event_logs_from(&mut self, previous: &Self) {
-        self.event_log = previous.event_log.clone();
-        self.durable_conversation_log = previous.durable_conversation_log.clone();
+    pub(crate) fn inherit_recent_event_logs_from(&mut self, previous: &mut Self) {
+        self.event_log = mem::take(&mut previous.event_log);
+        self.durable_conversation_log = mem::take(&mut previous.durable_conversation_log);
+        if let Some(last_event) = self.event_log.last() {
+            self.cursor = Some(last_event.id.clone());
+        }
     }
 
     pub(crate) fn apply_event(&mut self, event: AgentStreamEvent, log_writer: &TuiLogWriter) {
@@ -1008,6 +1012,46 @@ mod tests {
                 .map(|event| event.summary.as_str()),
             Some("provider round completed")
         );
+    }
+
+    #[test]
+    fn projection_refresh_moves_inherited_logs_and_advances_cursor() {
+        let mut previous = TuiProjection::from_snapshot(sample_snapshot());
+        previous.apply_event(
+            sample_event(
+                "provider_round_completed",
+                json!({ "round": 1, "text_preview": "partial" }),
+            ),
+            &test_log_writer(),
+        );
+        previous.apply_event(
+            sample_event(
+                "operator_notification_requested",
+                json!({
+                    "id": "notification-1",
+                    "summary": "needs review",
+                    "message": "needs review",
+                    "created_at": Utc::now(),
+                }),
+            ),
+            &test_log_writer(),
+        );
+        previous.apply_event(
+            sample_event(
+                "tool_executed",
+                json!({ "tool_name": "ExecCommand", "exec_command_cmd": "cargo test tui" }),
+            ),
+            &test_log_writer(),
+        );
+
+        let mut refreshed = TuiProjection::from_snapshot(sample_snapshot());
+        refreshed.inherit_recent_event_logs_from(&mut previous);
+
+        assert_eq!(refreshed.cursor.as_deref(), Some("evt-tool_executed"));
+        assert_eq!(refreshed.event_log().len(), 3);
+        assert_eq!(refreshed.durable_conversation_events().count(), 1);
+        assert!(previous.event_log().is_empty());
+        assert_eq!(previous.durable_conversation_events().count(), 0);
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -54,7 +54,7 @@ fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
 }
 
 fn draw_chat(frame: &mut Frame<'_>, area: Rect, app: &mut TuiApp) {
-    let body = chat_text(app);
+    let body = chat_text_for_width(app, area.width.saturating_sub(2).max(1));
     let max_scroll = paragraph_max_scroll(&body, area);
     app.chat_max_scroll = max_scroll;
     let scroll = app.chat_scroll.effective_scroll(max_scroll);

--- a/src/tui_markdown.rs
+++ b/src/tui_markdown.rs
@@ -22,11 +22,22 @@ struct LinkContext {
 }
 
 pub(crate) fn render_markdown_text(input: &str) -> Text<'static> {
+    render_markdown_text_with_spacing(input, false)
+}
+
+pub(crate) fn render_markdown_text_spaced(input: &str) -> Text<'static> {
+    render_markdown_text_with_spacing(input, true)
+}
+
+fn render_markdown_text_with_spacing(input: &str, block_spacing: bool) -> Text<'static> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
 
     let parser = Parser::new_ext(input, options);
-    let mut renderer = MarkdownRenderer::default();
+    let mut renderer = MarkdownRenderer {
+        block_spacing,
+        ..Default::default()
+    };
     for event in parser {
         renderer.handle_event(event);
     }
@@ -46,6 +57,7 @@ struct MarkdownRenderer {
     in_code_block: bool,
     show_code_block_fence: bool,
     pending_blank_line: bool,
+    block_spacing: bool,
 }
 
 impl MarkdownRenderer {
@@ -113,7 +125,12 @@ impl MarkdownRenderer {
                 }
                 self.in_code_block = true;
             }
-            Tag::List(start) => self.list_stack.push(ListContext { next_index: start }),
+            Tag::List(start) => {
+                if self.list_stack.is_empty() {
+                    self.ensure_blank_line_between_blocks();
+                }
+                self.list_stack.push(ListContext { next_index: start });
+            }
             Tag::Item => self.start_item(),
             Tag::Emphasis => self.push_style(Style::default().add_modifier(Modifier::ITALIC)),
             Tag::Strong => self.push_style(Style::default().add_modifier(Modifier::BOLD)),
@@ -211,6 +228,14 @@ impl MarkdownRenderer {
 
     fn finish(mut self) -> Text<'static> {
         self.flush_current_line();
+        while self
+            .text
+            .lines
+            .last()
+            .is_some_and(|line| line.spans.iter().all(|span| span.content.is_empty()))
+        {
+            self.text.lines.pop();
+        }
         self.text
     }
 
@@ -243,6 +268,16 @@ impl MarkdownRenderer {
     fn ensure_blank_line_between_blocks(&mut self) {
         if self.pending_blank_line {
             self.flush_current_line();
+            if self.block_spacing
+                && self.item_stack.is_empty()
+                && self
+                    .text
+                    .lines
+                    .last()
+                    .is_some_and(|line| !line.spans.iter().all(|span| span.content.is_empty()))
+            {
+                self.text.lines.push(Line::default());
+            }
             self.pending_blank_line = false;
         }
     }
@@ -358,10 +393,18 @@ fn quote_style() -> Style {
 
 #[cfg(test)]
 mod tests {
-    use super::render_markdown_text;
+    use super::{render_markdown_text, render_markdown_text_spaced};
 
     fn flatten_lines(input: &str) -> Vec<String> {
         render_markdown_text(input)
+            .lines
+            .into_iter()
+            .map(|line| line.spans.into_iter().map(|span| span.content).collect())
+            .collect()
+    }
+
+    fn flatten_spaced_lines(input: &str) -> Vec<String> {
+        render_markdown_text_spaced(input)
             .lines
             .into_iter()
             .map(|line| line.spans.into_iter().map(|span| span.content).collect())
@@ -396,5 +439,11 @@ mod tests {
     fn renders_indented_code_block() {
         let lines = flatten_lines("    one\n    two");
         assert_eq!(lines, vec!["    one", "    two"]);
+    }
+
+    #[test]
+    fn spaced_renderer_adds_blank_lines_between_top_level_blocks() {
+        let lines = flatten_spaced_lines("First\n\nSecond\n\n- one\n- two");
+        assert_eq!(lines, vec!["First", "", "Second", "", "- one", "- two"]);
     }
 }

--- a/src/tui_markdown.rs
+++ b/src/tui_markdown.rs
@@ -22,14 +22,14 @@ struct LinkContext {
 }
 
 pub(crate) fn render_markdown_text(input: &str) -> Text<'static> {
-    render_markdown_text_with_spacing(input, false)
+    render_markdown_text_inner(input, false)
 }
 
 pub(crate) fn render_markdown_text_spaced(input: &str) -> Text<'static> {
-    render_markdown_text_with_spacing(input, true)
+    render_markdown_text_inner(input, true)
 }
 
-fn render_markdown_text_with_spacing(input: &str, block_spacing: bool) -> Text<'static> {
+fn render_markdown_text_inner(input: &str, block_spacing: bool) -> Text<'static> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
 
@@ -442,8 +442,14 @@ mod tests {
     }
 
     #[test]
-    fn spaced_renderer_adds_blank_lines_between_top_level_blocks() {
+    fn spaced_renderer_keeps_one_blank_line_between_top_level_blocks() {
         let lines = flatten_spaced_lines("First\n\nSecond\n\n- one\n- two");
         assert_eq!(lines, vec!["First", "", "Second", "", "- one", "- two"]);
+    }
+
+    #[test]
+    fn spaced_renderer_keeps_one_blank_line_between_heading_and_body() {
+        let lines = flatten_spaced_lines("### Title\n\nBody");
+        assert_eq!(lines, vec!["### Title", "", "Body"]);
     }
 }


### PR DESCRIPTION
## Summary

- Refine the active Conversation cell so in-flight work remains visible and survives transient state refreshes.
- Move Queue/Children runtime details out of the conversation cell and keep active activity focused on Current, Assistant, and Action.
- Refactor conversation rendering around typed cells, including `AssistantMarkdownCell`, so assistant output can use markdown-specific rendering.
- Add width-aware chat text caching and extra spacing between top-level assistant markdown blocks for a more natural reading rhythm.

## Follow-up

- Filed #864 for the longer-term work to reduce unnecessary TUI state refresh churn.

## Tests

- `cargo fmt`
- `cargo test tui -- --nocapture`
- `cargo check`
