### PR TITLE
Add explicit provider transport aliases

### DIFF
--- a/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
+++ b/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
@@ -3,7 +3,7 @@
 When a provider family exposes both Anthropic Messages and OpenAI-compatible
 interfaces, Holon keeps explicit `provider-anthropic` and `provider-openai`
 entries. The bare `provider` id is the current default alias for that family.
-The default currently prefers Anthropic Messages for agent/coding use after live
+The default can prefer Anthropic Messages for agent/coding use after live
 validation confirms Holon's tool-use continuation shape with
 `context_management` enabled.
 
@@ -20,6 +20,10 @@ Z.ai and BigModel are separate provider families even though both expose Zhipu
 models, because they use separate account systems and base URLs. Holon exposes
 `zai`, `zai-anthropic`, `zai-openai`, `bigmodel`, `bigmodel-anthropic`, and
 `bigmodel-openai`.
+
+At this stage only DeepSeek and Xiaomi Anthropic-compatible endpoints have live
+probe evidence in this repository. Z.ai and BigModel Anthropic probes are wired
+as ignored tests but not yet validated with real credentials.
 
 DeepSeek uses `DEEPSEEK_API_KEY`. Xiaomi uses `XIAOMI_API_KEY`. Xiaomi
 token-plan uses `XIAOMI_TOKEN_PLAN_API_KEY`. Z.ai uses `ZAI_API_KEY`. BigModel

--- a/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
+++ b/docs/implementation-decisions/053-anthropic-compatible-provider-probes.md
@@ -1,20 +1,29 @@
 # 053 Anthropic-Compatible Provider Probes
 
-Holon uses the Anthropic Messages transport as the default transport for
-`deepseek` after live validation confirmed DeepSeek accepts Holon's tool-use
-request shape with `context_management` enabled.
+When a provider family exposes both Anthropic Messages and OpenAI-compatible
+interfaces, Holon keeps explicit `provider-anthropic` and `provider-openai`
+entries. The bare `provider` id is the current default alias for that family.
+The default currently prefers Anthropic Messages for agent/coding use after live
+validation confirms Holon's tool-use continuation shape with
+`context_management` enabled.
 
-Holon also keeps explicit `deepseek-anthropic` as a stable alias for the
-DeepSeek Anthropic-compatible endpoint.
+DeepSeek follows this family shape:
+`deepseek`, `deepseek-anthropic`, and `deepseek-openai`.
 
-Xiaomi's token-plan Anthropic-compatible endpoint is a separate service with a
-separate base URL and API key from the default Xiaomi MiMo API. Holon therefore
-keeps `xiaomi` on the default OpenAI-compatible endpoint and exposes token-plan
-as the separate `xiaomi-token-plan` provider.
+Xiaomi has two product entries because the default MiMo API and token-plan API
+use separate base URLs and API keys. Each product entry still exposes both
+transport variants:
+`xiaomi`, `xiaomi-anthropic`, `xiaomi-openai`, `xiaomi-token-plan`,
+`xiaomi-token-plan-anthropic`, and `xiaomi-token-plan-openai`.
 
-DeepSeek uses `https://api.deepseek.com/anthropic` with `DEEPSEEK_API_KEY`.
-Xiaomi token-plan uses `https://token-plan-cn.xiaomimimo.com/anthropic` with
-`XIAOMI_TOKEN_PLAN_API_KEY`.
+Z.ai and BigModel are separate provider families even though both expose Zhipu
+models, because they use separate account systems and base URLs. Holon exposes
+`zai`, `zai-anthropic`, `zai-openai`, `bigmodel`, `bigmodel-anthropic`, and
+`bigmodel-openai`.
+
+DeepSeek uses `DEEPSEEK_API_KEY`. Xiaomi uses `XIAOMI_API_KEY`. Xiaomi
+token-plan uses `XIAOMI_TOKEN_PLAN_API_KEY`. Z.ai uses `ZAI_API_KEY`. BigModel
+uses `BIGMODEL_API_KEY`.
 
 The validation tests are ignored by default because they require real
 credentials and network access:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1804,10 +1804,10 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["XAI_API_KEY"],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
