### PR TITLE
refactor: separate delivery projection helpers

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,6 +3,7 @@ mod callback;
 mod closure;
 mod command_task;
 mod continuation;
+mod delivery;
 mod failure;
 mod lifecycle;
 mod memory_refresh;
@@ -40,9 +41,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use uuid::Uuid;
 
-const OPERATOR_MESSAGE_SCAN_MIN: usize = 256;
-const OPERATOR_MESSAGE_SCAN_HEADROOM: usize = 16;
-
 #[cfg(test)]
 use crate::provider::{ConversationMessage, ProviderTurnRequest};
 use crate::{
@@ -70,12 +68,12 @@ use crate::{
         CancelWaitingResult, ClosureDecision, ContinuationResolution, ControlAction,
         ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerScope,
         ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, OperatorMessageRecord,
-        OperatorMessageStatus, PendingWakeHint, Priority, QueueEntryRecord, QueueEntryStatus,
-        ResolvedModelAvailability, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
-        SkillActivationSource, SkillActivationState, SkillsRuntimeView, TaskKind, TaskRecord,
-        TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
-        TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
+        Priority, QueueEntryRecord, QueueEntryStatus, ResolvedModelAvailability,
+        RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
+        SkillActivationState, SkillsRuntimeView, TaskKind, TaskRecord, TaskRecoverySpec,
+        TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
+        TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
         WaitingIntentSummary, WorkItemState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
     web::WebConfig,
@@ -802,62 +800,6 @@ impl RuntimeHandle {
         Ok(message)
     }
 
-    pub async fn recent_operator_messages(
-        &self,
-        limit: usize,
-    ) -> Result<Vec<OperatorMessageRecord>> {
-        if limit == 0 {
-            return Ok(Vec::new());
-        }
-
-        let state = {
-            let guard = self.inner.agent.lock().await;
-            guard.state.clone()
-        };
-        let scan_limit = limit
-            .saturating_mul(OPERATOR_MESSAGE_SCAN_HEADROOM)
-            .max(OPERATOR_MESSAGE_SCAN_MIN);
-        let messages_by_id = self
-            .inner
-            .storage
-            .read_recent_messages(scan_limit)?
-            .into_iter()
-            .filter(|message| message.kind == MessageKind::OperatorPrompt)
-            .map(|message| (message.id.clone(), message))
-            .collect::<std::collections::BTreeMap<_, _>>();
-
-        let mut latest_queue_entries = std::collections::BTreeMap::new();
-        for entry in self.inner.storage.read_recent_queue_entries(scan_limit)? {
-            latest_queue_entries.insert(entry.message_id.clone(), entry);
-        }
-
-        let mut records = latest_queue_entries
-            .values()
-            .into_iter()
-            .filter_map(|entry| {
-                let message = messages_by_id.get(&entry.message_id)?;
-                Some(OperatorMessageRecord {
-                    message_id: entry.message_id.clone(),
-                    agent_id: entry.agent_id.clone(),
-                    status: operator_message_status(&entry.status, &entry.priority, &state),
-                    created_at: entry.created_at,
-                    updated_at: entry.updated_at,
-                    body: message.body.clone(),
-                    error: None,
-                })
-            })
-            .collect::<Vec<_>>();
-        records.sort_by(|left, right| {
-            left.created_at
-                .cmp(&right.created_at)
-                .then_with(|| left.message_id.cmp(&right.message_id))
-        });
-        if records.len() > limit {
-            records.drain(0..records.len() - limit);
-        }
-        Ok(records)
-    }
-
     pub(crate) fn append_audit_event(&self, kind: &str, data: serde_json::Value) -> Result<()> {
         self.inner
             .storage
@@ -1049,27 +991,6 @@ impl RuntimeHandle {
         }
         self.emit_recovered_pending_wake_hint().await?;
         Ok(())
-    }
-}
-
-fn operator_message_status(
-    status: &QueueEntryStatus,
-    priority: &Priority,
-    state: &AgentState,
-) -> OperatorMessageStatus {
-    match status {
-        QueueEntryStatus::Queued
-            if *priority == Priority::Interrupt && state.current_run_id.is_some() =>
-        {
-            OperatorMessageStatus::WaitingForSafePoint
-        }
-        QueueEntryStatus::Queued => OperatorMessageStatus::Queued,
-        QueueEntryStatus::Dequeued | QueueEntryStatus::Interjected => {
-            OperatorMessageStatus::Processing
-        }
-        QueueEntryStatus::Processed => OperatorMessageStatus::Processed,
-        QueueEntryStatus::Interrupted => OperatorMessageStatus::Failed,
-        QueueEntryStatus::Dropped => OperatorMessageStatus::Dropped,
     }
 }
 

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+use std::collections::BTreeMap;
+
+use crate::types::{OperatorMessageRecord, OperatorMessageStatus};
+
+const OPERATOR_MESSAGE_SCAN_MIN: usize = 256;
+const OPERATOR_MESSAGE_SCAN_HEADROOM: usize = 16;
+
+impl RuntimeHandle {
+    pub async fn recent_briefs(&self, limit: usize) -> Result<Vec<BriefRecord>> {
+        self.inner.storage.read_recent_briefs(limit)
+    }
+
+    pub async fn recent_operator_messages(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<OperatorMessageRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let state = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.clone()
+        };
+        let scan_limit = limit
+            .saturating_mul(OPERATOR_MESSAGE_SCAN_HEADROOM)
+            .max(OPERATOR_MESSAGE_SCAN_MIN);
+        let messages_by_id = self
+            .inner
+            .storage
+            .read_recent_messages(scan_limit)?
+            .into_iter()
+            .filter(|message| message.kind == MessageKind::OperatorPrompt)
+            .map(|message| (message.id.clone(), message))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut latest_queue_entries = BTreeMap::new();
+        for entry in self.inner.storage.read_recent_queue_entries(scan_limit)? {
+            latest_queue_entries.insert(entry.message_id.clone(), entry);
+        }
+
+        let mut records = latest_queue_entries
+            .values()
+            .filter_map(|entry| {
+                let message = messages_by_id.get(&entry.message_id)?;
+                Some(OperatorMessageRecord {
+                    message_id: entry.message_id.clone(),
+                    agent_id: entry.agent_id.clone(),
+                    status: operator_message_status(&entry.status, &entry.priority, &state),
+                    created_at: entry.created_at,
+                    updated_at: entry.updated_at,
+                    body: message.body.clone(),
+                    error: None,
+                })
+            })
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.message_id.cmp(&right.message_id))
+        });
+        if records.len() > limit {
+            records.drain(0..records.len() - limit);
+        }
+        Ok(records)
+    }
+
+    pub(super) async fn persist_brief(&self, brief: &BriefRecord) -> Result<()> {
+        let mut bound_brief = brief.clone();
+        {
+            let guard = self.inner.agent.lock().await;
+            bound_brief.workspace_id = guard
+                .state
+                .active_workspace_entry
+                .as_ref()
+                .map(|entry| entry.workspace_id.clone())
+                .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
+            if bound_brief.work_item_id.is_none() {
+                bound_brief.work_item_id = guard.state.current_turn_work_item_id.clone();
+            }
+        }
+        self.inner.storage.append_brief(&bound_brief)?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "brief_created",
+            to_json_value(&bound_brief),
+        ))?;
+        let mut guard = self.inner.agent.lock().await;
+        guard.state.last_brief_at = Some(bound_brief.created_at);
+        self.inner.storage.write_agent(&guard.state)?;
+        Ok(())
+    }
+}
+
+fn operator_message_status(
+    status: &QueueEntryStatus,
+    priority: &Priority,
+    state: &AgentState,
+) -> OperatorMessageStatus {
+    match status {
+        QueueEntryStatus::Queued
+            if *priority == Priority::Interrupt && state.current_run_id.is_some() =>
+        {
+            OperatorMessageStatus::WaitingForSafePoint
+        }
+        QueueEntryStatus::Queued => OperatorMessageStatus::Queued,
+        QueueEntryStatus::Dequeued | QueueEntryStatus::Interjected => {
+            OperatorMessageStatus::Processing
+        }
+        QueueEntryStatus::Processed => OperatorMessageStatus::Processed,
+        QueueEntryStatus::Interrupted => OperatorMessageStatus::Failed,
+        QueueEntryStatus::Dropped => OperatorMessageStatus::Dropped,
+    }
+}

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -372,10 +372,6 @@ impl RuntimeHandle {
         })
     }
 
