### PR TITLE
feat: interject operator prompts during active turns

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -594,6 +594,9 @@ async fn enqueue_internal(
         ));
     }
     let priority = request.priority.unwrap_or(Priority::Normal);
+    if matches!(ingress, EnqueueIngress::Public) && priority == Priority::Interrupt {
+        return Err(forbidden("public enqueue may not use interrupt priority"));
+    }
     let origin = match ingress {
         EnqueueIngress::Public => match request.origin {
             Some(IncomingOrigin::Channel {
@@ -1724,7 +1727,7 @@ pub async fn control_prompt(
         agent_id,
         EnqueueRequest {
             kind: Some(MessageKind::OperatorPrompt),
-            priority: Some(Priority::Normal),
+            priority: Some(Priority::Interrupt),
             trust: Some(TrustLevel::TrustedOperator),
             body: Some(MessageBody::Text { text: request.text }),
             text: None,
@@ -1858,7 +1861,7 @@ pub async fn operator_ingress(
     let message = InboundRequest {
         agent_id: agent_id.clone(),
         kind: MessageKind::OperatorPrompt,
-        priority: Priority::Normal,
+        priority: Priority::Interrupt,
         origin: MessageOrigin::Operator {
             actor_id: Some(actor_id),
         },

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -20,6 +20,15 @@ impl RuntimeQueue {
         }
     }
 
+    pub fn push_front(&mut self, message: MessageEnvelope) {
+        match message.priority {
+            Priority::Interrupt => self.interrupt.push_front(message),
+            Priority::Next => self.next.push_front(message),
+            Priority::Normal => self.normal.push_front(message),
+            Priority::Background => self.background.push_front(message),
+        }
+    }
+
     pub fn pop(&mut self) -> Option<MessageEnvelope> {
         self.interrupt
             .pop_front()

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::types::{MessageEnvelope, Priority};
+use crate::types::{MessageEnvelope, MessageKind, MessageOrigin, Priority, TrustLevel};
 
 #[derive(Debug, Default, Clone)]
 pub struct RuntimeQueue {
@@ -26,6 +26,26 @@ impl RuntimeQueue {
             .or_else(|| self.next.pop_front())
             .or_else(|| self.normal.pop_front())
             .or_else(|| self.background.pop_front())
+    }
+
+    pub fn pop_interrupt_operator_prompt(&mut self) -> Option<MessageEnvelope> {
+        let position = self.interrupt.iter().position(|message| {
+            matches!(
+                (
+                    &message.kind,
+                    &message.origin,
+                    &message.trust,
+                    &message.priority,
+                ),
+                (
+                    MessageKind::OperatorPrompt,
+                    MessageOrigin::Operator { .. },
+                    TrustLevel::TrustedOperator,
+                    Priority::Interrupt,
+                )
+            )
+        })?;
+        self.interrupt.remove(position)
     }
 
     pub fn len(&self) -> usize {
@@ -57,6 +77,19 @@ mod tests {
         )
     }
 
+    fn operator_msg(priority: Priority, text: &str) -> MessageEnvelope {
+        MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("test".into()),
+            },
+            TrustLevel::TrustedOperator,
+            priority,
+            MessageBody::Text { text: text.into() },
+        )
+    }
+
     #[test]
     fn queue_respects_priority_and_fifo() {
         let mut queue = RuntimeQueue::default();
@@ -80,6 +113,33 @@ mod tests {
         assert_eq!(
             queue.pop().unwrap().body,
             MessageBody::Text { text: "n2".into() }
+        );
+    }
+
+    #[test]
+    fn pop_interrupt_operator_prompt_only_drains_trusted_operator_interrupts() {
+        let mut queue = RuntimeQueue::default();
+        queue.push(msg(Priority::Interrupt, "webhook"));
+        queue.push(operator_msg(Priority::Normal, "normal-operator"));
+        queue.push(operator_msg(Priority::Interrupt, "interrupt-operator"));
+
+        assert_eq!(
+            queue.pop_interrupt_operator_prompt().unwrap().body,
+            MessageBody::Text {
+                text: "interrupt-operator".into()
+            }
+        );
+        assert_eq!(
+            queue.pop().unwrap().body,
+            MessageBody::Text {
+                text: "webhook".into()
+            }
+        );
+        assert_eq!(
+            queue.pop().unwrap().body,
+            MessageBody::Text {
+                text: "normal-operator".into()
+            }
         );
     }
 }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -5,11 +5,63 @@ struct BlockingProvider {
     started: Arc<tokio::sync::Notify>,
 }
 
+struct OperatorInterjectionProbeProvider {
+    calls: Mutex<usize>,
+    requests: Mutex<Vec<ProviderTurnRequest>>,
+    first_tool_round: Arc<tokio::sync::Notify>,
+}
+
 #[async_trait]
 impl AgentProvider for BlockingProvider {
     async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
         self.started.notify_waiters();
         std::future::pending::<Result<ProviderTurnResponse>>().await
+    }
+}
+
+#[async_trait]
+impl AgentProvider for OperatorInterjectionProbeProvider {
+    async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        let call = *calls;
+        drop(calls);
+        self.requests.lock().await.push(request);
+        if call == 1 {
+            self.first_tool_round.notify_waiters();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::ToolUse {
+                    id: "sleep".into(),
+                    name: "Sleep".into(),
+                    input: serde_json::json!({
+                        "reason": "wait for operator interjection",
+                        "duration_ms": 1,
+                    }),
+                }],
+                stop_reason: None,
+                input_tokens: 10,
+                output_tokens: 10,
+                cache_usage: None,
+                request_diagnostics: None,
+            })
+        } else {
+            Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text {
+                    text: "interjection handled".into(),
+                }],
+                stop_reason: None,
+                input_tokens: 10,
+                output_tokens: 10,
+                cache_usage: None,
+                request_diagnostics: None,
+            })
+        }
+    }
+
+    #[cfg(test)]
+    fn configured_model_refs(&self) -> Vec<String> {
+        vec!["stub".into()]
     }
 }
 
