### PR TITLE
fix: handle multiline TUI paste

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1222,6 +1222,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn paste_updates_model_picker_filter() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.overlay = OverlayState::ModelPicker {
+            filter: "gpt".into(),
+            selected: 0,
+        };
+
+        app.handle_paste("-5.3\n").await.unwrap();
+
+        assert_eq!(
+            app.overlay,
+            OverlayState::ModelPicker {
+                filter: "gpt-5.3".into(),
+                selected: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn paste_into_debug_prompt_stays_single_line() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.overlay = OverlayState::DebugPromptInput {
+            composer: ComposerState::from("explain "),
+        };
+
+        app.handle_paste("first\nsecond").await.unwrap();
+
+        assert_eq!(
+            app.overlay,
+            OverlayState::DebugPromptInput {
+                composer: ComposerState::from("explain first second"),
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn enter_submits_instead_of_inserting_new_line() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -18,8 +18,9 @@ use anyhow::{anyhow, Result};
 use chrono::{DateTime, Local};
 use crossterm::{
     event::{
-        self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags,
-        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEvent, KeyEventKind,
+        KeyModifiers, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+        PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -81,6 +82,9 @@ pub async fn run_tui(config: AppConfig, no_alt_screen: bool) -> Result<()> {
         execute!(stdout, EnterAlternateScreen)?;
         terminal_guard.alternate_screen_enabled = true;
     }
+    if execute!(stdout, EnableBracketedPaste).is_ok() {
+        terminal_guard.bracketed_paste_enabled = true;
+    }
     if execute!(
         stdout,
         PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
@@ -134,12 +138,20 @@ async fn run_event_loop(
         }
 
         if event::poll(INPUT_POLL_INTERVAL)? {
-            if let Event::Key(key) = event::read()? {
-                if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            match event::read()? {
+                Event::Key(key)
+                    if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                {
                     if let Err(err) = app.handle_key(key).await {
                         app.status_line = format!("Action failed: {err}");
                     }
                 }
+                Event::Paste(text) => {
+                    if let Err(err) = app.handle_paste(&text).await {
+                        app.status_line = format!("Paste failed: {err}");
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -792,6 +804,7 @@ fn is_cursor_too_old_error(err: &anyhow::Error) -> bool {
 struct TerminalCleanupGuard {
     raw_mode_enabled: bool,
     alternate_screen_enabled: bool,
+    bracketed_paste_enabled: bool,
     keyboard_enhancement_enabled: bool,
 }
 
@@ -800,6 +813,7 @@ impl TerminalCleanupGuard {
         Self {
             raw_mode_enabled: false,
             alternate_screen_enabled: false,
+            bracketed_paste_enabled: false,
             keyboard_enhancement_enabled: false,
         }
     }
@@ -810,6 +824,10 @@ impl Drop for TerminalCleanupGuard {
         if self.keyboard_enhancement_enabled {
             let mut stdout = io::stdout();
             let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+        }
+        if self.bracketed_paste_enabled {
+            let mut stdout = io::stdout();
+            let _ = execute!(stdout, DisableBracketedPaste);
         }
         if self.raw_mode_enabled {
             let _ = disable_raw_mode();
@@ -1188,6 +1206,19 @@ mod tests {
             .unwrap();
 
         assert_eq!(app.composer.as_str(), "/de\n");
+    }
+
+    #[tokio::test]
+    async fn paste_inserts_multiline_text_without_submitting() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+
+        app.handle_paste("first\nsecond").await.unwrap();
+
+        assert_eq!(app.composer.as_str(), "first\nsecond");
     }
 
     #[tokio::test]

--- a/src/tui/composer.rs
+++ b/src/tui/composer.rs
@@ -31,6 +31,11 @@ impl ComposerState {
         self.cursor += ch.len_utf8();
     }
 
+    pub(super) fn insert_str(&mut self, text: &str) {
+        self.text.insert_str(self.cursor, text);
+        self.cursor += text.len();
+    }
+
     pub(super) fn insert_newline(&mut self) {
         self.insert_char('\n');
     }
@@ -179,6 +184,15 @@ mod tests {
         composer.insert_char('e');
         assert_eq!(composer.as_str(), "helo");
         assert_eq!(composer.cursor(), 2);
+    }
+
+    #[test]
+    fn inserts_pasted_text_at_cursor() {
+        let mut composer = ComposerState::from("ab");
+        composer.move_left();
+        composer.insert_str("x\ny");
+        assert_eq!(composer.as_str(), "ax\nyb");
+        assert_eq!(composer.cursor(), "ax\ny".len());
     }
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -280,6 +280,21 @@ fn slash_prompt_lines(buffer: &str) -> Option<Vec<String>> {
 }
 
 impl TuiApp {
+    pub(super) async fn handle_paste(&mut self, text: &str) -> Result<()> {
+        match &mut self.overlay {
+            OverlayState::None => {
+                let before = self.composer.as_str().to_string();
+                self.composer.insert_str(text);
+                self.sync_slash_menu_after_edit(before != self.composer.as_str());
+            }
+            OverlayState::DebugPromptInput { composer } => {
+                composer.insert_str(text);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     pub(super) async fn move_agent_selection(&mut self, delta: i32) -> Result<()> {
         let Some(target_index) = self.next_agent_index(delta) else {
             return Ok(());

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -279,16 +279,37 @@ fn slash_prompt_lines(buffer: &str) -> Option<Vec<String>> {
     ])
 }
 
+fn paste_inline_text(text: &str) -> String {
+    text.chars()
+        .filter(|ch| !matches!(ch, '\r' | '\n'))
+        .collect()
+}
+
+fn paste_single_line_text(text: &str) -> String {
+    text.chars()
+        .map(|ch| if matches!(ch, '\r' | '\n') { ' ' } else { ch })
+        .collect()
+}
+
 impl TuiApp {
     pub(super) async fn handle_paste(&mut self, text: &str) -> Result<()> {
+        let selected_agent = self.selected_agent_summary().cloned();
         match &mut self.overlay {
             OverlayState::None => {
                 let before = self.composer.as_str().to_string();
                 self.composer.insert_str(text);
                 self.sync_slash_menu_after_edit(before != self.composer.as_str());
             }
+            OverlayState::ModelPicker { filter, selected } => {
+                filter.push_str(&paste_inline_text(text));
+                *selected = crate::tui::model_picker::clamp_model_picker_selection(
+                    selected_agent.as_ref(),
+                    filter,
+                    *selected,
+                );
+            }
             OverlayState::DebugPromptInput { composer } => {
-                composer.insert_str(text);
+                composer.insert_str(&paste_single_line_text(text));
             }
             _ => {}
         }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -73,8 +73,15 @@ fn draw_agent_state(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
 }
 
 fn draw_prompt_pane(frame: &mut Frame<'_>, area: Rect, app: &TuiApp, slash_menu: &[Line<'static>]) {
+    let prompt_scroll = prompt_pane_scroll(
+        area,
+        app.composer.as_str(),
+        app.composer.cursor(),
+        slash_menu.len() as u16,
+    );
     let paragraph = Paragraph::new(render_prompt_text(app.composer.as_str(), slash_menu))
         .block(Block::default().borders(Borders::ALL))
+        .scroll((prompt_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 
@@ -84,6 +91,7 @@ fn draw_prompt_pane(frame: &mut Frame<'_>, area: Rect, app: &TuiApp, slash_menu:
             app.composer.as_str(),
             app.composer.cursor(),
             slash_menu.len() as u16,
+            prompt_scroll,
         );
         frame.set_cursor_position(ratatui::layout::Position { x, y });
     }
@@ -433,8 +441,37 @@ fn slash_menu_lines(app: &TuiApp) -> Vec<Line<'static>> {
         .collect()
 }
 
-fn prompt_cursor_position(area: Rect, buffer: &str, cursor: usize, hint_rows: u16) -> (u16, u16) {
+fn prompt_pane_scroll(area: Rect, buffer: &str, cursor: usize, hint_rows: u16) -> u16 {
     let input_width = area.width.saturating_sub(2).max(1);
+    let (_, cursor_row) = prompt_cursor_visual_position(buffer, cursor, input_width, hint_rows);
+    let viewport_rows = area.height.saturating_sub(2).max(1);
+    cursor_row.saturating_sub(viewport_rows.saturating_sub(1))
+}
+
+fn prompt_cursor_position(
+    area: Rect,
+    buffer: &str,
+    cursor: usize,
+    hint_rows: u16,
+    scroll: u16,
+) -> (u16, u16) {
+    let input_width = area.width.saturating_sub(2).max(1);
+    let (column, cursor_row) =
+        prompt_cursor_visual_position(buffer, cursor, input_width, hint_rows);
+    let max_x = area.x + area.width.saturating_sub(2);
+    let max_y = area.y + area.height.saturating_sub(2);
+    (
+        (area.x + 1 + column).min(max_x),
+        (area.y + 1 + cursor_row.saturating_sub(scroll)).min(max_y),
+    )
+}
+
+fn prompt_cursor_visual_position(
+    buffer: &str,
+    cursor: usize,
+    input_width: u16,
+    hint_rows: u16,
+) -> (u16, u16) {
     let rendered = render_prompt_buffer(&buffer[..cursor]);
     let lines = rendered.split('\n').collect::<Vec<_>>();
     let wrapped_rows_before = lines
@@ -454,12 +491,11 @@ fn prompt_cursor_position(area: Rect, buffer: &str, cursor: usize, hint_rows: u1
     } else {
         last_line_width - soft_wrap_row * input_width
     };
-    let max_x = area.x + area.width.saturating_sub(2);
-    let max_y = area.y + area.height.saturating_sub(2);
-    (
-        (area.x + 1 + column).min(max_x),
-        (area.y + 1 + hint_rows + 1 + wrapped_rows_before + soft_wrap_row).min(max_y),
-    )
+    let row = hint_rows
+        .saturating_add(1)
+        .saturating_add(wrapped_rows_before)
+        .saturating_add(soft_wrap_row);
+    (column, row)
 }
 
 fn wrapped_prompt_rows(line: &str, visible_line_width: u16) -> u16 {
@@ -869,9 +905,9 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        prompt_cursor_position, prompt_pane_height, render_header, render_model_status,
-        render_prompt_buffer, render_prompt_text, render_summary, render_task_detail,
-        status_bar_height, todo_summary_work_item,
+        prompt_cursor_position, prompt_pane_height, prompt_pane_scroll, render_header,
+        render_model_status, render_prompt_buffer, render_prompt_text, render_summary,
+        render_task_detail, status_bar_height, todo_summary_work_item,
     };
     use crate::system::{ExecutionProfile, ExecutionSnapshot};
     use crate::types::{
@@ -1123,7 +1159,7 @@ mod tests {
     fn prompt_cursor_tracks_multiline_end_position() {
         let area = Rect::new(10, 5, 40, 6);
         assert_eq!(
-            prompt_cursor_position(area, "first\nsecond", "first\nsecond".len(), 0),
+            prompt_cursor_position(area, "first\nsecond", "first\nsecond".len(), 0, 0),
             (19, 8)
         );
     }
@@ -1132,7 +1168,7 @@ mod tests {
     fn prompt_cursor_tracks_soft_wrapped_long_lines() {
         let area = Rect::new(10, 5, 10, 6);
         assert_eq!(
-            prompt_cursor_position(area, "abcdefgh", "abcdefgh".len(), 0),
+            prompt_cursor_position(area, "abcdefgh", "abcdefgh".len(), 0, 0),
             (13, 8)
         );
     }
@@ -1141,7 +1177,7 @@ mod tests {
     fn prompt_cursor_uses_display_width_for_wide_characters() {
         let area = Rect::new(10, 5, 10, 6);
         assert_eq!(
-            prompt_cursor_position(area, "你好你好", "你好你好".len(), 0),
+            prompt_cursor_position(area, "你好你好", "你好你好".len(), 0, 0),
             (13, 8)
         );
     }
@@ -1150,7 +1186,7 @@ mod tests {
     fn prompt_cursor_clamps_to_prompt_pane_height() {
         let area = Rect::new(10, 5, 10, 4);
         assert_eq!(
-            prompt_cursor_position(area, "abcdefgh\nabcdefgh", "abcdefgh\nabcdefgh".len(), 0),
+            prompt_cursor_position(area, "abcdefgh\nabcdefgh", "abcdefgh\nabcdefgh".len(), 0, 0),
             (13, 7)
         );
     }
@@ -1158,7 +1194,17 @@ mod tests {
     #[test]
     fn prompt_cursor_tracks_insert_position_inside_line() {
         let area = Rect::new(10, 5, 20, 6);
-        assert_eq!(prompt_cursor_position(area, "hello", 2, 0), (15, 7));
+        assert_eq!(prompt_cursor_position(area, "hello", 2, 0, 0), (15, 7));
+    }
+
+    #[test]
+    fn prompt_pane_scroll_keeps_multiline_cursor_visible() {
+        let area = Rect::new(10, 5, 20, 5);
+        let buffer = "first\n\nsecond\nthird\nfourth";
+        let scroll = prompt_pane_scroll(area, buffer, buffer.len(), 0);
+        assert!(scroll > 0);
+        let (_, y) = prompt_cursor_position(area, buffer, buffer.len(), 0, scroll);
+        assert!(y <= area.y + area.height.saturating_sub(2));
     }
 
     #[test]
@@ -1214,7 +1260,7 @@ mod tests {
     #[test]
     fn prompt_cursor_offsets_for_slash_menu_rows() {
         let area = Rect::new(10, 5, 20, 8);
-        assert_eq!(prompt_cursor_position(area, "/de", 3, 2), (16, 9));
+        assert_eq!(prompt_cursor_position(area, "/de", 3, 2, 0), (16, 9));
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -445,7 +445,7 @@ fn prompt_pane_scroll(area: Rect, buffer: &str, cursor: usize, hint_rows: u16) -
     let input_width = area.width.saturating_sub(2).max(1);
     let (_, cursor_row) = prompt_cursor_visual_position(buffer, cursor, input_width, hint_rows);
     let viewport_rows = area.height.saturating_sub(2).max(1);
-    cursor_row.saturating_sub(viewport_rows.saturating_sub(1))
+    cursor_row.saturating_sub(viewport_rows)
 }
 
 fn prompt_cursor_position(
@@ -1205,6 +1205,12 @@ mod tests {
         assert!(scroll > 0);
         let (_, y) = prompt_cursor_position(area, buffer, buffer.len(), 0, scroll);
         assert!(y <= area.y + area.height.saturating_sub(2));
+    }
+
+    #[test]
+    fn prompt_pane_scroll_keeps_single_line_visible_in_short_pane() {
+        let area = Rect::new(10, 5, 20, 3);
+        assert_eq!(prompt_pane_scroll(area, "hello", "hello".len(), 0), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- enable bracketed paste in the TUI event loop and route paste events into the active composer
- insert multiline pasted text without submitting the prompt
- scroll the prompt pane to keep long multiline input and blank lines visible near the cursor

Closes #898

## Tests
- cargo test -q --lib tui::
- cargo check -q
- git diff --check
