### PR TITLE
align provider timeout with stream-idle semantics

### DIFF
--- a/docs/providers/openai-chat-completions.md
+++ b/docs/providers/openai-chat-completions.md
@@ -230,8 +230,10 @@ cargo test --test live_openai_chat_completions
 
 ### Safety Limits
 
-- **Timeout**: 300 seconds default HTTP timeout; override with
+- **Request send timeout**: 300 seconds default for request send/header phase; override with
   `HOLON_PROVIDER_HTTP_TIMEOUT_SECS`
+- **Streaming idle timeout**: 300 seconds default between streamed chunks; override with
+  `HOLON_PROVIDER_STREAM_IDLE_TIMEOUT_MS`
 - **Token limits**: Configurable via `max_tokens`
 - **Response size**: Maximum output tokens enforced by model
 
@@ -340,7 +342,8 @@ Model references: `deepseek/deepseek-chat`
    - Consider higher-tier API plan
 
 4. **Streaming timeout**
-   - Increase `HOLON_PROVIDER_HTTP_TIMEOUT_SECS` if needed
+   - Increase `HOLON_PROVIDER_STREAM_IDLE_TIMEOUT_MS` for long gaps between stream chunks
+   - Increase `HOLON_PROVIDER_HTTP_TIMEOUT_SECS` only if request send/header setup is slow
    - Check network connectivity
    - Verify server load/status
 

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -249,6 +249,33 @@ pub(crate) fn invalid_response_error(
     )
 }
 