@@ -152,6 +204,124 @@ async fn interrupt_current_run_aborts_provider_turn_and_pauses_agent() {
         .await
         .unwrap();
     runner.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn interrupt_operator_prompt_is_interjected_before_next_provider_round() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let first_tool_round = Arc::new(tokio::sync::Notify::new());
+    let provider = Arc::new(OperatorInterjectionProbeProvider {
+        calls: Mutex::new(0),
+        requests: Mutex::new(Vec::new()),
+        first_tool_round: first_tool_round.clone(),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        ContextConfig {
+            prompt_budget_estimated_tokens: 100_000,
+            compaction_trigger_estimated_tokens: 80_000,
+            compaction_keep_recent_estimated_tokens: 40_000,
+            ..context_config()
+        },
+    )
+    .unwrap();
+
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "start slow command".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let runner = tokio::spawn(runtime.clone().run());
+    first_tool_round.notified().await;
+
+    let interjection = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("control".into()),
+        },
+        TrustLevel::TrustedOperator,
+        Priority::Interrupt,
+        MessageBody::Text {
+            text: "stop exploring and use the smaller fix".into(),
+        },
+    );
+    let interjection_id = interjection.id.clone();
+    runtime.enqueue(interjection).await.unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if provider.requests.lock().await.len() >= 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let requests = provider.requests.lock().await;
+    let second_request = requests.get(1).expect("second provider request");
+    assert!(second_request.conversation.iter().any(|message| {
+        matches!(
+            message,
+            ConversationMessage::UserText(text)
+                if text.contains("[Operator message received while this turn was in progress]")
+                    && text.contains(&interjection_id)
+                    && text.contains("stop exploring and use the smaller fix")
+        )
+    }));
+    drop(requests);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let state = runtime.agent_state().await.unwrap();
+            if state
+                .last_turn_terminal
+                .as_ref()
+                .is_some_and(|terminal| terminal.kind == TurnTerminalKind::Completed)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let queue_entries = runtime.storage().latest_queue_entries().unwrap();
+    let interjected_entry = queue_entries
+        .iter()
+        .find(|entry| entry.message_id == interjection_id)
+        .expect("interjection queue entry");
+    assert_eq!(interjected_entry.status, QueueEntryStatus::Interjected);
+    assert_eq!(runtime.agent_state().await.unwrap().pending, 0);
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "operator_interjection_admitted"
+            && event
+                .data
+                .get("message_id")
+                .and_then(serde_json::Value::as_str)
+                == Some(interjection_id.as_str())
+    }));
+
+    runner.abort();
 }
 
 #[tokio::test]

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -311,7 +311,7 @@ async fn interrupt_operator_prompt_is_interjected_before_next_provider_round() {
         .expect("interjection queue entry");
     assert_eq!(interjected_entry.status, QueueEntryStatus::Interjected);
     assert_eq!(runtime.agent_state().await.unwrap().pending, 0);
-    let events = runtime.storage().read_recent_events(20).unwrap();
+    let events = runtime.storage().read_recent_events(200).unwrap();
     assert!(events.iter().any(|event| {
         event.kind == "operator_interjection_admitted"
             && event

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -319,6 +319,11 @@ async fn interrupt_operator_prompt_is_interjected_before_next_provider_round() {
                 .get("message_id")
                 .and_then(serde_json::Value::as_str)
                 == Some(interjection_id.as_str())
+            && event
+                .data
+                .get("boundary")
+                .and_then(serde_json::Value::as_str)
+                == Some("before_tool_execution")
     }));
 
     runner.abort();

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -24,10 +24,11 @@ pub(crate) use crate::{
         AgentRegistryStatus, AgentState, AgentStatus, AgentVisibility, AuthorityClass, BriefKind,
         BriefRecord, CallbackDeliveryMode, ClosureDecision, ClosureOutcome, ContinuationClass,
         ContinuationTriggerKind, LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageKind,
-        MessageOrigin, PendingWakeHint, Priority, TaskKind, TaskOutputRetrievalStatus, TaskRecord,
-        TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, TodoItem, TodoItemState,
-        TokenUsage, TrustLevel, TurnTerminalKind, TurnTerminalRecord, WaitingIntentStatus,
-        WaitingReason, WorkItemRecord, WorkItemState, WorkReactivationMode, WorkspaceEntry,
+        MessageOrigin, PendingWakeHint, Priority, QueueEntryStatus, TaskKind,
+        TaskOutputRetrievalStatus, TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord,
+        TimerStatus, TodoItem, TodoItemState, TokenUsage, TrustLevel, TurnTerminalKind,
+        TurnTerminalRecord, WaitingIntentStatus, WaitingReason, WorkItemRecord, WorkItemState,
+        WorkReactivationMode, WorkspaceEntry,
     },
 };
 

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, env, time::Instant};
 
 use anyhow::Result;
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::{
@@ -20,15 +21,15 @@ use crate::{
         ToolCall, ToolError, ToolSpec,
     },
     types::{
-        AuditEvent, MessageBody, MessageEnvelope, QueueEntryRecord, QueueEntryStatus,
-        TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel,
-        TurnTerminalCheckpointRecord, TurnTerminalKind, TurnTerminalRecord, WorkItemPlanStatus,
-        WorkItemRecord,
+        AuditEvent, MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TodoItemState, TokenUsage,
+        TranscriptEntry, TranscriptEntryKind, TrustLevel, TurnTerminalCheckpointRecord,
+        TurnTerminalKind, TurnTerminalRecord, WorkItemPlanStatus, WorkItemRecord,
     },
 };
 
 use super::{
-    combine_text_history, is_max_output_stop_reason, CurrentRunInterrupted, RuntimeHandle,
+    combine_text_history, is_max_output_stop_reason, message_dispatch::message_text,
+    CurrentRunInterrupted, RuntimeHandle,
 };
 
 pub(super) struct AgentLoopOutcome {
@@ -218,26 +219,25 @@ fn append_follow_up_user_texts(round: &mut TurnRoundRecord, texts: Vec<String>) 
     );
 }
 