+    insert_openai_compatible_provider(
         &mut registry,
         "zai",
-        "https://api.z.ai/api/anthropic",
+        "https://api.z.ai/api/paas/v4",
         &["ZAI_API_KEY"],
         settings_env,
     )?;
@@ -1825,10 +1825,10 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["ZAI_API_KEY"],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
+    insert_openai_compatible_provider(
         &mut registry,
         "bigmodel",
-        "https://open.bigmodel.cn/api/anthropic",
+        "https://open.bigmodel.cn/api/paas/v4",
         &["BIGMODEL_API_KEY"],
         settings_env,
     )?;
@@ -3345,9 +3345,18 @@ mod tests {
         );
 
         let zai = providers.get(&ProviderId::parse("zai").unwrap()).unwrap();
-        assert_eq!(zai.transport, ProviderTransportKind::AnthropicMessages);
-        assert_eq!(zai.base_url, "https://api.z.ai/api/anthropic");
+        assert_eq!(zai.transport, ProviderTransportKind::OpenAiChatCompletions);
+        assert_eq!(zai.base_url, "https://api.z.ai/api/paas/v4");
         assert_eq!(zai.credential.as_deref(), Some("zai-key"));
+
+        let zai_anthropic = providers
+            .get(&ProviderId::parse("zai-anthropic").unwrap())
+            .unwrap();
+        assert_eq!(
+            zai_anthropic.transport,
+            ProviderTransportKind::AnthropicMessages
+        );
+        assert_eq!(zai_anthropic.base_url, "https://api.z.ai/api/anthropic");
 
         let zai_openai = providers
             .get(&ProviderId::parse("zai-openai").unwrap())
