### PR TITLE
fix: make TUI layout copy-first

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -48,10 +48,12 @@ mod runtime;
 
 use app::TuiApp;
 #[cfg(test)]
+use chat::paragraph_max_scroll;
+#[cfg(test)]
 use chat::{
     build_chat_text, chat_text, collect_chat_items, is_operator_origin_value, ConversationCell,
 };
-use chat::{chat_text_for_width, paragraph_max_scroll, ChatScrollState};
+use chat::{chat_text_for_width, paragraph_max_scroll_unframed, ChatScrollState};
 use composer::ComposerState;
 use logging::TuiLogWriter;
 #[cfg(test)]
@@ -202,8 +204,8 @@ mod tests {
 
     use super::{
         build_chat_text, centered_rect_rows, chat_text, collect_chat_items,
-        determine_alt_screen_mode_for_terminal, is_cursor_too_old_error, is_operator_origin_value,
-        paragraph_max_scroll,
+        determine_alt_screen_mode_for_terminal, draw, is_cursor_too_old_error,
+        is_operator_origin_value, paragraph_max_scroll, paragraph_max_scroll_unframed,
         projection::{OperatorVisibility, TuiProjection},
         AgentListChange, ChatScrollState, ComposerState, ConversationCell, OverlayState, TuiApp,
         TuiConnectionState, TuiRuntimeMessage,
@@ -224,8 +226,8 @@ mod tests {
             TokenUsage, TranscriptEntry, TranscriptEntryKind, WaitingIntentSummary,
         },
     };
-    use ratatui::layout::Rect;
     use ratatui::text::{Line, Text};
+    use ratatui::{backend::TestBackend, layout::Rect, Terminal};
 
     fn test_config() -> AppConfig {
         let temp = tempfile::tempdir().unwrap().keep();
@@ -386,6 +388,26 @@ mod tests {
             brief: None,
             cursor: Some(cursor.into()),
         }
+    }
+
+    fn rendered_buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>()
+    }
+
+    fn rendered_buffer_rows(terminal: &Terminal<TestBackend>) -> Vec<String> {
+        let buffer = terminal.backend().buffer();
+        let width = usize::from(buffer.area.width);
+        buffer
+            .content()
+            .chunks(width)
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect()
     }
 
     #[test]
@@ -839,6 +861,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn slash_state_opens_agent_state_overlay() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.composer = ComposerState::from("/state");
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .unwrap();
+        assert_eq!(app.overlay, OverlayState::AgentState { scroll: 0 });
+        assert_eq!(app.composer.as_str(), "");
+        assert_eq!(app.status_line, "Opened agent state overlay");
+    }
+
+    #[tokio::test]
+    async fn agent_state_overlay_scrolls_and_esc_closes() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.overlay = OverlayState::AgentState { scroll: 0 };
+
+        app.handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE))
+            .await
+            .unwrap();
+        assert_eq!(app.overlay, OverlayState::AgentState { scroll: 10 });
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .await
+            .unwrap();
+        assert_eq!(app.overlay, OverlayState::None);
+    }
+
+    #[tokio::test]
     async fn slash_display_sets_chat_visibility_level() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(
@@ -980,6 +1038,38 @@ mod tests {
         let area = Rect::new(0, 0, 6, 3);
         let text = Text::from(vec![Line::from("abcd      ")]);
         assert_eq!(paragraph_max_scroll(&text, area), 1);
+    }
+
+    #[test]
+    fn paragraph_max_scroll_unframed_uses_full_area() {
+        let area = Rect::new(0, 0, 12, 2);
+        let text = Text::from("one\ntwo\nthree");
+        assert_eq!(paragraph_max_scroll_unframed(&text, area), 1);
+        assert_eq!(paragraph_max_scroll(&text, area), 0);
+    }
+
+    #[test]
+    fn default_tui_render_omits_agent_state_panel_and_box_borders() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.projection = Some(TuiProjection::from_snapshot(sample_snapshot(
+            "default", "evt-0",
+        )));
+        app.apply_projection_view();
+
+        let backend = TestBackend::new(100, 28);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw(frame, &mut app)).unwrap();
+
+        let rendered = rendered_buffer_text(&terminal);
+        assert!(!rendered.contains("Agent State"));
+        assert!(!rendered.contains("Conversation"));
+        let rows = rendered_buffer_rows(&terminal);
+        let main_rows = &rows[2..22];
+        assert!(!main_rows.iter().any(|row| row.contains('│')));
     }
 
     #[test]

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -723,9 +723,22 @@ fn non_empty_value(value: &Value) -> Option<String> {
         .map(ToString::to_string)
 }
 