-fn message_body_text(body: &MessageBody) -> String {
-    match body {
-        MessageBody::Text { text } => text.clone(),
-        MessageBody::Json { value } => {
-            serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
-        }
-        MessageBody::Brief { title, text, .. } => title
-            .as_deref()
-            .map(|title| format!("{title}\n\n{text}"))
-            .unwrap_or_else(|| text.clone()),
+fn render_metadata_value<T: Serialize>(value: &T) -> String {
+    match serde_json::to_value(value) {
+        Ok(Value::String(label)) => label,
+        Ok(Value::Null) => "none".into(),
+        Ok(value) => value.to_string(),
+        Err(_) => "unavailable".into(),
     }
 }
 
 fn render_operator_interjection_text(message: &MessageEnvelope) -> String {
     format!(
-        "{OPERATOR_INTERJECTION_HEADER}\nmessage_id={}\norigin=operator\ntrust=trusted_operator\nauthority_class=operator_instruction\ndelivery_surface={}\nadmission_context={}\n\n{}",
+        "{OPERATOR_INTERJECTION_HEADER}\nmessage_id={}\norigin={}\ntrust={}\nauthority_class={}\ndelivery_surface={}\nadmission_context={}\n\n{}",
         message.id,
-        serde_json::to_string(&message.delivery_surface).unwrap_or_else(|_| format!("{:?}", message.delivery_surface)),
-        serde_json::to_string(&message.admission_context).unwrap_or_else(|_| format!("{:?}", message.admission_context)),
-        message_body_text(&message.body).trim(),
+        render_metadata_value(&message.origin),
+        render_metadata_value(&message.trust),
+        render_metadata_value(&message.authority_class),
+        render_metadata_value(&message.delivery_surface),
+        render_metadata_value(&message.admission_context),
+        message_text(&message.body).trim(),
     )
 }
 
@@ -1405,39 +1405,60 @@ impl RuntimeHandle {
                 messages.push(message);
             }
             if !messages.is_empty() {
-                self.inner.storage.write_agent(&guard.state)?;
+                if let Err(err) = self.inner.storage.write_agent(&guard.state) {
+                    for message in messages.iter().rev().cloned() {
+                        guard.queue.push_front(message);
+                    }
+                    guard.state.pending = guard.queue.len();
+                    return Err(err);
+                }
             }
         }
 
         let mut follow_up_texts = Vec::new();
-        for message in messages {
-            self.inner.storage.append_queue_entry(&QueueEntryRecord {
-                message_id: message.id.clone(),
-                agent_id: message.agent_id.clone(),
-                priority: message.priority.clone(),
-                status: QueueEntryStatus::Interjected,
-                created_at: message.created_at,
-                updated_at: chrono::Utc::now(),
-            })?;
-            self.record_incoming_transcript_entry(&message)?;
-            let text = render_operator_interjection_text(&message);
-            self.inner.storage.append_event(&AuditEvent::new(
-                "operator_interjection_admitted",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "round": round,
-                    "boundary": boundary,
-                    "message_id": message.id,
-                    "origin": message.origin,
-                    "trust": message.trust,
-                    "authority_class": message.authority_class,
-                    "priority": message.priority,
-                    "delivery_surface": message.delivery_surface,
-                    "admission_context": message.admission_context,
-                    "text_preview": truncate_preview(&message_body_text(&message.body), ROUND_TEXT_PREVIEW_LIMIT),
-                }),
-            ))?;
-            follow_up_texts.push(text);
+        for (index, message) in messages.iter().enumerate() {
+            let persist_result = (|| -> Result<String> {
+                self.inner.storage.append_queue_entry(&QueueEntryRecord {
+                    message_id: message.id.clone(),
+                    agent_id: message.agent_id.clone(),
+                    priority: message.priority.clone(),
+                    status: QueueEntryStatus::Interjected,
+                    created_at: message.created_at,
+                    updated_at: chrono::Utc::now(),
+                })?;
+                self.record_incoming_transcript_entry(message)?;
+                let text = render_operator_interjection_text(message);
+                self.inner.storage.append_event(&AuditEvent::new(
+                    "operator_interjection_admitted",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "round": round,
+                        "boundary": boundary,
+                        "message_id": message.id,
+                        "origin": message.origin,
+                        "trust": message.trust,
+                        "authority_class": message.authority_class,
+                        "priority": message.priority,
+                        "delivery_surface": message.delivery_surface,
+                        "admission_context": message.admission_context,
+                        "text_preview": truncate_preview(&message_text(&message.body), ROUND_TEXT_PREVIEW_LIMIT),
+                    }),
+                ))?;
+                Ok(text)
+            })();
+
+            match persist_result {
+                Ok(text) => follow_up_texts.push(text),
+                Err(err) => {
+                    let mut guard = self.inner.agent.lock().await;
+                    for message in messages[index..].iter().rev().cloned() {
+                        guard.queue.push_front(message);
+                    }
+                    guard.state.pending = guard.queue.len();
+                    let _ = self.inner.storage.write_agent(&guard.state);
+                    return Err(err);
+                }
+            }
         }
         Ok(follow_up_texts)
     }
