### PR TITLE
refactor: align work items with objective plan model

### DIFF
--- a/docs/implementation-decisions/015-objective-state-retired-in-favor-of-work-queue-truth.md
+++ b/docs/implementation-decisions/015-objective-state-retired-in-favor-of-work-queue-truth.md
@@ -4,7 +4,7 @@ Decision:
 
 - remove parallel `objective_state` from `AgentState`
 - keep work truth centered on persisted `WorkItemRecord` and
-  `WorkPlanSnapshot`
+  `WorkItemRecord`
 - derive continuity projections from work, plan, brief, tool, and waiting
   evidence
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1484,30 +1484,50 @@ that persisted field instead of inferring workspace from a later event scan.
 
 ### Work-Item Persistence Foundation
 
-The work-item rollout uses a persisted store that is separate from `AgentState`.
-
-Phase-1 foundation records are:
+Persistent work tracking uses two records:
 
 - `WorkItemRecord`
-- `WorkPlanSnapshot`
 - `DeliverySummaryRecord`
 
-`WorkItemRecord` is the persisted runtime record for one high-level delivery
-target. The minimal shape is:
+`WorkItemRecord` is the persisted runtime record for one high-level objective.
+The minimal shape is:
 
 - `id`
 - `agent_id`
 - `workspace_id`
-- `delivery_target`
+- `objective`
 - `state`
+- `plan_status`
+- `plan?`
+- `todo_list`
 - `blocked_by?`
+- `result_summary?`
 - `created_at`
 - `updated_at`
 
 `state` is one of:
 
 - `open`
-- `done`
+- `completed`
+
+`plan_status` is one of:
+
+- `draft`
+- `ready`
+- `needs_input`
+
+`plan` is durable prose attached to the work item. `todo_list` is the
+structured checklist snapshot for current execution bookkeeping. Each todo item
+contains:
+
+- `text`
+- `state`
+
+Todo item state is one of:
+
+- `pending`
+- `in_progress`
+- `completed`
 
 Current focus is not encoded in `WorkItemRecord.state`. The owning
 `AgentState.current_work_item_id` points at the currently selected open work
@@ -1515,43 +1535,7 @@ item. Queued and blocked are derived views:
 
 - queued: open work that is not current and has no `blocked_by`
 - blocked: open work with `blocked_by`
-- done: work whose state is `done`
-
-`WorkPlanSnapshot` is the latest full checklist snapshot for one work item. The
-minimal shape is:
-
-- `work_item_id`
-- `agent_id`
-- `created_at`
-- `items`
-
-Each persisted plan item contains:
-
-- `step`
-- `status`
-
-The initial plan-step status set is:
-
-- `pending`
-- `in_progress`
-- `completed`
-
-Model-visible work-item tool results project the same checklist through the RFC
-tool vocabulary instead of exposing the persisted field names. `CreateWorkItem`,
-`UpdateWorkItem`, `GetWorkItem`, and `ListWorkItems(include_plan=true)` return
-plan items as:
-
-- `step`
-- `state`
-
-The model-visible plan-step state set is:
-
-- `pending`
-- `doing`
-- `done`
-
-Tool inputs use the same model-visible `state` vocabulary. The internal
-`status` values remain a storage detail.
+- completed: work whose state is `completed`
 
 The runtime persists a `DeliverySummaryRecord` when `CompleteWorkItem` receives
 an explicit `result_summary`. It is associated with the completed work item and
@@ -1561,9 +1545,6 @@ is separate from raw terminal assistant text.
 `DeliverySummaryRecord.text` over the raw terminal assistant message. The raw
 terminal message remains available separately as `run_once.raw_final_text` for
 diagnostics and benchmark reporting.
-
-`WorkPlan` is work-item-scoped and is now the only formal checklist model in
-the runtime. The earlier agent-wide todo snapshot has been retired.
 
 Early rollout phases remain message-driven by default. Work items are optional
 until later scheduler integration lands; if no work items exist yet, the
@@ -1575,10 +1556,9 @@ When work items exist, prompt context should project them explicitly.
 
 Early rollout projection rules are:
 
-- project the full current snapshot of the active `WorkItemRecord`
-- project the full current `WorkPlanSnapshot` for that active item when present
+- project the full current `WorkItemRecord`, including plan and todo_list
 - project only compact entries for queued and blocked open items
-- exclude done items from the normal prompt projection
+- exclude completed items from the normal prompt projection
 - if no work items exist yet, preserve the current message-driven prompt path
   without synthesizing a bootstrap work item
 
@@ -1596,8 +1576,10 @@ The runtime exposes explicit trusted action tools for work-item state:
 
 `CreateWorkItem` creates a new open work item:
 
-- `delivery_target` is required
-- `plan` is optional
+- `objective` is required
+- `plan_status` is optional
+- `plan` is optional durable prose
+- `todo_list` is optional full checklist snapshot
 
 `PickWorkItem` sets `AgentState.current_work_item_id` to an existing open work
 item owned by the agent.
@@ -1605,28 +1587,31 @@ item owned by the agent.
 `UpdateWorkItem` updates mutable fields on an existing work item:
 
 - `work_item_id` is required
+- `objective` is optional
+- `plan_status` is optional
+- `plan` is optional and nullable
+- `todo_list` is optional and uses full-snapshot replacement semantics
 - `blocked_by` is optional and nullable
-- `plan` is optional and uses full-snapshot replacement semantics
 
-`CompleteWorkItem` marks an existing work item done:
+`CompleteWorkItem` marks an existing work item completed:
 
 - `work_item_id` is required
 - `result_summary` is optional completion metadata
 
-There is no separate agent-facing `UpdateWorkPlan` tool. Work-plan replacement
-is performed through `UpdateWorkItem.plan`; the storage layer may still persist
-plan snapshots separately.
+There is no separate agent-facing `UpdateWorkPlan` tool and no separate
+work-plan storage stream. Plan and todo state live on the latest
+`WorkItemRecord` snapshot.
 
 These tools are part of the explicit adoption path for work items. They do not
 require runtime-side semantic resolution of arbitrary ingress into a work item.
 
-Work-plan updates are coordination state, not the artifact progress ledger.
-Prompt guidance should frame `UpdateWorkItem.plan` as bookkeeping after
-material progress such as a file mutation, verification result, blocker
-discovery, or completed inspection objective. A successful work-item mutation
-may invalidate turn-local checkpoint state because the runtime focus changed,
-but failed tool inputs and `ExecCommand` calls do not invalidate checkpoint
-anchors by command-name heuristics.
+Work-item updates are coordination state, not the artifact progress ledger.
+Prompt guidance should frame plan_status, plan, and todo_list updates as
+bookkeeping after material progress such as a file mutation, verification
+result, blocker discovery, or completed inspection objective. A successful
+work-item mutation may invalidate turn-local checkpoint state because the
+runtime focus changed, but failed tool inputs and `ExecCommand` calls do not
+invalidate checkpoint anchors by command-name heuristics.
 
 ### Control-Plane Work-Item Enqueue
 
@@ -1639,7 +1624,7 @@ without creating a normal transcript message first.
 
 The minimal request shape is:
 
-- `delivery_target` required
+- `objective` required
 
 Rules:
 
@@ -1663,7 +1648,7 @@ Rules:
 
 - the turn-end commit path only applies when the turn started with a bound
   current work item
-- completing a work item is only done through explicit `CompleteWorkItem`
+- completing a work item is only completed through explicit `CompleteWorkItem`
 - if runtime facts show a blocking wait condition, the controller may set
   `blocked_by` on the bound open item
 - if the turn completes without an explicit completion or blocker, the item
@@ -1683,7 +1668,7 @@ Rules:
   unblocked work item, emit a system tick to continue that work item
 - if the runtime is idle, no current runnable work item exists, and at least one
   queued open work item exists, wake the agent so it can pick one
-- blocked and done items do not participate in activation
+- blocked and completed items do not participate in activation
 - if no work items exist, preserve the existing message-driven idle path
 - work-queue ticks are runtime-owned system ticks, not external ingress
 - coalesced wake hints still participate in the idle path and should not be

