### PR TITLE
feat: keep queued operator messages visible in TUI chat

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,9 +15,9 @@ use crate::{
     system::ExecutionSnapshot,
     types::{
         ActiveWorkspaceEntry, AgentSummary, BriefRecord, ExternalTriggerStateSnapshot,
-        OperatorNotificationRecord, TaskRecord, TimerRecord, TranscriptEntry, TrustLevel,
-        TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord, WorkspaceOccupancyRecord,
-        WorktreeSession,
+        OperatorMessageRecord, OperatorNotificationRecord, TaskRecord, TimerRecord,
+        TranscriptEntry, TrustLevel, TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord,
+        WorkspaceOccupancyRecord, WorktreeSession,
     },
 };
 
@@ -83,6 +83,8 @@ pub struct AgentStateSnapshot {
     pub tasks: Vec<TaskRecord>,
     pub transcript_tail: Vec<TranscriptEntry>,
     #[serde(default)]
+    pub operator_messages: Vec<OperatorMessageRecord>,
+    #[serde(default)]
     pub briefs_tail: Vec<BriefRecord>,
     #[serde(default)]
     pub timers: Vec<TimerRecord>,
@@ -101,6 +103,13 @@ pub struct AgentStateSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub brief: Option<BriefRecord>,
     pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlPromptResponse {
+    pub ok: bool,
+    pub agent_id: String,
+    pub message_id: String,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -252,7 +261,11 @@ impl LocalClient {
             .await
     }
 
-    pub async fn control_prompt(&self, agent_id: &str, text: impl Into<String>) -> Result<Value> {
+    pub async fn control_prompt(
+        &self,
+        agent_id: &str,
+        text: impl Into<String>,
+    ) -> Result<ControlPromptResponse> {
         self.post_control_json(
             &format!("/control/agents/{agent_id}/prompt"),
             &ControlPromptRequest { text: text.into() },

--- a/src/http.rs
+++ b/src/http.rs
@@ -57,7 +57,7 @@ use crate::{
         ActiveWorkspaceEntry, AdmissionContext, AgentRegistryStatus, AgentSummary, AgentVisibility,
         AuditEvent, BriefRecord, CallbackDeliveryPayload, CallbackDeliveryResult, ControlAction,
         ExternalTriggerStateSnapshot, MessageBody, MessageDeliverySurface, MessageKind,
-        MessageOrigin, OperatorNotificationRecord, OperatorTransportBinding,
+        MessageOrigin, OperatorMessageRecord, OperatorNotificationRecord, OperatorTransportBinding,
         OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskRecord,
         TimerRecord, TranscriptEntry, TrustLevel, TurnTerminalRecord, WaitingIntentRecord,
@@ -343,6 +343,7 @@ struct AgentStateSnapshot {
     session: StateSessionSnapshot,
     tasks: Vec<TaskRecord>,
     transcript_tail: Vec<TranscriptEntry>,
+    operator_messages: Vec<OperatorMessageRecord>,
     briefs_tail: Vec<BriefRecord>,
     timers: Vec<TimerRecord>,
     work_items: Vec<WorkItemRecord>,
@@ -749,6 +750,10 @@ pub async fn agent_state(
         .recent_transcript(100)
         .await
         .map_err(error_response)?;
+    let operator_messages = runtime
+        .recent_operator_messages(100)
+        .await
+        .map_err(error_response)?;
     let briefs_tail = runtime.recent_briefs(24).await.map_err(error_response)?;
     let brief = briefs_tail.last().cloned();
     let timers = runtime.recent_timers(50).await.map_err(error_response)?;
@@ -781,6 +786,7 @@ pub async fn agent_state(
         session,
         tasks,
         transcript_tail,
+        operator_messages,
         briefs_tail,
         timers,
         work_items,

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,7 +471,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
             let client = LocalClient::new(config)?;
             let response = client.control_prompt(&agent, text).await?;
-            print_json(&response)
+            print_json(&serde_json::to_value(response)?)
         }
         Commands::Status { agent } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -65,12 +65,12 @@ use crate::{
         CancelWaitingResult, ClosureDecision, ContinuationResolution, ControlAction,
         ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerScope,
         ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
-        Priority, QueueEntryRecord, QueueEntryStatus, ResolvedModelAvailability,
-        RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
-        SkillActivationState, SkillsRuntimeView, TaskKind, TaskRecord, TaskRecoverySpec,
-        TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, OperatorMessageRecord,
+        OperatorMessageStatus, PendingWakeHint, Priority, QueueEntryRecord, QueueEntryStatus,
+        ResolvedModelAvailability, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
+        SkillActivationSource, SkillActivationState, SkillsRuntimeView, TaskKind, TaskRecord,
+        TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
+        TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
         WaitingIntentSummary, WorkItemState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
     web::WebConfig,
@@ -765,6 +765,52 @@ impl RuntimeHandle {
         Ok(message)
     }
 
+    pub async fn recent_operator_messages(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<OperatorMessageRecord>> {
+        let state = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.clone()
+        };
+        let messages_by_id = self
+            .inner
+            .storage
+            .read_recent_messages(usize::MAX)?
+            .into_iter()
+            .filter(|message| message.kind == MessageKind::OperatorPrompt)
+            .map(|message| (message.id.clone(), message))
+            .collect::<std::collections::BTreeMap<_, _>>();
+
+        let mut records = self
+            .inner
+            .storage
+            .latest_queue_entries()?
+            .into_iter()
+            .filter_map(|entry| {
+                let message = messages_by_id.get(&entry.message_id)?;
+                Some(OperatorMessageRecord {
+                    message_id: entry.message_id,
+                    agent_id: entry.agent_id,
+                    status: operator_message_status(&entry.status, &entry.priority, &state),
+                    created_at: entry.created_at,
+                    updated_at: entry.updated_at,
+                    body: message.body.clone(),
+                    error: None,
+                })
+            })
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.message_id.cmp(&right.message_id))
+        });
+        if records.len() > limit {
+            records.drain(0..records.len() - limit);
+        }
+        Ok(records)
+    }
+
     pub(crate) fn append_audit_event(&self, kind: &str, data: serde_json::Value) -> Result<()> {
         self.inner
             .storage
@@ -1033,6 +1079,27 @@ impl RuntimeHandle {
             }
         }
         Ok(())
+    }
+}
+
+fn operator_message_status(
+    status: &QueueEntryStatus,
+    priority: &Priority,
+    state: &AgentState,
+) -> OperatorMessageStatus {
+    match status {
+        QueueEntryStatus::Queued
+            if *priority == Priority::Interrupt && state.current_run_id.is_some() =>
+        {
+            OperatorMessageStatus::WaitingForSafePoint
+        }
+        QueueEntryStatus::Queued => OperatorMessageStatus::Queued,
+        QueueEntryStatus::Dequeued | QueueEntryStatus::Interjected => {
+            OperatorMessageStatus::Processing
+        }
+        QueueEntryStatus::Processed => OperatorMessageStatus::Processed,
+        QueueEntryStatus::Interrupted => OperatorMessageStatus::Failed,
+        QueueEntryStatus::Dropped => OperatorMessageStatus::Dropped,
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -38,6 +38,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use uuid::Uuid;
 
+const OPERATOR_MESSAGE_SCAN_MIN: usize = 256;
+const OPERATOR_MESSAGE_SCAN_HEADROOM: usize = 16;
+
 #[cfg(test)]
 use crate::provider::{ConversationMessage, ProviderTurnRequest};
 use crate::{
@@ -769,29 +772,39 @@ impl RuntimeHandle {
         &self,
         limit: usize,
     ) -> Result<Vec<OperatorMessageRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
         let state = {
             let guard = self.inner.agent.lock().await;
             guard.state.clone()
         };
+        let scan_limit = limit
+            .saturating_mul(OPERATOR_MESSAGE_SCAN_HEADROOM)
+            .max(OPERATOR_MESSAGE_SCAN_MIN);
         let messages_by_id = self
             .inner
             .storage
-            .read_recent_messages(usize::MAX)?
+            .read_recent_messages(scan_limit)?
             .into_iter()
             .filter(|message| message.kind == MessageKind::OperatorPrompt)
             .map(|message| (message.id.clone(), message))
             .collect::<std::collections::BTreeMap<_, _>>();
 
-        let mut records = self
-            .inner
-            .storage
-            .latest_queue_entries()?
+        let mut latest_queue_entries = std::collections::BTreeMap::new();
+        for entry in self.inner.storage.read_recent_queue_entries(scan_limit)? {
+            latest_queue_entries.insert(entry.message_id.clone(), entry);
+        }
+
+        let mut records = latest_queue_entries
+            .values()
             .into_iter()
             .filter_map(|entry| {
                 let message = messages_by_id.get(&entry.message_id)?;
                 Some(OperatorMessageRecord {
-                    message_id: entry.message_id,
-                    agent_id: entry.agent_id,
+                    message_id: entry.message_id.clone(),
+                    agent_id: entry.agent_id.clone(),
                     status: operator_message_status(&entry.status, &entry.priority, &state),
                     created_at: entry.created_at,
                     updated_at: entry.updated_at,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -66,6 +66,7 @@ const AGENT_LIST_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 const BRIEF_LIMIT: usize = 24;
 const TRANSCRIPT_LIMIT: usize = 40;
 const TASK_LIMIT: usize = 40;
+const OPTIMISTIC_OPERATOR_MESSAGE_LIMIT: usize = 64;
 
 pub async fn run_tui(config: AppConfig, no_alt_screen: bool) -> Result<()> {
     let client = LocalClient::new(config.clone())?;
@@ -417,6 +418,31 @@ impl TuiApp {
         *self.chat_text_cache.borrow_mut() = None;
     }
 
+    fn prune_optimistic_operator_messages(&mut self) {
+        let Some(projection) = self.projection.as_ref() else {
+            return;
+        };
+
+        let mut durable_message_ids = projection
+            .operator_messages
+            .iter()
+            .map(|message| message.message_id.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        durable_message_ids.extend(
+            self.transcript
+                .iter()
+                .filter_map(|entry| entry.related_message_id.clone()),
+        );
+
+        self.optimistic_operator_messages
+            .retain(|message| !durable_message_ids.contains(&message.message_id));
+        if self.optimistic_operator_messages.len() > OPTIMISTIC_OPERATOR_MESSAGE_LIMIT {
+            self.optimistic_operator_messages.drain(
+                0..self.optimistic_operator_messages.len() - OPTIMISTIC_OPERATOR_MESSAGE_LIMIT,
+            );
+        }
+    }
+
     fn clear_agent_view(&mut self) {
         self.clear_projection_view();
         self.agents.clear();
@@ -717,6 +743,7 @@ impl TuiApp {
             },
             other => other.clone(),
         };
+        self.prune_optimistic_operator_messages();
     }
 
     fn schedule_reconnect(&mut self, error: String) {
@@ -2345,6 +2372,58 @@ mod tests {
                 status: Some(OperatorMessageStatus::Processing),
                 ..
             } if body == "persisted operator text"
+        ));
+    }
+
+    #[test]
+    fn projection_operator_message_prunes_reconciled_optimistic_entry() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let ts = Utc::now();
+        app.optimistic_operator_messages = vec![OperatorMessageRecord {
+            message_id: "message-1".into(),
+            agent_id: "default".into(),
+            status: OperatorMessageStatus::Queued,
+            created_at: ts,
+            updated_at: ts,
+            body: MessageBody::Text {
+                text: "optimistic text".into(),
+            },
+            error: None,
+        }];
+
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.operator_messages = vec![OperatorMessageRecord {
+            message_id: "message-1".into(),
+            agent_id: "default".into(),
+            status: OperatorMessageStatus::Processing,
+            created_at: ts,
+            updated_at: ts,
+            body: MessageBody::Text {
+                text: "durable text".into(),
+            },
+            error: None,
+        }];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+        app.apply_projection_view();
+
+        assert!(app.optimistic_operator_messages.is_empty());
+        let items = collect_chat_items(&app);
+        let user_messages = items
+            .iter()
+            .filter(|item| matches!(item, ConversationCell::UserMessage { .. }))
+            .collect::<Vec<_>>();
+        assert_eq!(user_messages.len(), 1);
+        assert!(matches!(
+            user_messages[0],
+            ConversationCell::UserMessage {
+                body,
+                status: Some(OperatorMessageStatus::Processing),
+                ..
+            } if body == "durable text"
         ));
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,7 +11,8 @@ use crate::{
     system::{workspace_access_mode_label, workspace_projection_label},
     tui_markdown::{render_markdown_text, render_markdown_text_spaced},
     types::{
-        AgentSummary, BriefRecord, TaskRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        AgentSummary, BriefRecord, MessageBody, OperatorMessageRecord, OperatorMessageStatus,
+        TaskRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
     },
 };
 use anyhow::{anyhow, Result};
@@ -162,6 +163,7 @@ struct TuiApp {
     agents: Vec<AgentSummary>,
     briefs: Vec<BriefRecord>,
     transcript: Vec<TranscriptEntry>,
+    optimistic_operator_messages: Vec<OperatorMessageRecord>,
     tasks: Vec<TaskRecord>,
     projection: Option<TuiProjection>,
     connection_state: TuiConnectionState,
@@ -225,6 +227,7 @@ impl TuiApp {
             agents: Vec::new(),
             briefs: Vec::new(),
             transcript: Vec::new(),
+            optimistic_operator_messages: Vec::new(),
             tasks: Vec::new(),
             projection: None,
             connection_state: TuiConnectionState::Bootstrapping,
@@ -370,6 +373,50 @@ impl TuiApp {
         self.agents.get(self.selected_agent)
     }
 
+    fn add_optimistic_operator_message(&mut self, agent_id: String, body: String) -> String {
+        let message_id = format!("local-{}", uuid::Uuid::new_v4());
+        let now = chrono::Utc::now();
+        self.optimistic_operator_messages
+            .push(OperatorMessageRecord {
+                message_id: message_id.clone(),
+                agent_id,
+                status: OperatorMessageStatus::Sending,
+                created_at: now,
+                updated_at: now,
+                body: MessageBody::Text { text: body },
+                error: None,
+            });
+        *self.chat_text_cache.borrow_mut() = None;
+        message_id
+    }
+
+    fn reconcile_optimistic_operator_message(&mut self, local_message_id: &str, accepted_id: &str) {
+        if let Some(message) = self
+            .optimistic_operator_messages
+            .iter_mut()
+            .find(|message| message.message_id == local_message_id)
+        {
+            message.message_id = accepted_id.to_string();
+            message.status = OperatorMessageStatus::Queued;
+            message.updated_at = chrono::Utc::now();
+            message.error = None;
+        }
+        *self.chat_text_cache.borrow_mut() = None;
+    }
+
+    fn fail_optimistic_operator_message(&mut self, local_message_id: &str, error: String) {
+        if let Some(message) = self
+            .optimistic_operator_messages
+            .iter_mut()
+            .find(|message| message.message_id == local_message_id)
+        {
+            message.status = OperatorMessageStatus::Failed;
+            message.updated_at = chrono::Utc::now();
+            message.error = Some(error);
+        }
+        *self.chat_text_cache.borrow_mut() = None;
+    }
+
     fn clear_agent_view(&mut self) {
         self.clear_projection_view();
         self.agents.clear();
@@ -380,6 +427,7 @@ impl TuiApp {
         self.stop_stream_task();
         self.briefs.clear();
         self.transcript.clear();
+        self.optimistic_operator_messages.clear();
         self.tasks.clear();
         self.projection = None;
         self.last_refresh_at = None;
@@ -864,7 +912,8 @@ mod tests {
             AgentIdentityView, AgentKind, AgentLifecycleHint, AgentModelSource, AgentModelState,
             AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus, AgentSummary,
             AgentTokenUsageSummary, AgentVisibility, BriefKind, BriefRecord, ChildAgentSummary,
-            ClosureDecision, ClosureOutcome, LoadedAgentsMdView, RuntimePosture, SkillsRuntimeView,
+            ClosureDecision, ClosureOutcome, LoadedAgentsMdView, MessageBody,
+            OperatorMessageRecord, OperatorMessageStatus, RuntimePosture, SkillsRuntimeView,
             TokenUsage, TranscriptEntry, TranscriptEntryKind, WaitingIntentSummary,
         },
     };
@@ -1018,6 +1067,7 @@ mod tests {
             },
             tasks: Vec::new(),
             transcript_tail: Vec::new(),
+            operator_messages: Vec::new(),
             briefs_tail: Vec::new(),
             timers: Vec::new(),
             work_items: Vec::new(),
@@ -2203,6 +2253,99 @@ mod tests {
         let items = collect_chat_items(&app);
         assert!(matches!(items[0], ConversationCell::UserMessage { .. }));
         assert!(matches!(items[1], ConversationCell::AssistantMarkdown(_)));
+    }
+
+    #[test]
+    fn chat_includes_pending_operator_message_from_snapshot() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.operator_messages = vec![OperatorMessageRecord {
+            message_id: "message-queued".into(),
+            agent_id: "default".into(),
+            status: OperatorMessageStatus::WaitingForSafePoint,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            body: MessageBody::Text {
+                text: "please stop soon".into(),
+            },
+            error: None,
+        }];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let items = collect_chat_items(&app);
+        let user_messages = items
+            .iter()
+            .filter(|item| matches!(item, ConversationCell::UserMessage { .. }))
+            .collect::<Vec<_>>();
+
+        assert_eq!(user_messages.len(), 1);
+        assert!(matches!(
+            user_messages[0],
+            ConversationCell::UserMessage {
+                body,
+                status: Some(OperatorMessageStatus::WaitingForSafePoint),
+                ..
+            } if body == "please stop soon"
+        ));
+    }
+
+    #[test]
+    fn chat_dedupes_pending_operator_message_when_transcript_contains_it() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let ts = Utc::now();
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.transcript_tail = vec![TranscriptEntry {
+            id: "tr-message-1".into(),
+            agent_id: "default".into(),
+            created_at: ts,
+            kind: TranscriptEntryKind::IncomingMessage,
+            round: None,
+            related_message_id: Some("message-1".into()),
+            stop_reason: None,
+            input_tokens: None,
+            output_tokens: None,
+            data: json!({
+                "origin": { "kind": "operator", "actor_id": null },
+                "body": { "type": "text", "text": "persisted operator text" }
+            }),
+        }];
+        snapshot.operator_messages = vec![OperatorMessageRecord {
+            message_id: "message-1".into(),
+            agent_id: "default".into(),
+            status: OperatorMessageStatus::Processing,
+            created_at: ts,
+            updated_at: ts,
+            body: MessageBody::Text {
+                text: "persisted operator text".into(),
+            },
+            error: None,
+        }];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+        app.apply_projection_view();
+
+        let items = collect_chat_items(&app);
+        let user_messages = items
+            .iter()
+            .filter(|item| matches!(item, ConversationCell::UserMessage { .. }))
+            .collect::<Vec<_>>();
+
+        assert_eq!(user_messages.len(), 1);
+        assert!(matches!(
+            user_messages[0],
+            ConversationCell::UserMessage {
+                body,
+                status: Some(OperatorMessageStatus::Processing),
+                ..
+            } if body == "persisted operator text"
+        ));
     }
 
     #[test]

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -201,13 +201,13 @@ fn operator_message_statuses(
     app: &TuiApp,
 ) -> std::collections::BTreeMap<String, OperatorMessageStatus> {
     let mut statuses = std::collections::BTreeMap::new();
+    for message in &app.optimistic_operator_messages {
+        statuses.insert(message.message_id.clone(), message.status.clone());
+    }
     if let Some(projection) = app.projection.as_ref() {
         for message in &projection.operator_messages {
             statuses.insert(message.message_id.clone(), message.status.clone());
         }
-    }
-    for message in &app.optimistic_operator_messages {
-        statuses.insert(message.message_id.clone(), message.status.clone());
     }
     statuses
 }

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -86,6 +86,7 @@ pub(super) enum ConversationCell {
     UserMessage {
         created_at: DateTime<chrono::Utc>,
         body: String,
+        status: Option<OperatorMessageStatus>,
     },
     AssistantMarkdown(AssistantMarkdownCell),
     ActiveActivity {
@@ -109,6 +110,8 @@ pub(super) struct CachedChatText {
 
 pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
     let mut cells = Vec::new();
+    let mut visible_operator_message_ids = std::collections::BTreeSet::new();
+    let operator_message_statuses = operator_message_statuses(app);
 
     for entry in &app.transcript {
         if entry.kind != TranscriptEntryKind::IncomingMessage {
@@ -126,10 +129,30 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
             .get("body")
             .and_then(render_message_body_value)
             .unwrap_or_else(|| compact_json(&entry.data));
+        let status = if let Some(message_id) = entry.related_message_id.as_deref() {
+            visible_operator_message_ids.insert(message_id.to_string());
+            operator_message_statuses.get(message_id).cloned()
+        } else {
+            None
+        };
         cells.push(ConversationCell::UserMessage {
             created_at: entry.created_at,
             body,
+            status,
         });
+    }
+
+    if let Some(projection) = app.projection.as_ref() {
+        for message in &projection.operator_messages {
+            push_pending_operator_message_cell(
+                &mut cells,
+                &mut visible_operator_message_ids,
+                message,
+            );
+        }
+    }
+    for message in &app.optimistic_operator_messages {
+        push_pending_operator_message_cell(&mut cells, &mut visible_operator_message_ids, message);
     }
 
     for brief in &app.briefs {
@@ -174,6 +197,38 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
     cells
 }
 
+fn operator_message_statuses(
+    app: &TuiApp,
+) -> std::collections::BTreeMap<String, OperatorMessageStatus> {
+    let mut statuses = std::collections::BTreeMap::new();
+    if let Some(projection) = app.projection.as_ref() {
+        for message in &projection.operator_messages {
+            statuses.insert(message.message_id.clone(), message.status.clone());
+        }
+    }
+    for message in &app.optimistic_operator_messages {
+        statuses.insert(message.message_id.clone(), message.status.clone());
+    }
+    statuses
+}
+
+fn push_pending_operator_message_cell(
+    cells: &mut Vec<ConversationCell>,
+    visible_operator_message_ids: &mut std::collections::BTreeSet<String>,
+    message: &OperatorMessageRecord,
+) {
+    if !visible_operator_message_ids.insert(message.message_id.clone()) {
+        return;
+    }
+    let body = render_operator_message_body(&message.body)
+        .unwrap_or_else(|| compact_json(&serde_json::to_value(&message.body).unwrap_or_default()));
+    cells.push(ConversationCell::UserMessage {
+        created_at: message.created_at,
+        body,
+        status: Some(message.status.clone()),
+    });
+}
+
 pub(super) fn is_chat_visible_conversation_event(kind: &str) -> bool {
     matches!(kind, "operator_notification_requested" | "runtime_error")
 }
@@ -215,13 +270,11 @@ impl ConversationCell {
 
     fn render_lines(&self, width: u16) -> Vec<Line<'static>> {
         match self {
-            Self::UserMessage { created_at, body } => render_prefixed_markdown_lines(
-                *created_at,
+            Self::UserMessage {
+                created_at,
                 body,
-                CachedChatRole::Operator,
-                width,
-                false,
-            ),
+                status,
+            } => render_operator_message_lines(*created_at, body, status.clone(), width),
             Self::AssistantMarkdown(cell) => cell.render_lines(width),
             Self::ActiveActivity { speaker, body, .. } => {
                 render_active_activity_lines(speaker, body)
@@ -333,6 +386,40 @@ fn render_prefixed_markdown_lines(
         lines.push(Line::from(prefix));
     }
     lines
+}
+
+fn render_operator_message_lines(
+    created_at: DateTime<chrono::Utc>,
+    body: &str,
+    status: Option<OperatorMessageStatus>,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let mut lines =
+        render_prefixed_markdown_lines(created_at, body, CachedChatRole::Operator, width, false);
+    if let Some(status) = status.and_then(operator_message_status_label) {
+        if let Some(first) = lines.first_mut() {
+            first.spans.insert(
+                3,
+                Span::styled(
+                    format!("[{status}] "),
+                    Style::default().add_modifier(Modifier::DIM),
+                ),
+            );
+        }
+    }
+    lines
+}
+
+fn operator_message_status_label(status: OperatorMessageStatus) -> Option<&'static str> {
+    match status {
+        OperatorMessageStatus::Sending => Some("sending"),
+        OperatorMessageStatus::Queued => Some("queued"),
+        OperatorMessageStatus::WaitingForSafePoint => Some("waiting"),
+        OperatorMessageStatus::Processing => Some("processing"),
+        OperatorMessageStatus::Processed => Some("processed"),
+        OperatorMessageStatus::Failed => Some("failed"),
+        OperatorMessageStatus::Dropped => Some("dropped"),
+    }
 }
 
 fn render_active_activity_lines(speaker: &str, body: &str) -> Vec<Line<'static>> {
@@ -737,6 +824,13 @@ fn render_message_body_value(value: &Value) -> Option<String> {
             .map(ToString::to_string),
         "json" => value.get("value").map(compact_json),
         _ => None,
+    }
+}
+
+fn render_operator_message_body(body: &MessageBody) -> Option<String> {
+    match body {
+        MessageBody::Text { text } | MessageBody::Brief { text, .. } => Some(text.clone()),
+        MessageBody::Json { value } => Some(compact_json(value)),
     }
 }
 

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -345,7 +345,18 @@ impl TuiApp {
                     .selected_agent_id()
                     .ok_or_else(|| anyhow!("no agent selected"))?
                     .to_string();
-                self.client.control_prompt(&agent_id, text).await?;
+                let local_message_id =
+                    self.add_optimistic_operator_message(agent_id.clone(), text.clone());
+                match self.client.control_prompt(&agent_id, text).await {
+                    Ok(response) => self.reconcile_optimistic_operator_message(
+                        &local_message_id,
+                        &response.message_id,
+                    ),
+                    Err(err) => {
+                        self.fail_optimistic_operator_message(&local_message_id, err.to_string());
+                        return Err(err);
+                    }
+                }
                 self.composer.clear();
                 self.chat_scroll.follow_tail();
                 self.status_line.clear();

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -17,9 +17,9 @@ use crate::{
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
         ActiveWorkspaceEntry, AgentState, AgentSummary, BriefRecord, ClosureDecision,
-        ExternalTriggerStateSnapshot, MessageEnvelope, TaskRecord, TimerRecord, TimerStatus,
-        TranscriptEntry, TranscriptEntryKind, WaitingIntentRecord, WorkItemRecord, WorkItemState,
-        WorktreeSession,
+        ExternalTriggerStateSnapshot, MessageEnvelope, OperatorMessageRecord,
+        OperatorMessageStatus, TaskRecord, TimerRecord, TimerStatus, TranscriptEntry,
+        TranscriptEntryKind, WaitingIntentRecord, WorkItemRecord, WorkItemState, WorktreeSession,
     },
 };
 
@@ -70,6 +70,7 @@ pub(crate) struct TuiProjection {
     pub(crate) session: StateSessionSnapshot,
     pub(crate) tasks: Vec<TaskRecord>,
     pub(crate) transcript_tail: Vec<TranscriptEntry>,
+    pub(crate) operator_messages: Vec<OperatorMessageRecord>,
     pub(crate) briefs_tail: Vec<BriefRecord>,
     pub(crate) timers: Vec<TimerRecord>,
     pub(crate) work_items: Vec<WorkItemRecord>,
@@ -93,6 +94,7 @@ impl TuiProjection {
             session: snapshot.session,
             tasks: snapshot.tasks,
             transcript_tail: snapshot.transcript_tail,
+            operator_messages: snapshot.operator_messages,
             briefs_tail: snapshot.briefs_tail,
             timers: snapshot.timers,
             work_items: snapshot.work_items,
@@ -168,6 +170,7 @@ impl TuiProjection {
             }
             "message_enqueued" => {
                 if let Some(message) = decode_payload::<MessageEnvelope>(&event.data.payload) {
+                    self.upsert_operator_message(operator_message_from_enqueued(&message));
                     self.append_transcript_message(message);
                     self.stale_slices.remove(&ProjectionSlice::TranscriptTail);
                 } else {
@@ -345,7 +348,37 @@ impl TuiProjection {
                     self.mark_stale([ProjectionSlice::OperatorNotifications]);
                 }
             }
-            "message_admitted" | "message_processing_started" | "control_applied" => {
+            "message_processing_started" => {
+                if let Some(message) = decode_payload::<MessageEnvelope>(&event.data.payload) {
+                    self.update_operator_message_status(
+                        &message.id,
+                        OperatorMessageStatus::Processing,
+                        event.data.ts,
+                        None,
+                    );
+                }
+                self.mark_stale([
+                    ProjectionSlice::Agent,
+                    ProjectionSlice::Session,
+                    ProjectionSlice::TranscriptTail,
+                ]);
+            }
+            "operator_interjection_admitted" => {
+                if let Some(message_id) = read_string(&event.data.payload, "message_id") {
+                    self.update_operator_message_status(
+                        &message_id,
+                        OperatorMessageStatus::Processing,
+                        event.data.ts,
+                        None,
+                    );
+                }
+                self.mark_stale([
+                    ProjectionSlice::Agent,
+                    ProjectionSlice::Session,
+                    ProjectionSlice::TranscriptTail,
+                ]);
+            }
+            "message_admitted" | "control_applied" => {
                 self.mark_stale([ProjectionSlice::Agent, ProjectionSlice::Session]);
             }
             _ => {}
@@ -449,6 +482,36 @@ impl TuiProjection {
             TRANSCRIPT_TAIL_LIMIT,
             |left, right| left.created_at.cmp(&right.created_at),
         );
+    }
+
+    fn upsert_operator_message(&mut self, record: OperatorMessageRecord) {
+        if let Some(existing) = self
+            .operator_messages
+            .iter_mut()
+            .find(|existing| existing.message_id == record.message_id)
+        {
+            *existing = record;
+        } else {
+            self.operator_messages.push(record);
+        }
+    }
+
+    fn update_operator_message_status(
+        &mut self,
+        message_id: &str,
+        status: OperatorMessageStatus,
+        updated_at: DateTime<Utc>,
+        error: Option<String>,
+    ) {
+        if let Some(existing) = self
+            .operator_messages
+            .iter_mut()
+            .find(|existing| existing.message_id == message_id)
+        {
+            existing.status = status;
+            existing.updated_at = updated_at;
+            existing.error = error;
+        }
     }
 
     fn apply_timer_fired(&mut self, payload: &Value, fired_at: DateTime<Utc>) -> bool {
@@ -638,10 +701,23 @@ fn work_item_rank(item: &WorkItemRecord) -> u8 {
     }
 }
 
+fn operator_message_from_enqueued(message: &MessageEnvelope) -> OperatorMessageRecord {
+    OperatorMessageRecord {
+        message_id: message.id.clone(),
+        agent_id: message.agent_id.clone(),
+        status: OperatorMessageStatus::Queued,
+        created_at: message.created_at,
+        updated_at: message.created_at,
+        body: message.body.clone(),
+        error: None,
+    }
+}
+
 pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
     matches!(
         kind,
         "message_enqueued"
+            | "operator_interjection_admitted"
             | "brief_created"
             | "runtime_error"
             | "turn_terminal"
@@ -696,6 +772,7 @@ fn is_loggable_event_kind(kind: &str) -> bool {
             | "worktree_entered"
             | "worktree_exited"
             | "runtime_error"
+            | "operator_interjection_admitted"
             | "turn_terminal"
     )
 }
@@ -723,6 +800,13 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
                 crate::types::MessageBody::Brief { text, .. } => trim_summary(&text),
             })
             .unwrap_or_else(|| event.data.event_type.clone()),
+        "operator_interjection_admitted" => event
+            .data
+            .payload
+            .get("text_preview")
+            .and_then(Value::as_str)
+            .map(|text| format!("operator message applied: {}", trim_summary(text)))
+            .unwrap_or_else(|| "operator message applied".into()),
         "brief_created" => decode_payload::<BriefRecord>(&event.data.payload)
             .map(|brief| trim_summary(&brief.text))
             .unwrap_or_else(|| event.data.event_type.clone()),
@@ -1432,6 +1516,7 @@ mod tests {
                 output_tokens: None,
                 data: json!({ "body": { "type": "text", "text": "hi" } }),
             }],
+            operator_messages: Vec::new(),
             briefs_tail: vec![BriefRecord::new(
                 "default",
                 BriefKind::Ack,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2515,6 +2515,30 @@ pub enum QueueEntryStatus {
     Dropped,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OperatorMessageStatus {
+    Sending,
+    Queued,
+    WaitingForSafePoint,
+    Processing,
+    Processed,
+    Failed,
+    Dropped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OperatorMessageRecord {
+    pub message_id: String,
+    pub agent_id: String,
+    pub status: OperatorMessageStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub body: MessageBody,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueueEntryRecord {
     pub message_id: String,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -410,6 +410,11 @@ pub async fn control_prompt_records_message_admission_fields() -> Result<()> {
         .send()
         .await?;
     assert!(response.status().is_success());
+    let accepted: serde_json::Value = response.json().await?;
+    let message_id = accepted["message_id"]
+        .as_str()
+        .expect("control prompt should return message_id")
+        .to_string();
 
     wait_until(|| {
         let messages = runtime.storage().read_recent_messages(10)?;
@@ -428,6 +433,21 @@ pub async fn control_prompt_records_message_admission_fields() -> Result<()> {
         }))
     })
     .await?;
+
+    let state_response = client
+        .get(format!("{base}/agents/default/state"))
+        .send()
+        .await?;
+    assert!(state_response.status().is_success());
+    let state_payload: serde_json::Value = state_response.json().await?;
+    let operator_messages = state_payload["operator_messages"]
+        .as_array()
+        .expect("state snapshot should include operator_messages");
+    assert!(operator_messages.iter().any(|message| {
+        message["message_id"] == message_id
+            && message["body"]["type"] == "text"
+            && message["body"]["text"] == "hello"
+    }));
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary
- add runtime/operator message records to the agent state snapshot so queued prompts survive refresh/reconnect
- reconcile TUI optimistic, queue, event, and transcript operator messages by message_id
- render compact outgoing status markers for sending/queued/waiting/processing/processed/failed/dropped states

Closes #896

## Verification
- CARGO_TARGET_DIR=target/verify-896 cargo check -q
- CARGO_TARGET_DIR=target/verify-896 cargo test -q --lib chat_includes_pending_operator_message_from_snapshot
- CARGO_TARGET_DIR=target/verify-896 cargo test -q --lib chat_dedupes_pending_operator_message_when_transcript_contains_it
- CARGO_TARGET_DIR=target/verify-896 cargo test -q --test http_control control_prompt_records_message_admission_fields
- git diff --check