### PR TITLE
fix: derive model defaults from auth

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -54,6 +54,10 @@ pub fn load_codex_cli_credential(codex_home: &Path) -> Result<CodexCliCredential
     ))
 }
 
+pub fn codex_cli_auth_file_exists(codex_home: &Path) -> bool {
+    auth_file_path(&canonical_or_original(codex_home)).is_file()
+}
+
 fn load_auth_from_file(codex_home: &Path) -> Result<AuthDotJson> {
     let path = auth_file_path(codex_home);
     let content =

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializ
 use serde_json::{json, Value};
 
 use crate::{
-    auth::load_codex_cli_credential,
+    auth::{codex_cli_auth_file_exists, load_codex_cli_credential},
     context::ContextConfig,
     model_catalog::{
         BuiltInModelCatalog, BuiltInModelMetadata, ModelRuntimeOverride, ResolvedRuntimeModelPolicy,
@@ -420,6 +420,21 @@ impl AppConfig {
     }
 
     pub fn load_with_home(home_override: Option<PathBuf>) -> Result<Self> {
+        Self::load_with_home_and_mode(home_override, ConfigLoadMode::Runtime)
+    }
+
+    pub fn load_for_config_inspection() -> Result<Self> {
+        Self::load_with_home_for_config_inspection(None)
+    }
+
+    pub fn load_with_home_for_config_inspection(home_override: Option<PathBuf>) -> Result<Self> {
+        Self::load_with_home_and_mode(home_override, ConfigLoadMode::ConfigInspection)
+    }
+
+    fn load_with_home_and_mode(
+        home_override: Option<PathBuf>,
+        mode: ConfigLoadMode,
+    ) -> Result<Self> {
         let settings_env = load_settings_env().unwrap_or_default();
         let home_dir = home_override.unwrap_or_else(|| {
             env::var("HOLON_HOME")
@@ -521,8 +536,21 @@ impl AppConfig {
             validate_optional_model_runtime_override(stored_config.model.unknown_fallback.clone())?;
         let providers =
             resolve_provider_registry(&stored_config, &settings_env, &credential_store)?;
-        let (default_model, fallback_models) =
-            resolve_model_selection(&stored_config, &providers, &validated_model_overrides)?;
+        let explicit_default = resolve_default_model(&stored_config)?;
+        let explicit_fallbacks = resolve_fallback_models(&stored_config)?;
+        let (default_model, fallback_models) = match resolve_model_selection_from_explicit(
+            explicit_default,
+            explicit_fallbacks,
+            &providers,
+            &validated_model_overrides,
+        ) {
+            Ok(selection) => selection,
+            Err(error) if mode.allow_unresolved_model() => {
+                tracing::debug!(error = %error, "using unresolved diagnostic model for config inspection");
+                (ModelRef::new(ProviderId::openai(), "unknown"), Vec::new())
+            }
+            Err(error) => return Err(error),
+        };
         let tui_alternate_screen = env::var("HOLON_TUI_ALTERNATE_SCREEN")
             .ok()
             .map(|value| AltScreenMode::parse(&value))
@@ -604,6 +632,18 @@ impl AppConfig {
             .parse::<std::net::SocketAddr>()
             .map(|addr| addr.ip().is_loopback())
             .unwrap_or(false)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigLoadMode {
+    Runtime,
+    ConfigInspection,
+}
+
+impl ConfigLoadMode {
+    fn allow_unresolved_model(self) -> bool {
+        matches!(self, Self::ConfigInspection)
     }
 }
 
@@ -1183,8 +1223,8 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             key: "model.fallbacks",
             kind: "model_ref_list",
             description:
-                "Explicit fallback provider/model refs. When unset, the runtime derives fallbacks from authenticated providers.",
-            default: json!([]),
+                "Explicit fallback provider/model refs. Null or an empty persisted list means unset; when unset, the runtime derives fallbacks from authenticated providers.",
+            default: Value::Null,
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
@@ -2479,19 +2519,6 @@ pub fn provider_registry_for_tests(
     registry
 }
 
-fn resolve_model_selection(
-    stored_config: &HolonConfigFile,
-    providers: &ProviderRegistry,
-    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
-) -> Result<(ModelRef, Vec<ModelRef>)> {
-    resolve_model_selection_from_explicit(
-        resolve_default_model(stored_config)?,
-        resolve_fallback_models(stored_config)?,
-        providers,
-        model_overrides,
-    )
-}
-
 fn resolve_model_selection_from_explicit(
     explicit_default: Option<ModelRef>,
     explicit_fallbacks: Option<Vec<ModelRef>>,
@@ -2589,7 +2616,9 @@ fn provider_has_usable_auth(provider: &ProviderRuntimeConfig) -> bool {
                 && provider
                     .codex_home
                     .as_deref()
-                    .map(|home| load_codex_cli_credential(home).is_ok())
+                    .map(|home| {
+                        codex_cli_auth_file_exists(home) && load_codex_cli_credential(home).is_ok()
+                    })
                     .unwrap_or(false)
         }
         CredentialSource::None | CredentialSource::CredentialProcess => false,
@@ -3024,7 +3053,7 @@ fn unknown_config_key(key: &str) -> anyhow::Error {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -3053,6 +3082,12 @@ mod tests {
     }
 
     impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
         fn unset(key: &'static str) -> Self {
             let original = std::env::var_os(key);
             std::env::remove_var(key);
@@ -4019,6 +4054,55 @@ mod tests {
 
         assert!(err.to_string().contains("no default model configured"));
         assert!(err.to_string().contains("configure provider credentials"));
+    }
+
+    #[test]
+    fn config_inspection_loads_provider_state_without_resolved_model() {
+        let home = tempdir().unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", home.path());
+        let _model_guard = EnvVarGuard::unset("HOLON_MODEL");
+        let _fallback_guard = EnvVarGuard::unset("HOLON_MODEL_FALLBACKS");
+        let _openai_guard = EnvVarGuard::unset("OPENAI_API_KEY");
+        let _anthropic_guard = EnvVarGuard::unset("ANTHROPIC_AUTH_TOKEN");
+        let provider_id = ProviderId::parse("custom-openai").unwrap();
+        save_persisted_config_at(
+            &persisted_config_path(home.path()),
+            &HolonConfigFile {
+                providers: BTreeMap::from([(
+                    provider_id.clone(),
+                    ProviderConfigFile {
+                        transport: ProviderTransportKind::OpenAiChatCompletions,
+                        base_url: "https://custom.example/v1".into(),
+                        auth: ProviderAuthConfig {
+                            source: CredentialSource::Env,
+                            kind: CredentialKind::ApiKey,
+                            env: Some("HOLON_TEST_MISSING_CUSTOM_OPENAI_API_KEY".into()),
+                            profile: None,
+                            external: None,
+                        },
+                        reasoning_effort: None,
+                    },
+                )]),
+                ..HolonConfigFile::default()
+            },
+        )
+        .unwrap();
+
+        let runtime_error = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap_err();
+        assert!(runtime_error
+            .to_string()
+            .contains("no default model configured"));
+
+        let config =
+            AppConfig::load_with_home_for_config_inspection(Some(home.path().to_path_buf()))
+                .unwrap();
+        let provider = config.providers.get(&provider_id).unwrap();
+        let view = super::provider_config_view(&config, provider);
+
+        assert_eq!(view.id, "custom-openai");
+        assert!(view.configured_in_config);
+        assert!(!view.credential_configured);
+        assert_eq!(config.default_model.as_string(), "openai/unknown");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializ
 use serde_json::{json, Value};
 
 use crate::{
+    auth::load_codex_cli_credential,
     context::ContextConfig,
     model_catalog::{
         BuiltInModelCatalog, BuiltInModelMetadata, ModelRuntimeOverride, ResolvedRuntimeModelPolicy,
@@ -514,16 +515,14 @@ impl AppConfig {
             .min(crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS as u32)
             .max(default_tool_output_tokens);
 
-        let anthropic_default_model = "claude-sonnet-4-6".to_string();
-        let default_model = resolve_default_model(&stored_config)?;
         let disable_provider_fallback = resolve_disable_provider_fallback(&stored_config)?;
-        let fallback_models =
-            resolve_fallback_models(&stored_config, &anthropic_default_model, &default_model)?;
         let validated_model_overrides = resolve_model_catalog(&stored_config)?;
         let validated_unknown_model_fallback =
             validate_optional_model_runtime_override(stored_config.model.unknown_fallback.clone())?;
         let providers =
             resolve_provider_registry(&stored_config, &settings_env, &credential_store)?;
+        let (default_model, fallback_models) =
+            resolve_model_selection(&stored_config, &providers, &validated_model_overrides)?;
         let tui_alternate_screen = env::var("HOLON_TUI_ALTERNATE_SCREEN")
             .ok()
             .map(|value| AltScreenMode::parse(&value))
@@ -1176,16 +1175,16 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
         ConfigSchemaEntry {
             key: "model.default",
             kind: "model_ref",
-            description: "Default provider/model ref used by the runtime.",
-            default: json!("openai/gpt-5.4"),
+            description: "Explicit default provider/model ref. When unset, the runtime derives one from authenticated providers.",
+            default: Value::Null,
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
             key: "model.fallbacks",
             kind: "model_ref_list",
             description:
-                "Fallback provider/model refs tried when earlier candidates are unavailable.",
-            default: json!(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"]),
+                "Explicit fallback provider/model refs. When unset, the runtime derives fallbacks from authenticated providers.",
+            default: json!([]),
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
@@ -2480,38 +2479,147 @@ pub fn provider_registry_for_tests(
     registry
 }
 
-fn resolve_default_model(stored_config: &HolonConfigFile) -> Result<ModelRef> {
-    if let Ok(value) = env::var("HOLON_MODEL") {
-        return ModelRef::parse(&value);
-    }
-    if let Some(value) = &stored_config.model.default {
-        return ModelRef::parse(value);
-    }
-    ModelRef::parse("openai/gpt-5.4")
+fn resolve_model_selection(
+    stored_config: &HolonConfigFile,
+    providers: &ProviderRegistry,
+    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+) -> Result<(ModelRef, Vec<ModelRef>)> {
+    resolve_model_selection_from_explicit(
+        resolve_default_model(stored_config)?,
+        resolve_fallback_models(stored_config)?,
+        providers,
+        model_overrides,
+    )
 }
 
-fn resolve_fallback_models(
-    stored_config: &HolonConfigFile,
-    anthropic_default_model: &str,
-    default_model: &ModelRef,
-) -> Result<Vec<ModelRef>> {
-    let configured = if let Ok(value) = env::var("HOLON_MODEL_FALLBACKS") {
-        parse_model_ref_list(&value)?
-    } else if !stored_config.model.fallbacks.is_empty() {
-        stored_config
-            .model
-            .fallbacks
-            .iter()
-            .map(|value| ModelRef::parse(value))
-            .collect::<Result<Vec<_>>>()?
+fn resolve_model_selection_from_explicit(
+    explicit_default: Option<ModelRef>,
+    explicit_fallbacks: Option<Vec<ModelRef>>,
+    providers: &ProviderRegistry,
+    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+) -> Result<(ModelRef, Vec<ModelRef>)> {
+    let auth_candidates = if explicit_default.is_none() || explicit_fallbacks.is_none() {
+        authenticated_model_candidates(providers, model_overrides)
     } else {
-        vec![
-            ModelRef::parse("openai/gpt-5.4")?,
-            ModelRef::parse(&format!("anthropic/{anthropic_default_model}"))?,
-        ]
+        Vec::new()
     };
 
-    Ok(configured
+    let default_model = explicit_default
+        .or_else(|| auth_candidates.first().cloned())
+        .ok_or_else(|| {
+            anyhow!(
+                "no default model configured and no authenticated provider with a known model is available; set HOLON_MODEL or model.default, or configure provider credentials"
+            )
+        })?;
+    let fallback_models = explicit_fallbacks.unwrap_or_else(|| {
+        auth_candidates
+            .into_iter()
+            .filter(|model| model != &default_model)
+            .collect()
+    });
+
+    Ok((
+        default_model.clone(),
+        dedupe_fallback_models(fallback_models, &default_model),
+    ))
+}
+
+fn resolve_default_model(stored_config: &HolonConfigFile) -> Result<Option<ModelRef>> {
+    if let Ok(value) = env::var("HOLON_MODEL") {
+        return ModelRef::parse(&value).map(Some);
+    }
+    if let Some(value) = &stored_config.model.default {
+        return ModelRef::parse(value).map(Some);
+    }
+    Ok(None)
+}
+
+fn resolve_fallback_models(stored_config: &HolonConfigFile) -> Result<Option<Vec<ModelRef>>> {
+    if let Ok(value) = env::var("HOLON_MODEL_FALLBACKS") {
+        Ok(Some(parse_model_ref_list(&value)?))
+    } else if !stored_config.model.fallbacks.is_empty() {
+        Ok(Some(
+            stored_config
+                .model
+                .fallbacks
+                .iter()
+                .map(|value| ModelRef::parse(value))
+                .collect::<Result<Vec<_>>>()?,
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+fn authenticated_model_candidates(
+    providers: &ProviderRegistry,
+    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+) -> Vec<ModelRef> {
+    let catalog = BuiltInModelCatalog::default();
+    let mut provider_ids = providers
+        .values()
+        .filter(|provider| provider_has_usable_auth(provider))
+        .map(|provider| provider.id.clone())
+        .collect::<Vec<_>>();
+    provider_ids.sort_by(|left, right| {
+        provider_auth_priority(left)
+            .cmp(&provider_auth_priority(right))
+            .then_with(|| left.as_str().cmp(right.as_str()))
+    });
+
+    let mut candidates = provider_ids
+        .into_iter()
+        .filter_map(|provider| {
+            catalog
+                .preferred_model_for_provider(&provider)
+                .or_else(|| preferred_override_model_for_provider(&provider, model_overrides))
+        })
+        .collect::<Vec<_>>();
+    candidates.dedup();
+    candidates
+}
+
+fn provider_has_usable_auth(provider: &ProviderRuntimeConfig) -> bool {
+    match provider.auth.source {
+        CredentialSource::Env | CredentialSource::AuthProfile => {
+            provider.has_configured_credential()
+        }
+        CredentialSource::ExternalCli => {
+            provider.auth.external.as_deref() == Some("codex_cli")
+                && provider
+                    .codex_home
+                    .as_deref()
+                    .map(|home| load_codex_cli_credential(home).is_ok())
+                    .unwrap_or(false)
+        }
+        CredentialSource::None | CredentialSource::CredentialProcess => false,
+    }
+}
+
+fn provider_auth_priority(provider: &ProviderId) -> usize {
+    match provider.as_str() {
+        ProviderId::OPENAI_CODEX => 0,
+        ProviderId::OPENAI => 1,
+        ProviderId::ANTHROPIC => 2,
+        _ => 100,
+    }
+}
+
+fn preferred_override_model_for_provider(
+    provider: &ProviderId,
+    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+) -> Option<ModelRef> {
+    let mut models = model_overrides
+        .keys()
+        .filter(|model| model.provider == *provider)
+        .cloned()
+        .collect::<Vec<_>>();
+    models.sort_by_key(ModelRef::as_string);
+    models.into_iter().next()
+}
+
+fn dedupe_fallback_models(configured: Vec<ModelRef>, default_model: &ModelRef) -> Vec<ModelRef> {
+    configured
         .into_iter()
         .filter(|model| model != default_model)
         .fold(Vec::new(), |mut acc, model| {
@@ -2519,7 +2627,7 @@ fn resolve_fallback_models(
                 acc.push(model);
             }
             acc
-        }))
+        })
 }
 
 fn resolve_disable_provider_fallback(stored_config: &HolonConfigFile) -> Result<bool> {
@@ -2934,8 +3042,9 @@ mod tests {
         resolve_anthropic_context_management_config, save_persisted_config_at, set_config_key,
         set_credential_profile_at, unset_config_key, AnthropicCacheStrategy,
         AnthropicContextManagementConfig, AppConfig, ControlAuthMode, CredentialKind,
-        CredentialSource, CredentialStoreFile, HolonConfigFile, ModelRef, ProviderAuthConfig,
-        ProviderConfigFile, ProviderId, ProviderTransportKind, RuntimeModelCatalog,
+        CredentialSource, CredentialStoreFile, HolonConfigFile, ModelConfigFile, ModelRef,
+        ProviderAuthConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
+        ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog,
     };
 
     struct EnvVarGuard {
@@ -3497,6 +3606,17 @@ mod tests {
     #[test]
     fn app_config_ignores_bad_credential_store_permissions_until_profile_auth_is_used() {
         let dir = tempdir().unwrap();
+        save_persisted_config_at(
+            &persisted_config_path(dir.path()),
+            &HolonConfigFile {
+                model: ModelConfigFile {
+                    default: Some("openai/gpt-5.4".into()),
+                    ..ModelConfigFile::default()
+                },
+                ..HolonConfigFile::default()
+            },
+        )
+        .unwrap();
         let store_path = credential_store_path(dir.path());
         fs::write(&store_path, r#"{"profiles":{}}"#).unwrap();
         #[cfg(unix)]
@@ -3507,8 +3627,7 @@ mod tests {
 
         AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap();
 
-        let config_path = persisted_config_path(dir.path());
-        let mut config = HolonConfigFile::default();
+        let mut config = load_persisted_config_at(&persisted_config_path(dir.path())).unwrap();
         config.providers.insert(
             ProviderId::parse("openrouter").unwrap(),
             ProviderConfigFile {
@@ -3524,7 +3643,7 @@ mod tests {
                 reasoning_effort: None,
             },
         );
-        save_persisted_config_at(&config_path, &config).unwrap();
+        save_persisted_config_at(&persisted_config_path(dir.path()), &config).unwrap();
 
         #[cfg(unix)]
         {
@@ -3836,6 +3955,112 @@ mod tests {
         assert!(runtime.codex_home.is_some());
         assert_eq!(runtime.originator.as_deref(), Some("codex_cli_rs"));
         assert_eq!(runtime.reasoning_effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn model_selection_explicit_config_wins() {
+        let providers = provider_registry_for_tests(
+            Some("openai-key"),
+            Some("anthropic-token"),
+            tempdir().unwrap().path().join("codex-home"),
+        );
+
+        let (default_model, fallback_models) = super::resolve_model_selection_from_explicit(
+            Some(ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap()),
+            Some(vec![
+                ModelRef::parse("openai/gpt-5.4").unwrap(),
+                ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            ]),
+            &providers,
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(default_model.as_string(), "anthropic/claude-sonnet-4-6");
+        assert_eq!(
+            fallback_models
+                .into_iter()
+                .map(|model| model.as_string())
+                .collect::<Vec<_>>(),
+            vec!["openai/gpt-5.4"]
+        );
+    }
+
+    #[test]
+    fn model_selection_derives_from_authenticated_providers() {
+        let providers = provider_registry_for_tests(
+            Some("openai-key"),
+            Some("anthropic-token"),
+            tempdir().unwrap().path().join("codex-home"),
+        );
+
+        let (default_model, fallback_models) =
+            super::resolve_model_selection_from_explicit(None, None, &providers, &HashMap::new())
+                .unwrap();
+
+        assert_eq!(default_model.as_string(), "openai/gpt-5.4");
+        assert_eq!(
+            fallback_models
+                .into_iter()
+                .map(|model| model.as_string())
+                .collect::<Vec<_>>(),
+            vec!["anthropic/claude-sonnet-4-6"]
+        );
+    }
+
+    #[test]
+    fn model_selection_fails_without_explicit_config_or_auth() {
+        let providers =
+            provider_registry_for_tests(None, None, tempdir().unwrap().path().join("codex-home"));
+
+        let err =
+            super::resolve_model_selection_from_explicit(None, None, &providers, &HashMap::new())
+                .unwrap_err();
+
+        assert!(err.to_string().contains("no default model configured"));
+        assert!(err.to_string().contains("configure provider credentials"));
+    }
+
+    #[test]
+    fn model_selection_derives_custom_provider_from_catalog_override() {
+        let mut providers = ProviderRegistry::new();
+        let id = ProviderId::parse("custom-openai").unwrap();
+        providers.insert(
+            id.clone(),
+            ProviderRuntimeConfig {
+                id: id.clone(),
+                transport: ProviderTransportKind::OpenAiChatCompletions,
+                base_url: "https://custom.example/v1".into(),
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::Env,
+                    kind: CredentialKind::ApiKey,
+                    env: Some("CUSTOM_API_KEY".into()),
+                    profile: None,
+                    external: None,
+                },
+                credential: Some("custom-key".into()),
+                codex_home: None,
+                originator: None,
+                reasoning_effort: None,
+                context_management: Default::default(),
+            },
+        );
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            ModelRef::parse("custom-openai/model-b").unwrap(),
+            ModelRuntimeOverride::default(),
+        );
+        overrides.insert(
+            ModelRef::parse("custom-openai/model-a").unwrap(),
+            ModelRuntimeOverride::default(),
+        );
+
+        let (default_model, fallback_models) =
+            super::resolve_model_selection_from_explicit(None, None, &providers, &overrides)
+                .unwrap();
+
+        assert_eq!(default_model.as_string(), "custom-openai/model-a");
+        assert!(fallback_models.is_empty());
     }
 
     #[test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -1408,6 +1408,8 @@ impl RuntimeHostBridge {
 #[cfg(test)]
 mod tests {
     use std::{
+        fs,
+        path::Path,
         path::PathBuf,
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -1434,6 +1436,14 @@ mod tests {
 
     use super::*;
 
+    fn write_test_model_config(home: &Path) {
+        fs::write(
+            home.join("config.json"),
+            r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+        )
+        .unwrap();
+    }
+
     struct ProviderConfigFixture {
         _home: tempfile::TempDir,
         _workspace: tempfile::TempDir,
@@ -1442,6 +1452,7 @@ mod tests {
 
     fn test_host() -> (tempfile::TempDir, RuntimeHost) {
         let home = tempdir().unwrap();
+        write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
@@ -2363,6 +2374,7 @@ mod tests {
     #[tokio::test]
     async fn host_shutdown_interrupts_active_run_with_daemon_shutdown_reason() {
         let home = tempdir().unwrap();
+        write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
         let agent_id = config.default_agent_id.clone();
         let started = Arc::new(Notify::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -970,7 +970,7 @@ async fn handle_config_command(command: ConfigCommands) -> Result<()> {
         }
         ConfigCommands::Schema => print_json(&serde_json::to_value(config_schema())?),
         ConfigCommands::Doctor => {
-            let config = AppConfig::load()?;
+            let config = AppConfig::load_for_config_inspection()?;
             print_json(&provider_doctor(&config))
         }
     }
@@ -979,7 +979,7 @@ async fn handle_config_command(command: ConfigCommands) -> Result<()> {
 async fn handle_config_models_command(command: ConfigModelCommands) -> Result<()> {
     match command {
         ConfigModelCommands::List => {
-            let config = AppConfig::load()?;
+            let config = AppConfig::load_for_config_inspection()?;
             print_json(&serde_json::to_value(resolved_model_availability(&config))?)
         }
     }
@@ -1053,7 +1053,7 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
             config.providers.insert(id.clone(), provider_config);
             save_persisted_config_at(&path, &config)?;
 
-            let effective = AppConfig::load()?;
+            let effective = AppConfig::load_for_config_inspection()?;
             let provider = effective.providers.get(&id).with_context(|| {
                 format!("provider {} was saved but did not resolve", id.as_str())
             })?;
@@ -1064,7 +1064,7 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
         }
         ConfigProviderCommands::Get { provider } => {
             let id = ProviderId::parse(&provider)?;
-            let config = AppConfig::load()?;
+            let config = AppConfig::load_for_config_inspection()?;
             let provider = config
                 .providers
                 .get(&id)
@@ -1074,7 +1074,7 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
             ))?)
         }
         ConfigProviderCommands::List => {
-            let config = AppConfig::load()?;
+            let config = AppConfig::load_for_config_inspection()?;
             print_json(&serde_json::to_value(provider_config_views(&config))?)
         }
         ConfigProviderCommands::Remove { provider } => {
@@ -1091,7 +1091,7 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
         }
         ConfigProviderCommands::Doctor { provider } => {
             let id = ProviderId::parse(&provider)?;
-            let config = AppConfig::load()?;
+            let config = AppConfig::load_for_config_inspection()?;
             let provider_cfg = config
                 .providers
                 .get(&id)

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -142,15 +142,23 @@ impl Default for ResolvedRuntimeModelPolicy {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuiltInModelCatalog {
     entries: HashMap<ModelRef, BuiltInModelMetadata>,
+    preferred_models: HashMap<ProviderId, ModelRef>,
 }
 
 impl BuiltInModelCatalog {
     pub fn new() -> Self {
-        let entries = built_in_entries()
-            .into_iter()
-            .map(|entry| (entry.model_ref.clone(), entry))
-            .collect();
-        Self { entries }
+        let mut entries = HashMap::new();
+        let mut preferred_models = HashMap::new();
+        for entry in built_in_entries() {
+            preferred_models
+                .entry(entry.model_ref.provider.clone())
+                .or_insert_with(|| entry.model_ref.clone());
+            entries.insert(entry.model_ref.clone(), entry);
+        }
+        Self {
+            entries,
+            preferred_models,
+        }
     }
 
     pub fn get(&self, model_ref: &ModelRef) -> Option<&BuiltInModelMetadata> {
@@ -168,10 +176,7 @@ impl BuiltInModelCatalog {
     }
 
     pub fn preferred_model_for_provider(&self, provider: &ProviderId) -> Option<ModelRef> {
-        built_in_entries()
-            .into_iter()
-            .find(|entry| entry.model_ref.provider == *provider)
-            .map(|entry| entry.model_ref)
+        self.preferred_models.get(provider).cloned()
     }
 
     pub fn resolve_policy(

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -167,6 +167,13 @@ impl BuiltInModelCatalog {
         entries
     }
 
+    pub fn preferred_model_for_provider(&self, provider: &ProviderId) -> Option<ModelRef> {
+        built_in_entries()
+            .into_iter()
+            .find(|entry| entry.model_ref.provider == *provider)
+            .map(|entry| entry.model_ref)
+    }
+
     pub fn resolve_policy(
         &self,
         model_ref: &ModelRef,

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -46,6 +46,11 @@ pub(crate) fn context_config() -> ContextConfig {
 
 pub(crate) async fn host_backed_test_runtime() -> (TempDir, RuntimeHost, RuntimeHandle) {
     let home = tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.json"),
+        r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+    )
+    .unwrap();
     let config = crate::config::AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
     let host = RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
     let runtime = host.default_runtime().await.unwrap();


### PR DESCRIPTION
## Summary

Closes #944.

- remove the hardcoded startup default/fallback model selection from persisted config resolution
- derive default/fallback candidates from authenticated providers using deterministic provider ordering and the model catalog
- keep explicit `HOLON_MODEL`, `HOLON_MODEL_FALLBACKS`, `model.default`, and `model.fallbacks` ahead of derived candidates
- fail fast with a clear config/auth error when no explicit model and no authenticated provider with a known model is available
- update host/runtime test fixtures that intentionally load config without real provider auth

## Verification

- `cargo check -q`
- `cargo test -q config::tests -- --test-threads=1`
- `cargo test -q host::tests::host_shutdown_interrupts_active_run_with_daemon_shutdown_reason -- --test-threads=1`
- `cargo test -q -- --test-threads=1`
- `cargo fmt --check`
- `git diff --check`

Note: plain parallel `cargo test -q` exposed an existing `HOME` env race in `agent_template::tests::seed_builtin_templates_is_idempotent`; the test passes standalone and the full suite passes serially.
