### PR TITLE
fix: harden external trigger lifecycle

### DIFF
--- a/docs/rfc-implementation-notes/work-items-and-waiting-plane.md
+++ b/docs/rfc-implementation-notes/work-items-and-waiting-plane.md
@@ -19,20 +19,35 @@ This is a strong foundation, but the implementation is still only partial
 because some workflow invariants are enforced by agent instructions rather than
 runtime state transitions.
 
-## Open gaps
+## v0.14 lifecycle contract
 
-1. Ensure every cross-turn wait is anchored to the correct current work item
-   before the agent sleeps.
-2. Cancel stale work-item scoped external triggers when the tracked condition
-   changes or the work item completes.
-3. Keep objective changes explicit through work-item objective/plan updates
+Work-item-scoped external triggers are owned by the current work item. The
+runtime rejects creation when there is no current work item, binds the waiting
+intent to that work item, and revokes the trigger when the work item completes,
+when focus switches to a different work item, or when a new work-item-scoped
+trigger replaces the old waiting condition for the same work item.
+
+Agent-scoped external triggers are owned by the agent lifecycle. They survive
+ordinary work-item switching, completed-work cleanup, and the absence of a
+current work item. They are appropriate for durable integration entry points
+such as AgentInbox wake hints.
+
+Both scopes preserve external-trigger provenance. A callback capability may
+reactivate or enqueue integration input, but its payload remains external
+integration input rather than operator authority. `wake_hint` records activation
+context and may wake the agent; `enqueue_message` appends a callback-origin
+message. The two modes must not be inferred from the payload body.
+
+## Remaining gaps
+
+1. Keep objective changes explicit through work-item objective/plan updates
    rather than accumulating unrelated objectives under one item.
-4. Make blocked, queued, open, completed, and current-focus states easy to
+2. Make blocked, queued, open, completed, and current-focus states easy to
    distinguish in runtime projection.
-5. Add verification for reactivation edge cases: queued continuation, external
+3. Add verification for reactivation edge cases: queued continuation, external
    trigger callback, operator interruption, and completed-work re-entry.
 
-Tracked by #914 for external trigger lifecycle and stale-trigger cleanup.
+The lifecycle rules above are tracked by #914.
 
 ## Verification direction
 

--- a/docs/rfcs/external-trigger-capability.md
+++ b/docs/rfcs/external-trigger-capability.md
@@ -350,8 +350,17 @@ For `work_item` scope, the agent or runtime should cancel obsolete triggers when
 
 - the relevant external condition is no longer needed
 - the active work item changes
+- the current work item completes
+- a new work-item-scoped trigger replaces the previous waiting condition for
+  the same work item
 - the waiting intent becomes stale
 - the user or runtime explicitly cancels it
+
+A work-item-scoped trigger requires a current work-item anchor at creation time.
+The runtime should fail creation rather than minting an unanchored work-item
+wait. Work-item cleanup should revoke the external trigger descriptor and mark
+the waiting intent cancelled, so later callback delivery fails without waking or
+enqueueing work.
 
 For `agent` scope, the trigger is a long-running integration entry point. It
 should not be cancelled by work-item cleanup or by the absence of an active work

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2065,6 +2065,9 @@ type ExternalTriggerCapability = {
    - A `ExternalTriggerRecord` with a secure token
    - A signed callback URL for external delivery
 
+   `work_item` scope requires a current work item. Creation fails if there is no
+   current work item to anchor the waiting intent.
+
 3. Agent passes the callback capability to an external tool/service
 
 4. External system registers the watch and calls back on completion
@@ -2088,7 +2091,12 @@ Agents should cancel waiting intents when:
 - The agent completes work regardless of the external condition
 - Cleanup is needed to avoid accumulating abandoned callbacks
 
-Cancellation revokes the external trigger and marks the waiting intent as cancelled.
+Cancellation revokes the external trigger and marks the waiting intent as
+cancelled. Runtime cleanup also cancels work-item-scoped waiting intents when
+the bound work item completes, when active work switches away from that item, or
+when a new work-item-scoped trigger replaces the previous waiting condition for
+the same work item. Agent-scoped triggers are not removed by ordinary work-item
+cleanup.
 
 ## Background Task Recovery
 

--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -73,6 +73,10 @@ impl RuntimeHandle {
             ),
             ExternalTriggerScope::Agent => None,
         };
