### PR TITLE
Fix work item continuity reminders

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1618,9 +1618,15 @@ progress reminder when many consecutive provider rounds complete without a
 successful `CreateWorkItem`, `PickWorkItem`, `UpdateWorkItem`, or
 `CompleteWorkItem` call. The reminder is derived from the current
 `WorkItemRecord` objective, plan_status, plan, todo_list, and blocker state. It
-does not mark progress by itself and should only ask the model to update work
-state when material progress, scope changes, blockers, or completed checklist
-items actually emerged.
+is bounded before injection, omits completed todo items from the reminder
+snapshot, and is skipped if it would make the continuation baseline exceed the
+prompt budget. It does not mark progress by itself and should only ask the
+model to update work state when material progress, scope changes, blockers, or
+completed checklist items actually emerged. The default reminder threshold,
+cooldown, and max reminder token budget are env-tunable through
+`HOLON_WORK_ITEM_STALE_REMINDER_ROUNDS`,
+`HOLON_WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS`, and
+`HOLON_WORK_ITEM_STALE_REMINDER_MAX_TOKENS`.
 
 ### Control-Plane Work-Item Enqueue
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1613,6 +1613,15 @@ work-item mutation may invalidate turn-local checkpoint state because the
 runtime focus changed, but failed tool inputs and `ExecCommand` calls do not
 invalidate checkpoint anchors by command-name heuristics.
 
+During a long provider turn, the runtime may inject a provider-only work-item
+progress reminder when many consecutive provider rounds complete without a
+successful `CreateWorkItem`, `PickWorkItem`, `UpdateWorkItem`, or
+`CompleteWorkItem` call. The reminder is derived from the current
+`WorkItemRecord` objective, plan_status, plan, todo_list, and blocker state. It
+does not mark progress by itself and should only ask the model to update work
+state when material progress, scope changes, blockers, or completed checklist
+items actually emerged.
+
 ### Control-Plane Work-Item Enqueue
 
 The runtime also exposes a control-plane enqueue path for future work items:

--- a/docs/single-agent-context-compression.md
+++ b/docs/single-agent-context-compression.md
@@ -25,7 +25,7 @@ Holon already has a good foundation for this problem.
 Relevant current behavior:
 
 - `src/storage.rs` keeps durable append-only logs for messages, briefs, tools,
-  transcript, tasks, timers, work items, and work plans.
+  transcript, tasks, timers, and work items.
 - `src/context.rs` builds model-visible context from recent messages, recent
   briefs, recent tool executions, work queue state, worktree state,
   `context_summary`, and the current input/continuation contract.
@@ -194,7 +194,6 @@ This is the existing append-only store:
 - transcript
 - tasks
 - work items
-- work plans
 
 This is the truth source. It is not prompt-bounded. It is not compacted away.
 
@@ -205,7 +204,7 @@ This is the smallest and most volatile layer. It should include:
 - current input
 - continuation context
 - active work item
-- active work plan
+- active work item plan and todo_list
 - latest result brief
 - most recent message tail
 - most recent tool-result tail
@@ -221,12 +220,12 @@ agent in this session.
 
 Suggested fields:
 
-- active delivery target
+- active work item objective
 - active work summary
 - scope hints and completion hints
 - active workspace/worktree snapshot
 - important open threads
-- current plan / next checkpoints
+- durable plan and todo_list
 - working set files
 - important recent decisions
 - most recent verified outcome
@@ -241,7 +240,7 @@ Older history should be grouped into immutable episode summaries.
 
 An episode is not "N messages". It is a meaningful work chunk, for example:
 
-- one active work item or delivery-target phase
+- one active work item or objective phase
 - one debug/fix cycle
 - one analysis chunk
 - one background-task coordination interval
@@ -253,7 +252,7 @@ Each episode summary should capture:
 - covered turn range
 - covered message range
 - active work item id at the time
-- delivery target / work summary at the time
+- objective / work summary at the time
 - scope hints at the time
 - key files touched
 - key commands / verification
@@ -332,10 +331,14 @@ Working memory:
 - Scope hints:
   - benchmark passes and output format remains unchanged
   - do not redesign the internal metric model
-- Current plan:
-  - isolate the failing export path
-  - patch the zero-value handling
-  - rerun focused verification
+- Plan:
+  isolate the failing export path
+  patch the zero-value handling
+  rerun focused verification
+- Todo list:
+  - [completed] isolate the failing export path
+  - [in_progress] patch the zero-value handling
+  - [pending] rerun focused verification
 - Working set files:
   - src/benchmark/report.rs
   - tests/metrics_export.rs
