### PR TITLE
Add Anthropic-compatible DeepSeek and MiMo providers

### DIFF
--- a/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
+++ b/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
@@ -1,18 +1,20 @@
 # 053 Anthropic-Compatible Provider Probes
 
 Holon uses the Anthropic Messages transport as the default transport for
-`deepseek` and `xiaomi` after live validation confirmed both providers accept
-Holon's tool-use request shape with `context_management` enabled.
+`deepseek` after live validation confirmed DeepSeek accepts Holon's tool-use
+request shape with `context_management` enabled.
 
-Holon also keeps explicit `deepseek-anthropic` and `xiaomi-anthropic` provider
-ids as stable aliases for the Anthropic-compatible endpoints.
+Holon also keeps explicit `deepseek-anthropic` as a stable alias for the
+DeepSeek Anthropic-compatible endpoint.
 
-The compatible providers use the same API keys as the default providers:
-`DEEPSEEK_API_KEY` and `XIAOMI_API_KEY`.
+Xiaomi's token-plan Anthropic-compatible endpoint is a separate service with a
+separate base URL and API key from the default Xiaomi MiMo API. Holon therefore
+keeps `xiaomi` on the default OpenAI-compatible endpoint and exposes token-plan
+as the separate `xiaomi-token-plan` provider.
 
-The default provider ids and their explicit Anthropic aliases use the same API
-keys. DeepSeek uses `https://api.deepseek.com/anthropic`; Xiaomi uses the token
-plan endpoint `https://token-plan-cn.xiaomimimo.com/anthropic`.
+DeepSeek uses `https://api.deepseek.com/anthropic` with `DEEPSEEK_API_KEY`.
+Xiaomi token-plan uses `https://token-plan-cn.xiaomimimo.com/anthropic` with
+`XIAOMI_TOKEN_PLAN_API_KEY`.
 
 The validation tests are ignored by default because they require real
 credentials and network access:

--- a/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
+++ b/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
@@ -1,16 +1,18 @@
 # 053 Anthropic-Compatible Provider Probes
 
-Holon keeps `deepseek` and `xiaomi` on the existing OpenAI Chat Completions
-transport while adding explicit `deepseek-anthropic` and `xiaomi-anthropic`
-provider ids for their Anthropic-compatible endpoints.
+Holon uses the Anthropic Messages transport as the default transport for
+`deepseek` and `xiaomi` after live validation confirmed both providers accept
+Holon's tool-use request shape with `context_management` enabled.
+
+Holon also keeps explicit `deepseek-anthropic` and `xiaomi-anthropic` provider
+ids as stable aliases for the Anthropic-compatible endpoints.
 
 The compatible providers use the same API keys as the default providers:
 `DEEPSEEK_API_KEY` and `XIAOMI_API_KEY`.
 
-This keeps the default user path stable while giving operators a concrete live
-smoke path for the Anthropic Messages transport. The default transport should
-only move to Anthropic after live validation confirms that both providers accept
-Holon's tool-use request shape with `context_management` enabled.
+The default provider ids and their explicit Anthropic aliases use the same API
+keys. DeepSeek uses `https://api.deepseek.com/anthropic`; Xiaomi uses the token
+plan endpoint `https://token-plan-cn.xiaomimimo.com/anthropic`.
 
 The validation tests are ignored by default because they require real
 credentials and network access:

