### PR TITLE
feat: add shared operator event presentation

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -403,9 +403,25 @@ The phase-1 TUI is expected to surface:
 - terminal alternate-screen behavior that can stay in normal scrollback mode
   when the operator environment makes full-screen TUI awkward
 
-The TUI should derive operator-visible presentation from raw runtime events
-through a shared operator visibility classifier. Levels are ordered from most
-operator-facing to most diagnostic:
+Operator-facing surfaces must derive human-visible event text from the shared
+operator event presentation layer before rendering or logging raw runtime
+events. The presentation layer turns a raw event into:
+
+- `visibility`: the operator visibility level
+- `category`: operator notification, brief, message, work item, task, waiting,
+  workspace, runtime, assistant progress, tool, state sync, or trace
+- `title`: short surface label
+- `body`: optional detail text
+- `summary`: one-line human-facing summary
+- `source_event_kind`: the raw runtime event kind
+- `debug_payload`: optional payload retained only for debug/log surfaces
+
+Do not add `severity` or delivery-routing hints to the first version of this
+structure. Severity is contextual, and each surface should decide delivery from
+visibility, category, and runtime context rather than from hard-coded transport
+hints.
+
+Visibility levels are ordered from most operator-facing to most diagnostic:
 
 1. `action_required`: the agent is awaiting operator input and emits an
    operator-facing brief
@@ -420,6 +436,19 @@ The default TUI display level is `3`. The main conversation shows items with
 current-turn items with `operator_visibility > display_level`. When the display
 level is `5`, the Working/activity area should be hidden because progress and
 trace items are already visible.
+
+State-sync events such as `agent_state_changed` and `session_state_changed`
+are projection refresh signals. They may be present in raw/debug event views,
+but they are not conversation messages by themselves. Provider round events
+should distinguish assistant text progress from tool requests:
+
+- text preview present: `Assistant progress: <preview>`
+- tools requested and no text preview: `Model requested tools: ExecCommand,
+  ReadFile`
+- no visible text or tools: concise provider-round progress wording
+
+Tool execution events are trace-level activity and may be shown in the
+Conversation only when the operator raises the display level to `5`.
 
 Working/activity summaries are scoped to the current turn, run, or message
 boundary. A newly submitted operator message must not inherit the previous

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -414,7 +414,6 @@ events. The presentation layer turns a raw event into:
 - `body`: optional detail text
 - `summary`: one-line human-facing summary
 - `source_event_kind`: the raw runtime event kind
-- `debug_payload`: optional payload retained only for debug/log surfaces
 
 Do not add `severity` or delivery-routing hints to the first version of this
 structure. Severity is contextual, and each surface should decide delivery from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod http;
 pub mod ingress;
 pub mod memory;
 pub mod model_catalog;
+pub mod operator_event;
 pub mod policy;
 pub mod prompt;
 pub mod provider;

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -59,7 +59,6 @@ pub struct OperatorEventPresentation {
     pub body: Option<String>,
     pub summary: String,
     pub source_event_kind: String,
-    pub debug_payload: Option<Value>,
 }
 
 #[derive(Debug, Default)]
