### PR TITLE
fix: define memory governance boundary

### DIFF
--- a/docs/rfc-implementation-notes/memory-and-compaction.md
+++ b/docs/rfc-implementation-notes/memory-and-compaction.md
@@ -19,18 +19,30 @@ tool traces are copied into durable memory without a clear rule, later turns can
 confuse short-lived execution context with long-lived agent or workspace
 knowledge.
 
-## Open gaps
+## v0.14 minimum closure
+
+- `MemorySearch` indexes only governed memory/evidence sources:
+  `agent_home/memory/self.md`, `agent_home/memory/operator.md`, workspace
+  profiles, briefs, context episodes, and work items.
+- Ordinary workspace Markdown remains a workspace file surface. It is inspected
+  through file tools, not returned as Holon memory by default.
+- `MemoryGet` accepts only opaque `source_ref` handles from the governed source
+  set. Paths, URLs, query strings, and unknown prefixes are rejected or return
+  not found; they are not retrieval authority.
+- Memory results expose governance/provenance metadata so curated durable
+  memory, workspace projections, and runtime evidence do not collapse into one
+  trust class.
+- Turn-local and provider remote compaction remain request/projection behavior.
+  They can preserve bounded context and observability metadata, but they do not
+  write curated durable memory.
+
+## Deferred scope
 
 1. Keep durable memory writes explicit and scoped to agent or workspace
    ownership.
-2. Keep compaction outputs traceable to source evidence and separate from
-   curated memory.
-3. Reconcile provider-specific remote compaction behavior with the local
-   request-projection contract.
-4. Add verification around memory search/retrieval boundaries so normal
-   workspace Markdown, runtime evidence, and curated memory do not collapse into
-   one trust class.
-5. Keep agent-home `AGENTS.md` as durable agent behavior guidance, not a cache
+2. Add a future explicit `MemoryWrite`/`Remember` contract only after the
+   authority, target scope, and review/audit boundary are defined.
+3. Keep agent-home `AGENTS.md` as durable agent behavior guidance, not a cache
    for project notes or task plans.
 
 Tracked by #924 for the memory and compaction governance boundary.

--- a/docs/rfcs/agent-and-workspace-memory.md
+++ b/docs/rfcs/agent-and-workspace-memory.md
@@ -92,6 +92,21 @@ state:
 An item can move between these layers over time, but the runtime should not
 collapse them into one file or one prompt blob.
 
+For v0.14 the boundary is:
+
+- `agent_home/AGENTS.md` is loaded durable behavior guidance. It shapes every
+  run, but it is not a searchable memory source returned by `MemorySearch`.
+- `agent_home/memory/self.md` and `agent_home/memory/operator.md` are curated
+  durable memory. They are explicit Markdown memory sources with
+  agent-scoped provenance.
+- runtime evidence such as briefs, work items, and context episodes is indexed
+  as evidence. It can be searched and retrieved, but it keeps runtime-evidence
+  provenance and must not be treated as curated durable memory.
+- working memory and request projections are model-facing continuity
+  projections derived from runtime state. They are not durable memory writes.
+- local, turn-local, or provider remote compaction output may bound a request
+  window. It cannot silently write or redefine durable memory.
+
 ### Workspace identity comes from the runtime
 
 Workspace-scoped memory must be keyed by `workspace_id`, not by a transient
@@ -112,6 +127,18 @@ They should be rebuildable from stronger sources:
 - runtime ledger records;
 - briefs, work items, and episodes;
 - explicit operator or agent notes.
+
+Ordinary workspace Markdown is not Holon memory merely because it lives under a
+workspace root. Agents should inspect workspace files through filesystem tools
+or explicit workspace profiles. A Markdown file becomes a Holon memory source
+only through a governed memory surface such as curated agent memory, a future
+explicit workspace-memory authoring flow, or runtime-indexed evidence with
+preserved provenance.
+
+Durable memory writes must be explicit and scoped. A runtime compaction summary,
+tool trace, implementation plan, or provider-owned opaque compaction item must
+not be copied into curated durable memory unless a future memory-writing
+contract names the target scope, authority, and source evidence.
 
 ## Memory Surfaces
 