+pub(crate) fn timeout_transport_error(
+    context: &str,
+    stage: &str,
+    provider: &str,
+    model_ref: Option<&str>,
+    url: Option<&str>,
+    reason: impl Into<String>,
+) -> anyhow::Error {
+    provider_transport_error(
+        ProviderFailureClassification {
+            kind: ProviderFailureKind::Timeout,
+            disposition: RetryDisposition::Retryable,
+        },
+        None,
+        Some(ProviderTransportDiagnostics {
+            stage: stage.to_string(),
+            provider: Some(provider.to_string()),
+            model_ref: model_ref.map(ToString::to_string),
+            url: url.map(sanitize_transport_url),
+            status: None,
+            reqwest: None,
+            source_chain: vec![reason.into()],
+        }),
+        context.to_string(),
+    )
+}
+
 fn sanitize_transport_url(raw: &str) -> String {
     let Ok(mut url) = reqwest::Url::parse(raw) else {
         return raw.to_string();

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -8,6 +8,7 @@ use std::sync::{
 use super::support::*;
 use super::*;
 use crate::config::ProviderId;
+use crate::provider::transports::set_stream_idle_timeout_override_for_tests;
 use axum::{http::StatusCode, response::IntoResponse, routing::post, Json, Router};
 use serde_json::{json, Value};
 
@@ -870,6 +871,68 @@ async fn openai_codex_retries_streaming_body_read_interruptions() {
     assert_eq!(
         timeline.attempts[0].failure_kind.as_deref(),
         Some("connection")
+    );
+    assert_eq!(
+        timeline.attempts[0].disposition.as_deref(),
+        Some("retryable")
+    );
+    assert_eq!(
+        timeline.attempts[0]
+            .transport_diagnostics
+            .as_ref()
+            .map(|diagnostics| diagnostics.stage.as_str()),
+        Some("streaming_response_body")
+    );
+    assert_eq!(
+        timeline.attempts[1].outcome,
+        ProviderAttemptOutcome::Succeeded
+    );
+}
+
+#[tokio::test]
+async fn openai_codex_retries_streaming_idle_timeout_interruptions() {
+    // First response sends headers immediately, then stalls before the first SSE chunk.
+    let delayed_headers =
+        b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n".to_vec();
+    let delayed_chunk = b"20\r\nevent: response.created\n".to_vec();
+    let body = openai_text_sse_response("resp_ok", "retry ok");
+    let complete = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .into_bytes();
+    let base_url = spawn_raw_http_server_scripted(vec![
+        vec![(0, delayed_headers), (400, delayed_chunk)],
+        vec![(0, complete)],
+    ])
+    .await;
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = base_url;
+    set_stream_idle_timeout_override_for_tests(Some(100));
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+
+    let (response, diagnostics) = provider
+        .complete_turn_with_diagnostics(provider_turn_request())
+        .await
+        .expect("idle timeout interruption should retry and recover");
+
+    set_stream_idle_timeout_override_for_tests(None);
+
+    assert!(matches!(
+        &response.blocks[0],
+        ModelBlock::Text { text } if text == "retry ok"
+    ));
+    let timeline = diagnostics.expect("missing attempt timeline");
+    assert_eq!(timeline.attempts.len(), 2);
+    assert_eq!(
+        timeline.attempts[0].failure_kind.as_deref(),
+        Some("timeout")
     );
     assert_eq!(
         timeline.attempts[0].disposition.as_deref(),

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -76,9 +76,7 @@ pub async fn spawn_raw_http_server_bytes_sequence_with_delay(
     format!("http://{}", addr)
 }
 
-pub async fn spawn_raw_http_server_scripted(
-    responses: Vec<Vec<(u64, Vec<u8>)>>,
-) -> String {
+pub async fn spawn_raw_http_server_scripted(responses: Vec<Vec<(u64, Vec<u8>)>>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -58,6 +58,44 @@ pub async fn spawn_raw_http_server_bytes_sequence(responses: Vec<Vec<u8>>) -> St
     format!("http://{}", addr)
 }
 
+pub async fn spawn_raw_http_server_bytes_sequence_with_delay(
+    responses: Vec<(u64, Vec<u8>)>,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        for (delay_ms, response) in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            drain_http_request(&mut stream).await;
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            stream.write_all(&response).await.unwrap();
+        }
+    });
+    format!("http://{}", addr)
+}
+
+pub async fn spawn_raw_http_server_scripted(
+    responses: Vec<Vec<(u64, Vec<u8>)>>,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        for chunks in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            drain_http_request(&mut stream).await;
+            for (delay_ms, chunk) in chunks {
+                if delay_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+                stream.write_all(&chunk).await.unwrap();
+            }
+        }
+    });
+    format!("http://{}", addr)
+}
+
 async fn drain_http_request(stream: &mut TcpStream) {
     let mut buffer = [0u8; 1024];
     let mut request = Vec::new();

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-use super::build_http_client;
+use super::{build_http_client, request_send_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error, classify_status_error, invalid_response_error,
 };
@@ -200,6 +200,7 @@ impl AgentProvider for AnthropicProvider {
                 request_builder.header("anthropic-beta", "context-management-2025-06-27");
         }
         let response = request_builder
+            .timeout(request_send_timeout())
             .json(&request_body)
             .send()
             .await

--- a/src/provider/transports/mod.rs
+++ b/src/provider/transports/mod.rs
@@ -16,16 +16,25 @@ pub(crate) use openai::{
 };
 pub use openai::{OpenAiChatCompletionsProvider, OpenAiCodexProvider, OpenAiProvider};
 
-const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 300;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS: u64 = 300_000;
 
 fn build_http_client() -> Result<Client> {
     let timeout_secs = env::var("HOLON_PROVIDER_HTTP_TIMEOUT_SECS")
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0);
+    let mut builder = Client::builder();
+    if let Some(timeout_secs) = timeout_secs {
+        builder = builder.timeout(Duration::from_secs(timeout_secs));
+    }
+    builder.build().context("failed to build HTTP client")
+}
+
+pub(super) fn stream_idle_timeout() -> Duration {
+    let timeout_ms = env::var("HOLON_PROVIDER_STREAM_IDLE_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
         .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_HTTP_TIMEOUT_SECS);
-    Client::builder()
-        .timeout(Duration::from_secs(timeout_secs))
-        .build()
-        .context("failed to build HTTP client")
+        .unwrap_or(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
+    Duration::from_millis(timeout_ms)
 }

--- a/src/provider/transports/mod.rs
+++ b/src/provider/transports/mod.rs
@@ -3,6 +3,8 @@ mod openai;
 
 use anyhow::{Context, Result};
 use reqwest::Client;
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{env, time::Duration};
 
 pub use anthropic::AnthropicProvider;
@@ -16,7 +18,10 @@ pub(crate) use openai::{
 };
 pub use openai::{OpenAiChatCompletionsProvider, OpenAiCodexProvider, OpenAiProvider};
 
+const DEFAULT_REQUEST_SEND_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS: u64 = 300_000;
+#[cfg(test)]
+static STREAM_IDLE_TIMEOUT_OVERRIDE_MS: AtomicU64 = AtomicU64::new(0);
 
 fn build_http_client() -> Result<Client> {
     let timeout_secs = env::var("HOLON_PROVIDER_HTTP_TIMEOUT_SECS")
@@ -31,10 +36,31 @@ fn build_http_client() -> Result<Client> {
 }
 
 pub(super) fn stream_idle_timeout() -> Duration {
+    #[cfg(test)]
+    {
+        let override_ms = STREAM_IDLE_TIMEOUT_OVERRIDE_MS.load(Ordering::Relaxed);
+        if override_ms > 0 {
+            return Duration::from_millis(override_ms);
+        }
+    }
     let timeout_ms = env::var("HOLON_PROVIDER_STREAM_IDLE_TIMEOUT_MS")
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
     Duration::from_millis(timeout_ms)
+}
+
+#[cfg(test)]
+pub(crate) fn set_stream_idle_timeout_override_for_tests(timeout_ms: Option<u64>) {
+    STREAM_IDLE_TIMEOUT_OVERRIDE_MS.store(timeout_ms.unwrap_or(0), Ordering::Relaxed);
+}
+
+pub(super) fn request_send_timeout() -> Duration {
+    let timeout_secs = env::var("HOLON_PROVIDER_HTTP_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_REQUEST_SEND_TIMEOUT_SECS);
+    Duration::from_secs(timeout_secs)
 }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use reqwest::{Client, Response};
+use reqwest::{Client, RequestBuilder, Response};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, Mutex, MutexGuard},
+    time::Duration,
 };
 
 use crate::{
@@ -20,11 +21,11 @@ use crate::{
     },
 };
 
-use super::{build_http_client, stream_idle_timeout};
+use super::{build_http_client, request_send_timeout, stream_idle_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error, classify_status_error, invalid_response_error,
-    provider_transport_error, ProviderFailureClassification, ProviderFailureKind,
-    ProviderTransportError, RetryDisposition,
+    provider_transport_error, timeout_transport_error, ProviderFailureClassification,
+    ProviderFailureKind, ProviderTransportError, RetryDisposition,
 };
 
 #[derive(Clone)]
@@ -2432,16 +2433,16 @@ async fn send_chat_completion_request(
         request = request.header(name, value);
     }
 
-    let response = request.json(&body).send().await.map_err(|error| {
-        classify_reqwest_transport_error(
-            "OpenAI Chat Completions request failed",
-            "request_send",
-            "openai",
-            Some(&provider_model_ref("openai", &body)),
-            Some(url.as_str()),
-            error,
-        )
-    })?;
+    let response = send_openai_request(
+        request.json(&body),
+        "OpenAI Chat Completions request failed",
+        "request_send",
+        "openai",
+        Some(&provider_model_ref("openai", &body)),
+        Some(url.as_str()),
+        true,
+    )
+    .await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -2729,16 +2730,16 @@ pub(crate) async fn send_chat_completion_stream_request(
         request = request.header(name, value);
     }
 
-    let response = request.json(&body).send().await.map_err(|error| {
-        classify_reqwest_transport_error(
-            "OpenAI Chat Completions streaming request failed",
-            "request_send",
-            "openai",
-            Some(&provider_model_ref("openai", &body)),
-            Some(url.as_str()),
-            error,
-        )
-    })?;
+    let response = send_openai_request(
+        request.json(&body),
+        "OpenAI Chat Completions streaming request failed",
+        "request_send",
+        "openai",
+        Some(&provider_model_ref("openai", &body)),
+        Some(url.as_str()),
+        true,
+    )
+    .await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -3055,16 +3056,16 @@ async fn send_openai_responses_request(
         request = request.header(name, value);
     }
 
-    let response = request.json(&body).send().await.map_err(|error| {
-        classify_reqwest_transport_error(
-            "OpenAI-style request failed",
-            "request_send",
-            "openai",
-            Some(&provider_model_ref("openai", &body)),
-            Some(url.as_str()),
-            error,
-        )
-    })?;
+    let response = send_openai_request(
+        request.json(&body),
+        "OpenAI-style request failed",
+        "request_send",
+        "openai",
+        Some(&provider_model_ref("openai", &body)),
+        Some(url.as_str()),
+        true,
+    )
+    .await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -3102,16 +3103,16 @@ async fn send_openai_compact_request(
         request = request.header(name, value);
     }
 
-    let response = request.json(&body).send().await.map_err(|error| {
-        classify_reqwest_transport_error(
-            "OpenAI compact request failed",
-            "request_send",
-            "openai",
-            Some(&provider_model_ref("openai", &body)),
-            Some(url.as_str()),
-            error,
-        )
-    })?;
+    let response = send_openai_request(
+        request.json(&body),
+        "OpenAI compact request failed",
+        "request_send",
+        "openai",
+        Some(&provider_model_ref("openai", &body)),
+        Some(url.as_str()),
+        true,
+    )
+    .await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -3162,16 +3163,16 @@ async fn send_openai_responses_streaming_request(
         request = request.header(name, value);
     }
 
-    let response = request.json(&body).send().await.map_err(|error| {
-        classify_reqwest_transport_error(
-            "OpenAI-style streaming request failed",
-            "streaming_request_send",
-            "openai-codex",
-            Some(&provider_model_ref("openai-codex", &body)),
-            Some(url.as_str()),
-            error,
-        )
-    })?;
+    let response = send_openai_request(
+        request.json(&body),
+        "OpenAI-style streaming request failed",
+        "streaming_request_send",
+        "openai-codex",
+        Some(&provider_model_ref("openai-codex", &body)),
+        Some(url.as_str()),
+        false,
+    )
+    .await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -3187,11 +3188,51 @@ async fn send_openai_responses_streaming_request(
     parse_openai_response_with_transport_state(terminal_response)
 }
 
+async fn send_openai_request(
+    mut request: RequestBuilder,
+    context: &str,
+    stage: &str,
+    provider: &str,
+    model_ref: Option<&str>,
+    url: Option<&str>,
+    enforce_full_request_deadline: bool,
+) -> Result<Response> {
+    let timeout = request_send_timeout();
+    if enforce_full_request_deadline {
+        request = request.timeout(timeout);
+        return request.send().await.map_err(|error| {
+            classify_reqwest_transport_error(context, stage, provider, model_ref, url, error)
+        });
+    }
+    tokio::time::timeout(timeout, request.send())
+        .await
+        .map_err(|_| {
+            timeout_transport_error(
+                context,
+                stage,
+                provider,
+                model_ref,
+                url,
+                format!("request_send_timeout_ms={}", timeout.as_millis()),
+            )
+        })?
+        .map_err(|error| {
+            classify_reqwest_transport_error(context, stage, provider, model_ref, url, error)
+        })
+}
+
 async fn read_openai_streaming_response(response: Response) -> Result<Value> {
+    let idle_timeout = stream_idle_timeout();
+    read_openai_streaming_response_with_timeout(response, idle_timeout).await
+}
+
+async fn read_openai_streaming_response_with_timeout(
+    response: Response,
+    idle_timeout: Duration,
+) -> Result<Value> {
     const MAX_STREAMED_OUTPUT_ITEMS: usize = 128;
 
     let mut response = response;
-    let idle_timeout = stream_idle_timeout();
     let mut pending = String::new();
     let mut data_lines = Vec::new();
     let mut streamed_output_items = Vec::new();
@@ -3199,29 +3240,29 @@ async fn read_openai_streaming_response(response: Response) -> Result<Value> {
     while let Some(chunk) = tokio::time::timeout(idle_timeout, response.chunk())
         .await
         .map_err(|_| {
-            provider_transport_error(
-                ProviderFailureClassification {
-                    kind: ProviderFailureKind::Timeout,
-                    disposition: RetryDisposition::Retryable,
-                },
+            timeout_transport_error(
+                "OpenAI-style streaming response body timed out",
+                "streaming_response_body",
+                "openai-codex",
                 None,
                 None,
                 format!(
-                    "OpenAI-style streaming response body timed out waiting for SSE chunk after {} ms",
+                    "timed out waiting for SSE chunk after {} ms",
                     idle_timeout.as_millis()
                 ),
             )
         })?
         .map_err(|error| {
-        classify_reqwest_transport_error(
-            "OpenAI-style streaming response body failed",
-            "streaming_response_body",
-            "openai-codex",
-            None,
-            None,
-            error,
-        )
-    })? {
+            classify_reqwest_transport_error(
+                "OpenAI-style streaming response body failed",
+                "streaming_response_body",
+                "openai-codex",
+                None,
+                None,
+                error,
+            )
+        })?
+    {
         pending.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(newline_idx) = pending.find('\n') {
             let mut line = pending[..newline_idx].to_string();

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-use super::build_http_client;
+use super::{build_http_client, stream_idle_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error, classify_status_error, invalid_response_error,
     provider_transport_error, ProviderFailureClassification, ProviderFailureKind,
@@ -3191,11 +3191,28 @@ async fn read_openai_streaming_response(response: Response) -> Result<Value> {
     const MAX_STREAMED_OUTPUT_ITEMS: usize = 128;
 
     let mut response = response;
+    let idle_timeout = stream_idle_timeout();
     let mut pending = String::new();
     let mut data_lines = Vec::new();
     let mut streamed_output_items = Vec::new();
 
-    while let Some(chunk) = response.chunk().await.map_err(|error| {
+    while let Some(chunk) = tokio::time::timeout(idle_timeout, response.chunk())
+        .await
+        .map_err(|_| {
+            provider_transport_error(
+                ProviderFailureClassification {
+                    kind: ProviderFailureKind::Timeout,
+                    disposition: RetryDisposition::Retryable,
+                },
+                None,
+                None,
+                format!(
+                    "OpenAI-style streaming response body timed out waiting for SSE chunk after {} ms",
+                    idle_timeout.as_millis()
+                ),
+            )
+        })?
+        .map_err(|error| {
         classify_reqwest_transport_error(
             "OpenAI-style streaming response body failed",
             "streaming_response_body",


### PR DESCRIPTION
## Summary
- remove default global reqwest timeout for provider transports; keep HOLON_PROVIDER_HTTP_TIMEOUT_SECS as optional override
- add stream idle timeout control via HOLON_PROVIDER_STREAM_IDLE_TIMEOUT_MS (default 300000ms)
- enforce OpenAI streaming chunk idle timeout in read_openai_streaming_response and classify it as retryable timeout

## Why
Recent holon benchmark runs on case #862 terminated with transport timeout/decode failures in streaming_response_body after retries were exhausted. The current default global HTTP timeout can abort long-running streaming turns prematurely. This change aligns behavior with Codex-style streaming semantics: no hard global request deadline by default, with explicit stream-idle protection.

## Verification
- cargo fmt --all
- cargo check -q