@@ -2026,6 +2047,40 @@ impl RuntimeHandle {
                             &[],
                         ),
                         assistant_blocks: completed_round_assistant_blocks,
+                        text_blocks,
+                        tool_calls: Vec::new(),
+                        tool_results: Vec::new(),
+                        tool_result_envelopes: Vec::new(),
+                        follow_up_user_texts: Vec::new(),
+                    };
+                    append_follow_up_user_texts(&mut round_record, interjections);
+                    if round_invalidates_checkpoint_anchor(&round_record) {
+                        checkpoint_state.anchor_generation =
+                            checkpoint_state.anchor_generation.saturating_add(1);
+                    }
+                    completed_rounds.push(round_record);
+                    continue;
+                }
+            }
+
+            if !tool_calls.is_empty() {
+                let interjections = self
+                    .drain_operator_interjections(agent_id, round, "before_tool_execution")
+                    .await?;
+                if !interjections.is_empty() {
+                    let text_only_assistant_blocks = text_blocks
+                        .iter()
+                        .cloned()
+                        .map(|text| ModelBlock::Text { text })
+                        .collect::<Vec<_>>();
+                    let mut round_record = TurnRoundRecord {
+                        round,
+                        estimated_tokens: build_round_estimated_tokens(
+                            &text_only_assistant_blocks,
+                            &[],
+                            &[],
+                        ),
+                        assistant_blocks: text_only_assistant_blocks,
                         text_blocks,
                         tool_calls: Vec::new(),
                         tool_results: Vec::new(),

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -20,7 +20,8 @@ use crate::{
         ToolCall, ToolError, ToolSpec,
     },
     types::{
-        AuditEvent, TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        AuditEvent, MessageBody, MessageEnvelope, QueueEntryRecord, QueueEntryStatus,
+        TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel,
         TurnTerminalCheckpointRecord, TurnTerminalKind, TurnTerminalRecord, WorkItemPlanStatus,
         WorkItemRecord,
     },
@@ -52,6 +53,8 @@ const WORK_ITEM_STALE_REMINDER_MAX_TOKENS: usize = 512;
 const WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT: usize = 8;
 const WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT: usize = 1_200;
 const WORK_ITEM_STALE_REMINDER_TODO_LIMIT: usize = 8;
+const OPERATOR_INTERJECTION_HEADER: &str =
+    "[Operator message received while this turn was in progress]";
 const COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT: &str = "\
 [Runtime-generated full progress checkpoint request]
 You are crossing a context compaction boundary. Before continuing, include a concise progress checkpoint for continuation in your next assistant message.
@@ -201,6 +204,41 @@ fn build_checkpoint_resume_round(
         tool_result_envelopes: Vec::new(),
         follow_up_user_texts: vec![continuation_text],
     }
+}
+
+fn append_follow_up_user_texts(round: &mut TurnRoundRecord, texts: Vec<String>) {
+    if texts.is_empty() {
+        return;
+    }
+    round.follow_up_user_texts.extend(texts);
+    round.estimated_tokens = build_round_estimated_tokens(
+        &round.assistant_blocks,
+        &round.tool_results,
+        &round.follow_up_user_texts,
+    );
+}
+
+fn message_body_text(body: &MessageBody) -> String {
+    match body {
+        MessageBody::Text { text } => text.clone(),
+        MessageBody::Json { value } => {
+            serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+        }
+        MessageBody::Brief { title, text, .. } => title
+            .as_deref()
+            .map(|title| format!("{title}\n\n{text}"))
+            .unwrap_or_else(|| text.clone()),
+    }
+}
+
+fn render_operator_interjection_text(message: &MessageEnvelope) -> String {
+    format!(
+        "{OPERATOR_INTERJECTION_HEADER}\nmessage_id={}\norigin=operator\ntrust=trusted_operator\nauthority_class=operator_instruction\ndelivery_surface={}\nadmission_context={}\n\n{}",
+        message.id,
+        serde_json::to_string(&message.delivery_surface).unwrap_or_else(|_| format!("{:?}", message.delivery_surface)),
+        serde_json::to_string(&message.admission_context).unwrap_or_else(|_| format!("{:?}", message.admission_context)),
+        message_body_text(&message.body).trim(),
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -591,7 +629,10 @@ fn build_round_recap_line(round: &TurnRoundRecord) -> String {
         parts.push(format!("results=[{}]", tool_results.join(" | ")));
     }
     if !round.follow_up_user_texts.is_empty() {
-        parts.push("continuation_prompt=max_output_tokens".into());
+        parts.push(format!(
+            "follow_up_user_texts={}",
+            round.follow_up_user_texts.len()
+        ));
     }
 
     let detail = if parts.is_empty() {
@@ -1350,6 +1391,74 @@ impl RuntimeHandle {
         Ok(())
     }
 
+    async fn drain_operator_interjections(
+        &self,
+        agent_id: &str,
+        round: usize,
+        boundary: &str,
+    ) -> Result<Vec<String>> {
+        let mut messages = Vec::new();
+        {
+            let mut guard = self.inner.agent.lock().await;
+            while let Some(message) = guard.queue.pop_interrupt_operator_prompt() {
+                guard.state.pending = guard.queue.len();
+                messages.push(message);
+            }
+            if !messages.is_empty() {
+                self.inner.storage.write_agent(&guard.state)?;
+            }
+        }
+
+        let mut follow_up_texts = Vec::new();
+        for message in messages {
+            self.inner.storage.append_queue_entry(&QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority.clone(),
+                status: QueueEntryStatus::Interjected,
+                created_at: message.created_at,
+                updated_at: chrono::Utc::now(),
+            })?;
+            self.record_incoming_transcript_entry(&message)?;
+            let text = render_operator_interjection_text(&message);
+            self.inner.storage.append_event(&AuditEvent::new(
+                "operator_interjection_admitted",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "round": round,
+                    "boundary": boundary,
+                    "message_id": message.id,
+                    "origin": message.origin,
+                    "trust": message.trust,
+                    "authority_class": message.authority_class,
+                    "priority": message.priority,
+                    "delivery_surface": message.delivery_surface,
+                    "admission_context": message.admission_context,
+                    "text_preview": truncate_preview(&message_body_text(&message.body), ROUND_TEXT_PREVIEW_LIMIT),
+                }),
+            ))?;
+            follow_up_texts.push(text);
+        }
+        Ok(follow_up_texts)
+    }
+
+    async fn append_operator_interjections_to_last_round(
+        &self,
+        agent_id: &str,
+        round: usize,
+        boundary: &str,
+        completed_rounds: &mut [TurnRoundRecord],
+    ) -> Result<bool> {
+        let interjections = self
+            .drain_operator_interjections(agent_id, round, boundary)
+            .await?;
+        let admitted = !interjections.is_empty();
+        if let Some(last_round) = completed_rounds.last_mut() {
+            append_follow_up_user_texts(last_round, interjections);
+        }
+        Ok(admitted)
+    }
+
     pub(super) async fn run_agent_loop(
         &self,
         agent_id: &str,
@@ -1405,6 +1514,15 @@ impl RuntimeHandle {
                         terminal_kind: TurnTerminalKind::Aborted,
                     });
                 }
+            }
+            if round > 1 {
+                self.append_operator_interjections_to_last_round(
+                    agent_id,
+                    round,
+                    "before_provider_continuation",
+                    &mut completed_rounds,
+                )
+                .await?;
             }
 
             let identity = self.agent_identity_view().await?;