--- a/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
+++ b/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
@@ -1,0 +1,20 @@
+# 053 Anthropic-Compatible Provider Probes
+
+Holon keeps `deepseek` and `xiaomi` on the existing OpenAI Chat Completions
+transport while adding explicit `deepseek-anthropic` and `xiaomi-anthropic`
+provider ids for their Anthropic-compatible endpoints.
+
+The compatible providers use the same API keys as the default providers:
+`DEEPSEEK_API_KEY` and `XIAOMI_API_KEY`.
+
+This keeps the default user path stable while giving operators a concrete live
+smoke path for the Anthropic Messages transport. The default transport should
+only move to Anthropic after live validation confirms that both providers accept
+Holon's tool-use request shape with `context_management` enabled.
+
+The validation tests are ignored by default because they require real
+credentials and network access:
+
+```bash
+cargo test --test live_anthropic_compatible -- --ignored
+```

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -70,3 +70,4 @@ Current decision notes:
 - [050 Anthropic Claude CLI-Like Cache Lowering](./050-anthropic-claude-cli-like-cache-lowering.md)
 - [051 Runtime Config Provider Credentials](./051-runtime-config-provider-credentials.md)
 - [052 Turn-Local Compaction Remains Request Projection](./052-turn-local-compaction-remains-request-projection.md)