@@ -3362,9 +3371,24 @@ mod tests {
         let bigmodel = providers
             .get(&ProviderId::parse("bigmodel").unwrap())
             .unwrap();
-        assert_eq!(bigmodel.transport, ProviderTransportKind::AnthropicMessages);
-        assert_eq!(bigmodel.base_url, "https://open.bigmodel.cn/api/anthropic");
+        assert_eq!(
+            bigmodel.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(bigmodel.base_url, "https://open.bigmodel.cn/api/paas/v4");
         assert_eq!(bigmodel.credential.as_deref(), Some("bigmodel-key"));
+
+        let bigmodel_anthropic = providers
+            .get(&ProviderId::parse("bigmodel-anthropic").unwrap())
+            .unwrap();
+        assert_eq!(
+            bigmodel_anthropic.transport,
+            ProviderTransportKind::AnthropicMessages
+        );
+        assert_eq!(
+            bigmodel_anthropic.base_url,
+            "https://open.bigmodel.cn/api/anthropic"
+        );
 
         let bigmodel_openai = providers
             .get(&ProviderId::parse("bigmodel-openai").unwrap())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1606,6 +1606,13 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
     )?;
     insert_openai_compatible_provider(
         &mut registry,
+        "deepseek-openai",
+        "https://api.deepseek.com/v1",
+        &["DEEPSEEK_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
         "fireworks",
         "https://api.fireworks.ai/inference/v1",
         &["FIREWORKS_API_KEY"],
@@ -1748,9 +1755,23 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         ],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_anthropic_compatible_provider(
         &mut registry,
         "xiaomi",
+        "https://api.xiaomimimo.com/anthropic",
+        &["XIAOMI_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "xiaomi-anthropic",
+        "https://api.xiaomimimo.com/anthropic",
+        &["XIAOMI_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
+        "xiaomi-openai",
         "https://api.xiaomimimo.com/v1",
         &["XIAOMI_API_KEY"],
         settings_env,
@@ -1762,6 +1783,20 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["XIAOMI_TOKEN_PLAN_API_KEY"],
         settings_env,
     )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "xiaomi-token-plan-anthropic",
+        "https://token-plan-cn.xiaomimimo.com/anthropic",
+        &["XIAOMI_TOKEN_PLAN_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
+        "xiaomi-token-plan-openai",
+        "https://token-plan-cn.xiaomimimo.com/v1",
+        &["XIAOMI_TOKEN_PLAN_API_KEY"],
+        settings_env,
+    )?;
     insert_openai_compatible_provider(
         &mut registry,
         "xai",
@@ -1769,11 +1804,46 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["XAI_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_anthropic_compatible_provider(
         &mut registry,
         "zai",
+        "https://api.z.ai/api/anthropic",
+        &["ZAI_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "zai-anthropic",
+        "https://api.z.ai/api/anthropic",
+        &["ZAI_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
+        "zai-openai",
         "https://api.z.ai/api/paas/v4",
         &["ZAI_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "bigmodel",
+        "https://open.bigmodel.cn/api/anthropic",
+        &["BIGMODEL_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "bigmodel-anthropic",
+        "https://open.bigmodel.cn/api/anthropic",
+        &["BIGMODEL_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
+        "bigmodel-openai",
+        "https://open.bigmodel.cn/api/paas/v4",
+        &["BIGMODEL_API_KEY"],
         settings_env,
     )?;
     insert_anthropic_compatible_provider(
@@ -3122,6 +3192,8 @@ mod tests {
             "XIAOMI_TOKEN_PLAN_API_KEY".to_string(),
             "xiaomi-token-plan-key".to_string(),
         );
+        settings_env.insert("ZAI_API_KEY".to_string(), "zai-key".to_string());
+        settings_env.insert("BIGMODEL_API_KEY".to_string(), "bigmodel-key".to_string());
         settings_env.insert("DASHSCOPE_API_KEY".to_string(), "dashscope-key".to_string());
 
         let providers = super::built_in_provider_registry(&settings_env).unwrap();
@@ -3176,15 +3248,49 @@ mod tests {
             AnthropicCacheStrategy::ClaudeCliLike
         );
 
+        let deepseek_openai = providers
+            .get(&ProviderId::parse("deepseek-openai").unwrap())
+            .unwrap();
+        assert_eq!(
+            deepseek_openai.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(deepseek_openai.base_url, "https://api.deepseek.com/v1");
+        assert_eq!(deepseek_openai.credential.as_deref(), Some("deepseek-key"));
+
         let xiaomi = providers
             .get(&ProviderId::parse("xiaomi").unwrap())
             .unwrap();
+        assert_eq!(xiaomi.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/anthropic");
+        assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
         assert_eq!(
-            xiaomi.transport,
+            xiaomi.context_management.cache_strategy,
+            AnthropicCacheStrategy::ClaudeCliLike
+        );
+
+        let xiaomi_anthropic = providers
+            .get(&ProviderId::parse("xiaomi-anthropic").unwrap())
+            .unwrap();
+        assert_eq!(
+            xiaomi_anthropic.transport,
+            ProviderTransportKind::AnthropicMessages
+        );
+        assert_eq!(
+            xiaomi_anthropic.base_url,
+            "https://api.xiaomimimo.com/anthropic"
+        );
+        assert_eq!(xiaomi_anthropic.credential.as_deref(), Some("xiaomi-key"));
+
+        let xiaomi_openai = providers
+            .get(&ProviderId::parse("xiaomi-openai").unwrap())
+            .unwrap();
+        assert_eq!(
+            xiaomi_openai.transport,
             ProviderTransportKind::OpenAiChatCompletions
         );
-        assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
-        assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
+        assert_eq!(xiaomi_openai.base_url, "https://api.xiaomimimo.com/v1");
+        assert_eq!(xiaomi_openai.credential.as_deref(), Some("xiaomi-key"));
 
         let xiaomi_token_plan = providers
             .get(&ProviderId::parse("xiaomi-token-plan").unwrap())
@@ -3205,6 +3311,73 @@ mod tests {
             xiaomi_token_plan.context_management.cache_strategy,
             AnthropicCacheStrategy::ClaudeCliLike
         );
+
+        let xiaomi_token_plan_anthropic = providers
+            .get(&ProviderId::parse("xiaomi-token-plan-anthropic").unwrap())
+            .unwrap();
+        assert_eq!(
+            xiaomi_token_plan_anthropic.transport,
+            ProviderTransportKind::AnthropicMessages
+        );
+        assert_eq!(
+            xiaomi_token_plan_anthropic.base_url,
+            "https://token-plan-cn.xiaomimimo.com/anthropic"
+        );
+        assert_eq!(
+            xiaomi_token_plan_anthropic.credential.as_deref(),
+            Some("xiaomi-token-plan-key")
+        );
+
+        let xiaomi_token_plan_openai = providers
+            .get(&ProviderId::parse("xiaomi-token-plan-openai").unwrap())
+            .unwrap();
+        assert_eq!(
+            xiaomi_token_plan_openai.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(
+            xiaomi_token_plan_openai.base_url,
+            "https://token-plan-cn.xiaomimimo.com/v1"
+        );
+        assert_eq!(
+            xiaomi_token_plan_openai.credential.as_deref(),
+            Some("xiaomi-token-plan-key")
+        );
+
+        let zai = providers.get(&ProviderId::parse("zai").unwrap()).unwrap();
+        assert_eq!(zai.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(zai.base_url, "https://api.z.ai/api/anthropic");
+        assert_eq!(zai.credential.as_deref(), Some("zai-key"));
+
+        let zai_openai = providers
+            .get(&ProviderId::parse("zai-openai").unwrap())
+            .unwrap();
+        assert_eq!(
+            zai_openai.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(zai_openai.base_url, "https://api.z.ai/api/paas/v4");
+        assert_eq!(zai_openai.credential.as_deref(), Some("zai-key"));
+
+        let bigmodel = providers
+            .get(&ProviderId::parse("bigmodel").unwrap())
+            .unwrap();
+        assert_eq!(bigmodel.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(bigmodel.base_url, "https://open.bigmodel.cn/api/anthropic");
+        assert_eq!(bigmodel.credential.as_deref(), Some("bigmodel-key"));
+
+        let bigmodel_openai = providers
+            .get(&ProviderId::parse("bigmodel-openai").unwrap())
+            .unwrap();
+        assert_eq!(
+            bigmodel_openai.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(
+            bigmodel_openai.base_url,
+            "https://open.bigmodel.cn/api/paas/v4"
+        );
+        assert_eq!(bigmodel_openai.credential.as_deref(), Some("bigmodel-key"));
 
         let minimax = providers
             .get(&ProviderId::parse("minimax").unwrap())

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -372,6 +372,36 @@ fn catalog_model(
     }
 }
 
+#[derive(Clone, Copy)]
+struct CatalogModelSpec {
+    model: &'static str,
+    display_name: &'static str,
+    context_window_tokens: usize,
+    max_output_tokens: u32,
+    reasoning_summaries: bool,
+    image_input: bool,
+}
+
+fn extend_catalog_model_aliases(
+    entries: &mut Vec<BuiltInModelMetadata>,
+    providers: &[&str],
+    models: &[CatalogModelSpec],
+) {
+    for provider in providers {
+        for model in models {
+            entries.push(catalog_model(
+                provider,
+                model.model,
+                model.display_name,
+                model.context_window_tokens,
+                model.max_output_tokens,
+                model.reasoning_summaries,
+                model.image_input,
+            ));
+        }
+    }
+}
+
 fn built_in_entries() -> Vec<BuiltInModelMetadata> {
     let mut entries = vec![
         BuiltInModelMetadata {
@@ -517,7 +547,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
 }
 
 fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
-    vec![
+    let mut entries = vec![
         catalog_model(
             "anthropic",
             "claude-opus-4-7",
@@ -1684,7 +1714,197 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model("zai", "glm-4.5v", "GLM-4.5V", 64_000, 16_384, true, true),
-    ]
+    ];
+    extend_catalog_model_aliases(
+        &mut entries,
+        &["deepseek-openai"],
+        &[
+            CatalogModelSpec {
+                model: "deepseek-v4-flash",
+                display_name: "DeepSeek V4 Flash",
+                context_window_tokens: 1_000_000,
+                max_output_tokens: 384_000,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "deepseek-v4-pro",
+                display_name: "DeepSeek V4 Pro",
+                context_window_tokens: 1_000_000,
+                max_output_tokens: 384_000,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "deepseek-chat",
+                display_name: "DeepSeek Chat",
+                context_window_tokens: 131_072,
+                max_output_tokens: 8_192,
+                reasoning_summaries: false,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "deepseek-reasoner",
+                display_name: "DeepSeek Reasoner",
+                context_window_tokens: 131_072,
+                max_output_tokens: 65_536,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+        ],
+    );
+    extend_catalog_model_aliases(
+        &mut entries,
+        &[
+            "xiaomi-anthropic",
+            "xiaomi-openai",
+            "xiaomi-token-plan-anthropic",
+            "xiaomi-token-plan-openai",
+        ],
+        &[
+            CatalogModelSpec {
+                model: "mimo-v2-flash",
+                display_name: "Xiaomi MiMo V2 Flash",
+                context_window_tokens: 262_144,
+                max_output_tokens: 8_192,
+                reasoning_summaries: false,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "mimo-v2-pro",
+                display_name: "Xiaomi MiMo V2 Pro",
+                context_window_tokens: 1_048_576,
+                max_output_tokens: 32_000,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "mimo-v2-omni",
+                display_name: "Xiaomi MiMo V2 Omni",
+                context_window_tokens: 262_144,
+                max_output_tokens: 32_000,
+                reasoning_summaries: true,
+                image_input: true,
+            },
+        ],
+    );
+    extend_catalog_model_aliases(
+        &mut entries,
+        &[
+            "zai-anthropic",
+            "zai-openai",
+            "bigmodel",
+            "bigmodel-anthropic",
+            "bigmodel-openai",
+        ],
+        &[
+            CatalogModelSpec {
+                model: "glm-5.1",
+                display_name: "GLM-5.1",
+                context_window_tokens: 202_800,
+                max_output_tokens: 131_100,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-5",
+                display_name: "GLM-5",
+                context_window_tokens: 202_800,
+                max_output_tokens: 131_100,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-5-turbo",
+                display_name: "GLM-5 Turbo",
+                context_window_tokens: 202_800,
+                max_output_tokens: 131_100,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-5v-turbo",
+                display_name: "GLM-5V Turbo",
+                context_window_tokens: 202_800,
+                max_output_tokens: 131_100,
+                reasoning_summaries: true,
+                image_input: true,
+            },
+            CatalogModelSpec {
+                model: "glm-4.7",
+                display_name: "GLM-4.7",
+                context_window_tokens: 204_800,
+                max_output_tokens: 131_072,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-4.7-flash",
+                display_name: "GLM-4.7 Flash",
+                context_window_tokens: 200_000,
+                max_output_tokens: 131_072,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-4.7-flashx",
+                display_name: "GLM-4.7 FlashX",
+                context_window_tokens: 200_000,
+                max_output_tokens: 128_000,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-4.6",
+                display_name: "GLM-4.6",
+                context_window_tokens: 204_800,
+                max_output_tokens: 131_072,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-4.6v",
+                display_name: "GLM-4.6V",
+                context_window_tokens: 128_000,
+                max_output_tokens: 32_768,
+                reasoning_summaries: true,
+                image_input: true,
+            },
+            CatalogModelSpec {
+                model: "glm-4.5",
+                display_name: "GLM-4.5",
+                context_window_tokens: 131_072,
+                max_output_tokens: 98_304,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-4.5-air",
+                display_name: "GLM-4.5 Air",
+                context_window_tokens: 131_072,
+                max_output_tokens: 98_304,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-4.5-flash",
+                display_name: "GLM-4.5 Flash",
+                context_window_tokens: 131_072,
+                max_output_tokens: 98_304,
+                reasoning_summaries: true,
+                image_input: false,
+            },
+            CatalogModelSpec {
+                model: "glm-4.5v",
+                display_name: "GLM-4.5V",
+                context_window_tokens: 64_000,
+                max_output_tokens: 16_384,
+                reasoning_summaries: true,
+                image_input: true,
+            },
+        ],
+    );
+    entries
 }
 
 #[cfg(test)]
@@ -1790,8 +2010,18 @@ mod tests {
         assert_eq!(deepseek.runtime_max_output_tokens, 384_000);
         assert_eq!(deepseek.source, ModelMetadataSource::BuiltInCatalog);
 
+        let deepseek_openai = catalog.resolve_policy(
+            &ModelRef::parse("deepseek-openai/deepseek-v4-flash").unwrap(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(deepseek_openai.display_name, "DeepSeek V4 Flash");
+        assert_eq!(deepseek_openai.source, ModelMetadataSource::BuiltInCatalog);
+
         let xiaomi = catalog.resolve_policy(
-            &ModelRef::parse("xiaomi-token-plan/mimo-v2-pro").unwrap(),
+            &ModelRef::parse("xiaomi-token-plan-openai/mimo-v2-pro").unwrap(),
             &HashMap::new(),
             None,
             &base_context(),
@@ -1802,6 +2032,26 @@ mod tests {
         assert_eq!(xiaomi.runtime_max_output_tokens, 32_000);
         assert!(xiaomi.capabilities.reasoning_summaries);
         assert_eq!(xiaomi.source, ModelMetadataSource::BuiltInCatalog);
+
+        let zai = catalog.resolve_policy(
+            &ModelRef::parse("zai-anthropic/glm-4.7").unwrap(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(zai.display_name, "GLM-4.7");
+        assert_eq!(zai.source, ModelMetadataSource::BuiltInCatalog);
+
+        let bigmodel = catalog.resolve_policy(
+            &ModelRef::parse("bigmodel-openai/glm-4.7").unwrap(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(bigmodel.display_name, "GLM-4.7");
+        assert_eq!(bigmodel.source, ModelMetadataSource::BuiltInCatalog);
     }
 
     #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -372,32 +372,29 @@ fn catalog_model(
     }
 }
 
-#[derive(Clone, Copy)]
-struct CatalogModelSpec {
-    model: &'static str,
-    display_name: &'static str,
-    context_window_tokens: usize,
-    max_output_tokens: u32,
-    reasoning_summaries: bool,
-    image_input: bool,
-}
-
-fn extend_catalog_model_aliases(
+fn extend_catalog_model_aliases_from_source(
     entries: &mut Vec<BuiltInModelMetadata>,
-    providers: &[&str],
-    models: &[CatalogModelSpec],
+    source_provider: &str,
+    alias_providers: &[&str],
 ) {
-    for provider in providers {
-        for model in models {
-            entries.push(catalog_model(
-                provider,
-                model.model,
-                model.display_name,
-                model.context_window_tokens,
-                model.max_output_tokens,
-                model.reasoning_summaries,
-                model.image_input,
-            ));
+    let source_provider_id = provider_id(source_provider);
+    let source_entries = entries
+        .iter()
+        .filter(|entry| entry.model_ref.provider == source_provider_id)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for provider in alias_providers {
+        let alias_provider_id = provider_id(provider);
+        for source_entry in &source_entries {
+            let mut alias_entry = source_entry.clone();
+            alias_entry.model_ref =
+                ModelRef::new(alias_provider_id.clone(), &source_entry.model_ref.model);
+            alias_entry.description = format!(
+                "Holon built-in runtime metadata for the {}/{} compatible provider model.",
+                provider, source_entry.model_ref.model
+            );
+            entries.push(alias_entry);
         }
     }
 }
@@ -1715,193 +1712,26 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model("zai", "glm-4.5v", "GLM-4.5V", 64_000, 16_384, true, true),
     ];
-    extend_catalog_model_aliases(
+    extend_catalog_model_aliases_from_source(&mut entries, "deepseek", &["deepseek-openai"]);
+    extend_catalog_model_aliases_from_source(
         &mut entries,
-        &["deepseek-openai"],
-        &[
-            CatalogModelSpec {
-                model: "deepseek-v4-flash",
-                display_name: "DeepSeek V4 Flash",
-                context_window_tokens: 1_000_000,
-                max_output_tokens: 384_000,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "deepseek-v4-pro",
-                display_name: "DeepSeek V4 Pro",
-                context_window_tokens: 1_000_000,
-                max_output_tokens: 384_000,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "deepseek-chat",
-                display_name: "DeepSeek Chat",
-                context_window_tokens: 131_072,
-                max_output_tokens: 8_192,
-                reasoning_summaries: false,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "deepseek-reasoner",
-                display_name: "DeepSeek Reasoner",
-                context_window_tokens: 131_072,
-                max_output_tokens: 65_536,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-        ],
-    );
-    extend_catalog_model_aliases(
-        &mut entries,
+        "xiaomi",
         &[
             "xiaomi-anthropic",
             "xiaomi-openai",
             "xiaomi-token-plan-anthropic",
             "xiaomi-token-plan-openai",
         ],
-        &[
-            CatalogModelSpec {
-                model: "mimo-v2-flash",
-                display_name: "Xiaomi MiMo V2 Flash",
-                context_window_tokens: 262_144,
-                max_output_tokens: 8_192,
-                reasoning_summaries: false,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "mimo-v2-pro",
-                display_name: "Xiaomi MiMo V2 Pro",
-                context_window_tokens: 1_048_576,
-                max_output_tokens: 32_000,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "mimo-v2-omni",
-                display_name: "Xiaomi MiMo V2 Omni",
-                context_window_tokens: 262_144,
-                max_output_tokens: 32_000,
-                reasoning_summaries: true,
-                image_input: true,
-            },
-        ],
     );
-    extend_catalog_model_aliases(
+    extend_catalog_model_aliases_from_source(
         &mut entries,
+        "zai",
         &[
             "zai-anthropic",
             "zai-openai",
             "bigmodel",
             "bigmodel-anthropic",
             "bigmodel-openai",
-        ],
-        &[
-            CatalogModelSpec {
-                model: "glm-5.1",
-                display_name: "GLM-5.1",
-                context_window_tokens: 202_800,
-                max_output_tokens: 131_100,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-5",
-                display_name: "GLM-5",
-                context_window_tokens: 202_800,
-                max_output_tokens: 131_100,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-5-turbo",
-                display_name: "GLM-5 Turbo",
-                context_window_tokens: 202_800,
-                max_output_tokens: 131_100,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-5v-turbo",
-                display_name: "GLM-5V Turbo",
-                context_window_tokens: 202_800,
-                max_output_tokens: 131_100,
-                reasoning_summaries: true,
-                image_input: true,
-            },
-            CatalogModelSpec {
-                model: "glm-4.7",
-                display_name: "GLM-4.7",
-                context_window_tokens: 204_800,
-                max_output_tokens: 131_072,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-4.7-flash",
-                display_name: "GLM-4.7 Flash",
-                context_window_tokens: 200_000,
-                max_output_tokens: 131_072,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-4.7-flashx",
-                display_name: "GLM-4.7 FlashX",
-                context_window_tokens: 200_000,
-                max_output_tokens: 128_000,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-4.6",
-                display_name: "GLM-4.6",
-                context_window_tokens: 204_800,
-                max_output_tokens: 131_072,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-4.6v",
-                display_name: "GLM-4.6V",
-                context_window_tokens: 128_000,
-                max_output_tokens: 32_768,
-                reasoning_summaries: true,
-                image_input: true,
-            },
-            CatalogModelSpec {
-                model: "glm-4.5",
-                display_name: "GLM-4.5",
-                context_window_tokens: 131_072,
-                max_output_tokens: 98_304,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-4.5-air",
-                display_name: "GLM-4.5 Air",
-                context_window_tokens: 131_072,
-                max_output_tokens: 98_304,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-4.5-flash",
-                display_name: "GLM-4.5 Flash",
-                context_window_tokens: 131_072,
-                max_output_tokens: 98_304,
-                reasoning_summaries: true,
-                image_input: false,
-            },
-            CatalogModelSpec {
-                model: "glm-4.5v",
-                display_name: "GLM-4.5V",
-                context_window_tokens: 64_000,
-                max_output_tokens: 16_384,
-                reasoning_summaries: true,
-                image_input: true,
-            },
         ],
     );
     entries

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use holon::{
-    config::{AppConfig, ProviderId},
+    config::{AppConfig, ProviderId, ProviderTransportKind},
     prompt::PromptStability,
     provider::{
         AgentProvider, AnthropicProvider, ConversationMessage, ModelBlock, PromptContentBlock,
@@ -30,6 +30,11 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
         .providers
         .get_mut(&provider_id)
         .with_context(|| format!("missing {provider_id_text} provider config"))?;
+    assert_eq!(
+        provider_config.transport,
+        ProviderTransportKind::AnthropicMessages,
+        "{provider_id_text} is not configured with Anthropic Messages transport"
+    );
     provider_config.context_management.enabled = true;
     provider_config.context_management.trigger_input_tokens = 1;
     provider_config.context_management.keep_recent_tool_uses = 1;

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -138,3 +138,43 @@ async fn live_xiaomi_token_plan_accepts_context_management() -> Result<()> {
     )
     .await
 }
+
+#[tokio::test]
+#[ignore = "requires XIAOMI_API_KEY and network access"]
+async fn live_xiaomi_anthropic_accepts_context_management() -> Result<()> {
+    provider_accepts_context_management(
+        "xiaomi-anthropic",
+        &provider_model_env("xiaomi-anthropic", "mimo-v2-pro"),
+    )
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires XIAOMI_TOKEN_PLAN_API_KEY and network access"]
+async fn live_xiaomi_token_plan_anthropic_accepts_context_management() -> Result<()> {
+    provider_accepts_context_management(
+        "xiaomi-token-plan-anthropic",
+        &provider_model_env("xiaomi-token-plan-anthropic", "mimo-v2-pro"),
+    )
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires ZAI_API_KEY and network access"]
+async fn live_zai_anthropic_accepts_context_management() -> Result<()> {
+    provider_accepts_context_management(
+        "zai-anthropic",
+        &provider_model_env("zai-anthropic", "glm-4.7"),
+    )
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires BIGMODEL_API_KEY and network access"]
+async fn live_bigmodel_anthropic_accepts_context_management() -> Result<()> {
+    provider_accepts_context_management(
+        "bigmodel-anthropic",
+        &provider_model_env("bigmodel-anthropic", "glm-4.7"),
+    )
+    .await
+}


### PR DESCRIPTION
## Summary

- add explicit `-anthropic` and `-openai` provider ids for multi-interface provider families
- keep bare provider ids as default aliases that currently prefer Anthropic Messages for agent/coding use
- add OpenAI-compatible fallback ids for DeepSeek, Xiaomi, Xiaomi token-plan, Z.ai, and BigModel
- split Xiaomi default MiMo and token-plan into separate provider families because they use different base URLs and API keys
- add built-in model catalog metadata for the new explicit provider ids
- add ignored live Anthropic-compatible probes for Xiaomi, Z.ai, and BigModel
- update implementation decision 053 with the provider-family alias rule

## Provider Shape

- `deepseek`, `deepseek-anthropic`, `deepseek-openai`
- `xiaomi`, `xiaomi-anthropic`, `xiaomi-openai`
- `xiaomi-token-plan`, `xiaomi-token-plan-anthropic`, `xiaomi-token-plan-openai`
- `zai`, `zai-anthropic`, `zai-openai`
- `bigmodel`, `bigmodel-anthropic`, `bigmodel-openai`

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test built_in_provider_registry_includes_compatible_provider_defaults`
- `cargo test resolves_anthropic_compatible_provider_model_policy`
- `cargo test --test live_anthropic_compatible live_deepseek_anthropic_accepts_context_management -- --ignored --nocapture`
- `cargo test --test live_anthropic_compatible live_xiaomi_anthropic_accepts_context_management -- --ignored --nocapture`
- `cargo test --test live_anthropic_compatible live_xiaomi_token_plan_accepts_context_management -- --ignored --nocapture`
- `cargo test --test live_anthropic_compatible live_xiaomi_token_plan_anthropic_accepts_context_management -- --ignored --nocapture`

## Not Run

- Z.ai and BigModel live probes were added but not run locally because this machine only has DeepSeek and Xiaomi credentials configured.
