### PR TITLE
test: codify runtime boundary regression matrix

### DIFF
--- a/docs/rfc-implementation-notes/runtime-boundary-extraction-regression-matrix.md
+++ b/docs/rfc-implementation-notes/runtime-boundary-extraction-regression-matrix.md
@@ -1,0 +1,48 @@
+# Runtime Boundary Extraction Regression Matrix
+
+Related issue: #940
+
+This matrix is the phase-1 safety net for extracting runtime execution
+boundaries without changing external behavior. It reviews existing coverage and
+identifies the focused characterization tests that should guard follow-up
+extraction issues.
+
+## Scope
+
+Phase 1 covers behavior-preserving extraction around:
+
+- one agent turn lifecycle
+- managed task orchestration
+- sleep, wake, and waiting-intent transitions
+- user-facing delivery and brief projection
+- cross-cutting external contracts that must not change during extraction
+
+Non-goals remain unchanged: no prompt contract rewrite, no tool schema change,
+no scheduler rewrite, no benchmark harness rewrite, and no UI/TUI work.
+
+## Matrix
+
+| Boundary | Contract to preserve | Existing coverage | Added or required coverage |
+| --- | --- | --- | --- |
+| Turn execution | A queued operator message moves through queued, dequeued, and processed states; incoming message and assistant round transcript entries are recorded; ack/result briefs and terminal event are persisted. | `src/runtime/tests/turns.rs`, `tests/runtime_tasks.rs` cover provider rounds, tool rounds, failure, and transcript details. | `turn_execution_boundary_persists_queue_transcript_and_briefs` adds one compact end-to-end characterization across queue, transcript, brief, and terminal event persistence. |
+| Managed task orchestration | Task tools keep lifecycle/status separate from output retrieval, command tasks persist terminal state, task result rejoin preserves runtime provenance, and task cancellation behavior is unchanged. | `tests/runtime_tasks.rs`, `tests/runtime_subagents.rs`, `tests/runtime_workspace_worktree.rs`, and `src/runtime/tests/agent_and_tools.rs`. | Existing coverage is sufficient for phase-1 extraction; follow-up #937 should run the focused task suites before and after refactor. |
+| Sleep, wake, and waiting intents | Sleep-only completion does not force extra provider turns; wake hints coalesce and re-enter once; callback waiting intents preserve scope, provenance, cancellation, and mode semantics. | `src/runtime/tests/turns.rs`, `src/runtime/tests/work_items.rs`, `tests/runtime_waiting_and_reactivation.rs`, and `tests/runtime_waiting_and_delivery_regressions.rs`. | Existing coverage is sufficient for phase-1 extraction; follow-up #938 should keep the waiting and callback suites green. |
+| Delivery and brief projection | Terminal result brief comes from the final assistant message, notification delivery uses the selected route, delivery failures are recorded without failing the notification, and remote operator provenance is preserved. | `tests/runtime_waiting_and_reactivation.rs`, `tests/runtime_waiting_and_delivery_regressions.rs`, and `tests/http_operator_transport.rs`. | Existing coverage is sufficient for phase-1 extraction; follow-up #939 should run delivery and operator-ingress suites. |
+| Cross-cutting external contracts | Tool schemas remain stable, provider failures surface as failure briefs and transcript entries, compaction preserves exact tool context or recap, and HTTP ingress validates provenance/trust. | `tests/runtime_tasks.rs`, `tests/runtime_compaction.rs`, `tests/regression_fixture.rs`, `tests/http_ingress.rs`, `tests/http_callback.rs`, and provider live tests where enabled. | No new broad suite is needed for phase 1. Use focused local tests plus existing CI; live tests remain opt-in. |
+
+## Focused Verification Commands
+
+Use these commands as the minimum local gates for the extraction sequence:
+
+```bash
+cargo test -q --test runtime_waiting_and_reactivation turn_execution_boundary_persists_queue_transcript_and_briefs
+cargo test -q --test runtime_tasks task_status_and_task_output_keep_lifecycle_and_output_boundaries
+cargo test -q --test runtime_waiting_and_delivery_regressions callback_tools_register_and_revoke_waiting_state
+cargo test -q --test runtime_waiting_and_delivery_regressions callback_wake_hint_routes_through_wake_hint
+cargo test -q --test runtime_waiting_and_reactivation terminal_brief_uses_last_assistant_message_without_terminal_delivery_round
+cargo fmt --check
+```
+
+Each follow-up extraction PR should run the focused command for its boundary and
+the broader suite that owns the touched code. Full `cargo test` remains the
+merge gate.