--- a/docs/single-agent-context-compression.md
+++ b/docs/single-agent-context-compression.md
@@ -487,7 +487,7 @@ pub struct ContextEpisodeRecord {
     pub start_message_offset: usize,
     pub end_message_offset: usize,
     pub active_work_item_id: Option<String>,
-    pub delivery_target: Option<String>,
+    pub objective: Option<String>,
     pub work_summary: Option<String>,
     pub scope_hints: Vec<String>,
     pub summary: String,
@@ -528,7 +528,7 @@ Suggested shape:
 ```rust
 pub struct WorkingMemorySnapshot {
     pub active_work_item_id: Option<String>,
-    pub delivery_target: Option<String>,
+    pub objective: Option<String>,
     pub work_summary: Option<String>,
     pub scope_hints: Vec<String>,
     pub current_plan: Vec<String>,
@@ -639,7 +639,7 @@ state, not free-authored by the model.
 Recommended source mapping:
 
 - `active_work_item_id`: active work item id when one exists
-- `delivery_target`: active work item delivery target
+- `objective`: active work item delivery target
 - `work_summary`: active work item summary
 - `scope_hints`: bounded extraction from trusted operator prompts, active work
   progress, and recent result briefs; prefer evidence bound to the current

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,8 +16,8 @@ use crate::{
     types::{
         ActiveWorkspaceEntry, AgentSummary, BriefRecord, ExternalTriggerStateSnapshot,
         OperatorNotificationRecord, TaskRecord, TimerRecord, TranscriptEntry, TrustLevel,
-        TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord, WorkPlanSnapshot,
-        WorkspaceOccupancyRecord, WorktreeSession,
+        TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord, WorkspaceOccupancyRecord,
+        WorktreeSession,
     },
 };
 
@@ -86,8 +86,6 @@ pub struct AgentStateSnapshot {
     pub timers: Vec<TimerRecord>,
     #[serde(default)]
     pub work_items: Vec<WorkItemRecord>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub work_plan: Option<WorkPlanSnapshot>,
     #[serde(default)]
     pub waiting_intents: Vec<WaitingIntentRecord>,
     #[serde(default)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,8 +7,8 @@ use crate::{
     types::{
         AdmissionContext, AgentState, AuthorityClass, BriefRecord, ContextEpisodeRecord,
         ContinuationClass, ContinuationResolution, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, ToolExecutionRecord,
-        TrustLevel, WorkItemRecord, WorkPlanSnapshot, WorkingMemoryDelta, WorkingMemorySnapshot,
+        MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TodoItemState,
+        ToolExecutionRecord, TrustLevel, WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot,
     },
 };
 
@@ -62,10 +62,6 @@ pub fn build_context(
     let episodes = storage.read_recent_context_episodes(config.recent_episode_candidates)?;
     let work_queue_projection = storage.work_queue_prompt_projection()?;
     let current_work_item = work_queue_projection.current.as_ref();
-    let current_work_plan = current_work_item
-        .map(|item| storage.latest_work_plan(&item.id))
-        .transpose()?
-        .flatten();
     let queued_blocked_items = work_queue_projection
         .queued_blocked
         .iter()
@@ -212,10 +208,7 @@ pub fn build_context(
         push_budgeted_section(
             &mut sections,
             &mut remaining_budget,
-            turn_section(
-                "current_work_item",
-                render_current_work_item(work_item, current_work_plan.as_ref()),
-            ),
+            turn_section("current_work_item", render_current_work_item(work_item)),
         );
     }
 
@@ -235,7 +228,7 @@ pub fn build_context(
         &mut remaining_budget,
         section(
             "context_contract",
-            "Interpret the memory block with this priority: current work item first for the committed delivery target and current runtime task, working memory delta next for the newest updates since the last prompt, and working memory after that for rolling agent context. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as the most reliable continuity evidence across turns. When these sources differ on task scope or delivery target, treat the current work item's `delivery_target` as the ground truth for the current committed task unless the current input explicitly changes it."
+            "Interpret the memory block with this priority: current work item objective first, durable plan second, todo_list third, working memory delta next, and rolling working memory after that. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as continuity evidence across turns. When sources differ on task scope, treat the current work item's `objective` and `plan` as the ground truth unless the current input explicitly changes it."
                 .to_string(),
         ),
     );
@@ -482,23 +475,31 @@ fn render_brief(brief: &BriefRecord) -> String {
     format!("- [{:?}] {}", brief.kind, brief.text)
 }
 
-fn render_current_work_item(work_item: &WorkItemRecord, plan: Option<&WorkPlanSnapshot>) -> String {
+fn render_current_work_item(work_item: &WorkItemRecord) -> String {
     let mut lines = vec![
         "Current work item:".to_string(),
         format!("- Id: {}", work_item.id),
         format!("- State: {:?}", work_item.state),
-        format!("- Delivery target: {}", work_item.delivery_target),
+        format!("- Objective: {}", work_item.objective),
+        format!("- Plan state: {:?}", work_item.plan_status),
     ];
+    if let Some(plan) = work_item.plan.as_deref() {
+        lines.push("- Plan:".to_string());
+        lines.extend(plan.lines().map(|line| format!("  {line}")));
+    }
+    if !work_item.todo_list.is_empty() {
+        lines.push("- Todo list:".to_string());
+        lines.extend(work_item.todo_list.iter().map(|item| {
+            let state = match item.state {
+                TodoItemState::Pending => "pending",
+                TodoItemState::InProgress => "in_progress",
+                TodoItemState::Completed => "completed",
+            };
+            format!("  - [{state}] {}", item.text)
+        }));
+    }
     if let Some(blocked_by) = work_item.blocked_by.as_deref() {
         lines.push(format!("- Blocked by: {blocked_by}"));
-    }
-    if let Some(plan) = plan {
-        lines.push("- Current work plan:".to_string());
-        lines.extend(
-            plan.items
-                .iter()
-                .map(|item| format!("  - [{:?}] {}", item.status, item.step)),
-        );
     }
     lines.join("\n")
 }
@@ -511,7 +512,7 @@ fn render_queued_blocked_work_items(items: &[&WorkItemRecord]) -> String {
         } else {
             "queued"
         };
-        let mut summary = format!("- [{view}] {} :: {}", item.id, item.delivery_target);
+        let mut summary = format!("- [{view}] {} :: {}", item.id, item.objective);
         if let Some(blocked_by) = item.blocked_by.as_deref() {
             summary.push_str(&format!(" :: blocked_by={blocked_by}"));
         }
@@ -529,8 +530,8 @@ fn render_working_memory(snapshot: &WorkingMemorySnapshot) -> String {
     if let Some(current_work_item_id) = snapshot.current_work_item_id.as_deref() {
         lines.push(format!("- Current work item id: {current_work_item_id}"));
     }
-    if let Some(delivery_target) = snapshot.delivery_target.as_deref() {
-        lines.push(format!("- Delivery target: {delivery_target}"));
+    if let Some(objective) = snapshot.objective.as_deref() {
+        lines.push(format!("- Objective: {objective}"));
     }
     if let Some(work_summary) = snapshot.work_summary.as_deref() {
         lines.push(format!("- Work summary: {work_summary}"));
@@ -858,8 +859,8 @@ fn render_work_queue_tick_context(message: &MessageEnvelope) -> Option<String> {
         .get("work_item_id")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("unknown");
-    let delivery_target = work_queue
-        .get("delivery_target")
+    let objective = work_queue
+        .get("objective")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("unknown");
     let runtime_switched_current = work_queue
@@ -870,7 +871,7 @@ fn render_work_queue_tick_context(message: &MessageEnvelope) -> Option<String> {
         " - Work queue:\n\
          - Reason: {reason}\n\
          - Work item id: {work_item_id}\n\
-         - Delivery target: {delivery_target}\n\
+         - Objective: {objective}\n\
          - Runtime switched current item: {runtime_switched_current}"
     ))
 }
@@ -1017,7 +1018,7 @@ fn render_budgeted_lines(heading: &str, lines: Vec<String>, budget: usize) -> Op
 #[derive(Debug, Clone)]
 struct EpisodeSelectionAnchor<'a> {
     current_work_item_id: Option<&'a str>,
-    delivery_target: Option<&'a str>,
+    objective: Option<&'a str>,
     work_summary: Option<&'a str>,
     working_set_files: &'a [String],
     pending_followups: &'a [String],
@@ -1043,7 +1044,7 @@ fn build_relevant_episode_memory_section(
         body_preview(&current_message.body),
         working_memory.work_summary.as_deref().unwrap_or_default(),
         current_work_item
-            .map(|item| item.delivery_target.as_str())
+            .map(|item| item.objective.as_str())
             .unwrap_or_default()
     );
     let anchor = EpisodeSelectionAnchor {
@@ -1051,10 +1052,10 @@ fn build_relevant_episode_memory_section(
             .current_work_item_id
             .as_deref()
             .or_else(|| current_work_item.map(|item| item.id.as_str())),
-        delivery_target: working_memory
-            .delivery_target
+        objective: working_memory
+            .objective
             .as_deref()
-            .or_else(|| current_work_item.map(|item| item.delivery_target.as_str())),
+            .or_else(|| current_work_item.map(|item| item.objective.as_str())),
         work_summary: working_memory.work_summary.as_deref(),
         working_set_files: &working_memory.working_set_files,
         pending_followups: &working_memory.pending_followups,
@@ -1115,8 +1116,8 @@ fn render_episode_block(episode: &ContextEpisodeRecord) -> String {
         episode.end_turn_index,
         enum_label(&episode.boundary_reason)
     )];
-    if let Some(delivery_target) = episode.delivery_target.as_deref() {
-        lines.push(format!("  - Delivery target: {delivery_target}"));
+    if let Some(objective) = episode.objective.as_deref() {
+        lines.push(format!("  - Objective: {objective}"));
     }
     if let Some(work_summary) = episode.work_summary.as_deref() {
         lines.push(format!("  - Work summary: {work_summary}"));
@@ -1184,7 +1185,7 @@ fn episode_relevance_score(
         .map(|_| 120)
         .unwrap_or(0);
 
-    if normalized_option_eq(episode.delivery_target.as_deref(), anchor.delivery_target) {
+    if normalized_option_eq(episode.objective.as_deref(), anchor.objective) {
         score += 80;
     }
     if normalized_option_eq(episode.work_summary.as_deref(), anchor.work_summary) {
@@ -1349,7 +1350,7 @@ mod tests {
 
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            delivery_target: Some("ship working memory".into()),
+            objective: Some("ship working memory".into()),
             current_plan: vec!["[InProgress] keep cache identity stable".into()],
             ..WorkingMemorySnapshot::default()
         };
@@ -1396,7 +1397,7 @@ mod tests {
 
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            delivery_target: Some("ship working memory".into()),
+            objective: Some("ship working memory".into()),
             current_plan: vec!["[InProgress] keep cache identity stable".into()],
             ..WorkingMemorySnapshot::default()
         };
@@ -1590,7 +1591,7 @@ mod tests {
             .contains("Use prior briefs and recent tool results"));
         assert!(context_contract
             .content
-            .contains("current work item first for the committed delivery target"));
+            .contains("current work item objective first"));
     }
 
     #[test]
@@ -1780,7 +1781,7 @@ mod tests {
         let mut session = AgentState::new("default");
         session.context_summary = Some("stale compacted summary".into());
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            delivery_target: Some("active work".into()),
+            objective: Some("active work".into()),
             ..WorkingMemorySnapshot::default()
         };
         let changed = maybe_compact_agent(
@@ -1819,7 +1820,7 @@ mod tests {
         let mut session = AgentState::new("default");
         session.context_summary = Some("legacy summary".into());
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            delivery_target: Some("ship working memory".into()),
+            objective: Some("ship working memory".into()),
             current_plan: vec!["[InProgress] wire post-turn refresh".into()],
             ..WorkingMemorySnapshot::default()
         };
@@ -1921,7 +1922,7 @@ mod tests {
 
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            delivery_target: Some("stabilize wake path".into()),
+            objective: Some("stabilize wake path".into()),
             recent_decisions: vec!["leave flaky verification as raw evidence".into()],
             ..WorkingMemorySnapshot::default()
         };
@@ -2177,28 +2178,23 @@ mod tests {
             },
         );
 
-        let active = crate::types::WorkItemRecord::new(
+        let mut active = crate::types::WorkItemRecord::new(
             "default",
             "storage and recovery foundation",
             crate::types::WorkItemState::Open,
         );
+        active.plan = Some("Persist the work item store and project it into prompts.".into());
+        active.todo_list = vec![
+            crate::types::TodoItem {
+                text: "Persist work-item store".into(),
+                state: crate::types::TodoItemState::Completed,
+            },
+            crate::types::TodoItem {
+                text: "Project active item into prompt".into(),
+                state: crate::types::TodoItemState::InProgress,
+            },
+        ];
         storage.append_work_item(&active).unwrap();
-        storage
-            .append_work_plan(&crate::types::WorkPlanSnapshot::new(
-                "default",
-                active.id.clone(),
-                vec![
-                    crate::types::WorkPlanItem {
-                        step: "Persist work-item store".into(),
-                        status: crate::types::WorkPlanStepStatus::Completed,
-                    },
-                    crate::types::WorkPlanItem {
-                        step: "Project active item into prompt".into(),
-                        status: crate::types::WorkPlanStepStatus::InProgress,
-                    },
-                ],
-            ))
-            .unwrap();
 
         let mut agent = AgentState::new("default");
         agent.current_work_item_id = Some(active.id.clone());
@@ -2263,7 +2259,7 @@ mod tests {
         let completed = crate::types::WorkItemRecord::new(
             "default",
             "Already finished item",
-            crate::types::WorkItemState::Done,
+            crate::types::WorkItemState::Completed,
         );
         storage.append_work_item(&queued).unwrap();
         storage.append_work_item(&waiting).unwrap();
@@ -2546,7 +2542,7 @@ mod tests {
             "work_queue": {
                 "reason": "continue_active",
                 "work_item_id": "work_123",
-                "delivery_target": "fix stale pid handling",
+                "objective": "fix stale pid handling",
                 "runtime_switched_current_item": false
             }
         }));
@@ -2750,7 +2746,7 @@ mod tests {
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
             current_work_item_id: Some(active.id.clone()),
-            delivery_target: Some(active.delivery_target.clone()),
+            objective: Some(active.objective.clone()),
             work_summary: Some("wake path patching".into()),
             current_plan: vec!["finish wake-path regression".into()],
             ..WorkingMemorySnapshot::default()
@@ -2862,7 +2858,7 @@ mod tests {
 
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            delivery_target: Some("ship the prompt delta gating fix".into()),
+            objective: Some("ship the prompt delta gating fix".into()),
             current_plan: vec!["[InProgress] wire prompt render acknowledgement".into()],
             ..WorkingMemorySnapshot::default()
         };
@@ -2918,7 +2914,7 @@ mod tests {
             end_message_count: 6,
             boundary_reason: EpisodeBoundaryReason::HardTurnCap,
             current_work_item_id: Some("work_old".into()),
-            delivery_target: Some("Refactor parser".into()),
+            objective: Some("Refactor parser".into()),
             work_summary: Some("parser cleanup".into()),
             scope_hints: vec!["keep unrelated runtime behavior unchanged".into()],
             summary: "Completed parser refactor and removed dead branches.".into(),
@@ -2943,7 +2939,7 @@ mod tests {
             end_message_count: 14,
             boundary_reason: EpisodeBoundaryReason::WaitBoundary,
             current_work_item_id: Some("work_runtime".into()),
-            delivery_target: Some("Fix wake path".into()),
+            objective: Some("Fix wake path".into()),
             work_summary: Some("wake path patching".into()),
             scope_hints: vec!["keep behavior unchanged outside the wake path".into()],
             summary:
@@ -2972,7 +2968,7 @@ mod tests {
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
             current_work_item_id: Some("work_runtime".into()),
-            delivery_target: Some("Fix wake path".into()),
+            objective: Some("Fix wake path".into()),
             work_summary: Some("wake path patching".into()),
             working_set_files: vec!["src/runtime.rs".into()],
             pending_followups: vec!["confirm remaining wake edge case".into()],
@@ -3021,7 +3017,7 @@ mod tests {
 
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
-            delivery_target: Some("Stabilize prompt budgeting".into()),
+            objective: Some("Stabilize prompt budgeting".into()),
             work_summary: Some("Trim oversized context sections before append".into()),
             scope_hints: vec![
                 "scope hint one repeats enough text to force truncation".repeat(8),

--- a/src/host.rs
+++ b/src/host.rs
@@ -33,8 +33,8 @@ use crate::{
         AgentIdentityRecord, AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset,
         AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentVisibility,
         ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord, ExternalTriggerStatus,
-        OperatorNotificationRecord, RuntimeFailureSummary, TaskRecord, TaskStatus, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WorkItemRecord, WorkPlanItem, WorkspaceEntry,
+        OperatorNotificationRecord, RuntimeFailureSummary, TaskRecord, TaskStatus, TodoItem,
+        TranscriptEntry, TranscriptEntryKind, TrustLevel, WorkItemRecord, WorkspaceEntry,
         WorkspaceOccupancyRecord,
     },
 };
@@ -259,11 +259,11 @@ impl RuntimeHost {
     pub async fn enqueue_public_work_item(
         &self,
         agent_id: &str,
-        delivery_target: String,
+        objective: String,
     ) -> std::result::Result<(RuntimeHandle, crate::types::WorkItemRecord), PublicAgentError> {
         let runtime = self.get_public_agent(agent_id).await?;
-        let (record, _) = runtime
-            .create_work_item(delivery_target, None)
+        let record = runtime
+            .create_work_item(objective, None, None, Vec::new())
             .await
             .map_err(PublicAgentError::Runtime)?;
         Ok((runtime, record))
@@ -1228,11 +1228,14 @@ impl RuntimeHostBridge {
     pub(crate) async fn create_child_work_item(
         &self,
         agent_id: &str,
-        delivery_target: String,
-        plan: Option<Vec<WorkPlanItem>>,
+        objective: String,
+        plan: Option<String>,
+        todo_list: Vec<TodoItem>,
     ) -> Result<WorkItemRecord> {
         let runtime = self.host()?.get_or_create_agent(agent_id).await?;
-        let (work_item, _) = runtime.create_work_item(delivery_target, plan).await?;
+        let work_item = runtime
+            .create_work_item(objective, None, plan, todo_list)
+            .await?;
         let (_, current) = runtime.pick_work_item(work_item.id.clone()).await?;
         Ok(current)
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -60,7 +60,7 @@ use crate::{
         OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskRecord,
         TimerRecord, TranscriptEntry, TrustLevel, TurnTerminalRecord, WaitingIntentRecord,
-        WorkItemRecord, WorkItemState, WorkPlanSnapshot, WorkspaceOccupancyRecord, WorktreeSession,
+        WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord, WorktreeSession,
     },
 };
 
@@ -332,7 +332,6 @@ struct AgentStateSnapshot {
     briefs_tail: Vec<BriefRecord>,
     timers: Vec<TimerRecord>,
     work_items: Vec<WorkItemRecord>,
-    work_plan: Option<WorkPlanSnapshot>,
     waiting_intents: Vec<WaitingIntentRecord>,
     external_triggers: Vec<ExternalTriggerStateSnapshot>,
     operator_notifications: Vec<OperatorNotificationRecord>,
@@ -383,7 +382,7 @@ pub struct CreateCommandTaskRequest {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CreateWorkItemRequest {
-    pub delivery_target: String,
+    pub objective: String,
     pub trust: Option<TrustLevel>,
 }
 
@@ -729,16 +728,6 @@ pub async fn agent_state(
     let timers = runtime.recent_timers(50).await.map_err(error_response)?;
     let mut work_items = runtime.latest_work_items().await.map_err(error_response)?;
     sort_state_work_items(&mut work_items);
-    let work_plan = match select_state_work_plan_target(
-        agent.agent.current_turn_work_item_id.as_deref(),
-        &work_items,
-    ) {
-        Some(work_item_id) => runtime
-            .latest_work_plan(&work_item_id)
-            .await
-            .map_err(error_response)?,
-        None => None,
-    };
     let waiting_intents = runtime
         .latest_waiting_intents()
         .await
@@ -769,7 +758,6 @@ pub async fn agent_state(
         briefs_tail,
         timers,
         work_items,
-        work_plan,
         waiting_intents,
         external_triggers,
         operator_notifications,
@@ -804,26 +792,8 @@ fn state_work_item_rank(item: &WorkItemRecord) -> u8 {
     match item.state {
         WorkItemState::Open if item.blocked_by.is_none() => 0,
         WorkItemState::Open => 1,
-        WorkItemState::Done => 2,
+        WorkItemState::Completed => 2,
     }
-}
-
-fn select_state_work_plan_target(
-    current_turn_work_item_id: Option<&str>,
-    work_items: &[WorkItemRecord],
-) -> Option<String> {
-    let selected = current_turn_work_item_id
-        .and_then(|id| {
-            work_items
-                .iter()
-                .find(|item| item.id == id && item.state != WorkItemState::Done)
-        })
-        .or_else(|| {
-            work_items
-                .iter()
-                .find(|item| item.state == WorkItemState::Open)
-        })?;
-    Some(selected.id.clone())
 }
 
 fn state_workspace_snapshot(agent: &AgentSummary) -> StateWorkspaceSnapshot {
@@ -837,7 +807,7 @@ fn state_workspace_snapshot(agent: &AgentSummary) -> StateWorkspaceSnapshot {
 
 #[cfg(test)]
 mod tests {
-    use super::{select_state_work_plan_target, sort_state_work_items};
+    use super::sort_state_work_items;
     use crate::types::{WorkItemRecord, WorkItemState};
     use chrono::{Duration, Utc};
 
@@ -858,7 +828,7 @@ mod tests {
         waiting.created_at = queued_late.created_at + Duration::minutes(1);
         waiting.updated_at = waiting.created_at;
 
-        let completed = WorkItemRecord::new("default", "completed", WorkItemState::Done);
+        let completed = WorkItemRecord::new("default", "completed", WorkItemState::Completed);
         let mut work_items = vec![
             waiting.clone(),
             completed,
@@ -871,37 +841,17 @@ mod tests {
 
         let ordered = work_items
             .iter()
-            .map(|item| item.delivery_target.as_str())
+            .map(|item| item.objective.as_str())
             .collect::<Vec<_>>();
         assert_eq!(
             ordered,
             vec![
-                active.delivery_target.as_str(),
-                queued_early.delivery_target.as_str(),
-                queued_late.delivery_target.as_str(),
-                waiting.delivery_target.as_str(),
+                active.objective.as_str(),
+                queued_early.objective.as_str(),
+                queued_late.objective.as_str(),
+                waiting.objective.as_str(),
                 "completed",
             ]
-        );
-    }
-
-    #[test]
-    fn state_work_plan_target_skips_completed_current_turn_binding() {
-        let completed_id = "completed-bound".to_string();
-        let queued_id = "queued-next".to_string();
-
-        let mut completed =
-            WorkItemRecord::new("default", "completed bound item", WorkItemState::Done);
-        completed.id = completed_id.clone();
-
-        let mut queued = WorkItemRecord::new("default", "queued next item", WorkItemState::Open);
-        queued.id = queued_id.clone();
-
-        let work_items = vec![completed, queued];
-
-        assert_eq!(
-            select_state_work_plan_target(Some(completed_id.as_str()), &work_items),
-            Some(queued_id)
         );
     }
 }
@@ -1253,13 +1203,13 @@ pub async fn create_work_item(
     authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let admission_context = control_admission_context(&state);
     let provided_trust = request.trust;
-    let delivery_target = request.delivery_target.trim().to_string();
-    if delivery_target.is_empty() {
-        return Err(bad_request("delivery_target must not be empty"));
+    let objective = request.objective.trim().to_string();
+    if objective.is_empty() {
+        return Err(bad_request("objective must not be empty"));
     }
     let (runtime, record) = state
         .host
-        .enqueue_public_work_item(&agent_id, delivery_target)
+        .enqueue_public_work_item(&agent_id, objective)
         .await
         .map_err(agent_access_error)?;
     let boundary = current_boundary_metadata(&runtime)

--- a/src/memory/episode.rs
+++ b/src/memory/episode.rs
@@ -174,8 +174,8 @@ fn merge_into_active_episode(
     if builder.current_work_item_id.is_none() {
         builder.current_work_item_id = current_snapshot.current_work_item_id.clone();
     }
-    if builder.delivery_target.is_none() {
-        builder.delivery_target = current_snapshot.delivery_target.clone();
+    if builder.objective.is_none() {
+        builder.objective = current_snapshot.objective.clone();
     }
     if builder.work_summary.is_none() {
         builder.work_summary = current_snapshot.work_summary.clone();
@@ -245,7 +245,7 @@ fn derive_boundary_reason(
 
     if !working_snapshot_is_empty(previous_snapshot)
         && (previous_snapshot.current_work_item_id != current_snapshot.current_work_item_id
-            || previous_snapshot.delivery_target != current_snapshot.delivery_target
+            || previous_snapshot.objective != current_snapshot.objective
             || previous_snapshot.work_summary != current_snapshot.work_summary)
     {
         return Some(EpisodeBoundaryReason::ActiveWorkSwitched);
@@ -301,7 +301,7 @@ fn finalize_episode(
         end_message_count: builder.latest_message_count,
         boundary_reason,
         current_work_item_id: builder.current_work_item_id,
-        delivery_target: builder.delivery_target,
+        objective: builder.objective,
         work_summary: builder.work_summary,
         scope_hints: builder.scope_hints,
         summary,
@@ -316,11 +316,7 @@ fn finalize_episode(
 
 fn render_episode_summary(builder: &ActiveEpisodeBuilder) -> String {
     let mut lines = Vec::new();
-    if let Some(target) = builder
-        .work_summary
-        .as_ref()
-        .or(builder.delivery_target.as_ref())
-    {
+    if let Some(target) = builder.work_summary.as_ref().or(builder.objective.as_ref()) {
         lines.push(format!("work: {}", truncate_line(target, 120)));
     }
     if !builder.scope_hints.is_empty() {
@@ -432,7 +428,7 @@ mod tests {
     fn snapshot(work_id: &str, summary: &str) -> WorkingMemorySnapshot {
         WorkingMemorySnapshot {
             current_work_item_id: Some(work_id.into()),
-            delivery_target: Some(summary.into()),
+            objective: Some(summary.into()),
             work_summary: Some(summary.into()),
             ..WorkingMemorySnapshot::default()
         }

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -650,7 +650,7 @@ fn work_item_documents(storage: &AppStorage) -> Result<Vec<MemoryDocument>> {
 }
 
 fn work_item_document(item: WorkItemRecord) -> MemoryDocument {
-    let body = item.delivery_target.clone();
+    let body = item.objective.clone();
     MemoryDocument {
         source_ref: format!("work_item:{}", item.id),
         source_kind: "work_item".into(),
@@ -658,7 +658,7 @@ fn work_item_document(item: WorkItemRecord) -> MemoryDocument {
         workspace_id: Some(item.workspace_id),
         agent_id: item.agent_id,
         source_path: None,
-        title: item.delivery_target.clone(),
+        title: item.objective.clone(),
         sanitized_excerpt: excerpt(&body),
         body,
         metadata: json!({
@@ -777,11 +777,11 @@ mod tests {
 
     fn work_item_with_workspace(
         agent_id: &str,
-        delivery_target: &str,
+        objective: &str,
         status: WorkItemState,
         workspace_id: &str,
     ) -> WorkItemRecord {
-        let mut work_item = WorkItemRecord::new(agent_id, delivery_target, status);
+        let mut work_item = WorkItemRecord::new(agent_id, objective, status);
         work_item.workspace_id = workspace_id.to_string();
         work_item
     }
@@ -934,7 +934,7 @@ mod tests {
         let mut work_item = WorkItemRecord::new(
             "default",
             "MemorySearch index implementation",
-            WorkItemState::Done,
+            WorkItemState::Completed,
         );
         work_item.workspace_id = "ws-holon".into();
         storage.append_work_item(&work_item).unwrap();
@@ -951,7 +951,7 @@ mod tests {
                 end_message_count: 3,
                 boundary_reason: EpisodeBoundaryReason::HardTurnCap,
                 current_work_item_id: Some(work_item.id.clone()),
-                delivery_target: Some("memory search".into()),
+                objective: Some("memory search".into()),
                 work_summary: Some("index worker".into()),
                 scope_hints: vec![],
                 summary: "Implemented workspace-aware recall over runtime evidence".into(),
@@ -1025,7 +1025,7 @@ mod tests {
         let work_item = work_item_with_workspace(
             "default",
             "existing work item",
-            WorkItemState::Done,
+            WorkItemState::Completed,
             "ws-existing",
         );
         storage.append_work_item(&work_item).unwrap();
@@ -1042,7 +1042,7 @@ mod tests {
                 end_message_count: 2,
                 boundary_reason: EpisodeBoundaryReason::HardTurnCap,
                 current_work_item_id: Some(work_item.id),
-                delivery_target: Some("existing episode".into()),
+                objective: Some("existing episode".into()),
                 work_summary: Some("existing episode summary".into()),
                 scope_hints: vec![],
                 summary: "existing context episode memory".into(),

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -650,7 +650,7 @@ fn work_item_documents(storage: &AppStorage) -> Result<Vec<MemoryDocument>> {
 }
 
 fn work_item_document(item: WorkItemRecord) -> MemoryDocument {
-    let body = item.objective.clone();
+    let body = work_item_document_body(&item);
     MemoryDocument {
         source_ref: format!("work_item:{}", item.id),
         source_kind: "work_item".into(),
@@ -667,6 +667,47 @@ fn work_item_document(item: WorkItemRecord) -> MemoryDocument {
             "blocked_by": item.blocked_by,
         }),
         updated_at: item.updated_at,
+    }
+}
+
+fn work_item_document_body(item: &WorkItemRecord) -> String {
+    let mut lines = vec![
+        format!("Objective: {}", item.objective),
+        format!(
+            "Plan status: {}",
+            work_item_plan_status_label(item.plan_status)
+        ),
+    ];
+    if let Some(plan) = item.plan.as_deref().filter(|plan| !plan.trim().is_empty()) {
+        lines.push("Plan:".into());
+        lines.push(plan.to_string());
+    }
+    if !item.todo_list.is_empty() {
+        lines.push("Todo list:".into());
+        for todo in &item.todo_list {
+            lines.push(format!(
+                "- [{}] {}",
+                todo_item_state_label(todo.state),
+                todo.text
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+fn work_item_plan_status_label(status: crate::types::WorkItemPlanStatus) -> &'static str {
+    match status {
+        crate::types::WorkItemPlanStatus::Draft => "draft",
+        crate::types::WorkItemPlanStatus::Ready => "ready",
+        crate::types::WorkItemPlanStatus::NeedsInput => "needs_input",
+    }
+}
+
+fn todo_item_state_label(state: crate::types::TodoItemState) -> &'static str {
+    match state {
+        crate::types::TodoItemState::Pending => "pending",
+        crate::types::TodoItemState::InProgress => "in_progress",
+        crate::types::TodoItemState::Completed => "completed",
     }
 }
 
@@ -760,7 +801,8 @@ mod tests {
     use crate::{
         agent_template::ensure_agent_home_layout,
         types::{
-            AgentState, BriefKind, ContextEpisodeRecord, EpisodeBoundaryReason, WorkItemState,
+            AgentState, BriefKind, ContextEpisodeRecord, EpisodeBoundaryReason, TodoItem,
+            TodoItemState, WorkItemPlanStatus, WorkItemState,
         },
     };
 
@@ -937,6 +979,18 @@ mod tests {
             WorkItemState::Completed,
         );
         work_item.workspace_id = "ws-holon".into();
+        work_item.plan_status = WorkItemPlanStatus::Ready;
+        work_item.plan = Some("Persist checksum-oriented task understanding in recall.".into());
+        work_item.todo_list = vec![
+            TodoItem {
+                text: "Index durable objective plan text".into(),
+                state: TodoItemState::Completed,
+            },
+            TodoItem {
+                text: "Verify checklist retrieval marker".into(),
+                state: TodoItemState::InProgress,
+            },
+        ];
         storage.append_work_item(&work_item).unwrap();
         storage
             .append_context_episode(&ContextEpisodeRecord {
@@ -976,6 +1030,22 @@ mod tests {
             .any(|result| result.kind == "context_episode"));
         let results = search_memory(&storage, "MemorySearch", 10, Some("ws-holon"), false).unwrap();
         assert!(results.iter().any(|result| result.kind == "work_item"));
+        let results = search_memory(&storage, "checksum", 10, Some("ws-holon"), false).unwrap();
+        assert!(results.iter().any(|result| result.kind == "work_item"));
+        let results = search_memory(&storage, "checklist", 10, Some("ws-holon"), false).unwrap();
+        assert!(results.iter().any(|result| result.kind == "work_item"));
+        let work_item_doc = get_memory(
+            &storage,
+            &format!("work_item:{}", work_item.id),
+            None,
+            Some("ws-holon"),
+        )
+        .unwrap()
+        .expect("work item memory document");
+        assert!(work_item_doc.content.contains("Plan status: ready"));
+        assert!(work_item_doc
+            .content
+            .contains("Verify checklist retrieval marker"));
         assert!(results.iter().all(|result| result.scope_kind == "agent"
             || result.workspace_id.as_deref() == Some("ws-holon")));
         let other_results = search_memory(&storage, "other", 10, Some("ws-holon"), false).unwrap();

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -7,9 +7,8 @@ use crate::{
     storage::AppStorage,
     types::{
         AgentState, AuditEvent, ClosureDecision, ExternalTriggerScope, MessageEnvelope,
-        MessageKind, ToolExecutionRecord, TurnMemoryDelta, WaitingIntentStatus, WorkItemRecord,
-        WorkPlanSnapshot, WorkPlanStepStatus, WorkingMemoryDelta, WorkingMemorySnapshot,
-        WorkingMemoryUpdateReason,
+        MessageKind, TodoItemState, ToolExecutionRecord, TurnMemoryDelta, WaitingIntentStatus,
+        WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot, WorkingMemoryUpdateReason,
     },
 };
 
@@ -143,10 +142,6 @@ pub fn derive_working_memory_snapshot(
             })
     });
     let current_work_item = waiting_anchor;
-    let current_work_plan = current_work_item
-        .map(|item| storage.latest_work_plan(&item.id))
-        .transpose()?
-        .flatten();
     let recent_tools = storage.read_recent_tool_executions(MEMORY_TOOL_SCAN_LIMIT)?;
     let active_waiting = storage
         .latest_waiting_intents()?
@@ -157,10 +152,10 @@ pub fn derive_working_memory_snapshot(
     let current_work_item_id = current_work_item.map(|item| item.id.as_str());
     let memory_tools = collect_memory_tools(&recent_tools, current_work_item_id);
 
-    let work_summary = current_work_item.map(|item| item.delivery_target.clone());
-    let current_plan = current_work_plan
+    let work_summary = current_work_item.map(|item| item.objective.clone());
+    let current_plan = current_work_item
         .as_ref()
-        .map(render_current_plan)
+        .map(|item| render_current_plan(item))
         .unwrap_or_default();
     let queued_waiting_followups = projection
         .queued_blocked
@@ -168,17 +163,13 @@ pub fn derive_working_memory_snapshot(
         .filter(|item| Some(item.id.as_str()) != current_work_item.map(|anchor| anchor.id.as_str()))
         .cloned()
         .collect::<Vec<_>>();
-    let pending_followups = collect_pending_followups(
-        current_work_item,
-        current_work_plan.as_ref(),
-        &queued_waiting_followups,
-    );
+    let pending_followups = collect_pending_followups(current_work_item, &queued_waiting_followups);
     let waiting_on = collect_waiting_on(&active_waiting, current_work_item_id, current_closure);
     let working_set_files = collect_working_set_files(&memory_tools);
 
     Ok(WorkingMemorySnapshot {
         current_work_item_id: current_work_item.map(|item| item.id.clone()),
-        delivery_target: current_work_item.map(|item| item.delivery_target.clone()),
+        objective: current_work_item.map(|item| item.objective.clone()),
         work_summary,
         current_plan,
         working_set_files,
@@ -195,7 +186,7 @@ fn derive_update_reason(
     next: &WorkingMemorySnapshot,
 ) -> WorkingMemoryUpdateReason {
     if previous.current_work_item_id != next.current_work_item_id
-        || previous.delivery_target != next.delivery_target
+        || previous.objective != next.objective
         || previous.work_summary != next.work_summary
     {
         return WorkingMemoryUpdateReason::ActiveWorkChanged;
@@ -249,9 +240,9 @@ fn derive_turn_memory_delta(
     TurnMemoryDelta {
         turn_index: turn_index.max(1),
         active_work_changed: previous.current_work_item_id != next.current_work_item_id
-            || previous.delivery_target != next.delivery_target
+            || previous.objective != next.objective
             || previous.work_summary != next.work_summary,
-        work_plan_changed: previous.current_plan != next.current_plan,
+        current_plan_changed: previous.current_plan != next.current_plan,
         scope_hints_changed: false,
         touched_files: diff_list(&previous.working_set_files, &next.working_set_files),
         commands,
@@ -283,10 +274,10 @@ fn derive_working_memory_delta(
     push_changed_field(
         &mut changed_fields,
         &mut summary_lines,
-        "delivery_target",
-        previous.delivery_target.as_deref(),
-        next.delivery_target.as_deref(),
-        "delivery target",
+        "objective",
+        previous.objective.as_deref(),
+        next.objective.as_deref(),
+        "objective",
     );
     push_changed_field(
         &mut changed_fields,
@@ -376,18 +367,29 @@ fn merge_pending_delta(
     }
 }
 
-fn render_current_plan(plan: &WorkPlanSnapshot) -> Vec<String> {
-    plan.items
-        .iter()
-        .filter(|item| item.status != WorkPlanStepStatus::Completed)
-        .map(|item| format!("[{:?}] {}", item.status, item.step))
-        .take(MEMORY_PLAN_LIMIT)
-        .collect()
+fn render_current_plan(plan: &WorkItemRecord) -> Vec<String> {
+    let mut lines = Vec::new();
+    if let Some(plan_text) = plan.plan.as_deref() {
+        lines.extend(
+            plan_text
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(ToString::to_string)
+                .take(MEMORY_PLAN_LIMIT),
+        );
+    }
+    lines.extend(
+        plan.todo_list
+            .iter()
+            .filter(|item| item.state != TodoItemState::Completed)
+            .map(|item| format!("[{:?}] {}", item.state, item.text)),
+    );
+    limit_vec(lines, MEMORY_PLAN_LIMIT)
 }
 
 fn collect_pending_followups(
     current_work_item: Option<&WorkItemRecord>,
-    current_work_plan: Option<&WorkPlanSnapshot>,
     queued_waiting: &[WorkItemRecord],
 ) -> Vec<String> {
     let mut items = Vec::new();
@@ -395,21 +397,21 @@ fn collect_pending_followups(
     if let Some(active) = current_work_item {
         items.push(format!(
             "current: {}",
-            truncate_line(&active.delivery_target, 120)
+            truncate_line(&active.objective, 120)
         ));
     }
-    if let Some(plan) = current_work_plan {
+    if let Some(plan) = current_work_item {
         items.extend(
-            plan.items
+            plan.todo_list
                 .iter()
-                .filter(|item| item.status != WorkPlanStepStatus::Completed)
-                .map(|item| format!("plan: {}", truncate_line(&item.step, 120))),
+                .filter(|item| item.state != TodoItemState::Completed)
+                .map(|item| format!("todo: {}", truncate_line(&item.text, 120))),
         );
     }
     items.extend(
         queued_waiting
             .iter()
-            .map(|item| format!("queued: {}", truncate_line(&item.delivery_target, 120))),
+            .map(|item| format!("queued: {}", truncate_line(&item.objective, 120))),
     );
 
     dedup_owned(items, MEMORY_FOLLOWUP_LIMIT)
@@ -732,10 +734,9 @@ mod tests {
         storage::AppStorage,
         types::{
             AgentState, BriefKind, BriefRecord, CallbackDeliveryMode, ClosureDecision, MessageBody,
-            MessageEnvelope, MessageKind, MessageOrigin, Priority, RuntimePosture,
-            ToolExecutionRecord, ToolExecutionStatus, TrustLevel, WaitingIntentRecord,
-            WaitingIntentStatus, WaitingReason, WorkItemRecord, WorkItemState, WorkPlanItem,
-            WorkPlanSnapshot, WorkPlanStepStatus,
+            MessageEnvelope, MessageKind, MessageOrigin, Priority, RuntimePosture, TodoItem,
+            TodoItemState, ToolExecutionRecord, ToolExecutionStatus, TrustLevel,
+            WaitingIntentRecord, WaitingIntentStatus, WaitingReason, WorkItemRecord, WorkItemState,
         },
     };
 
@@ -766,29 +767,24 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
 
-        let active = WorkItemRecord::new(
+        let mut active = WorkItemRecord::new(
             "default",
             "repair benchmark export output",
             WorkItemState::Open,
         );
+        active.plan = Some("Patch exporter and run focused test.".into());
+        active.todo_list = vec![
+            TodoItem {
+                text: "patch exporter".into(),
+                state: TodoItemState::InProgress,
+            },
+            TodoItem {
+                text: "run focused test".into(),
+                state: TodoItemState::Pending,
+            },
+        ];
         storage.append_work_item(&active).unwrap();
         set_current_work_item(&storage, &active.id);
-        storage
-            .append_work_plan(&WorkPlanSnapshot::new(
-                "default",
-                &active.id,
-                vec![
-                    WorkPlanItem {
-                        step: "patch exporter".into(),
-                        status: WorkPlanStepStatus::InProgress,
-                    },
-                    WorkPlanItem {
-                        step: "run focused test".into(),
-                        status: WorkPlanStepStatus::Pending,
-                    },
-                ],
-            ))
-            .unwrap();
         storage
             .append_brief(&BriefRecord::new(
                 "default",
@@ -905,7 +901,7 @@ mod tests {
             Some(waiting.id.as_str())
         );
         assert_eq!(
-            snapshot.delivery_target.as_deref(),
+            snapshot.objective.as_deref(),
             Some("wait for operator approval")
         );
         assert!(!snapshot
@@ -1400,9 +1396,9 @@ mod tests {
 
         agent.working_memory.current_working_memory = WorkingMemorySnapshot {
             current_work_item_id: Some(active.id.clone()),
-            delivery_target: Some(active.delivery_target.clone()),
-            work_summary: Some(active.delivery_target.clone()),
-            pending_followups: vec![format!("current: {}", active.delivery_target)],
+            objective: Some(active.objective.clone()),
+            work_summary: Some(active.objective.clone()),
+            pending_followups: vec![format!("current: {}", active.objective)],
             scope_hints: vec!["legacy brief text".into()],
             recent_decisions: vec!["legacy final answer prose".into()],
             ..WorkingMemorySnapshot::default()
@@ -1479,7 +1475,7 @@ mod tests {
         assert!(refresh.working_memory_updated);
         assert_eq!(agent.context_summary, None);
         assert_eq!(
-            agent.working_memory.current_working_memory.delivery_target,
+            agent.working_memory.current_working_memory.objective,
             Some("ship memory cleanup".into())
         );
     }

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -250,7 +250,7 @@ fn build_system_sections(
         section(
             "progress_reporting",
             PromptStability::Stable,
-            "Prefer durable action over narration. If progress, intent, or state can be expressed by the actual artifact, tool call, code change, test result, work item, work plan, or final deliverable, do that instead of describing it in assistant text. Use progress text only to keep the operator oriented when the next action would otherwise be opaque. For non-trivial tasks, keep the operator informed with concise progress updates at meaningful boundaries, but do not turn progress updates into mini reports. Before tool calls, use at most 1-2 short sentences that state the immediate action and why it is useful now. Do not include full reasoning, historical recap, hypothesis trees, implementation plans, or broad status reports in pre-tool progress text. After a cluster of related reads or searches, summarize only when the material state changed or when the next action would otherwise be unclear. Keep the summary limited to confirmed facts and the next bounded action. Do not restate known context. If a previous assistant or result brief already answered the same question, do not repeat it; only add newly discovered facts, corrections, or the next concrete action. If code, docs, diffs, tool output, or logs already express the detail, do not restate that detail at length in natural language. Before file mutation, briefly state the intended change in one sentence. Do not explain the full design unless the operator explicitly asked for analysis. When changing strategy, explain only the concrete trigger for the change and the next bounded action. Do not re-derive the whole task. After a tool failure, do not write a broad explanation. Use the tool-specific failure receipt to choose the smallest recovery action, state that action briefly if needed, then proceed. Do not emit filler updates or repeat progress updates when no material state changed. When a tool call is the next useful action, include the progress update in the same assistant response as that tool call rather than stopping after commentary.".to_string(),
+            "Prefer durable action over narration. If progress, intent, or state can be expressed by the actual artifact, tool call, code change, test result, work item objective, work item plan, todo list, or final deliverable, do that instead of describing it in assistant text. Use progress text only to keep the operator oriented when the next action would otherwise be opaque. For non-trivial tasks, keep the operator informed with concise progress updates at meaningful boundaries, but do not turn progress updates into mini reports. Before tool calls, use at most 1-2 short sentences that state the immediate action and why it is useful now. Do not include full reasoning, historical recap, hypothesis trees, implementation plans, or broad status reports in pre-tool progress text. After a cluster of related reads or searches, summarize only when the material state changed or when the next action would otherwise be unclear. Keep the summary limited to confirmed facts and the next bounded action. Do not restate known context. If a previous assistant or result brief already answered the same question, do not repeat it; only add newly discovered facts, corrections, or the next concrete action. If code, docs, diffs, tool output, or logs already express the detail, do not restate that detail at length in natural language. Before file mutation, briefly state the intended change in one sentence. Do not explain the full design unless the operator explicitly asked for analysis. When changing strategy, explain only the concrete trigger for the change and the next bounded action. Do not re-derive the whole task. After a tool failure, do not write a broad explanation. Use the tool-specific failure receipt to choose the smallest recovery action, state that action briefly if needed, then proceed. Do not emit filler updates or repeat progress updates when no material state changed. When a tool call is the next useful action, include the progress update in the same assistant response as that tool call rather than stopping after commentary.".to_string(),
         ),
         section(
             "exploration_discipline",
@@ -260,7 +260,7 @@ fn build_system_sections(
         section(
             "work_item_first_execution",
             PromptStability::Stable,
-            "Treat task-like work as WorkItem-first by default. If the turn is more than a brief status answer, casual chat, or a narrow one-shot explanation, do not ignore the absence of a current active work item anchor. First decide whether the delivery target is already clear enough to stabilize as a work item. If it is still ambiguous, proactively communicate with the operator to clarify the real delivery target, acceptance boundary, or priority before making high-commitment edits. If a little local inspection is needed to make the target concrete, do that bounded inspection first, then create or refresh the active work item once the target is stable enough to name. Prefer refreshing the current active work item over creating a new one unless the delivery target has actually changed.".to_string(),
+            "Treat task-like work as WorkItem-first by default. If the turn is more than a brief status answer, casual chat, or a narrow one-shot explanation, do not ignore the absence of a current active work item anchor. First decide whether the objective is already clear enough to stabilize as a work item. If it is still ambiguous, proactively communicate with the operator to clarify the real objective, acceptance boundary, or priority before making high-commitment edits. If a little local inspection is needed to make the objective concrete, do that bounded inspection first, then create or refresh the active work item once the objective is stable enough to name. Prefer refreshing the current active work item over creating a new one unless the objective has actually changed.".to_string(),
         ),
         section(
             "trust_boundary",
@@ -779,13 +779,13 @@ mod tests {
         assert!(section
             .content
             .contains("absence of a current active work item anchor"));
-        assert!(section.content.contains("clarify the real delivery target"));
+        assert!(section.content.contains("clarify the real objective"));
         assert!(section
             .content
-            .contains("local inspection is needed to make the target concrete"));
+            .contains("local inspection is needed to make the objective concrete"));
         assert!(section
             .content
-            .contains("once the target is stable enough to name"));
+            .contains("once the objective is stable enough to name"));
         assert!(section.content.contains("brief status answer"));
     }
 

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -71,14 +71,14 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_work_item_write",
             PromptStability::Stable,
-            "Use CreateWorkItem to create a new open delivery target only for genuinely separate work, PickWorkItem to make an existing open item current, UpdateWorkItem to refine delivery_target, replace blocked_by, and/or replace the full plan snapshot, and CompleteWorkItem only when the delivery target is actually done. If the current task is not just a brief answer and there is no current work item yet, clarify the delivery target with the operator if it is still ambiguous; if bounded inspection is needed to make the target concrete, do that inspection before creating the work item. Do not create a new WorkItem just to refine or narrow the current delivery target; if the current WorkItem is still the same underlying task, update its delivery_target and plan with UpdateWorkItem. If an old WorkItem should be replaced, complete it first or explicitly PickWorkItem for the intended item before creating genuinely independent work. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, maintain the full current checklist snapshot rather than patching individual steps. Update plan state after material progress such as a code change, verification result, blocker discovery, or completed inspection objective; if the next known action is a file mutation, use ApplyPatch first and update the plan afterward. Plan updates are coordination/bookkeeping and do not replace file mutation, verification, PR/issue updates, final delivery, or other artifact progress. If the current step remains doing, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Complete explicitly when done.".to_string(),
+            "Use CreateWorkItem to create a new open objective only for genuinely separate work, PickWorkItem to make an existing open item current, UpdateWorkItem to refine objective, plan_status, plan, todo_list, and/or blocked_by, and CompleteWorkItem only when the objective is actually complete. If the current task is not just a brief answer and there is no current work item yet, clarify the objective with the operator if it is still ambiguous; if bounded inspection is needed to make the objective concrete, do that inspection before creating the work item. Do not create a new WorkItem just to refine or narrow the current objective; if the current WorkItem is still the same underlying task, update its objective, plan, and todo_list with UpdateWorkItem. If an old WorkItem should be replaced, complete it first or explicitly PickWorkItem for the intended item before creating genuinely independent work. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, maintain plan as durable prose and todo_list as the full current checklist snapshot rather than patching individual items. Update plan_status or todo_list after material progress such as a code change, verification result, blocker discovery, or completed inspection objective; if the next known action is a file mutation, use ApplyPatch first and update the work item afterward. Work-item updates are coordination/bookkeeping and do not replace file mutation, verification, PR/issue updates, final delivery, or other artifact progress. If the current item remains open because progress is blocked, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Complete explicitly when complete.".to_string(),
         ));
     }
     if names.contains(&"GetWorkItem") || names.contains(&"ListWorkItems") {
         sections.push(section(
             "tool_work_item_read",
             PromptStability::Stable,
-            "Use ListWorkItems with filter=current to inspect the current work-item focus before relying on memory briefs. Use GetWorkItem when you already know the id and need its open/done state, focus flag, and optional plan. Use ListWorkItems for queue inspection with filters such as open, done, current, queued, and blocked. Treat current_work_item_id as focus, not lifecycle; open/done describes completion, while current/queued/blocked is the scheduling view. Read the work-item surface before switching, completing, or expanding cross-turn work so the next action is anchored to the right delivery target.".to_string(),
+            "Use ListWorkItems with filter=current to inspect the current work-item focus before relying on memory briefs. Use GetWorkItem when you already know the id and need its open/completed state, focus flag, optional plan, and optional todo_list. Use ListWorkItems for queue inspection with filters such as open, completed, current, queued, and blocked. Treat current_work_item_id as focus, not lifecycle; open/completed describes completion, while current/queued/blocked is the scheduling view. Read the work-item surface before switching, completing, or expanding cross-turn work so the next action is anchored to the right objective.".to_string(),
         ));
     }
     if names.contains(&"TaskList")
@@ -285,23 +285,23 @@ mod tests {
             .contains("there is no current work item yet"));
         assert!(section
             .content
-            .contains("clarify the delivery target with the operator"));
+            .contains("clarify the objective with the operator"));
         assert!(section
             .content
-            .contains("bounded inspection is needed to make the target concrete"));
+            .contains("bounded inspection is needed to make the objective concrete"));
         assert!(section.content.contains("genuinely separate work"));
         assert!(section
             .content
             .contains("Do not create a new WorkItem just to refine or narrow"));
         assert!(section
             .content
-            .contains("update its delivery_target and plan"));
+            .contains("update its objective, plan, and todo_list"));
         assert!(section
             .content
-            .contains("Update plan state after material progress"));
+            .contains("Update plan_status or todo_list after material progress"));
         assert!(section
             .content
-            .contains("use ApplyPatch first and update the plan afterward"));
+            .contains("use ApplyPatch first and update the work item afterward"));
         assert!(section.content.contains("coordination/bookkeeping"));
         assert!(section.content.contains("specific blocker or missing fact"));
         assert!(section
@@ -331,7 +331,7 @@ mod tests {
             .find(|s| s.name == "tool_work_item_read")
             .expect("work item read section");
         assert!(section.content.contains("current_work_item_id as focus"));
-        assert!(section.content.contains("open/done"));
+        assert!(section.content.contains("open/completed"));
         assert!(section.content.contains("before relying on memory briefs"));
     }
 

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -285,7 +285,7 @@ pub async fn run_once_with_host(
 
         if let Some((status, waiting_reason)) = candidate_status {
             if let Some(candidate) = candidate_completion.as_ref() {
-                if candidate.status == status
+                if candidate.state == status
                     && candidate.waiting_reason == waiting_reason
                     && candidate.activity_signature == poll_view.activity_signature
                     && candidate.observed_at.elapsed()
@@ -295,7 +295,7 @@ pub async fn run_once_with_host(
                 }
             }
             let should_reset_candidate = candidate_completion.as_ref().is_none_or(|candidate| {
-                candidate.status != status
+                candidate.state != status
                     || candidate.waiting_reason != waiting_reason
                     || candidate.activity_signature != poll_view.activity_signature
             });
@@ -312,7 +312,7 @@ pub async fn run_once_with_host(
 
         tokio::time::sleep(Duration::from_millis(RUN_POLL_INTERVAL_MS)).await;
     };
-    let final_status = final_candidate.status;
+    let final_status = final_candidate.state;
     let waiting_reason = final_candidate.waiting_reason;
     let mut final_state = session.runtime.agent_state().await?;
 
@@ -495,7 +495,7 @@ struct PollActivitySignature {
 
 #[derive(Debug, Clone)]
 struct CandidateCompletion {
-    status: RunFinalStatus,
+    state: RunFinalStatus,
     waiting_reason: Option<WaitingReason>,
     activity_signature: PollActivitySignature,
     observed_at: Instant,
@@ -503,12 +503,12 @@ struct CandidateCompletion {
 
 impl CandidateCompletion {
     fn new(
-        status: RunFinalStatus,
+        state: RunFinalStatus,
         waiting_reason: Option<WaitingReason>,
         activity_signature: PollActivitySignature,
     ) -> Self {
         Self {
-            status,
+            state,
             waiting_reason,
             activity_signature,
             observed_at: Instant::now(),
@@ -617,9 +617,9 @@ async fn active_new_task_ids(
     Ok(active)
 }
 
-fn is_active_task_status(status: &TaskStatus) -> bool {
+fn is_active_task_status(state: &TaskStatus) -> bool {
     matches!(
-        status,
+        state,
         TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling
     )
 }
@@ -1039,8 +1039,8 @@ fn normalize_workspace_relative_path(path: &str, workspace_root: &Path) -> Strin
         .unwrap_or_else(|_| path.to_string())
 }
 
-fn final_status_label(status: RunFinalStatus) -> &'static str {
-    match status {
+fn final_status_label(state: RunFinalStatus) -> &'static str {
+    match state {
         RunFinalStatus::Completed => "completed",
         RunFinalStatus::Waiting => "waiting",
         RunFinalStatus::Failed => "failed",
@@ -1057,8 +1057,8 @@ fn waiting_reason_label(reason: WaitingReason) -> &'static str {
     }
 }
 
-fn task_status_label(status: &TaskStatus) -> &'static str {
-    match status {
+fn task_status_label(state: &TaskStatus) -> &'static str {
+    match state {
         TaskStatus::Queued => "queued",
         TaskStatus::Running => "running",
         TaskStatus::Cancelling => "cancelling",

--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -150,7 +150,7 @@ impl RuntimeHandle {
             let Some(record) = self.inner.storage.latest_work_item(&candidate)? else {
                 continue;
             };
-            if record.agent_id != agent_id || record.state == WorkItemState::Done {
+            if record.agent_id != agent_id || record.state == WorkItemState::Completed {
                 continue;
             }
             return Ok(Some(record.id));

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -76,9 +76,13 @@ impl RuntimeHandle {
                 id: latest.id.clone(),
                 agent_id: latest.agent_id.clone(),
                 workspace_id: latest.workspace_id.clone(),
-                delivery_target: latest.delivery_target.clone(),
+                objective: latest.objective.clone(),
                 state: latest.state.clone(),
+                plan_status: latest.plan_status,
+                plan: latest.plan.clone(),
+                todo_list: latest.todo_list.clone(),
                 blocked_by,
+                result_summary: latest.result_summary.clone(),
                 created_at: latest.created_at,
                 updated_at: chrono::Utc::now(),
             };
@@ -177,11 +181,6 @@ impl RuntimeHandle {
             |record| record.id == work_item.id,
             DELIVERY_SUMMARY_EVIDENCE_LIMIT,
         )?;
-        let work_plans = read_recent_matching(
-            |limit| self.inner.storage.read_recent_work_plans(limit),
-            |record| record.work_item_id == work_item.id,
-            DELIVERY_SUMMARY_EVIDENCE_LIMIT,
-        )?;
         let briefs = read_recent_matching(
             |limit| self.inner.storage.read_recent_briefs(limit),
             |record| record.work_item_id.as_deref() == Some(work_item.id.as_str()),
@@ -209,7 +208,8 @@ impl RuntimeHandle {
             "work_item": work_item,
             "source_turn_index": turn_index,
             "work_item_snapshots": work_item_snapshots,
-            "work_plans": work_plans,
+            "plan": work_item.plan,
+            "todo_list": work_item.todo_list,
             "briefs": briefs,
             "tool_executions": tools,
             "recent_transcript": transcript,
@@ -626,13 +626,6 @@ impl RuntimeHandle {
             crate::memory::repair_memory_index_for_paths(&storage, &changed_paths)
         })
         .await?
-    }
-
-    pub async fn latest_work_plan(
-        &self,
-        work_item_id: &str,
-    ) -> Result<Option<crate::types::WorkPlanSnapshot>> {
-        self.inner.storage.latest_work_plan(work_item_id)
     }
 
     pub async fn recent_timers(&self, limit: usize) -> Result<Vec<TimerRecord>> {
@@ -1405,10 +1398,7 @@ fn fallback_delivery_summary_text(evidence: &serde_json::Value) -> String {
         .or_else(|| {
             evidence
                 .get("work_item")
-                .and_then(|item| {
-                    item.get("blocked_by")
-                        .or_else(|| item.get("delivery_target"))
-                })
+                .and_then(|item| item.get("blocked_by").or_else(|| item.get("objective")))
                 .and_then(|value| value.as_str())
                 .map(str::trim)
                 .filter(|text| !text.is_empty())

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -1,9 +1,7 @@
 use super::*;
 use crate::{
     storage::WorkQueuePromptProjection,
-    types::{
-        BriefKind, TaskStatus, WorkPlanStepStatus, WorkReactivationMode, WorkReactivationSignal,
-    },
+    types::{BriefKind, TaskStatus, TodoItemState, WorkReactivationMode, WorkReactivationSignal},
 };
 
 const CONTINUE_ACTIVE_SIGNAL_SCAN_LIMIT: usize = 512;
@@ -263,17 +261,10 @@ impl RuntimeHandle {
             return Ok(true);
         }
 
-        if self
-            .inner
-            .storage
-            .latest_work_plan(&work_item.id)?
-            .is_some_and(|plan| {
-                plan.created_at > anchor
-                    || plan
-                        .items
-                        .iter()
-                        .any(|item| item.status != WorkPlanStepStatus::Completed)
-            })
+        if work_item
+            .todo_list
+            .iter()
+            .any(|item| item.state != TodoItemState::Completed)
         {
             return Ok(true);
         }
@@ -429,12 +420,9 @@ impl RuntimeHandle {
             Priority::Normal,
             MessageBody::Text {
                 text: if reason == "queued_available" {
-                    format!(
-                        "Queued work item is available: {}",
-                        work_item.delivery_target
-                    )
+                    format!("Queued work item is available: {}", work_item.objective)
                 } else {
-                    format!("Continue current work item: {}", work_item.delivery_target)
+                    format!("Continue current work item: {}", work_item.objective)
                 },
             },
         )
@@ -446,7 +434,7 @@ impl RuntimeHandle {
             "work_queue": {
                 "reason": reason,
                 "work_item_id": work_item.id,
-                "delivery_target": work_item.delivery_target,
+                "objective": work_item.objective,
                 "state": work_item.state,
                 "runtime_switched_current_item": false,
             }
@@ -576,9 +564,7 @@ mod tests {
     use super::*;
     use crate::context::ContextConfig;
     use crate::provider::StubProvider;
-    use crate::types::{
-        AgentStatus, WorkItemRecord, WorkItemState, WorkPlanItem, WorkPlanSnapshot,
-    };
+    use crate::types::{AgentStatus, TodoItem, TodoItemState, WorkItemRecord, WorkItemState};
     use std::sync::Arc;
     use tempfile::{tempdir, TempDir};
 
@@ -630,16 +616,8 @@ mod tests {
     }
 
     fn add_queued_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
-        let record = WorkItemRecord {
-            id: id.to_string(),
-            agent_id: "default".to_string(),
-            workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.to_string(),
-            delivery_target: target.to_string(),
-            state: WorkItemState::Open,
-            blocked_by: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let mut record = WorkItemRecord::new("default", target, WorkItemState::Open);
+        record.id = id.to_string();
         test_runtime
             .runtime
             .inner
@@ -650,16 +628,8 @@ mod tests {
     }
 
     fn add_current_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
-        let record = WorkItemRecord {
-            id: id.to_string(),
-            agent_id: "default".to_string(),
-            workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.to_string(),
-            delivery_target: target.to_string(),
-            state: WorkItemState::Open,
-            blocked_by: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let mut record = WorkItemRecord::new("default", target, WorkItemState::Open);
+        record.id = id.to_string();
         test_runtime
             .runtime
             .inner
@@ -1338,23 +1308,21 @@ mod tests {
     }
 
     #[test]
-    fn continue_active_preserved_when_work_plan_has_pending_step() {
+    fn continue_active_preserved_when_todo_list_has_pending_item() {
         let test_runtime = test_runtime();
         set_agent_idle(&test_runtime);
 
-        let active = add_current_work_item(&test_runtime, "wi-active", "active-target");
+        let mut active = add_current_work_item(&test_runtime, "wi-active", "active-target");
+        active.todo_list = vec![TodoItem {
+            text: "finish remaining implementation".to_string(),
+            state: TodoItemState::InProgress,
+        }];
+        active.updated_at = chrono::Utc::now();
         test_runtime
             .runtime
             .inner
             .storage
-            .append_work_plan(&WorkPlanSnapshot::new(
-                "default",
-                &active.id,
-                vec![WorkPlanItem {
-                    step: "finish remaining implementation".to_string(),
-                    status: WorkPlanStepStatus::InProgress,
-                }],
-            ))
+            .append_work_item(&active)
             .unwrap();
         append_result_brief_for_work_item(&test_runtime, &active.id, "Progress report.");
 
@@ -1365,7 +1333,7 @@ mod tests {
 
         assert!(
             emitted,
-            "an unfinished work plan should keep continue_active eligible"
+            "an unfinished todo list should keep continue_active eligible"
         );
     }
 

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -7,9 +7,9 @@ use crate::types::{
     AgentProfilePreset, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot, DeliverySummaryRecord,
     FailureArtifact, FailureArtifactCategory, SpawnAgentResult, SpawnAgentWorkItemRequest,
     TaskHandle, TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult,
-    TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, ToolArtifactRef,
-    WorkItemDelegationRecord, WorkItemDelegationState, WorkItemRecord, WorkItemState, WorkPlanItem,
-    WorkPlanSnapshot, CHILD_AGENT_TASK_KIND,
+    TaskOutputRetrievalStatus, TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef,
+    WorkItemDelegationRecord, WorkItemDelegationState, WorkItemPlanStatus, WorkItemRecord,
+    WorkItemState, CHILD_AGENT_TASK_KIND,
 };
 use std::collections::BTreeMap;
 
@@ -19,7 +19,7 @@ const TASK_OUTPUT_PREVIEW_CHAR_BUDGET: usize = 8_000;
 
 #[derive(Debug, Clone)]
 struct TaskMessageSnapshot {
-    status: TaskStatus,
+    state: TaskStatus,
     text: String,
 }
 
@@ -255,9 +255,9 @@ impl RuntimeHandle {
                             &parent_agent_id,
                             &request.parent_work_item_id,
                         )?;
-                        if record.state == WorkItemState::Done {
+                        if record.state == WorkItemState::Completed {
                             return Err(anyhow!(
-                                "cannot delegate from done work item {}",
+                                "cannot delegate from completed work item {}",
                                 request.parent_work_item_id
                             ));
                         }
@@ -307,21 +307,22 @@ impl RuntimeHandle {
                 let delegation = if let (Some(request), Some(parent_work_item)) =
                     (work_item, parent_work_item)
                 {
-                    let child_delivery_target = request
-                        .child_delivery_target
+                    let child_objective = request
+                        .child_objective
                         .filter(|value| !value.trim().is_empty())
                         .unwrap_or_else(|| {
                             queued_task
                                 .summary
                                 .clone()
-                                .unwrap_or_else(|| parent_work_item.delivery_target.clone())
+                                .unwrap_or_else(|| parent_work_item.objective.clone())
                         });
                     Some(
                         self.create_child_work_item_delegation(
                             parent_work_item,
                             spawned.child_agent_id.clone(),
-                            child_delivery_target,
+                            child_objective,
                             request.child_plan,
+                            request.child_todo_list,
                         )
                         .await?,
                     )
@@ -943,7 +944,7 @@ impl RuntimeHandle {
             .open_work_item_delegation_for_child(&child_agent_id)?;
         if let Some(delegation) = delegation.as_ref() {
             let completed = WorkItemDelegationRecord {
-                state: WorkItemDelegationState::Done,
+                state: WorkItemDelegationState::Completed,
                 result_summary: Some(text.clone()),
                 updated_at: Utc::now(),
                 ..delegation.clone()
@@ -1911,12 +1912,18 @@ impl RuntimeHandle {
 
     pub async fn create_work_item(
         &self,
-        delivery_target: String,
-        plan: Option<Vec<WorkPlanItem>>,
-    ) -> Result<(WorkItemRecord, Option<WorkPlanSnapshot>)> {
+        objective: String,
+        plan_status: Option<WorkItemPlanStatus>,
+        plan: Option<String>,
+        todo_list: Vec<TodoItem>,
+    ) -> Result<WorkItemRecord> {
         let agent_id = self.agent_id().await?;
-        let mut record =
-            WorkItemRecord::new(agent_id.clone(), delivery_target, WorkItemState::Open);
+        let mut record = WorkItemRecord::new(agent_id.clone(), objective, WorkItemState::Open);
+        if let Some(plan_status) = plan_status {
+            record.plan_status = plan_status;
+        }
+        record.plan = plan;
+        record.todo_list = todo_list;
         record.workspace_id = self
             .agent_state()
             .await?
@@ -1931,12 +1938,8 @@ impl RuntimeHandle {
                 "record": record,
             }),
         ))?;
-        let plan = match plan {
-            Some(items) => Some(self.update_work_plan(record.id.clone(), items).await?),
-            None => None,
-        };
         self.inner.notify.notify_one();
-        Ok((record, plan))
+        Ok(record)
     }
 
     pub async fn pick_work_item(
@@ -1950,8 +1953,8 @@ impl RuntimeHandle {
             None => None,
         };
         let record = self.validate_owned_work_item(&agent_id, &work_item_id)?;
-        if record.state == WorkItemState::Done {
-            return Err(anyhow!("cannot pick done work item {}", work_item_id));
+        if record.state == WorkItemState::Completed {
+            return Err(anyhow!("cannot pick completed work item {}", work_item_id));
         }
         {
             let mut guard = self.inner.agent.lock().await;
@@ -1973,20 +1976,40 @@ impl RuntimeHandle {
     pub async fn update_work_item_fields(
         &self,
         work_item_id: String,
-        delivery_target: Option<String>,
+        objective: Option<String>,
+        plan_status: Option<WorkItemPlanStatus>,
+        plan: Option<Option<String>>,
+        todo_list: Option<Vec<TodoItem>>,
         blocked_by: Option<Option<String>>,
-        plan: Option<Vec<WorkPlanItem>>,
-    ) -> Result<(WorkItemRecord, Option<WorkPlanSnapshot>)> {
+    ) -> Result<WorkItemRecord> {
         let agent_id = self.agent_id().await?;
         let existing = self.validate_owned_work_item(&agent_id, &work_item_id)?;
-        if existing.state == WorkItemState::Done {
-            return Err(anyhow!("cannot update done work item {}", work_item_id));
+        if existing.state == WorkItemState::Completed {
+            return Err(anyhow!(
+                "cannot update completed work item {}",
+                work_item_id
+            ));
         }
         let mut record = existing.clone();
         let mut wrote_item = false;
-        let previous_delivery_target = record.delivery_target.clone();
-        if let Some(delivery_target) = delivery_target {
-            record.delivery_target = delivery_target;
+        let previous_objective = record.objective.clone();
+        if let Some(objective) = objective {
+            record.objective = objective;
+            record.updated_at = Utc::now();
+            wrote_item = true;
+        }
+        if let Some(plan_status) = plan_status {
+            record.plan_status = plan_status;
+            record.updated_at = Utc::now();
+            wrote_item = true;
+        }
+        if let Some(plan) = plan {
+            record.plan = plan;
+            record.updated_at = Utc::now();
+            wrote_item = true;
+        }
+        if let Some(todo_list) = todo_list {
+            record.todo_list = todo_list;
             record.updated_at = Utc::now();
             wrote_item = true;
         }
@@ -2002,19 +2025,15 @@ impl RuntimeHandle {
                 serde_json::json!({
                     "action": "updated",
                     "record": record,
-                    "previous_delivery_target": previous_delivery_target,
-                    "delivery_target_changed": previous_delivery_target != record.delivery_target,
+                    "previous_objective": previous_objective,
+                    "objective_changed": previous_objective != record.objective,
                 }),
             ))?;
         }
-        let plan = match plan {
-            Some(items) => Some(self.update_work_plan(work_item_id, items).await?),
-            None => None,
-        };
-        if wrote_item || plan.is_some() {
+        if wrote_item {
             self.inner.notify.notify_one();
         }
-        Ok((record, plan))
+        Ok(record)
     }
 
     pub async fn complete_work_item(
@@ -2024,7 +2043,7 @@ impl RuntimeHandle {
     ) -> Result<WorkItemRecord> {
         let agent_id = self.agent_id().await?;
         let existing = self.validate_owned_work_item(&agent_id, &work_item_id)?;
-        if existing.state == WorkItemState::Done {
+        if existing.state == WorkItemState::Completed {
             return Ok(existing);
         }
         let has_blocking_tasks = {
@@ -2038,8 +2057,9 @@ impl RuntimeHandle {
             ));
         }
         let record = WorkItemRecord {
-            state: WorkItemState::Done,
+            state: WorkItemState::Completed,
             blocked_by: None,
+            result_summary: result_summary.clone(),
             updated_at: Utc::now(),
             ..existing
         };
@@ -2076,33 +2096,6 @@ impl RuntimeHandle {
         Ok(record)
     }
 
-    pub async fn update_work_plan(
-        &self,
-        work_item_id: String,
-        items: Vec<WorkPlanItem>,
-    ) -> Result<WorkPlanSnapshot> {
-        let agent_id = self.agent_id().await?;
-        let work_item = self
-            .inner
-            .storage
-            .latest_work_item(&work_item_id)?
-            .ok_or_else(|| anyhow!("unknown work item {}", work_item_id))?;
-        if work_item.agent_id != agent_id {
-            return Err(anyhow!(
-                "work item {} belongs to another agent",
-                work_item_id
-            ));
-        }
-
-        let snapshot = WorkPlanSnapshot::new(agent_id, work_item_id, items);
-        self.inner.storage.append_work_plan(&snapshot)?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_plan_snapshot_written",
-            to_json_value(&snapshot),
-        ))?;
-        Ok(snapshot)
-    }
-
     fn validate_owned_work_item(
         &self,
         agent_id: &str,
@@ -2126,8 +2119,9 @@ impl RuntimeHandle {
         &self,
         parent_work_item: WorkItemRecord,
         child_agent_id: String,
-        child_delivery_target: String,
-        child_plan: Option<Vec<WorkPlanItem>>,
+        child_objective: String,
+        child_plan: Option<String>,
+        child_todo_list: Vec<TodoItem>,
     ) -> Result<WorkItemDelegationRecord> {
         let bridge = self
             .inner
@@ -2135,7 +2129,12 @@ impl RuntimeHandle {
             .clone()
             .ok_or_else(|| anyhow!("runtime host is required for work-item delegation"))?;
         let child_work_item = bridge
-            .create_child_work_item(&child_agent_id, child_delivery_target, child_plan)
+            .create_child_work_item(
+                &child_agent_id,
+                child_objective,
+                child_plan,
+                child_todo_list,
+            )
             .await?;
         let delegation = WorkItemDelegationRecord::new(
             parent_work_item.agent_id,
@@ -2154,8 +2153,8 @@ impl RuntimeHandle {
     }
 }
 
-fn task_status_name(status: &TaskStatus) -> &'static str {
-    match status {
+fn task_status_name(state: &TaskStatus) -> &'static str {
+    match state {
         TaskStatus::Queued => "queued",
         TaskStatus::Running => "running",
         TaskStatus::Cancelling => "cancelling",
@@ -2298,7 +2297,7 @@ fn latest_task_message_in(
         };
 
         let snapshot = TaskMessageSnapshot {
-            status: task_status_from_message(&message, metadata),
+            state: task_status_from_message(&message, metadata),
             text: render_task_message_body(&message.body),
         };
 
@@ -2322,14 +2321,14 @@ fn effective_task_output_status(
     }
 
     match latest_message {
-        Some(message) => message.status.clone(),
+        Some(message) => message.state.clone(),
         None => task_status.clone(),
     }
 }
 
-fn task_output_ready(task: &TaskRecord, status: &TaskStatus) -> bool {
+fn task_output_ready(task: &TaskRecord, state: &TaskStatus) -> bool {
     if matches!(
-        status,
+        state,
         TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling
     ) {
         return false;
@@ -2375,13 +2374,13 @@ fn task_output_ready(task: &TaskRecord, status: &TaskStatus) -> bool {
 
 fn task_failure_artifact(
     task: &TaskRecord,
-    status: &TaskStatus,
+    state: &TaskStatus,
     output: &str,
     output_path: Option<&str>,
     exit_status: Option<i32>,
 ) -> Option<FailureArtifact> {
     if !matches!(
-        status,
+        state,
         TaskStatus::Failed | TaskStatus::Cancelled | TaskStatus::Interrupted
     ) {
         return None;
@@ -2408,12 +2407,12 @@ fn task_failure_artifact(
         let kind = if let Some(code) = exit_status {
             if code != 0 {
                 "command_task_exit_nonzero"
-            } else if matches!(status, TaskStatus::Interrupted) {
+            } else if matches!(state, TaskStatus::Interrupted) {
                 "command_task_interrupted"
             } else {
                 "command_task_failed"
             }
-        } else if matches!(status, TaskStatus::Interrupted) {
+        } else if matches!(state, TaskStatus::Interrupted) {
             "command_task_interrupted"
         } else if has_error {
             "command_task_error"
@@ -2423,7 +2422,7 @@ fn task_failure_artifact(
             "command_task_output"
         };
 
-        let summary = if matches!(status, TaskStatus::Interrupted) {
+        let summary = if matches!(state, TaskStatus::Interrupted) {
             "command task interrupted by runtime restart".to_string()
         } else if let Some(code) = exit_status {
             format!("command task exited with status {code}")
@@ -2444,7 +2443,7 @@ fn task_failure_artifact(
 
         (kind, summary, exit_status)
     } else {
-        let kind = match status {
+        let kind = match state {
             TaskStatus::Cancelled => "task_cancelled",
             TaskStatus::Interrupted => "task_interrupted",
             _ => "task_failed",
@@ -2483,9 +2482,9 @@ fn task_output_artifacts(output_path: Option<&str>) -> (Vec<ToolArtifactRef>, Op
     )
 }
 
-fn is_terminal_task_status(status: &TaskStatus) -> bool {
+fn is_terminal_task_status(state: &TaskStatus) -> bool {
     matches!(
-        status,
+        state,
         TaskStatus::Completed
             | TaskStatus::Failed
             | TaskStatus::Cancelled

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -925,7 +925,7 @@ async fn interactive_turn_keeps_pending_working_memory_delta_when_prompt_omits_i
     {
         let mut guard = runtime.inner.agent.lock().await;
         guard.state.working_memory.current_working_memory = crate::types::WorkingMemorySnapshot {
-            delivery_target: Some("ship the prompt delta gating fix".into()),
+            objective: Some("ship the prompt delta gating fix".into()),
             current_plan: vec!["[InProgress] wire prompt render acknowledgement".into()],
             ..crate::types::WorkingMemorySnapshot::default()
         };

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -25,9 +25,9 @@ pub(crate) use crate::{
         BriefRecord, CallbackDeliveryMode, ClosureDecision, ClosureOutcome, ContinuationClass,
         ContinuationTriggerKind, LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageKind,
         MessageOrigin, PendingWakeHint, Priority, TaskKind, TaskOutputRetrievalStatus, TaskRecord,
-        TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, TokenUsage, TrustLevel,
-        TurnTerminalKind, TurnTerminalRecord, WaitingIntentStatus, WaitingReason, WorkItemRecord,
-        WorkItemState, WorkPlanItem, WorkPlanStepStatus, WorkReactivationMode, WorkspaceEntry,
+        TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, TodoItem, TodoItemState,
+        TokenUsage, TrustLevel, TurnTerminalKind, TurnTerminalRecord, WaitingIntentStatus,
+        WaitingReason, WorkItemRecord, WorkItemState, WorkReactivationMode, WorkspaceEntry,
     },
 };
 
@@ -142,27 +142,29 @@ pub(crate) async fn seed_bound_work_item(
     summary: Option<&str>,
     blocked_by: Option<&str>,
 ) -> String {
-    let (mut record, _) = runtime
+    let mut record = runtime
         .create_work_item(
-            summary
-                .unwrap_or("finish the bound delivery target")
-                .to_string(),
+            summary.unwrap_or("finish the bound objective").to_string(),
             None,
+            None,
+            Vec::new(),
         )
         .await
         .unwrap();
     if let Some(blocked_by) = blocked_by {
-        (record, _) = runtime
+        record = runtime
             .update_work_item_fields(
                 record.id.clone(),
                 None,
-                Some(Some(blocked_by.to_string())),
                 None,
+                None,
+                None,
+                Some(Some(blocked_by.to_string())),
             )
             .await
             .unwrap();
     }
-    if state == WorkItemState::Done {
+    if state == WorkItemState::Completed {
         record = runtime
             .complete_work_item(record.id.clone(), summary.map(str::to_string))
             .await

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -424,7 +424,7 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
         provider.clone(),
         "default".into(),
         ContextConfig {
-            prompt_budget_estimated_tokens: 3700,
+            prompt_budget_estimated_tokens: 3800,
             compaction_keep_recent_estimated_tokens: 180,
             ..context_config()
         },

--- a/src/runtime/tests/wake_hints.rs
+++ b/src/runtime/tests/wake_hints.rs
@@ -321,8 +321,13 @@ async fn queued_work_item_update_wakes_sleeping_runtime_and_surfaces_it() {
     let runtime_task = tokio::spawn(runtime.clone().run());
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-    let (queued, _) = runtime
-        .create_work_item("wake from direct queued work item update".into(), None)
+    let queued = runtime
+        .create_work_item(
+            "wake from direct queued work item update".into(),
+            None,
+            None,
+            Vec::new(),
+        )
         .await
         .unwrap();
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -16,27 +16,31 @@ async fn work_item_query_tools_return_current_open_done_views() {
     )
     .unwrap();
 
-    let (active, _) = runtime
-        .create_work_item("finish active delivery".into(), None)
+    let active = runtime
+        .create_work_item("finish active delivery".into(), None, None, Vec::new())
         .await
         .unwrap();
     runtime.pick_work_item(active.id.clone()).await.unwrap();
     runtime
-        .update_work_plan(
+        .update_work_item_fields(
             active.id.clone(),
-            vec![crate::types::WorkPlanItem {
-                step: "inspect query surface".into(),
-                status: crate::types::WorkPlanStepStatus::InProgress,
-            }],
+            None,
+            None,
+            Some(Some("Inspect query surface behavior.".into())),
+            Some(vec![crate::types::TodoItem {
+                text: "inspect query surface".into(),
+                state: crate::types::TodoItemState::InProgress,
+            }]),
+            None,
         )
         .await
         .unwrap();
-    let (queued, _) = runtime
-        .create_work_item("queued delivery".into(), None)
+    let queued = runtime
+        .create_work_item("queued delivery".into(), None, None, Vec::new())
         .await
         .unwrap();
-    let (completed, _) = runtime
-        .create_work_item("completed delivery".into(), None)
+    let completed = runtime
+        .create_work_item("completed delivery".into(), None, None, Vec::new())
         .await
         .unwrap();
     let completed = runtime
@@ -54,7 +58,7 @@ async fn work_item_query_tools_return_current_open_done_views() {
             &crate::tool::ToolCall {
                 id: "active".into(),
                 name: "ListWorkItems".into(),
-                input: serde_json::json!({"filter": "current", "include_plan": true}),
+                input: serde_json::json!({"filter": "current", "include_plan": true, "include_todo_list": true}),
             },
         )
         .await
@@ -68,12 +72,15 @@ async fn work_item_query_tools_return_current_open_done_views() {
     assert_eq!(active_item["state"].as_str(), Some("open"));
     assert_eq!(active_item["focus"].as_str(), Some("current"));
     assert_eq!(active_item["is_current"].as_bool(), Some(true));
-    assert_eq!(active_item["plan"]["items"].as_array().unwrap().len(), 1);
     assert_eq!(
-        active_item["plan"]["items"][0]["state"].as_str(),
-        Some("doing")
+        active_item["plan"].as_str(),
+        Some("Inspect query surface behavior.")
     );
-    assert!(active_item["plan"]["items"][0]["status"].is_null());
+    assert_eq!(active_item["todo_list"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        active_item["todo_list"][0]["state"].as_str(),
+        Some("in_progress")
+    );
 
     let (list_result, _) = registry
         .execute(
@@ -101,22 +108,28 @@ async fn work_item_query_tools_return_current_open_done_views() {
         .iter()
         .any(|item| item["id"].as_str() == Some(completed.id.as_str())));
 
-    let (done_result, _) = registry
+    let (completed_result, _) = registry
         .execute(
             &runtime,
             "default",
             &TrustLevel::TrustedOperator,
             &crate::tool::ToolCall {
-                id: "done".into(),
+                id: "completed".into(),
                 name: "GetWorkItem".into(),
                 input: serde_json::json!({"work_item_id": completed.id}),
             },
         )
         .await
         .unwrap();
-    let done_payload = done_result.envelope.result.unwrap();
-    assert_eq!(done_payload["work_item"]["state"].as_str(), Some("done"));
-    assert_eq!(done_payload["work_item"]["focus"].as_str(), Some("done"));
+    let completed_payload = completed_result.envelope.result.unwrap();
+    assert_eq!(
+        completed_payload["work_item"]["state"].as_str(),
+        Some("completed")
+    );
+    assert_eq!(
+        completed_payload["work_item"]["focus"].as_str(),
+        Some("completed")
+    );
 
     bind_turn_to_work_item(&runtime, completed.id.as_str()).await;
     let (fallback_result, _) = registry
@@ -144,7 +157,7 @@ async fn work_item_query_tools_return_current_open_done_views() {
 }
 
 #[tokio::test]
-async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
+async fn work_item_tools_use_objective_plan_and_todo_list_shape() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -168,11 +181,13 @@ async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
                 id: "create".into(),
                 name: "CreateWorkItem".into(),
                 input: serde_json::json!({
-                    "delivery_target": "ship work item plan contract",
-                    "plan": [
-                        { "step": "inspect current contract", "state": "done" },
-                        { "step": "update tool shape", "state": "doing" },
-                        { "step": "verify regression", "state": "pending" }
+                    "objective": "ship work item objective contract",
+                    "plan_status": "ready",
+                    "plan": "1. Inspect current contract\n2. Update tool shape\n3. Verify regression",
+                    "todo_list": [
+                        { "text": "inspect current contract", "state": "completed" },
+                        { "text": "update tool shape", "state": "in_progress" },
+                        { "text": "verify regression", "state": "pending" }
                     ]
                 }),
             },
@@ -182,18 +197,26 @@ async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
     let create_payload = create_result.envelope.result.unwrap();
     let work_item_id = create_payload["work_item"]["id"].as_str().unwrap();
     assert_eq!(
-        create_payload["plan"]["items"][0]["state"].as_str(),
-        Some("done")
+        create_payload["work_item"]["plan_status"].as_str(),
+        Some("ready")
     );
     assert_eq!(
-        create_payload["plan"]["items"][1]["state"].as_str(),
-        Some("doing")
+        create_payload["work_item"]["plan"].as_str(),
+        Some("1. Inspect current contract\n2. Update tool shape\n3. Verify regression")
     );
     assert_eq!(
-        create_payload["plan"]["items"][2]["state"].as_str(),
+        create_payload["work_item"]["todo_list"][0]["state"].as_str(),
+        Some("completed")
+    );
+    assert_eq!(
+        create_payload["work_item"]["todo_list"][1]["state"].as_str(),
+        Some("in_progress")
+    );
+    assert_eq!(
+        create_payload["work_item"]["todo_list"][2]["state"].as_str(),
         Some("pending")
     );
-    assert!(create_payload["plan"]["items"][0]["status"].is_null());
+    assert!(create_payload["work_item"]["todo_list"][0]["status"].is_null());
 
     let (get_result, _) = registry
         .execute(
@@ -205,7 +228,8 @@ async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
                 name: "GetWorkItem".into(),
                 input: serde_json::json!({
                     "work_item_id": work_item_id,
-                    "include_plan": true
+                    "include_plan": true,
+                    "include_todo_list": true
                 }),
             },
         )
@@ -213,12 +237,12 @@ async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
         .unwrap();
     let get_payload = get_result.envelope.result.unwrap();
     assert_eq!(
-        get_payload["work_item"]["plan"]["items"][1]["state"].as_str(),
-        Some("doing")
+        get_payload["work_item"]["todo_list"][1]["state"].as_str(),
+        Some("in_progress")
     );
-    assert!(get_payload["work_item"]["plan"]["items"][1]["status"].is_null());
+    assert!(get_payload["work_item"]["todo_list"][1]["status"].is_null());
 
-    let returned_items = get_payload["work_item"]["plan"]["items"].clone();
+    let returned_items = get_payload["work_item"]["todo_list"].clone();
     let (update_result, _) = registry
         .execute(
             &runtime,
@@ -229,7 +253,7 @@ async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
                 name: "UpdateWorkItem".into(),
                 input: serde_json::json!({
                     "work_item_id": work_item_id,
-                    "plan": returned_items
+                    "todo_list": returned_items
                 }),
             },
         )
@@ -237,14 +261,14 @@ async fn work_item_plan_tools_use_state_vocabulary_for_model_visible_shape() {
         .unwrap();
     let update_payload = update_result.envelope.result.unwrap();
     assert_eq!(
-        update_payload["plan"]["items"][1]["state"].as_str(),
-        Some("doing")
+        update_payload["work_item"]["todo_list"][1]["state"].as_str(),
+        Some("in_progress")
     );
-    assert!(update_payload["plan"]["items"][1]["status"].is_null());
+    assert!(update_payload["work_item"]["todo_list"][1]["status"].is_null());
 }
 
 #[tokio::test]
-async fn update_work_item_can_refine_delivery_target() {
+async fn update_work_item_can_refine_objective() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -258,8 +282,8 @@ async fn update_work_item_can_refine_delivery_target() {
     )
     .unwrap();
     let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
-    let (work_item, _) = runtime
-        .create_work_item("Fix issue #869".into(), None)
+    let work_item = runtime
+        .create_work_item("Fix issue #869".into(), None, None, Vec::new())
         .await
         .unwrap();
 
@@ -273,7 +297,7 @@ async fn update_work_item_can_refine_delivery_target() {
                 name: "UpdateWorkItem".into(),
                 input: serde_json::json!({
                     "work_item_id": work_item.id.clone(),
-                    "delivery_target": "Fix issue #869 by allowing delivery_target refinement"
+                    "objective": "Fix issue #869 by allowing objective refinement"
                 }),
             },
         )
@@ -281,8 +305,8 @@ async fn update_work_item_can_refine_delivery_target() {
         .unwrap();
     let payload = update_result.envelope.result.unwrap();
     assert_eq!(
-        payload["work_item"]["delivery_target"].as_str(),
-        Some("Fix issue #869 by allowing delivery_target refinement")
+        payload["work_item"]["objective"].as_str(),
+        Some("Fix issue #869 by allowing objective refinement")
     );
 
     let latest = runtime
@@ -291,13 +315,13 @@ async fn update_work_item_can_refine_delivery_target() {
         .unwrap()
         .unwrap();
     assert_eq!(
-        latest.delivery_target,
-        "Fix issue #869 by allowing delivery_target refinement"
+        latest.objective,
+        "Fix issue #869 by allowing objective refinement"
     );
 }
 
 #[tokio::test]
-async fn update_work_item_can_refine_delivery_target_and_plan_together() {
+async fn update_work_item_can_refine_objective_and_plan_together() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -311,8 +335,8 @@ async fn update_work_item_can_refine_delivery_target_and_plan_together() {
     )
     .unwrap();
     let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
-    let (work_item, _) = runtime
-        .create_work_item("Fix issue #869".into(), None)
+    let work_item = runtime
+        .create_work_item("Fix issue #869".into(), None, None, Vec::new())
         .await
         .unwrap();
 
@@ -326,10 +350,11 @@ async fn update_work_item_can_refine_delivery_target_and_plan_together() {
                 name: "UpdateWorkItem".into(),
                 input: serde_json::json!({
                     "work_item_id": work_item.id.clone(),
-                    "delivery_target": "Fix issue #869 by allowing delivery_target refinement",
-                    "plan": [
-                        { "step": "extend UpdateWorkItem schema", "state": "done" },
-                        { "step": "verify target update persistence", "state": "doing" }
+                    "objective": "Fix issue #869 by allowing objective refinement",
+                    "plan": "Extend UpdateWorkItem schema, then verify persistence.",
+                    "todo_list": [
+                        { "text": "extend UpdateWorkItem schema", "state": "completed" },
+                        { "text": "verify target update persistence", "state": "in_progress" }
                     ]
                 }),
             },
@@ -338,15 +363,21 @@ async fn update_work_item_can_refine_delivery_target_and_plan_together() {
         .unwrap();
     let payload = update_result.envelope.result.unwrap();
     assert_eq!(
-        payload["work_item"]["delivery_target"].as_str(),
-        Some("Fix issue #869 by allowing delivery_target refinement")
+        payload["work_item"]["objective"].as_str(),
+        Some("Fix issue #869 by allowing objective refinement")
     );
-    assert_eq!(payload["plan"]["items"][0]["state"].as_str(), Some("done"));
-    assert_eq!(payload["plan"]["items"][1]["state"].as_str(), Some("doing"));
+    assert_eq!(
+        payload["work_item"]["todo_list"][0]["state"].as_str(),
+        Some("completed")
+    );
+    assert_eq!(
+        payload["work_item"]["todo_list"][1]["state"].as_str(),
+        Some("in_progress")
+    );
 }
 
 #[tokio::test]
-async fn update_work_item_rejects_empty_delivery_target() {
+async fn update_work_item_rejects_empty_objective() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -360,8 +391,8 @@ async fn update_work_item_rejects_empty_delivery_target() {
     )
     .unwrap();
     let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
-    let (work_item, _) = runtime
-        .create_work_item("Fix issue #869".into(), None)
+    let work_item = runtime
+        .create_work_item("Fix issue #869".into(), None, None, Vec::new())
         .await
         .unwrap();
 
@@ -375,7 +406,7 @@ async fn update_work_item_rejects_empty_delivery_target() {
                 name: "UpdateWorkItem".into(),
                 input: serde_json::json!({
                     "work_item_id": work_item.id.clone(),
-                    "delivery_target": "   "
+                    "objective": "   "
                 }),
             },
         )
@@ -383,7 +414,7 @@ async fn update_work_item_rejects_empty_delivery_target() {
         .unwrap_err();
     let tool_error = crate::tool::ToolError::from_anyhow(&error);
     assert_eq!(tool_error.kind, "invalid_tool_input");
-    assert!(tool_error.message.contains("delivery_target"));
+    assert!(tool_error.message.contains("objective"));
 }
 
 #[tokio::test]
@@ -412,8 +443,8 @@ async fn update_work_item_old_plan_shape_returns_state_example_hint() {
                 name: "UpdateWorkItem".into(),
                 input: serde_json::json!({
                     "work_item_id": "item-1",
-                    "plan": [
-                        { "step": "inspect current handler", "status": "completed" }
+                    "todo_list": [
+                        { "text": "inspect current handler", "status": "completed" }
                     ]
                 }),
             },
@@ -432,8 +463,8 @@ async fn update_work_item_old_plan_shape_returns_state_example_hint() {
     assert!(parse_error.contains("state"));
     let recovery_hint = tool_error.recovery_hint.as_deref().unwrap_or_default();
     assert!(recovery_hint.contains("work_item_id"));
-    assert!(recovery_hint.contains("\"state\":\"done\""));
-    assert!(recovery_hint.contains("pending, doing, or done"));
+    assert!(recovery_hint.contains("\"state\":\"completed\""));
+    assert!(recovery_hint.contains("pending, in_progress, or completed"));
 }
 
 #[tokio::test]
@@ -461,8 +492,8 @@ async fn update_work_item_missing_id_returns_top_level_field_hint() {
                 id: "missing-id".into(),
                 name: "UpdateWorkItem".into(),
                 input: serde_json::json!({
-                    "plan": [
-                        { "step": "inspect current handler", "state": "done" }
+                    "todo_list": [
+                        { "text": "inspect current handler", "state": "completed" }
                     ]
                 }),
             },
@@ -474,7 +505,7 @@ async fn update_work_item_missing_id_returns_top_level_field_hint() {
     let recovery_hint = tool_error.recovery_hint.as_deref().unwrap_or_default();
     assert!(recovery_hint.contains("UpdateWorkItem schema"));
     assert!(recovery_hint.contains("work_item_id"));
-    assert!(recovery_hint.contains("\"state\":\"done\""));
+    assert!(recovery_hint.contains("\"state\":\"completed\""));
 }
 
 #[tokio::test]
@@ -570,8 +601,8 @@ async fn interactive_tool_execution_binds_current_turn_work_item() {
     )
     .unwrap();
 
-    let (work_item, _) = runtime
-        .create_work_item("verify binding".into(), None)
+    let work_item = runtime
+        .create_work_item("verify binding".into(), None, None, Vec::new())
         .await
         .unwrap();
     runtime.pick_work_item(work_item.id.clone()).await.unwrap();
@@ -811,7 +842,7 @@ async fn turn_end_work_item_commit_preserves_explicit_completed_claim_without_wa
 
     let work_item_id = seed_bound_work_item(
         &runtime,
-        WorkItemState::Done,
+        WorkItemState::Completed,
         Some("finished"),
         Some("all requested changes are done"),
     )
@@ -823,7 +854,7 @@ async fn turn_end_work_item_commit_preserves_explicit_completed_claim_without_wa
         .unwrap();
 
     assert_eq!(committed.id, work_item_id);
-    assert_eq!(committed.state, WorkItemState::Done);
+    assert_eq!(committed.state, WorkItemState::Completed);
     assert!(committed.blocked_by.is_none());
 }
 
@@ -844,7 +875,7 @@ async fn turn_end_work_item_commit_rejects_completed_claim_when_runtime_is_still
 
     let work_item_id = seed_bound_work_item(
         &runtime,
-        WorkItemState::Done,
+        WorkItemState::Completed,
         Some("finished"),
         Some("marked complete too early"),
     )
@@ -858,7 +889,7 @@ async fn turn_end_work_item_commit_rejects_completed_claim_when_runtime_is_still
         .unwrap();
 
     assert_eq!(committed.id, work_item_id);
-    assert_eq!(committed.state, WorkItemState::Done);
+    assert_eq!(committed.state, WorkItemState::Completed);
     assert!(committed.blocked_by.is_none());
 }
 
@@ -1087,8 +1118,8 @@ async fn reconcile_waiting_contract_cancels_old_waits_after_active_work_switch()
     )
     .unwrap();
 
-    let (old_work, _) = runtime
-        .create_work_item("old delivery target".into(), None)
+    let old_work = runtime
+        .create_work_item("old objective".into(), None, None, Vec::new())
         .await
         .unwrap();
     {
@@ -1122,8 +1153,8 @@ async fn reconcile_waiting_contract_cancels_old_waits_after_active_work_switch()
         .complete_work_item(old_work.id.clone(), Some("old work done".into()))
         .await
         .unwrap();
-    let (new_work, _) = runtime
-        .create_work_item("new delivery target".into(), None)
+    let new_work = runtime
+        .create_work_item("new objective".into(), None, None, Vec::new())
         .await
         .unwrap();
     runtime.pick_work_item(new_work.id.clone()).await.unwrap();
@@ -1181,8 +1212,8 @@ async fn reconcile_waiting_contract_keeps_agent_scoped_waits_after_active_work_s
     )
     .unwrap();
 
-    let (old_work, _) = runtime
-        .create_work_item("old delivery target".into(), None)
+    let old_work = runtime
+        .create_work_item("old objective".into(), None, None, Vec::new())
         .await
         .unwrap();
     runtime.pick_work_item(old_work.id.clone()).await.unwrap();
@@ -1209,8 +1240,8 @@ async fn reconcile_waiting_contract_keeps_agent_scoped_waits_after_active_work_s
         .complete_work_item(old_work.id.clone(), Some("old work done".into()))
         .await
         .unwrap();
-    let (new_work, _) = runtime
-        .create_work_item("new delivery target".into(), None)
+    let new_work = runtime
+        .create_work_item("new objective".into(), None, None, Vec::new())
         .await
         .unwrap();
     runtime.pick_work_item(new_work.id.clone()).await.unwrap();
@@ -1259,8 +1290,8 @@ async fn reconcile_waiting_contract_cancels_waits_when_only_waiting_anchor_exist
     )
     .unwrap();
 
-    let (waiting_work, _) = runtime
-        .create_work_item("waiting-only delivery target".into(), None)
+    let waiting_work = runtime
+        .create_work_item("waiting-only objective".into(), None, None, Vec::new())
         .await
         .unwrap();
     {
@@ -1332,8 +1363,8 @@ async fn reconcile_waiting_contract_keeps_waits_when_anchor_is_newly_established
     )
     .unwrap();
 
-    let (work, _) = runtime
-        .create_work_item("newly anchored delivery target".into(), None)
+    let work = runtime
+        .create_work_item("newly anchored objective".into(), None, None, Vec::new())
         .await
         .unwrap();
     runtime.pick_work_item(work.id.clone()).await.unwrap();

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -49,14 +49,14 @@ You are crossing a context compaction boundary. Before continuing, include a con
 
 Include:
 - current user goal
-- current work plan state
+- current work item objective, plan_status, plan, and todo_list state
 - files, commands, or sources already inspected
 - key findings and ruled-out paths
 - what remains unknown
 - the next goal-aligned action
 
 If continuing exploration, name the specific missing information and the next bounded command/query. If enough evidence already exists to act, make the next action the concrete mutation, verification, or delivery step instead of another read.
-If the current plan step became complete through material progress, update the work plan after that progress is recorded.
+If the current todo item became complete through material progress, update the work item after that progress is recorded.
 This is not a request to finish the task; after the checkpoint, continue with the next goal-aligned action when useful.
 Do not assume the task requires code changes unless the user goal does.";
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -17,7 +17,7 @@ use crate::types::{
     OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord, TaskRecord,
     TimerRecord, ToolExecutionRecord, TranscriptEntry, WaitingIntentRecord,
     WorkItemDelegationRecord, WorkItemDelegationState, WorkItemRecord, WorkItemState,
-    WorkPlanSnapshot, WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
+    WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 
 const RUNTIME_DIR: &str = ".holon";
@@ -39,7 +39,6 @@ pub struct RecoverySnapshot {
     pub active_tasks: Vec<TaskRecord>,
     pub active_timers: Vec<TimerRecord>,
     pub work_items: Vec<WorkItemRecord>,
-    pub work_plans: Vec<WorkPlanSnapshot>,
     pub work_item_delegations: Vec<WorkItemDelegationRecord>,
 }
 
@@ -52,7 +51,6 @@ pub struct AppStorage {
     tasks_path: PathBuf,
     work_items_path: PathBuf,
     delivery_summaries_path: PathBuf,
-    work_plans_path: PathBuf,
     work_item_delegations_path: PathBuf,
     timers_path: PathBuf,
     tools_path: PathBuf,
@@ -112,7 +110,6 @@ impl AppStorage {
             tasks_path: ledger_dir.join("tasks.jsonl"),
             work_items_path: ledger_dir.join("work_items.jsonl"),
             delivery_summaries_path: ledger_dir.join("delivery_summaries.jsonl"),
-            work_plans_path: ledger_dir.join("work_plans.jsonl"),
             work_item_delegations_path: ledger_dir.join("work_item_delegations.jsonl"),
             timers_path: ledger_dir.join("timers.jsonl"),
             tools_path: ledger_dir.join("tools.jsonl"),
@@ -191,10 +188,6 @@ impl AppStorage {
 
     pub fn append_delivery_summary(&self, record: &DeliverySummaryRecord) -> Result<()> {
         append_jsonl(&self.delivery_summaries_path, record)
-    }
-
-    pub fn append_work_plan(&self, snapshot: &WorkPlanSnapshot) -> Result<()> {
-        append_jsonl(&self.work_plans_path, snapshot)
     }
 
     pub fn append_work_item_delegation(&self, record: &WorkItemDelegationRecord) -> Result<()> {
@@ -333,10 +326,6 @@ impl AppStorage {
         limit: usize,
     ) -> Result<Vec<DeliverySummaryRecord>> {
         read_recent_jsonl(&self.delivery_summaries_path, limit)
-    }
-
-    pub fn read_recent_work_plans(&self, limit: usize) -> Result<Vec<WorkPlanSnapshot>> {
-        read_recent_jsonl(&self.work_plans_path, limit)
     }
 
     pub fn read_recent_work_item_delegations(
@@ -597,37 +586,6 @@ impl AppStorage {
         Ok(None)
     }
 
-    pub fn latest_work_plans(&self) -> Result<Vec<WorkPlanSnapshot>> {
-        let records = self.read_recent_work_plans(usize::MAX)?;
-        let mut latest = std::collections::BTreeMap::new();
-        for record in records {
-            latest.insert(record.work_item_id.clone(), record);
-        }
-        Ok(latest.into_values().collect())
-    }
-
-    pub fn latest_work_plan(&self, work_item_id: &str) -> Result<Option<WorkPlanSnapshot>> {
-        if !self.work_plans_path.exists() {
-            return Ok(None);
-        }
-
-        let content = fs::read_to_string(&self.work_plans_path)
-            .with_context(|| format!("failed to read {}", self.work_plans_path.display()))?;
-        for line in content.lines().rev().filter(|line| !line.trim().is_empty()) {
-            let record: WorkPlanSnapshot = serde_json::from_str(line).with_context(|| {
-                format!(
-                    "failed to decode line from {}",
-                    self.work_plans_path.display()
-                )
-            })?;
-            if record.work_item_id == work_item_id {
-                return Ok(Some(record));
-            }
-        }
-
-        Ok(None)
-    }
-
     pub fn latest_work_item_delegations(&self) -> Result<Vec<WorkItemDelegationRecord>> {
         let records = self.read_recent_work_item_delegations(usize::MAX)?;
         let mut latest = std::collections::BTreeMap::new();
@@ -771,7 +729,6 @@ impl AppStorage {
             .filter(|record| record.status == crate::types::TimerStatus::Active)
             .collect();
         let work_items = self.latest_work_items()?;
-        let work_plans = self.latest_work_plans()?;
         let work_item_delegations = self.latest_work_item_delegations()?;
 
         Ok(RecoverySnapshot {
@@ -780,7 +737,6 @@ impl AppStorage {
             active_tasks,
             active_timers,
             work_items,
-            work_plans,
             work_item_delegations,
         })
     }
@@ -927,8 +883,8 @@ mod tests {
 
     use crate::types::{
         AgentState, AgentStatus, EpisodeBoundaryReason, Priority, QueueEntryRecord,
-        QueueEntryStatus, TranscriptEntry, TranscriptEntryKind, WorkItemRecord, WorkItemState,
-        WorkPlanItem, WorkPlanSnapshot, WorkPlanStepStatus,
+        QueueEntryStatus, TodoItem, TodoItemState, TranscriptEntry, TranscriptEntryKind,
+        WorkItemState,
     };
 
     use super::*;
@@ -1083,56 +1039,29 @@ mod tests {
     }
 
     #[test]
-    fn storage_latest_work_plan_returns_latest_snapshot_per_work_item() {
+    fn storage_recovery_snapshot_includes_work_item_plan_and_todo_list() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
-        let first = WorkPlanSnapshot::new(
-            "default",
-            "work_1",
-            vec![WorkPlanItem {
-                step: "inspect".into(),
-                status: WorkPlanStepStatus::Pending,
-            }],
-        );
-        let second = WorkPlanSnapshot::new(
-            "default",
-            "work_1",
-            vec![WorkPlanItem {
-                step: "inspect".into(),
-                status: WorkPlanStepStatus::Completed,
-            }],
-        );
-
-        storage.append_work_plan(&first).unwrap();
-        storage.append_work_plan(&second).unwrap();
-
-        let latest = storage.latest_work_plan("work_1").unwrap().unwrap();
-        assert_eq!(latest.items.len(), 1);
-        assert_eq!(latest.items[0].status, WorkPlanStepStatus::Completed);
-    }
-
-    #[test]
-    fn storage_recovery_snapshot_includes_work_items_and_plans() {
-        let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
-        let work_item = WorkItemRecord::new("default", "fix issue #223", WorkItemState::Open);
-        let work_plan = WorkPlanSnapshot::new(
-            "default",
-            work_item.id.clone(),
-            vec![WorkPlanItem {
-                step: "persist work item store".into(),
-                status: WorkPlanStepStatus::InProgress,
-            }],
-        );
+        let mut work_item = WorkItemRecord::new("default", "fix issue #223", WorkItemState::Open);
+        work_item.plan = Some("Implement the new WorkItem model.".into());
+        work_item.todo_list = vec![TodoItem {
+            text: "persist work item store".into(),
+            state: TodoItemState::InProgress,
+        }];
 
         storage.append_work_item(&work_item).unwrap();
-        storage.append_work_plan(&work_plan).unwrap();
 
         let snapshot = storage.recovery_snapshot().unwrap();
         assert_eq!(snapshot.work_items.len(), 1);
         assert_eq!(snapshot.work_items[0].id, work_item.id);
-        assert_eq!(snapshot.work_plans.len(), 1);
-        assert_eq!(snapshot.work_plans[0].work_item_id, work_plan.work_item_id);
+        assert_eq!(
+            snapshot.work_items[0].plan.as_deref(),
+            Some("Implement the new WorkItem model.")
+        );
+        assert_eq!(
+            snapshot.work_items[0].todo_list[0].state,
+            TodoItemState::InProgress
+        );
     }
 
     #[test]
@@ -1187,7 +1116,7 @@ mod tests {
         queued_late.created_at = Utc::now() + chrono::Duration::minutes(1);
         queued_late.updated_at = queued_late.created_at;
 
-        let completed = WorkItemRecord::new("default", "completed", WorkItemState::Done);
+        let completed = WorkItemRecord::new("default", "completed", WorkItemState::Completed);
 
         storage.append_work_item(&current).unwrap();
         storage.append_work_item(&waiting).unwrap();
@@ -1203,13 +1132,13 @@ mod tests {
             projection
                 .current
                 .as_ref()
-                .map(|item| item.delivery_target.as_str()),
+                .map(|item| item.objective.as_str()),
             Some("current item")
         );
         let rendered = projection
             .queued_blocked
             .iter()
-            .map(|item| item.delivery_target.as_str())
+            .map(|item| item.objective.as_str())
             .collect::<Vec<_>>();
         assert_eq!(
             rendered,
@@ -1242,14 +1171,14 @@ mod tests {
 
         let anchor = storage.waiting_contract_anchor().unwrap();
         assert_eq!(
-            anchor.as_ref().map(|item| item.delivery_target.as_str()),
+            anchor.as_ref().map(|item| item.objective.as_str()),
             Some("newer waiting anchor")
         );
         let projection = storage.work_queue_prompt_projection().unwrap();
         let rendered = projection
             .queued_blocked
             .iter()
-            .map(|item| item.delivery_target.as_str())
+            .map(|item| item.objective.as_str())
             .collect::<Vec<_>>();
         assert_eq!(
             rendered,

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -390,7 +390,7 @@ mod tests {
             .find(|spec| spec.name == "UpdateWorkItem")
             .expect("UpdateWorkItem should be present");
         assert!(update_work_item.input_schema["properties"]
-            .get("delivery_target")
+            .get("objective")
             .is_some());
 
         let spawn_agent = specs

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -27,7 +27,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<CompleteWorkItemArgs>(
             NAME,
-            "Mark an open work item done and optionally record a concise result summary.",
+            "Mark an open work item completed and optionally record a concise result summary.",
         )?,
     })
 }
@@ -46,5 +46,5 @@ pub(crate) async fn execute(
             normalize_optional_non_empty(args.result_summary),
         )
         .await?;
-    serialize_success(NAME, &WorkItemMutationResult::new(work_item, None))
+    serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/create_work_item.rs
+++ b/src/tool/tools/create_work_item.rs
@@ -5,15 +5,15 @@ use serde_json::Value;
 
 use crate::{
     runtime::RuntimeHandle,
-    tool::helpers::validate_non_empty,
+    tool::helpers::{normalize_optional_non_empty, validate_non_empty},
     tool::spec::typed_spec,
-    types::{ToolCapabilityFamily, TrustLevel},
+    types::{ToolCapabilityFamily, TrustLevel, WorkItemPlanStatus},
 };
 
 use super::{
     serialize_success,
     work_item_action::{
-        convert_plan, parse_work_item_action_args, WorkItemMutationResult, WorkPlanItemArgs,
+        convert_todo_list, parse_work_item_action_args, TodoItemArgs, WorkItemMutationResult,
     },
     BuiltinToolDefinition,
 };
@@ -23,9 +23,32 @@ pub(crate) const NAME: &str = "CreateWorkItem";
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct CreateWorkItemArgs {
-    pub(crate) delivery_target: String,
+    pub(crate) objective: String,
     #[serde(default)]
-    pub(crate) plan: Option<Vec<WorkPlanItemArgs>>,
+    pub(crate) plan_status: Option<WorkItemPlanStatusArg>,
+    #[serde(default)]
+    pub(crate) plan: Option<String>,
+    #[serde(default)]
+    pub(crate) todo_list: Option<Vec<TodoItemArgs>>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub(crate) enum WorkItemPlanStatusArg {
+    Draft,
+    Ready,
+    NeedsInput,
+}
+
+impl From<WorkItemPlanStatusArg> for WorkItemPlanStatus {
+    fn from(value: WorkItemPlanStatusArg) -> Self {
+        match value {
+            WorkItemPlanStatusArg::Draft => Self::Draft,
+            WorkItemPlanStatusArg::Ready => Self::Ready,
+            WorkItemPlanStatusArg::NeedsInput => Self::NeedsInput,
+        }
+    }
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
@@ -33,7 +56,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<CreateWorkItemArgs>(
             NAME,
-            "Create a new open work item for a genuinely separate delivery target. Do not create a new work item just to refine the current task; use UpdateWorkItem.delivery_target for that. Use PickWorkItem separately to make a different existing item current.",
+            "Create a new open work item for a genuinely separate objective. Use plan for durable task understanding and todo_list only for progress checklist items. Do not create a new work item just to refine the current task; use UpdateWorkItem.objective and UpdateWorkItem.plan for that.",
         )?,
     })
 }
@@ -45,8 +68,23 @@ pub(crate) async fn execute(
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
     let args: CreateWorkItemArgs = parse_work_item_action_args(NAME, input)?;
-    let delivery_target = validate_non_empty(args.delivery_target, NAME, "delivery_target")?;
-    let plan = args.plan.map(|plan| convert_plan(NAME, plan)).transpose()?;
-    let (work_item, plan) = runtime.create_work_item(delivery_target, plan).await?;
-    serialize_success(NAME, &WorkItemMutationResult::new(work_item, plan))
+    let objective = validate_non_empty(args.objective, NAME, "objective")?;
+    let plan = args
+        .plan
+        .map(|value| validate_non_empty(value, NAME, "plan"))
+        .transpose()?;
+    let todo_list = args
+        .todo_list
+        .map(|items| convert_todo_list(NAME, items))
+        .transpose()?
+        .unwrap_or_default();
+    let work_item = runtime
+        .create_work_item(
+            objective,
+            args.plan_status.map(Into::into),
+            normalize_optional_non_empty(plan),
+            todo_list,
+        )
+        .await?;
+    serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/get_work_item.rs
+++ b/src/tool/tools/get_work_item.rs
@@ -24,6 +24,8 @@ pub(crate) struct GetWorkItemArgs {
     pub(crate) work_item_id: String,
     #[serde(default)]
     pub(crate) include_plan: bool,
+    #[serde(default)]
+    pub(crate) include_todo_list: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -37,7 +39,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<GetWorkItemArgs>(
             NAME,
-            "Read one work item by id, including its open/done lifecycle view, current focus flag, and optional latest plan snapshot.",
+            "Read one work item by id, including its open/completed lifecycle view, current focus flag, and optional plan and todo_list fields.",
         )?,
     })
 }
@@ -60,6 +62,13 @@ pub(crate) async fn execute(
             )
         })?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, record, args.include_plan).await?;
+    let work_item = view_for_record(
+        runtime,
+        &context,
+        record,
+        args.include_plan,
+        args.include_todo_list,
+    )
+    .await?;
     serialize_success(NAME, &GetWorkItemResult { context, work_item })
 }

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -29,7 +29,7 @@ const MAX_LIMIT: usize = 100;
 pub(crate) enum ListWorkItemsFilter {
     All,
     Open,
-    Done,
+    Completed,
     Current,
     Queued,
     Blocked,
@@ -44,6 +44,8 @@ pub(crate) struct ListWorkItemsArgs {
     pub(crate) limit: Option<usize>,
     #[serde(default)]
     pub(crate) include_plan: bool,
+    #[serde(default)]
+    pub(crate) include_todo_list: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -61,7 +63,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<ListWorkItemsArgs>(
             NAME,
-            "List recent work items with explicit current, open, done, queued, and blocked views. Use this before relying on memory briefs for work-item focus.",
+            "List recent work items with explicit current, open, completed, queued, and blocked views. Use this before relying on memory briefs for work-item focus.",
         )?,
     })
 }
@@ -86,7 +88,16 @@ pub(crate) async fn execute(
     let selected = matching.into_iter().take(limit).collect::<Vec<_>>();
     let mut work_items = Vec::with_capacity(selected.len());
     for record in selected {
-        work_items.push(view_for_record(runtime, &context, record, args.include_plan).await?);
+        work_items.push(
+            view_for_record(
+                runtime,
+                &context,
+                record,
+                args.include_plan,
+                args.include_todo_list,
+            )
+            .await?,
+        );
     }
     serialize_success(
         NAME,
@@ -111,7 +122,9 @@ fn matches_filter(
     match filter {
         ListWorkItemsFilter::All => true,
         ListWorkItemsFilter::Open => lifecycle_view(&record.state) == WorkItemLifecycleView::Open,
-        ListWorkItemsFilter::Done => lifecycle_view(&record.state) == WorkItemLifecycleView::Done,
+        ListWorkItemsFilter::Completed => {
+            lifecycle_view(&record.state) == WorkItemLifecycleView::Completed
+        }
         ListWorkItemsFilter::Current => is_current,
         ListWorkItemsFilter::Queued => {
             !is_current

--- a/src/tool/tools/spawn_agent.rs
+++ b/src/tool/tools/spawn_agent.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     serialize_success,
-    work_item_action::{convert_plan, WorkPlanItemArgs},
+    work_item_action::{convert_todo_list, TodoItemArgs},
     BuiltinToolDefinition,
 };
 use crate::tool::helpers::{
@@ -55,9 +55,11 @@ pub(crate) struct SpawnAgentArgs {
 pub(crate) struct SpawnAgentWorkItemArgs {
     pub(crate) parent_work_item_id: String,
     #[serde(default)]
-    pub(crate) child_delivery_target: Option<String>,
+    pub(crate) child_objective: Option<String>,
     #[serde(default)]
-    pub(crate) child_plan: Option<Vec<WorkPlanItemArgs>>,
+    pub(crate) child_plan: Option<String>,
+    #[serde(default)]
+    pub(crate) child_todo_list: Option<Vec<TodoItemArgs>>,
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
@@ -99,13 +101,13 @@ pub(crate) async fn execute(
                     NAME,
                     "parent_work_item_id",
                 )?,
-                child_delivery_target: normalize_optional_non_empty(
-                    work_item.child_delivery_target,
-                ),
-                child_plan: work_item
-                    .child_plan
-                    .map(|plan| convert_plan(NAME, plan))
-                    .transpose()?,
+                child_objective: normalize_optional_non_empty(work_item.child_objective),
+                child_plan: normalize_optional_non_empty(work_item.child_plan),
+                child_todo_list: work_item
+                    .child_todo_list
+                    .map(|items| convert_todo_list(NAME, items))
+                    .transpose()?
+                    .unwrap_or_default(),
             })
         })
         .transpose()?;

--- a/src/tool/tools/update_work_item.rs
+++ b/src/tool/tools/update_work_item.rs
@@ -11,9 +11,10 @@ use crate::{
 };
 
 use super::{
+    create_work_item::WorkItemPlanStatusArg,
     serialize_success,
     work_item_action::{
-        convert_plan, parse_work_item_action_args, WorkItemMutationResult, WorkPlanItemArgs,
+        convert_todo_list, parse_work_item_action_args, TodoItemArgs, WorkItemMutationResult,
     },
     BuiltinToolDefinition,
 };
@@ -25,11 +26,15 @@ pub(crate) const NAME: &str = "UpdateWorkItem";
 pub(crate) struct UpdateWorkItemArgs {
     pub(crate) work_item_id: String,
     #[serde(default)]
-    pub(crate) delivery_target: Option<String>,
+    pub(crate) objective: Option<String>,
+    #[serde(default)]
+    pub(crate) plan_status: Option<WorkItemPlanStatusArg>,
+    #[serde(default)]
+    pub(crate) plan: Option<Option<String>>,
+    #[serde(default)]
+    pub(crate) todo_list: Option<Vec<TodoItemArgs>>,
     #[serde(default)]
     pub(crate) blocked_by: Option<Option<String>>,
-    #[serde(default)]
-    pub(crate) plan: Option<Vec<WorkPlanItemArgs>>,
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
@@ -37,7 +42,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<UpdateWorkItemArgs>(
             NAME,
-            "Update mutable fields for an existing work item. Use delivery_target to refine the same underlying task instead of creating a duplicate work item. Plan updates replace the full checklist snapshot.",
+            "Update mutable fields for an existing work item. Use objective to refine the short target, plan to replace durable task understanding, and todo_list to replace the full progress checklist snapshot.",
         )?,
     })
 }
@@ -50,16 +55,34 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: UpdateWorkItemArgs = parse_work_item_action_args(NAME, input)?;
     let work_item_id = validate_non_empty(args.work_item_id, NAME, "work_item_id")?;
-    let delivery_target = args
-        .delivery_target
-        .map(|value| validate_non_empty(value, NAME, "delivery_target"))
+    let objective = args
+        .objective
+        .map(|value| validate_non_empty(value, NAME, "objective"))
         .transpose()?;
     let blocked_by = args
         .blocked_by
         .map(|value| value.and_then(|inner| normalize_optional_non_empty(Some(inner))));
-    let plan = args.plan.map(|plan| convert_plan(NAME, plan)).transpose()?;
-    let (work_item, plan) = runtime
-        .update_work_item_fields(work_item_id, delivery_target, blocked_by, plan)
+    let plan = args
+        .plan
+        .map(|value| {
+            value
+                .map(|inner| validate_non_empty(inner, NAME, "plan"))
+                .transpose()
+        })
+        .transpose()?;
+    let todo_list = args
+        .todo_list
+        .map(|items| convert_todo_list(NAME, items))
+        .transpose()?;
+    let work_item = runtime
+        .update_work_item_fields(
+            work_item_id,
+            objective,
+            args.plan_status.map(Into::into),
+            plan,
+            todo_list,
+            blocked_by,
+        )
         .await?;
-    serialize_success(NAME, &WorkItemMutationResult::new(work_item, plan))
+    serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/work_item_action.rs
+++ b/src/tool/tools/work_item_action.rs
@@ -1,43 +1,43 @@
 use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     tool::helpers::{parse_tool_args_with_recovery_hint, validate_non_empty},
-    types::{WorkItemRecord, WorkPlanItem, WorkPlanSnapshot, WorkPlanStepStatus},
+    types::{TodoItem, TodoItemState, WorkItemRecord},
 };
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
-pub(crate) enum WorkPlanStepStateArgs {
+pub(crate) enum TodoItemStateArgs {
     Pending,
-    Doing,
-    Done,
+    InProgress,
+    Completed,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct WorkPlanItemArgs {
-    pub(crate) step: String,
-    pub(crate) state: WorkPlanStepStateArgs,
+pub(crate) struct TodoItemArgs {
+    pub(crate) text: String,
+    pub(crate) state: TodoItemStateArgs,
 }
 
-pub(crate) fn convert_plan(
+pub(crate) fn convert_todo_list(
     tool_name: &str,
-    plan: Vec<WorkPlanItemArgs>,
-) -> Result<Vec<WorkPlanItem>> {
-    plan.into_iter()
+    items: Vec<TodoItemArgs>,
+) -> Result<Vec<TodoItem>> {
+    items
+        .into_iter()
         .enumerate()
         .map(|(index, item)| {
-            Ok(WorkPlanItem {
-                step: validate_non_empty(item.step, tool_name, "step")
-                    .with_context(|| format!("invalid work plan item {index}"))?,
-                status: match item.state {
-                    WorkPlanStepStateArgs::Pending => WorkPlanStepStatus::Pending,
-                    WorkPlanStepStateArgs::Doing => WorkPlanStepStatus::InProgress,
-                    WorkPlanStepStateArgs::Done => WorkPlanStepStatus::Completed,
+            Ok(TodoItem {
+                text: validate_non_empty(item.text, tool_name, "text")
+                    .with_context(|| format!("invalid todo_list item {index}"))?,
+                state: match item.state {
+                    TodoItemStateArgs::Pending => TodoItemState::Pending,
+                    TodoItemStateArgs::InProgress => TodoItemState::InProgress,
+                    TodoItemStateArgs::Completed => TodoItemState::Completed,
                 },
             })
         })
@@ -59,57 +59,13 @@ where
 fn work_item_action_recovery_hint(tool_name: &str) -> &'static str {
     match tool_name {
         "CreateWorkItem" => {
-            "ensure the JSON matches the CreateWorkItem schema, including required top-level field \"delivery_target\"; use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
+            "ensure the JSON matches the CreateWorkItem schema, including required top-level field \"objective\"; use todo_list items like {\"text\":\"inspect current handler\",\"state\":\"completed\"}; todo state must be pending, in_progress, or completed"
         }
         "UpdateWorkItem" => {
-            "ensure the JSON matches the UpdateWorkItem schema, including required top-level field \"work_item_id\"; use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
+            "ensure the JSON matches the UpdateWorkItem schema, including required top-level field \"work_item_id\"; use todo_list items like {\"text\":\"inspect current handler\",\"state\":\"completed\"}; todo state must be pending, in_progress, or completed"
         }
         _ => {
-            "ensure the JSON matches the tool schema exactly; use plan items like {\"step\":\"inspect current handler\",\"state\":\"done\"}; state must be pending, doing, or done"
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum WorkPlanStepStateView {
-    Pending,
-    Doing,
-    Done,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct WorkPlanItemView {
-    pub(crate) step: String,
-    pub(crate) state: WorkPlanStepStateView,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct WorkPlanView {
-    pub(crate) work_item_id: String,
-    pub(crate) agent_id: String,
-    pub(crate) created_at: DateTime<Utc>,
-    pub(crate) items: Vec<WorkPlanItemView>,
-}
-
-impl From<WorkPlanSnapshot> for WorkPlanView {
-    fn from(snapshot: WorkPlanSnapshot) -> Self {
-        Self {
-            work_item_id: snapshot.work_item_id,
-            agent_id: snapshot.agent_id,
-            created_at: snapshot.created_at,
-            items: snapshot
-                .items
-                .into_iter()
-                .map(|item| WorkPlanItemView {
-                    step: item.step,
-                    state: match item.status {
-                        WorkPlanStepStatus::Pending => WorkPlanStepStateView::Pending,
-                        WorkPlanStepStatus::InProgress => WorkPlanStepStateView::Doing,
-                        WorkPlanStepStatus::Completed => WorkPlanStepStateView::Done,
-                    },
-                })
-                .collect(),
+            "ensure the JSON matches the tool schema exactly; todo state must be pending, in_progress, or completed"
         }
     }
 }
@@ -117,15 +73,10 @@ impl From<WorkPlanSnapshot> for WorkPlanView {
 #[derive(Serialize)]
 pub(crate) struct WorkItemMutationResult {
     pub(crate) work_item: WorkItemRecord,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) plan: Option<WorkPlanView>,
 }
 
 impl WorkItemMutationResult {
-    pub(crate) fn new(work_item: WorkItemRecord, plan: Option<WorkPlanSnapshot>) -> Self {
-        Self {
-            work_item,
-            plan: plan.map(Into::into),
-        }
+    pub(crate) fn new(work_item: WorkItemRecord) -> Self {
+        Self { work_item }
     }
 }

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -4,16 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     runtime::RuntimeHandle,
-    types::{WorkItemRecord, WorkItemState},
+    types::{TodoItem, WorkItemPlanStatus, WorkItemRecord, WorkItemState},
 };
-
-use super::work_item_action::WorkPlanView;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum WorkItemLifecycleView {
     Open,
-    Done,
+    Completed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -22,7 +20,7 @@ pub(crate) enum WorkItemFocusView {
     Current,
     Queued,
     Blocked,
-    Done,
+    Completed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -30,14 +28,17 @@ pub(crate) struct WorkItemView {
     pub(crate) id: String,
     pub(crate) agent_id: String,
     pub(crate) workspace_id: String,
-    pub(crate) delivery_target: String,
+    pub(crate) objective: String,
     pub(crate) state: WorkItemLifecycleView,
     pub(crate) focus: WorkItemFocusView,
     pub(crate) is_current: bool,
+    pub(crate) plan_status: WorkItemPlanStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) plan: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) todo_list: Vec<TodoItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) blocked_by: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) plan: Option<WorkPlanView>,
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) updated_at: DateTime<Utc>,
 }
@@ -77,13 +78,16 @@ pub(crate) async fn view_for_record(
     context: &WorkItemQueryContext,
     record: WorkItemRecord,
     include_plan: bool,
+    include_todo_list: bool,
 ) -> Result<WorkItemView> {
+    let _ = runtime;
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
-    let plan = if include_plan {
-        runtime.latest_work_plan(&record.id).await?.map(Into::into)
+    let plan = include_plan.then(|| record.plan.clone()).flatten();
+    let todo_list = if include_todo_list {
+        record.todo_list.clone()
     } else {
-        None
+        Vec::new()
     };
     let state = lifecycle_view(&record.state);
     let focus = focus_view(&record, is_current);
@@ -91,12 +95,14 @@ pub(crate) async fn view_for_record(
         id: record.id,
         agent_id: record.agent_id,
         workspace_id: record.workspace_id,
-        delivery_target: record.delivery_target,
+        objective: record.objective,
         state,
         focus,
         is_current,
-        blocked_by: record.blocked_by,
+        plan_status: record.plan_status,
         plan,
+        todo_list,
+        blocked_by: record.blocked_by,
         created_at: record.created_at,
         updated_at: record.updated_at,
     })
@@ -105,13 +111,13 @@ pub(crate) async fn view_for_record(
 pub(crate) fn lifecycle_view(state: &WorkItemState) -> WorkItemLifecycleView {
     match state {
         WorkItemState::Open => WorkItemLifecycleView::Open,
-        WorkItemState::Done => WorkItemLifecycleView::Done,
+        WorkItemState::Completed => WorkItemLifecycleView::Completed,
     }
 }
 
 pub(crate) fn focus_view(record: &WorkItemRecord, is_current: bool) -> WorkItemFocusView {
-    if record.state == WorkItemState::Done {
-        return WorkItemFocusView::Done;
+    if record.state == WorkItemState::Completed {
+        return WorkItemFocusView::Completed;
     }
     if is_current {
         return WorkItemFocusView::Current;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1722,6 +1722,8 @@ mod tests {
                             "workspace_id": "agent_home",
                             "objective": "prepare rollout plan",
                             "state": "open",
+                            "plan_status": "draft",
+                            "todo_list": [],
                             "created_at": Utc::now(),
                             "updated_at": Utc::now()
                         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -761,7 +761,6 @@ impl TuiApp {
                 ProjectionSlice::BriefsTail => "briefs",
                 ProjectionSlice::Timers => "timers",
                 ProjectionSlice::WorkItems => "work-items",
-                ProjectionSlice::WorkPlan => "work-plan",
                 ProjectionSlice::WaitingIntents => "waiting",
                 ProjectionSlice::ExternalTriggers => "external-triggers",
                 ProjectionSlice::OperatorNotifications => "operator-notifications",
@@ -1003,7 +1002,6 @@ mod tests {
             briefs_tail: Vec::new(),
             timers: Vec::new(),
             work_items: Vec::new(),
-            work_plan: None,
             waiting_intents: Vec::new(),
             external_triggers: Vec::new(),
             operator_notifications: Vec::new(),
@@ -1722,7 +1720,7 @@ mod tests {
                             "id": "work-1",
                             "agent_id": "default",
                             "workspace_id": "agent_home",
-                            "delivery_target": "prepare rollout plan",
+                            "objective": "prepare rollout plan",
                             "state": "open",
                             "created_at": Utc::now(),
                             "updated_at": Utc::now()
@@ -1813,7 +1811,7 @@ mod tests {
         snapshot.agent.agent.working_memory.current_working_memory =
             crate::types::WorkingMemorySnapshot {
                 current_work_item_id: Some("work-1".into()),
-                delivery_target: Some("fix TUI active activity".into()),
+                objective: Some("fix TUI active activity".into()),
                 work_summary: Some("Improve the Conversation working indicator".into()),
                 ..Default::default()
             };

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -19,7 +19,7 @@ use crate::{
         ActiveWorkspaceEntry, AgentState, AgentSummary, BriefRecord, ClosureDecision,
         ExternalTriggerStateSnapshot, MessageEnvelope, TaskRecord, TimerRecord, TimerStatus,
         TranscriptEntry, TranscriptEntryKind, WaitingIntentRecord, WorkItemRecord, WorkItemState,
-        WorkPlanSnapshot, WorktreeSession,
+        WorktreeSession,
     },
 };
 
@@ -40,7 +40,6 @@ pub(crate) enum ProjectionSlice {
     BriefsTail,
     Timers,
     WorkItems,
-    WorkPlan,
     WaitingIntents,
     ExternalTriggers,
     OperatorNotifications,
@@ -74,7 +73,6 @@ pub(crate) struct TuiProjection {
     pub(crate) briefs_tail: Vec<BriefRecord>,
     pub(crate) timers: Vec<TimerRecord>,
     pub(crate) work_items: Vec<WorkItemRecord>,
-    pub(crate) work_plan: Option<WorkPlanSnapshot>,
     pub(crate) waiting_intents: Vec<WaitingIntentRecord>,
     pub(crate) external_triggers: Vec<ExternalTriggerStateSnapshot>,
     pub(crate) operator_notifications: Vec<crate::types::OperatorNotificationRecord>,
@@ -98,7 +96,6 @@ impl TuiProjection {
             briefs_tail: snapshot.briefs_tail,
             timers: snapshot.timers,
             work_items: snapshot.work_items,
-            work_plan: snapshot.work_plan,
             waiting_intents: snapshot.waiting_intents,
             external_triggers,
             operator_notifications,
@@ -232,14 +229,6 @@ impl TuiProjection {
                     self.stale_slices.remove(&ProjectionSlice::WorkItems);
                 } else {
                     self.mark_stale([ProjectionSlice::WorkItems]);
-                }
-            }
-            "work_plan_snapshot_written" => {
-                if let Some(plan) = decode_payload::<WorkPlanSnapshot>(&event.data.payload) {
-                    self.work_plan = Some(plan);
-                    self.stale_slices.remove(&ProjectionSlice::WorkPlan);
-                } else {
-                    self.mark_stale([ProjectionSlice::WorkPlan]);
                 }
             }
             "workspace_attached" => {
@@ -645,7 +634,7 @@ fn work_item_rank(item: &WorkItemRecord) -> u8 {
     match item.state {
         WorkItemState::Open if item.blocked_by.is_none() => 0,
         WorkItemState::Open => 1,
-        WorkItemState::Done => 2,
+        WorkItemState::Completed => 2,
     }
 }
 
@@ -754,7 +743,7 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
             .get("record")
             .cloned()
             .and_then(decode_value::<WorkItemRecord>)
-            .map(|record| format!("{} [{:?}]", record.delivery_target, record.state))
+            .map(|record| format!("{} [{:?}]", record.objective, record.state))
             .unwrap_or_else(|| event.data.event_type.clone()),
         "waiting_intent_created" => decode_payload::<WaitingIntentRecord>(&event.data.payload)
             .map(|waiting| format!("waiting: {}", trim_summary(&waiting.description)))
@@ -889,10 +878,10 @@ mod tests {
             ExternalTriggerStateSnapshot, ExternalTriggerStatus, LoadedAgentsMdView, MessageBody,
             MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
             RuntimePosture, SkillsRuntimeView, TaskRecord, TaskStatus, TimerRecord, TimerStatus,
-            TokenUsage, TranscriptEntry, TranscriptEntryKind, TurnTerminalKind, TurnTerminalRecord,
-            WaitingIntentRecord, WaitingIntentStatus, WaitingIntentSummary, WorkItemRecord,
-            WorkItemState, WorkPlanItem, WorkPlanSnapshot, WorkPlanStepStatus,
-            WorkspaceOccupancyRecord, WorktreeSession,
+            TodoItem, TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind,
+            TurnTerminalKind, TurnTerminalRecord, WaitingIntentRecord, WaitingIntentStatus,
+            WaitingIntentSummary, WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord,
+            WorktreeSession,
         },
     };
     use chrono::Utc;
@@ -1157,7 +1146,7 @@ mod tests {
                         "id": "work-1",
                         "agent_id": "default",
                         "workspace_id": "agent_home",
-                        "delivery_target": "operator",
+                        "objective": "operator",
                         "state": "open",
                         "created_at": Utc::now(),
                         "updated_at": Utc::now()
@@ -1460,20 +1449,15 @@ mod tests {
                 last_fired_at: None,
                 fire_count: 0,
             }],
-            work_items: vec![WorkItemRecord::new(
-                "default",
-                "active delivery",
-                WorkItemState::Open,
-            )],
-            work_plan: Some(WorkPlanSnapshot {
-                agent_id: "default".into(),
-                work_item_id: "work-1".into(),
-                created_at: Utc::now(),
-                items: vec![WorkPlanItem {
-                    step: "do it".into(),
-                    status: WorkPlanStepStatus::InProgress,
-                }],
-            }),
+            work_items: {
+                let mut item =
+                    WorkItemRecord::new("default", "active delivery", WorkItemState::Open);
+                item.todo_list = vec![TodoItem {
+                    text: "do it".into(),
+                    state: TodoItemState::InProgress,
+                }];
+                vec![item]
+            },
             waiting_intents: vec![WaitingIntentRecord {
                 id: "wait-1".into(),
                 agent_id: "default".into(),

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1148,6 +1148,8 @@ mod tests {
                         "workspace_id": "agent_home",
                         "objective": "operator",
                         "state": "open",
+                        "plan_status": "draft",
+                        "todo_list": [],
                         "created_at": Utc::now(),
                         "updated_at": Utc::now()
                     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -203,23 +203,28 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
             lines.push(format!(
                 "  - [{:?}] {}",
                 item.state,
-                trim(&item.delivery_target, 40)
+                trim(&item.objective, 40)
             ));
         }
     }
-    if let Some(plan) = projection.work_plan.as_ref() {
-        let active = plan
-            .items
+    if let Some(work_item) = projection
+        .work_items
+        .iter()
+        .find(|item| item.state == crate::types::WorkItemState::Open && item.blocked_by.is_none())
+    {
+        let active = work_item
+            .todo_list
             .iter()
-            .find(|item| matches!(item.status, crate::types::WorkPlanStepStatus::InProgress))
+            .find(|item| matches!(item.state, crate::types::TodoItemState::InProgress))
             .or_else(|| {
-                plan.items
+                work_item
+                    .todo_list
                     .iter()
-                    .find(|item| matches!(item.status, crate::types::WorkPlanStepStatus::Pending))
+                    .find(|item| matches!(item.state, crate::types::TodoItemState::Pending))
             })
-            .map(|item| trim(&item.step, 40))
+            .map(|item| trim(&item.text, 40))
             .unwrap_or_else(|| "<completed>".into());
-        lines.push(format!("  Plan: {active}"));
+        lines.push(format!("  Todo: {active}"));
     }
     lines.push(String::new());
     lines.push("Waiting".into());

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -207,10 +207,7 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
             ));
         }
     }
-    if let Some(work_item) = projection
-        .work_items
-        .iter()
-        .find(|item| item.state == crate::types::WorkItemState::Open && item.blocked_by.is_none())
+    if let Some(work_item) = todo_summary_work_item(&projection.agent.agent, &projection.work_items)
     {
         let active = work_item
             .todo_list
@@ -263,6 +260,22 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
     }
 
     lines.join("\n")
+}
+
+fn todo_summary_work_item<'a>(
+    agent: &crate::types::AgentState,
+    work_items: &'a [crate::types::WorkItemRecord],
+) -> Option<&'a crate::types::WorkItemRecord> {
+    agent
+        .current_turn_work_item_id
+        .as_deref()
+        .or(agent.current_work_item_id.as_deref())
+        .and_then(|current_id| work_items.iter().find(|item| item.id == current_id))
+        .or_else(|| {
+            work_items.iter().find(|item| {
+                item.state == crate::types::WorkItemState::Open && item.blocked_by.is_none()
+            })
+        })
 }
 
 fn prompt_pane_height(buffer: &str, slash_menu_rows: usize, pane_width: u16) -> u16 {
@@ -838,7 +851,7 @@ mod tests {
     use super::{
         prompt_cursor_position, prompt_pane_height, render_header, render_model_status,
         render_prompt_buffer, render_prompt_text, render_summary, render_task_detail,
-        status_bar_height,
+        status_bar_height, todo_summary_work_item,
     };
     use crate::system::{ExecutionProfile, ExecutionSnapshot};
     use crate::types::{
@@ -846,7 +859,8 @@ mod tests {
         AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentSummary,
         AgentTokenUsageSummary, AgentVisibility, ChildAgentObservabilitySnapshot, ChildAgentPhase,
         ChildAgentSummary, ClosureDecision, ClosureOutcome, LoadedAgentsMdView, RuntimePosture,
-        SkillsRuntimeView, TaskKind, TaskRecord, TaskStatus, TokenUsage,
+        SkillsRuntimeView, TaskKind, TaskRecord, TaskStatus, TodoItem, TodoItemState, TokenUsage,
+        WorkItemRecord, WorkItemState,
     };
     use chrono::{TimeZone, Utc};
     use ratatui::prelude::{Line, Rect};
@@ -1057,6 +1071,31 @@ mod tests {
             render_model_status(&fallback),
             "model: anthropic/claude-sonnet-4-6 (fallback from openai/gpt-5.4)"
         );
+    }
+
+    #[test]
+    fn todo_summary_prefers_current_work_item_over_first_open_item() {
+        let mut agent = AgentState::new("default");
+        agent.current_work_item_id = Some("work-current".into());
+        let mut first_open = WorkItemRecord::new("default", "first open", WorkItemState::Open);
+        first_open.id = "work-first".into();
+        first_open.todo_list = vec![TodoItem {
+            text: "wrong todo".into(),
+            state: TodoItemState::InProgress,
+        }];
+        let mut current = WorkItemRecord::new("default", "selected work", WorkItemState::Open);
+        current.id = "work-current".into();
+        current.blocked_by = Some("waiting on review".into());
+        current.todo_list = vec![TodoItem {
+            text: "selected todo".into(),
+            state: TodoItemState::Pending,
+        }];
+
+        let work_items = [first_open, current];
+        let selected = todo_summary_work_item(&agent, &work_items)
+            .expect("current work item should be selected");
+        assert_eq!(selected.id, "work-current");
+        assert_eq!(selected.todo_list[0].text, "selected todo");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1023,7 +1023,7 @@ pub struct WorkingMemorySnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delivery_target: Option<String>,
+    pub objective: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_summary: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1068,7 +1068,7 @@ pub struct TurnMemoryDelta {
     #[serde(default)]
     pub active_work_changed: bool,
     #[serde(default)]
-    pub work_plan_changed: bool,
+    pub current_plan_changed: bool,
     #[serde(default)]
     pub scope_hints_changed: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1107,7 +1107,7 @@ pub struct ActiveEpisodeBuilder {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delivery_target: Option<String>,
+    pub objective: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_summary: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1151,7 +1151,7 @@ impl ActiveEpisodeBuilder {
             start_message_count: message_count,
             latest_message_count: message_count,
             current_work_item_id: snapshot.current_work_item_id.clone(),
-            delivery_target: snapshot.delivery_target.clone(),
+            objective: snapshot.objective.clone(),
             work_summary: snapshot.work_summary.clone(),
             scope_hints: Vec::new(),
             working_set_files: snapshot.working_set_files.clone(),
@@ -1180,7 +1180,7 @@ pub struct ContextEpisodeRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delivery_target: Option<String>,
+    pub objective: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_summary: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -2075,9 +2075,11 @@ pub struct SpawnAgentResult {
 pub struct SpawnAgentWorkItemRequest {
     pub parent_work_item_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub child_delivery_target: Option<String>,
+    pub child_objective: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub child_plan: Option<Vec<WorkPlanItem>>,
+    pub child_plan: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub child_todo_list: Vec<TodoItem>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -2279,7 +2281,15 @@ pub struct CommandTaskSpec {
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemState {
     Open,
-    Done,
+    Completed,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkItemPlanStatus {
+    Draft,
+    Ready,
+    NeedsInput,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2289,10 +2299,17 @@ pub struct WorkItemRecord {
     pub agent_id: String,
     #[serde(default = "default_agent_home_workspace_id")]
     pub workspace_id: String,
-    pub delivery_target: String,
+    pub objective: String,
     pub state: WorkItemState,
+    pub plan_status: WorkItemPlanStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub todo_list: Vec<TodoItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blocked_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_summary: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -2300,7 +2317,7 @@ pub struct WorkItemRecord {
 impl WorkItemRecord {
     pub fn new(
         agent_id: impl Into<String>,
-        delivery_target: impl Into<String>,
+        objective: impl Into<String>,
         state: WorkItemState,
     ) -> Self {
         let now = Utc::now();
@@ -2308,9 +2325,13 @@ impl WorkItemRecord {
             id: format!("work_{}", Uuid::new_v4().simple()),
             agent_id: agent_id.into(),
             workspace_id: AGENT_HOME_WORKSPACE_ID.to_string(),
-            delivery_target: delivery_target.into(),
+            objective: objective.into(),
             state,
+            plan_status: WorkItemPlanStatus::Draft,
+            plan: None,
+            todo_list: Vec::new(),
             blocked_by: None,
+            result_summary: None,
             created_at: now,
             updated_at: now,
         }
@@ -2321,7 +2342,7 @@ impl WorkItemRecord {
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemDelegationState {
     Open,
-    Done,
+    Completed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2395,41 +2416,17 @@ impl DeliverySummaryRecord {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TodoItem {
+    pub text: String,
+    pub state: TodoItemState,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum WorkPlanStepStatus {
+pub enum TodoItemState {
     Pending,
     InProgress,
     Completed,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkPlanItem {
-    pub step: String,
-    pub status: WorkPlanStepStatus,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WorkPlanSnapshot {
-    pub work_item_id: String,
-    #[serde(alias = "session_id")]
-    pub agent_id: String,
-    pub created_at: DateTime<Utc>,
-    pub items: Vec<WorkPlanItem>,
-}
-
-impl WorkPlanSnapshot {
-    pub fn new(
-        agent_id: impl Into<String>,
-        work_item_id: impl Into<String>,
-        items: Vec<WorkPlanItem>,
-    ) -> Self {
-        Self {
-            work_item_id: work_item_id.into(),
-            agent_id: agent_id.into(),
-            created_at: Utc::now(),
-            items,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/tests/http_tasks.rs
+++ b/tests/http_tasks.rs
@@ -18,5 +18,5 @@ http_async_tests!(
     create_command_task_route_accepts_command_request,
     create_work_item_route_persists_queued_item_without_message_ingress,
     create_work_item_route_does_not_replace_existing_active_item,
-    create_work_item_route_rejects_empty_delivery_target_with_bad_request,
+    create_work_item_route_rejects_empty_objective_with_bad_request,
 );

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use chrono::Utc;
 use holon::{
     context::ContextConfig,
     prompt::build_effective_prompt,
@@ -11,8 +12,8 @@ use holon::{
         AgentRegistryStatus, AgentState, AgentVisibility, ContinuationClass,
         ContinuationResolution, ContinuationTriggerKind, LoadedAgentsMd, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
-        SkillsRuntimeView, TrustLevel, WaitingReason, WorkItemRecord, WorkItemState, WorkPlanItem,
-        WorkPlanSnapshot, WorkPlanStepStatus, WorkingMemoryDelta, WorkingMemorySnapshot,
+        SkillsRuntimeView, TodoItem, TodoItemState, TrustLevel, WaitingReason, WorkItemRecord,
+        WorkItemState, WorkingMemoryDelta, WorkingMemorySnapshot,
     },
 };
 use serde_json::json;
@@ -45,7 +46,7 @@ Process execution guarantees:
   - secret_isolation: not_enforced
   - child_process_containment: not_enforced"#;
 
-const CONTEXT_CONTRACT: &str = r#"Interpret the memory block with this priority: current work item first for the committed delivery target and current runtime task, working memory delta next for the newest updates since the last prompt, and working memory after that for rolling agent context. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as the most reliable continuity evidence across turns. When these sources differ on task scope or delivery target, treat the current work item's `delivery_target` as the ground truth for the current committed task unless the current input explicitly changes it."#;
+const CONTEXT_CONTRACT: &str = r#"Interpret the memory block with this priority: current work item objective first, durable plan second, todo_list third, working memory delta next, and rolling working memory after that. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as continuity evidence across turns. When sources differ on task scope, treat the current work item's `objective` and `plan` as the ground truth unless the current input explicitly changes it."#;
 
 fn sample_identity() -> AgentIdentityView {
     AgentIdentityView {
@@ -121,6 +122,20 @@ fn assert_snapshot(actual: &str, expected: &str) {
     assert_eq!(actual, expected);
 }
 
+fn append_work_item_todo(
+    storage: &AppStorage,
+    work_item_id: String,
+    todo_list: Vec<TodoItem>,
+) -> Result<()> {
+    let Some(mut work_item) = storage.latest_work_item(&work_item_id)? else {
+        anyhow::bail!("missing work item {work_item_id}");
+    };
+    work_item.todo_list = todo_list;
+    work_item.updated_at = Utc::now();
+    storage.append_work_item(&work_item)?;
+    Ok(())
+}
+
 #[test]
 fn operator_turn_context_snapshot_includes_work_memory_and_active_work() -> Result<()> {
     let dir = tempdir()?;
@@ -134,20 +149,20 @@ fn operator_turn_context_snapshot_includes_work_memory_and_active_work() -> Resu
     work_item.id = "work_prompt".into();
     work_item.blocked_by = Some("baseline operator snapshot first".into());
     storage.append_work_item(&work_item)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         work_item.id.clone(),
         vec![
-            WorkPlanItem {
-                step: "Capture baseline operator layout".into(),
-                status: WorkPlanStepStatus::InProgress,
+            TodoItem {
+                text: "Capture baseline operator layout".into(),
+                state: TodoItemState::InProgress,
             },
-            WorkPlanItem {
-                step: "Cover callback and task result surfaces".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Cover callback and task result surfaces".into(),
+                state: TodoItemState::Pending,
             },
         ],
-    ))?;
+    )?;
 
     let current_message = MessageEnvelope::new(
         "default",
@@ -170,7 +185,7 @@ fn operator_turn_context_snapshot_includes_work_memory_and_active_work() -> Resu
     session.current_work_item_id = Some(work_item.id.clone());
     session.working_memory.current_working_memory = WorkingMemorySnapshot {
         current_work_item_id: Some(work_item.id.clone()),
-        delivery_target: Some(work_item.delivery_target.clone()),
+        objective: Some(work_item.objective.clone()),
         work_summary: Some("prompt snapshot coverage".into()),
         current_plan: vec!["capture operator surface snapshot".into()],
         ..WorkingMemorySnapshot::default()
@@ -198,7 +213,7 @@ Agent id: default
 ## working_memory
 Working memory:
 - Current work item id: work_prompt
-- Delivery target: Ship prompt snapshot coverage
+- Objective: Ship prompt snapshot coverage
 - Work summary: prompt snapshot coverage
 - Current plan:
   - capture operator surface snapshot
@@ -217,11 +232,12 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_prompt
 - State: Open
-- Delivery target: Ship prompt snapshot coverage
+- Objective: Ship prompt snapshot coverage
+- Plan state: Draft
+- Todo list:
+  - [in_progress] Capture baseline operator layout
+  - [pending] Cover callback and task result surfaces
 - Blocked by: baseline operator snapshot first
-- Current work plan:
-  - [InProgress] Capture baseline operator layout
-  - [Pending] Cover callback and task result surfaces
 
 ## context_contract
 {CONTEXT_CONTRACT}
@@ -460,20 +476,20 @@ fn active_work_with_queued_work_shows_both_items() -> Result<()> {
     active_work.id = "work_active".into();
     active_work.blocked_by = Some("currently adding queued work interaction tests".into());
     storage.append_work_item(&active_work)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         active_work.id.clone(),
         vec![
-            WorkPlanItem {
-                step: "Add active work with queued work test".into(),
-                status: WorkPlanStepStatus::InProgress,
+            TodoItem {
+                text: "Add active work with queued work test".into(),
+                state: TodoItemState::InProgress,
             },
-            WorkPlanItem {
-                step: "Add post-compaction snapshot tests".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Add post-compaction snapshot tests".into(),
+                state: TodoItemState::Pending,
             },
         ],
-    ))?;
+    )?;
 
     // Create a queued work item
     let mut queued_work =
@@ -481,20 +497,20 @@ fn active_work_with_queued_work_shows_both_items() -> Result<()> {
     queued_work.id = "work_queued".into();
     queued_work.blocked_by = Some("blocked on active work completion".into());
     storage.append_work_item(&queued_work)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         queued_work.id.clone(),
         vec![
-            WorkPlanItem {
-                step: "Review expanded snapshot coverage changes".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Review expanded snapshot coverage changes".into(),
+                state: TodoItemState::Pending,
             },
-            WorkPlanItem {
-                step: "Verify tests pass".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Verify tests pass".into(),
+                state: TodoItemState::Pending,
             },
         ],
-    ))?;
+    )?;
 
     let current_message = MessageEnvelope::new(
         "default",
@@ -517,7 +533,7 @@ fn active_work_with_queued_work_shows_both_items() -> Result<()> {
     session.current_work_item_id = Some(active_work.id.clone());
     session.working_memory.current_working_memory = WorkingMemorySnapshot {
         current_work_item_id: Some(active_work.id.clone()),
-        delivery_target: Some(active_work.delivery_target.clone()),
+        objective: Some(active_work.objective.clone()),
         work_summary: Some("expand prompt context snapshot coverage".into()),
         current_plan: vec!["add active work with queued work test".into()],
         ..WorkingMemorySnapshot::default()
@@ -534,7 +550,7 @@ Agent id: default
 ## working_memory
 Working memory:
 - Current work item id: work_active
-- Delivery target: Complete snapshot coverage expansion
+- Objective: Complete snapshot coverage expansion
 - Work summary: expand prompt context snapshot coverage
 - Current plan:
   - add active work with queued work test
@@ -543,11 +559,12 @@ Working memory:
 Current work item:
 - Id: work_active
 - State: Open
-- Delivery target: Complete snapshot coverage expansion
+- Objective: Complete snapshot coverage expansion
+- Plan state: Draft
+- Todo list:
+  - [in_progress] Add active work with queued work test
+  - [pending] Add post-compaction snapshot tests
 - Blocked by: currently adding queued work interaction tests
-- Current work plan:
-  - [InProgress] Add active work with queued work test
-  - [Pending] Add post-compaction snapshot tests
 
 ## queued_blocked_work_items
 Queued and blocked work items:
@@ -574,14 +591,14 @@ fn operator_turn_without_working_memory_delta() -> Result<()> {
     work_item.id = "work_no_delta".into();
     work_item.blocked_by = Some("verifying snapshot without delta".into());
     storage.append_work_item(&work_item)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         work_item.id.clone(),
-        vec![WorkPlanItem {
-            step: "Verify delta absence".into(),
-            status: WorkPlanStepStatus::InProgress,
+        vec![TodoItem {
+            text: "Verify delta absence".into(),
+            state: TodoItemState::InProgress,
         }],
-    ))?;
+    )?;
 
     let current_message = MessageEnvelope::new(
         "default",
@@ -604,7 +621,7 @@ fn operator_turn_without_working_memory_delta() -> Result<()> {
     session.current_work_item_id = Some(work_item.id.clone());
     session.working_memory.current_working_memory = WorkingMemorySnapshot {
         current_work_item_id: Some(work_item.id.clone()),
-        delivery_target: Some(work_item.delivery_target.clone()),
+        objective: Some(work_item.objective.clone()),
         work_summary: Some("test working memory delta absence".into()),
         current_plan: vec!["verify delta absence".into()],
         ..WorkingMemorySnapshot::default()
@@ -622,7 +639,7 @@ Agent id: default
 ## working_memory
 Working memory:
 - Current work item id: work_no_delta
-- Delivery target: Test delta absence
+- Objective: Test delta absence
 - Work summary: test working memory delta absence
 - Current plan:
   - verify delta absence
@@ -631,10 +648,11 @@ Working memory:
 Current work item:
 - Id: work_no_delta
 - State: Open
-- Delivery target: Test delta absence
+- Objective: Test delta absence
+- Plan state: Draft
+- Todo list:
+  - [in_progress] Verify delta absence
 - Blocked by: verifying snapshot without delta
-- Current work plan:
-  - [InProgress] Verify delta absence
 
 ## context_contract
 {CONTEXT_CONTRACT}
@@ -657,24 +675,24 @@ fn callback_with_active_work_and_delta() -> Result<()> {
     work_item.id = "work_ci".into();
     work_item.blocked_by = Some("awaiting CI result".into());
     storage.append_work_item(&work_item)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         work_item.id.clone(),
         vec![
-            WorkPlanItem {
-                step: "Wait for CI callback".into(),
-                status: WorkPlanStepStatus::Completed,
+            TodoItem {
+                text: "Wait for CI callback".into(),
+                state: TodoItemState::Completed,
             },
-            WorkPlanItem {
-                step: "Process CI result".into(),
-                status: WorkPlanStepStatus::InProgress,
+            TodoItem {
+                text: "Process CI result".into(),
+                state: TodoItemState::InProgress,
             },
-            WorkPlanItem {
-                step: "Update work item status".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Update work item status".into(),
+                state: TodoItemState::Pending,
             },
         ],
-    ))?;
+    )?;
 
     let callback_message = MessageEnvelope::new(
         "default",
@@ -698,7 +716,7 @@ fn callback_with_active_work_and_delta() -> Result<()> {
     session.current_work_item_id = Some(work_item.id.clone());
     session.working_memory.current_working_memory = WorkingMemorySnapshot {
         current_work_item_id: Some(work_item.id.clone()),
-        delivery_target: Some(work_item.delivery_target.clone()),
+        objective: Some(work_item.objective.clone()),
         work_summary: Some("process CI completion callback".into()),
         current_plan: vec![
             "wait for CI callback".into(),
@@ -730,7 +748,7 @@ Agent id: default
 ## working_memory
 Working memory:
 - Current work item id: work_ci
-- Delivery target: Handle CI callback
+- Objective: Handle CI callback
 - Work summary: process CI completion callback
 - Current plan:
   - wait for CI callback
@@ -752,12 +770,13 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_ci
 - State: Open
-- Delivery target: Handle CI callback
+- Objective: Handle CI callback
+- Plan state: Draft
+- Todo list:
+  - [completed] Wait for CI callback
+  - [in_progress] Process CI result
+  - [pending] Update work item status
 - Blocked by: awaiting CI result
-- Current work plan:
-  - [Completed] Wait for CI callback
-  - [InProgress] Process CI result
-  - [Pending] Update work item status
 
 ## context_contract
 {CONTEXT_CONTRACT}
@@ -784,20 +803,20 @@ fn system_tick_with_waiting_work_item() -> Result<()> {
     waiting_work.id = "work_waiting".into();
     waiting_work.blocked_by = Some("blocked on API rate limit".into());
     storage.append_work_item(&waiting_work)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         waiting_work.id.clone(),
         vec![
-            WorkPlanItem {
-                step: "Wait for rate limit reset".into(),
-                status: WorkPlanStepStatus::InProgress,
+            TodoItem {
+                text: "Wait for rate limit reset".into(),
+                state: TodoItemState::InProgress,
             },
-            WorkPlanItem {
-                step: "Retry API request".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Retry API request".into(),
+                state: TodoItemState::Pending,
             },
         ],
-    ))?;
+    )?;
 
     let mut system_tick = MessageEnvelope::new(
         "default",
@@ -842,7 +861,7 @@ fn system_tick_with_waiting_work_item() -> Result<()> {
     session.current_work_item_id = Some(waiting_work.id.clone());
     session.working_memory.current_working_memory = WorkingMemorySnapshot {
         current_work_item_id: Some(waiting_work.id.clone()),
-        delivery_target: Some(waiting_work.delivery_target.clone()),
+        objective: Some(waiting_work.objective.clone()),
         work_summary: Some("waiting for external service response".into()),
         current_plan: vec![
             "wait for rate limit reset".into(),
@@ -862,7 +881,7 @@ Agent id: default
 ## working_memory
 Working memory:
 - Current work item id: work_waiting
-- Delivery target: External service integration
+- Objective: External service integration
 - Work summary: waiting for external service response
 - Current plan:
   - wait for rate limit reset
@@ -872,11 +891,12 @@ Working memory:
 Current work item:
 - Id: work_waiting
 - State: Open
-- Delivery target: External service integration
+- Objective: External service integration
+- Plan state: Draft
+- Todo list:
+  - [in_progress] Wait for rate limit reset
+  - [pending] Retry API request
 - Blocked by: blocked on API rate limit
-- Current work plan:
-  - [InProgress] Wait for rate limit reset
-  - [Pending] Retry API request
 
 ## context_contract
 {CONTEXT_CONTRACT}
@@ -918,24 +938,24 @@ fn post_compaction_snapshot_preserves_continuity() -> Result<()> {
     work_item.id = "work_compaction".into();
     work_item.blocked_by = Some("continuing after compaction".into());
     storage.append_work_item(&work_item)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         work_item.id.clone(),
         vec![
-            WorkPlanItem {
-                step: "Complete initial phase".into(),
-                status: WorkPlanStepStatus::Completed,
+            TodoItem {
+                text: "Complete initial phase".into(),
+                state: TodoItemState::Completed,
             },
-            WorkPlanItem {
-                step: "Work on expanded coverage".into(),
-                status: WorkPlanStepStatus::InProgress,
+            TodoItem {
+                text: "Work on expanded coverage".into(),
+                state: TodoItemState::InProgress,
             },
-            WorkPlanItem {
-                step: "Final verification".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Final verification".into(),
+                state: TodoItemState::Pending,
             },
         ],
-    ))?;
+    )?;
 
     let current_message = MessageEnvelope::new(
         "default",
@@ -960,7 +980,7 @@ fn post_compaction_snapshot_preserves_continuity() -> Result<()> {
     session.current_work_item_id = Some(work_item.id.clone());
     session.working_memory.current_working_memory = WorkingMemorySnapshot {
         current_work_item_id: Some(work_item.id.clone()),
-        delivery_target: Some(work_item.delivery_target.clone()),
+        objective: Some(work_item.objective.clone()),
         work_summary: Some("task spanning multiple compaction points".into()),
         current_plan: vec![
             "complete initial phase".into(),
@@ -992,7 +1012,7 @@ Agent id: default
 ## working_memory
 Working memory:
 - Current work item id: work_compaction
-- Delivery target: Long-running task with compaction
+- Objective: Long-running task with compaction
 - Work summary: task spanning multiple compaction points
 - Current plan:
   - complete initial phase
@@ -1013,12 +1033,13 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_compaction
 - State: Open
-- Delivery target: Long-running task with compaction
+- Objective: Long-running task with compaction
+- Plan state: Draft
+- Todo list:
+  - [completed] Complete initial phase
+  - [in_progress] Work on expanded coverage
+  - [pending] Final verification
 - Blocked by: continuing after compaction
-- Current work plan:
-  - [Completed] Complete initial phase
-  - [InProgress] Work on expanded coverage
-  - [Pending] Final verification
 
 ## context_contract
 {CONTEXT_CONTRACT}
@@ -1039,7 +1060,7 @@ fn task_result_with_multiple_work_items() -> Result<()> {
 
     // Create completed work item
     let mut completed_work =
-        WorkItemRecord::new("default", "Build task execution", WorkItemState::Done);
+        WorkItemRecord::new("default", "Build task execution", WorkItemState::Completed);
     completed_work.id = "work_build".into();
     storage.append_work_item(&completed_work)?;
 
@@ -1052,24 +1073,24 @@ fn task_result_with_multiple_work_items() -> Result<()> {
     active_work.id = "work_test".into();
     active_work.blocked_by = Some("awaiting test completion".into());
     storage.append_work_item(&active_work)?;
-    storage.append_work_plan(&WorkPlanSnapshot::new(
-        "default",
+    append_work_item_todo(
+        &storage,
         active_work.id.clone(),
         vec![
-            WorkPlanItem {
-                step: "Execute cargo test".into(),
-                status: WorkPlanStepStatus::Completed,
+            TodoItem {
+                text: "Execute cargo test".into(),
+                state: TodoItemState::Completed,
             },
-            WorkPlanItem {
-                step: "Verify test results".into(),
-                status: WorkPlanStepStatus::InProgress,
+            TodoItem {
+                text: "Verify test results".into(),
+                state: TodoItemState::InProgress,
             },
-            WorkPlanItem {
-                step: "Document any failures".into(),
-                status: WorkPlanStepStatus::Pending,
+            TodoItem {
+                text: "Document any failures".into(),
+                state: TodoItemState::Pending,
             },
         ],
-    ))?;
+    )?;
 
     let task_result = MessageEnvelope::new(
         "default",
@@ -1102,7 +1123,7 @@ fn task_result_with_multiple_work_items() -> Result<()> {
     session.current_work_item_id = Some(active_work.id.clone());
     session.working_memory.current_working_memory = WorkingMemorySnapshot {
         current_work_item_id: Some(active_work.id.clone()),
-        delivery_target: Some(active_work.delivery_target.clone()),
+        objective: Some(active_work.objective.clone()),
         work_summary: Some("run cargo test and verify results".into()),
         current_plan: vec![
             "execute cargo test".into(),
@@ -1135,7 +1156,7 @@ Agent id: default
 ## working_memory
 Working memory:
 - Current work item id: work_test
-- Delivery target: Test execution and verification
+- Objective: Test execution and verification
 - Work summary: run cargo test and verify results
 - Current plan:
   - execute cargo test
@@ -1157,12 +1178,13 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_test
 - State: Open
-- Delivery target: Test execution and verification
+- Objective: Test execution and verification
+- Plan state: Draft
+- Todo list:
+  - [completed] Execute cargo test
+  - [in_progress] Verify test results
+  - [pending] Document any failures
 - Blocked by: awaiting test completion
-- Current work plan:
-  - [Completed] Execute cargo test
-  - [InProgress] Verify test results
-  - [Pending] Document any failures
 
 ## context_contract
 {CONTEXT_CONTRACT}

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -236,8 +236,13 @@ async fn run_once_prefers_completed_work_item_delivery_summary_over_latest_turn_
     let host =
         RuntimeHost::new_with_provider(test_config(workspace_dir, home_dir), provider.clone())?;
     let runtime = host.default_runtime().await?;
-    let (work_item, _) = runtime
-        .create_work_item("cover prompt/context snapshots".into(), None)
+    let work_item = runtime
+        .create_work_item(
+            "cover prompt/context snapshots".into(),
+            None,
+            None,
+            Vec::new(),
+        )
         .await?;
     runtime.pick_work_item(work_item.id.clone()).await?;
     provider.set_work_item_id(work_item.id.clone()).await;

--- a/tests/support/http_callback.rs
+++ b/tests/support/http_callback.rs
@@ -22,8 +22,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageDeliverySurface,
-        MessageKind, MessageOrigin, OperatorDeliveryStatus, TrustLevel, WaitingIntentStatus,
-        WorkItemState, WorkPlanItem, WorkPlanStepStatus,
+        MessageKind, MessageOrigin, OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel,
+        WaitingIntentStatus, WorkItemState,
     },
 };
 use reqwest::Client;

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -23,8 +23,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TrustLevel, WaitingIntentStatus, WorkItemState, WorkPlanItem,
-        WorkPlanStepStatus,
+        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
+        WorkItemState,
     },
 };
 use reqwest::Client;

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -22,8 +22,8 @@ use holon::{
     types::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
-        MessageDeliverySurface, MessageKind, MessageOrigin, TrustLevel, WorkItemState,
-        WorkPlanItem, WorkPlanStepStatus,
+        MessageDeliverySurface, MessageKind, MessageOrigin, TodoItem, TodoItemState, TrustLevel,
+        WorkItemState,
     },
 };
 use reqwest::Client;
@@ -93,7 +93,7 @@ pub async fn agent_state_route_returns_aggregated_snapshot() -> Result<()> {
     assert!(state_payload["briefs_tail"].is_array());
     assert!(state_payload["timers"].is_array());
     assert!(state_payload["work_items"].is_array());
-    assert!(state_payload["work_plan"].is_null());
+    assert!(state_payload.get("work_plan").is_none());
     assert!(state_payload["waiting_intents"].is_array());
     assert!(state_payload["external_triggers"].is_array());
     assert!(state_payload["workspace"].is_object());
@@ -127,12 +127,16 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
     )
     .await?;
     runtime
-        .update_work_plan(
+        .update_work_item_fields(
             work_item.id.clone(),
-            vec![WorkPlanItem {
-                step: "expand /state".into(),
-                status: WorkPlanStepStatus::InProgress,
-            }],
+            None,
+            None,
+            None,
+            Some(vec![TodoItem {
+                text: "expand /state".into(),
+                state: TodoItemState::InProgress,
+            }]),
+            None,
         )
         .await?;
     runtime
@@ -159,7 +163,7 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
     assert!(
         runtime_work_items
             .iter()
-            .any(|item| item.id == work_item.id && item.state != WorkItemState::Done),
+            .any(|item| item.id == work_item.id && item.state != WorkItemState::Completed),
         "runtime work items missing expected bootstrap item: {:?}",
         runtime_work_items
     );
@@ -175,7 +179,7 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
             .as_array()
             .map(|items| items.iter().any(|item| {
                 item["id"] == serde_json::Value::String(work_item.id.clone())
-                    && item["state"] != serde_json::Value::String("done".into())
+                    && item["state"] != serde_json::Value::String("completed".into())
             }))
             .unwrap_or(false),
         "raw snapshot missing expected work item: {}",
@@ -195,12 +199,13 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
     assert!(snapshot
         .work_items
         .iter()
-        .any(|item| item.id == work_item.id && item.state != WorkItemState::Done));
+        .any(|item| item.id == work_item.id && item.state != WorkItemState::Completed));
     assert_eq!(
         snapshot
-            .work_plan
-            .as_ref()
-            .map(|plan| plan.work_item_id.clone()),
+            .work_items
+            .iter()
+            .find(|item| item.id == work_item.id)
+            .map(|item| item.id.clone()),
         Some(work_item.id.clone())
     );
     assert_eq!(snapshot.waiting_intents.len(), 1);

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -22,8 +22,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TrustLevel, WaitingIntentStatus, WorkItemState, WorkPlanItem,
-        WorkPlanStepStatus,
+        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
+        WorkItemState,
     },
 };
 use reqwest::Client;

--- a/tests/support/http_ingress.rs
+++ b/tests/support/http_ingress.rs
@@ -22,8 +22,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TrustLevel, WaitingIntentStatus, WorkItemState, WorkPlanItem,
-        WorkPlanStepStatus,
+        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
+        WorkItemState,
     },
 };
 use reqwest::Client;

--- a/tests/support/http_operator_ingress.rs
+++ b/tests/support/http_operator_ingress.rs
@@ -23,8 +23,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TrustLevel, WaitingIntentStatus, WorkItemState, WorkPlanItem,
-        WorkPlanStepStatus,
+        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
+        WorkItemState,
     },
 };
 use reqwest::Client;

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -22,8 +22,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TrustLevel, WaitingIntentStatus, WorkItemState, WorkPlanItem,
-        WorkPlanStepStatus,
+        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
+        WorkItemState,
     },
 };
 use reqwest::Client;
@@ -163,7 +163,7 @@ pub async fn create_work_item_route_persists_queued_item_without_message_ingress
     let response = client
         .post(format!("{base}/control/agents/default/work-items"))
         .json(&serde_json::json!({
-            "delivery_target": "follow up on queued runtime cleanup"
+            "objective": "follow up on queued runtime cleanup"
         }))
         .send()
         .await?;
@@ -171,10 +171,7 @@ pub async fn create_work_item_route_persists_queued_item_without_message_ingress
 
     let body: serde_json::Value = response.json().await?;
     assert_eq!(body["state"], "open");
-    assert_eq!(
-        body["delivery_target"],
-        "follow up on queued runtime cleanup"
-    );
+    assert_eq!(body["objective"], "follow up on queued runtime cleanup");
     let work_item_id = body["id"]
         .as_str()
         .expect("response should include work item id")
@@ -185,7 +182,7 @@ pub async fn create_work_item_route_persists_queued_item_without_message_ingress
         let item = runtime.storage().latest_work_item(&work_item_id)?;
         let events = runtime.storage().read_recent_events(200)?;
         Ok(item.is_some_and(|item| {
-            item.delivery_target == "follow up on queued runtime cleanup"
+            item.objective == "follow up on queued runtime cleanup"
                 && item.state == WorkItemState::Open
         }) && events.iter().any(|event| {
             event.kind == "work_item_enqueue_requested"
@@ -221,7 +218,7 @@ pub async fn create_work_item_route_does_not_replace_existing_active_item() -> R
     let response = client
         .post(format!("{base}/control/agents/default/work-items"))
         .json(&serde_json::json!({
-            "delivery_target": "queued follow-up after active work",
+            "objective": "queued follow-up after active work",
             "summary": "queued from route"
         }))
         .send()
@@ -234,7 +231,7 @@ pub async fn create_work_item_route_does_not_replace_existing_active_item() -> R
             .iter()
             .any(|item| item.id == active.id && item.state == WorkItemState::Open)
             && work_items.iter().any(|item| {
-                item.delivery_target == "queued follow-up after active work"
+                item.objective == "queued follow-up after active work"
                     && item.state == WorkItemState::Open
             }))
     })
@@ -244,14 +241,14 @@ pub async fn create_work_item_route_does_not_replace_existing_active_item() -> R
     Ok(())
 }
 
-pub async fn create_work_item_route_rejects_empty_delivery_target_with_bad_request() -> Result<()> {
+pub async fn create_work_item_route_rejects_empty_objective_with_bad_request() -> Result<()> {
     let (_host, base, server) = spawn_server().await?;
     let client = reqwest::Client::new();
 
     let response = client
         .post(format!("{base}/control/agents/default/work-items"))
         .json(&serde_json::json!({
-            "delivery_target": "   ",
+            "objective": "   ",
             "summary": "queued from control plane"
         }))
         .send()
@@ -260,7 +257,7 @@ pub async fn create_work_item_route_rejects_empty_delivery_target_with_bad_reque
 
     let body: serde_json::Value = response.json().await?;
     assert_eq!(body["ok"], false);
-    assert_eq!(body["error"], "delivery_target must not be empty");
+    assert_eq!(body["error"], "objective must not be empty");
 
     server.abort();
     Ok(())

--- a/tests/support/http_workspace.rs
+++ b/tests/support/http_workspace.rs
@@ -22,8 +22,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TrustLevel, WaitingIntentStatus, WorkItemState, WorkPlanItem,
-        WorkPlanStepStatus,
+        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
+        WorkItemState,
     },
 };
 use reqwest::Client;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -49,28 +49,30 @@ pub struct TestConfigBuilder {
 
 pub async fn test_work_item(
     runtime: &RuntimeHandle,
-    delivery_target: &str,
+    objective: &str,
     state: WorkItemState,
     current: bool,
     blocked_by: Option<&str>,
 ) -> Result<WorkItemRecord> {
-    let (mut record, _) = runtime
-        .create_work_item(delivery_target.to_string(), None)
+    let mut record = runtime
+        .create_work_item(objective.to_string(), None, None, Vec::new())
         .await?;
     if let Some(blocked_by) = blocked_by {
-        (record, _) = runtime
+        record = runtime
             .update_work_item_fields(
                 record.id.clone(),
                 None,
-                Some(Some(blocked_by.to_string())),
                 None,
+                None,
+                None,
+                Some(Some(blocked_by.to_string())),
             )
             .await?;
     }
     if current {
         runtime.pick_work_item(record.id.clone()).await?;
     }
-    if state == WorkItemState::Done {
+    if state == WorkItemState::Completed {
         record = runtime.complete_work_item(record.id.clone(), None).await?;
     }
     Ok(record)

--- a/tests/support/runtime_compaction.rs
+++ b/tests/support/runtime_compaction.rs
@@ -32,9 +32,9 @@ use holon::{
         FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationBoundary, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingIntentStatus, WaitingReason, WorkItemState,
-        WorkPlanItem, WorkPlanStepStatus,
+        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TodoItem, TodoItemState,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentStatus,
+        WaitingReason, WorkItemState,
     },
 };
 use serde_json::json;
@@ -81,18 +81,22 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
     )
     .await?;
     runtime
-        .update_work_plan(
+        .update_work_item_fields(
             active.id.clone(),
-            vec![
-                WorkPlanItem {
-                    step: "capture long-running survival case".into(),
-                    status: WorkPlanStepStatus::Completed,
+            None,
+            None,
+            None,
+            Some(vec![
+                TodoItem {
+                    text: "capture long-running survival case".into(),
+                    state: TodoItemState::Completed,
                 },
-                WorkPlanItem {
-                    step: "cover task rejoin after compaction".into(),
-                    status: WorkPlanStepStatus::InProgress,
+                TodoItem {
+                    text: "cover task rejoin after compaction".into(),
+                    state: TodoItemState::InProgress,
                 },
-            ],
+            ]),
+            None,
         )
         .await?;
 
@@ -115,7 +119,7 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
     let _completed = test_work_item(
         &runtime,
         "Already shipped shadow-state cleanup",
-        WorkItemState::Done,
+        WorkItemState::Completed,
         false,
         None,
     )
@@ -165,10 +169,10 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
         .expect("queued/blocked work section should be present after compaction");
     assert!(queued_blocked_section
         .content
-        .contains(queued.delivery_target.as_str()));
+        .contains(queued.objective.as_str()));
     assert!(queued_blocked_section
         .content
-        .contains(waiting.delivery_target.as_str()));
+        .contains(waiting.objective.as_str()));
     assert!(!queued_blocked_section
         .content
         .contains("Already shipped shadow-state cleanup"));
@@ -193,12 +197,16 @@ pub async fn task_result_rejoin_after_compaction_preserves_current_work_truth() 
     )
     .await?;
     runtime
-        .update_work_plan(
+        .update_work_item_fields(
             work_item.id.clone(),
-            vec![WorkPlanItem {
-                step: "verify task rejoin survives compaction".into(),
-                status: WorkPlanStepStatus::InProgress,
-            }],
+            None,
+            None,
+            None,
+            Some(vec![TodoItem {
+                text: "verify task rejoin survives compaction".into(),
+                state: TodoItemState::InProgress,
+            }]),
+            None,
         )
         .await?;
     for idx in 0..3 {
@@ -281,7 +289,7 @@ pub async fn task_result_rejoin_after_compaction_preserves_current_work_truth() 
         .await?
         .expect("current work item should still exist");
     assert_eq!(latest.state, WorkItemState::Open);
-    assert_eq!(latest.delivery_target, work_item.delivery_target);
+    assert_eq!(latest.objective, work_item.objective);
 
     Ok(())
 }
@@ -303,12 +311,16 @@ pub async fn contentful_wake_hint_after_compaction_keeps_active_work_truth() -> 
     )
     .await?;
     runtime
-        .update_work_plan(
+        .update_work_item_fields(
             active.id.clone(),
-            vec![WorkPlanItem {
-                step: "resume from contentful wake hint".into(),
-                status: WorkPlanStepStatus::InProgress,
-            }],
+            None,
+            None,
+            None,
+            Some(vec![TodoItem {
+                text: "resume from contentful wake hint".into(),
+                state: TodoItemState::InProgress,
+            }]),
+            None,
         )
         .await?;
     let queued = test_work_item(
@@ -418,12 +430,16 @@ pub async fn queued_notification_after_compaction_keeps_queued_work_visible() ->
     )
     .await?;
     runtime
-        .update_work_plan(
+        .update_work_item_fields(
             queued.id.clone(),
-            vec![WorkPlanItem {
-                step: "surface queued work after compaction".into(),
-                status: WorkPlanStepStatus::InProgress,
-            }],
+            None,
+            None,
+            None,
+            Some(vec![TodoItem {
+                text: "surface queued work after compaction".into(),
+                state: TodoItemState::InProgress,
+            }]),
+            None,
         )
         .await?;
     for idx in 0..3 {
@@ -724,8 +740,8 @@ pub async fn max_output_recovery_followed_by_turn_local_compaction_preserves_pro
     assert!(
         checkpoint_request
             .user_text_snapshot
-            .contains("current work plan state"),
-        "progress checkpoint should include work-plan continuity"
+            .contains("current work item objective, plan_status, plan, and todo_list state"),
+        "progress checkpoint should include work-item plan continuity"
     );
     assert!(
         checkpoint_request

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -32,9 +32,9 @@ use holon::{
         FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationBoundary, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingIntentStatus, WaitingReason, WorkItemState,
-        WorkPlanItem, WorkPlanStepStatus,
+        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TodoItem, TodoItemState,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentStatus,
+        WaitingReason, WorkItemState,
     },
 };
 use serde_json::json;

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -32,9 +32,9 @@ use holon::{
         FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationBoundary, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingIntentStatus, WaitingReason, WorkItemState,
-        WorkPlanItem, WorkPlanStepStatus,
+        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TodoItem, TodoItemState,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentStatus,
+        WaitingReason, WorkItemState,
     },
 };
 use serde_json::json;

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -32,9 +32,9 @@ use holon::{
         FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationBoundary, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingIntentStatus, WaitingReason, WorkItemState,
-        WorkPlanItem, WorkPlanStepStatus,
+        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TodoItem, TodoItemState,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentStatus,
+        WaitingReason, WorkItemState,
     },
 };
 use serde_json::json;
@@ -231,17 +231,24 @@ pub async fn update_work_item_creates_and_updates_persisted_snapshot() -> Result
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
     let runtime = host.default_runtime().await?;
 
-    let (created, _) = runtime
-        .create_work_item("Ship work-item runtime foundation".into(), None)
+    let created = runtime
+        .create_work_item(
+            "Ship work-item runtime foundation".into(),
+            None,
+            None,
+            Vec::new(),
+        )
         .await?;
     assert!(created.id.starts_with("work_"));
 
-    let (updated, _) = runtime
+    let updated = runtime
         .update_work_item_fields(
             created.id.clone(),
             None,
-            Some(Some("queued follow-up after CI".into())),
             None,
+            None,
+            None,
+            Some(Some("queued follow-up after CI".into())),
         )
         .await?;
 
@@ -262,8 +269,13 @@ pub async fn update_work_item_replaces_latest_plan_snapshot_for_existing_work_it
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
     let runtime = host.default_runtime().await?;
 
-    let (work_item, _) = runtime
-        .create_work_item("Stabilize work plan projection".into(), None)
+    let work_item = runtime
+        .create_work_item(
+            "Stabilize work item todo projection".into(),
+            None,
+            None,
+            Vec::new(),
+        )
         .await?;
 
     runtime
@@ -271,42 +283,45 @@ pub async fn update_work_item_replaces_latest_plan_snapshot_for_existing_work_it
             work_item.id.clone(),
             None,
             None,
-            Some(vec![WorkPlanItem {
-                step: "persist work-item store".into(),
-                status: WorkPlanStepStatus::Completed,
+            None,
+            Some(vec![TodoItem {
+                text: "persist work-item store".into(),
+                state: TodoItemState::Completed,
             }]),
+            None,
         )
         .await?;
 
-    let (_, updated_plan) = runtime
+    let updated = runtime
         .update_work_item_fields(
             work_item.id.clone(),
             None,
             None,
+            None,
             Some(vec![
-                WorkPlanItem {
-                    step: "persist work-item store".into(),
-                    status: WorkPlanStepStatus::Completed,
+                TodoItem {
+                    text: "persist work-item store".into(),
+                    state: TodoItemState::Completed,
                 },
-                WorkPlanItem {
-                    step: "project work queue into prompt".into(),
-                    status: WorkPlanStepStatus::InProgress,
+                TodoItem {
+                    text: "project work queue into prompt".into(),
+                    state: TodoItemState::InProgress,
                 },
             ]),
+            None,
         )
         .await?;
-    let updated_plan = updated_plan.expect("expected plan snapshot");
 
-    let latest = runtime.latest_work_plan(&work_item.id).await?.unwrap();
-    assert_eq!(latest.items.len(), 2);
+    let latest = runtime.latest_work_item(&work_item.id).await?.unwrap();
+    assert_eq!(latest.todo_list.len(), 2);
     assert_eq!(
-        latest.items[1],
-        WorkPlanItem {
-            step: "project work queue into prompt".into(),
-            status: WorkPlanStepStatus::InProgress,
+        latest.todo_list[1],
+        TodoItem {
+            text: "project work queue into prompt".into(),
+            state: TodoItemState::InProgress,
         }
     );
-    assert_eq!(latest.created_at, updated_plan.created_at);
+    assert_eq!(latest.updated_at, updated.updated_at);
     Ok(())
 }
 
@@ -880,8 +895,8 @@ pub async fn callback_tools_register_and_revoke_waiting_state() -> Result<()> {
     let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
     let runtime = host.default_runtime().await?;
     let registry = ToolRegistry::new(runtime.workspace_root());
-    let (work_item, _) = runtime
-        .create_work_item("wait for CI callback".into(), None)
+    let work_item = runtime
+        .create_work_item("wait for CI callback".into(), None, None, Vec::new())
         .await?;
     runtime.pick_work_item(work_item.id).await?;
 

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -32,9 +32,9 @@ use holon::{
         FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationBoundary, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingIntentStatus, WaitingReason, WorkItemState,
-        WorkPlanItem, WorkPlanStepStatus,
+        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TodoItem, TodoItemState,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentStatus,
+        WaitingReason, WorkItemState,
     },
 };
 use serde_json::json;
@@ -940,7 +940,7 @@ pub async fn worktree_subagent_task_auto_removes_worktree_when_no_changes_wt104(
     };
     assert!(
         task_result_text.contains("Worktree cleanup: auto-removed clean task-owned artifact."),
-        "task result should report cleanup status: {task_result_text}"
+        "task result should report cleanup state: {task_result_text}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- Align WorkItem with the new RFC model: `objective`, `plan_status`, durable `plan`, embedded `todo_list`, and `open/completed` lifecycle.
- Remove the separate WorkPlan snapshot stream and update runtime storage, HTTP/client/TUI projections, work-item tools, prompt guidance, and memory/context rendering.
- Update tests and snapshots for the new objective/plan/todo_list surface.

Closes #874

## Verification
- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test work_items --lib`
- `cargo test --test prompt_context_snapshots`
- `cargo test --lib test_work_item_`
