### PR TITLE
fix: run Homebrew formula generator through bash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
             rm -f ./*.sha256
             shasum -a 256 ./*.tar.gz | sort -k2 > checksums.txt
           )
-          scripts/generate-homebrew-formula.sh \
+          bash scripts/generate-homebrew-formula.sh \
             "$GITHUB_REF_NAME" \
             dist-artifacts/checksums.txt \
             homebrew-tap/Formula/holon.rb


### PR DESCRIPTION
## Summary
- fix the release workflow to invoke scripts/generate-homebrew-formula.sh through bash instead of relying on the executable bit
- unblock the v0.13.0 release publish job after the tag workflow failed with Permission denied

## Verification
- actionlint .github/workflows/release.yml
- bash scripts/generate-homebrew-formula.sh v0.13.0 <sample-checksums> <tmp-formula>

Refs #773