### PR TITLE
fix: disclose host-local execution limits

### DIFF
--- a/docs/rfc-implementation-notes/policy-and-execution-boundary.md
+++ b/docs/rfc-implementation-notes/policy-and-execution-boundary.md
@@ -15,6 +15,19 @@ process-execution policy as first-class concepts. It distinguishes the active
 workspace from shell `cwd` and reports host-local containment limitations rather
 than pretending the local backend is a hard sandbox.
 
+The v0.14 minimum closure is honest projection, not hard sandbox enforcement:
+
+- execution context renders `backend=host_local`;
+- path, write, network, secret, and child-process confinement are projected as
+  `not_enforced`;
+- command execution audit records include the resolved execution snapshot and
+  host-local boundary metadata;
+- TUI/operator summaries must display the same backend and confinement
+  limitations instead of only showing an internal enum.
+
+Hard filesystem, network, secret, and child-process sandbox enforcement remains
+deferred to #920 / `v0.15.0`.
+
 That explicit reporting is useful, but it is not the same as complete
 enforcement. Current policy posture should be treated as partial until
 admission and execution checks consistently gate sensitive actions.
@@ -23,8 +36,8 @@ admission and execution checks consistently gate sensitive actions.
 
 1. Strengthen auth/admission checks for control-plane and mutating workspace
    operations.
-2. Keep host-local execution limitations visible in operator projection and
-   tool receipts.
+2. Keep host-local execution limitations visible in any new operator projection
+   or model-visible receipt surfaces.
 3. Avoid policy drift between instruction-level behavior and runtime-enforced
    behavior.
 4. Add tests for denied operations, not only successful operations.

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1330,9 +1330,14 @@ Rules:
 - `exclusive_write` means only one writer is coordinated for a root; readers may still enter.
 - under `host_local`, process execution is projected and attributed, but path,
   write, network, secret, and child-process confinement are not hard guarantees.
+- operator-visible runtime projections should render these limitations
+  explicitly as `not_enforced`; they must not imply denied-operation sandbox
+  behavior while the backend remains `host_local`.
 - under `host_local`, process execution, background-task scheduling, and
   worktree projection are all gated through the effective execution-policy
   boundary rather than through scattered per-surface checks.
+- hard filesystem, network, secret, and child-process sandbox enforcement is
+  deferred to #920 / `v0.15.0`.
 - task-owned worktree artifact cleanup is runtime-owned lifecycle work driven
   by task detail metadata, not by a model-facing destructive tool.
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -2461,6 +2461,18 @@ mod tests {
         assert!(execution_section
             .content
             .contains("path_confinement: not_enforced"));
+        assert!(execution_section
+            .content
+            .contains("write_confinement: not_enforced"));
+        assert!(execution_section
+            .content
+            .contains("network_confinement: not_enforced"));
+        assert!(execution_section
+            .content
+            .contains("secret_isolation: not_enforced"));
+        assert!(execution_section
+            .content
+            .contains("child_process_containment: not_enforced"));
     }
 
     #[test]

--- a/src/system/host_local_policy.rs
+++ b/src/system/host_local_policy.rs
@@ -207,7 +207,7 @@ pub fn execution_policy_summary_lines(execution: &ExecutionSnapshot) -> Vec<Stri
 
 pub fn execution_confinement_summary_line(execution: &ExecutionSnapshot) -> String {
     format!(
-        "Confinement: path={}, write={}, network={}, secrets={}, child_process={}",
+        "Confinement: path_confinement={}, write_confinement={}, network_confinement={}, secret_isolation={}, child_process_containment={}",
         execution_guarantee_label(execution.policy.process_execution.path_confinement),
         execution_guarantee_label(execution.policy.process_execution.write_confinement),
         execution_guarantee_label(execution.policy.process_execution.network_confinement),

--- a/src/system/host_local_policy.rs
+++ b/src/system/host_local_policy.rs
@@ -204,3 +204,14 @@ pub fn execution_policy_summary_lines(execution: &ExecutionSnapshot) -> Vec<Stri
 
     lines
 }
+
+pub fn execution_confinement_summary_line(execution: &ExecutionSnapshot) -> String {
+    format!(
+        "Confinement: path={}, write={}, network={}, secrets={}, child_process={}",
+        execution_guarantee_label(execution.policy.process_execution.path_confinement),
+        execution_guarantee_label(execution.policy.process_execution.write_confinement),
+        execution_guarantee_label(execution.policy.process_execution.network_confinement),
+        execution_guarantee_label(execution.policy.process_execution.secret_isolation),
+        execution_guarantee_label(execution.policy.process_execution.child_process_containment)
+    )
+}

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -8,7 +8,8 @@ pub mod workspace;
 pub use file::FileHost;
 pub use host_local_policy::{
     ensure_background_task_allowed, ensure_process_execution_allowed,
-    ensure_workspace_projection_allowed, execution_policy_summary_lines, HostLocalBoundary,
+    ensure_workspace_projection_allowed, execution_confinement_summary_line,
+    execution_policy_summary_lines, HostLocalBoundary,
 };
 pub use local::LocalSystem;
 pub use process::{ProcessHost, RunningProcess};

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1079,7 +1079,7 @@ mod tests {
         assert!(rendered.contains("Execution backend: host_local"));
         assert!(rendered.contains("Process execution: runtime_shaped"));
         assert!(rendered.contains(
-            "Confinement: path=not_enforced, write=not_enforced, network=not_enforced, secrets=not_enforced, child_process=not_enforced"
+            "Confinement: path_confinement=not_enforced, write_confinement=not_enforced, network_confinement=not_enforced, secret_isolation=not_enforced, child_process_containment=not_enforced"
         ));
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -867,8 +867,17 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
     ));
     lines.push(String::new());
     lines.push(format!(
-        "Execution backend: {:?}",
-        agent.execution.policy.backend
+        "Execution backend: {}",
+        crate::system::execution_backend_label(agent.execution.policy.backend)
+    ));
+    lines.push(format!(
+        "Process execution: {}",
+        crate::system::execution_guarantee_label(
+            agent.execution.policy.resource_authority.process_execution
+        )
+    ));
+    lines.push(crate::system::execution_confinement_summary_line(
+        &agent.execution,
     ));
     lines.join("\n")
 }
@@ -1067,6 +1076,11 @@ mod tests {
         assert!(
             rendered.contains("child_1:AwakeRunning[private/parent_supervised (private_child)]")
         );
+        assert!(rendered.contains("Execution backend: host_local"));
+        assert!(rendered.contains("Process execution: runtime_shaped"));
+        assert!(rendered.contains(
+            "Confinement: path=not_enforced, write=not_enforced, network=not_enforced, secrets=not_enforced, child_process=not_enforced"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- render host-local execution summaries with stable labels plus explicit confinement limitations
- expand prompt-context projection tests so all host-local confinement fields are asserted as `not_enforced`
- update runtime/RFC notes to keep v0.14 scoped to honest projection and defer hard sandboxing to #920 / v0.15.0

## Verification

- `cargo fmt --check`
- `cargo test -q host_local_policy_snapshot_reports_capability_boundary`
- `cargo test -q execution_snapshot_derives_missing_policy_from_profile`
- `cargo test -q build_context_includes_execution_environment`
- `cargo test -q tui`
- `cargo test -q --test prompt_context_snapshots`
- `git diff --check`

Closes #921