@@ -1895,6 +2013,35 @@ impl RuntimeHandle {
                 ))?;
             }
 
+            if tool_calls.is_empty() {
+                let interjections = self
+                    .drain_operator_interjections(agent_id, round, "after_provider_round")
+                    .await?;
+                if !interjections.is_empty() {
+                    let mut round_record = TurnRoundRecord {
+                        round,
+                        estimated_tokens: build_round_estimated_tokens(
+                            &completed_round_assistant_blocks,
+                            &[],
+                            &[],
+                        ),
+                        assistant_blocks: completed_round_assistant_blocks,
+                        text_blocks,
+                        tool_calls: Vec::new(),
+                        tool_results: Vec::new(),
+                        tool_result_envelopes: Vec::new(),
+                        follow_up_user_texts: Vec::new(),
+                    };
+                    append_follow_up_user_texts(&mut round_record, interjections);
+                    if round_invalidates_checkpoint_anchor(&round_record) {
+                        checkpoint_state.anchor_generation =
+                            checkpoint_state.anchor_generation.saturating_add(1);
+                    }
+                    completed_rounds.push(round_record);
+                    continue;
+                }
+            }
+
             if tool_calls.is_empty() && is_max_output_stop_reason(stop_reason.as_deref()) {
                 if max_output_recovery_count < MAX_OUTPUT_RECOVERY_ATTEMPTS {
                     if !combined_text.is_empty() {
@@ -2203,19 +2350,23 @@ impl RuntimeHandle {
                         "results": tool_results.clone(),
                     }),
                 ))?;
