### PR TITLE
refactor: route task tools through supervisor boundary

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,6 +12,7 @@ mod operator_dispatch;
 mod provider_turn;
 mod subagent;
 mod task_state_reducer;
+mod task_supervisor;
 mod tasks;
 #[cfg(test)]
 mod test_util;

--- a/src/runtime/task_supervisor.rs
+++ b/src/runtime/task_supervisor.rs
@@ -1,0 +1,86 @@
+use anyhow::Result;
+
+use super::RuntimeHandle;
+use crate::types::{
+    AgentProfilePreset, CommandTaskSpec, ExecCommandResult, SpawnAgentResult,
+    SpawnAgentWorkItemRequest, TaskInputResult, TaskListEntry, TaskOutputResult, TaskRecord,
+    TaskStatusSnapshot, TrustLevel,
+};
+
+pub(crate) struct ManagedTaskSupervisor<'a> {
+    runtime: &'a RuntimeHandle,
+}
+
+impl RuntimeHandle {
+    pub(crate) fn managed_tasks(&self) -> ManagedTaskSupervisor<'_> {
+        ManagedTaskSupervisor { runtime: self }
+    }
+}
+
+impl ManagedTaskSupervisor<'_> {
+    pub(crate) async fn execute_exec_command(
+        &self,
+        spec: CommandTaskSpec,
+        trust: &TrustLevel,
+    ) -> Result<ExecCommandResult> {
+        self.runtime.execute_exec_command(spec, trust).await
+    }
+
+    pub(crate) async fn execute_exec_command_once(
+        &self,
+        spec: CommandTaskSpec,
+        trust: &TrustLevel,
+    ) -> Result<ExecCommandResult> {
+        self.runtime.execute_exec_command_once(spec, trust).await
+    }
+
+    pub(crate) async fn spawn_agent(
+        &self,
+        summary: String,
+        prompt: String,
+        trust: TrustLevel,
+        preset: AgentProfilePreset,
+        agent_id: Option<String>,
+        worktree: bool,
+        template: Option<String>,
+        work_item: Option<SpawnAgentWorkItemRequest>,
+    ) -> Result<SpawnAgentResult> {
+        self.runtime
+            .spawn_agent(
+                summary, prompt, trust, preset, agent_id, worktree, template, work_item,
+            )
+            .await
+    }
+
+    pub(crate) async fn latest_task_list_entries(&self) -> Result<Vec<TaskListEntry>> {
+        self.runtime.latest_task_list_entries().await
+    }
+
+    pub(crate) async fn task_status_snapshot(&self, task_id: &str) -> Result<TaskStatusSnapshot> {
+        self.runtime.task_status_snapshot(task_id).await
+    }
+
+    pub(crate) async fn task_output(
+        &self,
+        task_id: &str,
+        block: bool,
+        timeout_ms: u64,
+    ) -> Result<TaskOutputResult> {
+        self.runtime.task_output(task_id, block, timeout_ms).await
+    }
+
+    pub(crate) async fn stop_task(&self, task_id: &str, trust: &TrustLevel) -> Result<TaskRecord> {
+        self.runtime.stop_task(task_id, trust).await
+    }
+
+    pub(crate) async fn task_input_with_trust(
+        &self,
+        task_id: &str,
+        input: &str,
+        trust: &TrustLevel,
+    ) -> Result<TaskInputResult> {
+        self.runtime
+            .task_input_with_trust(task_id, input, trust)
+            .await
+    }
+}

--- a/src/tool/tools/exec_command.rs
+++ b/src/tool/tools/exec_command.rs
@@ -62,7 +62,10 @@ pub(crate) async fn execute(
         accepts_input: args.accepts_input.unwrap_or(tty),
         continue_on_result: args.continue_on_result.unwrap_or(false),
     };
-    let result: ExecCommandResult = runtime.execute_exec_command(spec, trust).await?;
+    let result: ExecCommandResult = runtime
+        .managed_tasks()
+        .execute_exec_command(spec, trust)
+        .await?;
     serialize_success(NAME, &result)
 }
 

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -189,7 +189,11 @@ async fn execute_batch_item(
         continue_on_result: false,
     };
 
