### PR TITLE
feat: split TUI model picker and add effort selection

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -320,11 +320,13 @@ impl LocalClient {
         &self,
         agent_id: &str,
         model: impl Into<String>,
+        reasoning_effort: Option<String>,
     ) -> Result<Value> {
         self.post_control_json(
             &format!("/control/agents/{agent_id}/model"),
             &SetAgentModelRequest {
                 model: model.into(),
+                reasoning_effort,
                 trust: Some(TrustLevel::TrustedOperator),
             },
         )

--- a/src/host.rs
+++ b/src/host.rs
@@ -1566,7 +1566,7 @@ mod tests {
         let host = RuntimeHost::new(fixture.config).unwrap();
         let parent = host.default_runtime().await.unwrap();
         parent
-            .set_model_override(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap())
+            .set_model_override(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap(), None)
             .await
             .unwrap();
 
@@ -1658,7 +1658,7 @@ mod tests {
             .any(|entry| entry.model_ref.as_string() == "openai/gpt-5.4"));
 
         let updated = runtime
-            .set_model_override(ModelRef::parse("openai/gpt-5.4").unwrap())
+            .set_model_override(ModelRef::parse("openai/gpt-5.4").unwrap(), None)
             .await
             .unwrap();
         assert_eq!(
@@ -1746,7 +1746,7 @@ mod tests {
         let host = RuntimeHost::new(fixture.config).unwrap();
         let parent = host.default_runtime().await.unwrap();
         parent
-            .set_model_override(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap())
+            .set_model_override(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap(), None)
             .await
             .unwrap();
         let parent_state = parent.agent_state().await.unwrap();

--- a/src/http.rs
+++ b/src/http.rs
@@ -423,6 +423,8 @@ pub struct DetachWorkspaceRequest {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SetAgentModelRequest {
     pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
     pub trust: Option<TrustLevel>,
 }
 
@@ -1493,7 +1495,7 @@ pub async fn set_agent_model(
         .await
         .map_err(error_response)?;
     let model_state = runtime
-        .set_model_override(model.clone())
+        .set_model_override(model.clone(), request.reasoning_effort.clone())
         .await
         .map_err(error_response)?;
     runtime

--- a/src/http.rs
+++ b/src/http.rs
@@ -1483,6 +1483,9 @@ pub async fn set_agent_model(
     Json(request): Json<SetAgentModelRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    if let Some(reasoning_effort) = request.reasoning_effort.as_deref() {
+        validate_reasoning_effort(reasoning_effort)?;
+    }
     let admission_context = control_admission_context(&state);
     let provided_trust = request.trust;
     let model = ModelRef::parse(&request.model).map_err(error_response)?;
@@ -1516,6 +1519,15 @@ pub async fn set_agent_model(
         "agent_id": agent_id,
         "model": model_state,
     })))
+}
+
+fn validate_reasoning_effort(value: &str) -> Result<(), (StatusCode, Json<Value>)> {
+    match value {
+        "low" | "medium" | "high" | "xhigh" => Ok(()),
+        _ => Err(bad_request(format!(
+            "invalid reasoning_effort '{value}'; must be one of low, medium, high, xhigh"
+        ))),
+    }
 }
 
 pub async fn clear_agent_model(

--- a/src/main.rs
+++ b/src/main.rs
@@ -772,7 +772,7 @@ async fn handle_agents_command(config: &AppConfig, command: Option<AgentsCommand
                 }
                 AgentModelCommands::Set { model, agent } => {
                     let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
-                    print_json(&client.set_agent_model_override(&agent, model).await?)
+                    print_json(&client.set_agent_model_override(&agent, model, None).await?)
                 }
                 AgentModelCommands::Clear { agent } => {
                     let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -367,6 +367,7 @@ impl RuntimeHandle {
             fallback_active,
             effective_fallback_models: effective_chain.into_iter().skip(1).collect(),
             override_model: state.model_override.clone(),
+            override_reasoning_effort: state.model_override_reasoning_effort.clone(),
             resolved_policy,
             available_models: self.inner.model_catalog.available_models(),
             model_availability: self.inner.model_availability.clone(),
@@ -388,6 +389,14 @@ impl RuntimeHandle {
             state.model_override.as_ref(),
         );
         let mut provider_config = reconfig.config.clone();
+        if let (Some(primary), Some(reasoning_effort)) = (
+            chain.first(),
+            state.model_override_reasoning_effort.as_ref(),
+        ) {
+            if let Some(provider) = provider_config.providers.get_mut(&primary.provider) {
+                provider.reasoning_effort = Some(reasoning_effort.clone());
+            }
+        }
         provider_config.runtime_max_output_tokens = self
             .inner
             .model_catalog

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -635,15 +635,18 @@ impl RuntimeHandle {
     pub async fn set_model_override(
         &self,
         model_override: crate::config::ModelRef,
+        reasoning_effort: Option<String>,
     ) -> Result<crate::types::AgentModelState> {
         let mut next_state = self.agent_state().await?;
         next_state.model_override = Some(model_override.clone());
+        next_state.model_override_reasoning_effort = reasoning_effort.clone();
         self.reconfigure_provider_for_state(&next_state).await?;
 
         let model_state = self.model_state_for(&next_state);
         {
             let mut guard = self.inner.agent.lock().await;
             guard.state.model_override = Some(model_override);
+            guard.state.model_override_reasoning_effort = reasoning_effort;
             self.inner.storage.write_agent(&guard.state)?;
         }
         self.append_audit_event(
@@ -659,12 +662,14 @@ impl RuntimeHandle {
     pub async fn clear_model_override(&self) -> Result<crate::types::AgentModelState> {
         let mut next_state = self.agent_state().await?;
         next_state.model_override = None;
+        next_state.model_override_reasoning_effort = None;
         self.reconfigure_provider_for_state(&next_state).await?;
 
         let model_state = self.model_state_for(&next_state);
         {
             let mut guard = self.inner.agent.lock().await;
             guard.state.model_override = None;
+            guard.state.model_override_reasoning_effort = None;
             self.inner.storage.write_agent(&guard.state)?;
         }
         self.append_audit_event(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -928,6 +928,7 @@ mod tests {
                 )
                 .unwrap(),
                 override_model: None,
+                override_reasoning_effort: None,
                 source: AgentModelSource::RuntimeDefault,
                 effective_fallback_models: Vec::new(),
                 resolved_policy: crate::model_catalog::ResolvedRuntimeModelPolicy {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -561,12 +561,14 @@ impl TuiApp {
             OverlayState::ModelEffortPicker {
                 model,
                 mut selected,
+                return_filter,
+                return_selected,
             } => {
                 match key.code {
                     KeyCode::Esc => {
                         self.overlay = OverlayState::ModelPicker {
-                            filter: String::new(),
-                            selected: 0,
+                            filter: return_filter,
+                            selected: return_selected,
                         };
                     }
                     KeyCode::Enter => {
@@ -575,14 +577,30 @@ impl TuiApp {
                     }
                     KeyCode::Up | KeyCode::Char('k') => {
                         selected = selected.saturating_sub(1);
-                        self.overlay = OverlayState::ModelEffortPicker { model, selected };
+                        self.overlay = OverlayState::ModelEffortPicker {
+                            model,
+                            selected,
+                            return_filter,
+                            return_selected,
+                        };
                     }
                     KeyCode::Down | KeyCode::Char('j') => {
-                        selected = (selected + 1).min(4);
-                        self.overlay = OverlayState::ModelEffortPicker { model, selected };
+                        let max = crate::tui::overlay::MODEL_REASONING_EFFORT_OPTIONS.len() - 1;
+                        selected = (selected + 1).min(max);
+                        self.overlay = OverlayState::ModelEffortPicker {
+                            model,
+                            selected,
+                            return_filter,
+                            return_selected,
+                        };
                     }
                     _ => {
-                        self.overlay = OverlayState::ModelEffortPicker { model, selected };
+                        self.overlay = OverlayState::ModelEffortPicker {
+                            model,
+                            selected,
+                            return_filter,
+                            return_selected,
+                        };
                     }
                 }
                 Ok(())
@@ -847,7 +865,12 @@ impl TuiApp {
                 self.bootstrap_selected_agent().await?;
             }
             crate::tui::model_picker::ModelPickerChoice::Model { model } => {
-                self.overlay = OverlayState::ModelEffortPicker { model, selected: 0 };
+                self.overlay = OverlayState::ModelEffortPicker {
+                    model,
+                    selected: 0,
+                    return_filter: filter.to_string(),
+                    return_selected: selected,
+                };
             }
         }
         Ok(())
@@ -862,12 +885,14 @@ impl TuiApp {
             .selected_agent_id()
             .ok_or_else(|| anyhow!("no agent selected"))?
             .to_string();
-        let reasoning_effort = match selected {
-            0 => None,
-            1 => Some("low".to_string()),
-            2 => Some("medium".to_string()),
-            3 => Some("high".to_string()),
-            _ => Some("xhigh".to_string()),
+        let reasoning_effort = crate::tui::overlay::MODEL_REASONING_EFFORT_OPTIONS
+            .get(selected)
+            .copied()
+            .unwrap_or("xhigh");
+        let reasoning_effort = if reasoning_effort == "inherit" {
+            None
+        } else {
+            Some(reasoning_effort.to_string())
         };
         self.client
             .set_agent_model_override(&agent_id, model.to_string(), reasoning_effort.clone())

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -558,6 +558,35 @@ impl TuiApp {
                 }
                 Ok(())
             }
+            OverlayState::ModelEffortPicker {
+                model,
+                mut selected,
+            } => {
+                match key.code {
+                    KeyCode::Esc => {
+                        self.overlay = OverlayState::ModelPicker {
+                            filter: String::new(),
+                            selected: 0,
+                        };
+                    }
+                    KeyCode::Enter => {
+                        self.apply_model_effort_picker_selection(&model, selected)
+                            .await?;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        selected = selected.saturating_sub(1);
+                        self.overlay = OverlayState::ModelEffortPicker { model, selected };
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        selected = (selected + 1).min(4);
+                        self.overlay = OverlayState::ModelEffortPicker { model, selected };
+                    }
+                    _ => {
+                        self.overlay = OverlayState::ModelEffortPicker { model, selected };
+                    }
+                }
+                Ok(())
+            }
             OverlayState::DebugPromptInput { mut composer } => {
                 match edit_buffer(key, &mut composer) {
                     Some(BufferAction::Submit) => {
@@ -814,14 +843,40 @@ impl TuiApp {
                 self.client.clear_agent_model_override(&agent_id).await?;
                 self.status_line =
                     format!("Cleared model override for {agent_id}; inheriting runtime default");
+                self.overlay = OverlayState::None;
+                self.bootstrap_selected_agent().await?;
             }
             crate::tui::model_picker::ModelPickerChoice::Model { model } => {
-                self.client
-                    .set_agent_model_override(&agent_id, model.clone())
-                    .await?;
-                self.status_line = format!("Set model override for {agent_id} to {model}");
+                self.overlay = OverlayState::ModelEffortPicker { model, selected: 0 };
             }
         }
+        Ok(())
+    }
+
+    async fn apply_model_effort_picker_selection(
+        &mut self,
+        model: &str,
+        selected: usize,
+    ) -> Result<()> {
+        let agent_id = self
+            .selected_agent_id()
+            .ok_or_else(|| anyhow!("no agent selected"))?
+            .to_string();
+        let reasoning_effort = match selected {
+            0 => None,
+            1 => Some("low".to_string()),
+            2 => Some("medium".to_string()),
+            3 => Some("high".to_string()),
+            _ => Some("xhigh".to_string()),
+        };
+        self.client
+            .set_agent_model_override(&agent_id, model.to_string(), reasoning_effort.clone())
+            .await?;
+        let suffix = reasoning_effort
+            .as_deref()
+            .map(|value| format!(" with reasoning effort {value}"))
+            .unwrap_or_default();
+        self.status_line = format!("Set model override for {agent_id} to {model}{suffix}");
         self.overlay = OverlayState::None;
         self.bootstrap_selected_agent().await?;
         Ok(())

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -25,6 +25,7 @@ pub(super) fn model_picker_rows(agent: Option<&AgentSummary>, filter: &str) -> V
         .model
         .model_availability
         .iter()
+        .filter(|entry| entry.available)
         .map(model_availability_row);
     if query.is_empty() {
         let mut rows = vec![inherit_row];
@@ -196,6 +197,7 @@ mod tests {
                 fallback_active: false,
                 effective_fallback_models: Vec::new(),
                 override_model: None,
+                override_reasoning_effort: None,
                 resolved_policy: policy("openai/gpt-5.4", "GPT-5.4"),
                 available_models: Vec::new(),
                 model_availability: vec![
@@ -244,20 +246,18 @@ mod tests {
     fn picker_rows_include_inherit_and_runtime_availability() {
         let agent = summary();
         let rows = model_picker_rows(Some(&agent), "");
-        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.len(), 2);
         assert!(rows[0].title.contains("inherit runtime default"));
         assert!(rows[1].title.contains("openai/gpt-5.4"));
-        assert!(!rows[2].available);
-        assert!(rows[2].detail.contains("credential_missing"));
+        assert!(rows[1].available);
     }
 
     #[test]
     fn picker_rows_filter_by_model_and_label() {
         let agent = summary();
         let rows = model_picker_rows(Some(&agent), "sonnet");
-        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.len(), 1);
         assert!(rows[0].title.contains("inherit runtime default"));
-        assert!(rows[1].title.contains("claude-sonnet-4-6"));
     }
 
     #[test]

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -2,6 +2,9 @@ use super::*;
 use crate::tui::composer::ComposerState;
 use unicode_width::UnicodeWidthStr;
 
+pub(super) const MODEL_REASONING_EFFORT_OPTIONS: [&str; 5] =
+    ["inherit", "low", "medium", "high", "xhigh"];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum OverlayState {
     None,
@@ -24,6 +27,8 @@ pub(super) enum OverlayState {
     ModelEffortPicker {
         model: String,
         selected: usize,
+        return_filter: String,
+        return_selected: usize,
     },
     DebugPromptInput {
         composer: ComposerState,
@@ -54,9 +59,9 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
         OverlayState::ModelPicker { filter, selected } => {
             draw_model_picker_overlay(frame, app, filter, *selected)
         }
-        OverlayState::ModelEffortPicker { model, selected } => {
-            draw_model_effort_picker_overlay(frame, app, model, *selected)
-        }
+        OverlayState::ModelEffortPicker {
+            model, selected, ..
+        } => draw_model_effort_picker_overlay(frame, app, model, *selected),
         OverlayState::DebugPromptInput { composer } => draw_input_modal(
             frame,
             "Debug Prompt",
@@ -352,8 +357,7 @@ fn draw_model_effort_picker_overlay(
     );
     frame.render_widget(header, layout[0]);
 
-    let options = ["inherit", "low", "medium", "high", "xhigh"];
-    let items = options
+    let items = MODEL_REASONING_EFFORT_OPTIONS
         .iter()
         .map(|option| {
             let detail = if *option == "inherit" {
@@ -365,7 +369,9 @@ fn draw_model_effort_picker_overlay(
         })
         .collect::<Vec<_>>();
     let mut state = ListState::default();
-    state.select(Some(selected.min(options.len().saturating_sub(1))));
+    state.select(Some(
+        selected.min(MODEL_REASONING_EFFORT_OPTIONS.len().saturating_sub(1)),
+    ));
     let list = List::new(items)
         .block(Block::default().title("Effort").borders(Borders::ALL))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -21,6 +21,10 @@ pub(super) enum OverlayState {
         filter: String,
         selected: usize,
     },
+    ModelEffortPicker {
+        model: String,
+        selected: usize,
+    },
     DebugPromptInput {
         composer: ComposerState,
     },
@@ -49,6 +53,9 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
         } => draw_tasks_overlay(frame, app, *selected, *detail_scroll),
         OverlayState::ModelPicker { filter, selected } => {
             draw_model_picker_overlay(frame, app, filter, *selected)
+        }
+        OverlayState::ModelEffortPicker { model, selected } => {
+            draw_model_effort_picker_overlay(frame, app, model, *selected)
         }
         OverlayState::DebugPromptInput { composer } => draw_input_modal(
             frame,
@@ -315,6 +322,62 @@ fn draw_model_picker_overlay(frame: &mut Frame<'_>, app: &TuiApp, filter: &str, 
         .unwrap_or_else(|| "model: <no agent selected>".into());
     let help = Paragraph::new(format!(
         "{current}\nType to filter, Backspace edits, Up/Down moves, Enter selects, Esc cancels"
+    ))
+    .block(Block::default().borders(Borders::ALL))
+    .wrap(Wrap { trim: false });
+    frame.render_widget(help, layout[2]);
+}
+
+fn draw_model_effort_picker_overlay(
+    frame: &mut Frame<'_>,
+    app: &TuiApp,
+    model: &str,
+    selected: usize,
+) {
+    let popup = centered_rect(70, 42, frame.area());
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(popup);
+    frame.render_widget(Clear, popup);
+
+    let header = Paragraph::new(format!("Model: {model}")).block(
+        Block::default()
+            .title("Reasoning Effort")
+            .borders(Borders::ALL),
+    );
+    frame.render_widget(header, layout[0]);
+
+    let options = ["inherit", "low", "medium", "high", "xhigh"];
+    let items = options
+        .iter()
+        .map(|option| {
+            let detail = if *option == "inherit" {
+                "use provider/runtime default"
+            } else {
+                "force reasoning effort"
+            };
+            ListItem::new(format!("{option}\n  {detail}"))
+        })
+        .collect::<Vec<_>>();
+    let mut state = ListState::default();
+    state.select(Some(selected.min(options.len().saturating_sub(1))));
+    let list = List::new(items)
+        .block(Block::default().title("Effort").borders(Borders::ALL))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(list, layout[1], &mut state);
+
+    let current = app
+        .selected_agent_summary()
+        .map(render::render_model_status)
+        .unwrap_or_else(|| "model: <no agent selected>".into());
+    let help = Paragraph::new(format!(
+        "{current}\nUp/Down moves, Enter confirms, Esc goes back"
     ))
     .block(Block::default().borders(Borders::ALL))
     .wrap(Wrap { trim: false });

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1602,6 +1602,7 @@ mod tests {
                 )
                 .unwrap(),
                 override_model: None,
+                override_reasoning_effort: None,
                 source: AgentModelSource::RuntimeDefault,
                 effective_fallback_models: Vec::new(),
                 resolved_policy: crate::model_catalog::ResolvedRuntimeModelPolicy {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -110,6 +110,9 @@ fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
         OverlayState::ModelPicker { .. } => {
             "Model: type filter, Backspace edit, Up/Down move, Enter select, Esc cancel"
         }
+        OverlayState::ModelEffortPicker { .. } => {
+            "Reasoning effort: Up/Down move, Enter select, Esc back"
+        }
         OverlayState::DebugPromptInput { .. } => "Debug prompt: Enter confirm, Esc cancel",
         OverlayState::DebugPromptView { .. } => "Debug prompt: Up/Down, PgUp/PgDn, Home/End, Esc",
         OverlayState::HelpView { .. } => "Help: Up/Down, PgUp/PgDn, Home/End, Esc",
@@ -721,6 +724,13 @@ pub(super) fn render_model_status(agent: &AgentSummary) -> String {
         );
     }
     if agent.model.override_model.is_some() {
+        if let Some(effort) = agent.model.override_reasoning_effort.as_deref() {
+            return format!(
+                "model: {} (agent override, effort={})",
+                model.as_string(),
+                effort
+            );
+        }
         return format!("model: {} (agent override)", model.as_string());
     }
     format!("model: {}", model.as_string())
@@ -756,6 +766,9 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
     ];
     if let Some(model_override) = agent.model.override_model.as_ref() {
         lines.push(format!("Override: {}", model_override.as_string()));
+        if let Some(effort) = agent.model.override_reasoning_effort.as_deref() {
+            lines.push(format!("Override effort: {}", effort));
+        }
     }
     if let Some(hint) = agent.lifecycle.operator_hint.as_deref() {
         lines.push(format!("Lifecycle hint: {}", hint));
@@ -900,6 +913,7 @@ mod tests {
                 )
                 .unwrap(),
                 override_model: None,
+                override_reasoning_effort: None,
                 source: AgentModelSource::RuntimeDefault,
                 effective_fallback_models: Vec::new(),
                 resolved_policy: crate::model_catalog::ResolvedRuntimeModelPolicy {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1276,6 +1276,8 @@ pub struct AgentState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_override: Option<ModelRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_override_reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_requested_model: Option<ModelRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_active_model: Option<ModelRef>,
@@ -1347,6 +1349,7 @@ impl AgentState {
             active_skills: Vec::new(),
             last_continuation: None,
             model_override: None,
+            model_override_reasoning_effort: None,
             last_requested_model: None,
             last_active_model: None,
             last_turn_terminal: None,
@@ -2695,6 +2698,8 @@ pub struct AgentModelState {
     pub effective_fallback_models: Vec<ModelRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub override_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_reasoning_effort: Option<String>,
     #[serde(default)]
     pub resolved_policy: ResolvedRuntimeModelPolicy,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## Summary
- filter TUI model picker rows to only show available models plus inherit
- split model override flow into two steps: pick model first, then pick reasoning effort
- persist agent-level reasoning effort override and apply it to runtime provider reconfigure path

## Validation
- cargo fmt --check
- cargo test -q tui::model_picker::tests --lib
- cargo test -q tui::render::tests --lib
- cargo test -q tui::projection::tests --lib
- cargo test -q tui::input::tests --lib
- cargo test -q agent_summary_reports_runtime_default_then_override_and_clear --lib