### PR TITLE
fix: separate work item readiness from lifecycle

### DIFF
--- a/docs/rfcs/operator-wait-and-intervention.md
+++ b/docs/rfcs/operator-wait-and-intervention.md
@@ -1,12 +1,23 @@
 ---
 title: RFC: Operator Notification and Intervention
 date: 2026-04-23
-status: draft
+status: superseded
 issue:
   - 375
 ---
 
 # RFC: Operator Notification and Intervention
+
+## 2026-05 Update
+
+The phase-1 `NotifyOperator` tool described below is no longer exposed to
+normal agent profiles. Operator delivery policy belongs to runtime, UI, and
+transport adapters. Agents should express operator-relevant facts through final
+responses, WorkItem `plan_status`, `blocked_by`, completion summaries, briefs,
+and structured runtime events instead of choosing ad hoc notification delivery.
+
+The lower-level operator notification record/event capability remains available
+for runtime policy and adapters.
 
 ## Summary
 

--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -202,6 +202,8 @@ The initial state set is:
 
 `needs_input`
 - the plan cannot be safely finalized without operator or external input.
+- the work item remains open but is not scheduler-runnable until the agent
+  processes the input and updates the work item back to `ready` or `draft`.
 
 Daemon mode does not require a human to confirm every plan. The agent may move
 from `draft` to `ready` when the task boundary is clear. It should use
@@ -352,10 +354,16 @@ Tick should ask:
 
 - is there runnable work worth activating?
 
+Runnable is a derived view, not a stored lifecycle state:
+
+- `state = open`
+- no `blocked_by`
+- `plan_status != needs_input`
+
 The minimal rule is:
 
-1. if the current WorkItem is open and not blocked, wake and continue it;
-2. otherwise, if another open and unblocked WorkItem exists, wake the agent so
+1. if the current WorkItem is runnable, wake and continue it;
+2. otherwise, if another queued runnable WorkItem exists, wake the agent so
    it can explicitly pick one;
 3. otherwise, remain idle.
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1541,6 +1541,16 @@ item. Queued and blocked are derived views:
 - blocked: open work with `blocked_by`
 - completed: work whose state is `completed`
 
+Scheduler readiness is also a derived view:
+
+- runnable: open work with no `blocked_by` and `plan_status != needs_input`
+- waiting_for_operator: open work with `plan_status = needs_input`
+- blocked: open work with `blocked_by`
+- completed: completed work
+
+`open` is a lifecycle state only. It must not be used by itself as evidence
+that scheduler-owned continuation is allowed.
+
 The runtime persists a `DeliverySummaryRecord` when `CompleteWorkItem` receives
 an explicit `result_summary`. It is associated with the completed work item and
 is separate from raw terminal assistant text.
@@ -1688,11 +1698,12 @@ persisted work queue rather than raw message arrival.
 
 Rules:
 
-- if the runtime is idle and `current_work_item_id` points to an open,
-  unblocked work item, emit a system tick to continue that work item
+- if the runtime is idle and `current_work_item_id` points to a runnable work
+  item, emit a system tick to continue that work item
 - if the runtime is idle, no current runnable work item exists, and at least one
-  queued open work item exists, wake the agent so it can pick one
-- blocked and completed items do not participate in activation
+  queued runnable work item exists, wake the agent so it can pick one
+- blocked, waiting_for_operator, and completed items do not participate in
+  scheduler-owned activation
 - if no work items exist, preserve the existing message-driven idle path
 - work-queue ticks are runtime-owned system ticks, not external ingress
 - coalesced wake hints still participate in the idle path and should not be

