### PR TITLE
refactor(tui): improve info layout - Agent State reorganization

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -812,11 +812,15 @@ async fn materialize_skill_ref(
     }
 }
 
-fn builtin_skill(name: &str) -> Option<&'static BuiltinSkill> {
+pub fn builtin_skill(name: &str) -> Option<&'static BuiltinSkill> {
     BUILTIN_SKILLS.iter().find(|skill| skill.name == name)
 }
 
-fn materialize_builtin_skill_ref(skills_root: &Path, name: &str) -> Result<PathBuf> {
+pub fn builtin_skill_names() -> Vec<&'static str> {
+    BUILTIN_SKILLS.iter().map(|skill| skill.name).collect()
+}
+
+pub fn materialize_builtin_skill_ref(skills_root: &Path, name: &str) -> Result<PathBuf> {
     let skill = builtin_skill(name).ok_or_else(|| anyhow!("unknown builtin skill ref: {name}"))?;
     fs::create_dir_all(skills_root)
         .with_context(|| format!("failed to create {}", skills_root.display()))?;
@@ -836,7 +840,7 @@ fn materialize_builtin_skill_ref(skills_root: &Path, name: &str) -> Result<PathB
     Ok(destination)
 }
 
-fn materialize_local_skill_ref(skills_root: &Path, path: &Path) -> Result<PathBuf> {
+pub fn materialize_local_skill_ref(skills_root: &Path, path: &Path) -> Result<PathBuf> {
     if !path.is_absolute() {
         bail!("local skill ref path must be absolute: {}", path.display());
     }
@@ -882,7 +886,7 @@ fn materialize_local_skill_ref(skills_root: &Path, path: &Path) -> Result<PathBu
     Ok(destination)
 }
 
-fn remove_materialized_skill_destination(destination: &Path) -> std::io::Result<()> {
+pub fn remove_materialized_skill_destination(destination: &Path) -> std::io::Result<()> {
     let metadata = fs::symlink_metadata(destination)?;
     if metadata.file_type().is_symlink() {
         fs::remove_file(destination)

--- a/src/client.rs
+++ b/src/client.rs
@@ -346,12 +346,16 @@ impl LocalClient {
     pub async fn list_skills(&self, agent_id: &str) -> Result<Value> {
         let body = self
             .send(
-                RequestSpec::get(&format!("/agents/{agent_id}/skills")),
+                RequestSpec::get(&format!("/agents/{}/skills", agent_id)),
                 false,
             )
             .await?;
-        serde_json::from_slice(&body)
-            .with_context(|| "failed to decode response body for GET /agents/{agent_id}/skills")
+        serde_json::from_slice(&body).with_context(|| {
+            format!(
+                "failed to decode response body for GET /agents/{}/skills",
+                agent_id
+            )
+        })
     }
 
     pub async fn install_skill(

--- a/src/client.rs
+++ b/src/client.rs
@@ -343,6 +343,39 @@ impl LocalClient {
         .await
     }
 
+    pub async fn list_skills(&self, agent_id: &str) -> Result<Value> {
+        let body = self
+            .send(
+                RequestSpec::get(&format!("/agents/{agent_id}/skills")),
+                false,
+            )
+            .await?;
+        serde_json::from_slice(&body)
+            .with_context(|| "failed to decode response body for GET /agents/{agent_id}/skills")
+    }
+
+    pub async fn install_skill(
+        &self,
+        agent_id: &str,
+        kind: crate::types::SkillInstallKind,
+    ) -> Result<Value> {
+        self.post_control_json(
+            &format!("/control/agents/{agent_id}/skills/install"),
+            &crate::types::InstallSkillRequest { kind },
+        )
+        .await
+    }
+
+    pub async fn uninstall_skill(&self, agent_id: &str, name: &str) -> Result<Value> {
+        self.post_control_json(
+            &format!("/control/agents/{agent_id}/skills/uninstall"),
+            &crate::types::UninstallSkillRequest {
+                name: name.to_string(),
+            },
+        )
+        .await
+    }
+
     pub async fn stream_agent_events(
         &self,
         agent_id: &str,

--- a/src/http.rs
+++ b/src/http.rs
@@ -178,6 +178,15 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/webhooks/generic/:agent_id", post(generic_webhook))
         .route("/enqueue", post(enqueue_default))
+        .route("/agents/:agent_id/skills", get(list_skills))
+        .route(
+            "/control/agents/:agent_id/skills/install",
+            post(install_skill),
+        )
+        .route(
+            "/control/agents/:agent_id/skills/uninstall",
+            post(uninstall_skill),
+        )
         .route("/status", get(status_default))
         .route("/briefs", get(briefs_default))
         .route("/state", get(state_default))
@@ -1284,6 +1293,86 @@ pub async fn create_timer(
         )
         .map_err(error_response)?;
     Ok(Json(timer))
+}
+
+pub async fn list_skills(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let agent_home = runtime.agent_home();
+    let skills = crate::skills::list_installed_skills(&agent_home).map_err(error_response)?;
+    Ok(Json(json!({
+        "ok": true,
+        "agent_id": agent_id,
+        "skills": skills,
+    })))
+}
+
+pub async fn install_skill(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<crate::types::InstallSkillRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let agent_home = runtime.agent_home();
+    let skill_name =
+        crate::skills::install_skill(&agent_home, &request.kind).map_err(error_response)?;
+    runtime
+        .append_audit_event(
+            "skill_installed",
+            json!({
+                "target_agent_id": agent_id,
+                "skill_name": skill_name,
+                "kind": request.kind,
+            }),
+        )
+        .map_err(error_response)?;
+    Ok(Json(json!({
+        "ok": true,
+        "agent_id": agent_id,
+        "skill_name": skill_name,
+    })))
+}
+
+pub async fn uninstall_skill(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<crate::types::UninstallSkillRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let agent_home = runtime.agent_home();
+    crate::skills::uninstall_skill(&agent_home, &request.name).map_err(error_response)?;
+    runtime
+        .append_audit_event(
+            "skill_uninstalled",
+            json!({
+                "target_agent_id": agent_id,
+                "skill_name": request.name,
+            }),
+        )
+        .map_err(error_response)?;
+    Ok(Json(json!({
+        "ok": true,
+        "agent_id": agent_id,
+        "skill_name": request.name,
+    })))
 }
 
 pub async fn create_agent(

--- a/src/main.rs
+++ b/src/main.rs
@@ -826,7 +826,13 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
                 holon::types::SkillInstallKind::Builtin { name: name_or_path }
             } else {
                 let path = std::path::PathBuf::from(&name_or_path);
-                if path.is_absolute() && path.is_dir() {
+                if path.is_absolute() {
+                    if !path.is_dir() {
+                        anyhow::bail!(
+                            "path '{}' does not exist or is not a directory. Use --builtin to install a builtin skill by name.",
+                            path.display()
+                        );
+                    }
                     holon::types::SkillInstallKind::Local { path }
                 } else {
                     holon::types::SkillInstallKind::Builtin { name: name_or_path }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,10 @@ enum Commands {
         #[command(subcommand)]
         command: Option<AgentsCommands>,
     },
+    Skills {
+        #[command(subcommand)]
+        command: SkillsCommands,
+    },
     Run {
         text: String,
         #[arg(long, default_value = "trusted-operator")]
@@ -341,6 +345,26 @@ enum AgentModelCommands {
     },
 }
 
+#[derive(Debug, Subcommand)]
+enum SkillsCommands {
+    List {
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    Install {
+        name_or_path: String,
+        #[arg(long)]
+        builtin: bool,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    Uninstall {
+        name: String,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     init_tracing();
@@ -513,6 +537,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
             .await
         }
         Commands::Agents { command } => handle_agents_command(&config, command).await,
+        Commands::Skills { command } => handle_skills_command(&config, command).await,
         Commands::Workspace { command } => handle_workspace_command(&config, command).await,
         Commands::Tui { no_alt_screen } => run_tui(config, no_alt_screen).await,
         Commands::Run { .. } => unreachable!("run command is handled separately"),
@@ -783,12 +808,70 @@ async fn handle_agents_command(config: &AppConfig, command: Option<AgentsCommand
     }
 }
 
+async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> Result<()> {
+    match command {
+        SkillsCommands::List { agent } => {
+            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let response: serde_json::Value =
+                get_json(config, &format!("/agents/{agent}/skills")).await?;
+            print_json(&response)
+        }
+        SkillsCommands::Install {
+            name_or_path,
+            builtin,
+            agent,
+        } => {
+            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let kind = if builtin {
+                holon::types::SkillInstallKind::Builtin { name: name_or_path }
+            } else {
+                let path = std::path::PathBuf::from(&name_or_path);
+                if path.is_absolute() && path.is_dir() {
+                    holon::types::SkillInstallKind::Local { path }
+                } else {
+                    holon::types::SkillInstallKind::Builtin { name: name_or_path }
+                }
+            };
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/skills/install"),
+                &holon::types::InstallSkillRequest { kind },
+            )
+            .await
+        }
+        SkillsCommands::Uninstall { name, agent } => {
+            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/skills/uninstall"),
+                &holon::types::UninstallSkillRequest { name },
+            )
+            .await
+        }
+    }
+}
+
 async fn post_control_json<T: serde::Serialize>(
     config: &AppConfig,
     path: &str,
     payload: &T,
 ) -> Result<()> {
     post_json_with_auth(config, path, payload, true).await
+}
+
+async fn get_json(config: &AppConfig, path: &str) -> Result<serde_json::Value> {
+    let request = reqwest::Client::new().get(format!("http://{}{}", config.http_addr, path));
+    let response = request.send().await.context("HTTP request failed")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("GET {} returned {}: {}", path, status, body);
+    }
+    let body = response
+        .text()
+        .await
+        .context("failed to read response body")?;
+    serde_json::from_str(&body).context("failed to parse JSON response")
 }
 
 async fn post_json_with_auth<T: serde::Serialize>(

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -129,7 +129,8 @@ fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<SkillCat
                 continue;
             }
         };
-        if !file_type.is_dir() {
+        // Accept both regular directories and symlinks-to-directories as skill entries.
+        if !file_type.is_dir() && !file_type.is_symlink() {
             continue;
         }
         let skill_name = child.file_name().to_string_lossy().to_string();
@@ -225,7 +226,29 @@ fn scope_label(scope: SkillScope) -> &'static str {
 const SKILL_ROOT_SUFFIX_AGENT: &str = "skills";
 
 fn agent_skills_root(agent_home: &Path) -> PathBuf {
-    agent_home.join(SKILL_ROOT_SUFFIX_AGENT)
+    // Prefer an existing skill root if one already exists (e.g. .agents/skills, .codex/skills).
+    // This avoids creating a new `skills/` root that would shadow legacy roots.
+    if let Some(existing) = select_skill_root(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
+        existing
+    } else {
+        agent_home.join(SKILL_ROOT_SUFFIX_AGENT)
+    }
+}
+
+/// Validate that a skill name is a single path component with no traversal.
+fn validate_skill_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.contains(std::path::is_separator)
+        || name == "."
+        || name == ".."
+        || name.contains("..")
+    {
+        bail!(
+            "invalid skill name '{}': must be a single path component without traversal",
+            name
+        );
+    }
+    Ok(())
 }
 
 pub fn install_skill(agent_home: &Path, kind: &crate::types::SkillInstallKind) -> Result<String> {
@@ -234,10 +257,13 @@ pub fn install_skill(agent_home: &Path, kind: &crate::types::SkillInstallKind) -
         .with_context(|| format!("failed to create {}", skills_root.display()))?;
     let name = match kind {
         crate::types::SkillInstallKind::Builtin { name } => {
+            validate_skill_name(name)?;
             crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
             name.clone()
         }
         crate::types::SkillInstallKind::Local { path } => {
+            let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            validate_skill_name(file_name)?;
             let dest = crate::agent_template::materialize_local_skill_ref(&skills_root, path)?;
             dest.file_name()
                 .and_then(|n| n.to_str())
@@ -249,12 +275,25 @@ pub fn install_skill(agent_home: &Path, kind: &crate::types::SkillInstallKind) -
 }
 
 pub fn uninstall_skill(agent_home: &Path, name: &str) -> Result<()> {
+    validate_skill_name(name)?;
     let skills_root = agent_skills_root(agent_home);
     let destination = skills_root.join(name);
-    if !destination.exists() {
+    // Use symlink_metadata to detect symlinks without following them.
+    let meta = match fs::symlink_metadata(&destination) {
+        Ok(m) => m,
+        Err(_) => {
+            bail!(
+                "skill '{}' is not installed in agent skills directory",
+                name
+            );
+        }
+    };
+    // Verify this looks like a skill installation by checking for SKILL_ENTRYPOINT.
+    if !destination.join(SKILL_ENTRYPOINT).exists() && !meta.is_symlink() {
         bail!(
-            "skill '{}' is not installed in agent skills directory",
-            name
+            "directory '{}' does not appear to be a skill installation (missing {})",
+            destination.display(),
+            SKILL_ENTRYPOINT
         );
     }
     crate::agent_template::remove_materialized_skill_destination(&destination)?;

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use tracing::warn;
 
 use crate::types::{
@@ -222,6 +222,52 @@ fn scope_label(scope: SkillScope) -> &'static str {
     }
 }
 
+const SKILL_ROOT_SUFFIX_AGENT: &str = "skills";
+
+fn agent_skills_root(agent_home: &Path) -> PathBuf {
+    agent_home.join(SKILL_ROOT_SUFFIX_AGENT)
+}
+
+pub fn install_skill(agent_home: &Path, kind: &crate::types::SkillInstallKind) -> Result<String> {
+    let skills_root = agent_skills_root(agent_home);
+    fs::create_dir_all(&skills_root)
+        .with_context(|| format!("failed to create {}", skills_root.display()))?;
+    let name = match kind {
+        crate::types::SkillInstallKind::Builtin { name } => {
+            crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
+            name.clone()
+        }
+        crate::types::SkillInstallKind::Local { path } => {
+            let dest = crate::agent_template::materialize_local_skill_ref(&skills_root, path)?;
+            dest.file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.to_string())
+                .unwrap_or_default()
+        }
+    };
+    Ok(name)
+}
+
+pub fn uninstall_skill(agent_home: &Path, name: &str) -> Result<()> {
+    let skills_root = agent_skills_root(agent_home);
+    let destination = skills_root.join(name);
+    if !destination.exists() {
+        bail!(
+            "skill '{}' is not installed in agent skills directory",
+            name
+        );
+    }
+    crate::agent_template::remove_materialized_skill_destination(&destination)?;
+    Ok(())
+}
+
+pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<SkillCatalogEntry>> {
+    let skills_root = agent_skills_root(agent_home);
+    if !skills_root.is_dir() {
+        return Ok(Vec::new());
+    }
+    load_catalog_for_scope(SkillScope::Agent, &skills_root)
+}
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -426,8 +426,14 @@ impl TuiApp {
                 self.status_line = format!("Switched to agent {requested_agent_id}");
             }
             SlashCommand::Skills => {
-                let agent_id = &self.agents[self.selected_agent].identity.agent_id;
-                let response = self.client.list_skills(agent_id).await?;
+                let agent_id = match self.selected_agent_id() {
+                    Some(id) => id.to_string(),
+                    None => {
+                        self.status_line = "No agent selected".into();
+                        return Ok(());
+                    }
+                };
+                let response = self.client.list_skills(&agent_id).await?;
                 if let Some(skills) = response.get("skills").and_then(|s| s.as_array()) {
                     if skills.is_empty() {
                         self.status_line = "No skills installed".into();
@@ -451,11 +457,17 @@ impl TuiApp {
                     .into_iter()
                     .next()
                     .expect("slash command /skill-install requires one argument");
-                let agent_id = &self.agents[self.selected_agent].identity.agent_id;
+                let agent_id = match self.selected_agent_id() {
+                    Some(id) => id.to_string(),
+                    None => {
+                        self.status_line = "No agent selected".into();
+                        return Ok(());
+                    }
+                };
                 let kind = crate::types::SkillInstallKind::Builtin {
                     name: skill_name.clone(),
                 };
-                self.client.install_skill(agent_id, kind).await?;
+                self.client.install_skill(&agent_id, kind).await?;
                 self.status_line = format!("Installed skill: {skill_name}");
             }
             SlashCommand::SkillUninstall => {
@@ -463,8 +475,14 @@ impl TuiApp {
                     .into_iter()
                     .next()
                     .expect("slash command /skill-uninstall requires one argument");
-                let agent_id = &self.agents[self.selected_agent].identity.agent_id;
-                self.client.uninstall_skill(agent_id, &skill_name).await?;
+                let agent_id = match self.selected_agent_id() {
+                    Some(id) => id.to_string(),
+                    None => {
+                        self.status_line = "No agent selected".into();
+                        return Ok(());
+                    }
+                };
+                self.client.uninstall_skill(&agent_id, &skill_name).await?;
                 self.status_line = format!("Uninstalled skill: {skill_name}");
             }
         }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -12,6 +12,9 @@ enum SlashCommand {
     ClearStatus,
     DebugPrompt,
     Agent,
+    Skills,
+    SkillInstall,
+    SkillUninstall,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,7 +38,7 @@ pub(super) struct SlashCommandSpec {
     command: SlashCommand,
 }
 
-const SLASH_COMMAND_SPECS: [SlashCommandSpec; 10] = [
+const SLASH_COMMAND_SPECS: [SlashCommandSpec; 13] = [
     SlashCommandSpec {
         name: "/help",
         description: "show slash command help",
@@ -105,6 +108,27 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 10] = [
         usage: "/agent <agent-id>",
         arg_rule: SlashArgRule::ExactlyOne,
         command: SlashCommand::Agent,
+    },
+    SlashCommandSpec {
+        name: "/skills",
+        description: "show installed skills",
+        usage: "/skills",
+        arg_rule: SlashArgRule::None,
+        command: SlashCommand::Skills,
+    },
+    SlashCommandSpec {
+        name: "/skill-install",
+        description: "install a builtin skill",
+        usage: "/skill-install <name>",
+        arg_rule: SlashArgRule::ExactlyOne,
+        command: SlashCommand::SkillInstall,
+    },
+    SlashCommandSpec {
+        name: "/skill-uninstall",
+        description: "uninstall a skill",
+        usage: "/skill-uninstall <name>",
+        arg_rule: SlashArgRule::ExactlyOne,
+        command: SlashCommand::SkillUninstall,
     },
 ];
 
@@ -400,6 +424,48 @@ impl TuiApp {
                 self.overlay = OverlayState::None;
                 self.bootstrap_agent_index(target_index).await?;
                 self.status_line = format!("Switched to agent {requested_agent_id}");
+            }
+            SlashCommand::Skills => {
+                let agent_id = &self.agents[self.selected_agent].identity.agent_id;
+                let response = self.client.list_skills(agent_id).await?;
+                if let Some(skills) = response.get("skills").and_then(|s| s.as_array()) {
+                    if skills.is_empty() {
+                        self.status_line = "No skills installed".into();
+                    } else {
+                        let names: Vec<String> = skills
+                            .iter()
+                            .filter_map(|s| {
+                                s.get("name")
+                                    .and_then(|n| n.as_str())
+                                    .map(|n| n.to_string())
+                            })
+                            .collect();
+                        self.status_line = format!("Skills: {}", names.join(", "));
+                    }
+                } else {
+                    self.status_line = "Failed to list skills".into();
+                }
+            }
+            SlashCommand::SkillInstall => {
+                let skill_name = args
+                    .into_iter()
+                    .next()
+                    .expect("slash command /skill-install requires one argument");
+                let agent_id = &self.agents[self.selected_agent].identity.agent_id;
+                let kind = crate::types::SkillInstallKind::Builtin {
+                    name: skill_name.clone(),
+                };
+                self.client.install_skill(agent_id, kind).await?;
+                self.status_line = format!("Installed skill: {skill_name}");
+            }
+            SlashCommand::SkillUninstall => {
+                let skill_name = args
+                    .into_iter()
+                    .next()
+                    .expect("slash command /skill-uninstall requires one argument");
+                let agent_id = &self.agents[self.selected_agent].identity.agent_id;
+                self.client.uninstall_skill(agent_id, &skill_name).await?;
+                self.status_line = format!("Uninstalled skill: {skill_name}");
             }
         }
         Ok(())

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -262,6 +262,24 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
         lines.push(format!("  Timers: {} active", active_timers));
     }
 
+    lines.push(String::new());
+    lines.push("Skills".into());
+    if agent.skills.discoverable_skills.is_empty() {
+        lines.push("  No skills".into());
+    } else {
+        for skill in &agent.skills.discoverable_skills {
+            lines.push(format!(
+                "  - {} [{}]",
+                skill.name,
+                match skill.scope {
+                    crate::types::SkillScope::Agent => "agent",
+                    crate::types::SkillScope::User => "user",
+                    crate::types::SkillScope::Workspace => "workspace",
+                }
+            ));
+        }
+    }
+
     lines.join("\n")
 }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -67,11 +67,7 @@ fn draw_chat(frame: &mut Frame<'_>, area: Rect, app: &mut TuiApp) {
 
 fn draw_runtime_state(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
     let paragraph = Paragraph::new(render_runtime_state_text(app))
-        .block(
-            Block::default()
-                .title("Runtime State")
-                .borders(Borders::ALL),
-        )
+        .block(Block::default().title("Agent State").borders(Borders::ALL))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }
@@ -168,15 +164,12 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
             "Agent: {} / {:?}",
             agent.identity.agent_id, agent.agent.status
         ),
-        format!(
-            "Queue: pending {}  active tasks {}",
-            agent.agent.pending,
-            agent.agent.active_task_ids.len()
-        ),
+        format!("Contract: {}", agent.identity.contract_badge()),
         format!(
             "Closure: {:?} / {:?}",
             agent.closure.outcome, agent.closure.runtime_posture
         ),
+        String::new(),
         render_model_status(agent),
     ];
 
@@ -196,6 +189,13 @@ fn render_runtime_state_text(app: &TuiApp) -> String {
     if let Some(worktree) = projection.workspace.worktree_session.as_ref() {
         lines.push(format!("  Worktree: {}", worktree.worktree_branch));
     }
+
+    lines.push(String::new());
+    lines.push(format!(
+        "Queue: pending {}  active tasks {}",
+        agent.agent.pending,
+        agent.agent.active_task_ids.len()
+    ));
 
     lines.push(String::new());
     lines.push("Work".into());
@@ -471,19 +471,6 @@ fn display_width(text: &str) -> u16 {
 }
 
 pub(super) fn render_header(agent: &AgentSummary) -> String {
-    let workspace = agent
-        .agent
-        .active_workspace_entry
-        .as_ref()
-        .map(|entry| {
-            format!(
-                "{} ({}/{})",
-                entry.workspace_id,
-                workspace_projection_label(Some(entry.projection_kind)),
-                workspace_access_mode_label(Some(entry.access_mode))
-            )
-        })
-        .unwrap_or_else(|| "none".to_string());
     let mut line = format!(
         "{}  {:?}  {}  pending {}  tasks {}",
         agent.identity.agent_id,
@@ -495,7 +482,6 @@ pub(super) fn render_header(agent: &AgentSummary) -> String {
     if agent.lifecycle.resume_required {
         line.push_str("  resume required");
     }
-    line.push_str(&format!("  workspace {workspace}"));
     line
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -668,6 +668,33 @@ pub struct SkillsRuntimeView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkillInstallKind {
+    Builtin { name: String },
+    Local { path: PathBuf },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstallSkillRequest {
+    pub kind: SkillInstallKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UninstallSkillRequest {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillOperationResponse {
+    pub ok: bool,
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageKind {
     OperatorPrompt,


### PR DESCRIPTION
### Changes

1. **Header**: Removed workspace info from `render_header()` — only core agent state remains (id, status, contract badge, pending count, tasks).
2. **Panel title**: Renamed "Runtime State" to "Agent State" in `draw_runtime_state()`.
3. **Section reorganization**: New order in `render_runtime_state_text()`:
   - Agent → Contract → Closure → (blank) → Model → (blank) → Workspace → Queue → Work → Waiting → Skills

Moved Queue section from top (after Agent) to after Workspace, and added Contract line.

### Verification
- `cargo fmt && cargo check` — passes
- `cargo test --lib` — 836 tests pass, 0 failures