### PR TITLE
feat: project delegated child supervision

### DIFF
--- a/docs/rfcs/agent-delegation-tool-plane.md
+++ b/docs/rfcs/agent-delegation-tool-plane.md
@@ -150,6 +150,19 @@ private child delegation. Worktree isolation is represented with metadata:
 - worktree path and branch metadata
 - artifact cleanup state
 
+The operator-facing projection for that task is `child_supervision`. It is
+returned by `SpawnAgent(private_child, ...)` and repeated by `TaskStatus` and
+`TaskOutput` so every surface uses the same names:
+
+- `child_agent_id` is the delegated private context
+- `supervision_task_id` is the parent-visible handle for status, output, stop,
+  and follow-up delivery
+- `parent_agent_id` and optional work-item delegation ids preserve ownership
+- `cleanup_owner=supervision_task` keeps worktree artifacts attached to the
+  supervising task rather than to the child identity
+- `followup_target=parent_supervisor` keeps child blocked/notify/follow-up
+  traffic inside the parent-supervisor boundary
+
 ## Migration Direction
 
 The safest migration path is:

--- a/docs/rfcs/task-surface-narrowing.md
+++ b/docs/rfcs/task-surface-narrowing.md
@@ -171,6 +171,11 @@ That means:
 The task handle is therefore not the child agent itself.
 
 It is a parent-visible supervision capability for a managed execution unit.
+Receipts and task snapshots should keep that distinction explicit by exposing
+both `child_agent_id` and `supervision_task_id` when the task is a supervised
+private child. The shared `child_supervision` projection is the operator-facing
+shape for that boundary; it is not a raw child transcript and it should not be
+treated as an alternate agent identity.
 
 ## `TaskStatus` Instead Of `TaskGet`
 
@@ -243,6 +248,8 @@ worktree should be treated as task-owned artifact state:
 - completion of the child turn does not automatically transfer ownership to the
   child agent
 - cleanup responsibility belongs to task cleanup or later artifact GC
+- operator-facing cleanup state is projected under `child_supervision` with
+  `cleanup_owner=supervision_task`
 
 This means `worktree_subagent_task` should not remain a runtime-created task
 kind. Holon now uses a unified `child_agent_task` plus

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -835,6 +835,9 @@ Delegation rules:
 - omitted `preset` defaults to `private_child`
 - `private_child` returns `agent_id` plus a task handle that maps onto internal
   `child_agent_task` supervision state
+- `private_child` also returns `child_agent_id`, `supervision_task_id`, and a
+  `child_supervision` projection; `child_agent_id` names the private context,
+  while `supervision_task_id` names the parent-visible control handle
 - `public_named` requires an explicit `agent_id` and returns only `agent_id`
 - spawning a new `public_named` agent may record lineage provenance without
   placing that agent under parent supervision
@@ -868,6 +871,9 @@ Agent inspection rules:
 - parent-visible child summaries should expose a compact observability snapshot
   together with the same identity semantics, rather than forcing parent agents
   to infer progress from raw output polling or changed files alone
+- parent-visible child supervision should use the same projection shape in
+  `SpawnAgent`, `TaskStatus`, and `TaskOutput` so UI, logs, and delivery messages
+  do not invent competing names for the same boundary
 
 ## Core Runtime Model
 
@@ -2270,6 +2276,22 @@ Phase-1 envelope rules:
   - `last_result_brief`: recent terminal brief
 - an `interrupted` supervision task may still carry live `child_observability`
   after daemon restart when the parent-supervised private child remains active
