### PR TITLE
feat: default zai and bigmodel to anthropic transport

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1048,6 +1048,21 @@ pub fn validate_provider_config(
     validate_provider_auth(provider_id, &provider_config.auth)
 }
 
+pub fn built_in_provider_default_config(
+    provider_id: &ProviderId,
+) -> Result<Option<ProviderConfigFile>> {
+    let settings_env = load_settings_env()?;
+    let registry = built_in_provider_registry(&settings_env)?;
+    Ok(registry
+        .get(provider_id)
+        .map(|provider| ProviderConfigFile {
+            transport: provider.transport,
+            base_url: provider.base_url.clone(),
+            auth: provider.auth.clone(),
+            reasoning_effort: None,
+        }))
+}
+
 pub fn provider_config_views(config: &AppConfig) -> Vec<ProviderConfigView> {
     config
         .providers
@@ -1804,10 +1819,10 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["XAI_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_anthropic_compatible_provider(
         &mut registry,
         "zai",
-        "https://api.z.ai/api/paas/v4",
+        "https://api.z.ai/api/anthropic",
         &["ZAI_API_KEY"],
         settings_env,
     )?;
@@ -1825,10 +1840,10 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
         &["ZAI_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
+    insert_anthropic_compatible_provider(
         &mut registry,
         "bigmodel",
-        "https://open.bigmodel.cn/api/paas/v4",
+        "https://open.bigmodel.cn/api/anthropic",
         &["BIGMODEL_API_KEY"],
         settings_env,
     )?;
@@ -3345,8 +3360,8 @@ mod tests {
         );
 
         let zai = providers.get(&ProviderId::parse("zai").unwrap()).unwrap();
-        assert_eq!(zai.transport, ProviderTransportKind::OpenAiChatCompletions);
-        assert_eq!(zai.base_url, "https://api.z.ai/api/paas/v4");
+        assert_eq!(zai.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(zai.base_url, "https://api.z.ai/api/anthropic");
         assert_eq!(zai.credential.as_deref(), Some("zai-key"));
 
         let zai_anthropic = providers
@@ -3371,11 +3386,8 @@ mod tests {
         let bigmodel = providers
             .get(&ProviderId::parse("bigmodel").unwrap())
             .unwrap();
-        assert_eq!(
-            bigmodel.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(bigmodel.base_url, "https://open.bigmodel.cn/api/paas/v4");
+        assert_eq!(bigmodel.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(bigmodel.base_url, "https://open.bigmodel.cn/api/anthropic");
         assert_eq!(bigmodel.credential.as_deref(), Some("bigmodel-key"));
 
         let bigmodel_anthropic = providers

--- a/src/config.rs
+++ b/src/config.rs
@@ -1052,13 +1052,20 @@ pub fn built_in_provider_default_config(
     provider_id: &ProviderId,
 ) -> Result<Option<ProviderConfigFile>> {
     let settings_env = load_settings_env()?;
+    built_in_provider_default_config_with_settings(provider_id, &settings_env)
+}
+
+fn built_in_provider_default_config_with_settings(
+    provider_id: &ProviderId,
+    settings_env: &HashMap<String, String>,
+) -> Result<Option<ProviderConfigFile>> {
     let registry = built_in_provider_registry(&settings_env)?;
     Ok(registry
         .get(provider_id)
         .map(|provider| ProviderConfigFile {
             transport: provider.transport,
             base_url: provider.base_url.clone(),
-            auth: provider.auth.clone(),
+            auth: ProviderAuthConfig::default(),
             reasoning_effort: None,
         }))
 }
@@ -3439,6 +3446,30 @@ mod tests {
         let vllm = providers.get(&ProviderId::parse("vllm").unwrap()).unwrap();
         assert_eq!(vllm.auth.source, CredentialSource::None);
         assert_eq!(vllm.credential, None);
+    }
+
+    #[test]
+    fn built_in_provider_default_config_resolves_known_and_unknown_provider() {
+        let settings_env = HashMap::new();
+
+        let known = super::built_in_provider_default_config_with_settings(
+            &ProviderId::parse("zai-anthropic").unwrap(),
+            &settings_env,
+        )
+        .unwrap()
+        .expect("expected built-in default");
+        assert_eq!(known.transport, ProviderTransportKind::AnthropicMessages);
+        assert_eq!(known.base_url, "https://api.z.ai/api/anthropic");
+        assert_eq!(known.auth.source, CredentialSource::None);
+        assert_eq!(known.auth.kind, CredentialKind::None);
+        assert!(known.auth.env.is_none());
+
+        let unknown = super::built_in_provider_default_config_with_settings(
+            &ProviderId::parse("unknown-provider").unwrap(),
+            &settings_env,
+        )
+        .unwrap();
+        assert!(unknown.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,20 @@
 use std::{
-    io::Read,
+    io::Write,
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 use holon::{
     client::LocalClient,
     config::{
-        config_schema, credential_store_path, default_holon_home, get_config_key,
-        list_credential_profiles_at, load_persisted_config_at, persisted_config_path,
-        provider_config_view, provider_config_views, remove_credential_profile_at,
-        save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
-        validate_provider_config, AppConfig, CredentialKind, CredentialSource, ProviderAuthConfig,
-        ProviderConfigFile, ProviderId, ProviderTransportKind,
+        built_in_provider_default_config, config_schema, credential_store_path, default_holon_home,
+        get_config_key, list_credential_profiles_at, load_persisted_config_at,
+        persisted_config_path, provider_config_view, provider_config_views,
+        remove_credential_profile_at, save_persisted_config_at, set_config_key,
+        set_credential_profile_at, unset_config_key, validate_provider_config, AppConfig,
+        CredentialKind, CredentialSource, ProviderAuthConfig, ProviderConfigFile, ProviderId,
+        ProviderTransportKind,
     },
     daemon::{
         daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
@@ -223,9 +224,9 @@ enum ConfigProviderCommands {
     Set {
         provider: String,
         #[arg(long)]
-        transport: String,
+        transport: Option<String>,
         #[arg(long)]
-        base_url: String,
+        base_url: Option<String>,
         #[arg(long, default_value = "none")]
         credential_source: String,
         #[arg(long, default_value = "none")]
@@ -257,6 +258,8 @@ enum ConfigCredentialCommands {
         kind: String,
         #[arg(long)]
         stdin: bool,
+        #[arg(long)]
+        material: Option<String>,
     },
     List,
     Remove {
@@ -870,8 +873,44 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
             credential_external,
         } => {
             let id = ProviderId::parse(&provider)?;
+            let built_in_defaults = built_in_provider_default_config(&id)?;
+            let transport = match (transport, built_in_defaults.as_ref()) {
+                (Some(raw), Some(defaults)) => {
+                    let parsed = ProviderTransportKind::parse(&raw)?;
+                    let id_str = id.as_str();
+                    if (id_str.ends_with("-anthropic") || id_str.ends_with("-openai"))
+                        && parsed != defaults.transport
+                    {
+                        return Err(anyhow!(
+                            "provider {} has fixed transport {}; remove --transport or set it to {}",
+                            id_str,
+                            defaults.transport.as_str(),
+                            defaults.transport.as_str()
+                        ));
+                    }
+                    parsed
+                }
+                (Some(raw), None) => ProviderTransportKind::parse(&raw)?,
+                (None, Some(defaults)) => defaults.transport,
+                (None, None) => {
+                    return Err(anyhow!(
+                        "provider {} requires --transport when no built-in default exists",
+                        id.as_str()
+                    ));
+                }
+            };
+            let base_url = match (base_url, built_in_defaults.as_ref()) {
+                (Some(value), _) => value,
+                (None, Some(defaults)) => defaults.base_url.clone(),
+                (None, None) => {
+                    return Err(anyhow!(
+                        "provider {} requires --base-url when no built-in default exists",
+                        id.as_str()
+                    ));
+                }
+            };
             let provider_config = ProviderConfigFile {
-                transport: ProviderTransportKind::parse(&transport)?,
+                transport,
                 base_url,
                 auth: ProviderAuthConfig {
                     source: CredentialSource::parse(&credential_source)?,
@@ -958,14 +997,24 @@ async fn handle_config_credentials_command(command: ConfigCredentialCommands) ->
             profile,
             kind,
             stdin,
+            material,
         } => {
-            if !stdin {
-                anyhow::bail!("credential material input requires --stdin");
+            if stdin && material.is_some() {
+                anyhow::bail!("--stdin cannot be used together with --material");
             }
-            let mut material = String::new();
-            std::io::stdin()
-                .read_to_string(&mut material)
-                .context("failed to read credential material from stdin")?;
+            let mut material = if let Some(value) = material {
+                value
+            } else if stdin {
+                eprint!("Enter credential material for {profile} and press Enter: ");
+                std::io::stderr().flush().ok();
+                let mut value = String::new();
+                std::io::stdin()
+                    .read_line(&mut value)
+                    .context("failed to read credential material from stdin")?;
+                value
+            } else {
+                anyhow::bail!("credential set requires either --stdin or --material");
+            };
             trim_trailing_newlines(&mut material);
             let status = set_credential_profile_at(
                 &path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,10 @@ enum ConfigCredentialCommands {
         kind: String,
         #[arg(long)]
         stdin: bool,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Raw credential material (not recommended for secrets; prefer --stdin to avoid shell history/process args leakage)."
+        )]
         material: Option<String>,
     },
     List,
@@ -1006,7 +1009,9 @@ async fn handle_config_credentials_command(command: ConfigCredentialCommands) ->
                 value
             } else if stdin {
                 eprint!("Enter credential material for {profile} and press Enter: ");
-                std::io::stderr().flush().ok();
+                std::io::stderr()
+                    .flush()
+                    .context("failed to flush credential prompt to stderr")?;
                 let mut value = String::new();
                 std::io::stdin()
                     .read_line(&mut value)

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -183,3 +183,10 @@ async fn live_bigmodel_anthropic_accepts_context_management() -> Result<()> {
     )
     .await
 }
+
+#[tokio::test]
+#[ignore = "requires MINIMAX_API_KEY and network access"]
+async fn live_minimax_anthropic_accepts_context_management() -> Result<()> {
+    provider_accepts_context_management("minimax", &provider_model_env("minimax", "MiniMax-M2.7"))
+        .await
+}


### PR DESCRIPTION
## Summary
- switch bare `zai` and `bigmodel` provider aliases to Anthropic-compatible defaults
- keep explicit `zai-openai` and `bigmodel-openai` aliases for fallback
- improve `config credentials set` UX: support `--material` and make `--stdin` single-line prompt mode
- add MiniMax Anthropic context-management live probe test case

## Validation
- `cargo fmt --check`
- `cargo test built_in_provider_registry_includes_compatible_provider_defaults`
- `cargo test resolves_anthropic_compatible_provider_model_policy`
- `cargo test live_bigmodel_anthropic_accepts_context_management --test live_anthropic_compatible -- --ignored --nocapture`
- `cargo test live_minimax_anthropic_accepts_context_management --test live_anthropic_compatible -- --ignored --nocapture`
