### PR TITLE
fix: bound daemon shutdown on active runs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -21,6 +21,8 @@ use crate::{
     },
 };
 
+const UNIX_CONTROL_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 #[derive(Clone)]
 pub struct LocalClient {
     config: AppConfig,
@@ -578,14 +580,24 @@ impl LocalClient {
         }
         raw.push_str("\r\n");
 
-        stream.write_all(raw.as_bytes()).await?;
-        if let Some(body) = request.body.as_ref() {
-            stream.write_all(body).await?;
-        }
-        stream.flush().await?;
+        let response = tokio::time::timeout(UNIX_CONTROL_REQUEST_TIMEOUT, async {
+            stream.write_all(raw.as_bytes()).await?;
+            if let Some(body) = request.body.as_ref() {
+                stream.write_all(body).await?;
+            }
+            stream.flush().await?;
 
-        let mut response = Vec::new();
-        stream.read_to_end(&mut response).await?;
+            let mut response = Vec::new();
+            stream.read_to_end(&mut response).await?;
+            Ok::<Vec<u8>, anyhow::Error>(response)
+        })
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "timed out waiting for unix-socket response for {}",
+                request.path
+            )
+        })??;
         let parsed = parse_http_response(&response).with_context(|| {
             format!("failed to parse unix-socket response for {}", request.path)
         })?;

--- a/src/host.rs
+++ b/src/host.rs
@@ -55,6 +55,7 @@ pub struct RuntimeHost {
 pub(crate) const TEMP_AGENT_PREFIX: &str = "tmp_";
 const TEMP_RUN_AGENT_PREFIX: &str = "tmp_run_";
 const TEMP_CHILD_AGENT_PREFIX: &str = "tmp_child_";
+const HOST_SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
 
 #[derive(Debug)]
 pub enum PublicAgentError {
@@ -154,9 +155,27 @@ impl RuntimeHost {
             let mut agents = self.inner.agents.write().await;
             agents.drain().map(|(_, entry)| entry).collect::<Vec<_>>()
         };
-        for entry in entries {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let abort_handles = entries
+            .iter()
+            .map(|entry| entry.task.abort_handle())
+            .collect::<Vec<_>>();
+        for entry in &entries {
             let _ = entry.runtime.request_service_shutdown().await;
-            let _ = entry.task.await;
+        }
+        if tokio::time::timeout(HOST_SHUTDOWN_GRACE, async move {
+            for entry in entries {
+                let _ = entry.task.await;
+            }
+        })
+        .await
+        .is_err()
+        {
+            for handle in abort_handles {
+                handle.abort();
+            }
         }
         Ok(())
     }
@@ -1385,17 +1404,20 @@ impl RuntimeHostBridge {
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
+    use async_trait::async_trait;
     use tempfile::tempdir;
+    use tokio::sync::Notify;
 
     use crate::{
         config::{provider_registry_for_tests, ControlAuthMode, ModelRef},
-        provider::StubProvider,
+        provider::{AgentProvider, ProviderTurnRequest, ProviderTurnResponse, StubProvider},
         runtime::RuntimeHandle,
         storage::AppStorage,
         types::{
             AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus,
             AgentVisibility, ControlAction, MessageBody, MessageEnvelope, MessageKind,
             MessageOrigin, Priority, TaskRecord, TaskRecoverySpec, TaskStatus, TrustLevel,
+            TurnTerminalKind,
         },
     };
 
@@ -1413,6 +1435,21 @@ mod tests {
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
+    }
+
+    struct BlockingProvider {
+        started: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl AgentProvider for BlockingProvider {
+        async fn complete_turn(
+            &self,
+            _request: ProviderTurnRequest,
+        ) -> anyhow::Result<ProviderTurnResponse> {
+            self.started.notify_waiters();
+            std::future::pending::<anyhow::Result<ProviderTurnResponse>>().await
+        }
     }
 
     fn provider_test_config(anthropic_token: Option<&str>) -> ProviderConfigFixture {
@@ -2302,6 +2339,66 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.kind == "runtime_service_shutdown_requested"));
+    }
+
+    #[tokio::test]
+    async fn host_shutdown_interrupts_active_run_with_daemon_shutdown_reason() {
+        let home = tempdir().unwrap();
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let agent_id = config.default_agent_id.clone();
+        let started = Arc::new(Notify::new());
+        let provider = Arc::new(BlockingProvider {
+            started: started.clone(),
+        });
+        let host = RuntimeHost::new_with_provider(config, provider).unwrap();
+        let runtime = host.default_runtime().await.unwrap();
+        let started_wait = started.notified();
+
+        runtime
+            .enqueue(MessageEnvelope::new(
+                &agent_id,
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                TrustLevel::TrustedOperator,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "block until daemon shutdown".into(),
+                },
+            ))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), started_wait)
+            .await
+            .expect("provider turn should start");
+
+        tokio::time::timeout(Duration::from_secs(5), host.shutdown())
+            .await
+            .expect("host shutdown should be bounded")
+            .unwrap();
+
+        let storage = AppStorage::new(host.agent_data_dir(&agent_id)).unwrap();
+        let persisted = storage.read_agent().unwrap().unwrap();
+        assert_ne!(persisted.status, AgentStatus::Stopped);
+        assert_eq!(persisted.current_run_id, None);
+        let terminal = persisted
+            .last_turn_terminal
+            .expect("interrupted run should persist a terminal record");
+        assert_eq!(terminal.kind, TurnTerminalKind::Aborted);
+        assert_eq!(terminal.reason.as_deref(), Some("daemon_shutdown"));
+
+        let events = storage.read_recent_events(32).unwrap();
+        assert!(events.iter().any(|event| {
+            event.kind == "runtime_service_shutdown_requested"
+                && event.data.get("interrupted_run_id").is_some()
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == "current_run_interrupted"
+                && event.data.get("reason").and_then(Value::as_str) == Some("daemon_shutdown")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == "message_processing_interrupted"
+                && event.data.get("reason").and_then(Value::as_str) == Some("daemon_shutdown")
+        }));
     }
 
     #[tokio::test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -55,7 +55,11 @@ pub struct RuntimeHost {
 pub(crate) const TEMP_AGENT_PREFIX: &str = "tmp_";
 const TEMP_RUN_AGENT_PREFIX: &str = "tmp_run_";
 const TEMP_CHILD_AGENT_PREFIX: &str = "tmp_child_";