@@ -419,7 +422,7 @@ Suggested prompt shape:
 ```text
 Active episode checkpoint:
 - Started at turn: 41
-- Current delivery target: fix flaky benchmark failure in metrics export
+- Current objective: fix flaky benchmark failure in metrics export
 - Scope hints:
   - keep output format unchanged
 - Working set files:
@@ -531,7 +534,8 @@ pub struct WorkingMemorySnapshot {
     pub objective: Option<String>,
     pub work_summary: Option<String>,
     pub scope_hints: Vec<String>,
-    pub current_plan: Vec<String>,
+    pub plan: Option<String>,
+    pub todo_list: Vec<TodoItem>,
     pub working_set_files: Vec<String>,
     pub recent_decisions: Vec<String>,
     pub pending_followups: Vec<String>,
@@ -582,7 +586,8 @@ from durable evidence:
 pub struct TurnMemoryDelta {
     pub turn_index: u64,
     pub active_work_changed: bool,
-    pub work_plan_changed: bool,
+    pub plan_changed: bool,
+    pub todo_list_changed: bool,
     pub scope_hints_changed: bool,
     pub touched_files: Vec<String>,
     pub commands: Vec<String>,
@@ -623,7 +628,7 @@ After every terminal interactive turn:
 Episode finalization boundaries should include:
 
 - active work item switch
-- delivery target changed materially
+- objective changed materially
 - strong scope-hint change
 - completed result with a meaningful state transition
 - explicit long wait / sleep boundary
@@ -639,13 +644,14 @@ state, not free-authored by the model.
 Recommended source mapping:
 
 - `active_work_item_id`: active work item id when one exists
-- `objective`: active work item delivery target
+- `objective`: active work item objective
 - `work_summary`: active work item summary
 - `scope_hints`: bounded extraction from trusted operator prompts, active work
   progress, and recent result briefs; prefer evidence bound to the current
   active work item and only fall back to legacy unbound records when no
   active-work-bound evidence exists
-- `current_plan`: active work plan items that are not completed
+- `plan`: active work item durable prose plan
+- `todo_list`: active work item structured checklist snapshot
 - `working_set_files`: recent `ApplyPatch`, relevant
   `read_file`, and file-oriented tool arguments, using the same active-work
   binding preference and legacy-unbound fallback
@@ -747,7 +753,7 @@ Recommended sources:
 
 - current message for `current_input`
 - continuation resolution for `continuation_context`
-- active work item and work plan for work coordination sections
+- active work item, plan, and todo_list for work coordination sections
 - latest result brief for immediate follow-up grounding
 - recent messages for short conversation continuity
 - recent tool executions for concrete recent evidence
@@ -798,7 +804,7 @@ Episode extraction should use existing durable evidence, especially:
   verification evidence
 - `agent_home/.holon/ledger/transcript.jsonl` for assistant round boundaries,
   continuation prompts, and rejoin/wake signals
-- active work item, work plan, and waiting intent state for semantic phase
+- active work item, plan, todo_list, and waiting intent state for semantic phase
   changes
 
 This is deliberately different from "take old prompt text and summarize it."
@@ -811,7 +817,7 @@ That builder accumulates:
 
 - covered turn range
 - active work item snapshot
-- delivery target / work summary snapshot
+- objective / work summary snapshot
 - scope hints snapshot
 - touched files
 - commands
@@ -831,7 +837,7 @@ Episode boundaries should be semantic, not purely count-based.
 Recommended first-pass boundary reasons:
 
 - active work item switched
-- delivery target changed materially
+- objective changed materially
 - scope hints changed materially
 - meaningful terminal result checkpoint
 - entered waiting or sleep state

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,6 +4,7 @@ use crate::{
     prompt::{PromptSection, PromptStability},
     storage::AppStorage,
     system::{execution_policy_summary_lines, ExecutionSnapshot},
+    tool::helpers::truncate_text,
     types::{
         AdmissionContext, AgentState, AuthorityClass, BriefRecord, ContextEpisodeRecord,
         ContinuationClass, ContinuationResolution, MessageBody, MessageDeliverySurface,
@@ -538,18 +539,30 @@ fn render_working_memory(snapshot: &WorkingMemorySnapshot) -> String {
     }
     if let Some(plan) = snapshot.plan.as_deref() {
         lines.push("- Plan:".to_string());
-        lines.extend(plan.lines().map(|line| format!("  {line}")));
+        lines.push(format!(
+            "  {}",
+            truncate_text(&plan.replace('\n', " "), 160)
+        ));
     }
     if !snapshot.todo_list.is_empty() {
         lines.push("- Todo list:".to_string());
-        lines.extend(snapshot.todo_list.iter().map(|item| {
-            let state = match item.state {
-                TodoItemState::Pending => "pending",
-                TodoItemState::InProgress => "in_progress",
-                TodoItemState::Completed => "completed",
-            };
-            format!("  - [{state}] {}", item.text)
-        }));
+        let active_items = snapshot
+            .todo_list
+            .iter()
+            .filter(|item| item.state != TodoItemState::Completed)
+            .take(3);
+        lines.extend(active_items.map(|item| format!("  - {}", render_todo_item_compact(item))));
+        let omitted = snapshot
+            .todo_list
+            .iter()
+            .filter(|item| item.state != TodoItemState::Completed)
+            .skip(3)
+            .count();
+        if omitted > 0 {
+            lines.push(format!(
+                "  - ... {omitted} more active todo item(s) omitted"
+            ));
+        }
     }
     if !snapshot.working_set_files.is_empty() {
         lines.push("- Working set files:".to_string());
@@ -579,6 +592,15 @@ fn render_working_memory(snapshot: &WorkingMemorySnapshot) -> String {
         );
     }
     lines.join("\n")
+}
+
+fn render_todo_item_compact(item: &crate::types::TodoItem) -> String {
+    let state = match item.state {
+        TodoItemState::Pending => "pending",
+        TodoItemState::InProgress => "in_progress",
+        TodoItemState::Completed => "completed",
+    };
+    format!("[{state}] {}", truncate_text(&item.text, 120))
 }
 
 fn render_working_memory_delta_with_budget(

--- a/src/context.rs
+++ b/src/context.rs
@@ -482,7 +482,10 @@ fn render_current_work_item(work_item: &WorkItemRecord) -> String {
         format!("- Id: {}", work_item.id),
         format!("- State: {:?}", work_item.state),
         format!("- Objective: {}", work_item.objective),
-        format!("- Plan state: {:?}", work_item.plan_status),
+        format!(
+            "- Plan status: {}",
+            work_item_plan_status_label(work_item.plan_status)
+        ),
     ];
     if let Some(plan) = work_item.plan.as_deref() {
         lines.push("- Plan:".to_string());
@@ -503,6 +506,14 @@ fn render_current_work_item(work_item: &WorkItemRecord) -> String {
         lines.push(format!("- Blocked by: {blocked_by}"));
     }
     lines.join("\n")
+}
+
+fn work_item_plan_status_label(status: crate::types::WorkItemPlanStatus) -> &'static str {
+    match status {
+        crate::types::WorkItemPlanStatus::Draft => "draft",
+        crate::types::WorkItemPlanStatus::Ready => "ready",
+        crate::types::WorkItemPlanStatus::NeedsInput => "needs_input",
+    }
 }
 
 fn render_queued_blocked_work_items(items: &[&WorkItemRecord]) -> String {

--- a/src/context.rs
+++ b/src/context.rs
@@ -536,14 +536,20 @@ fn render_working_memory(snapshot: &WorkingMemorySnapshot) -> String {
     if let Some(work_summary) = snapshot.work_summary.as_deref() {
         lines.push(format!("- Work summary: {work_summary}"));
     }
-    if !snapshot.current_plan.is_empty() {
-        lines.push("- Current plan:".to_string());
-        lines.extend(
-            snapshot
-                .current_plan
-                .iter()
-                .map(|step| format!("  - {step}")),
-        );
+    if let Some(plan) = snapshot.plan.as_deref() {
+        lines.push("- Plan:".to_string());
+        lines.extend(plan.lines().map(|line| format!("  {line}")));
+    }
+    if !snapshot.todo_list.is_empty() {
+        lines.push("- Todo list:".to_string());
+        lines.extend(snapshot.todo_list.iter().map(|item| {
+            let state = match item.state {
+                TodoItemState::Pending => "pending",
+                TodoItemState::InProgress => "in_progress",
+                TodoItemState::Completed => "completed",
+            };
+            format!("  - [{state}] {}", item.text)
+        }));
     }
     if !snapshot.working_set_files.is_empty() {
         lines.push("- Working set files:".to_string());
@@ -1351,7 +1357,7 @@ mod tests {
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
             objective: Some("ship working memory".into()),
-            current_plan: vec!["[InProgress] keep cache identity stable".into()],
+            plan: Some(vec!["[InProgress] keep cache identity stable"].join("\n")),
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.compression_epoch = 7;
@@ -1398,7 +1404,7 @@ mod tests {
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
             objective: Some("ship working memory".into()),
-            current_plan: vec!["[InProgress] keep cache identity stable".into()],
+            plan: Some(vec!["[InProgress] keep cache identity stable"].join("\n")),
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.working_memory_revision = 3;
@@ -1821,7 +1827,7 @@ mod tests {
         session.context_summary = Some("legacy summary".into());
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
             objective: Some("ship working memory".into()),
-            current_plan: vec!["[InProgress] wire post-turn refresh".into()],
+            plan: Some(vec!["[InProgress] wire post-turn refresh"].join("\n")),
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
@@ -1829,8 +1835,8 @@ mod tests {
             to_revision: 1,
             created_at_turn: 1,
             reason: crate::types::WorkingMemoryUpdateReason::TerminalTurnCompleted,
-            changed_fields: vec!["current_plan".into()],
-            summary_lines: vec!["updated current plan: [InProgress] wire post-turn refresh".into()],
+            changed_fields: vec!["plan".into()],
+            summary_lines: vec!["updated plan: [InProgress] wire post-turn refresh".into()],
         });
 
         let built = build_context(
@@ -2748,7 +2754,7 @@ mod tests {
             current_work_item_id: Some(active.id.clone()),
             objective: Some(active.objective.clone()),
             work_summary: Some("wake path patching".into()),
-            current_plan: vec!["finish wake-path regression".into()],
+            plan: Some(vec!["finish wake-path regression"].join("\n")),
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
@@ -2756,8 +2762,8 @@ mod tests {
             to_revision: 2,
             created_at_turn: 2,
             reason: crate::types::WorkingMemoryUpdateReason::TerminalTurnCompleted,
-            changed_fields: vec!["current_plan".into()],
-            summary_lines: vec!["updated current plan: finish wake-path regression".into()],
+            changed_fields: vec!["plan".into()],
+            summary_lines: vec!["updated plan: finish wake-path regression".into()],
         });
 
         let built = build_context(
@@ -2859,7 +2865,7 @@ mod tests {
         let mut session = AgentState::new("default");
         session.working_memory.current_working_memory = WorkingMemorySnapshot {
             objective: Some("ship the prompt delta gating fix".into()),
-            current_plan: vec!["[InProgress] wire prompt render acknowledgement".into()],
+            plan: Some(vec!["[InProgress] wire prompt render acknowledgement"].join("\n")),
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
@@ -2867,9 +2873,9 @@ mod tests {
             to_revision: 5,
             created_at_turn: 7,
             reason: crate::types::WorkingMemoryUpdateReason::TerminalTurnCompleted,
-            changed_fields: vec!["current_plan".into()],
+            changed_fields: vec!["plan".into()],
             summary_lines: vec![
-                "updated the current plan with a long-form explanation of why prompt rendering acknowledgement must happen after budgeted assembly rather than before prompt construction".into(),
+                "updated the plan with a long-form explanation of why prompt rendering acknowledgement must happen after budgeted assembly rather than before prompt construction".into(),
                 "recorded the continuity decision that pending deltas stay durable across turns until the model actually sees the delta section in a rendered prompt".into(),
                 "captured low-budget prompt coverage for the interactive runtime path that previously cleared the delta too early".into(),
             ],
@@ -3023,10 +3029,13 @@ mod tests {
                 "scope hint one repeats enough text to force truncation".repeat(8),
                 "scope hint two repeats enough text to force truncation".repeat(8),
             ],
-            current_plan: vec![
-                "inspect pre-turn sections for hard budget compliance".repeat(8),
-                "retain current input after oversized section truncation".repeat(8),
-            ],
+            plan: Some(
+                vec![
+                    "inspect pre-turn sections for hard budget compliance".repeat(8),
+                    "retain current input after oversized section truncation".repeat(8),
+                ]
+                .join("\n"),
+            ),
             working_set_files: vec![
                 "src/context.rs".repeat(12),
                 "src/runtime/message_dispatch.rs".repeat(12),

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -7,8 +7,9 @@ use crate::{
     storage::AppStorage,
     types::{
         AgentState, AuditEvent, ClosureDecision, ExternalTriggerScope, MessageEnvelope,
-        MessageKind, TodoItemState, ToolExecutionRecord, TurnMemoryDelta, WaitingIntentStatus,
-        WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot, WorkingMemoryUpdateReason,
+        MessageKind, TodoItem, TodoItemState, ToolExecutionRecord, TurnMemoryDelta,
+        WaitingIntentStatus, WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot,
+        WorkingMemoryUpdateReason,
     },
 };
 
@@ -153,9 +154,9 @@ pub fn derive_working_memory_snapshot(
     let memory_tools = collect_memory_tools(&recent_tools, current_work_item_id);
 
     let work_summary = current_work_item.map(|item| item.objective.clone());
-    let current_plan = current_work_item
-        .as_ref()
-        .map(|item| render_current_plan(item))
+    let plan = current_work_item.and_then(|item| item.plan.clone());
+    let todo_list = current_work_item
+        .map(|item| item.todo_list.clone())
         .unwrap_or_default();
     let queued_waiting_followups = projection
         .queued_blocked
@@ -171,7 +172,8 @@ pub fn derive_working_memory_snapshot(
         current_work_item_id: current_work_item.map(|item| item.id.clone()),
         objective: current_work_item.map(|item| item.objective.clone()),
         work_summary,
-        current_plan,
+        plan,
+        todo_list,
         working_set_files,
         pending_followups,
         waiting_on,
@@ -242,7 +244,8 @@ fn derive_turn_memory_delta(
         active_work_changed: previous.current_work_item_id != next.current_work_item_id
             || previous.objective != next.objective
             || previous.work_summary != next.work_summary,
-        current_plan_changed: previous.current_plan != next.current_plan,
+        plan_changed: previous.plan != next.plan,
+        todo_list_changed: previous.todo_list != next.todo_list,
         scope_hints_changed: false,
         touched_files: diff_list(&previous.working_set_files, &next.working_set_files),
         commands,
@@ -287,13 +290,19 @@ fn derive_working_memory_delta(
         next.work_summary.as_deref(),
         "work summary",
     );
-    push_changed_vec(
+    push_changed_field(
         &mut changed_fields,
         &mut summary_lines,
-        "current_plan",
-        &previous.current_plan,
-        &next.current_plan,
-        "current plan",
+        "plan",
+        previous.plan.as_deref(),
+        next.plan.as_deref(),
+        "plan",
+    );
+    push_changed_todo_list(
+        &mut changed_fields,
+        &mut summary_lines,
+        &previous.todo_list,
+        &next.todo_list,
     );
     push_changed_vec(
         &mut changed_fields,
@@ -365,27 +374,6 @@ fn merge_pending_delta(
             MEMORY_SUMMARY_LINE_LIMIT,
         ),
     }
-}
-
-fn render_current_plan(plan: &WorkItemRecord) -> Vec<String> {
-    let mut lines = Vec::new();
-    if let Some(plan_text) = plan.plan.as_deref() {
-        lines.extend(
-            plan_text
-                .lines()
-                .map(str::trim)
-                .filter(|line| !line.is_empty())
-                .map(ToString::to_string)
-                .take(MEMORY_PLAN_LIMIT),
-        );
-    }
-    lines.extend(
-        plan.todo_list
-            .iter()
-            .filter(|item| item.state != TodoItemState::Completed)
-            .map(|item| format!("[{:?}] {}", item.state, item.text)),
-    );
-    limit_vec(lines, MEMORY_PLAN_LIMIT)
 }
 
 fn collect_pending_followups(
@@ -686,6 +674,44 @@ fn push_changed_vec(
     }
 }
 
+fn push_changed_todo_list(
+    changed_fields: &mut Vec<String>,
+    summary_lines: &mut Vec<String>,
+    previous: &[TodoItem],
+    next: &[TodoItem],
+) {
+    if previous == next {
+        return;
+    }
+    changed_fields.push("todo_list".to_string());
+    if next.is_empty() {
+        summary_lines.push("cleared todo list".to_string());
+    } else {
+        summary_lines.push(format!(
+            "updated todo list: {}",
+            truncate_line(&render_todo_list_summary(next).join("; "), 120)
+        ));
+    }
+}
+
+fn render_todo_list_summary(items: &[TodoItem]) -> Vec<String> {
+    limit_vec(
+        items
+            .iter()
+            .map(|item| format!("[{}] {}", todo_state_label(item.state), item.text))
+            .collect(),
+        MEMORY_PLAN_LIMIT,
+    )
+}
+
+fn todo_state_label(state: TodoItemState) -> &'static str {
+    match state {
+        TodoItemState::Pending => "pending",
+        TodoItemState::InProgress => "in_progress",
+        TodoItemState::Completed => "completed",
+    }
+}
+
 fn format_waiting_reason(reason: crate::types::WaitingReason) -> &'static str {
     match reason {
         crate::types::WaitingReason::AwaitingOperatorInput => "awaiting operator input",
@@ -861,10 +887,14 @@ mod tests {
             snapshot.current_work_item_id.as_deref(),
             Some(active.id.as_str())
         );
+        assert_eq!(
+            snapshot.plan.as_deref(),
+            Some("Patch exporter and run focused test.")
+        );
         assert!(snapshot
-            .current_plan
+            .todo_list
             .iter()
-            .any(|item| item.contains("patch exporter")));
+            .any(|item| item.text.contains("patch exporter")));
         assert!(snapshot
             .working_set_files
             .contains(&"src/export.rs".to_string()));

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -71,7 +71,7 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_work_item_write",
             PromptStability::Stable,
-            "Use CreateWorkItem to create a new open objective only for genuinely separate work, PickWorkItem to make an existing open item current, UpdateWorkItem to refine objective, plan_status, plan, todo_list, and/or blocked_by, and CompleteWorkItem only when the objective is actually complete. If the current task is not just a brief answer and there is no current work item yet, clarify the objective with the operator if it is still ambiguous; if bounded inspection is needed to make the objective concrete, do that inspection before creating the work item. Do not create a new WorkItem just to refine or narrow the current objective; if the current WorkItem is still the same underlying task, update its objective, plan, and todo_list with UpdateWorkItem. If an old WorkItem should be replaced, complete it first or explicitly PickWorkItem for the intended item before creating genuinely independent work. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, maintain plan as durable prose and todo_list as the full current checklist snapshot rather than patching individual items. Update plan_status or todo_list after material progress such as a code change, verification result, blocker discovery, or completed inspection objective; if the next known action is a file mutation, use ApplyPatch first and update the work item afterward. Work-item updates are coordination/bookkeeping and do not replace file mutation, verification, PR/issue updates, final delivery, or other artifact progress. If the current item remains open because progress is blocked, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Complete explicitly when complete.".to_string(),
+            "Use CreateWorkItem to create a new open objective only for genuinely separate work, PickWorkItem to make an existing open item current, UpdateWorkItem to refine objective, plan_status, plan, todo_list, and/or blocked_by, and CompleteWorkItem only when the objective is actually complete. If the current task is not just a brief answer and there is no current work item yet, clarify the objective with the operator if it is still ambiguous; if bounded inspection is needed to make the objective concrete, do that inspection, then create or refresh the work item once the objective is stable enough to name. Do not create a new WorkItem just to refine or narrow the current objective; if the current WorkItem is still the same underlying task, update its objective, plan, and todo_list with UpdateWorkItem. If an old WorkItem should be replaced, complete it first or explicitly PickWorkItem for the intended item before creating genuinely independent work. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, maintain plan as durable prose and todo_list as the full current checklist snapshot rather than patching individual items. Before nontrivial file mutation or other high-commitment action, make sure the current work item has a durable plan and set plan_status=ready once the plan is stable; if task interpretation, scope, or acceptance changes, update objective or plan before continuing. Update todo_list after material progress such as a code change, verification result, blocker discovery, or completed inspection objective. Work-item updates are coordination/bookkeeping and do not replace file mutation, verification, PR/issue updates, final delivery, or other artifact progress. If the current item remains open because progress is blocked, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Complete explicitly when complete; when using result_summary, include the result and any verification performed or why verification was not applicable.".to_string(),
         ));
     }
     if names.contains(&"GetWorkItem") || names.contains(&"ListWorkItems") {
@@ -296,13 +296,18 @@ mod tests {
         assert!(section
             .content
             .contains("update its objective, plan, and todo_list"));
+        assert!(section.content.contains("plan_status=ready"));
         assert!(section
             .content
-            .contains("Update plan_status or todo_list after material progress"));
+            .contains("update objective or plan before continuing"));
         assert!(section
+            .content
+            .contains("Update todo_list after material progress"));
+        assert!(!section
             .content
             .contains("use ApplyPatch first and update the work item afterward"));
         assert!(section.content.contains("coordination/bookkeeping"));
+        assert!(section.content.contains("result_summary"));
         assert!(section.content.contains("specific blocker or missing fact"));
         assert!(section
             .content

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -926,7 +926,7 @@ async fn interactive_turn_keeps_pending_working_memory_delta_when_prompt_omits_i
         let mut guard = runtime.inner.agent.lock().await;
         guard.state.working_memory.current_working_memory = crate::types::WorkingMemorySnapshot {
             objective: Some("ship the prompt delta gating fix".into()),
-            current_plan: vec!["[InProgress] wire prompt render acknowledgement".into()],
+            plan: Some(vec!["[InProgress] wire prompt render acknowledgement"].join("\n")),
             ..crate::types::WorkingMemorySnapshot::default()
         };
         guard.state.working_memory.working_memory_revision = 5;
@@ -936,9 +936,9 @@ async fn interactive_turn_keeps_pending_working_memory_delta_when_prompt_omits_i
                 to_revision: 5,
                 created_at_turn: 7,
                 reason: crate::types::WorkingMemoryUpdateReason::TerminalTurnCompleted,
-                changed_fields: vec!["current_plan".into()],
+                changed_fields: vec!["plan".into()],
                 summary_lines: vec![
-                    "updated the current plan with a long-form explanation of why prompt rendering acknowledgement must happen after budgeted assembly rather than before prompt construction".into(),
+                    "updated the plan with a long-form explanation of why prompt rendering acknowledgement must happen after budgeted assembly rather than before prompt construction".into(),
                     "recorded the continuity decision that pending deltas stay durable across turns until the model actually sees the delta section in a rendered prompt".into(),
                     "captured low-budget prompt coverage for the interactive runtime path that previously cleared the delta too early".into(),
                 ],

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -20,8 +20,9 @@ use crate::{
         ToolCall, ToolError, ToolSpec,
     },
     types::{
-        AuditEvent, TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel,
-        TurnTerminalCheckpointRecord, TurnTerminalKind, TurnTerminalRecord,
+        AuditEvent, TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        TurnTerminalCheckpointRecord, TurnTerminalKind, TurnTerminalRecord, WorkItemPlanStatus,
+        WorkItemRecord,
     },
 };
 
@@ -43,6 +44,8 @@ const ROUND_TEXT_PREVIEW_LIMIT: usize = 600;
 const RECAP_TEXT_PREVIEW_LIMIT: usize = 160;
 const MIN_EXACT_TAIL_ROUNDS: usize = 2;
 const CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS: usize = 256;
+const WORK_ITEM_STALE_REMINDER_ROUNDS: usize = 10;
+const WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS: usize = 10;
 const COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT: &str = "\
 [Runtime-generated full progress checkpoint request]
 You are crossing a context compaction boundary. Before continuing, include a concise progress checkpoint for continuation in your next assistant message.
@@ -654,6 +657,70 @@ fn round_invalidates_checkpoint_anchor(round: &TurnRoundRecord) -> bool {
         .any(tool_result_invalidates_checkpoint_anchor)
 }
 
+fn round_updated_work_item(round: &TurnRoundRecord) -> bool {
+    round.tool_result_envelopes.iter().any(|envelope| {
+        envelope.status == ToolResultStatus::Success
+            && matches!(
+                envelope.tool_name.as_str(),
+                "CreateWorkItem" | "PickWorkItem" | "UpdateWorkItem" | "CompleteWorkItem"
+            )
+    })
+}
+
+fn build_work_item_stale_reminder(
+    work_item: &WorkItemRecord,
+    rounds_since_update: usize,
+) -> String {
+    let mut lines = vec![
+        "[Runtime-generated work item progress reminder]".to_string(),
+        format!(
+            "The current work item has gone {rounds_since_update} provider rounds without a successful CreateWorkItem, PickWorkItem, UpdateWorkItem, or CompleteWorkItem call."
+        ),
+        "Before continuing broad exploration, realign with the current work item. If material progress, scope changes, blockers, or completed checklist items have emerged, call UpdateWorkItem. If the current in-progress step is still not ready to update, state the specific missing fact and run only the next bounded command/query.".to_string(),
+        String::new(),
+        "Current work item snapshot:".to_string(),
+        format!("- Id: {}", work_item.id),
+        format!("- Objective: {}", work_item.objective),
+        format!(
+            "- Plan status: {}",
+            work_item_plan_status_label(work_item.plan_status)
+        ),
+    ];
+    if let Some(plan) = work_item.plan.as_deref() {
+        lines.push("- Plan:".to_string());
+        lines.extend(plan.lines().map(|line| format!("  {line}")));
+    }
+    if !work_item.todo_list.is_empty() {
+        lines.push("- Todo list:".to_string());
+        lines.extend(
+            work_item
+                .todo_list
+                .iter()
+                .map(|todo| format!("  - [{}] {}", todo_item_state_label(todo.state), todo.text)),
+        );
+    }
+    if let Some(blocked_by) = work_item.blocked_by.as_deref() {
+        lines.push(format!("- Blocked by: {blocked_by}"));
+    }
+    lines.join("\n")
+}
+
+fn work_item_plan_status_label(status: WorkItemPlanStatus) -> &'static str {
+    match status {
+        WorkItemPlanStatus::Draft => "draft",
+        WorkItemPlanStatus::Ready => "ready",
+        WorkItemPlanStatus::NeedsInput => "needs_input",
+    }
+}
+
+fn todo_item_state_label(state: TodoItemState) -> &'static str {
+    match state {
+        TodoItemState::Pending => "pending",
+        TodoItemState::InProgress => "in_progress",
+        TodoItemState::Completed => "completed",
+    }
+}
+
 fn build_delta_checkpoint_prompt(
     previous_round: Option<usize>,
     source_turn_index: Option<u64>,
@@ -684,6 +751,15 @@ Include:
 If no material facts changed, say exactly that and continue from the base checkpoint's next action.
 Keep this delta brief; it exists to preserve continuity after tool output compression, not to re-summarize the full task."
     )
+}
+
+fn push_runtime_reminder_message(
+    conversation: &mut Vec<ConversationMessage>,
+    runtime_reminder: Option<&str>,
+) {
+    if let Some(reminder) = runtime_reminder.filter(|text| !text.trim().is_empty()) {
+        conversation.push(ConversationMessage::UserText(reminder.to_string()));
+    }
 }
 
 fn build_turn_local_checkpoint_request(
@@ -741,15 +817,41 @@ fn build_turn_local_projection(
     prompt_budget: usize,
     keep_recent_budget: usize,
 ) -> TurnLocalProjectionOutcome {
+    build_turn_local_projection_with_runtime_reminder(
+        prompt_frame,
+        rounds,
+        available_tools,
+        checkpoint_state,
+        checkpoint_request_id,
+        prompt_budget,
+        keep_recent_budget,
+        None,
+    )
+}
+
+fn build_turn_local_projection_with_runtime_reminder(
+    prompt_frame: &ProviderPromptFrame,
+    rounds: &[TurnRoundRecord],
+    available_tools: &[ToolSpec],
+    checkpoint_state: &TurnLocalCheckpointState,
+    checkpoint_request_id: Option<String>,
+    prompt_budget: usize,
+    keep_recent_budget: usize,
+    runtime_reminder: Option<&str>,
+) -> TurnLocalProjectionOutcome {
     let tool_overhead_estimated_tokens = estimate_tool_specs_tokens(available_tools);
     let system_prompt_estimated_tokens = estimate_prompt_frame_tokens(prompt_frame);
     let context_attachment_estimated_tokens =
         estimate_prompt_blocks_tokens(&prompt_frame.context_blocks);
+    let runtime_reminder_estimated_tokens = runtime_reminder
+        .map(estimate_text_tokens)
+        .unwrap_or_default();
     let effective_budget_estimated_tokens = prompt_budget
         .saturating_sub(tool_overhead_estimated_tokens)
         .saturating_sub(CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS);
-    let estimated_baseline_tokens =
-        system_prompt_estimated_tokens.saturating_add(context_attachment_estimated_tokens);
+    let estimated_baseline_tokens = system_prompt_estimated_tokens
+        .saturating_add(context_attachment_estimated_tokens)
+        .saturating_add(runtime_reminder_estimated_tokens);
 
     let baseline_over_budget =
         |reason: &str,
@@ -774,6 +876,7 @@ fn build_turn_local_projection(
     let mut exact_conversation = vec![ConversationMessage::UserBlocks(
         prompt_frame.context_blocks.clone(),
     )];
+    push_runtime_reminder_message(&mut exact_conversation, runtime_reminder);
     for round in rounds {
         exact_conversation.extend(exact_round_messages(round));
     }
@@ -791,6 +894,7 @@ fn build_turn_local_projection(
     let mut minimum_viable_conversation = vec![ConversationMessage::UserBlocks(
         prompt_frame.context_blocks.clone(),
     )];
+    push_runtime_reminder_message(&mut minimum_viable_conversation, runtime_reminder);
     if let Some(last_round) = rounds.last() {
         minimum_viable_conversation.extend(exact_round_messages(last_round));
     }
@@ -811,6 +915,7 @@ fn build_turn_local_projection(
         let mut conversation = vec![ConversationMessage::UserBlocks(
             prompt_frame.context_blocks.clone(),
         )];
+        push_runtime_reminder_message(&mut conversation, runtime_reminder);
         let exact_tail = &rounds[tail_start..];
         let exact_tail_tokens = exact_tail.iter().map(estimate_round_tokens).sum::<usize>();
         let include_checkpoint = exact_tail
@@ -832,6 +937,7 @@ fn build_turn_local_projection(
         let recap_budget = effective_budget_estimated_tokens.saturating_sub(
             system_prompt_estimated_tokens
                 .saturating_add(context_attachment_estimated_tokens)
+                .saturating_add(runtime_reminder_estimated_tokens)
                 .saturating_add(exact_tail_tokens)
                 .saturating_add(checkpoint_estimated_tokens),
         );
@@ -1090,6 +1196,8 @@ impl RuntimeHandle {
         let mut truncated_text_history = Vec::new();
         let mut last_assistant_message: Option<String> = None;
         let mut max_output_recovery_count = 0usize;
+        let mut rounds_since_work_item_update = 0usize;
+        let mut rounds_since_work_item_reminder = WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS;
         let mut checkpoint_state = {
             let guard = self.inner.agent.lock().await;
             checkpoint_state_from_last_terminal(guard.state.last_turn_terminal.as_ref())
@@ -1164,7 +1272,40 @@ impl RuntimeHandle {
                 let checkpoint_request_id =
                     Some(format!("turn-{turn_index}-round-{round}-checkpoint"));
                 let prompt_frame = build_provider_prompt_frame(&effective_prompt);
-                let projection = match build_turn_local_projection(
+                let stale_work_item_reminder = if rounds_since_work_item_update
+                    >= WORK_ITEM_STALE_REMINDER_ROUNDS
+                    && rounds_since_work_item_reminder >= WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS
+                {
+                    let current_work_item_id = {
+                        let guard = self.inner.agent.lock().await;
+                        guard.state.current_work_item_id.clone()
+                    };
+                    current_work_item_id
+                        .as_deref()
+                        .and_then(|id| self.inner.storage.latest_work_item(id).ok().flatten())
+                        .map(|work_item| {
+                            build_work_item_stale_reminder(
+                                &work_item,
+                                rounds_since_work_item_update,
+                            )
+                        })
+                } else {
+                    None
+                };
+                if let Some(reminder) = stale_work_item_reminder.as_ref() {
+                    self.inner.storage.append_event(&AuditEvent::new(
+                        "work_item_stale_reminder_injected",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "round": round,
+                            "rounds_since_work_item_update": rounds_since_work_item_update,
+                            "cooldown_rounds": WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
+                            "text_preview": truncate_preview(reminder, ROUND_TEXT_PREVIEW_LIMIT),
+                        }),
+                    ))?;
+                    rounds_since_work_item_reminder = 0;
+                }
+                let projection = match build_turn_local_projection_with_runtime_reminder(
                     &prompt_frame,
                     &completed_rounds,
                     &available_tools,
@@ -1172,6 +1313,7 @@ impl RuntimeHandle {
                     checkpoint_request_id,
                     context_config.prompt_budget_estimated_tokens,
                     context_config.compaction_keep_recent_estimated_tokens,
+                    stale_work_item_reminder.as_deref(),
                 ) {
                     TurnLocalProjectionOutcome::Projection(projection) => projection,
                     TurnLocalProjectionOutcome::BaselineOverBudget(diagnostics) => {
@@ -1807,6 +1949,13 @@ impl RuntimeHandle {
                 checkpoint_state.anchor_generation =
                     checkpoint_state.anchor_generation.saturating_add(1);
             }
+            if round_updated_work_item(&round_record) {
+                rounds_since_work_item_update = 0;
+                rounds_since_work_item_reminder = WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS;
+            } else {
+                rounds_since_work_item_update = rounds_since_work_item_update.saturating_add(1);
+                rounds_since_work_item_reminder = rounds_since_work_item_reminder.saturating_add(1);
+            }
             completed_rounds.push(round_record);
 
             if only_sleep_tools {
@@ -1965,6 +2114,64 @@ mod tests {
             error: None,
         }];
         record
+    }
+
+    #[test]
+    fn build_work_item_stale_reminder_includes_current_work_item_snapshot() {
+        let mut work_item = WorkItemRecord::new(
+            "default",
+            "Ship work item reminder tests",
+            crate::types::WorkItemState::Open,
+        );
+        work_item.id = "work_reminder".into();
+        work_item.plan_status = WorkItemPlanStatus::Ready;
+        work_item.plan = Some("Patch runtime reminder.\nRun focused tests.".into());
+        work_item.todo_list = vec![
+            crate::types::TodoItem {
+                text: "Patch runtime reminder".into(),
+                state: TodoItemState::InProgress,
+            },
+            crate::types::TodoItem {
+                text: "Run focused tests".into(),
+                state: TodoItemState::Pending,
+            },
+        ];
+
+        let reminder = build_work_item_stale_reminder(&work_item, 10);
+
+        assert!(reminder.contains("[Runtime-generated work item progress reminder]"));
+        assert!(reminder.contains("- Id: work_reminder"));
+        assert!(reminder.contains("- Objective: Ship work item reminder tests"));
+        assert!(reminder.contains("- Plan status: ready"));
+        assert!(reminder.contains("Patch runtime reminder."));
+        assert!(reminder.contains("  - [in_progress] Patch runtime reminder"));
+        assert!(reminder.contains("  - [pending] Run focused tests"));
+    }
+
+    #[test]
+    fn build_turn_local_projection_includes_runtime_reminder() {
+        let prompt_frame = fixture_prompt_frame();
+        let reminder = "[Runtime-generated work item progress reminder]\nCall UpdateWorkItem if material progress emerged.";
+
+        let projection = build_turn_local_projection_with_runtime_reminder(
+            &prompt_frame,
+            &[],
+            &[],
+            &TurnLocalCheckpointState::default(),
+            Some("req-1".into()),
+            4_000,
+            120,
+            Some(reminder),
+        );
+
+        let TurnLocalProjectionOutcome::Projection(projection) = projection else {
+            panic!("expected projection outcome");
+        };
+        assert!(projection.conversation.iter().any(|message| matches!(
+            message,
+            ConversationMessage::UserText(text) if text == reminder
+        )));
+        assert!(projection.compaction.is_none());
     }
 
     fn checkpoint_state_with_latest(

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Instant};
+use std::{collections::HashSet, env, time::Instant};
 
 use anyhow::Result;
 use serde_json::Value;
@@ -46,6 +46,10 @@ const MIN_EXACT_TAIL_ROUNDS: usize = 2;
 const CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS: usize = 256;
 const WORK_ITEM_STALE_REMINDER_ROUNDS: usize = 10;
 const WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS: usize = 10;
+const WORK_ITEM_STALE_REMINDER_MAX_TOKENS: usize = 512;
+const WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT: usize = 8;
+const WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT: usize = 1_200;
+const WORK_ITEM_STALE_REMINDER_TODO_LIMIT: usize = 8;
 const COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT: &str = "\
 [Runtime-generated full progress checkpoint request]
 You are crossing a context compaction boundary. Before continuing, include a concise progress checkpoint for continuation in your next assistant message.
@@ -667,6 +671,35 @@ fn round_updated_work_item(round: &TurnRoundRecord) -> bool {
     })
 }
 
+fn work_item_stale_reminder_rounds() -> usize {
+    env_usize_or_default(
+        "HOLON_WORK_ITEM_STALE_REMINDER_ROUNDS",
+        WORK_ITEM_STALE_REMINDER_ROUNDS,
+    )
+}
+
+fn work_item_stale_reminder_cooldown_rounds() -> usize {
+    env_usize_or_default(
+        "HOLON_WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS",
+        WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
+    )
+}
+
+fn work_item_stale_reminder_max_tokens() -> usize {
+    env_usize_or_default(
+        "HOLON_WORK_ITEM_STALE_REMINDER_MAX_TOKENS",
+        WORK_ITEM_STALE_REMINDER_MAX_TOKENS,
+    )
+}
+
+fn env_usize_or_default(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
 fn build_work_item_stale_reminder(
     work_item: &WorkItemRecord,
     rounds_since_update: usize,
@@ -688,7 +721,23 @@ fn build_work_item_stale_reminder(
     ];
     if let Some(plan) = work_item.plan.as_deref() {
         lines.push("- Plan:".to_string());
-        lines.extend(plan.lines().map(|line| format!("  {line}")));
+        let mut plan_chars = 0usize;
+        for line in plan.lines().take(WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT) {
+            let remaining = WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT.saturating_sub(plan_chars);
+            if remaining == 0 {
+                break;
+            }
+            let rendered = truncate_preview(line, remaining);
+            plan_chars = plan_chars.saturating_add(rendered.len());
+            lines.push(format!("  {rendered}"));
+        }
+        let omitted_lines = plan
+            .lines()
+            .skip(WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT)
+            .count();
+        if omitted_lines > 0 || plan_chars >= WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT {
+            lines.push("  ... plan truncated".to_string());
+        }
     }
     if !work_item.todo_list.is_empty() {
         lines.push("- Todo list:".to_string());
@@ -696,13 +745,53 @@ fn build_work_item_stale_reminder(
             work_item
                 .todo_list
                 .iter()
+                .filter(|todo| todo.state != TodoItemState::Completed)
+                .take(WORK_ITEM_STALE_REMINDER_TODO_LIMIT)
                 .map(|todo| format!("  - [{}] {}", todo_item_state_label(todo.state), todo.text)),
         );
+        let omitted = work_item
+            .todo_list
+            .iter()
+            .filter(|todo| todo.state != TodoItemState::Completed)
+            .skip(WORK_ITEM_STALE_REMINDER_TODO_LIMIT)
+            .count();
+        if omitted > 0 {
+            lines.push(format!(
+                "  - ... {omitted} more active todo item(s) omitted"
+            ));
+        }
     }
     if let Some(blocked_by) = work_item.blocked_by.as_deref() {
         lines.push(format!("- Blocked by: {blocked_by}"));
     }
-    lines.join("\n")
+    let reminder = lines.join("\n");
+    truncate_reminder_to_token_budget(&reminder, work_item_stale_reminder_max_tokens())
+}
+
+fn truncate_reminder_to_token_budget(reminder: &str, max_tokens: usize) -> String {
+    if estimate_text_tokens(reminder) <= max_tokens {
+        return reminder.to_string();
+    }
+    let max_chars = max_tokens.saturating_mul(4).max(256);
+    format!(
+        "{}\n... reminder truncated to fit token budget",
+        truncate_preview(reminder, max_chars)
+    )
+}
+
+fn runtime_reminder_fits_baseline(
+    prompt_frame: &ProviderPromptFrame,
+    available_tools: &[ToolSpec],
+    prompt_budget: usize,
+    reminder: &str,
+) -> bool {
+    let effective_budget_estimated_tokens = prompt_budget
+        .saturating_sub(estimate_tool_specs_tokens(available_tools))
+        .saturating_sub(CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS);
+    let baseline_with_reminder = estimate_prompt_frame_tokens(prompt_frame)
+        .saturating_add(estimate_prompt_blocks_tokens(&prompt_frame.context_blocks))
+        .saturating_add(estimate_text_tokens(reminder));
+    baseline_with_reminder <= effective_budget_estimated_tokens
 }
 
 fn work_item_plan_status_label(status: WorkItemPlanStatus) -> &'static str {
@@ -1197,7 +1286,7 @@ impl RuntimeHandle {
         let mut last_assistant_message: Option<String> = None;
         let mut max_output_recovery_count = 0usize;
         let mut rounds_since_work_item_update = 0usize;
-        let mut rounds_since_work_item_reminder = WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS;
+        let mut rounds_since_work_item_reminder = work_item_stale_reminder_cooldown_rounds();
         let mut checkpoint_state = {
             let guard = self.inner.agent.lock().await;
             checkpoint_state_from_last_terminal(guard.state.last_turn_terminal.as_ref())
@@ -1272,9 +1361,10 @@ impl RuntimeHandle {
                 let checkpoint_request_id =
                     Some(format!("turn-{turn_index}-round-{round}-checkpoint"));
                 let prompt_frame = build_provider_prompt_frame(&effective_prompt);
-                let stale_work_item_reminder = if rounds_since_work_item_update
-                    >= WORK_ITEM_STALE_REMINDER_ROUNDS
-                    && rounds_since_work_item_reminder >= WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS
+                let reminder_rounds = work_item_stale_reminder_rounds();
+                let reminder_cooldown_rounds = work_item_stale_reminder_cooldown_rounds();
+                let stale_work_item_reminder = if rounds_since_work_item_update >= reminder_rounds
+                    && rounds_since_work_item_reminder >= reminder_cooldown_rounds
                 {
                     let current_work_item_id = {
                         let guard = self.inner.agent.lock().await;
@@ -1284,22 +1374,53 @@ impl RuntimeHandle {
                         .as_deref()
                         .and_then(|id| self.inner.storage.latest_work_item(id).ok().flatten())
                         .map(|work_item| {
-                            build_work_item_stale_reminder(
+                            let reminder = build_work_item_stale_reminder(
                                 &work_item,
                                 rounds_since_work_item_update,
-                            )
+                            );
+                            (work_item, reminder)
                         })
                 } else {
                     None
                 };
-                if let Some(reminder) = stale_work_item_reminder.as_ref() {
+                let stale_work_item_reminder =
+                    if let Some((work_item, reminder)) = stale_work_item_reminder {
+                        if runtime_reminder_fits_baseline(
+                            &prompt_frame,
+                            &available_tools,
+                            context_config.prompt_budget_estimated_tokens,
+                            &reminder,
+                        ) {
+                            Some((work_item, reminder))
+                        } else {
+                            self.inner.storage.append_event(&AuditEvent::new(
+                            "work_item_stale_reminder_skipped",
+                            serde_json::json!({
+                                "agent_id": agent_id,
+                                "round": round,
+                                "work_item_id": work_item.id,
+                                "plan_status": work_item_plan_status_label(work_item.plan_status),
+                                "rounds_since_work_item_update": rounds_since_work_item_update,
+                                "cooldown_rounds": reminder_cooldown_rounds,
+                                "reason": "baseline_budget",
+                            }),
+                        ))?;
+                            rounds_since_work_item_reminder = 0;
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                if let Some((work_item, reminder)) = stale_work_item_reminder.as_ref() {
                     self.inner.storage.append_event(&AuditEvent::new(
                         "work_item_stale_reminder_injected",
                         serde_json::json!({
                             "agent_id": agent_id,
                             "round": round,
+                            "work_item_id": work_item.id,
+                            "plan_status": work_item_plan_status_label(work_item.plan_status),
                             "rounds_since_work_item_update": rounds_since_work_item_update,
-                            "cooldown_rounds": WORK_ITEM_STALE_REMINDER_COOLDOWN_ROUNDS,
+                            "cooldown_rounds": reminder_cooldown_rounds,
                             "text_preview": truncate_preview(reminder, ROUND_TEXT_PREVIEW_LIMIT),
                         }),
                     ))?;
@@ -1313,7 +1434,9 @@ impl RuntimeHandle {
                     checkpoint_request_id,
                     context_config.prompt_budget_estimated_tokens,
                     context_config.compaction_keep_recent_estimated_tokens,
-                    stale_work_item_reminder.as_deref(),
+                    stale_work_item_reminder
+                        .as_ref()
+                        .map(|(_, reminder)| reminder.as_str()),
                 ) {
                     TurnLocalProjectionOutcome::Projection(projection) => projection,
                     TurnLocalProjectionOutcome::BaselineOverBudget(diagnostics) => {

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -2297,6 +2297,64 @@ mod tests {
         assert!(projection.compaction.is_none());
     }
 
+    #[test]
+    fn large_work_item_stale_reminder_does_not_force_baseline_over_budget() {
+        let mut work_item = WorkItemRecord::new(
+            "default",
+            "Keep reminder bounded with large plan and todo list",
+            crate::types::WorkItemState::Open,
+        );
+        work_item.id = "work_large_reminder".into();
+        work_item.plan_status = WorkItemPlanStatus::Ready;
+        work_item.plan = Some(
+            (0..80)
+                .map(|idx| format!("step {idx}: {}", "inspect and verify ".repeat(40)))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        work_item.todo_list = (0..80)
+            .map(|idx| crate::types::TodoItem {
+                text: format!("todo {idx}: {}", "finish bounded work ".repeat(30)),
+                state: if idx % 3 == 0 {
+                    TodoItemState::Completed
+                } else if idx % 3 == 1 {
+                    TodoItemState::InProgress
+                } else {
+                    TodoItemState::Pending
+                },
+            })
+            .collect();
+        let reminder = build_work_item_stale_reminder(&work_item, 10);
+        let prompt_frame = fixture_prompt_frame();
+
+        assert!(reminder.contains("... plan truncated"));
+        assert!(!reminder.contains("[completed]"));
+        assert!(runtime_reminder_fits_baseline(
+            &prompt_frame,
+            &[],
+            4_000,
+            &reminder
+        ));
+        let projection = build_turn_local_projection_with_runtime_reminder(
+            &prompt_frame,
+            &[],
+            &[],
+            &TurnLocalCheckpointState::default(),
+            Some("req-large".into()),
+            4_000,
+            120,
+            Some(&reminder),
+        );
+
+        let TurnLocalProjectionOutcome::Projection(projection) = projection else {
+            panic!("expected bounded reminder to fit baseline");
+        };
+        assert!(projection.conversation.iter().any(|message| matches!(
+            message,
+            ConversationMessage::UserText(text) if text == &reminder
+        )));
+    }
+
     fn checkpoint_state_with_latest(
         text: &str,
         response_round: usize,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1028,8 +1028,10 @@ pub struct WorkingMemorySnapshot {
     pub work_summary: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scope_hints: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub current_plan: Vec<String>,
+    pub todo_list: Vec<TodoItem>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub working_set_files: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1068,7 +1070,9 @@ pub struct TurnMemoryDelta {
     #[serde(default)]
     pub active_work_changed: bool,
     #[serde(default)]
-    pub current_plan_changed: bool,
+    pub plan_changed: bool,
+    #[serde(default)]
+    pub todo_list_changed: bool,
     #[serde(default)]
     pub scope_hints_changed: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -187,7 +187,7 @@ fn operator_turn_context_snapshot_includes_work_memory_and_active_work() -> Resu
         current_work_item_id: Some(work_item.id.clone()),
         objective: Some(work_item.objective.clone()),
         work_summary: Some("prompt snapshot coverage".into()),
-        current_plan: vec!["capture operator surface snapshot".into()],
+        plan: Some(vec!["capture operator surface snapshot"].join("\n")),
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
@@ -195,7 +195,7 @@ fn operator_turn_context_snapshot_includes_work_memory_and_active_work() -> Resu
         to_revision: 3,
         created_at_turn: 4,
         reason: holon::types::WorkingMemoryUpdateReason::TerminalTurnCompleted,
-        changed_fields: vec!["current_plan".into()],
+        changed_fields: vec!["plan".into()],
         summary_lines: vec![
             "captured the baseline operator turn layout".into(),
             "queued callback and task-result follow-up snapshots".into(),
@@ -215,15 +215,15 @@ Working memory:
 - Current work item id: work_prompt
 - Objective: Ship prompt snapshot coverage
 - Work summary: prompt snapshot coverage
-- Current plan:
-  - capture operator surface snapshot
+- Plan:
+  capture operator surface snapshot
 
 ## working_memory_delta
 Working memory updated since the last prompt:
 - Revision: 2 -> 3
 - Reason: terminal_turn_completed
 - Changed fields:
-  - current_plan
+  - plan
 - Summary:
   - captured the baseline operator turn layout
   - queued callback and task-result follow-up snapshots
@@ -535,7 +535,7 @@ fn active_work_with_queued_work_shows_both_items() -> Result<()> {
         current_work_item_id: Some(active_work.id.clone()),
         objective: Some(active_work.objective.clone()),
         work_summary: Some("expand prompt context snapshot coverage".into()),
-        current_plan: vec!["add active work with queued work test".into()],
+        plan: Some(vec!["add active work with queued work test"].join("\n")),
         ..WorkingMemorySnapshot::default()
     };
 
@@ -552,8 +552,8 @@ Working memory:
 - Current work item id: work_active
 - Objective: Complete snapshot coverage expansion
 - Work summary: expand prompt context snapshot coverage
-- Current plan:
-  - add active work with queued work test
+- Plan:
+  add active work with queued work test
 
 ## current_work_item
 Current work item:
@@ -623,7 +623,7 @@ fn operator_turn_without_working_memory_delta() -> Result<()> {
         current_work_item_id: Some(work_item.id.clone()),
         objective: Some(work_item.objective.clone()),
         work_summary: Some("test working memory delta absence".into()),
-        current_plan: vec!["verify delta absence".into()],
+        plan: Some(vec!["verify delta absence"].join("\n")),
         ..WorkingMemorySnapshot::default()
     };
     // No pending_working_memory_delta set
@@ -641,8 +641,8 @@ Working memory:
 - Current work item id: work_no_delta
 - Objective: Test delta absence
 - Work summary: test working memory delta absence
-- Current plan:
-  - verify delta absence
+- Plan:
+  verify delta absence
 
 ## current_work_item
 Current work item:
@@ -718,11 +718,14 @@ fn callback_with_active_work_and_delta() -> Result<()> {
         current_work_item_id: Some(work_item.id.clone()),
         objective: Some(work_item.objective.clone()),
         work_summary: Some("process CI completion callback".into()),
-        current_plan: vec![
-            "wait for CI callback".into(),
-            "process CI result".into(),
-            "update work item status".into(),
-        ],
+        plan: Some(
+            vec![
+                "wait for CI callback",
+                "process CI result",
+                "update work item status",
+            ]
+            .join("\n"),
+        ),
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
@@ -730,7 +733,7 @@ fn callback_with_active_work_and_delta() -> Result<()> {
         to_revision: 6,
         created_at_turn: 12,
         reason: holon::types::WorkingMemoryUpdateReason::TaskRejoined,
-        changed_fields: vec!["current_plan".into(), "waiting_on".into()],
+        changed_fields: vec!["plan".into(), "waiting_on".into()],
         summary_lines: vec![
             "CI pipeline completed successfully".into(),
             "ready to proceed with next work item".into(),
@@ -750,17 +753,17 @@ Working memory:
 - Current work item id: work_ci
 - Objective: Handle CI callback
 - Work summary: process CI completion callback
-- Current plan:
-  - wait for CI callback
-  - process CI result
-  - update work item status
+- Plan:
+  wait for CI callback
+  process CI result
+  update work item status
 
 ## working_memory_delta
 Working memory updated since the last prompt:
 - Revision: 5 -> 6
 - Reason: task_rejoined
 - Changed fields:
-  - current_plan
+  - plan
   - waiting_on
 - Summary:
   - CI pipeline completed successfully
@@ -863,10 +866,7 @@ fn system_tick_with_waiting_work_item() -> Result<()> {
         current_work_item_id: Some(waiting_work.id.clone()),
         objective: Some(waiting_work.objective.clone()),
         work_summary: Some("waiting for external service response".into()),
-        current_plan: vec![
-            "wait for rate limit reset".into(),
-            "retry API request".into(),
-        ],
+        plan: Some(vec!["wait for rate limit reset", "retry API request"].join("\n")),
         ..WorkingMemorySnapshot::default()
     };
 
@@ -883,9 +883,9 @@ Working memory:
 - Current work item id: work_waiting
 - Objective: External service integration
 - Work summary: waiting for external service response
-- Current plan:
-  - wait for rate limit reset
-  - retry API request
+- Plan:
+  wait for rate limit reset
+  retry API request
 
 ## current_work_item
 Current work item:
@@ -982,11 +982,14 @@ fn post_compaction_snapshot_preserves_continuity() -> Result<()> {
         current_work_item_id: Some(work_item.id.clone()),
         objective: Some(work_item.objective.clone()),
         work_summary: Some("task spanning multiple compaction points".into()),
-        current_plan: vec![
-            "complete initial phase".into(),
-            "work on expanded coverage".into(),
-            "final verification".into(),
-        ],
+        plan: Some(
+            vec![
+                "complete initial phase",
+                "work on expanded coverage",
+                "final verification",
+            ]
+            .join("\n"),
+        ),
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
@@ -1014,10 +1017,10 @@ Working memory:
 - Current work item id: work_compaction
 - Objective: Long-running task with compaction
 - Work summary: task spanning multiple compaction points
-- Current plan:
-  - complete initial phase
-  - work on expanded coverage
-  - final verification
+- Plan:
+  complete initial phase
+  work on expanded coverage
+  final verification
 
 ## working_memory_delta
 Working memory updated since the last prompt:
@@ -1125,11 +1128,14 @@ fn task_result_with_multiple_work_items() -> Result<()> {
         current_work_item_id: Some(active_work.id.clone()),
         objective: Some(active_work.objective.clone()),
         work_summary: Some("run cargo test and verify results".into()),
-        current_plan: vec![
-            "execute cargo test".into(),
-            "verify test results".into(),
-            "document any failures".into(),
-        ],
+        plan: Some(
+            vec![
+                "execute cargo test",
+                "verify test results",
+                "document any failures",
+            ]
+            .join("\n"),
+        ),
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
@@ -1137,7 +1143,7 @@ fn task_result_with_multiple_work_items() -> Result<()> {
         to_revision: 4,
         created_at_turn: 8,
         reason: holon::types::WorkingMemoryUpdateReason::TaskRejoined,
-        changed_fields: vec!["current_plan".into()],
+        changed_fields: vec!["plan".into()],
         summary_lines: vec![
             "cargo test completed successfully".into(),
             "120 tests passed, 0 failed".into(),
@@ -1158,17 +1164,17 @@ Working memory:
 - Current work item id: work_test
 - Objective: Test execution and verification
 - Work summary: run cargo test and verify results
-- Current plan:
-  - execute cargo test
-  - verify test results
-  - document any failures
+- Plan:
+  execute cargo test
+  verify test results
+  document any failures
 
 ## working_memory_delta
 Working memory updated since the last prompt:
 - Revision: 3 -> 4
 - Reason: task_rejoined
 - Changed fields:
-  - current_plan
+  - plan
 - Summary:
   - cargo test completed successfully
   - 120 tests passed, 0 failed

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -754,9 +754,7 @@ Working memory:
 - Objective: Handle CI callback
 - Work summary: process CI completion callback
 - Plan:
-  wait for CI callback
-  process CI result
-  update work item status
+  wait for CI callback process CI result update work item status
 
 ## working_memory_delta
 Working memory updated since the last prompt:
@@ -884,8 +882,7 @@ Working memory:
 - Objective: External service integration
 - Work summary: waiting for external service response
 - Plan:
-  wait for rate limit reset
-  retry API request
+  wait for rate limit reset retry API request
 
 ## current_work_item
 Current work item:
@@ -1018,9 +1015,7 @@ Working memory:
 - Objective: Long-running task with compaction
 - Work summary: task spanning multiple compaction points
 - Plan:
-  complete initial phase
-  work on expanded coverage
-  final verification
+  complete initial phase work on expanded coverage final verification
 
 ## working_memory_delta
 Working memory updated since the last prompt:
@@ -1165,9 +1160,7 @@ Working memory:
 - Objective: Test execution and verification
 - Work summary: run cargo test and verify results
 - Plan:
-  execute cargo test
-  verify test results
-  document any failures
+  execute cargo test verify test results document any failures
 
 ## working_memory_delta
 Working memory updated since the last prompt:

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -233,7 +233,7 @@ Current work item:
 - Id: work_prompt
 - State: Open
 - Objective: Ship prompt snapshot coverage
-- Plan state: Draft
+- Plan status: draft
 - Todo list:
   - [in_progress] Capture baseline operator layout
   - [pending] Cover callback and task result surfaces
@@ -560,7 +560,7 @@ Current work item:
 - Id: work_active
 - State: Open
 - Objective: Complete snapshot coverage expansion
-- Plan state: Draft
+- Plan status: draft
 - Todo list:
   - [in_progress] Add active work with queued work test
   - [pending] Add post-compaction snapshot tests
@@ -649,7 +649,7 @@ Current work item:
 - Id: work_no_delta
 - State: Open
 - Objective: Test delta absence
-- Plan state: Draft
+- Plan status: draft
 - Todo list:
   - [in_progress] Verify delta absence
 - Blocked by: verifying snapshot without delta
@@ -772,7 +772,7 @@ Current work item:
 - Id: work_ci
 - State: Open
 - Objective: Handle CI callback
-- Plan state: Draft
+- Plan status: draft
 - Todo list:
   - [completed] Wait for CI callback
   - [in_progress] Process CI result
@@ -889,7 +889,7 @@ Current work item:
 - Id: work_waiting
 - State: Open
 - Objective: External service integration
-- Plan state: Draft
+- Plan status: draft
 - Todo list:
   - [in_progress] Wait for rate limit reset
   - [pending] Retry API request
@@ -1032,7 +1032,7 @@ Current work item:
 - Id: work_compaction
 - State: Open
 - Objective: Long-running task with compaction
-- Plan state: Draft
+- Plan status: draft
 - Todo list:
   - [completed] Complete initial phase
   - [in_progress] Work on expanded coverage
@@ -1178,7 +1178,7 @@ Current work item:
 - Id: work_test
 - State: Open
 - Objective: Test execution and verification
-- Plan state: Draft
+- Plan status: draft
 - Todo list:
   - [completed] Execute cargo test
   - [in_progress] Verify test results


### PR DESCRIPTION
## Summary
- align working memory and prompt projection on work item objective, durable plan, and todo_list
- remove stale current_plan/work plan terminology from the compression RFC and context snapshots
- inject a provider-only reminder after extended provider-round progress without successful work-item mutation

Closes #873.
Closes #876.

## Tests
- cargo test --test prompt_context_snapshots -- --nocapture
- cargo test --lib build_work_item_stale_reminder_includes_current_work_item_snapshot
- cargo test --lib build_turn_local_projection_includes_runtime_reminder
- cargo test --lib test_work_item_write_section_emitted_when_available
- cargo test --lib derive_working_memory_snapshot_projects_work_state_and_tool_evidence
- cargo test --all-targets -- --test-threads=1