### PR TITLE
feat: add current run interrupt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1.43", features = ["full"] }
 tokio-stream = "0.1"
+tokio-util = "0.7"
 tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/docs/rfcs/agent-control-plane-model.md
+++ b/docs/rfcs/agent-control-plane-model.md
@@ -241,6 +241,20 @@ The central inspection primitive should be:
 managed execution handle, while `AgentGet` should inspect the agent that owns
 the broader context.
 
+The agent plane also owns the current-run intervention surface.
+
+`current_run_id` identifies the provider/tool turn currently executing inside
+the agent. Operator interruption is a control-plane mutation, not an enqueued
+message. It should:
+
+- cancel only the current provider/tool future;
+- preserve the agent, work item, ledger, and workspace state;
+- reject an optional stale `run_id` guard if the observed run has changed;
+- record an aborted terminal turn with reason `operator_interrupted`;
+- record the dequeued message outcome as interrupted rather than processed;
+- pause the agent by default after the abort so it does not immediately repeat
+  the same path.
+
 For bounded parent-supervised delegation, `SpawnAgent` should always return the
 new `agent_id` and return a task-plane handle when the parent keeps a
 supervising execution record for that child.

--- a/src/client.rs
+++ b/src/client.rs
@@ -258,6 +258,22 @@ impl LocalClient {
         .await
     }
 