--- a/tests/runtime_waiting_and_reactivation.rs
+++ b/tests/runtime_waiting_and_reactivation.rs
@@ -20,6 +20,7 @@ fn policy_blocks_mismatched_origin() {
 }
 
 runtime_async_tests!(
+    turn_execution_boundary_persists_queue_transcript_and_briefs,
     message_processing_creates_briefs_and_sleeps,
     terminal_brief_uses_last_assistant_message_without_terminal_delivery_round,
     sleep_only_completion_keeps_last_assistant_message_from_previous_round,

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -32,9 +32,9 @@ use holon::{
         FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
         OperatorNotificationBoundary, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
-        OperatorTransportDeliveryAuthKind, Priority, TaskStatus, TodoItem, TodoItemState,
-        TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentStatus,
-        WaitingReason, WorkItemState,
+        OperatorTransportDeliveryAuthKind, Priority, QueueEntryStatus, TaskStatus, TodoItem,
+        TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        WaitingIntentStatus, WaitingReason, WorkItemState,
     },
 };
 use serde_json::json;
@@ -62,6 +62,80 @@ use crate::support::{
 
 // ============================================================================
 // Runtime waiting and reactivation domain test support
+pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> Result<()> {
+    let host = RuntimeHost::new_with_provider(
+        test_config(),
+        Arc::new(StubProvider::new("turn boundary result")),
+    )?;
+    let runtime = host.default_runtime().await?;
+
+    let message = runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "exercise the turn boundary".into(),
+            },
+        ))
+        .await?;
+
+    wait_until(|| {
+        let queue_entries = runtime.storage().read_recent_queue_entries(20)?;
+        Ok(queue_entries.iter().any(|entry| {
+            entry.message_id == message.id && entry.status == QueueEntryStatus::Processed
+        }))
+    })
+    .await?;
+
+    let queue_entries = runtime.storage().read_recent_queue_entries(20)?;
+    let statuses = queue_entries
+        .iter()
+        .filter(|entry| entry.message_id == message.id)
+        .map(|entry| entry.status.clone())
+        .collect::<Vec<_>>();
+    assert!(statuses.contains(&QueueEntryStatus::Queued));
+    assert!(statuses.contains(&QueueEntryStatus::Dequeued));
+    assert!(statuses.contains(&QueueEntryStatus::Processed));
+
+    let transcript = runtime.storage().read_recent_transcript(20)?;
+    assert!(transcript.iter().any(|entry| {
+        entry.kind == TranscriptEntryKind::IncomingMessage
+            && entry.related_message_id.as_deref() == Some(message.id.as_str())
+            && entry.data["body"]["text"].as_str() == Some("exercise the turn boundary")
+    }));
+    assert!(transcript.iter().any(|entry| {
+        entry.kind == TranscriptEntryKind::AssistantRound && entry.round == Some(1)
+    }));
+
+    let briefs = runtime.recent_briefs(10).await?;
+    assert!(briefs.iter().any(|brief| {
+        brief.kind == BriefKind::Ack
+            && brief.related_message_id.as_deref() == Some(message.id.as_str())
+            && brief.text == "Queued work: exercise the turn boundary"
+    }));
+    assert!(briefs.iter().any(|brief| {
+        brief.kind == BriefKind::Result
+            && brief.related_message_id.as_deref() == Some(message.id.as_str())
+            && brief.text == "turn boundary result"
+    }));
+
+    let events = runtime.recent_events(20).await?;
+    let terminal_event = events
+        .iter()
+        .find(|event| event.kind == "turn_terminal")
+        .expect("turn terminal event should be recorded");
+    assert_eq!(terminal_event.data["kind"].as_str(), Some("completed"));
+    assert_eq!(
+        terminal_event.data["last_assistant_message"].as_str(),
+        Some("turn boundary result")
+    );
+
+    Ok(())
+}
+
 pub async fn message_processing_creates_briefs_and_sleeps() -> Result<()> {
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("stub result")))?;


### PR DESCRIPTION
## Summary
- document the phase-1 runtime boundary extraction regression matrix for #940
- add a compact turn-execution characterization test covering queue state, transcript persistence, briefs, and terminal event output
- list the focused verification commands for follow-up extraction PRs

Closes #940

## Verification
- cargo test -q --test runtime_waiting_and_reactivation turn_execution_boundary_persists_queue_transcript_and_briefs
- cargo test -q --test runtime_tasks task_status_and_task_output_keep_lifecycle_and_output_boundaries
- cargo test -q --test runtime_waiting_and_delivery_regressions callback_tools_register_and_revoke_waiting_state
- cargo test -q --test runtime_waiting_and_delivery_regressions callback_wake_hint_routes_through_wake_hint
- cargo test -q --test runtime_waiting_and_reactivation terminal_brief_uses_last_assistant_message_without_terminal_delivery_round
- cargo fmt --check
- git diff --check
- cargo test -q