@@ -117,14 +116,6 @@ pub fn present_operator_event(
     let category = event_category(kind);
     let visibility = event_visibility(kind, payload, category, context);
     let (title, body, summary) = event_text(kind, payload, fallback_summary, category);
-    let debug_payload = if matches!(
-        category,
-        OperatorEventCategory::StateSync | OperatorEventCategory::Trace
-    ) {
-        Some(payload.clone())
-    } else {
-        None
-    };
 
     OperatorEventPresentation {
         visibility,
@@ -133,7 +124,6 @@ pub fn present_operator_event(
         body,
         summary,
         source_event_kind: kind.to_string(),
-        debug_payload,
     }
 }
 
@@ -265,9 +255,9 @@ fn provider_round_text(payload: &Value) -> (String, Option<String>, String) {
     let text_preview = payload
         .get("text_preview")
         .and_then(Value::as_str)
-        .map(str::trim)
+        .map(collapse_whitespace)
         .filter(|text| !text.is_empty());
-    if let Some(text_preview) = text_preview {
+    if let Some(text_preview) = text_preview.as_deref() {
         let body = trim_summary(text_preview);
         return (
             "Assistant progress".into(),
@@ -370,6 +360,10 @@ fn trim_summary(value: &str) -> String {
     }
 }
 
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -390,6 +384,17 @@ mod tests {
         assert_eq!(text.visibility, OperatorVisibility::Progress);
         assert_eq!(text.category, OperatorEventCategory::AssistantProgress);
         assert_eq!(text.summary, "Assistant progress: thinking");
+
+        let multiline = present_operator_event(
+            "provider_round_completed",
+            &json!({ "text_preview": "thinking\n\nabout\ttools  now" }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(
+            multiline.summary,
+            "Assistant progress: thinking about tools now"
+        );
 
         let tools = present_operator_event(
             "provider_round_completed",

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -1,0 +1,418 @@
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use crate::types::{BriefRecord, WorkItemState};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OperatorVisibility {
+    /// Operator attention is required before the agent can continue.
+    ActionRequired = 1,
+    /// A work item reached a durable completion point.
+    WorkDone = 2,
+    /// Default operator-facing turn result or durable conversation event.
+    TurnResult = 3,
+    /// In-turn assistant progress that is useful while the agent is active.
+    Progress = 4,
+    /// Tool and internal trace events for detailed inspection.
+    Trace = 5,
+}
+
+impl OperatorVisibility {
+    pub const DEFAULT_DISPLAY_LEVEL: Self = Self::TurnResult;
+
+    pub fn from_display_level(level: u8) -> Option<Self> {
+        match level {
+            3 => Some(Self::TurnResult),
+            4 => Some(Self::Progress),
+            5 => Some(Self::Trace),
+            _ => None,
+        }
+    }
+
+    pub fn display_level(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperatorEventCategory {
+    OperatorNotification,
+    Brief,
+    Message,
+    WorkItem,
+    Task,
+    Waiting,
+    Workspace,
+    Runtime,
+    AssistantProgress,
+    Tool,
+    StateSync,
+    Trace,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorEventPresentation {
+    pub visibility: OperatorVisibility,
+    pub category: OperatorEventCategory,
+    pub title: String,
+    pub body: Option<String>,
+    pub summary: String,
+    pub source_event_kind: String,
+    pub debug_payload: Option<Value>,
+}
+
+#[derive(Debug, Default)]
+pub struct OperatorPresentationContext {
+    pub awaiting_operator_input: bool,
+    pub completed_work_item_ids: BTreeSet<String>,
+}
+
+impl OperatorEventPresentation {
+    pub fn is_conversation_candidate(&self) -> bool {
+        !matches!(
+            self.category,
+            OperatorEventCategory::AssistantProgress
+                | OperatorEventCategory::Tool
+                | OperatorEventCategory::StateSync
+                | OperatorEventCategory::Trace
+        )
+    }
+
+    pub fn is_current_activity_candidate(&self) -> bool {
+        matches!(
+            self.category,
+            OperatorEventCategory::AssistantProgress
+                | OperatorEventCategory::Tool
+                | OperatorEventCategory::Trace
+                | OperatorEventCategory::Task
+                | OperatorEventCategory::WorkItem
+                | OperatorEventCategory::Waiting
+                | OperatorEventCategory::Workspace
+                | OperatorEventCategory::Runtime
+                | OperatorEventCategory::OperatorNotification
+                | OperatorEventCategory::Brief
+                | OperatorEventCategory::Message
+        )
+    }
+
+    pub fn is_loggable(&self) -> bool {
+        !matches!(self.category, OperatorEventCategory::StateSync)
+    }
+
+    pub fn is_error_loggable(&self) -> bool {
+        matches!(
+            self.source_event_kind.as_str(),
+            "runtime_error" | "turn_terminal"
+        )
+    }
+}
+
+pub fn present_operator_event(
+    kind: &str,
+    payload: &Value,
+    fallback_summary: &str,
+    context: &OperatorPresentationContext,
+) -> OperatorEventPresentation {
+    let category = event_category(kind);
+    let visibility = event_visibility(kind, payload, category, context);
+    let (title, body, summary) = event_text(kind, payload, fallback_summary, category);
+    let debug_payload = if matches!(
+        category,
+        OperatorEventCategory::StateSync | OperatorEventCategory::Trace
+    ) {
+        Some(payload.clone())
+    } else {
+        None
+    };
+
+    OperatorEventPresentation {
+        visibility,
+        category,
+        title,
+        body,
+        summary,
+        source_event_kind: kind.to_string(),
+        debug_payload,
+    }
+}
+
+pub fn is_durable_operator_event_kind(kind: &str) -> bool {
+    matches!(
+        event_category(kind),
+        OperatorEventCategory::OperatorNotification
+            | OperatorEventCategory::Brief
+            | OperatorEventCategory::Message
+            | OperatorEventCategory::WorkItem
+            | OperatorEventCategory::Task
+            | OperatorEventCategory::Waiting
+            | OperatorEventCategory::Workspace
+            | OperatorEventCategory::Runtime
+    )
+}
+
+pub fn is_activity_reset_event_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "turn_started"
+            | "message_processing_started"
+            | "operator_interjection_admitted"
+            | "brief_created"
+            | "turn_terminal"
+            | "runtime_error"
+    )
+}
+
+fn event_category(kind: &str) -> OperatorEventCategory {
+    match kind {
+        "operator_notification_requested" => OperatorEventCategory::OperatorNotification,
+        "brief_created" => OperatorEventCategory::Brief,
+        "message_enqueued" | "turn_started" | "operator_interjection_admitted" => {
+            OperatorEventCategory::Message
+        }
+        "work_item_written" => OperatorEventCategory::WorkItem,
+        "task_created" | "task_status_updated" | "task_result_received" => {
+            OperatorEventCategory::Task
+        }
+        "waiting_intent_created" | "waiting_intent_cancelled" | "callback_delivered" => {
+            OperatorEventCategory::Waiting
+        }
+        "workspace_entered" | "workspace_exited" | "workspace_detached" | "worktree_entered"
+        | "worktree_exited" => OperatorEventCategory::Workspace,
+        "runtime_error" | "turn_terminal" => OperatorEventCategory::Runtime,
+        "provider_round_completed" | "text_only_round_observed" => {
+            OperatorEventCategory::AssistantProgress
+        }
+        "tool_executed" | "tool_execution_failed" => OperatorEventCategory::Tool,
+        "agent_state_changed" | "session_state_changed" => OperatorEventCategory::StateSync,
+        _ => OperatorEventCategory::Trace,
+    }
+}
+
+fn event_visibility(
+    kind: &str,
+    payload: &Value,
+    category: OperatorEventCategory,
+    context: &OperatorPresentationContext,
+) -> OperatorVisibility {
+    match (kind, category) {
+        ("operator_notification_requested", _) => OperatorVisibility::ActionRequired,
+        ("brief_created", _) => brief_visibility(payload, context),
+        ("work_item_written", _) if work_item_completed(payload) => OperatorVisibility::WorkDone,
+        ("work_item_written", _) => OperatorVisibility::Trace,
+        ("runtime_error", _) => OperatorVisibility::TurnResult,
+        (_, OperatorEventCategory::AssistantProgress) => OperatorVisibility::Progress,
+        (_, OperatorEventCategory::Tool)
+        | (_, OperatorEventCategory::Task)
+        | (_, OperatorEventCategory::Waiting)
+        | (_, OperatorEventCategory::Workspace)
+        | (_, OperatorEventCategory::Message)
+        | (_, OperatorEventCategory::StateSync)
+        | (_, OperatorEventCategory::Trace) => OperatorVisibility::Trace,
+        _ if is_durable_operator_event_kind(kind) => OperatorVisibility::TurnResult,
+        _ => OperatorVisibility::Trace,
+    }
+}
+
+fn brief_visibility(payload: &Value, context: &OperatorPresentationContext) -> OperatorVisibility {
+    if context.awaiting_operator_input {
+        return OperatorVisibility::ActionRequired;
+    }
+    let Some(brief) = decode_value::<BriefRecord>(payload.clone()) else {
+        return OperatorVisibility::TurnResult;
+    };
+    if brief
+        .work_item_id
+        .as_deref()
+        .is_some_and(|id| context.completed_work_item_ids.contains(id))
+    {
+        OperatorVisibility::WorkDone
+    } else {
+        OperatorVisibility::TurnResult
+    }
+}
+
+fn work_item_completed(payload: &Value) -> bool {
+    payload
+        .get("record")
+        .cloned()
+        .and_then(decode_value::<crate::types::WorkItemRecord>)
+        .is_some_and(|record| record.state == WorkItemState::Completed)
+}
+
+fn event_text(
+    kind: &str,
+    payload: &Value,
+    fallback_summary: &str,
+    category: OperatorEventCategory,
+) -> (String, Option<String>, String) {
+    match kind {
+        "provider_round_completed" => provider_round_text(payload),
+        "text_only_round_observed" => (
+            "Assistant progress".into(),
+            None,
+            "Text-only model round observed".into(),
+        ),
+        "tool_executed" | "tool_execution_failed" => tool_text(kind, payload, fallback_summary),
+        _ => {
+            let title = category_title(category, kind);
+            (title, None, fallback_summary.to_string())
+        }
+    }
+}
+
+fn provider_round_text(payload: &Value) -> (String, Option<String>, String) {
+    let text_preview = payload
+        .get("text_preview")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty());
+    if let Some(text_preview) = text_preview {
+        let body = trim_summary(text_preview);
+        return (
+            "Assistant progress".into(),
+            Some(body.clone()),
+            format!("Assistant progress: {body}"),
+        );
+    }
+
+    let tool_names = payload
+        .get("tool_names")
+        .and_then(Value::as_array)
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|name| !name.trim().is_empty())
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !tool_names.is_empty() {
+        let tools = tool_names.join(", ");
+        return (
+            "Model requested tools".into(),
+            Some(tools.clone()),
+            format!("Model requested tools: {tools}"),
+        );
+    }
+
+    (
+        "Assistant progress".into(),
+        None,
+        "Provider round completed".into(),
+    )
+}
+
+fn tool_text(
+    kind: &str,
+    payload: &Value,
+    fallback_summary: &str,
+) -> (String, Option<String>, String) {
+    let title = if kind == "tool_execution_failed" {
+        "Tool failed"
+    } else {
+        "Tool executed"
+    };
+    let Some(tool_name) = payload.get("tool_name").and_then(Value::as_str) else {
+        return (title.into(), None, fallback_summary.to_string());
+    };
+    if tool_name == "ExecCommand" {
+        if let Some(cmd) = payload.get("exec_command_cmd").and_then(Value::as_str) {
+            let summary = if kind == "tool_execution_failed" {
+                format!("ExecCommand failed: {cmd}")
+            } else {
+                format!("ExecCommand: {cmd}")
+            };
+            return (title.into(), Some(cmd.to_string()), summary);
+        }
+    }
+    let summary = if kind == "tool_execution_failed" {
+        format!("Tool failed: {tool_name}")
+    } else {
+        format!("Tool executed: {tool_name}")
+    };
+    (title.into(), Some(tool_name.to_string()), summary)
+}
+
+fn category_title(category: OperatorEventCategory, kind: &str) -> String {
+    match category {
+        OperatorEventCategory::OperatorNotification => "Operator attention".into(),
+        OperatorEventCategory::Brief => "Brief".into(),
+        OperatorEventCategory::Message => "Message".into(),
+        OperatorEventCategory::WorkItem => "Work item".into(),
+        OperatorEventCategory::Task => "Task".into(),
+        OperatorEventCategory::Waiting => "External trigger".into(),
+        OperatorEventCategory::Workspace => "Workspace".into(),
+        OperatorEventCategory::Runtime => "Runtime".into(),
+        OperatorEventCategory::AssistantProgress => "Assistant progress".into(),
+        OperatorEventCategory::Tool => "Tool".into(),
+        OperatorEventCategory::StateSync => "State sync".into(),
+        OperatorEventCategory::Trace => kind.to_string(),
+    }
+}
+
+fn decode_value<T: serde::de::DeserializeOwned>(value: Value) -> Option<T> {
+    serde_json::from_value(value).ok()
+}
+
+fn trim_summary(value: &str) -> String {
+    const LIMIT: usize = 120;
+    if value.chars().count() <= LIMIT {
+        value.to_string()
+    } else {
+        let mut trimmed = value
+            .chars()
+            .take(LIMIT.saturating_sub(1))
+            .collect::<String>();
+        trimmed.push('…');
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        present_operator_event, OperatorEventCategory, OperatorPresentationContext,
+        OperatorVisibility,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn provider_round_distinguishes_text_from_tool_requests() {
+        let context = OperatorPresentationContext::default();
+        let text = present_operator_event(
+            "provider_round_completed",
+            &json!({ "text_preview": "thinking", "tool_names": ["ExecCommand"] }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(text.visibility, OperatorVisibility::Progress);
+        assert_eq!(text.category, OperatorEventCategory::AssistantProgress);
+        assert_eq!(text.summary, "Assistant progress: thinking");
+
+        let tools = present_operator_event(
+            "provider_round_completed",
+            &json!({ "text_preview": null, "tool_names": ["ExecCommand", "ReadFile"] }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(
+            tools.summary,
+            "Model requested tools: ExecCommand, ReadFile"
+        );
+    }
+
+    #[test]
+    fn state_sync_is_not_conversation_presentation() {
+        let presentation = present_operator_event(
+            "agent_state_changed",
+            &json!({ "status": "AwakeRunning" }),
+            "agent_state_changed",
+            &OperatorPresentationContext::default(),
+        );
+        assert_eq!(presentation.category, OperatorEventCategory::StateSync);
+        assert_eq!(presentation.visibility, OperatorVisibility::Trace);
+        assert!(!presentation.is_conversation_candidate());
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1963,6 +1963,21 @@ mod tests {
             },
             &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
         );
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-state".into(),
+                event: "agent_state_changed".into(),
+                data: StreamEventEnvelope {
+                    id: "evt-state".into(),
+                    seq: 3,
+                    ts: Utc::now(),
+                    agent_id: "default".into(),
+                    event_type: "agent_state_changed".into(),
+                    payload: json!({ "status": "AwakeRunning" }),
+                },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
         app.projection = Some(projection);
 
         let items = collect_chat_items(&app);
@@ -1974,9 +1989,11 @@ mod tests {
         assert!(items.iter().any(|item| matches!(
             item,
             ConversationCell::SystemNotice { body, .. }
-                if body.contains("tool executed: ExecCommand")
+                if body.contains("ExecCommand: cargo test tui")
         )));
-        assert!(rendered.contains("tool executed: ExecCommand"));
+        assert!(rendered.contains("ExecCommand: cargo test tui"));
+        assert!(!rendered.contains("State sync"));
+        assert!(!rendered.contains("agent_state_changed"));
         assert!(!rendered.contains("Working"));
     }
 

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -175,18 +175,21 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
             if event.kind == "message_enqueued" || event.kind == "brief_created" {
                 continue;
             }
-            if is_progress_event_kind(&event.kind) {
+            if is_progress_event(event) {
                 cells.push(ConversationCell::AssistantMarkdown(AssistantMarkdownCell {
                     created_at: event.ts,
                     agent_id: "Holon (progress)".to_string(),
                     markdown: conversation_event_body(event),
                 }));
-            } else if is_chat_visible_conversation_event(&event.kind)
-                || projection.operator_visibility(event).display_level() >= 4
+            } else if !matches!(
+                event.presentation.category,
+                crate::operator_event::OperatorEventCategory::StateSync
+            ) && (is_chat_visible_conversation_event(event)
+                || projection.operator_visibility(event).display_level() >= 4)
             {
                 cells.push(ConversationCell::SystemNotice {
                     created_at: event.ts,
-                    speaker: conversation_event_speaker(&event.kind),
+                    speaker: conversation_event_speaker(event),
                     body: conversation_event_body(event),
                 });
             }
@@ -239,8 +242,16 @@ fn push_pending_operator_message_cell(
     });
 }
 
-pub(super) fn is_chat_visible_conversation_event(kind: &str) -> bool {
-    matches!(kind, "operator_notification_requested" | "runtime_error")
+pub(super) fn is_chat_visible_conversation_event(
+    event: &crate::tui::projection::ProjectionEventRecord,
+) -> bool {
+    event.presentation.is_conversation_candidate()
+        && matches!(
+            event.presentation.visibility,
+            crate::operator_event::OperatorVisibility::ActionRequired
+                | crate::operator_event::OperatorVisibility::TurnResult
+                | crate::operator_event::OperatorVisibility::WorkDone
+        )
 }
 
 impl ConversationCell {
@@ -613,41 +624,7 @@ fn latest_action_event<'a>(
         .iter()
         .rev()
         .copied()
-        .find(|event| is_active_action_event_kind(&event.kind))
-}
-
-fn is_active_action_event_kind(kind: &str) -> bool {
-    matches!(
-        kind,
-        "tool_executed"
-            | "tool_execution_failed"
-            | "task_created"
-            | "task_status_updated"
-            | "task_result_received"
-            | "work_item_written"
-            | "waiting_intent_created"
-            | "waiting_intent_cancelled"
-            | "callback_delivered"
-            | "operator_notification_requested"
-            | "workspace_entered"
-            | "workspace_exited"
-            | "workspace_detached"
-            | "worktree_entered"
-            | "worktree_exited"
-            | "worktree_auto_cleaned_up"
-            | "worktree_auto_cleanup_failed"
-            | "task_worktree_branch_cleanup_retained"
-            | "skill_activated"
-            | "system_tick_emitted"
-            | "message_admitted"
-            | "message_processing_started"
-            | "control_applied"
-            | "brief_created"
-            | "turn_terminal"
-            | "runtime_error"
-            | "max_output_tokens_recovery"
-            | "turn_local_checkpoint_recorded"
-    )
+        .find(|event| event.presentation.is_current_activity_candidate())
 }
 
 fn latest_assistant_message(
@@ -662,16 +639,20 @@ fn latest_assistant_message(
 fn assistant_message_from_event(
     event: &crate::tui::projection::ProjectionEventRecord,
 ) -> Option<String> {
-    if event.kind != "provider_round_completed" && event.kind != "text_only_round_observed" {
+    if !is_progress_event(event) {
         return None;
     }
-    event.payload.get("text_preview").and_then(non_empty_value)
+    event
+        .presentation
+        .body
+        .clone()
+        .or_else(|| event.payload.get("text_preview").and_then(non_empty_value))
 }
 
-fn is_progress_event_kind(kind: &str) -> bool {
+fn is_progress_event(event: &crate::tui::projection::ProjectionEventRecord) -> bool {
     matches!(
-        kind,
-        "provider_round_completed" | "text_only_round_observed"
+        event.presentation.category,
+        crate::operator_event::OperatorEventCategory::AssistantProgress
     )
 }
 
@@ -787,18 +768,13 @@ fn compact_json(value: &Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "<invalid json>".into())
 }
 
-fn conversation_event_speaker(kind: &str) -> String {
-    match kind {
-        "task_created" | "task_status_updated" | "task_result_received" | "work_item_written" => {
-            "System (work)".into()
-        }
-        "waiting_intent_created" | "waiting_intent_cancelled" | "callback_delivered" => {
-            "System (waiting)".into()
-        }
-        "workspace_entered" | "workspace_exited" | "worktree_entered" | "worktree_exited" => {
-            "System (workspace)".into()
-        }
-        "runtime_error" | "turn_terminal" => "System (runtime)".into(),
+fn conversation_event_speaker(event: &crate::tui::projection::ProjectionEventRecord) -> String {
+    match event.presentation.category {
+        crate::operator_event::OperatorEventCategory::Task
+        | crate::operator_event::OperatorEventCategory::WorkItem => "System (work)".into(),
+        crate::operator_event::OperatorEventCategory::Waiting => "System (waiting)".into(),
+        crate::operator_event::OperatorEventCategory::Workspace => "System (workspace)".into(),
+        crate::operator_event::OperatorEventCategory::Runtime => "System (runtime)".into(),
         _ => "System".into(),
     }
 }
@@ -806,50 +782,31 @@ fn conversation_event_speaker(kind: &str) -> String {
 pub(super) fn conversation_event_body(
     event: &crate::tui::projection::ProjectionEventRecord,
 ) -> String {
-    let prefix = match event.kind.as_str() {
-        "task_created" => "[task] ",
-        "task_status_updated" => "[task] ",
-        "task_result_received" => "[task] ",
-        "work_item_written" => "[work-item] ",
-        "waiting_intent_created" => "[external-trigger] ",
-        "waiting_intent_cancelled" => "[external-trigger] ",
-        "callback_delivered" => "[external-trigger] ",
-        "workspace_entered" => "[workspace] ",
-        "workspace_exited" => "[workspace] ",
-        "worktree_entered" => "[worktree] ",
-        "worktree_exited" => "[worktree] ",
-        "runtime_error" => "[runtime-error] ",
-        "turn_terminal" => "[turn] ",
+    let prefix = match event.presentation.category {
+        crate::operator_event::OperatorEventCategory::Task => "[task] ",
+        crate::operator_event::OperatorEventCategory::WorkItem => "[work-item] ",
+        crate::operator_event::OperatorEventCategory::Waiting => "[external-trigger] ",
+        crate::operator_event::OperatorEventCategory::Workspace
+            if event.kind.starts_with("worktree_") =>
+        {
+            "[worktree] "
+        }
+        crate::operator_event::OperatorEventCategory::Workspace => "[workspace] ",
+        crate::operator_event::OperatorEventCategory::Runtime if event.kind == "runtime_error" => {
+            "[runtime-error] "
+        }
+        crate::operator_event::OperatorEventCategory::Runtime => "[turn] ",
         _ => "",
     };
     format!("{prefix}{}", event.summary)
 }
 
 fn progress_event_body(event: &crate::tui::projection::ProjectionEventRecord) -> String {
-    if event.kind == "tool_executed" || event.kind == "tool_execution_failed" {
-        return event
-            .payload
-            .get("tool_name")
-            .and_then(serde_json::Value::as_str)
-            .map(|tool_name| {
-                if tool_name == "ExecCommand" {
-                    event
-                        .payload
-                        .get("exec_command_cmd")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|cmd| {
-                            if event.kind == "tool_execution_failed" {
-                                format!("ExecCommand failed: {cmd}")
-                            } else {
-                                format!("ExecCommand: {cmd}")
-                            }
-                        })
-                        .unwrap_or_else(|| event.summary.clone())
-                } else {
-                    event.summary.clone()
-                }
-            })
-            .unwrap_or_else(|| event.summary.clone());
+    if matches!(
+        event.presentation.category,
+        crate::operator_event::OperatorEventCategory::Tool
+    ) {
+        return event.summary.clone();
     }
     conversation_event_body(event)
 }
@@ -892,42 +849,54 @@ fn trim_preview(input: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{is_chat_visible_conversation_event, progress_event_body};
+    use crate::operator_event::{present_operator_event, OperatorPresentationContext};
     use crate::tui::projection::{ProjectionEventLane, ProjectionEventRecord};
     use chrono::Utc;
-    use serde_json::json;
+    use serde_json::{json, Value};
 
-    #[test]
-    fn progress_event_body_shows_full_exec_command() {
-        let event = ProjectionEventRecord {
+    fn event(kind: &str, summary: &str, payload: Value) -> ProjectionEventRecord {
+        let presentation = present_operator_event(
+            kind,
+            &payload,
+            summary,
+            &OperatorPresentationContext::default(),
+        );
+        ProjectionEventRecord {
             id: "evt-1".into(),
             seq: 1,
             ts: Utc::now(),
             lane: ProjectionEventLane::Debug,
-            kind: "tool_executed".into(),
-            summary: "tool executed: ExecCommand".into(),
-            payload: json!({
+            kind: kind.into(),
+            summary: presentation.summary.clone(),
+            presentation,
+            payload,
+        }
+    }
+
+    #[test]
+    fn progress_event_body_shows_full_exec_command() {
+        let event = event(
+            "tool_executed",
+            "tool executed: ExecCommand",
+            json!({
                 "tool_name": "ExecCommand",
                 "exec_command_cmd": "git status --short --branch"
             }),
-        };
+        );
         let rendered = progress_event_body(&event);
         assert_eq!(rendered, "ExecCommand: git status --short --branch");
     }
 
     #[test]
     fn progress_event_body_marks_failed_exec_command() {
-        let event = ProjectionEventRecord {
-            id: "evt-2".into(),
-            seq: 2,
-            ts: Utc::now(),
-            lane: ProjectionEventLane::Debug,
-            kind: "tool_execution_failed".into(),
-            summary: "tool execution failed: ExecCommand".into(),
-            payload: json!({
+        let event = event(
+            "tool_execution_failed",
+            "tool execution failed: ExecCommand",
+            json!({
                 "tool_name": "ExecCommand",
                 "exec_command_cmd": "cargo test tui"
             }),
-        };
+        );
 
         let rendered = progress_event_body(&event);
 
@@ -936,39 +905,39 @@ mod tests {
 
     #[test]
     fn progress_event_body_uses_summary_for_non_command_tools() {
-        let event = ProjectionEventRecord {
-            id: "evt-2".into(),
-            seq: 2,
-            ts: Utc::now(),
-            lane: ProjectionEventLane::Debug,
-            kind: "tool_executed".into(),
-            summary: "tool executed: Sleep".into(),
-            payload: json!({
+        let event = event(
+            "tool_executed",
+            "tool executed: Sleep",
+            json!({
                 "tool_name": "Sleep"
             }),
-        };
+        );
         let rendered = progress_event_body(&event);
-        assert_eq!(rendered, "tool executed: Sleep");
+        assert_eq!(rendered, "Tool executed: Sleep");
     }
 
     #[test]
     fn chat_visible_conversation_events_are_user_facing_only() {
-        assert!(is_chat_visible_conversation_event(
-            "operator_notification_requested"
-        ));
-        assert!(is_chat_visible_conversation_event("runtime_error"));
+        assert!(is_chat_visible_conversation_event(&event(
+            "operator_notification_requested",
+            "needs input",
+            json!({})
+        )));
+        assert!(is_chat_visible_conversation_event(&event(
+            "runtime_error",
+            "runtime error",
+            json!({})
+        )));
 
-        assert!(!is_chat_visible_conversation_event("work_item_written"));
-        assert!(!is_chat_visible_conversation_event(
-            "waiting_intent_created"
-        ));
-        assert!(!is_chat_visible_conversation_event(
-            "waiting_intent_cancelled"
-        ));
-        assert!(!is_chat_visible_conversation_event("callback_delivered"));
-        assert!(!is_chat_visible_conversation_event("workspace_attached"));
-        assert!(!is_chat_visible_conversation_event(
-            "provider_round_completed"
-        ));
+        assert!(!is_chat_visible_conversation_event(&event(
+            "workspace_attached",
+            "workspace",
+            json!({})
+        )));
+        assert!(!is_chat_visible_conversation_event(&event(
+            "provider_round_completed",
+            "round",
+            json!({})
+        )));
     }
 }

--- a/src/tui/logging.rs
+++ b/src/tui/logging.rs
@@ -53,7 +53,7 @@ impl TuiLogWriter {
             )?;
         }
 
-        if is_chat_visible_conversation_event(&event.kind) {
+        if is_chat_visible_conversation_event(event) {
             append_jsonl(
                 &self.root.join("conversation.jsonl"),
                 &PersistedConversationLogRecord::from_event(event),
@@ -105,20 +105,10 @@ impl<'a> PersistedConversationLogRecord<'a> {
             event_id: &event.id,
             seq: event.seq,
             kind: &event.kind,
-            speaker: conversation_log_speaker(&event.kind),
+            speaker: event.presentation.title.clone(),
             body: conversation_event_body(event),
             payload: &event.payload,
         }
-    }
-}
-
-fn conversation_log_speaker(kind: &str) -> String {
-    match kind {
-        "runtime_error" | "turn_terminal" => "System (runtime)".into(),
-        "provider_round_completed" | "text_only_round_observed" | "max_output_tokens_recovery" => {
-            "System".into()
-        }
-        _ => "System".into(),
     }
 }
 

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -12,8 +12,13 @@ use serde_json::{json, Value};
 
 use super::logging::TuiLogWriter;
 
+pub(crate) use crate::operator_event::OperatorVisibility;
 use crate::{
     client::{AgentStateSnapshot, AgentStreamEvent, StateSessionSnapshot, StateWorkspaceSnapshot},
+    operator_event::{
+        is_activity_reset_event_kind, is_durable_operator_event_kind, present_operator_event,
+        OperatorEventCategory, OperatorEventPresentation, OperatorPresentationContext,
+    },
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
         ActiveWorkspaceEntry, AgentState, AgentSummary, BriefRecord, ClosureDecision,
@@ -53,37 +58,6 @@ pub(crate) enum ProjectionEventLane {
     Debug,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum OperatorVisibility {
-    /// Operator attention is required before the agent can continue.
-    ActionRequired = 1,
-    /// A work item reached a durable completion point.
-    WorkDone = 2,
-    /// Default operator-facing turn result or durable conversation event.
-    TurnResult = 3,
-    /// In-turn assistant progress that is useful while the agent is active.
-    Progress = 4,
-    /// Tool and internal trace events for detailed inspection.
-    Trace = 5,
-}
-
-impl OperatorVisibility {
-    pub(crate) const DEFAULT_DISPLAY_LEVEL: Self = Self::TurnResult;
-
-    pub(crate) fn from_display_level(level: u8) -> Option<Self> {
-        match level {
-            3 => Some(Self::TurnResult),
-            4 => Some(Self::Progress),
-            5 => Some(Self::Trace),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn display_level(self) -> u8 {
-        self as u8
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ProjectionEventRecord {
     pub(crate) id: String,
@@ -92,6 +66,7 @@ pub(crate) struct ProjectionEventRecord {
     pub(crate) kind: String,
     pub(crate) lane: ProjectionEventLane,
     pub(crate) summary: String,
+    pub(crate) presentation: OperatorEventPresentation,
     pub(crate) payload: Value,
 }
 
@@ -153,13 +128,22 @@ impl TuiProjection {
     }
 
     pub(crate) fn apply_event(&mut self, event: AgentStreamEvent, log_writer: &TuiLogWriter) {
+        let fallback_summary = summarize_event(&event);
+        let presentation_context = self.operator_presentation_context();
+        let presentation = present_operator_event(
+            &event.data.event_type,
+            &event.data.payload,
+            &fallback_summary,
+            &presentation_context,
+        );
         let record = ProjectionEventRecord {
             id: event.id.clone(),
             seq: event.data.seq,
             ts: event.data.ts,
             kind: event.data.event_type.clone(),
-            lane: classify_event_lane(&event.data.event_type),
-            summary: summarize_event(&event),
+            lane: classify_event_lane(&presentation),
+            summary: presentation.summary.clone(),
+            presentation,
             payload: event.data.payload.clone(),
         };
         push_limited(&mut self.event_log, record.clone(), EVENT_LOG_LIMIT);
@@ -439,7 +423,7 @@ impl TuiProjection {
     pub(crate) fn recent_activity_events(&self) -> Vec<&ProjectionEventRecord> {
         let mut events = Vec::new();
         for event in self.current_turn_events_rev() {
-            if is_ephemeral_activity_kind(&event.kind) {
+            if event.presentation.is_current_activity_candidate() {
                 events.push(event);
             }
             if events.len() >= 4 {
@@ -473,40 +457,20 @@ impl TuiProjection {
     }
 
     pub(crate) fn operator_visibility(&self, event: &ProjectionEventRecord) -> OperatorVisibility {
-        match event.kind.as_str() {
-            "operator_notification_requested" => OperatorVisibility::ActionRequired,
-            "brief_created" => self.brief_visibility(event),
-            "work_item_written" if work_item_event_completed(event) => OperatorVisibility::WorkDone,
-            "runtime_error" => OperatorVisibility::TurnResult,
-            "provider_round_completed" | "text_only_round_observed" => OperatorVisibility::Progress,
-            "tool_executed"
-            | "tool_execution_failed"
-            | "max_output_tokens_recovery"
-            | "turn_local_checkpoint_recorded" => OperatorVisibility::Trace,
-            _ if is_ephemeral_activity_kind(&event.kind) => OperatorVisibility::Trace,
-            _ if is_durable_conversation_kind(&event.kind) => OperatorVisibility::TurnResult,
-            _ => OperatorVisibility::Trace,
-        }
+        event.presentation.visibility
     }
 
-    fn brief_visibility(&self, event: &ProjectionEventRecord) -> OperatorVisibility {
-        if self.agent.closure.waiting_reason
-            == Some(crate::types::WaitingReason::AwaitingOperatorInput)
-        {
-            return OperatorVisibility::ActionRequired;
-        }
-        let Some(brief) = decode_payload::<BriefRecord>(&event.payload) else {
-            return OperatorVisibility::TurnResult;
-        };
-        if brief
-            .work_item_id
-            .as_deref()
-            .and_then(|work_item_id| self.work_items.iter().find(|item| item.id == work_item_id))
-            .is_some_and(|item| item.state == WorkItemState::Completed)
-        {
-            OperatorVisibility::WorkDone
-        } else {
-            OperatorVisibility::TurnResult
+    fn operator_presentation_context(&self) -> OperatorPresentationContext {
+        let completed_work_item_ids = self
+            .work_items
+            .iter()
+            .filter(|item| item.state == WorkItemState::Completed)
+            .map(|item| item.id.clone())
+            .collect();
+        OperatorPresentationContext {
+            awaiting_operator_input: self.agent.closure.waiting_reason
+                == Some(crate::types::WaitingReason::AwaitingOperatorInput),
+            completed_work_item_ids,
         }
     }
 
@@ -536,7 +500,7 @@ impl TuiProjection {
         self.event_log
             .iter()
             .rev()
-            .filter(|event| is_loggable_event_kind(&event.kind))
+            .filter(|event| event.presentation.is_loggable())
             .take(limit)
             .collect::<Vec<_>>()
             .into_iter()
@@ -837,89 +801,22 @@ fn operator_message_from_enqueued(message: &MessageEnvelope) -> OperatorMessageR
 }
 
 pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
-    matches!(
-        kind,
-        "message_enqueued"
-            | "turn_started"
-            | "operator_interjection_admitted"
-            | "brief_created"
-            | "runtime_error"
-            | "turn_terminal"
-            | "task_created"
-            | "task_status_updated"
-            | "task_result_received"
-            | "work_item_written"
-            | "waiting_intent_created"
-            | "waiting_intent_cancelled"
-            | "callback_delivered"
-            | "operator_notification_requested"
-            | "workspace_entered"
-            | "workspace_exited"
-            | "workspace_detached"
-            | "worktree_entered"
-            | "worktree_exited"
-    )
-}
-
-pub(crate) fn is_ephemeral_activity_kind(kind: &str) -> bool {
-    matches!(
-        kind,
-        "provider_round_completed"
-            | "text_only_round_observed"
-            | "tool_executed"
-            | "tool_execution_failed"
-            | "skill_activated"
-            | "system_tick_emitted"
-            | "workspace_attached"
-            | "worktree_auto_cleaned_up"
-            | "worktree_auto_cleanup_failed"
-            | "task_worktree_branch_cleanup_retained"
-    )
-}
-
-fn is_loggable_event_kind(kind: &str) -> bool {
-    matches!(
-        kind,
-        "message_enqueued"
-            | "turn_started"
-            | "provider_round_completed"
-            | "text_only_round_observed"
-            | "tool_executed"
-            | "tool_execution_failed"
-            | "task_created"
-            | "task_status_updated"
-            | "task_result_received"
-            | "work_item_written"
-            | "waiting_intent_created"
-            | "waiting_intent_cancelled"
-            | "callback_delivered"
-            | "operator_notification_requested"
-            | "workspace_entered"
-            | "workspace_exited"
-            | "worktree_entered"
-            | "worktree_exited"
-            | "runtime_error"
-            | "operator_interjection_admitted"
-            | "turn_terminal"
-    )
+    is_durable_operator_event_kind(kind)
 }
 
 fn is_activity_reset_kind(kind: &str) -> bool {
-    matches!(
-        kind,
-        "turn_started"
-            | "message_processing_started"
-            | "operator_interjection_admitted"
-            | "brief_created"
-            | "turn_terminal"
-            | "runtime_error"
-    )
+    is_activity_reset_event_kind(kind)
 }
 
-fn classify_event_lane(kind: &str) -> ProjectionEventLane {
-    if is_durable_conversation_kind(kind) {
+fn classify_event_lane(presentation: &OperatorEventPresentation) -> ProjectionEventLane {
+    if presentation.is_conversation_candidate() {
         ProjectionEventLane::Timeline
-    } else if is_ephemeral_activity_kind(kind) {
+    } else if matches!(
+        presentation.category,
+        OperatorEventCategory::AssistantProgress
+            | OperatorEventCategory::Tool
+            | OperatorEventCategory::Trace
+    ) {
         ProjectionEventLane::Debug
     } else {
         ProjectionEventLane::State
@@ -1093,6 +990,7 @@ mod tests {
             AgentStateSnapshot, AgentStreamEvent, StateSessionSnapshot, StateWorkspaceSnapshot,
             StreamEventEnvelope,
         },
+        operator_event::{present_operator_event, OperatorPresentationContext},
         system::{
             ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind,
         },
@@ -1255,7 +1153,7 @@ mod tests {
                 .event_log()
                 .last()
                 .map(|event| event.summary.as_str()),
-            Some("provider round completed")
+            Some("Provider round completed")
         );
     }
 
@@ -1319,7 +1217,10 @@ mod tests {
                 .iter()
                 .map(|event| event.summary.as_str())
                 .collect::<Vec<_>>(),
-            vec!["current turn", "tool executed: ExecCommand"]
+            vec![
+                "Assistant progress: current turn",
+                "ExecCommand: cargo test"
+            ]
         );
     }
 
@@ -1327,7 +1228,50 @@ mod tests {
     fn brief_visibility_marks_operator_wait_and_completed_work() {
         let mut snapshot = sample_snapshot();
         snapshot.agent.closure.waiting_reason = Some(WaitingReason::AwaitingOperatorInput);
-        let projection = TuiProjection::from_snapshot(snapshot);
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+        let wait_brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "Need operator input",
+            None,
+            None,
+        );
+        assert_eq!(
+            {
+                projection.apply_event(
+                    sample_event("brief_created", serde_json::to_value(&wait_brief).unwrap()),
+                    &test_log_writer(),
+                );
+                projection
+                    .event_log()
+                    .last()
+                    .map(|event| projection.operator_visibility(event))
+            },
+            Some(OperatorVisibility::ActionRequired)
+        );
+
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let mut completed = WorkItemRecord::new("default", "finish docs", WorkItemState::Completed);
+        completed.id = "work-done".into();
+        projection.work_items = vec![completed];
+        let mut work_brief =
+            BriefRecord::new("default", BriefKind::Result, "Work done", None, None);
+        work_brief.work_item_id = Some("work-done".into());
+        projection.apply_event(
+            sample_event("brief_created", serde_json::to_value(&work_brief).unwrap()),
+            &test_log_writer(),
+        );
+        assert_eq!(
+            projection
+                .event_log()
+                .last()
+                .map(|event| projection.operator_visibility(event)),
+            Some(OperatorVisibility::WorkDone)
+        );
+    }
+
+    #[test]
+    fn projection_event_record_helper_uses_default_context() {
         let wait_brief = BriefRecord::new(
             "default",
             BriefKind::Result,
@@ -1338,22 +1282,8 @@ mod tests {
         let wait_event =
             projection_event_record("brief_created", serde_json::to_value(&wait_brief).unwrap());
         assert_eq!(
-            projection.operator_visibility(&wait_event),
-            OperatorVisibility::ActionRequired
-        );
-
-        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
-        let mut completed = WorkItemRecord::new("default", "finish docs", WorkItemState::Completed);
-        completed.id = "work-done".into();
-        projection.work_items = vec![completed];
-        let mut work_brief =
-            BriefRecord::new("default", BriefKind::Result, "Work done", None, None);
-        work_brief.work_item_id = Some("work-done".into());
-        let work_event =
-            projection_event_record("brief_created", serde_json::to_value(&work_brief).unwrap());
-        assert_eq!(
-            projection.operator_visibility(&work_event),
-            OperatorVisibility::WorkDone
+            wait_event.presentation.visibility,
+            OperatorVisibility::TurnResult
         );
     }
 
@@ -1833,13 +1763,20 @@ mod tests {
     }
 
     fn projection_event_record(kind: &str, payload: Value) -> super::ProjectionEventRecord {
+        let presentation = present_operator_event(
+            kind,
+            &payload,
+            kind,
+            &OperatorPresentationContext::default(),
+        );
         super::ProjectionEventRecord {
             id: format!("evt-{kind}"),
             seq: 1,
             ts: Utc::now(),
             kind: kind.to_string(),
-            lane: super::classify_event_lane(kind),
-            summary: kind.to_string(),
+            lane: super::classify_event_lane(&presentation),
+            summary: presentation.summary.clone(),
+            presentation,
             payload,
         }
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -496,10 +496,10 @@ pub(super) fn render_header(agent: &AgentSummary) -> String {
 pub(super) fn render_projection_event_summary(
     event: &crate::tui::projection::ProjectionEventRecord,
 ) -> String {
-    let description = if event.summary == event.kind {
+    let description = if event.presentation.title == event.summary {
         event.summary.clone()
     } else {
-        format!("{}: {}", event.kind, event.summary)
+        format!("{}: {}", event.presentation.title, event.summary)
     };
     format!(
         "{} [{:?}] {}",

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -496,11 +496,13 @@ pub(super) fn render_header(agent: &AgentSummary) -> String {
 pub(super) fn render_projection_event_summary(
     event: &crate::tui::projection::ProjectionEventRecord,
 ) -> String {
-    let description = if event.presentation.title == event.summary {
-        event.summary.clone()
-    } else {
-        format!("{}: {}", event.presentation.title, event.summary)
-    };
+    let title_prefix = format!("{}:", event.presentation.title);
+    let description =
+        if event.presentation.title == event.summary || event.summary.starts_with(&title_prefix) {
+            event.summary.clone()
+        } else {
+            format!("{}: {}", event.presentation.title, event.summary)
+        };
     format!(
         "{} [{:?}] {}",
         event.ts.with_timezone(&Local).format("%H:%M:%S"),


### PR DESCRIPTION
## Summary

- Adds a shared `operator_event` presentation layer for runtime events.
- Moves TUI visibility/category/text decisions onto `OperatorEventPresentation`.
- Keeps state-sync events out of Conversation while allowing trace-level tool events at display level 5.
- Documents the #919 presentation contract in `docs/runtime-spec.md`.

## Verification

- `cargo fmt --check`
- `cargo test -q operator_event`
- `cargo test -q tui`

Closes #919.
