### PR TITLE
feat: add authorized event replay projection

### DIFF
--- a/docs/rfc-implementation-notes/event-and-operator-transport.md
+++ b/docs/rfc-implementation-notes/event-and-operator-transport.md
@@ -22,6 +22,21 @@ operator contract:
 - how operator intervention attaches to an existing work item or waiting
   posture.
 
+The v0.14 replay/projection minimum is:
+
+- `/events` is a recent replay projection surface, not the raw append-only log
+  as a public API.
+- replay preserves safe provenance outside the event payload: cursor/id,
+  sequence, timestamp, event kind, agent id, origin, trust, authority class,
+  delivery surface, admission context, transport/source, reply route, message
+  id, task id, work item id, correlation id, and causation id when available.
+- operator replay is the default projection and only includes raw payloads for
+  explicitly allowlisted event kinds.
+- local first-party debug replay may include raw payloads only after control
+  authorization.
+- cursor expiry remains a deterministic `/state` refresh path rather than a
+  client-side history reconstruction guess.
+
 ## Open gaps
 
 1. Define the remote operator delivery envelope before treating a transport as

--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -177,7 +177,8 @@ replaying arbitrary historical events.
 The event endpoint provides the incremental updates after snapshot bootstrap.
 
 The stream is per-agent. It should emit Holon's raw events relevant to the
-requested agent.
+requested agent through an authorized replay projection, not by exposing the
+append-only internal log as a public API.
 
 ### Replay Behavior
 
@@ -189,6 +190,38 @@ requested agent.
 
 Replay failure must be explicit and deterministic. A client must know when it
 has to discard its local projection and rebuild from `/state`.
+
+Replay is historical projection/state recovery only. Replayed records must not
+be treated as new ingress, must not synthesize operator intent, and must not
+trigger tool execution.
+
+### Replay Projection Boundary
+
+The replay surface authorizes and projects events before delivery. Presentation
+visibility and replay authorization are related but separate concerns:
+
+- `OperatorVisibility` tells a client how prominently an already-authorized
+  event-derived item should be displayed.
+- replay projection decides which payload fields a client is allowed to
+  receive.
+
+Every replay envelope should preserve safe provenance needed for recovery and
+audit, including event cursor/id, sequence, timestamp, event kind, agent id,
+and any available origin, trust, authority class, delivery surface, admission
+context, transport/source, reply route, message id, task id, work item id,
+correlation id, and causation id.
+
+Payloads that contain trace/internal detail require an explicit projection
+capability or must be redacted before replay. This includes raw tool output,
+raw external payloads, internal diagnostics, local paths, and artifact
+references. Redaction should keep enough stable summary/provenance fields for a
+client to reconcile state without receiving the raw internal detail.
+
+The default replay projection is the operator projection. Operator replay may
+include raw payloads only for explicit schema-stable allowlisted event kinds;
+all other payloads must be redacted regardless of their presentation
+visibility. A local debug projection may expose raw payloads, but it requires
+control authorization and is not the public default.
 
 ## Event Envelope
 
@@ -203,6 +236,17 @@ Every stream event should use one canonical envelope.
   "ts": "2026-04-18T14:00:00Z",
   "agent_id": "default",
   "type": "task_status_updated",