+        if let Some(work_item_id) = work_item_id.as_deref() {
+            self.cancel_work_item_waiting_intents(work_item_id, "waiting_condition_replaced")
+                .await?;
+        }
         let waiting = WaitingIntentRecord {
             id: waiting_intent_id.clone(),
             agent_id: agent_id.clone(),
@@ -513,6 +517,37 @@ impl RuntimeHandle {
             }),
         ))?;
         Ok(())
+    }
+
+    pub(super) async fn cancel_work_item_waiting_intents(
+        &self,
+        work_item_id: &str,
+        reason: &'static str,
+    ) -> Result<Vec<String>> {
+        let waiting_intent_ids = self
+            .latest_waiting_intents()
+            .await?
+            .into_iter()
+            .filter(|record| record.status == WaitingIntentStatus::Active)
+            .filter(|record| record.scope == ExternalTriggerScope::WorkItem)
+            .filter(|record| record.work_item_id.as_deref() == Some(work_item_id))
+            .map(|record| record.id)
+            .collect::<Vec<_>>();
+        if waiting_intent_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let cancelled_ids = self.cancel_waiting_intents(waiting_intent_ids).await?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "work_item_waiting_intents_cancelled",
+            serde_json::json!({
+                "agent_id": self.agent_id().await?,
+                "work_item_id": work_item_id,
+                "reason": reason,
+                "waiting_intent_ids": cancelled_ids,
+            }),
+        ))?;
+        Ok(cancelled_ids)
     }
 
     async fn cancel_waiting_intents(&self, waiting_intent_ids: Vec<String>) -> Result<Vec<String>> {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2003,6 +2003,12 @@ impl RuntimeHandle {
         if record.state == WorkItemState::Completed {
             return Err(anyhow!("cannot pick completed work item {}", work_item_id));
         }
+        if current_id.as_deref().is_some_and(|id| id != record.id) {
+            if let Some(previous_id) = current_id.as_deref() {
+                self.cancel_work_item_waiting_intents(previous_id, "active_work_item_switched")
+                    .await?;
+            }
+        }
         {
             let mut guard = self.inner.agent.lock().await;
             guard.state.current_work_item_id = Some(record.id.clone());
@@ -2122,6 +2128,8 @@ impl RuntimeHandle {
                     None,
                 ))?;
         }
+        self.cancel_work_item_waiting_intents(&record.id, "work_item_completed")
+            .await?;
         {
             let mut guard = self.inner.agent.lock().await;
             if guard.state.current_work_item_id.as_deref() == Some(record.id.as_str()) {

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1228,6 +1228,221 @@ async fn agent_scoped_wake_hint_preserves_external_trigger_provenance() {
 }
 
 #[tokio::test]
+async fn completing_work_item_cancels_work_item_scoped_external_trigger() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("wait for external review".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+    let capability = runtime
+        .create_external_trigger(
+            "wait for review".into(),
+            "github".into(),
+            ExternalTriggerScope::WorkItem,
+            CallbackDeliveryMode::WakeHint,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    runtime
+        .complete_work_item(work.id.clone(), Some("review no longer needed".into()))
+        .await
+        .unwrap();
+
+    let waiting = runtime.latest_waiting_intents().await.unwrap();
+    let descriptor = runtime
+        .latest_external_triggers()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|record| record.external_trigger_id == capability.external_trigger_id)
+        .expect("external trigger descriptor should exist");
+    assert_eq!(waiting.len(), 1);
+    assert_eq!(waiting[0].id, capability.waiting_intent_id);
+    assert_eq!(waiting[0].status, WaitingIntentStatus::Cancelled);
+    assert_eq!(descriptor.status, ExternalTriggerStatus::Revoked);
+
+    let result = runtime
+        .deliver_callback(
+            &capability.external_trigger_id,
+            CallbackDeliveryPayload {
+                body: Some(MessageBody::Text {
+                    text: "late callback".into(),
+                }),
+                content_type: Some("text/plain".into()),
+                correlation_id: None,
+                causation_id: None,
+            },
+        )
+        .await;
+    assert!(result.unwrap_err().to_string().contains("not active"));
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "work_item_waiting_intents_cancelled"
+            && event.data["reason"] == "work_item_completed"
+            && event.data["work_item_id"].as_str() == Some(work.id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn replacing_work_item_trigger_revokes_previous_waiting_condition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("replace external condition".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+    let old_capability = runtime
+        .create_external_trigger(
+            "wait for CI".into(),
+            "github".into(),
+            ExternalTriggerScope::WorkItem,
+            CallbackDeliveryMode::WakeHint,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let new_capability = runtime
+        .create_external_trigger(
+            "wait for review approval".into(),
+            "github".into(),
+            ExternalTriggerScope::WorkItem,
+            CallbackDeliveryMode::EnqueueMessage,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let waiting = runtime.latest_waiting_intents().await.unwrap();
+    let descriptors = runtime.latest_external_triggers().await.unwrap();
+    assert_eq!(
+        waiting
+            .iter()
+            .filter(|record| record.status == WaitingIntentStatus::Active)
+            .count(),
+        1
+    );
+    assert!(waiting.iter().any(|record| {
+        record.id == old_capability.waiting_intent_id
+            && record.status == WaitingIntentStatus::Cancelled
+    }));
+    assert!(waiting.iter().any(|record| {
+        record.id == new_capability.waiting_intent_id
+            && record.status == WaitingIntentStatus::Active
+    }));
+    assert!(descriptors.iter().any(|record| {
+        record.external_trigger_id == old_capability.external_trigger_id
+            && record.status == ExternalTriggerStatus::Revoked
+    }));
+    assert!(descriptors.iter().any(|record| {
+        record.external_trigger_id == new_capability.external_trigger_id
+            && record.status == ExternalTriggerStatus::Active
+    }));
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "work_item_waiting_intents_cancelled"
+            && event.data["reason"] == "waiting_condition_replaced"
+            && event.data["work_item_id"].as_str() == Some(work.id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn picking_new_work_item_cancels_previous_work_item_scoped_trigger_only() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let old_work = runtime
+        .create_work_item("old waiting condition".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(old_work.id.clone()).await.unwrap();
+    let old_work_trigger = runtime
+        .create_external_trigger(
+            "wait for old work event".into(),
+            "github".into(),
+            ExternalTriggerScope::WorkItem,
+            CallbackDeliveryMode::WakeHint,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let agent_trigger = runtime
+        .create_external_trigger(
+            "watch durable inbox".into(),
+            "agentinbox".into(),
+            ExternalTriggerScope::Agent,
+            CallbackDeliveryMode::WakeHint,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let new_work = runtime
+        .create_work_item("new active condition".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+
+    runtime.pick_work_item(new_work.id.clone()).await.unwrap();
+
+    let waiting = runtime.latest_waiting_intents().await.unwrap();
+    assert!(waiting.iter().any(|record| {
+        record.id == old_work_trigger.waiting_intent_id
+            && record.status == WaitingIntentStatus::Cancelled
+    }));
+    assert!(waiting.iter().any(|record| {
+        record.id == agent_trigger.waiting_intent_id
+            && record.scope == ExternalTriggerScope::Agent
+            && record.status == WaitingIntentStatus::Active
+    }));
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "work_item_waiting_intents_cancelled"
+            && event.data["reason"] == "active_work_item_switched"
+            && event.data["work_item_id"].as_str() == Some(old_work.id.as_str())
+    }));
+}
+
+#[tokio::test]
 async fn reconcile_waiting_contract_cancels_old_waits_after_active_work_switch() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -1316,9 +1531,11 @@ async fn reconcile_waiting_contract_cancels_old_waits_after_active_work_switch()
         Some(new_work.id.as_str())
     );
     let events = runtime.storage().read_recent_events(20).unwrap();
-    assert!(events
-        .iter()
-        .any(|event| event.kind == "stale_waiting_intents_cancelled"));
+    assert!(events.iter().any(|event| {
+        event.kind == "work_item_waiting_intents_cancelled"
+            && event.data["reason"] == "work_item_completed"
+            && event.data["work_item_id"].as_str() == Some(old_work.id.as_str())
+    }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- cancel work-item-scoped external triggers when the work item completes, active focus switches, or a new work-item trigger replaces the previous waiting condition
- preserve agent-scoped triggers across ordinary work-item lifecycle cleanup
- document the v0.14 external trigger lifecycle contract in the RFC/runtime notes

Closes #914.

## Verification
- cargo test -q runtime::tests::work_items::completing_work_item_cancels_work_item_scoped_external_trigger
- cargo test -q runtime::tests::work_items::replacing_work_item_trigger_revokes_previous_waiting_condition
- cargo test -q runtime::tests::work_items::picking_new_work_item_cancels_previous_work_item_scoped_trigger_only
- cargo test -q runtime::tests::work_items::
- cargo test -q --test runtime_waiting_and_delivery_regressions callback_enqueue_message_repeats_until_cancelled
- cargo test -q --test runtime_waiting_and_delivery_regressions callback_wake_hint_routes_through_wake_hint
- cargo fmt --check
- git diff --check