### PR TITLE
fix: avoid redundant TUI connection label allocation

### DIFF
--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -122,7 +122,7 @@ fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
         OverlayState::HelpView { .. } => "Help: Up/Down, PgUp/PgDn, Home/End, Esc",
     };
 
-    let connection = app.connection_label().to_string();
+    let connection = app.connection_label();
     let model = app
         .selected_agent_summary()
         .map(render_model_status)


### PR DESCRIPTION
## Summary
- address the unresolved Copilot review comment from closed PR #906
- remove a redundant `to_string()` when rendering the TUI connection label

## Verification
- `cargo fmt --check`
- `cargo check -q`
- `git diff --check`
