### PR TITLE
feat: add TUI operator visibility levels

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -538,38 +538,65 @@ impl RuntimeHandle {
 
     async fn begin_interactive_turn(
         &self,
+        message: Option<&MessageEnvelope>,
         operator_binding_id: Option<&str>,
         operator_reply_route_id: Option<&str>,
     ) -> Result<()> {
-        let mut guard = self.inner.agent.lock().await;
-        guard.state.turn_index += 1;
-        guard.state.last_turn_terminal = None;
-        if guard.state.current_turn_work_item_id.is_none() {
-            guard.state.current_turn_work_item_id = guard.state.current_work_item_id.clone();
-        }
-        guard.state.current_turn_operator_binding_id = operator_binding_id.and_then(|binding_id| {
-            let binding_id = binding_id.trim();
-            if binding_id.is_empty() {
-                None
-            } else {
-                Some(binding_id.to_string())
+        let state = {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state.turn_index += 1;
+            guard.state.last_turn_terminal = None;
+            if guard.state.current_turn_work_item_id.is_none() {
+                guard.state.current_turn_work_item_id = guard.state.current_work_item_id.clone();
             }
-        });
-        guard.state.current_turn_operator_reply_route_id =
-            operator_reply_route_id.and_then(|route| {
-                let route = route.trim();
-                if route.is_empty() {
-                    None
-                } else {
-                    Some(route.to_string())
-                }
+            guard.state.current_turn_operator_binding_id =
+                operator_binding_id.and_then(|binding_id| {
+                    let binding_id = binding_id.trim();
+                    if binding_id.is_empty() {
+                        None
+                    } else {
+                        Some(binding_id.to_string())
+                    }
+                });
+            guard.state.current_turn_operator_reply_route_id =
+                operator_reply_route_id.and_then(|route| {
+                    let route = route.trim();
+                    if route.is_empty() {
+                        None
+                    } else {
+                        Some(route.to_string())
+                    }
+                });
+            guard.state.active_skills.retain(|skill| {
+                matches!(skill.activation_state, SkillActivationState::SessionActive)
             });
-        guard
-            .state
-            .active_skills
-            .retain(|skill| matches!(skill.activation_state, SkillActivationState::SessionActive));
-        self.inner.storage.write_agent(&guard.state)?;
+            self.inner.storage.write_agent(&guard.state)?;
+            guard.state.clone()
+        };
+        self.append_state_changed_events(&state)?;
+        if let Some(message) = message {
+            self.inner.storage.append_event(&AuditEvent::new(
+                "turn_started",
+                serde_json::json!({
+                    "agent_id": message.agent_id.clone(),
+                    "message_id": message.id.clone(),
+                    "message_kind": message.kind.clone(),
+                    "run_id": state.current_run_id,
+                    "turn_index": state.turn_index,
+                }),
+            ))?;
+        }
         Ok(())
+    }
+
+    #[cfg(test)]
+    async fn begin_interactive_turn_for_test(
+        &self,
+        operator_binding_id: Option<&str>,
+        operator_reply_route_id: Option<&str>,
+    ) -> Result<()> {
+        self.begin_interactive_turn(None, operator_binding_id, operator_reply_route_id)
+            .await
     }
 
     fn operator_transport_from_message(
@@ -941,12 +968,13 @@ impl RuntimeHandle {
                     guard.state.status = AgentStatus::AwakeRunning;
                     guard.state.current_run_id = Some(run_id.clone());
                     guard.current_run_interrupt = Some(CurrentRunInterruptHandle {
-                        run_id,
+                        run_id: run_id.clone(),
                         token: interrupt_token,
                         reason: Arc::new(StdMutex::new("operator_interrupted".into())),
                     });
                     guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
                     self.inner.storage.write_agent(&guard.state)?;
+                    self.append_state_changed_events(&guard.state)?;
                     self.inner.storage.append_queue_entry(&QueueEntryRecord {
                         message_id: message.id.clone(),
                         agent_id: message.agent_id.clone(),
@@ -1037,6 +1065,7 @@ impl RuntimeHandle {
                 guard.state.current_run_id = None;
                 guard.current_run_interrupt = None;
                 self.inner.storage.write_agent(&guard.state)?;
+                self.append_state_changed_events(&guard.state)?;
                 drop(guard);
                 self.maybe_commit_turn_end_work_item_transition().await?;
                 self.record_closure_decision_event(Some(true)).await?;
@@ -1044,6 +1073,7 @@ impl RuntimeHandle {
             } else {
                 let mut guard = self.inner.agent.lock().await;
                 guard.current_run_interrupt = None;
+                self.append_state_changed_events(&guard.state)?;
                 drop(guard);
                 self.inner.storage.append_queue_entry(&QueueEntryRecord {
                     message_id: message.id.clone(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -974,26 +974,18 @@ impl RuntimeHandle {
                     });
                     guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
                     self.inner.storage.write_agent(&guard.state)?;
-                    self.append_state_changed_events(&guard.state)?;
-                    self.inner.storage.append_queue_entry(&QueueEntryRecord {
-                        message_id: message.id.clone(),
-                        agent_id: message.agent_id.clone(),
-                        priority: message.priority.clone(),
-                        status: QueueEntryStatus::Dequeued,
-                        created_at: message.created_at,
-                        updated_at: Utc::now(),
-                    })?;
-                    Some((message, prior_state))
+                    let running_state = guard.state.clone();
+                    Some((message, prior_state, running_state))
                 } else {
                     None
                 }
             };
 
-            let Some((message, prior_state)) = next_message else {
+            let Some((message, prior_state, running_state)) = next_message else {
                 if self.maybe_emit_pending_system_tick(None).await? {
                     continue;
                 }
-                {
+                let idle_state = {
                     let mut guard = self.inner.agent.lock().await;
                     if !matches!(
                         guard.state.status,
@@ -1004,12 +996,27 @@ impl RuntimeHandle {
                         guard.state.current_run_id = None;
                         guard.state.sleeping_until = None;
                         self.inner.storage.write_agent(&guard.state)?;
-                        self.append_state_changed_events(&guard.state)?;
+                        Some(guard.state.clone())
+                    } else {
+                        None
                     }
+                };
+                if let Some(idle_state) = idle_state {
+                    self.append_state_changed_events(&idle_state)?;
                 }
                 self.inner.notify.notified().await;
                 continue;
             };
+
+            self.append_state_changed_events(&running_state)?;
+            self.inner.storage.append_queue_entry(&QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: message.agent_id.clone(),
+                priority: message.priority.clone(),
+                status: QueueEntryStatus::Dequeued,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            })?;
 
             let prior_closure = self.closure_decision_for_state(&prior_state, None).await?;
             if let Err(err) = self.process_message(message.clone(), prior_closure).await {
@@ -1048,33 +1055,37 @@ impl RuntimeHandle {
                     self.persist_runtime_failure_artifacts(&message, &err)
                         .await?;
                 }
-                let mut guard = self.inner.agent.lock().await;
-                if !matches!(
-                    guard.state.status,
-                    AgentStatus::Paused | AgentStatus::Stopped
-                ) {
-                    guard.state.status = if task_state_reducer::has_blocking_active_tasks(
-                        &self.inner.storage,
-                        &guard.state.active_task_ids,
-                    )? {
-                        AgentStatus::AwaitingTask
-                    } else {
-                        AgentStatus::AwakeIdle
-                    };
-                }
-                guard.state.current_run_id = None;
-                guard.current_run_interrupt = None;
-                self.inner.storage.write_agent(&guard.state)?;
-                self.append_state_changed_events(&guard.state)?;
-                drop(guard);
+                let failed_state = {
+                    let mut guard = self.inner.agent.lock().await;
+                    if !matches!(
+                        guard.state.status,
+                        AgentStatus::Paused | AgentStatus::Stopped
+                    ) {
+                        guard.state.status = if task_state_reducer::has_blocking_active_tasks(
+                            &self.inner.storage,
+                            &guard.state.active_task_ids,
+                        )? {
+                            AgentStatus::AwaitingTask
+                        } else {
+                            AgentStatus::AwakeIdle
+                        };
+                    }
+                    guard.state.current_run_id = None;
+                    guard.current_run_interrupt = None;
+                    self.inner.storage.write_agent(&guard.state)?;
+                    guard.state.clone()
+                };
+                self.append_state_changed_events(&failed_state)?;
                 self.maybe_commit_turn_end_work_item_transition().await?;
                 self.record_closure_decision_event(Some(true)).await?;
                 self.maybe_emit_pending_system_tick(None).await?;
             } else {
-                let mut guard = self.inner.agent.lock().await;
-                guard.current_run_interrupt = None;
-                self.append_state_changed_events(&guard.state)?;
-                drop(guard);
+                let processed_state = {
+                    let mut guard = self.inner.agent.lock().await;
+                    guard.current_run_interrupt = None;
+                    guard.state.clone()
+                };
+                self.append_state_changed_events(&processed_state)?;
                 self.inner.storage.append_queue_entry(&QueueEntryRecord {
                     message_id: message.id.clone(),
                     agent_id: message.agent_id.clone(),

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -980,14 +980,15 @@ impl RuntimeHandle {
             chrono::Utc::now()
                 + chrono::Duration::milliseconds(i64::try_from(duration_ms).unwrap_or(i64::MAX))
         });
-        {
+        let state = {
             let mut guard = self.inner.agent.lock().await;
             guard.state.status = AgentStatus::Asleep;
             guard.state.current_run_id = None;
             guard.state.sleeping_until = sleeping_until;
             self.inner.storage.write_agent(&guard.state)?;
-            self.append_state_changed_events(&guard.state)?;
-        }
+            guard.state.clone()
+        };
+        self.append_state_changed_events(&state)?;
         if let (Some(duration_ms), Some(sleeping_until)) = (duration_ms, sleeping_until) {
             self.spawn_session_sleep_wake(duration_ms, sleeping_until);
         }

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -10,6 +10,7 @@ impl RuntimeHandle {
         let (operator_binding_id, operator_reply_route_id) =
             Self::operator_transport_from_message(message);
         self.begin_interactive_turn(
+            Some(message),
             operator_binding_id.as_deref(),
             operator_reply_route_id.as_deref(),
         )

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -861,7 +861,10 @@ async fn reading_discovered_skill_marks_it_active_and_promotes_on_success() {
     )
     .unwrap();
 
-    runtime.begin_interactive_turn(None, None).await.unwrap();
+    runtime
+        .begin_interactive_turn_for_test(None, None)
+        .await
+        .unwrap();
     let prompt = runtime
         .preview_prompt(
             "use the demo skill".to_string(),

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1882,11 +1882,17 @@ impl RuntimeHandle {
                 }
             }
             let token_usage = TokenUsage::new(response.input_tokens, response.output_tokens);
+            let (turn_index, run_id) = {
+                let guard = self.inner.agent.lock().await;
+                (guard.state.turn_index, guard.state.current_run_id.clone())
+            };
 
             self.inner.storage.append_event(&AuditEvent::new(
                 "provider_round_completed",
                 serde_json::json!({
                     "agent_id": agent_id,
+                    "turn_index": turn_index,
+                    "run_id": run_id,
                     "round": round,
                     "stop_reason": stop_reason,
                     "input_tokens": response.input_tokens,
@@ -2020,6 +2026,8 @@ impl RuntimeHandle {
                     "text_only_round_observed",
                     serde_json::json!({
                         "agent_id": agent_id,
+                        "turn_index": turn_index,
+                        "run_id": run_id,
                         "round": round,
                         "stop_reason": stop_reason,
                         "has_text": !combined_text.is_empty(),
@@ -2218,11 +2226,17 @@ impl RuntimeHandle {
                     )
                     .with_retryable(false);
                     let message = error.render();
+                    let (turn_index, run_id) = {
+                        let guard = self.inner.agent.lock().await;
+                        (guard.state.turn_index, guard.state.current_run_id.clone())
+                    };
                     self.inner.storage.append_event(&AuditEvent::new(
                         "tool_execution_failed",
                         serde_json::json!({
                             "tool_call_id": tool_call_id,
                             "tool_name": tool_name,
+                            "turn_index": turn_index,
+                            "run_id": run_id,
                             "exec_command_cmd": command_preview_field(&call),
                             "exec_command_cost": command_cost_field(
                                 &call,
@@ -2306,10 +2320,11 @@ impl RuntimeHandle {
                         let result_content =
                             crate::tool::tools::render_tool_result_for_model(&result)?;
                         let duration_ms = record.duration_ms;
-                        let (turn_index, work_item_id) = {
+                        let (turn_index, run_id, work_item_id) = {
                             let guard = self.inner.agent.lock().await;
                             (
                                 guard.state.turn_index,
+                                guard.state.current_run_id.clone(),
                                 guard.state.current_turn_work_item_id.clone(),
                             )
                         };
@@ -2333,6 +2348,8 @@ impl RuntimeHandle {
                             serde_json::json!({
                                 "tool_call_id": tool_call_id,
                                 "tool_name": tool_name,
+                                "turn_index": turn_index,
+                                "run_id": run_id,
                                 "exec_command_cmd": command_preview_field(&call),
                                 "exec_command_cost": command_cost_field(
                                     &call,
@@ -2368,11 +2385,17 @@ impl RuntimeHandle {
                         }
                         let error = ToolError::from_anyhow(&err);
                         let message = error.render();
+                        let (turn_index, run_id) = {
+                            let guard = self.inner.agent.lock().await;
+                            (guard.state.turn_index, guard.state.current_run_id.clone())
+                        };
                         self.inner.storage.append_event(&AuditEvent::new(
                             "tool_execution_failed",
                             serde_json::json!({
                                 "tool_call_id": tool_call_id,
                                 "tool_name": tool_name,
+                                "turn_index": turn_index,
+                                "run_id": run_id,
                                 "exec_command_cmd": command_preview_field(&call),
                                 "exec_command_cost": command_cost_field(
                                     &call,

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1816,7 +1816,7 @@ impl RuntimeHandle {
             let request_diagnostics = response.request_diagnostics.clone();
             let model_attempt_state = provider_attempt_model_state(attempt_timeline.as_ref());
 
-            {
+            let (turn_index, run_id) = {
                 let mut guard = self.inner.agent.lock().await;
                 guard.state.total_input_tokens += response.input_tokens;
                 guard.state.total_output_tokens += response.output_tokens;
@@ -1828,7 +1828,8 @@ impl RuntimeHandle {
                 guard.state.last_requested_model = model_attempt_state.requested_model.clone();
                 guard.state.last_active_model = model_attempt_state.active_model.clone();
                 self.inner.storage.write_agent(&guard.state)?;
-            }
+                (guard.state.turn_index, guard.state.current_run_id.clone())
+            };
 
             let assistant_blocks = response.blocks.clone();
             let mut tool_calls = Vec::new();
@@ -1882,10 +1883,6 @@ impl RuntimeHandle {
                 }
             }
             let token_usage = TokenUsage::new(response.input_tokens, response.output_tokens);
-            let (turn_index, run_id) = {
-                let guard = self.inner.agent.lock().await;
-                (guard.state.turn_index, guard.state.current_run_id.clone())
-            };
 
             self.inner.storage.append_event(&AuditEvent::new(
                 "provider_round_completed",

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -56,7 +56,7 @@ use logging::TuiLogWriter;
 #[cfg(test)]
 use overlay::centered_rect_rows;
 use overlay::OverlayState;
-use projection::{ProjectionSlice, TuiProjection};
+use projection::{OperatorVisibility, ProjectionSlice, TuiProjection};
 use render::draw;
 
 const INPUT_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -183,6 +183,7 @@ struct TuiApp {
     overlay: OverlayState,
     last_refresh_at: Option<DateTime<Local>>,
     last_event_at: Option<DateTime<Local>>,
+    display_level: OperatorVisibility,
     pub(crate) status_line: String,
     should_quit: bool,
     chat_text_cache: RefCell<Option<CachedChatText>>,
@@ -247,6 +248,7 @@ impl TuiApp {
             overlay: OverlayState::None,
             last_refresh_at: None,
             last_event_at: None,
+            display_level: OperatorVisibility::DEFAULT_DISPLAY_LEVEL,
             status_line: "Connecting to local Holon runtime...".into(),
             should_quit: false,
             chat_text_cache: RefCell::new(None),
@@ -924,9 +926,10 @@ mod tests {
     use super::{
         build_chat_text, centered_rect_rows, chat_text, collect_chat_items,
         determine_alt_screen_mode_for_terminal, is_cursor_too_old_error, is_operator_origin_value,
-        paragraph_max_scroll, projection::TuiProjection, AgentListChange, ChatScrollState,
-        ComposerState, ConversationCell, OverlayState, TuiApp, TuiConnectionState,
-        TuiRuntimeMessage,
+        paragraph_max_scroll,
+        projection::{OperatorVisibility, TuiProjection},
+        AgentListChange, ChatScrollState, ComposerState, ConversationCell, OverlayState, TuiApp,
+        TuiConnectionState, TuiRuntimeMessage,
     };
     use crate::{
         client::{
@@ -1559,6 +1562,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn slash_display_sets_chat_visibility_level() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/display 5");
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .unwrap();
+
+        assert_eq!(app.display_level, OperatorVisibility::Trace);
+        assert_eq!(app.overlay, OverlayState::None);
+        assert_eq!(app.composer.as_str(), "");
+        assert_eq!(app.status_line, "Display level set to 5");
+    }
+
+    #[tokio::test]
     async fn slash_menu_enter_runs_selected_prefix_command() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(
@@ -1907,9 +1929,54 @@ mod tests {
             .into_iter()
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
-        assert!(!rendered.contains("System (work)"));
         assert!(rendered.contains("Assistant hidden provider partial"));
-        assert!(rendered.contains("Action    prepare rollout plan [Open]"));
+        assert!(rendered.contains("Action    Waiting for activity"));
+    }
+
+    #[test]
+    fn chat_display_level_five_shows_trace_events_without_working_row() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.display_level = OperatorVisibility::Trace;
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-tool".into(),
+                event: "tool_executed".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-tool".into(),
+                    seq: 2,
+                    ts: Utc::now(),
+                    agent_id: "default".into(),
+                    event_type: "tool_executed".into(),
+                    payload: json!({
+                        "tool_name": "ExecCommand",
+                        "exec_command_cmd": "cargo test tui"
+                    }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.projection = Some(projection);
+
+        let items = collect_chat_items(&app);
+        let rendered: String = build_chat_text(&items)
+            .lines
+            .into_iter()
+            .flat_map(|line| line.spans.into_iter().map(|span| span.content))
+            .collect();
+        assert!(items.iter().any(|item| matches!(
+            item,
+            ConversationCell::SystemNotice { body, .. }
+                if body.contains("tool executed: ExecCommand")
+        )));
+        assert!(rendered.contains("tool executed: ExecCommand"));
+        assert!(!rendered.contains("Working"));
     }
 
     #[test]
@@ -2025,7 +2092,7 @@ mod tests {
         assert!(rendered.contains("Working"));
         assert!(rendered.contains("Current   Improve the Conversation working indicator"));
         assert!(rendered.contains("Assistant ..."));
-        assert!(rendered.contains("Action    Still working"));
+        assert!(rendered.contains("Action    Waiting for activity"));
     }
 
     #[test]
@@ -2373,6 +2440,44 @@ mod tests {
                 ..
             } if body == "persisted operator text"
         ));
+    }
+
+    #[test]
+    fn chat_text_omits_processing_and_processed_operator_status_labels() {
+        for status in [
+            OperatorMessageStatus::Processing,
+            OperatorMessageStatus::Processed,
+        ] {
+            let client = LocalClient::new(test_config()).unwrap();
+            let mut app = TuiApp::new(
+                client,
+                crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+            );
+            let ts = Utc::now();
+            let mut snapshot = sample_snapshot("default", "evt-0");
+            snapshot.operator_messages = vec![OperatorMessageRecord {
+                message_id: "message-1".into(),
+                agent_id: "default".into(),
+                status: status.clone(),
+                created_at: ts,
+                updated_at: ts,
+                body: MessageBody::Text {
+                    text: "operator text".into(),
+                },
+                error: None,
+            }];
+            app.projection = Some(TuiProjection::from_snapshot(snapshot));
+            app.apply_projection_view();
+
+            let rendered: String = build_chat_text(&collect_chat_items(&app))
+                .lines
+                .into_iter()
+                .flat_map(|line| line.spans.into_iter().map(|span| span.content))
+                .collect();
+            assert!(rendered.contains("operator text"));
+            assert!(!rendered.contains("[processing]"));
+            assert!(!rendered.contains("[processed]"));
+        }
     }
 
     #[test]

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -171,15 +171,25 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
     }
 
     if let Some(projection) = app.projection.as_ref() {
-        for event in projection.durable_conversation_events() {
-            if !is_chat_visible_conversation_event(&event.kind) {
+        for event in projection.visible_events(app.display_level) {
+            if event.kind == "message_enqueued" || event.kind == "brief_created" {
                 continue;
             }
-            cells.push(ConversationCell::SystemNotice {
-                created_at: event.ts,
-                speaker: conversation_event_speaker(&event.kind),
-                body: conversation_event_body(event),
-            });
+            if is_progress_event_kind(&event.kind) {
+                cells.push(ConversationCell::AssistantMarkdown(AssistantMarkdownCell {
+                    created_at: event.ts,
+                    agent_id: "Holon (progress)".to_string(),
+                    markdown: conversation_event_body(event),
+                }));
+            } else if is_chat_visible_conversation_event(&event.kind)
+                || projection.operator_visibility(event).display_level() >= 4
+            {
+                cells.push(ConversationCell::SystemNotice {
+                    created_at: event.ts,
+                    speaker: conversation_event_speaker(&event.kind),
+                    body: conversation_event_body(event),
+                });
+            }
         }
     }
 
@@ -415,8 +425,7 @@ fn operator_message_status_label(status: OperatorMessageStatus) -> Option<&'stat
         OperatorMessageStatus::Sending => Some("sending"),
         OperatorMessageStatus::Queued => Some("queued"),
         OperatorMessageStatus::WaitingForSafePoint => Some("waiting"),
-        OperatorMessageStatus::Processing => Some("processing"),
-        OperatorMessageStatus::Processed => Some("processed"),
+        OperatorMessageStatus::Processing | OperatorMessageStatus::Processed => None,
         OperatorMessageStatus::Failed => Some("failed"),
         OperatorMessageStatus::Dropped => Some("dropped"),
     }
@@ -526,6 +535,9 @@ fn active_activity_item(
     app: &TuiApp,
     fallback_ts: Option<DateTime<chrono::Utc>>,
 ) -> Option<ConversationCell> {
+    if app.display_level >= crate::tui::projection::OperatorVisibility::Trace {
+        return None;
+    }
     let projection = app.projection.as_ref();
     let agent = projection
         .map(|projection| &projection.agent)
@@ -534,8 +546,11 @@ fn active_activity_item(
         return None;
     }
 
-    let latest_action = projection.and_then(latest_action_event);
-    let latest_assistant = latest_assistant_message(app, projection);
+    let hidden_events = projection
+        .map(|projection| projection.hidden_current_turn_events(app.display_level))
+        .unwrap_or_default();
+    let latest_action = latest_action_event(hidden_events.as_slice());
+    let latest_assistant = latest_assistant_message(app, projection, hidden_events.as_slice());
     let latest_event_ts =
         projection.and_then(|projection| projection.event_log().last().map(|event| event.ts));
     let created_at = [
@@ -592,13 +607,13 @@ fn agent_has_active_activity(agent: &AgentSummary) -> bool {
         || active_child
 }
 
-fn latest_action_event(
-    projection: &crate::tui::projection::TuiProjection,
-) -> Option<&crate::tui::projection::ProjectionEventRecord> {
-    projection
-        .event_log()
+fn latest_action_event<'a>(
+    events: &'a [&'a crate::tui::projection::ProjectionEventRecord],
+) -> Option<&'a crate::tui::projection::ProjectionEventRecord> {
+    events
         .iter()
         .rev()
+        .copied()
         .find(|event| is_active_action_event_kind(&event.kind))
 }
 
@@ -639,16 +654,16 @@ fn is_active_action_event_kind(kind: &str) -> bool {
 fn latest_assistant_message(
     app: &TuiApp,
     projection: Option<&crate::tui::projection::TuiProjection>,
+    hidden_events: &[&crate::tui::projection::ProjectionEventRecord],
 ) -> Option<String> {
-    projection
-        .and_then(|projection| {
-            projection
-                .event_log()
-                .iter()
-                .rev()
-                .find_map(assistant_message_from_event)
-        })
+    hidden_events
+        .iter()
+        .rev()
+        .find_map(|event| assistant_message_from_event(event))
         .or_else(|| {
+            if projection.is_some_and(|projection| agent_has_active_activity(&projection.agent)) {
+                return None;
+            }
             app.transcript
                 .iter()
                 .rev()
@@ -663,6 +678,13 @@ fn assistant_message_from_event(
         return None;
     }
     event.payload.get("text_preview").and_then(non_empty_value)
+}
+
+fn is_progress_event_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "provider_round_completed" | "text_only_round_observed"
+    )
 }
 
 fn assistant_message_from_transcript(entry: &TranscriptEntry) -> Option<String> {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -11,6 +11,7 @@ enum SlashCommand {
     Refresh,
     ClearStatus,
     DebugPrompt,
+    Display,
     Interrupt,
     Agent,
     Skills,
@@ -39,7 +40,7 @@ pub(super) struct SlashCommandSpec {
     command: SlashCommand,
 }
 
-const SLASH_COMMAND_SPECS: [SlashCommandSpec; 14] = [
+const SLASH_COMMAND_SPECS: [SlashCommandSpec; 15] = [
     SlashCommandSpec {
         name: "/help",
         description: "show slash command help",
@@ -102,6 +103,13 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 14] = [
         usage: "/debug-prompt",
         arg_rule: SlashArgRule::None,
         command: SlashCommand::DebugPrompt,
+    },
+    SlashCommandSpec {
+        name: "/display",
+        description: "set chat display level",
+        usage: "/display <3|4|5>",
+        arg_rule: SlashArgRule::ExactlyOne,
+        command: SlashCommand::Display,
     },
     SlashCommandSpec {
         name: "/interrupt",
@@ -461,6 +469,20 @@ impl TuiApp {
                     composer: ComposerState::new(),
                 };
                 self.status_line = "Opened debug prompt dialog".into();
+            }
+            SlashCommand::Display => {
+                let level = args
+                    .into_iter()
+                    .next()
+                    .expect("slash command /display requires one argument")
+                    .parse::<u8>()
+                    .map_err(|_| anyhow!("/display expects 3, 4, or 5"))?;
+                let display_level = OperatorVisibility::from_display_level(level)
+                    .ok_or_else(|| anyhow!("/display expects 3, 4, or 5"))?;
+                self.display_level = display_level;
+                self.chat_text_cache.borrow_mut().take();
+                self.overlay = OverlayState::None;
+                self.status_line = format!("Display level set to {level}");
             }
             SlashCommand::Interrupt => {
                 let agent_id = match self.selected_agent_id() {
@@ -1305,6 +1327,13 @@ mod tests {
                 vec!["default".into()]
             ))
         );
+        assert_eq!(
+            parse_composer_submission("/display 4").unwrap(),
+            Some(ComposerSubmission::Slash(
+                SlashCommand::Display,
+                vec!["4".into()]
+            ))
+        );
     }
 
     #[test]
@@ -1322,6 +1351,12 @@ mod tests {
     #[test]
     fn slash_commands_require_arguments_for_agent() {
         let err = parse_composer_submission("/agent").unwrap_err();
+        assert!(err.to_string().contains("requires one argument"));
+    }
+
+    #[test]
+    fn slash_display_requires_one_argument() {
+        let err = parse_composer_submission("/display").unwrap_err();
         assert!(err.to_string().contains("requires one argument"));
     }
 

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -437,6 +437,7 @@ fn draw_help_overlay(frame: &mut Frame<'_>, scroll: u16) {
         "  /refresh re-bootstrap the selected agent from /state",
         "  /clear-status clear transient local status text",
         "  /debug-prompt open debug prompt dialog",
+        "  /display <3|4|5> set chat visibility level",
         "  //text send /text as normal chat input",
         "",
         "Overlays",

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -437,9 +437,6 @@ impl TuiProjection {
     pub(crate) fn recent_activity_events(&self) -> Vec<&ProjectionEventRecord> {
         let mut events = Vec::new();
         for event in self.current_turn_events_rev() {
-            if is_activity_reset_kind(&event.kind) {
-                break;
-            }
             if is_ephemeral_activity_kind(&event.kind) {
                 events.push(event);
             }

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -53,6 +53,32 @@ pub(crate) enum ProjectionEventLane {
     Debug,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum OperatorVisibility {
+    ActionRequired = 1,
+    WorkDone = 2,
+    TurnResult = 3,
+    Progress = 4,
+    Trace = 5,
+}
+
+impl OperatorVisibility {
+    pub(crate) const DEFAULT_DISPLAY_LEVEL: Self = Self::TurnResult;
+
+    pub(crate) fn from_display_level(level: u8) -> Option<Self> {
+        match level {
+            3 => Some(Self::TurnResult),
+            4 => Some(Self::Progress),
+            5 => Some(Self::Trace),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn display_level(self) -> u8 {
+        self as u8
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ProjectionEventRecord {
     pub(crate) id: String,
@@ -405,7 +431,7 @@ impl TuiProjection {
 
     pub(crate) fn recent_activity_events(&self) -> Vec<&ProjectionEventRecord> {
         let mut events = Vec::new();
-        for event in self.event_log.iter().rev() {
+        for event in self.current_turn_events_rev() {
             if is_activity_reset_kind(&event.kind) {
                 break;
             }
@@ -418,6 +444,88 @@ impl TuiProjection {
         }
         events.reverse();
         events
+    }
+
+    pub(crate) fn visible_events(
+        &self,
+        display_level: OperatorVisibility,
+    ) -> impl Iterator<Item = &ProjectionEventRecord> {
+        self.event_log
+            .iter()
+            .filter(move |event| self.operator_visibility(event) <= display_level)
+    }
+
+    pub(crate) fn hidden_current_turn_events(
+        &self,
+        display_level: OperatorVisibility,
+    ) -> Vec<&ProjectionEventRecord> {
+        let mut events = self
+            .current_turn_events_rev()
+            .filter(|event| self.operator_visibility(event) > display_level)
+            .take(8)
+            .collect::<Vec<_>>();
+        events.reverse();
+        events
+    }
+
+    pub(crate) fn operator_visibility(&self, event: &ProjectionEventRecord) -> OperatorVisibility {
+        match event.kind.as_str() {
+            "operator_notification_requested" => OperatorVisibility::ActionRequired,
+            "brief_created" => self.brief_visibility(event),
+            "work_item_written" if work_item_event_completed(event) => OperatorVisibility::WorkDone,
+            "runtime_error" => OperatorVisibility::TurnResult,
+            "provider_round_completed" | "text_only_round_observed" => OperatorVisibility::Progress,
+            "tool_executed"
+            | "tool_execution_failed"
+            | "max_output_tokens_recovery"
+            | "turn_local_checkpoint_recorded" => OperatorVisibility::Trace,
+            _ if is_ephemeral_activity_kind(&event.kind) => OperatorVisibility::Trace,
+            _ if is_durable_conversation_kind(&event.kind) => OperatorVisibility::TurnResult,
+            _ => OperatorVisibility::Trace,
+        }
+    }
+
+    fn brief_visibility(&self, event: &ProjectionEventRecord) -> OperatorVisibility {
+        if self.agent.closure.waiting_reason
+            == Some(crate::types::WaitingReason::AwaitingOperatorInput)
+        {
+            return OperatorVisibility::ActionRequired;
+        }
+        let Some(brief) = decode_payload::<BriefRecord>(&event.payload) else {
+            return OperatorVisibility::TurnResult;
+        };
+        if brief
+            .work_item_id
+            .as_deref()
+            .and_then(|work_item_id| self.work_items.iter().find(|item| item.id == work_item_id))
+            .is_some_and(|item| item.state == WorkItemState::Completed)
+        {
+            OperatorVisibility::WorkDone
+        } else {
+            OperatorVisibility::TurnResult
+        }
+    }
+
+    fn current_turn_events_rev(&self) -> impl Iterator<Item = &ProjectionEventRecord> {
+        let active_turn = self.agent.agent.turn_index;
+        let active_run = self.agent.agent.current_run_id.as_deref();
+        self.event_log.iter().rev().take_while(move |event| {
+            if is_activity_reset_kind(&event.kind) {
+                return false;
+            }
+            let event_turn = event.payload.get("turn_index").and_then(Value::as_u64);
+            let event_run = event.payload.get("run_id").and_then(Value::as_str);
+            if let Some(event_run) = event_run {
+                return Some(event_run) == active_run;
+            }
+            if let Some(event_turn) = event_turn {
+                return event_turn == active_turn;
+            }
+            !matches!(
+                event.kind.as_str(),
+                "turn_started" | "message_processing_started" | "message_enqueued"
+            )
+        })
     }
 
     pub(crate) fn recent_log_events(&self, limit: usize) -> Vec<&ProjectionEventRecord> {
@@ -703,6 +811,15 @@ fn work_item_rank(item: &WorkItemRecord) -> u8 {
     }
 }
 
+fn work_item_event_completed(event: &ProjectionEventRecord) -> bool {
+    event
+        .payload
+        .get("record")
+        .cloned()
+        .and_then(decode_value::<WorkItemRecord>)
+        .is_some_and(|record| record.state == WorkItemState::Completed)
+}
+
 fn operator_message_from_enqueued(message: &MessageEnvelope) -> OperatorMessageRecord {
     OperatorMessageRecord {
         message_id: message.id.clone(),
@@ -719,6 +836,7 @@ pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
     matches!(
         kind,
         "message_enqueued"
+            | "turn_started"
             | "operator_interjection_admitted"
             | "brief_created"
             | "runtime_error"
@@ -742,7 +860,9 @@ pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
 pub(crate) fn is_ephemeral_activity_kind(kind: &str) -> bool {
     matches!(
         kind,
-        "tool_executed"
+        "provider_round_completed"
+            | "text_only_round_observed"
+            | "tool_executed"
             | "tool_execution_failed"
             | "skill_activated"
             | "system_tick_emitted"
@@ -757,6 +877,7 @@ fn is_loggable_event_kind(kind: &str) -> bool {
     matches!(
         kind,
         "message_enqueued"
+            | "turn_started"
             | "provider_round_completed"
             | "text_only_round_observed"
             | "tool_executed"
@@ -780,7 +901,15 @@ fn is_loggable_event_kind(kind: &str) -> bool {
 }
 
 fn is_activity_reset_kind(kind: &str) -> bool {
-    matches!(kind, "brief_created" | "turn_terminal" | "runtime_error")
+    matches!(
+        kind,
+        "turn_started"
+            | "message_processing_started"
+            | "operator_interjection_admitted"
+            | "brief_created"
+            | "turn_terminal"
+            | "runtime_error"
+    )
 }
 
 fn classify_event_lane(kind: &str) -> ProjectionEventLane {
@@ -802,6 +931,13 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
                 crate::types::MessageBody::Brief { text, .. } => trim_summary(&text),
             })
             .unwrap_or_else(|| event.data.event_type.clone()),
+        "turn_started" => event
+            .data
+            .payload
+            .get("message_id")
+            .and_then(Value::as_str)
+            .map(|message_id| format!("turn started for {message_id}"))
+            .unwrap_or_else(|| "turn started".into()),
         "operator_interjection_admitted" => event
             .data
             .payload
@@ -1064,7 +1200,7 @@ mod tests {
     }
 
     #[test]
-    fn projection_logs_provider_rounds_without_recent_activity() {
+    fn projection_logs_provider_rounds_as_progress_activity() {
         let mut projection = TuiProjection::from_snapshot(sample_snapshot());
 
         projection.apply_event(
@@ -1075,10 +1211,12 @@ mod tests {
             &test_log_writer(),
         );
 
-        assert!(projection.recent_activity_events().is_empty());
+        let activity = projection.recent_activity_events();
+        assert_eq!(activity.len(), 1);
+        assert_eq!(activity[0].kind, "provider_round_completed");
         assert_eq!(
             projection.event_log().last().map(|event| event.lane),
-            Some(ProjectionEventLane::State)
+            Some(ProjectionEventLane::Debug)
         );
         assert_eq!(
             projection
@@ -1223,11 +1361,9 @@ mod tests {
         );
 
         let activity = projection.recent_activity_events();
-        assert_eq!(activity.len(), 1);
-        assert_eq!(activity[0].kind, "tool_executed");
-        assert!(!activity.iter().any(|event| {
-            event.summary.contains("partial") || event.payload.get("text_preview").is_some()
-        }));
+        assert_eq!(activity.len(), 2);
+        assert_eq!(activity[0].kind, "provider_round_completed");
+        assert_eq!(activity[1].kind, "tool_executed");
 
         projection.apply_event(
             sample_event(

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -55,10 +55,15 @@ pub(crate) enum ProjectionEventLane {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum OperatorVisibility {
+    /// Operator attention is required before the agent can continue.
     ActionRequired = 1,
+    /// A work item reached a durable completion point.
     WorkDone = 2,
+    /// Default operator-facing turn result or durable conversation event.
     TurnResult = 3,
+    /// In-turn assistant progress that is useful while the agent is active.
     Progress = 4,
+    /// Tool and internal trace events for detailed inspection.
     Trace = 5,
 }
 
@@ -1083,7 +1088,7 @@ fn trim_summary(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{ProjectionEventLane, ProjectionSlice, TuiProjection};
+    use super::{OperatorVisibility, ProjectionEventLane, ProjectionSlice, TuiProjection};
     use crate::{
         client::{
             AgentStateSnapshot, AgentStreamEvent, StateSessionSnapshot, StateWorkspaceSnapshot,
@@ -1102,8 +1107,8 @@ mod tests {
             RuntimePosture, SkillsRuntimeView, TaskRecord, TaskStatus, TimerRecord, TimerStatus,
             TodoItem, TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind,
             TurnTerminalKind, TurnTerminalRecord, WaitingIntentRecord, WaitingIntentStatus,
-            WaitingIntentSummary, WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord,
-            WorktreeSession,
+            WaitingIntentSummary, WaitingReason, WorkItemRecord, WorkItemState,
+            WorkspaceOccupancyRecord, WorktreeSession,
         },
     };
     use chrono::Utc;
@@ -1224,6 +1229,104 @@ mod tests {
                 .last()
                 .map(|event| event.summary.as_str()),
             Some("provider round completed")
+        );
+    }
+
+    #[test]
+    fn hidden_current_turn_events_stop_at_current_run_boundary() {
+        let mut snapshot = sample_snapshot();
+        snapshot.agent.agent.status = crate::types::AgentStatus::AwakeRunning;
+        snapshot.agent.agent.turn_index = 2;
+        snapshot.agent.agent.current_run_id = Some("run-2".into());
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+
+        projection.apply_event(
+            sample_event(
+                "provider_round_completed",
+                json!({
+                    "run_id": "run-1",
+                    "turn_index": 1,
+                    "round": 1,
+                    "text_preview": "previous turn"
+                }),
+            ),
+            &test_log_writer(),
+        );
+        projection.apply_event(
+            sample_event(
+                "turn_started",
+                json!({
+                    "run_id": "run-2",
+                    "turn_index": 2,
+                    "message_id": "msg-2"
+                }),
+            ),
+            &test_log_writer(),
+        );
+        projection.apply_event(
+            sample_event(
+                "provider_round_completed",
+                json!({
+                    "run_id": "run-2",
+                    "turn_index": 2,
+                    "round": 1,
+                    "text_preview": "current turn"
+                }),
+            ),
+            &test_log_writer(),
+        );
+        projection.apply_event(
+            sample_event(
+                "tool_executed",
+                json!({
+                    "tool_name": "ExecCommand",
+                    "exec_command_cmd": "cargo test"
+                }),
+            ),
+            &test_log_writer(),
+        );
+
+        let events = projection.hidden_current_turn_events(OperatorVisibility::TurnResult);
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.summary.as_str())
+                .collect::<Vec<_>>(),
+            vec!["current turn", "tool executed: ExecCommand"]
+        );
+    }
+
+    #[test]
+    fn brief_visibility_marks_operator_wait_and_completed_work() {
+        let mut snapshot = sample_snapshot();
+        snapshot.agent.closure.waiting_reason = Some(WaitingReason::AwaitingOperatorInput);
+        let projection = TuiProjection::from_snapshot(snapshot);
+        let wait_brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "Need operator input",
+            None,
+            None,
+        );
+        let wait_event =
+            projection_event_record("brief_created", serde_json::to_value(&wait_brief).unwrap());
+        assert_eq!(
+            projection.operator_visibility(&wait_event),
+            OperatorVisibility::ActionRequired
+        );
+
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let mut completed = WorkItemRecord::new("default", "finish docs", WorkItemState::Completed);
+        completed.id = "work-done".into();
+        projection.work_items = vec![completed];
+        let mut work_brief =
+            BriefRecord::new("default", BriefKind::Result, "Work done", None, None);
+        work_brief.work_item_id = Some("work-done".into());
+        let work_event =
+            projection_event_record("brief_created", serde_json::to_value(&work_brief).unwrap());
+        assert_eq!(
+            projection.operator_visibility(&work_event),
+            OperatorVisibility::WorkDone
         );
     }
 
@@ -1699,6 +1802,18 @@ mod tests {
                 event_type: kind.to_string(),
                 payload,
             },
+        }
+    }
+
+    fn projection_event_record(kind: &str, payload: Value) -> super::ProjectionEventRecord {
+        super::ProjectionEventRecord {
+            id: format!("evt-{kind}"),
+            seq: 1,
+            ts: Utc::now(),
+            kind: kind.to_string(),
+            lane: super::classify_event_lane(kind),
+            summary: kind.to_string(),
+            payload,
         }
     }
 


### PR DESCRIPTION
## Summary
- classify runtime/TUI events into operator visibility levels and use level 3 as the default conversation view
- add `/display <3|4|5>` to switch between result, progress, and trace detail in the TUI
- restore a current-turn Working row from hidden progress/trace events while avoiding stale assistant text after a new user message
- tag provider/tool events with turn/run metadata so the TUI can scope activity to the current turn

## Verification
- cargo test -q