--- a/docs/rfcs/long-lived-context-memory.md
+++ b/docs/rfcs/long-lived-context-memory.md
@@ -30,6 +30,11 @@ The core design is:
 - keep provider prompt-cache identity aligned with slow-changing memory
   revisions
 
+This RFC uses "memory" in the runtime-continuity sense. Curated durable memory,
+loaded guidance, runtime evidence, working-memory projection, and compaction
+output remain separate governance surfaces; see
+`agent-and-workspace-memory.md` for the durable memory and retrieval boundary.
+
 ## Problem
 
 Long-lived coding agents accumulate context quickly:
@@ -91,6 +96,10 @@ Examples include:
 The ledger is not prompt-bounded. Compression changes the model-visible
 projection, not the audit trail.
 
+Ledger records are runtime evidence. Indexing selected ledger records for
+`MemorySearch` does not promote them to curated durable memory; they must keep
+runtime-evidence provenance.
+
 ### Hot Turn Context
 
 Hot turn context is rebuilt every prompt assembly.
@@ -130,6 +139,10 @@ monotonic `working_memory_revision`.
 
 Working memory is derived from durable runtime state, not authored as a
 free-form model summary.
+
+Working memory is a request and continuity projection. Updating working memory
+does not write curated durable memory, and compaction output must not be used as
+independent authority to update curated memory.
 
 ### Episode Memory
 
@@ -276,6 +289,12 @@ The primary compaction path is:
 
 Fallback message compaction may still exist for migration or empty-memory cases,
 but it must not be the primary continuity mechanism.
+
+Compaction output is governed as projection-level state. It can affect what is
+rendered into a bounded request window, and any facts retained through
+compaction should remain traceable to durable ledger evidence, but compaction
+does not create `agent_home/memory/*.md` content or a new durable memory
+authority.
 
 ## Model Calls
 

--- a/docs/rfcs/openai-remote-compaction.md
+++ b/docs/rfcs/openai-remote-compaction.md
@@ -41,6 +41,11 @@ That creates three design constraints:
 Holon should therefore treat remote compaction as a provider-window optimization,
 not as Holon's source of semantic memory.
 
+This boundary is also a governance rule: OpenAI remote compaction cannot mutate
+or redefine Holon's local durable memory contract. The encrypted provider item
+may be stored and replayed as provider transport state, but it is not
+`agent_home` memory, runtime evidence, or an authority for `MemoryGet`.
+
 ## 2. External API Facts
 
 This design relies on the public OpenAI Responses API documentation:
@@ -107,6 +112,12 @@ It keeps provider-shaped history bounded:
 
 This layer is not inspectable. Holon should store metadata about it, not infer
 meaning from it.