+- [053 Anthropic-Compatible Provider Probes](./053-anthropic-compatible-provider-probes.md)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1748,18 +1748,18 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         ],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
+    insert_openai_compatible_provider(
         &mut registry,
         "xiaomi",
-        "https://token-plan-cn.xiaomimimo.com/anthropic",
+        "https://api.xiaomimimo.com/v1",
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
         &mut registry,
-        "xiaomi-anthropic",
+        "xiaomi-token-plan",
         "https://token-plan-cn.xiaomimimo.com/anthropic",
-        &["XIAOMI_API_KEY"],
+        &["XIAOMI_TOKEN_PLAN_API_KEY"],
         settings_env,
     )?;
     insert_openai_compatible_provider(
@@ -3097,6 +3097,10 @@ mod tests {
         );
         settings_env.insert("DEEPSEEK_API_KEY".to_string(), "deepseek-key".to_string());
         settings_env.insert("XIAOMI_API_KEY".to_string(), "xiaomi-key".to_string());
+        settings_env.insert(
+            "XIAOMI_TOKEN_PLAN_API_KEY".to_string(),
+            "xiaomi-token-plan-key".to_string(),
+        );
         settings_env.insert("DASHSCOPE_API_KEY".to_string(), "dashscope-key".to_string());
 
         let providers = super::built_in_provider_registry(&settings_env).unwrap();
@@ -3150,25 +3154,28 @@ mod tests {
         let xiaomi = providers
             .get(&ProviderId::parse("xiaomi").unwrap())
             .unwrap();
-        assert_eq!(xiaomi.transport, ProviderTransportKind::AnthropicMessages);
         assert_eq!(
-            xiaomi.base_url,
-            "https://token-plan-cn.xiaomimimo.com/anthropic"
+            xiaomi.transport,
+            ProviderTransportKind::OpenAiChatCompletions
         );
+        assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
         assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
 
-        let xiaomi_anthropic = providers
-            .get(&ProviderId::parse("xiaomi-anthropic").unwrap())
+        let xiaomi_token_plan = providers
+            .get(&ProviderId::parse("xiaomi-token-plan").unwrap())
             .unwrap();
         assert_eq!(
-            xiaomi_anthropic.transport,
+            xiaomi_token_plan.transport,
             ProviderTransportKind::AnthropicMessages
         );
         assert_eq!(
-            xiaomi_anthropic.base_url,
+            xiaomi_token_plan.base_url,
             "https://token-plan-cn.xiaomimimo.com/anthropic"
         );
-        assert_eq!(xiaomi_anthropic.credential.as_deref(), Some("xiaomi-key"));
+        assert_eq!(
+            xiaomi_token_plan.credential.as_deref(),
+            Some("xiaomi-token-plan-key")
+        );
 
         let minimax = providers
             .get(&ProviderId::parse("minimax").unwrap())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1824,13 +1824,14 @@ fn insert_anthropic_compatible_provider(
     env_names: &[&str],
     settings_env: &HashMap<String, String>,
 ) -> Result<()> {
-    insert_builtin_http_provider(
+    insert_builtin_http_provider_with_context_management(
         registry,
         provider,
         ProviderTransportKind::AnthropicMessages,
         default_base_url,
         env_names,
         settings_env,
+        resolve_anthropic_context_management_config()?,
     )
 }
 
@@ -1841,6 +1842,26 @@ fn insert_builtin_http_provider(
     default_base_url: &str,
     env_names: &[&str],
     settings_env: &HashMap<String, String>,
+) -> Result<()> {
+    insert_builtin_http_provider_with_context_management(
+        registry,
+        provider,
+        transport,
+        default_base_url,
+        env_names,
+        settings_env,
+        Default::default(),
+    )
+}
+
+fn insert_builtin_http_provider_with_context_management(
+    registry: &mut ProviderRegistry,
+    provider: &str,
+    transport: ProviderTransportKind,
+    default_base_url: &str,
+    env_names: &[&str],
+    settings_env: &HashMap<String, String>,
+    context_management: AnthropicContextManagementConfig,
 ) -> Result<()> {
     let id = ProviderId::parse(provider)?;
     let base_url_env = format!("HOLON_{}_BASE_URL", env_key_fragment(provider));
@@ -1877,7 +1898,7 @@ fn insert_builtin_http_provider(
             codex_home: None,
             originator: None,
             reasoning_effort: None,
-            context_management: Default::default(),
+            context_management,
         },
     );
     Ok(())
@@ -3150,6 +3171,10 @@ mod tests {
             deepseek_anthropic.credential.as_deref(),
             Some("deepseek-key")
         );
+        assert_eq!(
+            deepseek_anthropic.context_management.cache_strategy,
+            AnthropicCacheStrategy::ClaudeCliLike
+        );
 
         let xiaomi = providers
             .get(&ProviderId::parse("xiaomi").unwrap())
@@ -3175,6 +3200,10 @@ mod tests {
         assert_eq!(
             xiaomi_token_plan.credential.as_deref(),
             Some("xiaomi-token-plan-key")
+        );
+        assert_eq!(
+            xiaomi_token_plan.context_management.cache_strategy,
+            AnthropicCacheStrategy::ClaudeCliLike
         );
 
         let minimax = providers

--- a/src/config.rs
+++ b/src/config.rs
@@ -1590,10 +1590,10 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["CHUTES_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_anthropic_compatible_provider(
         &mut registry,
         "deepseek",
-        "https://api.deepseek.com",
+        "https://api.deepseek.com/anthropic",
         &["DEEPSEEK_API_KEY"],
         settings_env,
     )?;
@@ -1748,10 +1748,10 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         ],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_anthropic_compatible_provider(
         &mut registry,
         "xiaomi",
-        "https://api.xiaomimimo.com/v1",
+        "https://token-plan-cn.xiaomimimo.com/anthropic",
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
@@ -3127,11 +3127,8 @@ mod tests {
         let deepseek = providers
             .get(&ProviderId::parse("deepseek").unwrap())
             .unwrap();
-        assert_eq!(
-            deepseek.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(deepseek.base_url, "https://api.deepseek.com");
+        assert_eq!(deepseek.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(deepseek.base_url, "https://api.deepseek.com/anthropic");
         assert_eq!(deepseek.credential.as_deref(), Some("deepseek-key"));
 
         let deepseek_anthropic = providers
@@ -3153,11 +3150,11 @@ mod tests {
         let xiaomi = providers
             .get(&ProviderId::parse("xiaomi").unwrap())
             .unwrap();
+        assert_eq!(xiaomi.transport, ProviderTransportKind::AnthropicMessages);
         assert_eq!(
-            xiaomi.transport,
-            ProviderTransportKind::OpenAiChatCompletions
+            xiaomi.base_url,
+            "https://token-plan-cn.xiaomimimo.com/anthropic"
         );
-        assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
         assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
 
         let xiaomi_anthropic = providers

--- a/src/config.rs
+++ b/src/config.rs
@@ -1597,6 +1597,13 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["DEEPSEEK_API_KEY"],
         settings_env,
     )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "deepseek-anthropic",
+        "https://api.deepseek.com/anthropic",
+        &["DEEPSEEK_API_KEY"],
+        settings_env,
+    )?;
     insert_openai_compatible_provider(
         &mut registry,
         "fireworks",
@@ -1745,6 +1752,13 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &mut registry,
         "xiaomi",
         "https://api.xiaomimimo.com/v1",
+        &["XIAOMI_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "xiaomi-anthropic",
+        "https://api.xiaomimimo.com/anthropic",
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
@@ -3081,6 +3095,8 @@ mod tests {
             "HOLON_OPENROUTER_BASE_URL".to_string(),
             "https://openrouter.example/api/v3".to_string(),
         );
+        settings_env.insert("DEEPSEEK_API_KEY".to_string(), "deepseek-key".to_string());
+        settings_env.insert("XIAOMI_API_KEY".to_string(), "xiaomi-key".to_string());
         settings_env.insert("DASHSCOPE_API_KEY".to_string(), "dashscope-key".to_string());
 
         let providers = super::built_in_provider_registry(&settings_env).unwrap();
@@ -3107,6 +3123,55 @@ mod tests {
             stepfun_plan.auth.env.as_deref(),
             Some("STEPFUN_PLAN_API_KEY or STEPFUN_API_KEY")
         );
+
+        let deepseek = providers
+            .get(&ProviderId::parse("deepseek").unwrap())
+            .unwrap();
+        assert_eq!(
+            deepseek.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(deepseek.base_url, "https://api.deepseek.com");
+        assert_eq!(deepseek.credential.as_deref(), Some("deepseek-key"));
+
+        let deepseek_anthropic = providers
+            .get(&ProviderId::parse("deepseek-anthropic").unwrap())
+            .unwrap();
+        assert_eq!(
+            deepseek_anthropic.transport,
+            ProviderTransportKind::AnthropicMessages
+        );
+        assert_eq!(
+            deepseek_anthropic.base_url,
+            "https://api.deepseek.com/anthropic"
+        );
+        assert_eq!(
+            deepseek_anthropic.credential.as_deref(),
+            Some("deepseek-key")
+        );
+
+        let xiaomi = providers
+            .get(&ProviderId::parse("xiaomi").unwrap())
+            .unwrap();
+        assert_eq!(
+            xiaomi.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
+        assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
+
+        let xiaomi_anthropic = providers
+            .get(&ProviderId::parse("xiaomi-anthropic").unwrap())
+            .unwrap();
+        assert_eq!(
+            xiaomi_anthropic.transport,
+            ProviderTransportKind::AnthropicMessages
+        );
+        assert_eq!(
+            xiaomi_anthropic.base_url,
+            "https://api.xiaomimimo.com/anthropic"
+        );
+        assert_eq!(xiaomi_anthropic.credential.as_deref(), Some("xiaomi-key"));
 
         let minimax = providers
             .get(&ProviderId::parse("minimax").unwrap())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1758,7 +1758,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
     insert_anthropic_compatible_provider(
         &mut registry,
         "xiaomi-anthropic",
-        "https://api.xiaomimimo.com/anthropic",
+        "https://token-plan-cn.xiaomimimo.com/anthropic",
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
@@ -3169,7 +3169,7 @@ mod tests {
         );
         assert_eq!(
             xiaomi_anthropic.base_url,
-            "https://api.xiaomimimo.com/anthropic"
+            "https://token-plan-cn.xiaomimimo.com/anthropic"
         );
         assert_eq!(xiaomi_anthropic.credential.as_deref(), Some("xiaomi-key"));
 

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -719,6 +719,42 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
+            "deepseek-anthropic",
+            "deepseek-v4-flash",
+            "DeepSeek V4 Flash",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "deepseek-anthropic",
+            "deepseek-v4-pro",
+            "DeepSeek V4 Pro",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "deepseek-anthropic",
+            "deepseek-chat",
+            "DeepSeek Chat",
+            131_072,
+            8_192,
+            false,
+            false,
+        ),
+        catalog_model(
+            "deepseek-anthropic",
+            "deepseek-reasoner",
+            "DeepSeek Reasoner",
+            131_072,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
             "fireworks",
             "accounts/fireworks/models/kimi-k2p6",
             "Kimi K2.6",
@@ -1495,6 +1531,33 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             true,
         ),
+        catalog_model(
+            "xiaomi-anthropic",
+            "mimo-v2-flash",
+            "Xiaomi MiMo V2 Flash",
+            262_144,
+            8_192,
+            false,
+            false,
+        ),
+        catalog_model(
+            "xiaomi-anthropic",
+            "mimo-v2-pro",
+            "Xiaomi MiMo V2 Pro",
+            1_048_576,
+            32_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "xiaomi-anthropic",
+            "mimo-v2-omni",
+            "Xiaomi MiMo V2 Omni",
+            262_144,
+            32_000,
+            true,
+            true,
+        ),
         catalog_model("xai", "grok-3", "Grok 3", 131_072, 8_192, false, false),
         catalog_model(
             "xai",
@@ -1709,6 +1772,36 @@ mod tests {
         assert_eq!(policy.runtime_max_output_tokens, 384_000);
         assert!(policy.capabilities.reasoning_summaries);
         assert_eq!(policy.source, ModelMetadataSource::BuiltInCatalog);
+    }
+
+    #[test]
+    fn resolves_anthropic_compatible_provider_model_policy() {
+        let catalog = BuiltInModelCatalog::new();
+
+        let deepseek = catalog.resolve_policy(
+            &ModelRef::parse("deepseek-anthropic/deepseek-v4-flash").unwrap(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(deepseek.display_name, "DeepSeek V4 Flash");
+        assert_eq!(deepseek.context_window_tokens, Some(1_000_000));
+        assert_eq!(deepseek.runtime_max_output_tokens, 384_000);
+        assert_eq!(deepseek.source, ModelMetadataSource::BuiltInCatalog);
+
+        let xiaomi = catalog.resolve_policy(
+            &ModelRef::parse("xiaomi-anthropic/mimo-v2-pro").unwrap(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(xiaomi.display_name, "Xiaomi MiMo V2 Pro");
+        assert_eq!(xiaomi.context_window_tokens, Some(1_048_576));
+        assert_eq!(xiaomi.runtime_max_output_tokens, 32_000);
+        assert!(xiaomi.capabilities.reasoning_summaries);
+        assert_eq!(xiaomi.source, ModelMetadataSource::BuiltInCatalog);
     }
 
     #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1532,7 +1532,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
         ),
         catalog_model(
-            "xiaomi-anthropic",
+            "xiaomi-token-plan",
             "mimo-v2-flash",
             "Xiaomi MiMo V2 Flash",
             262_144,
@@ -1541,7 +1541,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "xiaomi-anthropic",
+            "xiaomi-token-plan",
             "mimo-v2-pro",
             "Xiaomi MiMo V2 Pro",
             1_048_576,
@@ -1550,7 +1550,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "xiaomi-anthropic",
+            "xiaomi-token-plan",
             "mimo-v2-omni",
             "Xiaomi MiMo V2 Omni",
             262_144,
@@ -1791,7 +1791,7 @@ mod tests {
         assert_eq!(deepseek.source, ModelMetadataSource::BuiltInCatalog);
 
         let xiaomi = catalog.resolve_policy(
-            &ModelRef::parse("xiaomi-anthropic/mimo-v2-pro").unwrap(),
+            &ModelRef::parse("xiaomi-token-plan/mimo-v2-pro").unwrap(),
             &HashMap::new(),
             None,
             &base_context(),

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -15,7 +15,7 @@ fn live_config() -> Result<AppConfig> {
 
 fn provider_model_env(provider: &str, default_model: &str) -> String {
     let env_name = format!(
-        "HOLON_LIVE_{}_ANTHROPIC_MODEL",
+        "HOLON_LIVE_{}_MODEL",
         provider.replace('-', "_").to_ascii_uppercase()
     );
     std::env::var(env_name).unwrap_or_else(|_| default_model.into())
@@ -52,6 +52,12 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
         }),
         freeform_grammar: None,
     };
+    let context_blocks = vec![PromptContentBlock {
+        text: "Runtime context block: the probe result must be preserved in the continuation."
+            .into(),
+        stability: PromptStability::AgentScoped,
+        cache_breakpoint: true,
+    }];
     let prompt_frame = ProviderPromptFrame::structured(
         "Reply to the user briefly after reading the tool result.",
         vec![PromptContentBlock {
@@ -59,7 +65,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
             stability: PromptStability::AgentScoped,
             cache_breakpoint: false,
         }],
-        vec![],
+        context_blocks.clone(),
         Some(ProviderPromptCache {
             agent_id: format!("live-{provider_id_text}-context-management"),
             prompt_cache_key: format!("live-{provider_id_text}-context-management"),
@@ -72,6 +78,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
         .complete_turn(ProviderTurnRequest {
             prompt_frame,
             conversation: vec![
+                ConversationMessage::UserBlocks(context_blocks),
                 ConversationMessage::UserText("Use the probe result and answer exactly OK.".into()),
                 ConversationMessage::AssistantBlocks(vec![ModelBlock::ToolUse {
                     id: "call_context_management_probe".into(),
@@ -89,9 +96,25 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
         })
         .await?;
 
+    let response_text = output
+        .blocks
+        .iter()
+        .filter_map(|block| match block {
+            ModelBlock::Text { text } => Some(text.as_str()),
+            ModelBlock::ToolUse { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(
-        !output.blocks.is_empty(),
-        "{provider_id_text}/{model} returned no supported content blocks"
+        output
+            .blocks
+            .iter()
+            .all(|block| matches!(block, ModelBlock::Text { .. })),
+        "{provider_id_text}/{model} emitted another tool call instead of completing the continuation"
+    );
+    assert!(
+        response_text.trim().trim_end_matches('.') == "OK",
+        "{provider_id_text}/{model} did not answer from the tool result; got {response_text:?}"
     );
     Ok(())
 }

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -107,11 +107,11 @@ async fn live_deepseek_anthropic_accepts_context_management() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "requires XIAOMI_API_KEY and network access"]
-async fn live_xiaomi_anthropic_accepts_context_management() -> Result<()> {
+#[ignore = "requires XIAOMI_TOKEN_PLAN_API_KEY and network access"]
+async fn live_xiaomi_token_plan_accepts_context_management() -> Result<()> {
     provider_accepts_context_management(
-        "xiaomi-anthropic",
-        &provider_model_env("xiaomi-anthropic", "mimo-v2-pro"),
+        "xiaomi-token-plan",
+        &provider_model_env("xiaomi-token-plan", "mimo-v2-pro"),
     )
     .await
 }

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -1,0 +1,117 @@
+use anyhow::{Context, Result};
+use holon::{
+    config::{AppConfig, ProviderId},
+    prompt::PromptStability,
+    provider::{
+        AgentProvider, AnthropicProvider, ConversationMessage, ModelBlock, PromptContentBlock,
+        ProviderPromptCache, ProviderPromptFrame, ProviderTurnRequest, ToolResultBlock,
+    },
+    tool::ToolSpec,
+};
+
+fn live_config() -> Result<AppConfig> {
+    AppConfig::load()
+}
+
+fn provider_model_env(provider: &str, default_model: &str) -> String {
+    let env_name = format!(
+        "HOLON_LIVE_{}_ANTHROPIC_MODEL",
+        provider.replace('-', "_").to_ascii_uppercase()
+    );
+    std::env::var(env_name).unwrap_or_else(|_| default_model.into())
+}
+
+async fn provider_accepts_context_management(provider_id: &str, model: &str) -> Result<()> {
+    let mut config = live_config()?;
+    let provider_id = ProviderId::parse(provider_id)?;
+    let provider_id_text = provider_id.as_str().to_string();
+    let runtime_max_output_tokens = config.runtime_max_output_tokens;
+    let provider_config = config
+        .providers
+        .get_mut(&provider_id)
+        .with_context(|| format!("missing {provider_id_text} provider config"))?;
+    provider_config.context_management.enabled = true;
+    provider_config.context_management.trigger_input_tokens = 1;
+    provider_config.context_management.keep_recent_tool_uses = 1;
+
+    let provider =
+        AnthropicProvider::from_runtime_config(provider_config, model, runtime_max_output_tokens)?;
+
+    let tool = ToolSpec {
+        name: "ProbeTool".into(),
+        description: "Returns a short probe value.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "description": "Why the probe is being called."
+                }
+            },
+            "required": ["reason"]
+        }),
+        freeform_grammar: None,
+    };
+    let prompt_frame = ProviderPromptFrame::structured(
+        "Reply to the user briefly after reading the tool result.",
+        vec![PromptContentBlock {
+            text: "Live Anthropic-compatible context management smoke test.".into(),
+            stability: PromptStability::AgentScoped,
+            cache_breakpoint: false,
+        }],
+        vec![],
+        Some(ProviderPromptCache {
+            agent_id: format!("live-{provider_id_text}-context-management"),
+            prompt_cache_key: format!("live-{provider_id_text}-context-management"),
+            working_memory_revision: 0,
+            compression_epoch: 0,
+        }),
+    );
+
+    let output = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame,
+            conversation: vec![
+                ConversationMessage::UserText("Use the probe result and answer exactly OK.".into()),
+                ConversationMessage::AssistantBlocks(vec![ModelBlock::ToolUse {
+                    id: "call_context_management_probe".into(),
+                    name: "ProbeTool".into(),
+                    input: serde_json::json!({ "reason": "context-management-smoke" }),
+                }]),
+                ConversationMessage::UserToolResults(vec![ToolResultBlock {
+                    tool_use_id: "call_context_management_probe".into(),
+                    content: "probe_result=OK".into(),
+                    is_error: false,
+                    error: None,
+                }]),
+            ],
+            tools: vec![tool],
+        })
+        .await?;
+
+    assert!(
+        !output.blocks.is_empty(),
+        "{provider_id_text}/{model} returned no supported content blocks"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires DEEPSEEK_API_KEY and network access"]
+async fn live_deepseek_anthropic_accepts_context_management() -> Result<()> {
+    provider_accepts_context_management(
+        "deepseek-anthropic",
+        &provider_model_env("deepseek-anthropic", "deepseek-chat"),
+    )
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires XIAOMI_API_KEY and network access"]
+async fn live_xiaomi_anthropic_accepts_context_management() -> Result<()> {
+    provider_accepts_context_management(
+        "xiaomi-anthropic",
+        &provider_model_env("xiaomi-anthropic", "mimo-v2-pro"),
+    )
+    .await
+}


### PR DESCRIPTION
## Summary

- add `deepseek-anthropic` as an explicit Anthropic-compatible alias for DeepSeek
- add `xiaomi-token-plan` as a separate Anthropic-compatible provider for Xiaomi token-plan
- keep default `xiaomi` on the normal OpenAI-compatible MiMo API because token-plan has a separate base URL and API key
- add matching model catalog entries and live provider probes for Anthropic-compatible `context_management`
- switch default `deepseek` to the Anthropic Messages transport after live validation
- document the provider split and credential boundary

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test built_in_provider_registry_includes_compatible_provider_defaults`
- `cargo test resolves_anthropic_compatible_provider_model_policy`
- `cargo test --test live_anthropic_compatible -- --ignored --nocapture`

## Live Result

- DeepSeek Anthropic-compatible endpoint accepted `context_management`
- Xiaomi token-plan Anthropic-compatible endpoint accepted `context_management`