+// Give runtime loops a short cleanup window while keeping daemon stop bounded.
+#[cfg(not(test))]
 const HOST_SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
+#[cfg(test)]
+const HOST_SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
 
 #[derive(Debug)]
 pub enum PublicAgentError {
@@ -158,23 +162,24 @@ impl RuntimeHost {
         if entries.is_empty() {
             return Ok(());
         }
-        let abort_handles = entries
-            .iter()
-            .map(|entry| entry.task.abort_handle())
-            .collect::<Vec<_>>();
-        for entry in &entries {
+        let mut tasks = Vec::with_capacity(entries.len());
+        for entry in entries {
             let _ = entry.runtime.request_service_shutdown().await;
+            tasks.push(entry.task);
         }
-        if tokio::time::timeout(HOST_SHUTDOWN_GRACE, async move {
-            for entry in entries {
-                let _ = entry.task.await;
+        if tokio::time::timeout(HOST_SHUTDOWN_GRACE, async {
+            for task in &mut tasks {
+                let _ = task.await;
             }
         })
         .await
         .is_err()
         {
-            for handle in abort_handles {
-                handle.abort();
+            for task in &tasks {
+                task.abort();
+            }
+            for task in tasks {
+                let _ = task.await;
             }
         }
         Ok(())
@@ -1402,7 +1407,13 @@ impl RuntimeHostBridge {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc};
+    use std::{
+        path::PathBuf,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
 
     use async_trait::async_trait;
     use tempfile::tempdir;
@@ -1439,6 +1450,14 @@ mod tests {
 
     struct BlockingProvider {
         started: Arc<Notify>,
+    }
+
+    struct AbortObserved(Arc<AtomicBool>);
+
+    impl Drop for AbortObserved {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
     }
 
     #[async_trait]
@@ -2378,7 +2397,7 @@ mod tests {
 
         let storage = AppStorage::new(host.agent_data_dir(&agent_id)).unwrap();
         let persisted = storage.read_agent().unwrap().unwrap();
-        assert_ne!(persisted.status, AgentStatus::Stopped);
+        assert_eq!(persisted.status, AgentStatus::AwakeIdle);
         assert_eq!(persisted.current_run_id, None);
         let terminal = persisted
             .last_turn_terminal
@@ -2399,6 +2418,38 @@ mod tests {
             event.kind == "message_processing_interrupted"
                 && event.data.get("reason").and_then(Value::as_str) == Some("daemon_shutdown")
         }));
+    }
+
+    #[tokio::test]
+    async fn host_shutdown_awaits_runtime_task_after_abort() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+        let _runtime = host.default_runtime().await.unwrap();
+        let aborted = Arc::new(AtomicBool::new(false));
+        let replacement_task = {
+            let aborted = aborted.clone();
+            tokio::spawn(async move {
+                let _abort_observed = AbortObserved(aborted);
+                std::future::pending::<()>().await;
+            })
+        };
+
+        let old_task = {
+            let mut agents = host.inner.agents.write().await;
+            let entry = agents
+                .get_mut(&agent_id)
+                .expect("default runtime should be loaded");
+            std::mem::replace(&mut entry.task, replacement_task)
+        };
+        old_task.abort();
+        let _ = old_task.await;
+
+        host.shutdown().await.unwrap();
+
+        assert!(
+            aborted.load(Ordering::SeqCst),
+            "host shutdown should await the aborted runtime task"
+        );
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -24,7 +24,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex as StdMutex,
     },
     time::Duration,
 };
@@ -167,6 +167,7 @@ struct RuntimeAgent {
 struct CurrentRunInterruptHandle {
     run_id: String,
     token: CancellationToken,
+    reason: Arc<StdMutex<String>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -213,9 +214,26 @@ pub enum CurrentRunInterruptError {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("current run interrupted by operator")]
+#[error("current run interrupted: {reason}")]
 pub struct CurrentRunInterrupted {
     pub run_id: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CurrentRunInterruptSnapshot {
+    pub(crate) run_id: String,
+    pub(crate) token: CancellationToken,
+    pub(crate) reason: Arc<StdMutex<String>>,
+}
+
+impl CurrentRunInterruptSnapshot {
+    pub(crate) fn reason(&self) -> String {
+        self.reason
+            .lock()
+            .map(|reason| reason.clone())
+            .unwrap_or_else(|_| "operator_interrupted".into())
+    }
 }
 
 impl RuntimeHandle {
@@ -258,6 +276,9 @@ impl RuntimeHandle {
             }
         }
 
+        if let Ok(mut reason) = handle.reason.lock() {
+            *reason = "operator_interrupted".into();
+        }
         handle.token.cancel();
         guard.state.status = AgentStatus::Paused;
         guard.state.current_run_id = None;
@@ -281,12 +302,16 @@ impl RuntimeHandle {
         })
     }
 
-    pub(crate) async fn current_run_interrupt_token(&self) -> Option<(String, CancellationToken)> {
+    pub(crate) async fn current_run_interrupt_token(&self) -> Option<CurrentRunInterruptSnapshot> {
         let guard = self.inner.agent.lock().await;
         guard
             .current_run_interrupt
             .as_ref()
-            .map(|handle| (handle.run_id.clone(), handle.token.clone()))
+            .map(|handle| CurrentRunInterruptSnapshot {
+                run_id: handle.run_id.clone(),
+                token: handle.token.clone(),
+                reason: handle.reason.clone(),
+            })
     }
 
     pub fn all_events(&self) -> Result<Vec<AuditEvent>> {
@@ -859,6 +884,7 @@ impl RuntimeHandle {
                     guard.current_run_interrupt = Some(CurrentRunInterruptHandle {
                         run_id,
                         token: interrupt_token,
+                        reason: Arc::new(StdMutex::new("operator_interrupted".into())),
                     });
                     guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
                     self.inner.storage.write_agent(&guard.state)?;
@@ -916,7 +942,7 @@ impl RuntimeHandle {
                             "message_id": message.id,
                             "message_kind": message.kind,
                             "run_id": interrupted.run_id,
-                            "reason": "operator_interrupted",
+                            "reason": interrupted.reason,
                         }),
                     ))?;
                 } else {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -338,6 +338,16 @@ impl RuntimeHandle {
                 handle.token.cancel();
                 interrupted_run_id = Some(handle.run_id.clone());
                 guard.state.current_run_id = None;
+                if matches!(guard.state.status, AgentStatus::AwakeRunning) {
+                    guard.state.status = if task_state_reducer::has_blocking_active_tasks(
+                        &self.inner.storage,
+                        &guard.state.active_task_ids,
+                    )? {
+                        AgentStatus::AwaitingTask
+                    } else {
+                        AgentStatus::AwakeIdle
+                    };
+                }
                 self.inner.storage.write_agent(&guard.state)?;
             }
         }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -328,10 +328,36 @@ impl RuntimeHandle {
         self.inner
             .shutdown_requested
             .store(true, std::sync::atomic::Ordering::SeqCst);
+        let mut interrupted_run_id = None;
+        {
+            let mut guard = self.inner.agent.lock().await;
+            if let Some(handle) = guard.current_run_interrupt.as_ref() {
+                if let Ok(mut reason) = handle.reason.lock() {
+                    *reason = "daemon_shutdown".into();
+                }
+                handle.token.cancel();
+                interrupted_run_id = Some(handle.run_id.clone());
+                guard.state.current_run_id = None;
+                self.inner.storage.write_agent(&guard.state)?;
+            }
+        }
         self.inner.storage.append_event(&AuditEvent::new(
             "runtime_service_shutdown_requested",
-            serde_json::json!({}),
+            serde_json::json!({
+                "interrupted_run_id": interrupted_run_id,
+            }),
         ))?;
+        if let Some(run_id) = interrupted_run_id {
+            self.inner.storage.append_event(&AuditEvent::new(
+                "current_run_interrupted",
+                serde_json::json!({
+                    "agent_id": self.agent_id().await?,
+                    "run_id": run_id,
+                    "mode": "shutdown",
+                    "reason": "daemon_shutdown",
+                }),
+            ))?;
+        }
         self.inner.notify.notify_one();
         Ok(())
     }

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1285,6 +1285,7 @@ impl RuntimeHandle {
     async fn persist_turn_interrupted_record(
         &self,
         run_id: &str,
+        reason: &str,
         last_assistant_message: Option<String>,
         duration_ms: u64,
     ) -> Result<TurnTerminalRecord> {
@@ -1293,7 +1294,7 @@ impl RuntimeHandle {
             let record = TurnTerminalRecord {
                 turn_index: guard.state.turn_index,
                 kind: TurnTerminalKind::Aborted,
-                reason: Some("operator_interrupted".into()),
+                reason: Some(reason.to_string()),
                 last_assistant_message,
                 checkpoint: None,
                 completed_at: chrono::Utc::now(),
@@ -1311,7 +1312,7 @@ impl RuntimeHandle {
             "turn_terminal_aborted",
             serde_json::json!({
                 "run_id": run_id,
-                "reason": "operator_interrupted",
+                "reason": reason,
                 "record": record,
             }),
         ))?;
@@ -1323,10 +1324,13 @@ impl RuntimeHandle {
         provider: std::sync::Arc<dyn AgentProvider>,
         request: ProviderTurnRequest,
     ) -> Result<(ProviderTurnResponse, Option<ProviderAttemptTimeline>)> {
-        if let Some((run_id, token)) = self.current_run_interrupt_token().await {
+        if let Some(snapshot) = self.current_run_interrupt_token().await {
             tokio::select! {
                 result = provider.complete_turn_with_diagnostics(request) => result,
-                _ = token.cancelled() => Err(CurrentRunInterrupted { run_id }.into()),
+                _ = snapshot.token.cancelled() => Err(CurrentRunInterrupted {
+                    run_id: snapshot.run_id.clone(),
+                    reason: snapshot.reason(),
+                }.into()),
             }
         } else {
             provider.complete_turn_with_diagnostics(request).await
@@ -1334,9 +1338,13 @@ impl RuntimeHandle {
     }
 
     async fn ensure_not_interrupted(&self) -> Result<()> {
-        if let Some((run_id, token)) = self.current_run_interrupt_token().await {
-            if token.is_cancelled() {
-                return Err(CurrentRunInterrupted { run_id }.into());
+        if let Some(snapshot) = self.current_run_interrupt_token().await {
+            if snapshot.token.is_cancelled() {
+                return Err(CurrentRunInterrupted {
+                    run_id: snapshot.run_id.clone(),
+                    reason: snapshot.reason(),
+                }
+                .into());
             }
         }
         Ok(())
@@ -1369,6 +1377,7 @@ impl RuntimeHandle {
                 if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
                     self.persist_turn_interrupted_record(
                         &interrupted.run_id,
+                        &interrupted.reason,
                         last_assistant_message.clone(),
                         turn_started_at.elapsed().as_millis() as u64,
                     )
@@ -1417,6 +1426,7 @@ impl RuntimeHandle {
                         if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
                             self.persist_turn_interrupted_record(
                                 &interrupted.run_id,
+                                &interrupted.reason,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                             )
@@ -1633,6 +1643,7 @@ impl RuntimeHandle {
                         if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
                             self.persist_turn_interrupted_record(
                                 &interrupted.run_id,
+                                &interrupted.reason,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                             )
@@ -1982,6 +1993,7 @@ impl RuntimeHandle {
                     if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
                         self.persist_turn_interrupted_record(
                             &interrupted.run_id,
+                            &interrupted.reason,
                             last_assistant_message.clone(),
                             turn_started_at.elapsed().as_millis() as u64,
                         )
@@ -2071,12 +2083,15 @@ impl RuntimeHandle {
                     tool_result_envelopes.push(result.envelope);
                     continue;
                 }
-                let tool_execution = if let Some((run_id, token)) =
+                let tool_execution = if let Some(snapshot) =
                     self.current_run_interrupt_token().await
                 {
                     tokio::select! {
                         result = self.inner.tools.execute(self, agent_id, &trust, &call) => result,
-                        _ = token.cancelled() => Err(CurrentRunInterrupted { run_id }.into()),
+                        _ = snapshot.token.cancelled() => Err(CurrentRunInterrupted {
+                            run_id: snapshot.run_id.clone(),
+                            reason: snapshot.reason(),
+                        }.into()),
                     }
                 } else {
                     self.inner
@@ -2142,6 +2157,7 @@ impl RuntimeHandle {
                         if let Some(interrupted) = err.downcast_ref::<CurrentRunInterrupted>() {
                             self.persist_turn_interrupted_record(
                                 &interrupted.run_id,
+                                &interrupted.reason,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
                             )


### PR DESCRIPTION
Fixes #894

## Summary
- interrupt active runtime turns during daemon shutdown with a structured `daemon_shutdown` reason
- request shutdown for all loaded runtimes before waiting, then abort remaining runtime tasks after a bounded grace period
- bound Unix control socket request/response waits so daemon stop does not hang indefinitely on a stalled control endpoint
- persist interrupted turn terminal/audit records with the shutdown reason

## Verification
- cargo fmt --all -- --check
- cargo check
- cargo test --lib host_shutdown_interrupts_active_run_with_daemon_shutdown_reason -- --nocapture
- cargo test --lib host_shutdown -- --nocapture
- cargo test --lib