+- for `child_agent_task`, `TaskStatus.task.child_supervision` and
+  `TaskOutputResult.task.child_supervision` expose the operator-facing
+  supervision projection:
+  - `parent_agent_id`: the supervising parent agent
+  - `child_agent_id`: the private delegated child context
+  - `supervision_task_id`: the parent-visible task handle for status, output,
+    stop, and follow-up delivery
+  - `parent_work_item_id`, `child_work_item_id`, and `delegation_id` when the
+    child is linked through work-item delegation
+  - `workspace_mode` and `worktree` when the child uses inherited workspace or a
+    task-owned worktree artifact
+  - `cleanup_owner = supervision_task`; worktree cleanup state belongs to the
+    supervising task, not to the child identity
+  - `followup_target = parent_supervisor`; child `notify_operator`, blocked
+    posture, and parent follow-up are projected to the supervising parent
+    boundary, not to ordinary user/operator message channels
 - `AgentGet.active_children` should expose the same child observability fields
   alongside child identity and lifecycle metadata so parents can inspect
   in-flight delegated work without collapsing agent-plane and task-plane
@@ -2284,6 +2306,8 @@ Phase-1 envelope rules:
   - `input_target = stdin` means pipe-backed command continuation
   - `input_target = tty` means managed PTY-backed continuation for a
     `tty = true` command task
+  - `input_target = child_followup` means parent follow-up delivered to a
+    supervised private child through the supervising task handle
 - `TaskOutput` remains the heavyweight output envelope:
   - `TaskOutputResult { retrieval_status, task }`
   - `TaskOutputResult.task` is the canonical v0.14 task-result envelope for
@@ -2299,6 +2323,7 @@ Phase-1 envelope rules:
     - `result_summary`
     - `exit_status`
     - `failure_artifact`
+    - `child_supervision`
   - `output_preview` is a bounded model-facing preview, never the promise of
     full task output
   - `output_truncated = true` means `output_preview` was clipped at the
@@ -2316,8 +2341,9 @@ Phase-1 envelope rules:
     one combined stream rather than a guaranteed stdout/stderr split
   - for `child_agent_task`, this same envelope is a compatible subset:
     `task_id`, `kind`, `status`, `summary`, `output_preview`,
-    `output_truncated`, and `result_summary` are meaningful; command-only fields
-    such as `exit_status` and command-output artifact indices may be absent
+    `output_truncated`, `result_summary`, and `child_supervision` are meaningful;
+    command-only fields such as `exit_status` and command-output artifact
+    indices may be absent
 - `TaskStop` returns a stable structured stop receipt:
   - updated `task` snapshot
   - whether stop was requested
@@ -2418,6 +2444,10 @@ delegated work that is currently supervised through an internal
    audit event instead of blocking task completion
 
 This supports parallel experimentation without polluting the parent workspace.