+
+Provider-window compaction metadata should be observability metadata. It may
+point at the covered provider item range and local evidence checkpoints, but it
+must not be indexed as curated durable memory or exposed as the same
+trust/provenance class as briefs, work items, context episodes, or
+`agent_home/memory/*.md`.
 
 Suggested metadata:
 

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1211,9 +1211,10 @@ mod tests {
         ensure_agent_home_layout(dir.path()).unwrap();
         let workspace = dir.path().join("workspace");
         fs::create_dir_all(&workspace).unwrap();
+        let readme_marker = "governance_sentinel_924_workspace_markdown";
         fs::write(
             workspace.join("README.md"),
-            "ordinary workspace markdown should not become Holon memory",
+            format!("ordinary workspace markdown {readme_marker} should not become Holon memory"),
         )
         .unwrap();
         storage
@@ -1225,28 +1226,12 @@ mod tests {
             .unwrap();
 
         rebuild_memory_index(&storage, Some("ws-markdown")).unwrap();
-        let results = search_memory(
-            &storage,
-            "ordinary workspace markdown",
-            10,
-            Some("ws-markdown"),
-            false,
-        )
-        .unwrap();
+        let results =
+            search_memory(&storage, readme_marker, 10, Some("ws-markdown"), false).unwrap();
 
-        assert!(results
-            .iter()
-            .all(|result| result.kind != "agent_memory_markdown"
-                || result.source_ref.starts_with("agent_memory:")));
-        assert!(!results.iter().any(|result| {
-            result
-                .source_path
-                .as_deref()
-                .is_some_and(|path| path.ends_with("README.md"))
-        }));
-        assert!(results
-            .iter()
-            .all(|result| result.metadata["governance_surface"].as_str()
-                != Some("ordinary_workspace_markdown")));
+        assert!(
+            results.is_empty(),
+            "workspace README marker must not be searchable as Holon memory: {results:?}"
+        );
     }
 }

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -526,7 +526,12 @@ fn agent_memory_document(
         title: title.into(),
         sanitized_excerpt: excerpt(&body),
         body,
-        metadata: json!({ "memory_name": name }),
+        metadata: json!({
+            "memory_name": name,
+            "governance_surface": "curated_durable_memory",
+            "provenance_class": "agent_home_memory_markdown",
+            "trust_class": "agent_curated",
+        }),
         updated_at: file_updated_at(path),
     }))
 }
@@ -559,7 +564,12 @@ fn workspace_profile_documents(storage: &AppStorage) -> Result<Vec<MemoryDocumen
                 title,
                 sanitized_excerpt: excerpt(&body),
                 body,
-                metadata: json!({ "workspace_anchor": entry.workspace_anchor }),
+                metadata: json!({
+                    "workspace_anchor": entry.workspace_anchor,
+                    "governance_surface": "workspace_profile_projection",
+                    "provenance_class": "workspace_registry",
+                    "trust_class": "runtime_projection",
+                }),
                 updated_at: entry.updated_at,
             }
         })
@@ -591,6 +601,9 @@ fn brief_document(storage: &AppStorage, brief: BriefRecord) -> MemoryDocument {
             "related_message_id": brief.related_message_id,
             "related_task_id": brief.related_task_id,
             "agent_home": storage.data_dir(),
+            "governance_surface": "runtime_evidence",
+            "provenance_class": "brief_record",
+            "trust_class": "runtime_evidence",
         }),
         updated_at: brief.created_at,
     }
@@ -636,6 +649,9 @@ fn episode_document(episode: ContextEpisodeRecord) -> MemoryDocument {
             "current_work_item_id": episode.current_work_item_id,
             "boundary_reason": episode.boundary_reason,
             "working_set_files": episode.working_set_files,
+            "governance_surface": "runtime_evidence",
+            "provenance_class": "context_episode_record",
+            "trust_class": "runtime_evidence",
         }),
         updated_at: episode.finalized_at,
     }
@@ -665,6 +681,9 @@ fn work_item_document(item: WorkItemRecord) -> MemoryDocument {
             "work_item_id": item.id,
             "state": item.state,
             "blocked_by": item.blocked_by,
+            "governance_surface": "runtime_evidence",
+            "provenance_class": "work_item_record",
+            "trust_class": "runtime_evidence",
         }),
         updated_at: item.updated_at,
     }