+            let interjections = self
+                .drain_operator_interjections(agent_id, round, "after_tool_results")
+                .await?;
+            let has_operator_interjections = !interjections.is_empty();
             let round_record = TurnRoundRecord {
                 round,
                 estimated_tokens: build_round_estimated_tokens(
                     &completed_round_assistant_blocks,
                     &tool_results,
-                    &[],
+                    &interjections,
                 ),
                 assistant_blocks: completed_round_assistant_blocks,
                 text_blocks,
                 tool_calls: round_tool_calls,
                 tool_results,
                 tool_result_envelopes,
-                follow_up_user_texts: Vec::new(),
+                follow_up_user_texts: interjections,
             };
             if round_invalidates_checkpoint_anchor(&round_record) {
                 checkpoint_state.anchor_generation =
@@ -2230,7 +2381,7 @@ impl RuntimeHandle {
             }
             completed_rounds.push(round_record);
 
-            if only_sleep_tools {
+            if only_sleep_tools && !has_operator_interjections {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
                 self.persist_turn_terminal_record(
                     TurnTerminalKind::Completed,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -706,6 +706,7 @@ impl AppStorage {
                     messages_by_id.get(&entry.message_id).cloned()
                 }
                 crate::types::QueueEntryStatus::Processed
+                | crate::types::QueueEntryStatus::Interjected
                 | crate::types::QueueEntryStatus::Interrupted
                 | crate::types::QueueEntryStatus::Dropped => None,
             })

--- a/src/types.rs
+++ b/src/types.rs
@@ -2510,6 +2510,7 @@ pub enum QueueEntryStatus {
     Queued,
     Dequeued,
     Processed,
+    Interjected,
     Interrupted,
     Dropped,
 }

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -22,8 +22,8 @@ use holon::{
     types::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
-        MessageDeliverySurface, MessageKind, MessageOrigin, TodoItem, TodoItemState, TrustLevel,
-        WorkItemState,
+        MessageDeliverySurface, MessageKind, MessageOrigin, Priority, TodoItem, TodoItemState,
+        TrustLevel, WorkItemState,
     },
 };
 use reqwest::Client;
@@ -419,6 +419,7 @@ pub async fn control_prompt_records_message_admission_fields() -> Result<()> {
                 && message.delivery_surface == Some(MessageDeliverySurface::HttpControlPrompt)
                 && message.admission_context == Some(AdmissionContext::LocalProcess)
                 && message.authority_class == AuthorityClass::OperatorInstruction
+                && message.priority == Priority::Interrupt
         }) && events.iter().any(|event| {
             event.kind == "message_admitted"
                 && event.data["delivery_surface"] == "http_control_prompt"

--- a/tests/support/http_ingress.rs
+++ b/tests/support/http_ingress.rs
@@ -225,6 +225,21 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
         .await?;
     assert_eq!(trust_override.status(), reqwest::StatusCode::FORBIDDEN);
 
+    let interrupt_override = client
+        .post(format!("{base}/agents/default/enqueue"))
+        .json(&serde_json::json!({
+            "kind": "webhook_event",
+            "origin": {
+                "kind": "webhook",
+                "source": "http-test"
+            },
+            "priority": "interrupt",
+            "text": "forged interrupt",
+        }))
+        .send()
+        .await?;
+    assert_eq!(interrupt_override.status(), reqwest::StatusCode::FORBIDDEN);
+
     let forged_system_tick = client
         .post(format!("{base}/agents/default/enqueue"))
         .json(&serde_json::json!({

--- a/tests/support/http_operator_ingress.rs
+++ b/tests/support/http_operator_ingress.rs
@@ -23,7 +23,7 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
+        OperatorDeliveryStatus, Priority, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
         WorkItemState,
     },
 };
@@ -97,6 +97,7 @@ pub async fn operator_ingress_records_remote_operator_provenance() -> Result<()>
         })
         .expect("remote operator message should be stored");
     assert_eq!(message.kind, MessageKind::OperatorPrompt);
+    assert_eq!(message.priority, Priority::Interrupt);
     assert_eq!(
         message.origin,
         MessageOrigin::Operator {


### PR DESCRIPTION
## Summary
- make local control and authenticated remote operator prompts interrupt-priority by default
- admit trusted operator interrupt prompts at safe turn-loop boundaries without aborting active tools
- record interjected queue status, transcript/audit provenance, and exclude interjected messages from recovery replay

## Tests
- `cargo test -q runtime::tests::runtime_state::interrupt_operator_prompt_is_interjected_before_next_provider_round`
- `cargo test -q queue::tests::pop_interrupt_operator_prompt_only_drains_trusted_operator_interrupts`
- `cargo test -q --test http_control control_prompt_records_message_admission_fields`
- `cargo test -q --test runtime_waiting_and_delivery_regressions operator_ingress_records_remote_operator_provenance`

Closes #893