--- a/src/context.rs
+++ b/src/context.rs
@@ -481,6 +481,7 @@ fn render_current_work_item(work_item: &WorkItemRecord) -> String {
         "Current work item:".to_string(),
         format!("- Id: {}", work_item.id),
         format!("- State: {:?}", work_item.state),
+        format!("- Readiness: {:?}", work_item.readiness()),
         format!("- Objective: {}", work_item.objective),
         format!(
             "- Plan status: {}",
@@ -519,10 +520,11 @@ fn work_item_plan_status_label(status: crate::types::WorkItemPlanStatus) -> &'st
 fn render_queued_blocked_work_items(items: &[&WorkItemRecord]) -> String {
     let mut lines = vec!["Queued and blocked work items:".to_string()];
     lines.extend(items.iter().map(|item| {
-        let view = if item.blocked_by.is_some() {
-            "blocked"
-        } else {
-            "queued"
+        let view = match item.readiness() {
+            crate::types::WorkItemReadiness::Runnable => "queued",
+            crate::types::WorkItemReadiness::WaitingForOperator => "waiting_for_operator",
+            crate::types::WorkItemReadiness::Blocked => "blocked",
+            crate::types::WorkItemReadiness::Completed => "completed",
         };
         let mut summary = format!("- [{view}] {} :: {}", item.id, item.objective);
         if let Some(blocked_by) = item.blocked_by.as_deref() {

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -46,7 +46,7 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_notify_operator",
             PromptStability::Stable,
-            "Use NotifyOperator when something should be explicitly surfaced to the relevant operator without stopping the current turn. Provide a clear free-form `message`; Holon records an operator-facing notification and derives a short summary from the first non-empty line. NotifyOperator is non-terminal: keep working afterward when there is a reasonable default path, or call Sleep explicitly after notifying if the agent should wait. For private child agents, the notification routes to the parent/supervision boundary rather than creating an independent operator route.".to_string(),
+            "NotifyOperator is a constrained runtime-policy surface for operator delivery adapters, not a normal agent progress or completion channel. Prefer final responses, WorkItem plan_status/blocked_by/completion state, briefs, and runtime-derived activity for operator-facing communication; do not duplicate those facts through ad hoc notifications.".to_string(),
         ));
     }
     if names.contains(&"Enqueue") {
@@ -71,14 +71,14 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_work_item_write",
             PromptStability::Stable,
-            "Use CreateWorkItem to create a new open objective only for genuinely separate work, PickWorkItem to make an existing open item current, UpdateWorkItem to refine objective, plan_status, plan, todo_list, and/or blocked_by, and CompleteWorkItem only when the objective is actually complete. If the current task is not just a brief answer and there is no current work item yet, clarify the objective with the operator if it is still ambiguous; if bounded inspection is needed to make the objective concrete, do that inspection, then create or refresh the work item once the objective is stable enough to name. Do not create a new WorkItem just to refine or narrow the current objective; if the current WorkItem is still the same underlying task, update its objective, plan, and todo_list with UpdateWorkItem. If an old WorkItem should be replaced, complete it first or explicitly PickWorkItem for the intended item before creating genuinely independent work. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, maintain plan as durable prose and todo_list as the full current checklist snapshot rather than patching individual items. Before nontrivial file mutation or other high-commitment action, make sure the current work item has a durable plan and set plan_status=ready once the plan is stable; if task interpretation, scope, or acceptance changes, update objective or plan before continuing. Update todo_list after material progress such as a code change, verification result, blocker discovery, or completed inspection objective. Work-item updates are coordination/bookkeeping and do not replace file mutation, verification, PR/issue updates, final delivery, or other artifact progress. If the current item remains open because progress is blocked, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Complete explicitly when complete; when using result_summary, include the result and any verification performed or why verification was not applicable.".to_string(),
+            "Use CreateWorkItem to create a new open objective only for genuinely separate work, PickWorkItem to make an existing open item current, UpdateWorkItem to refine objective, plan_status, plan, todo_list, and/or blocked_by, and CompleteWorkItem only when the objective is actually complete. If the current task is not just a brief answer and there is no current work item yet, clarify the objective with the operator if it is still ambiguous; if bounded inspection is needed to make the objective concrete, do that inspection, then create or refresh the work item once the objective is stable enough to name. Continuous discussion, planning threads, candidate issue screening, option comparison, and incremental decisions should normally reuse one WorkItem; record candidate issues, options, and decisions in that WorkItem's plan and todo_list. Create a new WorkItem only when the operator asks for independent execution or the objective has an independent lifecycle. Do not create a new WorkItem just to refine, narrow, or switch candidates inside the same planning thread; if the current WorkItem is still the same underlying task, update its objective, plan, and todo_list with UpdateWorkItem. If an old WorkItem should be replaced, complete it first or explicitly PickWorkItem for the intended item before creating genuinely independent work. Any cross-turn waiting, callback-driven continuation, or sleep-ready handoff should already be anchored in a current work item before the turn ends. For genuine multi-step work, maintain plan as durable prose and todo_list as the full current checklist snapshot rather than patching individual items. Before nontrivial file mutation or other high-commitment action, make sure the current work item has a durable plan and set plan_status=ready once the plan is stable; use plan_status=needs_input when the current open item is waiting for operator input and must not be scheduler-resumed as runnable work. If task interpretation, scope, or acceptance changes, update objective or plan before continuing. Update todo_list after material progress such as a code change, verification result, blocker discovery, or completed inspection objective. Work-item updates are coordination/bookkeeping and do not replace file mutation, verification, PR/issue updates, final delivery, or other artifact progress. If the current item remains open because progress is blocked, record the specific blocker or missing fact in blocked_by instead of silently widening exploration. Complete explicitly when complete; when using result_summary, include the result and any verification performed or why verification was not applicable.".to_string(),
         ));
     }
     if names.contains(&"GetWorkItem") || names.contains(&"ListWorkItems") {
         sections.push(section(
             "tool_work_item_read",
             PromptStability::Stable,
-            "Use ListWorkItems with filter=current to inspect the current work-item focus before relying on memory briefs. Use GetWorkItem when you already know the id and need its open/completed state, focus flag, optional plan, and optional todo_list. Use ListWorkItems for queue inspection with filters such as open, completed, current, queued, and blocked. Treat current_work_item_id as focus, not lifecycle; open/completed describes completion, while current/queued/blocked is the scheduling view. Read the work-item surface before switching, completing, or expanding cross-turn work so the next action is anchored to the right objective.".to_string(),
+            "Use ListWorkItems with filter=current to inspect the current work-item focus before relying on memory briefs. Use GetWorkItem when you already know the id and need its open/completed state, focus flag, readiness, optional plan, and optional todo_list. Use ListWorkItems for queue inspection with filters such as open, completed, current, queued, blocked, waiting_for_operator, and runnable. Treat current_work_item_id as focus, not lifecycle; open/completed describes completion, current/queued/blocked describes focus, and readiness describes scheduler eligibility. Read the work-item surface before switching, completing, or expanding cross-turn work so the next action is anchored to the right objective.".to_string(),
         ));
     }
     if names.contains(&"TaskList")
@@ -210,8 +210,9 @@ mod tests {
             .iter()
             .find(|s| s.name == "tool_notify_operator")
             .expect("notify operator section");
-        assert!(section.content.contains("non-terminal"));
-        assert!(section.content.contains("Sleep"));
+        assert!(section.content.contains("runtime-policy surface"));
+        assert!(section.content.contains("not a normal agent progress"));
+        assert!(section.content.contains("WorkItem plan_status/blocked_by"));
     }
 
     #[test]
@@ -292,11 +293,26 @@ mod tests {
         assert!(section.content.contains("genuinely separate work"));
         assert!(section
             .content
-            .contains("Do not create a new WorkItem just to refine or narrow"));
+            .contains("Continuous discussion, planning threads"));
+        assert!(section.content.contains("candidate issue screening"));
+        assert!(section
+            .content
+            .contains("record candidate issues, options, and decisions"));
+        assert!(section.content.contains("independent lifecycle"));
+        assert!(section
+            .content
+            .contains("Do not create a new WorkItem just to refine"));
+        assert!(section
+            .content
+            .contains("switch candidates inside the same planning thread"));
         assert!(section
             .content
             .contains("update its objective, plan, and todo_list"));
         assert!(section.content.contains("plan_status=ready"));
+        assert!(section.content.contains("plan_status=needs_input"));
+        assert!(section
+            .content
+            .contains("must not be scheduler-resumed as runnable work"));
         assert!(section
             .content
             .contains("update objective or plan before continuing"));
@@ -337,6 +353,11 @@ mod tests {
             .expect("work item read section");
         assert!(section.content.contains("current_work_item_id as focus"));
         assert!(section.content.contains("open/completed"));
+        assert!(section.content.contains("waiting_for_operator"));
+        assert!(section.content.contains("runnable"));
+        assert!(section
+            .content
+            .contains("readiness describes scheduler eligibility"));
         assert!(section.content.contains("before relying on memory briefs"));
     }
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -129,13 +129,18 @@ impl RuntimeHandle {
                 &self.inner.storage.read_recent_briefs(64)?,
             ),
         };
+        let work_queue_projection = self.inner.storage.work_queue_prompt_projection()?;
         Ok(derive_closure_decision(&ClosureFacts {
             runtime_error,
-            awaiting_operator_input: false,
+            awaiting_operator_input: super::memory_refresh::work_queue_waits_for_operator(
+                &work_queue_projection,
+            ),
             active_blocking_tasks: self.blocking_active_task_count().await?,
             active_waiting_intents,
             active_timers,
-            work_signal: self.current_work_reactivation_signal()?,
+            work_signal: super::memory_refresh::work_queue_reactivation_signal(
+                &work_queue_projection,
+            ),
             turn_started: state.turn_index > 0,
             turn_in_progress: state.current_run_id.is_some(),
             turn_terminal_kind: state
@@ -416,17 +421,20 @@ impl RuntimeHandle {
             .into_iter()
             .filter(|timer| timer.status == TimerStatus::Active)
             .count();
+        let work_queue_projection = storage.work_queue_prompt_projection()?;
         let closure = derive_closure_decision(&ClosureFacts {
             runtime_error: runtime_error_active(
                 &storage.read_recent_events(64)?,
                 &storage.read_recent_briefs(64)?,
             ),
-            awaiting_operator_input: false,
+            awaiting_operator_input: super::memory_refresh::work_queue_waits_for_operator(
+                &work_queue_projection,
+            ),
             active_blocking_tasks: blocking_task_count(&active_tasks),
             active_waiting_intents: active_waiting_intent_count,
             active_timers,
             work_signal: super::memory_refresh::work_queue_reactivation_signal(
-                &storage.work_queue_prompt_projection()?,
+                &work_queue_projection,
             ),
             turn_started: state.turn_index > 0,
             turn_in_progress: state.current_run_id.is_some(),

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -17,7 +17,7 @@ pub(super) fn work_queue_reactivation_signal(
     projection: &WorkQueuePromptProjection,
 ) -> Option<WorkReactivationSignal> {
     if let Some(current) = projection.current.as_ref() {
-        if current.blocked_by.is_none() {
+        if current.is_runnable() {
             return Some(WorkReactivationSignal {
                 work_item_id: current.id.clone(),
                 state: current.state.clone(),
@@ -28,12 +28,19 @@ pub(super) fn work_queue_reactivation_signal(
     projection
         .queued_blocked
         .iter()
-        .find(|item| item.blocked_by.is_none())
+        .find(|item| item.is_runnable())
         .map(|queued| WorkReactivationSignal {
             work_item_id: queued.id.clone(),
             state: queued.state.clone(),
             reactivation_mode: WorkReactivationMode::ActivateQueued,
         })
+}
+
+pub(super) fn work_queue_waits_for_operator(projection: &WorkQueuePromptProjection) -> bool {
+    projection
+        .current
+        .as_ref()
+        .is_some_and(|item| item.is_waiting_for_operator())
 }
 
 fn idle_tick_trigger_from_state(
@@ -44,14 +51,14 @@ fn idle_tick_trigger_from_state(
         Some(IdleTickTrigger::WakeHint(pending))
     } else {
         if let Some(current) = projection.current {
-            if current.blocked_by.is_none() {
+            if current.is_runnable() {
                 return Some(IdleTickTrigger::WorkQueueActive(current));
             }
         }
         projection
             .queued_blocked
             .into_iter()
-            .find(|item| item.blocked_by.is_none())
+            .find(|item| item.is_runnable())
             .map(IdleTickTrigger::WorkQueueQueued)
     }
 }
@@ -452,13 +459,6 @@ impl RuntimeHandle {
         ))?;
         let _ = self.enqueue(message).await?;
         Ok(())
-    }
-
-    pub(super) fn current_work_reactivation_signal(
-        &self,
-    ) -> Result<Option<WorkReactivationSignal>> {
-        let projection = self.inner.storage.work_queue_prompt_projection()?;
-        Ok(work_queue_reactivation_signal(&projection))
     }
 
     pub(super) async fn emit_system_tick_from_interrupted_tasks(

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -274,6 +274,34 @@ async fn filtered_tool_specs_expose_no_public_task_creation_tool() {
 }
 
 #[tokio::test]
+async fn filtered_tool_specs_hide_notify_operator_for_normal_agents() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let identity = runtime.agent_identity_view().await.unwrap();
+    let public_tools = runtime.filtered_tool_specs(&identity).unwrap();
+    let private_tools = runtime
+        .filtered_tool_specs(&private_child_identity("tmp_child_demo"))
+        .unwrap();
+
+    assert!(!public_tools
+        .iter()
+        .any(|tool| tool.name == "NotifyOperator"));
+    assert!(!private_tools
+        .iter()
+        .any(|tool| tool.name == "NotifyOperator"));
+}
+
+#[tokio::test]
 async fn filtered_tool_specs_keep_spawn_agent_visible_without_host_bridge() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -255,6 +255,17 @@ async fn work_item_query_tools_return_readiness_views() {
         Some(false)
     );
 
+    let queued_payload = list("queued").await;
+    assert_eq!(queued_payload["total_matching"].as_u64(), Some(2));
+    let queued_ids = queued_payload["work_items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["id"].as_str())
+        .collect::<Vec<_>>();
+    assert!(queued_ids.contains(&runnable.id.as_str()));
+    assert!(queued_ids.contains(&waiting.id.as_str()));
+
     let blocked_payload = list("blocked").await;
     assert_eq!(blocked_payload["total_matching"].as_u64(), Some(1));
     assert_eq!(

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use super::support::*;
+use crate::types::WorkItemPlanStatus;
 
 #[tokio::test]
 async fn work_item_query_tools_return_current_open_done_views() {
@@ -71,7 +72,9 @@ async fn work_item_query_tools_return_current_open_done_views() {
     );
     assert_eq!(active_item["state"].as_str(), Some("open"));
     assert_eq!(active_item["focus"].as_str(), Some("current"));
+    assert_eq!(active_item["readiness"].as_str(), Some("runnable"));
     assert_eq!(active_item["is_current"].as_bool(), Some(true));
+    assert_eq!(active_item["is_runnable"].as_bool(), Some(true));
     assert_eq!(
         active_item["plan"].as_str(),
         Some("Inspect query surface behavior.")
@@ -130,6 +133,10 @@ async fn work_item_query_tools_return_current_open_done_views() {
         completed_payload["work_item"]["focus"].as_str(),
         Some("completed")
     );
+    assert_eq!(
+        completed_payload["work_item"]["readiness"].as_str(),
+        Some("completed")
+    );
 
     bind_turn_to_work_item(&runtime, completed.id.as_str()).await;
     let (fallback_result, _) = registry
@@ -153,6 +160,110 @@ async fn work_item_query_tools_return_current_open_done_views() {
     assert_eq!(
         fallback_payload["work_items"][0]["id"].as_str(),
         Some(active.id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn work_item_query_tools_return_readiness_views() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let runnable = runtime
+        .create_work_item("runnable work".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let waiting = runtime
+        .create_work_item(
+            "waiting work".into(),
+            Some(WorkItemPlanStatus::NeedsInput),
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let blocked = runtime
+        .create_work_item("blocked work".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime
+        .update_work_item_fields(
+            blocked.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            Some(Some("waiting for CI".into())),
+        )
+        .await
+        .unwrap();
+
+    let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+    let list = |filter: &'static str| {
+        let registry = &registry;
+        let runtime = &runtime;
+        async move {
+            let (result, _) = registry
+                .execute(
+                    runtime,
+                    "default",
+                    &TrustLevel::TrustedOperator,
+                    &crate::tool::ToolCall {
+                        id: format!("list-{filter}"),
+                        name: "ListWorkItems".into(),
+                        input: serde_json::json!({"filter": filter}),
+                    },
+                )
+                .await
+                .unwrap();
+            result.envelope.result.unwrap()
+        }
+    };
+
+    let runnable_payload = list("runnable").await;
+    assert_eq!(runnable_payload["total_matching"].as_u64(), Some(1));
+    assert_eq!(
+        runnable_payload["work_items"][0]["id"].as_str(),
+        Some(runnable.id.as_str())
+    );
+    assert_eq!(
+        runnable_payload["work_items"][0]["readiness"].as_str(),
+        Some("runnable")
+    );
+
+    let waiting_payload = list("waiting_for_operator").await;
+    assert_eq!(waiting_payload["total_matching"].as_u64(), Some(1));
+    assert_eq!(
+        waiting_payload["work_items"][0]["id"].as_str(),
+        Some(waiting.id.as_str())
+    );
+    assert_eq!(
+        waiting_payload["work_items"][0]["readiness"].as_str(),
+        Some("waiting_for_operator")
+    );
+    assert_eq!(
+        waiting_payload["work_items"][0]["is_runnable"].as_bool(),
+        Some(false)
+    );
+
+    let blocked_payload = list("blocked").await;
+    assert_eq!(blocked_payload["total_matching"].as_u64(), Some(1));
+    assert_eq!(
+        blocked_payload["work_items"][0]["id"].as_str(),
+        Some(blocked.id.as_str())
+    );
+    assert_eq!(
+        blocked_payload["work_items"][0]["readiness"].as_str(),
+        Some("blocked")
     );
 }
 
@@ -1467,6 +1578,53 @@ async fn current_closure_reports_continuable_for_current_work_item() {
 }
 
 #[tokio::test]
+async fn current_needs_input_work_item_waits_for_operator_without_work_signal() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut active = WorkItemRecord::new(
+        "default",
+        "choose implementation direction",
+        WorkItemState::Open,
+    );
+    active.plan_status = WorkItemPlanStatus::NeedsInput;
+    let active_id = active.id.clone();
+    storage.append_work_item(&active).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.current_work_item_id = Some(active_id.clone());
+    storage.write_agent(&agent).unwrap();
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("tick done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let closure = runtime.current_closure_decision().await.unwrap();
+    assert_eq!(closure.outcome, ClosureOutcome::Waiting);
+    assert_eq!(
+        closure.waiting_reason,
+        Some(WaitingReason::AwaitingOperatorInput)
+    );
+    assert!(closure.work_signal.is_none());
+    assert!(closure
+        .evidence
+        .iter()
+        .any(|item| item == "awaiting_operator_input_signal"));
+
+    let emitted = runtime.maybe_emit_pending_system_tick(None).await.unwrap();
+    assert!(
+        !emitted,
+        "needs_input current work item must not auto-resume through work_queue"
+    );
+}
+
+#[tokio::test]
 async fn current_closure_reports_continuable_for_queued_work_item_without_active_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -1499,6 +1657,39 @@ async fn current_closure_reports_continuable_for_queued_work_item_without_active
     assert_eq!(
         signal.reactivation_mode,
         WorkReactivationMode::ActivateQueued
+    );
+}
+
+#[tokio::test]
+async fn queued_needs_input_work_item_is_not_runnable() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut queued =
+        WorkItemRecord::new("default", "waiting planning candidate", WorkItemState::Open);
+    queued.plan_status = WorkItemPlanStatus::NeedsInput;
+    storage.append_work_item(&queued).unwrap();
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("tick done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let closure = runtime.current_closure_decision().await.unwrap();
+    assert_eq!(closure.outcome, ClosureOutcome::Completed);
+    assert_eq!(closure.waiting_reason, None);
+    assert!(closure.work_signal.is_none());
+
+    let emitted = runtime.maybe_emit_pending_system_tick(None).await.unwrap();
+    assert!(
+        !emitted,
+        "queued needs_input work item should not emit queued_available"
     );
 }
 

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(family_for("Sleep"), ToolCapabilityFamily::CoreAgent);
         assert_eq!(
             family_for("NotifyOperator"),
-            ToolCapabilityFamily::CoreAgent
+            ToolCapabilityFamily::OperatorNotification
         );
         assert_eq!(family_for("MemorySearch"), ToolCapabilityFamily::CoreAgent);
         assert_eq!(family_for("MemoryGet"), ToolCapabilityFamily::CoreAgent);

--- a/src/tool/tools/create_work_item.rs
+++ b/src/tool/tools/create_work_item.rs
@@ -56,7 +56,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<CreateWorkItemArgs>(
             NAME,
-            "Create a new open work item for a genuinely separate objective. Use plan for durable task understanding and todo_list only for progress checklist items. Do not create a new work item just to refine the current task; use UpdateWorkItem.objective and UpdateWorkItem.plan for that.",
+            "Create a new open work item for a genuinely separate objective with an independent lifecycle. Use plan for durable task understanding and todo_list only for progress checklist items. Continuous discussion, planning, candidate screening, and option comparison should usually update the current work item instead. Do not create a new work item just to refine, narrow, or switch candidates inside the current task; use UpdateWorkItem.objective, UpdateWorkItem.plan, and UpdateWorkItem.todo_list for that.",
         )?,
     })
 }

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -132,7 +132,6 @@ fn matches_filter(
             !is_current
                 && super::work_item_query::focus_view(record, is_current)
                     == WorkItemFocusView::Queued
-                && record.readiness() == WorkItemReadiness::Runnable
         }
         ListWorkItemsFilter::Blocked => {
             !is_current

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::{
     runtime::RuntimeHandle,
     tool::spec::typed_spec,
-    types::{ToolCapabilityFamily, TrustLevel, WorkItemState},
+    types::{ToolCapabilityFamily, TrustLevel, WorkItemReadiness, WorkItemState},
 };
 
 use super::{
@@ -33,6 +33,8 @@ pub(crate) enum ListWorkItemsFilter {
     Current,
     Queued,
     Blocked,
+    WaitingForOperator,
+    Runnable,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -63,7 +65,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<ListWorkItemsArgs>(
             NAME,
-            "List recent work items with explicit current, open, completed, queued, and blocked views. Use this before relying on memory briefs for work-item focus.",
+            "List recent work items with explicit current, open, completed, queued, blocked, waiting_for_operator, and runnable views. Use this before relying on memory briefs for work-item focus.",
         )?,
     })
 }
@@ -130,11 +132,16 @@ fn matches_filter(
             !is_current
                 && super::work_item_query::focus_view(record, is_current)
                     == WorkItemFocusView::Queued
+                && record.readiness() == WorkItemReadiness::Runnable
         }
         ListWorkItemsFilter::Blocked => {
             !is_current
                 && super::work_item_query::focus_view(record, is_current)
                     == WorkItemFocusView::Blocked
         }
+        ListWorkItemsFilter::WaitingForOperator => {
+            record.readiness() == WorkItemReadiness::WaitingForOperator
+        }
+        ListWorkItemsFilter::Runnable => record.readiness() == WorkItemReadiness::Runnable,
     }
 }

--- a/src/tool/tools/notify_operator.rs
+++ b/src/tool/tools/notify_operator.rs
@@ -22,10 +22,10 @@ pub(crate) struct NotifyOperatorArgs {
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
     Ok(BuiltinToolDefinition {
-        family: ToolCapabilityFamily::CoreAgent,
+        family: ToolCapabilityFamily::OperatorNotification,
         spec: typed_spec::<NotifyOperatorArgs>(
             NAME,
-            "Create an operator-facing notification record/event without stopping the current turn. Call Sleep explicitly afterward only if the agent should wait.",
+            "Create an operator-facing notification record/event for runtime policy or delivery adapters. Normal agent profiles do not expose this tool; agents should use final responses, work item blockers, and completion summaries instead of deciding notification policy themselves.",
         )?,
     })
 }

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     runtime::RuntimeHandle,
-    types::{TodoItem, WorkItemPlanStatus, WorkItemRecord, WorkItemState},
+    types::{TodoItem, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -31,7 +31,9 @@ pub(crate) struct WorkItemView {
     pub(crate) objective: String,
     pub(crate) state: WorkItemLifecycleView,
     pub(crate) focus: WorkItemFocusView,
+    pub(crate) readiness: WorkItemReadiness,
     pub(crate) is_current: bool,
+    pub(crate) is_runnable: bool,
     pub(crate) plan_status: WorkItemPlanStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) plan: Option<String>,
@@ -91,6 +93,7 @@ pub(crate) async fn view_for_record(
     };
     let state = lifecycle_view(&record.state);
     let focus = focus_view(&record, is_current);
+    let readiness = record.readiness();
     Ok(WorkItemView {
         id: record.id,
         agent_id: record.agent_id,
@@ -98,7 +101,9 @@ pub(crate) async fn view_for_record(
         objective: record.objective,
         state,
         focus,
+        readiness,
         is_current,
+        is_runnable: readiness == WorkItemReadiness::Runnable,
         plan_status: record.plan_status,
         plan,
         todo_list,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -278,11 +278,7 @@ fn todo_summary_work_item<'a>(
         .as_deref()
         .or(agent.current_work_item_id.as_deref())
         .and_then(|current_id| work_items.iter().find(|item| item.id == current_id))
-        .or_else(|| {
-            work_items.iter().find(|item| {
-                item.state == crate::types::WorkItemState::Open && item.blocked_by.is_none()
-            })
-        })
+        .or_else(|| work_items.iter().find(|item| item.is_runnable()))
 }
 
 fn prompt_pane_height(buffer: &str, slash_menu_rows: usize, pane_width: u16) -> u16 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -142,6 +142,7 @@ pub(crate) enum ToolCapabilityFamily {
     AgentCreation,
     AuthorityExpanding,
     ExternalTrigger,
+    OperatorNotification,
 }
 
 impl ToolCapabilityFamily {
@@ -153,6 +154,7 @@ impl ToolCapabilityFamily {
             Self::AgentCreation => "agent_creation",
             Self::AuthorityExpanding => "authority_expanding",
             Self::ExternalTrigger => "external_trigger",
+            Self::OperatorNotification => "operator_notification",
         }
     }
 }
@@ -2332,6 +2334,15 @@ pub enum WorkItemPlanStatus {
     NeedsInput,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkItemReadiness {
+    Runnable,
+    WaitingForOperator,
+    Blocked,
+    Completed,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkItemRecord {
     pub id: String,
@@ -2375,6 +2386,27 @@ impl WorkItemRecord {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    pub fn readiness(&self) -> WorkItemReadiness {
+        if self.state == WorkItemState::Completed {
+            return WorkItemReadiness::Completed;
+        }
+        if self.blocked_by.is_some() {
+            return WorkItemReadiness::Blocked;
+        }
+        if self.plan_status == WorkItemPlanStatus::NeedsInput {
+            return WorkItemReadiness::WaitingForOperator;
+        }
+        WorkItemReadiness::Runnable
+    }
+
+    pub fn is_runnable(&self) -> bool {
+        self.readiness() == WorkItemReadiness::Runnable
+    }
+
+    pub fn is_waiting_for_operator(&self) -> bool {
+        self.readiness() == WorkItemReadiness::WaitingForOperator
     }
 }
 
@@ -3099,6 +3131,8 @@ mod tests {
             .allows_tool_capability_family(ToolCapabilityFamily::AgentCreation));
         assert!(!AgentProfilePreset::PrivateChild
             .allows_tool_capability_family(ToolCapabilityFamily::AuthorityExpanding));
+        assert!(!AgentProfilePreset::PrivateChild
+            .allows_tool_capability_family(ToolCapabilityFamily::OperatorNotification));
         assert!(AgentProfilePreset::PrivateChild
             .allows_tool_capability_family(ToolCapabilityFamily::LocalEnvironment));
         assert!(AgentProfilePreset::PrivateChild
@@ -3106,7 +3140,7 @@ mod tests {
     }
 
     #[test]
-    fn public_named_enables_all_current_tool_capability_families() {
+    fn public_named_keeps_operator_notification_policy_owned_by_runtime() {
         for family in [
             ToolCapabilityFamily::CoreAgent,
             ToolCapabilityFamily::LocalEnvironment,
@@ -3116,5 +3150,7 @@ mod tests {
         ] {
             assert!(AgentProfilePreset::PublicNamed.allows_tool_capability_family(family));
         }
+        assert!(!AgentProfilePreset::PublicNamed
+            .allows_tool_capability_family(ToolCapabilityFamily::OperatorNotification));
     }
 }

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -232,6 +232,7 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_prompt
 - State: Open
+- Readiness: Blocked
 - Objective: Ship prompt snapshot coverage
 - Plan status: draft
 - Todo list:
@@ -559,6 +560,7 @@ Working memory:
 Current work item:
 - Id: work_active
 - State: Open
+- Readiness: Blocked
 - Objective: Complete snapshot coverage expansion
 - Plan status: draft
 - Todo list:
@@ -648,6 +650,7 @@ Working memory:
 Current work item:
 - Id: work_no_delta
 - State: Open
+- Readiness: Blocked
 - Objective: Test delta absence
 - Plan status: draft
 - Todo list:
@@ -771,6 +774,7 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_ci
 - State: Open
+- Readiness: Blocked
 - Objective: Handle CI callback
 - Plan status: draft
 - Todo list:
@@ -888,6 +892,7 @@ Working memory:
 Current work item:
 - Id: work_waiting
 - State: Open
+- Readiness: Blocked
 - Objective: External service integration
 - Plan status: draft
 - Todo list:
@@ -1031,6 +1036,7 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_compaction
 - State: Open
+- Readiness: Blocked
 - Objective: Long-running task with compaction
 - Plan status: draft
 - Todo list:
@@ -1177,6 +1183,7 @@ Working memory updated since the last prompt:
 Current work item:
 - Id: work_test
 - State: Open
+- Readiness: Blocked
 - Objective: Test execution and verification
 - Plan status: draft
 - Todo list:

--- a/tests/runtime_waiting_and_delivery_regressions.rs
+++ b/tests/runtime_waiting_and_delivery_regressions.rs
@@ -41,7 +41,7 @@ runtime_async_tests!(
     wake_hint_coalesces_while_running_and_reenters_once,
     paused_agent_ignores_wake_hint,
     notify_operator_records_default_public_and_private_child_targets,
-    notify_operator_does_not_stop_same_turn_tool_execution,
+    notify_operator_is_not_agent_facing_for_normal_profiles,
     notify_operator_prefers_reply_route_for_delivery,
     notify_operator_ignores_reply_route_when_binding_no_longer_matches,
     notify_operator_falls_back_to_default_route_without_reply_route,

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -495,52 +495,25 @@ pub async fn multi_session_state_is_isolated() -> Result<()> {
 pub async fn notify_operator_records_default_public_and_private_child_targets() -> Result<()> {
     let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
     let default_runtime = host.default_runtime().await?;
-    let registry = ToolRegistry::new(default_runtime.workspace_root());
 
-    let (default_result, default_record) = registry
-        .execute(
-            &default_runtime,
-            "default",
-            &TrustLevel::TrustedOperator,
-            &ToolCall {
-                id: "notify-default".into(),
-                name: "NotifyOperator".into(),
-                input: json!({ "message": "\nDefault operator note\nsecond line" }),
-            },
-        )
+    let default_notification = default_runtime
+        .notify_operator("\nDefault operator note\nsecond line".into())
         .await?;
-    assert!(!default_result.should_sleep);
-    assert_eq!(default_record.tool_name, "NotifyOperator");
-    let default_value: serde_json::Value = parse_tool_result_payload(&default_result)?;
+    let default_value = serde_json::to_value(default_notification)?;
     assert_eq!(
-        default_value["notification"]["target_operator_boundary"],
+        default_value["target_operator_boundary"],
         "primary_operator"
     );
-    assert_eq!(
-        default_value["notification"]["summary"],
-        "Default operator note"
-    );
+    assert_eq!(default_value["summary"], "Default operator note");
 
     host.create_named_agent("public-agent", None).await?;
     let public_runtime = host.get_public_agent("public-agent").await?;
-    let (public_result, _) = registry
-        .execute(
-            &public_runtime,
-            "public-agent",
-            &TrustLevel::TrustedOperator,
-            &ToolCall {
-                id: "notify-public".into(),
-                name: "NotifyOperator".into(),
-                input: json!({ "message": "Public named note" }),
-            },
-        )
+    let public_notification = public_runtime
+        .notify_operator("Public named note".into())
         .await?;
-    let public_value: serde_json::Value = parse_tool_result_payload(&public_result)?;
-    assert_eq!(
-        public_value["notification"]["target_operator_boundary"],
-        "primary_operator"
-    );
-    assert_eq!(public_value["notification"]["agent_id"], "public-agent");
+    let public_value = serde_json::to_value(public_notification)?;
+    assert_eq!(public_value["target_operator_boundary"], "primary_operator");
+    assert_eq!(public_value["agent_id"], "public-agent");
 
     let spawned = default_runtime
         .spawn_agent(
@@ -555,32 +528,14 @@ pub async fn notify_operator_records_default_public_and_private_child_targets() 
         )
         .await?;
     let child_runtime = host.get_or_create_agent(&spawned.agent_id).await?;
-    let (child_result, _) = registry
-        .execute(
-            &child_runtime,
-            &spawned.agent_id,
-            &TrustLevel::TrustedOperator,
-            &ToolCall {
-                id: "notify-child".into(),
-                name: "NotifyOperator".into(),
-                input: json!({ "message": "Child needs supervision visibility" }),
-            },
-        )
+    let child_notification = child_runtime
+        .notify_operator("Child needs supervision visibility".into())
         .await?;
-    let child_value: serde_json::Value = parse_tool_result_payload(&child_result)?;
-    assert_eq!(
-        child_value["notification"]["target_operator_boundary"],
-        "parent_supervisor"
-    );
-    assert_eq!(child_value["notification"]["agent_id"], "default");
-    assert_eq!(
-        child_value["notification"]["requested_by_agent_id"],
-        spawned.agent_id
-    );
-    assert_eq!(
-        child_value["notification"]["target_parent_agent_id"],
-        "default"
-    );
+    let child_value = serde_json::to_value(child_notification)?;
+    assert_eq!(child_value["target_operator_boundary"], "parent_supervisor");
+    assert_eq!(child_value["agent_id"], "default");
+    assert_eq!(child_value["requested_by_agent_id"], spawned.agent_id);
+    assert_eq!(child_value["target_parent_agent_id"], "default");
 
     let child_notifications = child_runtime.recent_operator_notifications(10).await?;
     assert_eq!(
@@ -605,52 +560,31 @@ pub async fn notify_operator_records_default_public_and_private_child_targets() 
     Ok(())
 }
 
-pub async fn notify_operator_does_not_stop_same_turn_tool_execution() -> Result<()> {
-    let host =
-        RuntimeHost::new_with_provider(test_config(), Arc::new(NotifyThenAgentGetProvider::new()))?;
+pub async fn notify_operator_is_not_agent_facing_for_normal_profiles() -> Result<()> {
+    let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
     let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
 
-    runtime
-        .enqueue(MessageEnvelope::new(
-            "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            TrustLevel::TrustedOperator,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "notify and continue".into(),
-            },
-        ))
+    let prompt = runtime
+        .preview_prompt("check tool visibility".into(), TrustLevel::TrustedOperator)
         .await?;
-    wait_until(|| {
-        Ok(runtime
-            .storage()
-            .read_recent_briefs(10)?
-            .iter()
-            .any(|brief| brief.text.contains("continued after notifying operator")))
-    })
-    .await?;
+    assert!(!prompt.rendered_system_prompt.contains("NotifyOperator"));
 
-    let tool_records = runtime.storage().read_recent_tool_executions(10)?;
-    assert!(tool_records
-        .iter()
-        .any(|record| record.tool_name == "NotifyOperator"));
-    assert!(tool_records
-        .iter()
-        .any(|record| record.tool_name == "AgentGet"));
-    let notification = runtime
-        .recent_operator_notifications(10)
-        .await?
-        .into_iter()
-        .next()
-        .expect("notification should be recorded");
-    assert_eq!(notification.summary, "Operator FYI");
-    let summary = runtime.agent_summary().await?;
-    assert_ne!(
-        summary.closure.waiting_reason,
-        Some(WaitingReason::AwaitingOperatorInput)
-    );
-    assert_eq!(summary.recent_operator_notifications.len(), 1);
+    let error = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "notify-rejected".into(),
+                name: "NotifyOperator".into(),
+                input: json!({ "message": "Operator FYI" }),
+            },
+        )
+        .await
+        .expect_err("normal agent profiles should not execute NotifyOperator");
+    assert!(error.to_string().contains("operator_notification"));
+    assert!(runtime.recent_operator_notifications(10).await?.is_empty());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add derived WorkItem readiness and use it for scheduler/work queue activation
- keep needs_input work waiting for operator instead of auto-resuming as runnable work
- constrain NotifyOperator out of normal agent profiles and update work-item prompts/docs for continuous planning reuse

Fixes #911.
Fixes #915.
Fixes #916.

## Verification
- cargo fmt --check
- cargo test -q --test prompt_context_snapshots
- cargo test -q