@@ -843,6 +862,14 @@ mod tests {
         rebuild_memory_index(&storage, None).unwrap();
         let results = search_memory(&storage, "release", 10, None, false).unwrap();
         assert_eq!(results[0].kind, "agent_memory_markdown");
+        assert_eq!(
+            results[0].metadata["governance_surface"].as_str(),
+            Some("curated_durable_memory")
+        );
+        assert_eq!(
+            results[0].metadata["trust_class"].as_str(),
+            Some("agent_curated")
+        );
 
         fs::write(
             agent_memory_self_path(dir.path()),
@@ -1023,7 +1050,18 @@ mod tests {
         assert!(results
             .iter()
             .any(|result| result.kind == "workspace_profile"));
-        assert!(results.iter().any(|result| result.kind == "brief"));
+        let brief_result = results
+            .iter()
+            .find(|result| result.kind == "brief")
+            .expect("brief memory result");
+        assert_eq!(
+            brief_result.metadata["governance_surface"].as_str(),
+            Some("runtime_evidence")
+        );
+        assert_eq!(
+            brief_result.metadata["provenance_class"].as_str(),
+            Some("brief_record")
+        );
         let results = search_memory(&storage, "SQLite", 10, Some("ws-holon"), false).unwrap();
         assert!(results
             .iter()
@@ -1163,5 +1201,52 @@ mod tests {
         assert!(results
             .iter()
             .any(|result| result.source_ref == "agent_memory:operator"));
+    }
+
+    #[test]
+    fn ordinary_workspace_markdown_is_not_indexed_as_memory() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        ensure_agent_home_layout(dir.path()).unwrap();
+        let workspace = dir.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(
+            workspace.join("README.md"),
+            "ordinary workspace markdown should not become Holon memory",
+        )
+        .unwrap();
+        storage
+            .append_workspace_entry(&WorkspaceEntry::new(
+                "ws-markdown",
+                workspace,
+                Some("markdown workspace".into()),
+            ))
+            .unwrap();
+
+        rebuild_memory_index(&storage, Some("ws-markdown")).unwrap();
+        let results = search_memory(
+            &storage,
+            "ordinary workspace markdown",
+            10,
+            Some("ws-markdown"),
+            false,
+        )
+        .unwrap();
+
+        assert!(results
+            .iter()
+            .all(|result| result.kind != "agent_memory_markdown"
+                || result.source_ref.starts_with("agent_memory:")));
+        assert!(!results.iter().any(|result| {
+            result
+                .source_path
+                .as_deref()
+                .is_some_and(|path| path.ends_with("README.md"))
+        }));
+        assert!(results
+            .iter()
+            .all(|result| result.metadata["governance_surface"].as_str()
+                != Some("ordinary_workspace_markdown")));
     }
 }

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -99,6 +99,15 @@ fn validate_source_ref(source_ref: String) -> Result<String> {
             "missing source_ref identifier",
         ));
     }
+    if !suffix
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return Err(invalid_source_ref_error(
+            &source_ref,
+            "source_ref identifier must be an opaque id, not a path, URL, or query",
+        ));
+    }
 
     let prefix = format!("{prefix}:");
     if !ALLOWED_SOURCE_REF_PREFIXES.contains(&prefix.as_str()) {
@@ -181,6 +190,10 @@ mod tests {
             "skill.md:/Users/jolestar/.agents/skills/agentinbox/SKILL.md",
             "agentinbox:///SKILL.md",
             "memory:invalid-ref-123",
+            "brief:/Users/jolestar/project/README.md",
+            "brief:https://example.com/memory",
+            "episode:../ledger/episode-1",
+            "work_item:work_123?raw=true",
         ] {
             let error = tool_error(validate_source_ref(source_ref.to_string()).unwrap_err());
             assert_eq!(error.kind, "invalid_tool_input");


### PR DESCRIPTION
Closes #924.

## Summary
- define the v0.14 governance boundary between loaded guidance, curated durable memory, runtime evidence, working-memory projection, and compaction output
- add explicit governance/provenance/trust metadata to indexed memory result classes
- harden `MemoryGet` source refs so path, URL, and query-like forged handles are not accepted as retrieval authority
- add regression coverage that ordinary workspace Markdown is not indexed as Holon memory and that curated memory/runtime evidence keep distinct provenance

## Verification
- `cargo test -q memory::index`
- `cargo test -q tool::tools::memory_get`
- `cargo fmt --check`
- `git diff --check`