+The operator-facing projection presents the worktree as a supervising-task
+artifact: retained worktrees mean review or cleanup is pending on that
+supervision handle, not that the private child has become a durable public
+agent.
 
 ### Recovery
 

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -160,15 +160,31 @@ fn event_category(kind: &str) -> OperatorEventCategory {
         "message_enqueued" | "turn_started" | "operator_interjection_admitted" => {
             OperatorEventCategory::Message
         }
-        "work_item_written" => OperatorEventCategory::WorkItem,
-        "task_created" | "task_status_updated" | "task_result_received" => {
-            OperatorEventCategory::Task
+        "work_item_written" | "work_item_delegation_created" | "work_item_delegation_completed" => {
+            OperatorEventCategory::WorkItem
         }
+        "task_created"
+        | "task_status_updated"
+        | "task_result_received"
+        | "task_child_spawned"
+        | "task_input_delivered" => OperatorEventCategory::Task,
         "waiting_intent_created" | "waiting_intent_cancelled" | "callback_delivered" => {
             OperatorEventCategory::Waiting
         }
-        "workspace_entered" | "workspace_exited" | "workspace_detached" | "worktree_entered"
-        | "worktree_exited" => OperatorEventCategory::Workspace,
+        "workspace_entered"
+        | "workspace_exited"
+        | "workspace_detached"
+        | "worktree_entered"
+        | "worktree_exited"
+        | "worktree_created_for_task"
+        | "task_worktree_metadata_recorded"
+        | "worktree_retained_for_review"
+        | "worktree_auto_cleaned_up"
+        | "worktree_auto_cleanup_failed"
+        | "task_worktree_cleanup_already_removed"
+        | "task_worktree_cleanup_retained"
+        | "task_worktree_cleanup_failed"
+        | "task_worktree_branch_cleanup_retained" => OperatorEventCategory::Workspace,
         "runtime_error" | "turn_terminal" => OperatorEventCategory::Runtime,
         "provider_round_completed" | "text_only_round_observed" => {
             OperatorEventCategory::AssistantProgress
@@ -237,6 +253,11 @@ fn event_text(
     category: OperatorEventCategory,
 ) -> (String, Option<String>, String) {
     match kind {
+        "operator_notification_requested" => operator_notification_text(payload, fallback_summary),
+        "task_child_spawned" => task_child_spawned_text(payload, fallback_summary),
+        "task_input_delivered" => task_input_delivered_text(payload, fallback_summary),
+        "work_item_delegation_created" => work_item_delegation_text(payload, false),
+        "work_item_delegation_completed" => work_item_delegation_text(payload, true),
         "provider_round_completed" => provider_round_text(payload),
         "text_only_round_observed" => (
             "Assistant progress".into(),
@@ -248,6 +269,119 @@ fn event_text(
             let title = category_title(category, kind);
             (title, None, fallback_summary.to_string())
         }
+    }
+}
+
+fn operator_notification_text(
+    payload: &Value,
+    fallback_summary: &str,
+) -> (String, Option<String>, String) {
+    let summary = payload
+        .get("summary")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("message").and_then(Value::as_str))
+        .map(trim_summary)
+        .unwrap_or_else(|| fallback_summary.to_string());
+    let boundary = payload
+        .get("target_operator_boundary")
+        .and_then(Value::as_str)
+        .unwrap_or("primary_operator");
+    if boundary == "parent_supervisor" {
+        let requested_by = payload
+            .get("requested_by_agent_id")
+            .and_then(Value::as_str)
+            .unwrap_or("child");
+        return (
+            "Parent supervision needed".into(),
+            Some(summary.clone()),
+            format!("Child {requested_by} needs parent supervision: {summary}"),
+        );
+    }
+    (
+        "Operator attention".into(),
+        Some(summary.clone()),
+        format!("Operator attention needed: {summary}"),
+    )
+}
+
+fn task_child_spawned_text(
+    payload: &Value,
+    fallback_summary: &str,
+) -> (String, Option<String>, String) {
+    let task_id = payload.get("id").and_then(Value::as_str);
+    let child_agent_id = payload
+        .get("detail")
+        .and_then(|detail| detail.get("child_agent_id"))
+        .and_then(Value::as_str);
+    let workspace_mode = payload
+        .get("detail")
+        .and_then(|detail| detail.get("workspace_mode"))
+        .and_then(Value::as_str);
+    let summary = match (child_agent_id, task_id) {
+        (Some(child), Some(task)) => {
+            let mut text = format!("Delegated child {child} started under supervision task {task}");
+            if let Some(mode) = workspace_mode {
+                text.push_str(&format!(" ({mode})"));
+            }
+            text
+        }
+        _ => fallback_summary.to_string(),
+    };
+    (
+        "Delegated child started".into(),
+        child_agent_id.map(ToString::to_string),
+        summary,
+    )
+}
+
+fn task_input_delivered_text(
+    payload: &Value,
+    fallback_summary: &str,
+) -> (String, Option<String>, String) {
+    let child_agent_id = payload.get("child_agent_id").and_then(Value::as_str);
+    let task_id = payload.get("task_id").and_then(Value::as_str);
+    let input_target = payload.get("input_target").and_then(Value::as_str);
+    if input_target == Some("child_followup") {
+        if let (Some(child), Some(task)) = (child_agent_id, task_id) {
+            return (
+                "Parent follow-up delivered".into(),
+                Some(child.to_string()),
+                format!("Parent follow-up delivered to child {child} via supervision task {task}"),
+            );
+        }
+    }
+    (
+        "Task input delivered".into(),
+        task_id.map(ToString::to_string),
+        fallback_summary.to_string(),
+    )
+}
+
+fn work_item_delegation_text(payload: &Value, completed: bool) -> (String, Option<String>, String) {
+    let parent = payload
+        .get("parent_work_item_id")
+        .and_then(Value::as_str)
+        .unwrap_or("parent work item");
+    let child = payload
+        .get("child_work_item_id")
+        .and_then(Value::as_str)
+        .unwrap_or("child work item");
+    let child_agent = payload
+        .get("child_agent_id")
+        .and_then(Value::as_str)
+        .unwrap_or("child");
+    if completed {
+        (
+            "Delegated work completed".into(),
+            Some(child_agent.to_string()),
+            format!("Delegated work from {parent} completed by child {child_agent} ({child})"),
+        )
+    } else {
+        (
+            "Delegated work linked".into(),
+            Some(child_agent.to_string()),
+            format!("Delegated work from {parent} linked to child {child_agent} ({child})"),
+        )
     }
 }
 
@@ -419,5 +553,61 @@ mod tests {
         assert_eq!(presentation.category, OperatorEventCategory::StateSync);
         assert_eq!(presentation.visibility, OperatorVisibility::Trace);
         assert!(!presentation.is_conversation_candidate());
+    }
+
+    #[test]
+    fn delegated_child_events_use_supervision_vocabulary() {
+        let context = OperatorPresentationContext::default();
+        let spawned = present_operator_event(
+            "task_child_spawned",
+            &json!({
+                "id": "task-1",
+                "detail": {
+                    "child_agent_id": "child-1",
+                    "workspace_mode": "worktree"
+                }
+            }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(spawned.category, OperatorEventCategory::Task);
+        assert_eq!(spawned.title, "Delegated child started");
+        assert_eq!(
+            spawned.summary,
+            "Delegated child child-1 started under supervision task task-1 (worktree)"
+        );
+
+        let followup = present_operator_event(
+            "task_input_delivered",
+            &json!({
+                "task_id": "task-1",
+                "child_agent_id": "child-1",
+                "input_target": "child_followup"
+            }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(followup.title, "Parent follow-up delivered");
+        assert_eq!(
+            followup.summary,
+            "Parent follow-up delivered to child child-1 via supervision task task-1"
+        );
+
+        let notification = present_operator_event(
+            "operator_notification_requested",
+            &json!({
+                "requested_by_agent_id": "child-1",
+                "target_operator_boundary": "parent_supervisor",
+                "summary": "need parent decision"
+            }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(notification.visibility, OperatorVisibility::ActionRequired);
+        assert_eq!(notification.title, "Parent supervision needed");
+        assert_eq!(
+            notification.summary,
+            "Child child-1 needs parent supervision: need parent decision"
+        );
     }
 }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -355,12 +355,26 @@ impl RuntimeHandle {
                     command_task::ManagedTaskHandle::Async(handle),
                 );
 
+                let child_supervision = crate::types::ChildSupervisionProjection::from_task_record(
+                    &queued_task,
+                )
+                .map(|projection| {
+                    if let Some(delegation) = delegation.as_ref() {
+                        projection.with_work_item_delegation(delegation)
+                    } else {
+                        projection
+                    }
+                });
+
                 Ok(SpawnAgentResult {
                     agent_id: spawned.child_agent_id.clone(),
+                    child_agent_id: Some(spawned.child_agent_id.clone()),
                     task_handle: Some(TaskHandle::from_task_record(&queued_task, None)),
+                    supervision_task_id: Some(queued_task.id.clone()),
+                    child_supervision,
                     summary_text: Some(format!(
-                        "spawned private child agent {} with supervising task handle",
-                        spawned.child_agent_id
+                        "delegated child {} started under supervision task {}",
+                        spawned.child_agent_id, queued_task.id
                     )),
                     delegation_id: delegation
                         .as_ref()
@@ -393,7 +407,10 @@ impl RuntimeHandle {
 
                 Ok(SpawnAgentResult {
                     agent_id: spawned_agent_id.clone(),
+                    child_agent_id: None,
                     task_handle: None,
+                    supervision_task_id: None,
+                    child_supervision: None,
                     summary_text: Some(format!(
                         "spawned public named agent {} without a supervising task handle",
                         spawned_agent_id
@@ -1272,6 +1289,19 @@ impl RuntimeHandle {
                 }
             }
         }
+        if let Some(projection) = snapshot.child_supervision.take() {
+            snapshot.child_supervision = Some(
+                if let Ok(Some(delegation)) = self
+                    .inner
+                    .storage
+                    .latest_work_item_delegation_for_child(&projection.child_agent_id)
+                {
+                    projection.with_work_item_delegation(&delegation)
+                } else {
+                    projection
+                },
+            );
+        }
 
         Ok(snapshot)
     }
@@ -1364,6 +1394,19 @@ impl RuntimeHandle {
             exit_status,
         );
 
+        let child_supervision = crate::types::ChildSupervisionProjection::from_task_record(&task)
+            .map(|projection| {
+                if let Ok(Some(delegation)) = self
+                    .inner
+                    .storage
+                    .latest_work_item_delegation_for_child(&projection.child_agent_id)
+                {
+                    projection.with_work_item_delegation(&delegation)
+                } else {
+                    projection
+                }
+            });
+
         Ok(TaskOutputSnapshot {
             task_id: task.id,
             kind: task.kind.as_str().to_string(),
@@ -1376,6 +1419,7 @@ impl RuntimeHandle {
             result_summary,
             exit_status,
             failure_artifact,
+            child_supervision,
         })
     }
 
@@ -1868,7 +1912,10 @@ impl RuntimeHandle {
             accepted_input: true,
             input_target: Some(input_target.into()),
             bytes_written: Some(bytes_written),
-            summary_text: Some(format!("delivered input to task {}", task.id)),
+            summary_text: Some(format!(
+                "delivered parent follow-up to child {} via supervision task {}",
+                child_agent_id, task.id
+            )),
         })
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::VecDeque,
     fs::{self, OpenOptions},
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     time::UNIX_EPOCH,
 };
@@ -613,11 +613,10 @@ impl AppStorage {
         &self,
         child_agent_id: &str,
     ) -> Result<Option<WorkItemDelegationRecord>> {
-        Ok(self
-            .latest_work_item_delegations()?
-            .into_iter()
-            .filter(|record| record.child_agent_id == child_agent_id)
-            .max_by(|left, right| left.updated_at.cmp(&right.updated_at)))
+        read_latest_jsonl_matching(
+            &self.work_item_delegations_path,
+            |record: &WorkItemDelegationRecord| record.child_agent_id == child_agent_id,
+        )
     }
 
     pub fn latest_timer_records(&self) -> Result<Vec<TimerRecord>> {
@@ -840,6 +839,68 @@ fn read_jsonl_from<T: DeserializeOwned>(
     Ok(lines)
 }
 
+fn read_latest_jsonl_matching<T, F>(path: &Path, mut matches: F) -> Result<Option<T>>
+where
+    T: DeserializeOwned,
+    F: FnMut(&T) -> bool,
+{
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    const CHUNK_SIZE: u64 = 8192;
+    let mut file =
+        fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut cursor = file.seek(SeekFrom::End(0))?;
+    let mut prefix = Vec::new();
+
+    while cursor > 0 {
+        let read_len = cursor.min(CHUNK_SIZE);
+        cursor -= read_len;
+        file.seek(SeekFrom::Start(cursor))?;
+
+        let mut chunk = vec![0; read_len as usize];
+        file.read_exact(&mut chunk)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        chunk.extend_from_slice(&prefix);
+
+        let mut line_end = chunk.len();
+        for idx in (0..chunk.len()).rev() {
+            if chunk[idx] != b'\n' {
+                continue;
+            }
+            if let Some(record) =
+                parse_jsonl_match(&chunk[(idx + 1)..line_end], path, &mut matches)?
+            {
+                return Ok(Some(record));
+            }
+            line_end = idx;
+        }
+        prefix = chunk[..line_end].to_vec();
+    }
+
+    parse_jsonl_match(&prefix, path, &mut matches)
+}
+
+fn parse_jsonl_match<T, F>(line: &[u8], path: &Path, matches: &mut F) -> Result<Option<T>>
+where
+    T: DeserializeOwned,
+    F: FnMut(&T) -> bool,
+{
+    let line = std::str::from_utf8(line)
+        .with_context(|| format!("failed to decode UTF-8 from {}", path.display()))?;
+    if line.trim().is_empty() {
+        return Ok(None);
+    }
+    let record: T = serde_json::from_str(line)
+        .with_context(|| format!("failed to decode line from {}", path.display()))?;
+    if matches(&record) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
 fn compare_queue_display_order(
     left: &WorkItemRecord,
     right: &WorkItemRecord,
@@ -972,6 +1033,48 @@ mod tests {
         let entries = read_recent_jsonl::<TranscriptEntry>(&path, 1).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].related_message_id.as_deref(), Some("newer"));
+    }
+
+    #[test]
+    fn latest_work_item_delegation_for_child_scans_from_tail() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        fs::write(
+            &storage.work_item_delegations_path,
+            "{not valid json and should not be parsed}\n",
+        )
+        .unwrap();
+
+        let other = WorkItemDelegationRecord::new(
+            "parent-agent",
+            "parent-work-other",
+            "other-child",
+            "child-work-other",
+        );
+        let older = WorkItemDelegationRecord::new(
+            "parent-agent",
+            "parent-work-1",
+            "target-child",
+            "child-work-1",
+        );
+        let latest = WorkItemDelegationRecord {
+            state: WorkItemDelegationState::Completed,
+            result_summary: Some("done".into()),
+            updated_at: Utc::now(),
+            ..older.clone()
+        };
+
+        storage.append_work_item_delegation(&other).unwrap();
+        storage.append_work_item_delegation(&older).unwrap();
+        storage.append_work_item_delegation(&latest).unwrap();
+
+        let found = storage
+            .latest_work_item_delegation_for_child("target-child")
+            .unwrap()
+            .expect("target child delegation should be found");
+        assert_eq!(found.delegation_id, older.delegation_id);
+        assert_eq!(found.state, WorkItemDelegationState::Completed);
+        assert_eq!(found.result_summary.as_deref(), Some("done"));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -609,6 +609,17 @@ impl AppStorage {
             .max_by(|left, right| left.updated_at.cmp(&right.updated_at)))
     }
 
+    pub fn latest_work_item_delegation_for_child(
+        &self,
+        child_agent_id: &str,
+    ) -> Result<Option<WorkItemDelegationRecord>> {
+        Ok(self
+            .latest_work_item_delegations()?
+            .into_iter()
+            .filter(|record| record.child_agent_id == child_agent_id)
+            .max_by(|left, right| left.updated_at.cmp(&right.updated_at)))
+    }
+
     pub fn latest_timer_records(&self) -> Result<Vec<TimerRecord>> {
         let records = self.read_recent_timers(usize::MAX)?;
         let mut latest = std::collections::BTreeMap::new();

--- a/src/tool/tools/task_output.rs
+++ b/src/tool/tools/task_output.rs
@@ -127,6 +127,7 @@ mod tests {
                     result_summary: Some("done".into()),
                     exit_status: Some(0),
                     failure_artifact: None,
+                    child_supervision: None,
                 },
             },
         )

--- a/src/types.rs
+++ b/src/types.rs
@@ -2017,6 +2017,63 @@ pub struct CommandTaskStatusSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChildSupervisionProjection {
+    pub parent_agent_id: String,
+    pub child_agent_id: String,
+    pub supervision_task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_mode: Option<ChildAgentWorkspaceMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<Value>,
+    pub cleanup_owner: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_status: Option<String>,
+    pub followup_target: String,
+}
+
+impl ChildSupervisionProjection {
+    pub fn from_task_record(task: &TaskRecord) -> Option<Self> {
+        if !task.is_child_agent_task() {
+            return None;
+        }
+        let child_agent_id = task_detail_string(&task.detail, "child_agent_id")?;
+        let worktree = task_detail_value(&task.detail, "worktree").cloned();
+        let cleanup_status = worktree
+            .as_ref()
+            .and_then(|worktree| worktree.get("cleanup_status"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+
+        Some(Self {
+            parent_agent_id: task.agent_id.clone(),
+            child_agent_id,
+            supervision_task_id: task.id.clone(),
+            parent_work_item_id: None,
+            child_work_item_id: None,
+            delegation_id: None,
+            workspace_mode: task.child_agent_workspace_mode(),
+            worktree,
+            cleanup_owner: "supervision_task".into(),
+            cleanup_status,
+            followup_target: "parent_supervisor".into(),
+        })
+    }
+
+    pub fn with_work_item_delegation(mut self, delegation: &WorkItemDelegationRecord) -> Self {
+        self.parent_work_item_id = Some(delegation.parent_work_item_id.clone());
+        self.child_work_item_id = Some(delegation.child_work_item_id.clone());
+        self.delegation_id = Some(delegation.delegation_id.clone());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TaskStatusSnapshot {
     pub task_id: String,
     pub kind: String,
@@ -2034,6 +2091,8 @@ pub struct TaskStatusSnapshot {
     pub child_agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_observability: Option<ChildAgentObservabilitySnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_supervision: Option<ChildSupervisionProjection>,
 }
 
 impl TaskStatusSnapshot {
@@ -2058,6 +2117,7 @@ impl TaskStatusSnapshot {
         let child_agent_id = task_detail_string(&task.detail, "child_agent_id");
         let child_observability = task_detail_value(&task.detail, "child_observability")
             .and_then(|value| serde_json::from_value(value.clone()).ok());
+        let child_supervision = ChildSupervisionProjection::from_task_record(task);
 
         Self {
             task_id: task.id.clone(),
@@ -2071,6 +2131,7 @@ impl TaskStatusSnapshot {
             command,
             child_agent_id,
             child_observability,
+            child_supervision,
         }
     }
 }
@@ -2099,6 +2160,8 @@ pub struct TaskOutputSnapshot {
     pub exit_status: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_artifact: Option<FailureArtifact>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_supervision: Option<ChildSupervisionProjection>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -2220,7 +2283,13 @@ pub struct AgentGetResult {
 pub struct SpawnAgentResult {
     pub agent_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task_handle: Option<TaskHandle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supervision_task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_supervision: Option<ChildSupervisionProjection>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_text: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/runtime_subagents.rs
+++ b/tests/runtime_subagents.rs
@@ -16,6 +16,7 @@ macro_rules! runtime_async_tests {
 
 runtime_async_tests!(
     task_output_returns_subagent_result_text,
+    spawn_agent_receipt_projects_child_supervision_boundary,
     subagent_task_updates_parent_state_and_child_summary_during_lifecycle,
     subagent_task_status_exposes_live_and_terminal_child_observability,
     blocking_subagent_result_does_not_regress_to_running_task_status,

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -108,6 +108,62 @@ pub async fn task_output_returns_subagent_result_text() -> Result<()> {
         .as_str()
         .expect("subagent output should be text")
         .contains("subagent final result"));
+    let supervision = &value["task"]["child_supervision"];
+    assert_eq!(supervision["parent_agent_id"], "default");
+    assert!(supervision["child_agent_id"].as_str().is_some());
+    assert_eq!(supervision["supervision_task_id"], task.id);
+    assert_eq!(supervision["workspace_mode"], "inherit");
+    assert_eq!(supervision["cleanup_owner"], "supervision_task");
+    assert_eq!(supervision["followup_target"], "parent_supervisor");
+    Ok(())
+}
+
+pub async fn spawn_agent_receipt_projects_child_supervision_boundary() -> Result<()> {
+    let host = RuntimeHost::new_with_provider(
+        test_config(),
+        Arc::new(StubProvider::new("child completed")),
+    )?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+
+    let (result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-spawn-agent-supervision".into(),
+                name: "SpawnAgent".into(),
+                input: json!({
+                    "summary": "delegate focused work",
+                    "prompt": "finish delegated work",
+                    "preset": "private_child"
+                }),
+            },
+        )
+        .await?;
+
+    let value = parse_tool_result_payload(&result)?;
+    assert_eq!(value["child_agent_id"], value["agent_id"]);
+    assert_eq!(
+        value["supervision_task_id"],
+        value["task_handle"]["task_id"]
+    );
+    assert_eq!(value["task_handle"]["task_kind"], "child_agent_task");
+
+    let supervision = &value["child_supervision"];
+    assert_eq!(supervision["parent_agent_id"], "default");
+    assert_eq!(supervision["child_agent_id"], value["child_agent_id"]);
+    assert_eq!(
+        supervision["supervision_task_id"],
+        value["supervision_task_id"]
+    );
+    assert_eq!(supervision["workspace_mode"], "inherit");
+    assert_eq!(supervision["cleanup_owner"], "supervision_task");
+    assert_eq!(supervision["followup_target"], "parent_supervisor");
+    assert!(result
+        .summary_text()
+        .is_some_and(|text| text.contains("supervision task")));
     Ok(())
 }
 
@@ -138,6 +194,10 @@ pub async fn subagent_task_updates_parent_state_and_child_summary_during_lifecyc
                 saw_child_summary = true;
                 assert_eq!(child.identity.kind, AgentKind::Child);
                 assert_eq!(child.identity.parent_agent_id.as_deref(), Some("default"));
+                assert_eq!(
+                    child.identity.delegated_from_task_id.as_deref(),
+                    Some(task.id.as_str())
+                );
                 assert_eq!(child.observability.phase, ChildAgentPhase::Running);
                 assert!(child.observability.last_result_brief.is_none());
                 break;
@@ -205,6 +265,22 @@ pub async fn subagent_task_status_exposes_live_and_terminal_child_observability(
     let running_snapshot = runtime.task_status_snapshot(&task.id).await?;
 
     assert_eq!(running_snapshot.status, TaskStatus::Running);
+    let supervision = running_snapshot
+        .child_supervision
+        .as_ref()
+        .expect("running child task should project supervision boundary");
+    assert_eq!(supervision.parent_agent_id, "default");
+    assert_eq!(
+        supervision.child_agent_id,
+        running_snapshot.child_agent_id.clone().unwrap()
+    );
+    assert_eq!(supervision.supervision_task_id, task.id);
+    assert_eq!(
+        supervision.workspace_mode,
+        Some(holon::types::ChildAgentWorkspaceMode::Inherit)
+    );
+    assert_eq!(supervision.cleanup_owner, "supervision_task");
+    assert_eq!(supervision.followup_target, "parent_supervisor");
     let live_child = running_snapshot
         .child_observability
         .as_ref()


### PR DESCRIPTION
## Summary
- add a structured `child_supervision` projection for `SpawnAgent(private_child)`, `TaskStatus`, and `TaskOutput`
- keep `child_agent_id` distinct from the parent-visible `supervision_task_id`
- render delegated child events, parent follow-up, and work-item delegation with supervision vocabulary
- document the projection in runtime spec and delegation/task RFCs

## Tests
- `cargo fmt --check`
- `cargo test -q operator_event`
- `cargo test -q --test runtime_subagents`
- `cargo test -q --test runtime_workspace_worktree`
- `cargo test -q --test runtime_tasks`
- `git diff --check`

Closes #923