+#[cfg(test)]
 pub(super) fn paragraph_max_scroll(text: &Text<'_>, area: Rect) -> u16 {
-    let inner_width = area.width.saturating_sub(2).max(1);
-    let inner_height = area.height.saturating_sub(2) as usize;
+    paragraph_max_scroll_for_size(
+        text,
+        area.width.saturating_sub(2).max(1),
+        area.height.saturating_sub(2),
+    )
+}
+
+pub(super) fn paragraph_max_scroll_unframed(text: &Text<'_>, area: Rect) -> u16 {
+    paragraph_max_scroll_for_size(text, area.width.max(1), area.height)
+}
+
+fn paragraph_max_scroll_for_size(text: &Text<'_>, width: u16, height: u16) -> u16 {
+    let inner_width = width.max(1);
+    let inner_height = height as usize;
     if inner_height == 0 {
         return 0;
     }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -8,6 +8,7 @@ enum SlashCommand {
     Model,
     Tasks,
     Transcript,
+    State,
     Refresh,
     ClearStatus,
     DebugPrompt,
@@ -40,7 +41,7 @@ pub(super) struct SlashCommandSpec {
     command: SlashCommand,
 }
 
-const SLASH_COMMAND_SPECS: [SlashCommandSpec; 15] = [
+const SLASH_COMMAND_SPECS: [SlashCommandSpec; 16] = [
     SlashCommandSpec {
         name: "/help",
         description: "show slash command help",
@@ -82,6 +83,13 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 15] = [
         usage: "/transcript",
         arg_rule: SlashArgRule::None,
         command: SlashCommand::Transcript,
+    },
+    SlashCommandSpec {
+        name: "/state",
+        description: "open agent state overlay",
+        usage: "/state",
+        arg_rule: SlashArgRule::None,
+        command: SlashCommand::State,
     },
     SlashCommandSpec {
         name: "/refresh",
@@ -455,6 +463,10 @@ impl TuiApp {
                 self.overlay = OverlayState::Transcript { scroll: 0 };
                 self.status_line = "Opened transcript overlay".into();
             }
+            SlashCommand::State => {
+                self.overlay = OverlayState::AgentState { scroll: 0 };
+                self.status_line = "Opened agent state overlay".into();
+            }
             SlashCommand::Refresh => {
                 self.overlay = OverlayState::None;
                 self.status_line = "Refreshing selected agent from /state".into();
@@ -635,6 +647,13 @@ impl TuiApp {
                 if key.code != KeyCode::Esc {
                     scroll = adjust_scroll_for_key(scroll, key.code);
                     self.overlay = OverlayState::Transcript { scroll };
+                }
+                Ok(())
+            }
+            OverlayState::AgentState { mut scroll } => {
+                if key.code != KeyCode::Esc {
+                    scroll = adjust_scroll_for_key(scroll, key.code);
+                    self.overlay = OverlayState::AgentState { scroll };
                 }
                 Ok(())
             }

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -16,6 +16,9 @@ pub(super) enum OverlayState {
     Transcript {
         scroll: u16,
     },
+    AgentState {
+        scroll: u16,
+    },
     Tasks {
         selected: usize,
         detail_scroll: u16,
@@ -52,6 +55,7 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
             detail_scroll,
         } => draw_events_overlay(frame, app, selected_event_id.as_deref(), *detail_scroll),
         OverlayState::Transcript { scroll } => draw_transcript_overlay(frame, app, *scroll),
+        OverlayState::AgentState { scroll } => draw_agent_state_overlay(frame, app, *scroll),
         OverlayState::Tasks {
             selected,
             detail_scroll,
@@ -228,6 +232,20 @@ fn draw_transcript_overlay(frame: &mut Frame<'_>, app: &TuiApp, scroll: u16) {
         .block(
             Block::default()
                 .title("Transcript (Esc closes)")
+                .borders(Borders::ALL),
+        )
+        .scroll((scroll, 0))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(widget, popup);
+}
+
+fn draw_agent_state_overlay(frame: &mut Frame<'_>, app: &TuiApp, scroll: u16) {
+    let popup = centered_rect(92, 82, frame.area());
+    frame.render_widget(Clear, popup);
+    let widget = Paragraph::new(render::render_agent_state_text(app))
+        .block(
+            Block::default()
+                .title("Agent State (Esc closes)")
                 .borders(Borders::ALL),
         )
         .scroll((scroll, 0))
@@ -434,6 +452,7 @@ fn draw_help_overlay(frame: &mut Frame<'_>, scroll: u16) {
         "  /model open model picker for the selected agent",
         "  /tasks open task overlay",
         "  /transcript open transcript overlay",
+        "  /state open agent state overlay",
         "  /refresh re-bootstrap the selected agent from /state",
         "  /clear-status clear transient local status text",
         "  /debug-prompt open debug prompt dialog",

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -27,19 +27,7 @@ pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
 }
 
 fn draw_main_panels(frame: &mut Frame<'_>, area: Rect, app: &mut TuiApp) {
-    let layout = if area.width >= 110 {
-        Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(66), Constraint::Percentage(34)])
-            .split(area)
-    } else {
-        Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Percentage(68), Constraint::Percentage(32)])
-            .split(area)
-    };
-    draw_chat(frame, layout[0], app);
-    draw_agent_state(frame, layout[1], app);
+    draw_chat(frame, area, app);
 }
 
 fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
@@ -54,20 +42,12 @@ fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
 }
 
 fn draw_chat(frame: &mut Frame<'_>, area: Rect, app: &mut TuiApp) {
-    let body = chat_text_for_width(app, area.width.saturating_sub(2).max(1));
-    let max_scroll = paragraph_max_scroll(&body, area);
+    let body = chat_text_for_width(app, area.width.max(1));
+    let max_scroll = paragraph_max_scroll_unframed(&body, area);
     app.chat_max_scroll = max_scroll;
     let scroll = app.chat_scroll.effective_scroll(max_scroll);
     let paragraph = Paragraph::new(body)
-        .block(Block::default().title("Conversation").borders(Borders::ALL))
         .scroll((scroll, 0))
-        .wrap(Wrap { trim: false });
-    frame.render_widget(paragraph, area);
-}
-
-fn draw_agent_state(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
-    let paragraph = Paragraph::new(render_agent_state_text(app))
-        .block(Block::default().title("Agent State").borders(Borders::ALL))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }
@@ -103,11 +83,12 @@ fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
             "Slash: Up/Down select  Tab complete  Enter run  Esc close"
         }
         OverlayState::None => {
-            "/help commands  Up/Down history (empty)  PgUp/PgDn scroll  Ctrl+A/E edit  ? help  Ctrl+C quit"
+            "/help commands  /state agent state  /transcript  PgUp/PgDn scroll  Ctrl+A/E edit  Ctrl+C quit"
         }
         OverlayState::Agents => "Agents: Up/Down, Esc",
         OverlayState::Events { .. } => "Events: Up/Down, PgUp/PgDn, Home/End, Esc",
         OverlayState::Transcript { .. } => "Transcript: Up/Down, PgUp/PgDn, Home/End, Esc",
+        OverlayState::AgentState { .. } => "Agent state: Up/Down, PgUp/PgDn, Home/End, Esc",
         OverlayState::Tasks { .. } => {
             "Tasks: Up/Down, PgUp/PgDn, Home/End, Esc"
         }
@@ -136,7 +117,7 @@ fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
     frame.render_widget(paragraph, area);
 }
 
-fn render_agent_state_text(app: &TuiApp) -> String {
+pub(super) fn render_agent_state_text(app: &TuiApp) -> String {
     let Some(projection) = app.projection.as_ref() else {
         return "Projection not initialized yet.".into();
     };


### PR DESCRIPTION
## Summary
- make the default TUI conversation area full-width and unframed for cleaner terminal selection
- move Agent State out of the default split panel into a `/state` overlay
- keep the change copy-first: no copy mode, no mouse capture, no mouse wheel handling

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test --lib tui:: -q`
- `cargo test --lib -q`
