### PR TITLE
ci: add release asset smoke workflow

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,44 @@
+name: Release Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to smoke test.
+        required: false
+        default: v0.13.0
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/release-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  linux-asset:
+    name: Linux asset
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ inputs.version || 'v0.13.0' }}
+    steps:
+      - name: Download release asset
+        run: |
+          set -euo pipefail
+          mkdir -p dist smoke
+          curl -fsSL \
+            "https://github.com/holon-run/holon/releases/download/${RELEASE_VERSION}/holon-linux-amd64.tar.gz" \
+            -o dist/holon-linux-amd64.tar.gz
+          curl -fsSL \
+            "https://github.com/holon-run/holon/releases/download/${RELEASE_VERSION}/checksums.txt" \
+            -o dist/checksums.txt
+          (cd dist && shasum -a 256 -c checksums.txt --ignore-missing)
+          tar -xzf dist/holon-linux-amd64.tar.gz -C smoke
+
+      - name: Run release asset
+        run: |
+          set -euo pipefail
+          expected="${RELEASE_VERSION#v}"
+          actual="$(./smoke/holon --version)"
+          echo "$actual"
+          test "$actual" = "holon ${expected}"

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -32,7 +32,12 @@ jobs:
           curl -fsSL \
             "https://github.com/holon-run/holon/releases/download/${RELEASE_VERSION}/checksums.txt" \
             -o dist/checksums.txt
-          (cd dist && shasum -a 256 -c checksums.txt --ignore-missing)
+          (
+            cd dist
+            grep -E '[[:space:]]([.]/)?holon-linux-amd64[.]tar[.]gz$' checksums.txt > linux-amd64.checksums
+            test "$(wc -l < linux-amd64.checksums | tr -d ' ')" = "1"
+            shasum -a 256 -c linux-amd64.checksums
+          )
           tar -xzf dist/holon-linux-amd64.tar.gz -C smoke
 
       - name: Run release asset


### PR DESCRIPTION
## Summary

- add a dedicated `Release Smoke` workflow for release asset verification
- download the Linux amd64 tarball and `checksums.txt` for a release tag
- verify the checksum and run `holon --version` on GitHub-hosted Ubuntu

## Why

#773 still needs a real Linux release asset run for `v0.13.0`. The local machine cannot run the Linux binary because Docker Desktop is blocked behind an admin prompt and no other Linux runner is installed. This workflow gives the release tracker a reproducible GitHub-hosted Linux smoke path and defaults to `v0.13.0`.

## Verification

- `actionlint .github/workflows/*.yml`