+    pub async fn interrupt_current_run(
+        &self,
+        agent_id: &str,
+        run_id: Option<String>,
+    ) -> Result<Value> {
+        self.post_control_json(
+            &format!("/control/agents/{agent_id}/current-run/interrupt"),
+            &crate::http::InterruptCurrentRunRequest {
+                run_id,
+                mode: Some("pause_after_abort".into()),
+                trust: Some(TrustLevel::TrustedOperator),
+            },
+        )
+        .await
+    }
+
     pub async fn attach_workspace(
         &self,
         agent_id: &str,

--- a/src/host.rs
+++ b/src/host.rs
@@ -256,6 +256,18 @@ impl RuntimeHost {
         Ok(runtime)
     }
 
+    pub async fn interrupt_public_agent_current_run(
+        &self,
+        agent_id: &str,
+        request: crate::runtime::CurrentRunInterruptRequest,
+    ) -> std::result::Result<crate::runtime::CurrentRunInterruptOutcome, PublicAgentError> {
+        let runtime = self.get_public_agent(agent_id).await?;
+        runtime
+            .interrupt_current_run(request)
+            .await
+            .map_err(PublicAgentError::Runtime)
+    }
+
     pub async fn enqueue_public_work_item(
         &self,
         agent_id: &str,
@@ -2000,6 +2012,7 @@ mod tests {
         child_state.last_turn_terminal = Some(crate::types::TurnTerminalRecord {
             turn_index: 1,
             kind: crate::types::TurnTerminalKind::Completed,
+            reason: None,
             last_assistant_message: Some("child finished after restart".into()),
             checkpoint: None,
             completed_at: chrono::Utc::now(),

--- a/src/http.rs
+++ b/src/http.rs
@@ -50,7 +50,7 @@ use crate::{
     host::{PublicAgentError, RuntimeHost},
     ingress::{InboundRequest, WakeDisposition, WakeHint},
     policy::{default_trust_for_origin, validate_message_kind_for_origin},
-    runtime::{CurrentRunInterruptMode, CurrentRunInterruptRequest},
+    runtime::{CurrentRunInterruptError, CurrentRunInterruptMode, CurrentRunInterruptRequest},
     storage::FileActivityMarker,
     system::{ExecutionScopeKind, ExecutionSnapshot, HostLocalBoundary},
     types::{
@@ -2361,28 +2361,31 @@ fn agent_access_error(error: PublicAgentError) -> (StatusCode, Json<Value>) {
 }
 
 fn interrupt_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
-    let message = error.to_string();
-    if message.contains("stale run_id") {
-        return (
+    match error.downcast::<CurrentRunInterruptError>() {
+        Ok(CurrentRunInterruptError::StaleRunId {
+            requested_run_id,
+            current_run_id,
+        }) => (
             StatusCode::CONFLICT,
             Json(json!({
                 "ok": false,
                 "code": "stale_run_id",
-                "error": message,
+                "error": format!("stale run_id {requested_run_id}; current run is {current_run_id}"),
+                "requested_run_id": requested_run_id,
+                "current_run_id": current_run_id,
             })),
-        );
-    }
-    if message.contains("has no current run to interrupt") {
-        return (
+        ),
+        Ok(CurrentRunInterruptError::NoCurrentRun { agent_id }) => (
             StatusCode::CONFLICT,
             Json(json!({
                 "ok": false,
                 "code": "no_current_run",
-                "error": message,
+                "error": format!("agent {agent_id} has no current run to interrupt"),
+                "agent_id": agent_id,
             })),
-        );
+        ),
+        Err(error) => error_response(error),
     }
-    error_response(error)
 }
 
 fn error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {

--- a/src/http.rs
+++ b/src/http.rs
@@ -50,6 +50,7 @@ use crate::{
     host::{PublicAgentError, RuntimeHost},
     ingress::{InboundRequest, WakeDisposition, WakeHint},
     policy::{default_trust_for_origin, validate_message_kind_for_origin},
+    runtime::{CurrentRunInterruptMode, CurrentRunInterruptRequest},
     storage::FileActivityMarker,
     system::{ExecutionScopeKind, ExecutionSnapshot, HostLocalBoundary},
     types::{
@@ -152,6 +153,10 @@ pub fn router(state: AppState) -> Router {
             post(clear_agent_model),
         )
         .route("/control/agents/:agent_id/control", post(control))
+        .route(
+            "/control/agents/:agent_id/current-run/interrupt",
+            post(interrupt_current_run),
+        )
         .route("/control/agents/:agent_id/prompt", post(control_prompt))
         .route(
             "/control/agents/:agent_id/operator-bindings",
@@ -406,6 +411,13 @@ pub struct CreateTimerRequest {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ControlRequest {
     pub action: ControlAction,
+    pub trust: Option<TrustLevel>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InterruptCurrentRunRequest {
+    pub run_id: Option<String>,
+    pub mode: Option<String>,
     pub trust: Option<TrustLevel>,
 }
 
@@ -1444,6 +1456,46 @@ pub async fn control(
     Ok(Json(json!({ "ok": true })))
 }
 
+pub async fn interrupt_current_run(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<InterruptCurrentRunRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let mode = match request.mode.as_deref().unwrap_or("pause_after_abort") {
+        "pause_after_abort" => CurrentRunInterruptMode::PauseAfterAbort,
+        other => {
+            return Err(bad_request(format!(
+                "unsupported interrupt mode {other}; expected pause_after_abort"
+            )))
+        }
+    };
+    let admission_context = control_admission_context(&state);
+    let provided_trust = request.trust.clone();
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let outcome = runtime
+        .interrupt_current_run(CurrentRunInterruptRequest {
+            run_id: request.run_id.clone(),
+            mode,
+        })
+        .await
+        .map_err(interrupt_error_response)?;
+    Ok(Json(json!({
+        "ok": true,
+        "interrupted": true,
+        "agent_id": outcome.agent_id,
+        "run_id": outcome.run_id,
+        "mode": outcome.mode.as_str(),
+        "admission_context": admission_context,
+        "provided_trust": provided_trust,
+    })))
+}
+
 pub async fn attach_workspace(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -2306,6 +2358,31 @@ fn agent_access_error(error: PublicAgentError) -> (StatusCode, Json<Value>) {
         ),
         PublicAgentError::Runtime(error) => error_response(error),
     }
+}
+
+fn interrupt_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
+    let message = error.to_string();
+    if message.contains("stale run_id") {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "ok": false,
+                "code": "stale_run_id",
+                "error": message,
+            })),
+        );
+    }
+    if message.contains("has no current run to interrupt") {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "ok": false,
+                "code": "no_current_run",
+                "error": message,
+            })),
+        );
+    }
+    error_response(error)
 }
 
 fn error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use holon::{
     client::LocalClient,
     config::{
@@ -38,6 +38,25 @@ use tracing_subscriber::EnvFilter;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+enum ControlCommandAction {
+    Pause,
+    Resume,
+    Stop,
+    Interrupt,
+}
+
+impl ControlCommandAction {
+    fn as_control_action(&self) -> Option<ControlAction> {
+        match self {
+            Self::Pause => Some(ControlAction::Pause),
+            Self::Resume => Some(ControlAction::Resume),
+            Self::Stop => Some(ControlAction::Stop),
+            Self::Interrupt => None,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -104,7 +123,7 @@ enum Commands {
         agent: Option<String>,
     },
     Control {
-        action: ControlAction,
+        action: ControlCommandAction,
         #[arg(long)]
         agent: Option<String>,
     },
@@ -526,11 +545,25 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         }
         Commands::Control { action, agent } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            if action == ControlCommandAction::Interrupt {
+                return post_control_json(
+                    &config,
+                    &format!("/control/agents/{agent}/current-run/interrupt"),
+                    &http::InterruptCurrentRunRequest {
+                        run_id: None,
+                        mode: Some("pause_after_abort".into()),
+                        trust: Some(TrustLevel::TrustedOperator),
+                    },
+                )
+                .await;
+            }
             post_control_json(
                 &config,
                 &format!("/control/agents/{agent}/control"),
                 &ControlRequest {
-                    action,
+                    action: action
+                        .as_control_action()
+                        .expect("interrupt action should be handled separately"),
                     trust: Some(TrustLevel::TrustedOperator),
                 },
             )

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -201,6 +201,17 @@ pub struct CurrentRunInterruptOutcome {
     pub mode: CurrentRunInterruptMode,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CurrentRunInterruptError {
+    #[error("agent {agent_id} has no current run to interrupt")]
+    NoCurrentRun { agent_id: String },
+    #[error("stale run_id {requested_run_id}; current run is {current_run_id}")]
+    StaleRunId {
+        requested_run_id: String,
+        current_run_id: String,
+    },
+}
+
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("current run interrupted by operator")]
 pub struct CurrentRunInterrupted {
@@ -235,14 +246,15 @@ impl RuntimeHandle {
         let mut guard = self.inner.agent.lock().await;
         let agent_id = guard.state.id.clone();
         let Some(handle) = guard.current_run_interrupt.as_ref().cloned() else {
-            return Err(anyhow!("agent {agent_id} has no current run to interrupt"));
+            return Err(CurrentRunInterruptError::NoCurrentRun { agent_id }.into());
         };
         if let Some(expected_run_id) = request.run_id.as_deref() {
             if expected_run_id != handle.run_id {
-                return Err(anyhow!(
-                    "stale run_id {expected_run_id}; current run is {}",
-                    handle.run_id
-                ));
+                return Err(CurrentRunInterruptError::StaleRunId {
+                    requested_run_id: expected_run_id.to_string(),
+                    current_run_id: handle.run_id.clone(),
+                }
+                .into());
             }
         }
 
@@ -938,14 +950,7 @@ impl RuntimeHandle {
                     };
                 }
                 guard.state.current_run_id = None;
-                if interrupted.as_ref().is_some_and(|interrupted| {
-                    guard
-                        .current_run_interrupt
-                        .as_ref()
-                        .is_some_and(|handle| handle.run_id == interrupted.run_id)
-                }) {
-                    guard.current_run_interrupt = None;
-                }
+                guard.current_run_interrupt = None;
                 self.inner.storage.write_agent(&guard.state)?;
                 drop(guard);
                 self.maybe_commit_turn_end_work_item_transition().await?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -34,6 +34,7 @@ use bootstrap::ProviderReconfigurator;
 use chrono::Utc;
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use uuid::Uuid;
 
@@ -159,6 +160,51 @@ struct RuntimeInner {
 struct RuntimeAgent {
     state: AgentState,
     queue: RuntimeQueue,
+    current_run_interrupt: Option<CurrentRunInterruptHandle>,
+}
+
+#[derive(Debug, Clone)]
+struct CurrentRunInterruptHandle {
+    run_id: String,
+    token: CancellationToken,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CurrentRunInterruptMode {
+    PauseAfterAbort,
+}
+
+impl CurrentRunInterruptMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PauseAfterAbort => "pause_after_abort",
+        }
+    }
+}
+
+impl Default for CurrentRunInterruptMode {
+    fn default() -> Self {
+        Self::PauseAfterAbort
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentRunInterruptRequest {
+    pub run_id: Option<String>,
+    pub mode: CurrentRunInterruptMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentRunInterruptOutcome {
+    pub agent_id: String,
+    pub run_id: String,
+    pub mode: CurrentRunInterruptMode,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("current run interrupted by operator")]
+pub struct CurrentRunInterrupted {
+    pub run_id: String,
 }
 
 impl RuntimeHandle {
@@ -180,6 +226,55 @@ impl RuntimeHandle {
 
     pub fn poll_activity_marker(&self) -> Result<PollActivityMarker> {
         self.inner.storage.poll_activity_marker()
+    }
+
+    pub async fn interrupt_current_run(
+        &self,
+        request: CurrentRunInterruptRequest,
+    ) -> Result<CurrentRunInterruptOutcome> {
+        let mut guard = self.inner.agent.lock().await;
+        let agent_id = guard.state.id.clone();
+        let Some(handle) = guard.current_run_interrupt.as_ref().cloned() else {
+            return Err(anyhow!("agent {agent_id} has no current run to interrupt"));
+        };
+        if let Some(expected_run_id) = request.run_id.as_deref() {
+            if expected_run_id != handle.run_id {
+                return Err(anyhow!(
+                    "stale run_id {expected_run_id}; current run is {}",
+                    handle.run_id
+                ));
+            }
+        }
+
+        handle.token.cancel();
+        guard.state.status = AgentStatus::Paused;
+        guard.state.current_run_id = None;
+        self.inner.storage.write_agent(&guard.state)?;
+        drop(guard);
+
+        self.inner.storage.append_event(&AuditEvent::new(
+            "current_run_interrupted",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "run_id": handle.run_id,
+                "mode": request.mode.as_str(),
+                "reason": "operator_interrupted",
+            }),
+        ))?;
+        self.inner.notify.notify_waiters();
+        Ok(CurrentRunInterruptOutcome {
+            agent_id,
+            run_id: handle.run_id,
+            mode: request.mode,
+        })
+    }
+
+    pub(crate) async fn current_run_interrupt_token(&self) -> Option<(String, CancellationToken)> {
+        let guard = self.inner.agent.lock().await;
+        guard
+            .current_run_interrupt
+            .as_ref()
+            .map(|handle| (handle.run_id.clone(), handle.token.clone()))
     }
 
     pub fn all_events(&self) -> Result<Vec<AuditEvent>> {
@@ -743,10 +838,16 @@ impl RuntimeHandle {
                 if guard.state.status == AgentStatus::Paused {
                     None
                 } else if let Some(message) = guard.queue.pop() {
+                    let run_id = Uuid::new_v4().to_string();
+                    let interrupt_token = CancellationToken::new();
                     let prior_state = guard.state.clone();
                     guard.state.pending = guard.queue.len();
                     guard.state.status = AgentStatus::AwakeRunning;
-                    guard.state.current_run_id = Some(Uuid::new_v4().to_string());
+                    guard.state.current_run_id = Some(run_id.clone());
+                    guard.current_run_interrupt = Some(CurrentRunInterruptHandle {
+                        run_id,
+                        token: interrupt_token,
+                    });
                     guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
                     self.inner.storage.write_agent(&guard.state)?;
                     self.inner.storage.append_queue_entry(&QueueEntryRecord {
@@ -787,20 +888,41 @@ impl RuntimeHandle {
 
             let prior_closure = self.closure_decision_for_state(&prior_state, None).await?;
             if let Err(err) = self.process_message(message.clone(), prior_closure).await {
-                error!("failed to process message {}: {err:#}", message.id);
-                self.inner.storage.append_event(&AuditEvent::new(
-                    "runtime_error",
-                    serde_json::json!({
-                        "message_id": message.id,
-                        "message_kind": message.kind,
-                        "error": err.to_string(),
-                        "token_usage": provider_attempt_timeline(&err)
-                            .and_then(|timeline| timeline.aggregated_token_usage.clone()),
-                        "provider_attempt_timeline": provider_attempt_timeline(&err),
-                    }),
-                ))?;
-                self.persist_runtime_failure_artifacts(&message, &err)
-                    .await?;
+                let interrupted = err.downcast_ref::<CurrentRunInterrupted>().cloned();
+                if let Some(interrupted) = interrupted.as_ref() {
+                    self.inner.storage.append_queue_entry(&QueueEntryRecord {
+                        message_id: message.id.clone(),
+                        agent_id: message.agent_id.clone(),
+                        priority: message.priority.clone(),
+                        status: QueueEntryStatus::Interrupted,
+                        created_at: message.created_at,
+                        updated_at: Utc::now(),
+                    })?;
+                    self.inner.storage.append_event(&AuditEvent::new(
+                        "message_processing_interrupted",
+                        serde_json::json!({
+                            "message_id": message.id,
+                            "message_kind": message.kind,
+                            "run_id": interrupted.run_id,
+                            "reason": "operator_interrupted",
+                        }),
+                    ))?;
+                } else {
+                    error!("failed to process message {}: {err:#}", message.id);
+                    self.inner.storage.append_event(&AuditEvent::new(
+                        "runtime_error",
+                        serde_json::json!({
+                            "message_id": message.id,
+                            "message_kind": message.kind,
+                            "error": err.to_string(),
+                            "token_usage": provider_attempt_timeline(&err)
+                                .and_then(|timeline| timeline.aggregated_token_usage.clone()),
+                            "provider_attempt_timeline": provider_attempt_timeline(&err),
+                        }),
+                    ))?;
+                    self.persist_runtime_failure_artifacts(&message, &err)
+                        .await?;
+                }
                 let mut guard = self.inner.agent.lock().await;
                 if !matches!(
                     guard.state.status,
@@ -816,12 +938,23 @@ impl RuntimeHandle {
                     };
                 }
                 guard.state.current_run_id = None;
+                if interrupted.as_ref().is_some_and(|interrupted| {
+                    guard
+                        .current_run_interrupt
+                        .as_ref()
+                        .is_some_and(|handle| handle.run_id == interrupted.run_id)
+                }) {
+                    guard.current_run_interrupt = None;
+                }
                 self.inner.storage.write_agent(&guard.state)?;
                 drop(guard);
                 self.maybe_commit_turn_end_work_item_transition().await?;
                 self.record_closure_decision_event(Some(true)).await?;
                 self.maybe_emit_pending_system_tick(None).await?;
             } else {
+                let mut guard = self.inner.agent.lock().await;
+                guard.current_run_interrupt = None;
+                drop(guard);
                 self.inner.storage.append_queue_entry(&QueueEntryRecord {
                     message_id: message.id.clone(),
                     agent_id: message.agent_id.clone(),

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -309,7 +309,11 @@ impl RuntimeHandle {
 
         Ok(Self {
             inner: Arc::new(RuntimeInner {
-                agent: Mutex::new(RuntimeAgent { state, queue }),
+                agent: Mutex::new(RuntimeAgent {
+                    state,
+                    queue,
+                    current_run_interrupt: None,
+                }),
                 notify: Notify::new(),
                 storage,
                 provider: RwLock::new(provider),

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,6 +1,18 @@
 use super::super::*;
 use super::support::*;
 
+struct BlockingProvider {
+    started: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl AgentProvider for BlockingProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        self.started.notify_waiters();
+        std::future::pending::<Result<ProviderTurnResponse>>().await
+    }
+}
+
 #[tokio::test]
 async fn non_model_visible_external_events_do_not_run_interactive_turn() {
     let dir = tempdir().unwrap();
@@ -42,6 +54,167 @@ async fn non_model_visible_external_events_do_not_run_interactive_turn() {
     assert!(transcript
         .iter()
         .all(|entry| entry.kind != TranscriptEntryKind::AssistantRound));
+}
+
+#[tokio::test]
+async fn interrupt_current_run_aborts_provider_turn_and_pauses_agent() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(BlockingProvider {
+            started: started.clone(),
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "block".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let runner = tokio::spawn(runtime.clone().run());
+    started.notified().await;
+    let run_id = runtime
+        .agent_state()
+        .await
+        .unwrap()
+        .current_run_id
+        .expect("run id should be active");
+
+    let outcome = runtime
+        .interrupt_current_run(CurrentRunInterruptRequest {
+            run_id: Some(run_id.clone()),
+            mode: CurrentRunInterruptMode::PauseAfterAbort,
+        })
+        .await
+        .unwrap();
+    assert_eq!(outcome.run_id, run_id);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let state = runtime.agent_state().await.unwrap();
+            if state
+                .last_turn_terminal
+                .as_ref()
+                .is_some_and(|terminal| terminal.reason.as_deref() == Some("operator_interrupted"))
+            {
+                break state;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("interrupted terminal should be persisted");
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::Paused);
+    assert_eq!(state.current_run_id, None);
+    assert_eq!(
+        state
+            .last_turn_terminal
+            .as_ref()
+            .map(|terminal| terminal.kind),
+        Some(TurnTerminalKind::Aborted)
+    );
+    assert_eq!(
+        state
+            .last_turn_terminal
+            .as_ref()
+            .and_then(|terminal| terminal.reason.as_deref()),
+        Some("operator_interrupted")
+    );
+    let queue_entries = runtime.storage().latest_queue_entries().unwrap();
+    assert!(queue_entries
+        .iter()
+        .any(|entry| entry.status == QueueEntryStatus::Interrupted));
+    let events = runtime.all_events().unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "current_run_interrupted"));
+
+    runtime
+        .control(crate::types::ControlAction::Stop)
+        .await
+        .unwrap();
+    runner.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn interrupt_current_run_rejects_stale_run_id() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(BlockingProvider {
+            started: started.clone(),
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "block".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let runner = tokio::spawn(runtime.clone().run());
+    started.notified().await;
+
+    let err = runtime
+        .interrupt_current_run(CurrentRunInterruptRequest {
+            run_id: Some("stale-run".into()),
+            mode: CurrentRunInterruptMode::PauseAfterAbort,
+        })
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("stale run_id"));
+    assert!(runtime
+        .agent_state()
+        .await
+        .unwrap()
+        .current_run_id
+        .is_some());
+
+    runtime
+        .interrupt_current_run(CurrentRunInterruptRequest {
+            run_id: None,
+            mode: CurrentRunInterruptMode::PauseAfterAbort,
+        })
+        .await
+        .unwrap();
+    runtime
+        .control(crate::types::ControlAction::Stop)
+        .await
+        .unwrap();
+    runner.await.unwrap().unwrap();
 }
 
 #[tokio::test]

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -129,6 +129,7 @@ pub(crate) async fn bind_turn_to_work_item(runtime: &RuntimeHandle, work_item_id
     guard.state.last_turn_terminal = Some(TurnTerminalRecord {
         turn_index: 1,
         kind: TurnTerminalKind::Completed,
+        reason: None,
         last_assistant_message: Some("done".into()),
         checkpoint: None,
         completed_at: Utc::now(),

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -725,6 +725,7 @@ async fn turn_end_work_item_commit_keeps_failed_turn_open_without_blocker() {
         guard.state.last_turn_terminal = Some(TurnTerminalRecord {
             turn_index: guard.state.turn_index,
             kind: TurnTerminalKind::Aborted,
+            reason: None,
             last_assistant_message: Some("provider context_length_exceeded".into()),
             checkpoint: None,
             completed_at: Utc::now(),
@@ -771,6 +772,7 @@ async fn turn_end_work_item_commit_preserves_existing_blocker_on_failed_turn() {
         guard.state.last_turn_terminal = Some(TurnTerminalRecord {
             turn_index: guard.state.turn_index,
             kind: TurnTerminalKind::Aborted,
+            reason: None,
             last_assistant_message: Some("provider timeout".into()),
             checkpoint: None,
             completed_at: Utc::now(),

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -9,7 +9,7 @@ use crate::{
     provider::{
         provider_attempt_timeline, provider_error_is_context_length_exceeded, AgentProvider,
         ConversationMessage, ModelBlock, PromptContentBlock, ProviderAttemptTimeline,
-        ProviderPromptFrame, ProviderTurnRequest, ToolResultBlock,
+        ProviderPromptFrame, ProviderTurnRequest, ProviderTurnResponse, ToolResultBlock,
     },
     runtime::provider_turn::{
         build_continuation_request, build_provider_prompt_frame, build_provider_turn_request,
@@ -26,7 +26,9 @@ use crate::{
     },
 };
 
-use super::{combine_text_history, is_max_output_stop_reason, RuntimeHandle};
+use super::{
+    combine_text_history, is_max_output_stop_reason, CurrentRunInterrupted, RuntimeHandle,
+};
 
 pub(super) struct AgentLoopOutcome {
     pub(super) final_text: String,
@@ -1263,6 +1265,7 @@ impl RuntimeHandle {
             let record = TurnTerminalRecord {
                 turn_index: guard.state.turn_index,
                 kind,
+                reason: None,
                 last_assistant_message,
                 checkpoint,
                 completed_at: chrono::Utc::now(),
@@ -1277,6 +1280,66 @@ impl RuntimeHandle {
             serde_json::to_value(&record)?,
         ))?;
         Ok(record)
+    }
+
+    async fn persist_turn_interrupted_record(
+        &self,
+        run_id: &str,
+        last_assistant_message: Option<String>,
+        duration_ms: u64,
+    ) -> Result<TurnTerminalRecord> {
+        let record = {
+            let mut guard = self.inner.agent.lock().await;
+            let record = TurnTerminalRecord {
+                turn_index: guard.state.turn_index,
+                kind: TurnTerminalKind::Aborted,
+                reason: Some("operator_interrupted".into()),
+                last_assistant_message,
+                checkpoint: None,
+                completed_at: chrono::Utc::now(),
+                duration_ms,
+            };
+            guard.state.last_turn_terminal = Some(record.clone());
+            self.inner.storage.write_agent(&guard.state)?;
+            record
+        };
+        self.inner.storage.append_event(&AuditEvent::new(
+            "turn_terminal",
+            serde_json::to_value(&record)?,
+        ))?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "turn_terminal_aborted",
+            serde_json::json!({
+                "run_id": run_id,
+                "reason": "operator_interrupted",
+                "record": record,
+            }),
+        ))?;
+        Ok(record)
+    }
+
+    async fn complete_turn_with_interrupt(
+        &self,
+        provider: std::sync::Arc<dyn AgentProvider>,
+        request: ProviderTurnRequest,
+    ) -> Result<(ProviderTurnResponse, Option<ProviderAttemptTimeline>)> {
+        if let Some((run_id, token)) = self.current_run_interrupt_token().await {
+            tokio::select! {
+                result = provider.complete_turn_with_diagnostics(request) => result,
+                _ = token.cancelled() => Err(CurrentRunInterrupted { run_id }.into()),
+            }
+        } else {
+            provider.complete_turn_with_diagnostics(request).await
+        }
+    }
+
+    async fn ensure_not_interrupted(&self) -> Result<()> {
+        if let Some((run_id, token)) = self.current_run_interrupt_token().await {
+            if token.is_cancelled() {
+                return Err(CurrentRunInterrupted { run_id }.into());
+            }
+        }
+        Ok(())
     }
 
     pub(super) async fn run_agent_loop(
@@ -1302,6 +1365,17 @@ impl RuntimeHandle {
         };
 
         loop {
+            if let Err(err) = self.ensure_not_interrupted().await {
+                if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
+                    self.persist_turn_interrupted_record(
+                        &interrupted.run_id,
+                        last_assistant_message.clone(),
+                        turn_started_at.elapsed().as_millis() as u64,
+                    )
+                    .await?;
+                }
+                return Err(err);
+            }
             round += 1;
             if let Some(max_tool_rounds) = loop_control.max_tool_rounds {
                 if round > max_tool_rounds {
@@ -1335,11 +1409,20 @@ impl RuntimeHandle {
                 let request = build_provider_turn_request(&effective_prompt, available_tools);
                 let provider = self.current_provider().await;
                 let context_management = context_management_diagnostic(provider.as_ref(), &request);
-                match provider.complete_turn_with_diagnostics(request).await {
+                match self.complete_turn_with_interrupt(provider, request).await {
                     Ok((response, attempt_timeline)) => {
                         (response, attempt_timeline, context_management)
                     }
                     Err(err) => {
+                        if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
+                            self.persist_turn_interrupted_record(
+                                &interrupted.run_id,
+                                last_assistant_message.clone(),
+                                turn_started_at.elapsed().as_millis() as u64,
+                            )
+                            .await?;
+                            return Err(err);
+                        }
                         if let Some(outcome) = self
                             .maybe_handle_context_length_exceeded(
                                 agent_id,
@@ -1542,11 +1625,20 @@ impl RuntimeHandle {
                 );
                 let provider = self.current_provider().await;
                 let context_management = context_management_diagnostic(provider.as_ref(), &request);
-                match provider.complete_turn_with_diagnostics(request).await {
+                match self.complete_turn_with_interrupt(provider, request).await {
                     Ok((response, attempt_timeline)) => {
                         (response, attempt_timeline, context_management)
                     }
                     Err(err) => {
+                        if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
+                            self.persist_turn_interrupted_record(
+                                &interrupted.run_id,
+                                last_assistant_message.clone(),
+                                turn_started_at.elapsed().as_millis() as u64,
+                            )
+                            .await?;
+                            return Err(err);
+                        }
                         if let Some(outcome) = self
                             .maybe_handle_context_length_exceeded(
                                 agent_id,
@@ -1886,6 +1978,17 @@ impl RuntimeHandle {
             let mut tool_results = Vec::new();
             let mut tool_result_envelopes = Vec::new();
             for call in tool_calls {
+                if let Err(err) = self.ensure_not_interrupted().await {
+                    if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
+                        self.persist_turn_interrupted_record(
+                            &interrupted.run_id,
+                            last_assistant_message.clone(),
+                            turn_started_at.elapsed().as_millis() as u64,
+                        )
+                        .await?;
+                    }
+                    return Err(err);
+                }
                 let tool_call_id = call.id.clone();
                 let tool_name = call.name.clone();
                 if !allowed_tool_names.contains(&call.name) {
@@ -1968,12 +2071,20 @@ impl RuntimeHandle {
                     tool_result_envelopes.push(result.envelope);
                     continue;
                 }
-                match self
-                    .inner
-                    .tools
-                    .execute(self, agent_id, &trust, &call)
-                    .await
+                let tool_execution = if let Some((run_id, token)) =
+                    self.current_run_interrupt_token().await
                 {
+                    tokio::select! {
+                        result = self.inner.tools.execute(self, agent_id, &trust, &call) => result,
+                        _ = token.cancelled() => Err(CurrentRunInterrupted { run_id }.into()),
+                    }
+                } else {
+                    self.inner
+                        .tools
+                        .execute(self, agent_id, &trust, &call)
+                        .await
+                };
+                match tool_execution {
                     Ok((result, mut record)) => {
                         let result_content =
                             crate::tool::tools::render_tool_result_for_model(&result)?;
@@ -2028,6 +2139,15 @@ impl RuntimeHandle {
                         });
                     }
                     Err(err) => {
+                        if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
+                            self.persist_turn_interrupted_record(
+                                &interrupted.run_id,
+                                last_assistant_message.clone(),
+                                turn_started_at.elapsed().as_millis() as u64,
+                            )
+                            .await?;
+                            return Err(err);
+                        }
                         let error = ToolError::from_anyhow(&err);
                         let message = error.render();
                         self.inner.storage.append_event(&AuditEvent::new(
@@ -3393,6 +3513,7 @@ mod tests {
         let terminal = TurnTerminalRecord {
             turn_index: 7,
             kind: TurnTerminalKind::Completed,
+            reason: None,
             last_assistant_message: Some("ordinary final text without checkpoint keywords".into()),
             checkpoint: Some(TurnTerminalCheckpointRecord {
                 request_id: "checkpoint-7".into(),
@@ -3424,6 +3545,7 @@ mod tests {
         let terminal = TurnTerminalRecord {
             turn_index: 7,
             kind: TurnTerminalKind::Completed,
+            reason: None,
             last_assistant_message: Some(
                 "Progress checkpoint:\n\n- current user goal: fix issue\n- next goal-aligned action: apply patch"
                     .into(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -706,6 +706,7 @@ impl AppStorage {
                     messages_by_id.get(&entry.message_id).cloned()
                 }
                 crate::types::QueueEntryStatus::Processed
+                | crate::types::QueueEntryStatus::Interrupted
                 | crate::types::QueueEntryStatus::Dropped => None,
             })
             .collect::<Vec<_>>();

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -11,6 +11,7 @@ enum SlashCommand {
     Refresh,
     ClearStatus,
     DebugPrompt,
+    Interrupt,
     Agent,
     Skills,
     SkillInstall,
@@ -38,7 +39,7 @@ pub(super) struct SlashCommandSpec {
     command: SlashCommand,
 }
 
-const SLASH_COMMAND_SPECS: [SlashCommandSpec; 13] = [
+const SLASH_COMMAND_SPECS: [SlashCommandSpec; 14] = [
     SlashCommandSpec {
         name: "/help",
         description: "show slash command help",
@@ -101,6 +102,13 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 13] = [
         usage: "/debug-prompt",
         arg_rule: SlashArgRule::None,
         command: SlashCommand::DebugPrompt,
+    },
+    SlashCommandSpec {
+        name: "/interrupt",
+        description: "interrupt current agent run",
+        usage: "/interrupt",
+        arg_rule: SlashArgRule::None,
+        command: SlashCommand::Interrupt,
     },
     SlashCommandSpec {
         name: "/agent",
@@ -406,6 +414,23 @@ impl TuiApp {
                     composer: ComposerState::new(),
                 };
                 self.status_line = "Opened debug prompt dialog".into();
+            }
+            SlashCommand::Interrupt => {
+                let agent_id = match self.selected_agent_id() {
+                    Some(id) => id.to_string(),
+                    None => {
+                        self.status_line = "No agent selected".into();
+                        return Ok(());
+                    }
+                };
+                let run_id = self
+                    .projection
+                    .as_ref()
+                    .and_then(|projection| projection.session.current_run_id.clone());
+                self.client.interrupt_current_run(&agent_id, run_id).await?;
+                self.overlay = OverlayState::None;
+                self.status_line = format!("Interrupted current run for {agent_id}");
+                let _ = self.bootstrap_selected_agent().await;
             }
             SlashCommand::Agent => {
                 let requested_agent_id = args
@@ -1221,6 +1246,10 @@ mod tests {
         assert_eq!(
             parse_composer_submission("/debug-prompt").unwrap(),
             Some(ComposerSubmission::Slash(SlashCommand::DebugPrompt, vec![]))
+        );
+        assert_eq!(
+            parse_composer_submission("/interrupt").unwrap(),
+            Some(ComposerSubmission::Slash(SlashCommand::Interrupt, vec![]))
         );
         assert_eq!(
             parse_composer_submission("/agent default").unwrap(),

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1412,6 +1412,7 @@ mod tests {
                 last_turn: Some(TurnTerminalRecord {
                     turn_index: 1,
                     kind: TurnTerminalKind::Completed,
+                    reason: None,
                     last_assistant_message: Some("done".into()),
                     checkpoint: None,
                     completed_at: Utc::now(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1029,6 +1029,8 @@ pub struct TurnTerminalRecord {
     pub turn_index: u64,
     pub kind: TurnTerminalKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_assistant_message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<TurnTerminalCheckpointRecord>,
@@ -2508,6 +2510,7 @@ pub enum QueueEntryStatus {
     Queued,
     Dequeued,
     Processed,
+    Interrupted,
     Dropped,
 }
 


### PR DESCRIPTION
## Summary

- add an operator-only current-run interrupt primitive with per-run cancellation token support
- expose interruption through HTTP, `holon control interrupt`, and TUI `/interrupt`
- record interrupted queue outcomes and aborted terminal records with `operator_interrupted` reason
- document current-run intervention in the agent control-plane RFC

Fixes #892.

## Verification

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test --lib interrupt_current_run -- --nocapture`
- `cargo test --lib parses_safe_slash_commands -- --nocapture`
- `cargo test --lib`