-    match runtime.execute_exec_command_once(spec, trust).await {
+    match runtime
+        .managed_tasks()
+        .execute_exec_command_once(spec, trust)
+        .await
+    {
         Ok(result) => {
             let status = match result.outcome {
                 ExecCommandOutcome::Completed { exit_status, .. } if exit_status == Some(0) => {

--- a/src/tool/tools/spawn_agent.rs
+++ b/src/tool/tools/spawn_agent.rs
@@ -168,6 +168,7 @@ pub(crate) async fn execute(
     }
 
     let result = runtime
+        .managed_tasks()
         .spawn_agent(
             summary,
             prompt,

--- a/src/tool/tools/task_input.rs
+++ b/src/tool/tools/task_input.rs
@@ -40,6 +40,7 @@ pub(crate) async fn execute(
     let args: TaskInputArgs = parse_tool_args(NAME, input)?;
     let task_id = validate_non_empty(args.task_id, NAME, "task_id")?;
     let result: TaskInputResult = runtime
+        .managed_tasks()
         .task_input_with_trust(&task_id, &args.input, trust)
         .await?;
     serialize_success(NAME, &result)

--- a/src/tool/tools/task_list.rs
+++ b/src/tool/tools/task_list.rs
@@ -35,6 +35,6 @@ pub(crate) async fn execute(
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
     let _: TaskListArgs = parse_tool_args(NAME, input)?;
-    let tasks = runtime.latest_task_list_entries().await?;
+    let tasks = runtime.managed_tasks().latest_task_list_entries().await?;
     serialize_success(NAME, &tasks)
 }

--- a/src/tool/tools/task_output.rs
+++ b/src/tool/tools/task_output.rs
@@ -45,7 +45,10 @@ pub(crate) async fn execute(
     let task_id = validate_non_empty(args.task_id, NAME, "task_id")?;
     let block = args.block.unwrap_or(true);
     let timeout_ms = args.timeout_ms.unwrap_or(30_000);
-    let result: TaskOutputResult = runtime.task_output(&task_id, block, timeout_ms).await?;
+    let result: TaskOutputResult = runtime
+        .managed_tasks()
+        .task_output(&task_id, block, timeout_ms)
+        .await?;
     serialize_success(NAME, &result)
 }
 

--- a/src/tool/tools/task_status.rs
+++ b/src/tool/tools/task_status.rs
@@ -35,7 +35,10 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: TaskStatusArgs = parse_tool_args(NAME, input)?;
     let task_id = validate_non_empty(args.task_id, NAME, "task_id")?;
-    let snapshot = runtime.task_status_snapshot(&task_id).await?;
+    let snapshot = runtime
+        .managed_tasks()
+        .task_status_snapshot(&task_id)
+        .await?;
     serialize_success(
         NAME,
         &TaskStatusResult {

--- a/src/tool/tools/task_stop.rs
+++ b/src/tool/tools/task_stop.rs
@@ -38,7 +38,7 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: TaskStopArgs = parse_tool_args(NAME, input)?;
     let task_id = validate_non_empty(args.task_id, NAME, "task_id")?;
-    let task = runtime.stop_task(&task_id, trust).await?;
+    let task = runtime.managed_tasks().stop_task(&task_id, trust).await?;
     let force_stop_requested = task
         .detail
         .as_ref()


### PR DESCRIPTION
Closes #937.

## Summary

- Add `ManagedTaskSupervisor` as the explicit task orchestration facade.
- Route TaskList, TaskStatus, TaskOutput, TaskStop, TaskInput, ExecCommand, ExecCommandBatch, and SpawnAgent through the supervisor boundary.
- Preserve existing command task, child-agent supervision, output, and stop/input behavior by delegating to the current runtime implementations.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -q --test runtime_tasks task_status_and_task_output_keep_lifecycle_and_output_boundaries`
- `cargo test -q runtime::task_state_reducer`
- `cargo test -q`