-    pub async fn recent_briefs(&self, limit: usize) -> Result<Vec<BriefRecord>> {
-        self.inner.storage.read_recent_briefs(limit)
-    }
-
     pub async fn recent_events(&self, limit: usize) -> Result<Vec<AuditEvent>> {
         self.inner.storage.read_recent_events(limit)
     }
@@ -1050,31 +1046,6 @@ impl RuntimeHandle {
             ));
             let _ = runtime.enqueue(message).await;
         });
-    }
-
-    pub(super) async fn persist_brief(&self, brief: &BriefRecord) -> Result<()> {
-        let mut bound_brief = brief.clone();
-        {
-            let guard = self.inner.agent.lock().await;
-            bound_brief.workspace_id = guard
-                .state
-                .active_workspace_entry
-                .as_ref()
-                .map(|entry| entry.workspace_id.clone())
-                .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
-            if bound_brief.work_item_id.is_none() {
-                bound_brief.work_item_id = guard.state.current_turn_work_item_id.clone();
-            }
-        }
-        self.inner.storage.append_brief(&bound_brief)?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "brief_created",
-            to_json_value(&bound_brief),
-        ))?;
-        let mut guard = self.inner.agent.lock().await;
-        guard.state.last_brief_at = Some(bound_brief.created_at);
-        self.inner.storage.write_agent(&guard.state)?;
-        Ok(())
     }
 
     pub(super) async fn agent_id(&self) -> Result<String> {


### PR DESCRIPTION
## Summary

Closes #939.

- Add `runtime::delivery` as the user-facing delivery projection boundary for brief reads/persistence and operator message status projection.
- Keep the existing brief records, audit event emission, operator message queue status mapping, and task output preview behavior unchanged.
- Leave task output preview logic in the task runtime for this PR; its existing boundary is covered by focused task-output tests and not broadened into UI/prompt changes.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check -q`
- `cargo test -q runtime::tests::work_items::persist_brief_binds_current_turn_work_item`
- `cargo test -q --test runtime_tasks task_status_and_task_output_keep_lifecycle_and_output_boundaries`
- `cargo test -q --test http_control runtime_status_route_reports_waiting_activity_summary`
- `cargo test -q`