+  "projection": {
+    "name": "operator",
+    "raw_payload_included": false,
+    "redactions": ["internal_detail_payload"]
+  },
+  "provenance": {
+    "origin": {"kind": "operator"},
+    "trust": "trusted_operator",
+    "authority_class": "operator_instruction",
+    "delivery_surface": "http_control_prompt"
+  },
   "payload": {}
 }
 ```
@@ -220,8 +264,16 @@ Every stream event should use one canonical envelope.
   - agent identity
 - `type`
   - raw runtime event kind
+- `projection`
+  - the replay projection applied to this envelope
+  - `raw_payload_included=false` means the payload is a safe projection, not
+    the raw event data
+- `provenance`
+  - provenance fields that survive replay projection independently of payload
+    redaction
 - `payload`
-  - raw event payload
+  - authorized projected payload
+  - may be raw only when the selected replay projection permits it
 
 ### SSE Projection
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -420,6 +420,25 @@ structure. Severity is contextual, and each surface should decide delivery from
 visibility, category, and runtime context rather than from hard-coded transport
 hints.
 
+Event replay is a separate authorization/projection boundary. A replayed event
+is historical state recovery, not re-ingress, re-execution, or a new operator
+instruction. The stream envelope must carry safe provenance independently of
+the event payload so payload redaction does not erase audit context. Required
+replay provenance includes the event cursor/id, sequence, timestamp, event
+kind, agent id, and any available origin, trust, authority class, delivery
+surface, admission context, transport/source, reply route, message id, task id,
+work item id, correlation id, and causation id.
+
+Operator replay is the default projection. It may include raw payloads only for
+explicitly allowlisted schema-stable event kinds; all other payloads must be
+redacted even when the same event would have prominent presentation visibility.
+Trace/internal payloads, including raw tool output, raw external payloads, local
+paths, artifact references, and internal diagnostics, require a stronger debug
+projection. A local debug replay projection may expose raw payloads only after
+control authorization. A client may still decide how to display an authorized
+event from `visibility`, but display level is not the same as replay
+authorization.
+
 Visibility levels are ordered from most operator-facing to most diagnostic:
 
 1. `action_required`: the agent is awaiting operator input and emits an

--- a/src/client.rs
+++ b/src/client.rs
@@ -117,6 +117,7 @@ pub struct EventStreamRequest {
     pub since: Option<String>,
     pub last_event_id: Option<String>,
     pub limit: Option<usize>,
+    pub projection: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -127,6 +128,10 @@ pub struct StreamEventEnvelope {
     pub agent_id: String,
     #[serde(rename = "type")]
     pub event_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<Value>,
     pub payload: Value,
 }
 
@@ -865,6 +870,9 @@ fn event_stream_path(agent_id: &str, request: &EventStreamRequest) -> Result<Str
         if let Some(since) = request.since.as_deref() {
             query.append_pair("since", since);
         }
+        if let Some(projection) = request.projection.as_deref() {
+            query.append_pair("projection", projection);
+        }
     }
 
     let mut path = url.path().to_string();
@@ -1169,10 +1177,14 @@ mod tests {
                 since: Some("evt_123".into()),
                 last_event_id: Some("evt_122".into()),
                 limit: Some(20),
+                projection: Some("local_debug".into()),
             },
         )
         .unwrap();
-        assert_eq!(path, "/agents/default/events?limit=20&since=evt_123");
+        assert_eq!(
+            path,
+            "/agents/default/events?limit=20&since=evt_123&projection=local_debug"
+        );
     }
 
     #[test]
@@ -1183,6 +1195,7 @@ mod tests {
                 since: Some("evt?x=1&y=2".into()),
                 last_event_id: None,
                 limit: None,
+                projection: None,
             },
         )
         .unwrap();

--- a/src/http.rs
+++ b/src/http.rs
@@ -320,6 +320,51 @@ pub struct LimitQuery {
 pub struct EventsQuery {
     limit: Option<usize>,
     since: Option<String>,
+    projection: Option<EventReplayProjection>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum EventReplayProjection {
+    LocalDebug,
+    Operator,
+}
+
+#[derive(Debug, Serialize)]
+struct EventReplayProjectionRecord {
+    name: EventReplayProjection,
+    raw_payload_included: bool,
+    redactions: Vec<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct EventReplayProvenance {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    origin: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trust: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    authority_class: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delivery_surface: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    admission_context: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transport: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reply_route: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task_id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    work_item_id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    correlation_id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    causation_id: Option<Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -366,6 +411,8 @@ struct StreamEventEnvelope {
     agent_id: String,
     #[serde(rename = "type")]
     event_type: String,
+    projection: EventReplayProjectionRecord,
+    provenance: EventReplayProvenance,
     payload: Value,
 }
 
@@ -373,6 +420,7 @@ struct EventStreamState {
     runtime: crate::runtime::RuntimeHandle,
     runtime_id: String,
     event_window_limit: usize,
+    projection: EventReplayProjection,
     event_marker: FileActivityMarker,
     last_seen_cursor: Option<String>,
     next_seq: u64,
@@ -977,6 +1025,10 @@ pub async fn events(
         .get_public_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
+    let projection = query.projection.unwrap_or(EventReplayProjection::Operator);
+    if projection == EventReplayProjection::LocalDebug {
+        authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    }
     let initial_event_marker = runtime
         .storage()
         .poll_activity_marker()
@@ -994,6 +1046,7 @@ pub async fn events(
             runtime,
             runtime_id: agent_id,
             event_window_limit,
+            projection,
             event_marker: initial_event_marker,
             last_seen_cursor,
             next_seq: 0,
@@ -1001,7 +1054,12 @@ pub async fn events(
         };
         loop {
             if let Some(event) = state.buffered.pop_front() {
-                let envelope = stream_event_envelope(state.next_seq, &state.runtime_id, &event);
+                let envelope = stream_event_envelope(
+                    state.next_seq,
+                    &state.runtime_id,
+                    &event,
+                    state.projection,
+                );
                 state.next_seq += 1;
                 state.last_seen_cursor = Some(event.id.clone());
                 let payload = serde_json::to_string(&envelope).unwrap_or_else(|_| "{}".to_string());
@@ -1094,15 +1152,132 @@ fn refresh_buffered_events(
     Ok(())
 }
 
-fn stream_event_envelope(seq: u64, agent_id: &str, event: &AuditEvent) -> StreamEventEnvelope {
+fn stream_event_envelope(
+    seq: u64,
+    agent_id: &str,
+    event: &AuditEvent,
+    projection: EventReplayProjection,
+) -> StreamEventEnvelope {
+    let projected = project_event_payload_for_replay(event, projection);
     StreamEventEnvelope {
         id: event.id.clone(),
         seq,
         ts: event.created_at,
         agent_id: agent_id.to_string(),
         event_type: event.kind.clone(),
-        payload: event.data.clone(),
+        projection: projected.projection,
+        provenance: projected.provenance,
+        payload: projected.payload,
     }
+}
+
+struct ProjectedReplayEvent {
+    payload: Value,
+    projection: EventReplayProjectionRecord,
+    provenance: EventReplayProvenance,
+}
+
+fn project_event_payload_for_replay(
+    event: &AuditEvent,
+    projection: EventReplayProjection,
+) -> ProjectedReplayEvent {
+    let provenance = event_replay_provenance(&event.data);
+    match projection {
+        EventReplayProjection::LocalDebug => ProjectedReplayEvent {
+            payload: event.data.clone(),
+            projection: EventReplayProjectionRecord {
+                name: projection,
+                raw_payload_included: true,
+                redactions: Vec::new(),
+            },
+            provenance,
+        },
+        EventReplayProjection::Operator => {
+            if is_raw_operator_replay_allowed(&event.kind) {
+                return ProjectedReplayEvent {
+                    payload: event.data.clone(),
+                    projection: EventReplayProjectionRecord {
+                        name: projection,
+                        raw_payload_included: true,
+                        redactions: Vec::new(),
+                    },
+                    provenance,
+                };
+            }
+            ProjectedReplayEvent {
+                payload: redacted_operator_replay_payload(event),
+                projection: EventReplayProjectionRecord {
+                    name: projection,
+                    raw_payload_included: false,
+                    redactions: vec!["internal_detail_payload".to_string()],
+                },
+                provenance,
+            }
+        }
+    }
+}
+
+fn is_raw_operator_replay_allowed(event_kind: &str) -> bool {
+    matches!(
+        event_kind,
+        "message_admitted"
+            | "brief_created"
+            | "waiting_intent_created"
+            | "waiting_intent_cancelled"
+            | "work_item_written"
+            | "work_item_completed"
+            | "workspace_entered"
+            | "workspace_exited"
+    )
+}
+
+fn event_replay_provenance(payload: &Value) -> EventReplayProvenance {
+    EventReplayProvenance {
+        origin: clone_payload_field(payload, "origin"),
+        trust: clone_payload_field(payload, "trust"),
+        authority_class: clone_payload_field(payload, "authority_class"),
+        delivery_surface: clone_payload_field(payload, "delivery_surface"),
+        admission_context: clone_payload_field(payload, "admission_context"),
+        transport: clone_payload_field(payload, "transport"),
+        source: clone_payload_field(payload, "source"),
+        reply_route: clone_payload_field(payload, "reply_route"),
+        message_id: clone_payload_field(payload, "message_id"),
+        task_id: clone_payload_field(payload, "task_id"),
+        work_item_id: clone_payload_field(payload, "work_item_id"),
+        correlation_id: clone_payload_field(payload, "correlation_id"),
+        causation_id: clone_payload_field(payload, "causation_id"),
+    }
+}
+
+fn redacted_operator_replay_payload(event: &AuditEvent) -> Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert("redacted".to_string(), Value::Bool(true));
+    payload.insert(
+        "redaction_reason".to_string(),
+        Value::String("internal_detail_requires_trace_projection".to_string()),
+    );
+    payload.insert("summary".to_string(), Value::String(event.kind.clone()));
+    for field in [
+        "agent_id",
+        "message_id",
+        "task_id",
+        "work_item_id",
+        "run_id",
+        "turn_index",
+        "round",
+        "status",
+        "kind",
+        "tool_name",
+    ] {
+        if let Some(value) = clone_payload_field(&event.data, field) {
+            payload.insert(field.to_string(), value);
+        }
+    }
+    Value::Object(payload)
+}
+
+fn clone_payload_field(payload: &Value, field: &str) -> Option<Value> {
+    payload.get(field).filter(|value| !value.is_null()).cloned()
 }
 
 fn cursor_too_old(cursor: String) -> (StatusCode, Json<Value>) {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1889,6 +1889,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "work_item_written".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({
                         "action": "created",
                         "record": {
@@ -1917,6 +1919,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "provider_round_completed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({ "round": 1, "text_preview": "hidden provider partial" }),
                 },
             },
@@ -1955,6 +1959,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "tool_executed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({
                         "tool_name": "ExecCommand",
                         "exec_command_cmd": "cargo test tui"
@@ -1973,6 +1979,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "agent_state_changed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({ "status": "AwakeRunning" }),
                 },
             },
@@ -2014,6 +2022,8 @@ mod tests {
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "task_result_received".into(),
+                projection: None,
+                provenance: None,
                 payload: json!({
                     "id": "task-1",
                     "agent_id": "default",
@@ -2066,6 +2076,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "tool_executed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({
                         "tool_name": "ExecCommand",
                         "exec_command_cmd": "cargo test tui"
@@ -2084,6 +2096,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "brief_created".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({
                         "id": "brief-1",
                         "agent_id": "default",
@@ -2139,6 +2153,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "tool_executed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({
                         "tool_name": "ExecCommand",
                         "exec_command_cmd": "cargo test tui"
@@ -2182,6 +2198,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "tool_executed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({
                         "tool_name": "ExecCommand",
                         "exec_command_cmd": "cargo test stale"
@@ -2259,6 +2277,8 @@ mod tests {
                     ts,
                     agent_id: "default".into(),
                     event_type: "tool_executed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({
                         "tool_name": "ExecCommand",
                         "exec_command_cmd": "cargo test tui"
@@ -2569,6 +2589,8 @@ mod tests {
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "provider_round_completed".into(),
+                    projection: None,
+                    provenance: None,
                     payload: json!({"text_preview":"older"}),
                 },
             },
@@ -2591,6 +2613,8 @@ mod tests {
                         ts: Utc::now(),
                         agent_id: "default".into(),
                         event_type: "provider_round_completed".into(),
+                        projection: None,
+                        provenance: None,
                         payload: json!({"text_preview":"newer"}),
                     },
                 },
@@ -2837,6 +2861,8 @@ mod tests {
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "waiting_intent_created".into(),
+                projection: None,
+                provenance: None,
                 payload: json!({
                     "waiting_intent_id": "wait-2",
                     "external_trigger_id": "cb-2",

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1528,6 +1528,8 @@ mod tests {
                         ts: Utc::now(),
                         agent_id: "default".into(),
                         event_type: "provider_round_completed".into(),
+                        projection: None,
+                        provenance: None,
                         payload: json!({ "text_preview": format!("partial-{index}") }),
                     },
                 },
@@ -1757,6 +1759,8 @@ mod tests {
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: kind.to_string(),
+                projection: None,
+                provenance: None,
                 payload,
             },
         }

--- a/tests/http_events.rs
+++ b/tests/http_events.rs
@@ -14,5 +14,8 @@ macro_rules! http_async_tests {
 http_async_tests!(
     events_route_supports_cursor_replay,
     events_route_supports_last_event_id_header_and_rfc3339_ts,
+    events_route_preserves_replay_provenance,
+    events_route_operator_projection_redacts_trace_payload,
+    events_route_local_debug_projection_requires_control_auth,
     events_route_with_missing_cursor_returns_refresh_hint,
 );

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -119,6 +119,24 @@ pub async fn local_client_over_http_can_stream_events_with_since_query() -> Resu
     let first_event = tokio::time::timeout(Duration::from_secs(5), stream.next_event()).await??;
     assert_eq!(first_event.event, "message_admitted");
     assert_eq!(first_event.data.event_type, "message_admitted");
+    assert_eq!(
+        first_event
+            .data
+            .projection
+            .as_ref()
+            .and_then(|projection| projection.get("name"))
+            .and_then(|name| name.as_str()),
+        Some("operator")
+    );
+    assert_eq!(
+        first_event
+            .data
+            .provenance
+            .as_ref()
+            .and_then(|provenance| provenance.get("trust"))
+            .and_then(|trust| trust.as_str()),
+        Some("trusted_operator")
+    );
 
     server.abort();
     Ok(())

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -19,7 +19,7 @@ use holon::{
     provider::{AgentProvider, ProviderTurnRequest, ProviderTurnResponse, StubProvider},
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
-        AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
+        AdmissionContext, AgentStatus, AuditEvent, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
         OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
@@ -125,6 +125,150 @@ pub async fn events_route_supports_last_event_id_header_and_rfc3339_ts() -> Resu
         replayed.data["ts"].as_str().expect("ts should be a string")
     )
     .is_ok());
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn events_route_preserves_replay_provenance() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    client
+        .post(format!("{base}/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": "provenance bootstrap" }))
+        .send()
+        .await?;
+    wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
+
+    let bootstrap: serde_json::Value = client
+        .get(format!("{base}/agents/default/state"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let cursor = bootstrap["cursor"]
+        .as_str()
+        .expect("cursor should be present")
+        .to_string();
+
+    client
+        .post(format!("{base}/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": "provenance replay" }))
+        .send()
+        .await?;
+
+    let mut stream = client
+        .get(format!("{base}/agents/default/events?since={cursor}"))
+        .send()
+        .await?;
+    let replayed =
+        tokio::time::timeout(Duration::from_secs(5), read_next_sse_event(&mut stream)).await??;
+    assert_eq!(replayed.event, "message_admitted");
+    assert_eq!(replayed.data["type"], "message_admitted");
+    assert_eq!(replayed.data["provenance"]["origin"]["kind"], "operator");
+    assert_eq!(replayed.data["provenance"]["trust"], "trusted_operator");
+    assert_eq!(
+        replayed.data["provenance"]["authority_class"],
+        "operator_instruction"
+    );
+    assert_eq!(
+        replayed.data["provenance"]["delivery_surface"],
+        "http_control_prompt"
+    );
+    assert_eq!(
+        replayed.data["projection"]["name"],
+        serde_json::json!("operator")
+    );
+    assert_eq!(
+        replayed.data["projection"]["raw_payload_included"],
+        serde_json::json!(true)
+    );
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn events_route_operator_projection_redacts_trace_payload() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    client
+        .post(format!("{base}/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": "operator projection bootstrap" }))
+        .send()
+        .await?;
+    wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
+
+    let bootstrap: serde_json::Value = client
+        .get(format!("{base}/agents/default/state"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let cursor = bootstrap["cursor"]
+        .as_str()
+        .expect("cursor should be present")
+        .to_string();
+
+    runtime.storage().append_event(&AuditEvent::new(
+        "tool_executed",
+        serde_json::json!({
+            "agent_id": "default",
+            "tool_name": "ExecCommand",
+            "task_id": "task-secret",
+            "exec_command_cmd": "cat /private/tmp/secret-command.txt",
+            "raw_output": "secret command output",
+            "local_path": "/private/tmp/secret-output.txt",
+            "artifact_ref": "artifact://secret",
+        }),
+    ))?;
+
+    let mut stream = client
+        .get(format!(
+            "{base}/agents/default/events?since={cursor}&projection=operator"
+        ))
+        .send()
+        .await?;
+    let replayed =
+        tokio::time::timeout(Duration::from_secs(5), read_next_sse_event(&mut stream)).await??;
+    assert_eq!(replayed.event, "tool_executed");
+    assert_eq!(replayed.data["type"], "tool_executed");
+    assert_eq!(replayed.data["projection"]["name"], "operator");
+    assert_eq!(replayed.data["projection"]["raw_payload_included"], false);
+    assert_eq!(replayed.data["payload"]["redacted"], true);
+    assert_eq!(replayed.data["payload"]["tool_name"], "ExecCommand");
+    assert_eq!(replayed.data["payload"]["task_id"], "task-secret");
+
+    let replayed_text = serde_json::to_string(&replayed.data)?;
+    assert!(!replayed_text.contains("secret-command"));
+    assert!(!replayed_text.contains("secret command output"));
+    assert!(!replayed_text.contains("/private/tmp/secret-output.txt"));
+    assert!(!replayed_text.contains("artifact://secret"));
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn events_route_local_debug_projection_requires_control_auth() -> Result<()> {
+    let config = test_config_with_paths(
+        tempdir()?.keep(),
+        tempdir()?.keep(),
+        "127.0.0.1:0".into(),
+        ControlAuthMode::Required,
+    );
+    let (_host, base, server) = spawn_server_with_config(config).await?;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!(
+            "{base}/agents/default/events?projection=local_debug"
+        ))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary

- add explicit event replay projection metadata to `/events` envelopes
- preserve replay provenance outside the projected payload so redaction does not erase audit context
- add an operator replay projection that redacts trace/internal payload detail while keeping safe reconciliation fields
- document the replay/projection boundary and its relationship to #919 operator presentation visibility

Closes #922

## Verification

- `cargo fmt --check`
- `cargo test -q --test http_events`
- `cargo test -q --test http_client`
- `cargo test -q tui`
- `git diff --check`
