### PR TITLE
fix: separate assistant progress from provider telemetry

### DIFF
--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -641,8 +641,8 @@ Typical ephemeral items include:
 
 - `provider_round_completed` and `text_only_round_observed` classified as
   `progress`; `provider_round_completed` is provider telemetry, while
-  `assistant_round_recorded` carries assistant text/tool-request progress for
-  chat/activity rendering
+  `assistant_round_recorded` carries bounded assistant text previews and
+  tool-request progress for chat/activity rendering
 - `tool_executed` and `tool_execution_failed` classified as `trace`
 - lightweight task/workspace/worktree progress that is only relevant while the
   turn is in flight

--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -311,6 +311,7 @@ Important first-party event families currently include:
 ### Turn and model execution
 
 - `provider_round_completed`
+- `assistant_round_recorded`
 - `text_only_round_observed`
 - `max_output_tokens_recovery`
 - `turn_terminal`
@@ -639,7 +640,9 @@ the durable conversation history.
 Typical ephemeral items include:
 
 - `provider_round_completed` and `text_only_round_observed` classified as
-  `progress`
+  `progress`; `provider_round_completed` is provider telemetry, while
+  `assistant_round_recorded` carries assistant text/tool-request progress for
+  chat/activity rendering
 - `tool_executed` and `tool_execution_failed` classified as `trace`
 - lightweight task/workspace/worktree progress that is only relevant while the
   turn is in flight

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -191,6 +191,8 @@ Phase-1 token visibility rules:
   `output_tokens` fields and also mirror them under `data.token_usage`
 - `provider_round_completed` and `terminal_delivery_round_completed` audit
   events include `token_usage`
+- `provider_round_completed` is provider telemetry only; assistant-visible
+  round text and tool requests are emitted as `assistant_round_recorded`
 - `runtime_error` and transcript `RuntimeFailure` entries include token usage
   only when provider diagnostics can aggregate it
 - `holon run --json` includes a top-level `token_usage`

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -192,7 +192,8 @@ Phase-1 token visibility rules:
 - `provider_round_completed` and `terminal_delivery_round_completed` audit
   events include `token_usage`
 - `provider_round_completed` is provider telemetry only; assistant-visible
-  round text and tool requests are emitted as `assistant_round_recorded`
+  bounded text previews and tool requests are emitted as
+  `assistant_round_recorded`
 - `runtime_error` and transcript `RuntimeFailure` entries include token usage
   only when provider diagnostics can aggregate it
 - `holon run --json` includes a top-level `token_usage`

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -764,7 +764,7 @@ fn process_execution_text(
 
 fn assistant_round_recorded_text(payload: &Value) -> (String, Option<String>, String) {
     let text = payload
-        .get("text")
+        .get("text_preview")
         .and_then(Value::as_str)
         .map(collapse_whitespace)
         .filter(|text| !text.is_empty());
@@ -780,9 +780,10 @@ fn assistant_round_recorded_text(payload: &Value) -> (String, Option<String>, St
     let tool_names = tool_names(payload);
     if !tool_names.is_empty() {
         let tools = tool_names.join(", ");
+        let body = format!("requested tools: {tools}");
         return (
             "Assistant requested tools".into(),
-            Some(tools.clone()),
+            Some(body),
             format!("Assistant requested tools: {tools}"),
         );
     }
@@ -1077,7 +1078,7 @@ mod tests {
         let context = OperatorPresentationContext::default();
         let text = present_operator_event(
             "assistant_round_recorded",
-            &json!({ "text": "thinking", "tool_names": ["ExecCommand"] }),
+            &json!({ "text_preview": "thinking", "tool_names": ["ExecCommand"] }),
             "fallback",
             &context,
         );
@@ -1087,7 +1088,7 @@ mod tests {
 
         let multiline = present_operator_event(
             "assistant_round_recorded",
-            &json!({ "text": "thinking\n\nabout\ttools  now" }),
+            &json!({ "text_preview": "thinking\n\nabout\ttools  now" }),
             "fallback",
             &context,
         );
@@ -1098,7 +1099,7 @@ mod tests {
 
         let tools = present_operator_event(
             "assistant_round_recorded",
-            &json!({ "text": null, "tool_names": ["ExecCommand", "ReadFile"] }),
+            &json!({ "text_preview": null, "tool_names": ["ExecCommand", "ReadFile"] }),
             "fallback",
             &context,
         );
@@ -1106,10 +1107,14 @@ mod tests {
             tools.summary,
             "Assistant requested tools: ExecCommand, ReadFile"
         );
+        assert_eq!(
+            tools.body.as_deref(),
+            Some("requested tools: ExecCommand, ReadFile")
+        );
 
         let empty = present_operator_event(
             "assistant_round_recorded",
-            &json!({ "text": null, "tool_names": [], "stop_reason": "end_turn" }),
+            &json!({ "text_preview": null, "tool_names": [], "stop_reason": "end_turn" }),
             "fallback",
             &context,
         );

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -196,7 +196,8 @@ fn event_category(kind: &str) -> OperatorEventCategory {
         | "task_worktree_cleanup_failed"
         | "task_worktree_branch_cleanup_retained" => OperatorEventCategory::Workspace,
         "runtime_error" | "turn_terminal" => OperatorEventCategory::Runtime,
-        "provider_round_completed"
+        "assistant_round_recorded"
+        | "provider_round_completed"
         | "text_only_round_observed"
         | "max_output_tokens_recovery"
         | "turn_local_compaction_applied"
@@ -224,6 +225,7 @@ fn event_visibility(
         ("work_item_written", _) if work_item_completed(payload) => OperatorVisibility::WorkDone,
         ("work_item_written", _) => OperatorVisibility::Trace,
         ("runtime_error", _) => OperatorVisibility::TurnResult,
+        ("turn_terminal", _) if turn_terminal_completed(payload) => OperatorVisibility::Trace,
         (_, OperatorEventCategory::AssistantProgress) => OperatorVisibility::Progress,
         (_, OperatorEventCategory::Tool)
         | (_, OperatorEventCategory::Task)
@@ -263,6 +265,13 @@ fn work_item_completed(payload: &Value) -> bool {
         .is_some_and(|record| record.state == WorkItemState::Completed)
 }
 
+fn turn_terminal_completed(payload: &Value) -> bool {
+    payload
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind == "completed")
+}
+
 fn event_text(
     kind: &str,
     payload: &Value,
@@ -296,6 +305,8 @@ fn event_text(
         "workspace_detached" => workspace_text(payload, fallback_summary, "Detached workspace"),
         "worktree_entered" => worktree_text(payload, fallback_summary, true),
         "worktree_exited" => worktree_text(payload, fallback_summary, false),
+        "turn_terminal" => turn_terminal_text(payload),
+        "assistant_round_recorded" => assistant_round_recorded_text(payload),
         "provider_round_completed" => provider_round_text(payload),
         "text_only_round_observed" => text_only_round_text(payload),
         "max_output_tokens_recovery" => max_output_recovery_text(payload),
@@ -714,7 +725,7 @@ fn work_item_delegation_text(payload: &Value, completed: bool) -> (String, Optio
 
 fn process_execution_text(
     payload: &Value,
-    fallback_summary: &str,
+    _fallback_summary: &str,
 ) -> (String, Option<String>, String) {
     let surface = payload
         .get("surface")
@@ -743,60 +754,124 @@ fn process_execution_text(
             format!("{label}: {cmd_preview}"),
         );
     }
-    (label.into(), None, fallback_summary.to_string())
+    let body = match surface {
+        "ExecCommand" | "ExecCommandBatch" => "Command details are available in the event log.",
+        "command_task" => "Background command details are available in the task and event logs.",
+        _ => "Process details are available in the event log.",
+    };
+    (label.into(), Some(body.into()), label.into())
 }
 
-fn provider_round_text(payload: &Value) -> (String, Option<String>, String) {
-    let text_preview = payload
-        .get("text_preview")
+fn assistant_round_recorded_text(payload: &Value) -> (String, Option<String>, String) {
+    let text = payload
+        .get("text")
         .and_then(Value::as_str)
         .map(collapse_whitespace)
         .filter(|text| !text.is_empty());
-    if let Some(text_preview) = text_preview.as_deref() {
-        let body = trim_summary(text_preview);
+    if let Some(text) = text {
+        let body = trim_summary(&text);
         return (
-            "Assistant progress".into(),
+            "Assistant round".into(),
             Some(body.clone()),
-            format!("Assistant progress: {body}"),
+            format!("Assistant round: {body}"),
         );
     }
 
-    let tool_names = payload
+    let tool_names = tool_names(payload);
+    if !tool_names.is_empty() {
+        let tools = tool_names.join(", ");
+        return (
+            "Assistant requested tools".into(),
+            Some(tools.clone()),
+            format!("Assistant requested tools: {tools}"),
+        );
+    }
+
+    let stop_reason = payload
+        .get("stop_reason")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    (
+        "Assistant round".into(),
+        Some(format!("Stop reason: {stop_reason}")),
+        format!("Assistant round completed without text (stop={stop_reason})"),
+    )
+}
+
+fn tool_names(payload: &Value) -> Vec<String> {
+    payload
         .get("tool_names")
         .and_then(Value::as_array)
         .map(|tools| {
             tools
                 .iter()
                 .filter_map(Value::as_str)
-                .filter(|name| !name.trim().is_empty())
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
         })
-        .unwrap_or_default();
-    if !tool_names.is_empty() {
-        let tools = tool_names.join(", ");
-        return (
-            "Model requested tools".into(),
-            Some(tools.clone()),
-            format!("Model requested tools: {tools}"),
-        );
-    }
+        .unwrap_or_default()
+}
 
-    let stop_reason = payload.get("stop_reason").and_then(Value::as_str);
-    if stop_reason.is_some_and(is_max_output_stop_reason) {
-        return (
-            "Output limit reached".into(),
-            Some("Requesting continuation from the model.".into()),
-            "Output limit reached: requesting continuation".into(),
-        );
-    }
+fn provider_round_text(payload: &Value) -> (String, Option<String>, String) {
+    let round = payload
+        .get("round")
+        .and_then(Value::as_u64)
+        .map(|round| format!("round {round}"))
+        .unwrap_or_else(|| "round".into());
+    let model = payload
+        .get("active_model")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("requested_model").and_then(Value::as_str))
+        .filter(|model| !model.trim().is_empty())
+        .unwrap_or("model");
+    let stop = payload
+        .get("stop_reason")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let input_tokens = payload.get("input_tokens").and_then(Value::as_u64);
+    let output_tokens = payload.get("output_tokens").and_then(Value::as_u64);
+    let tokens = match (input_tokens, output_tokens) {
+        (Some(input), Some(output)) => format!("{input}/{output} tokens"),
+        _ => "tokens unavailable".into(),
+    };
+    let tool_count = payload
+        .get("tool_call_count")
+        .and_then(Value::as_u64)
+        .unwrap_or_else(|| tool_names(payload).len() as u64);
+    let body = format!("model={model}; stop={stop}; {tokens}; tools={tool_count}");
+    (
+        "Provider round completed".into(),
+        Some(body.clone()),
+        format!("Provider {round}: {body}"),
+    )
+}
 
-    let body = stop_reason.map(|reason| format!("Stop reason: {reason}"));
+fn turn_terminal_text(payload: &Value) -> (String, Option<String>, String) {
+    let kind = payload
+        .get("kind")
+        .and_then(Value::as_str)
+        .unwrap_or("terminal");
+    let duration = payload.get("duration_ms").and_then(Value::as_u64);
+    let last_message = payload
+        .get("last_assistant_message")
+        .and_then(Value::as_str)
+        .map(collapse_whitespace)
+        .filter(|message| !message.is_empty())
+        .map(|message| trim_summary(&message));
+    let title = match kind {
+        "completed" => "Turn completed",
+        "aborted" => "Turn aborted",
+        "baseline_over_budget" => "Turn stopped",
+        _ => "Turn terminal",
+    };
+    let body = last_message.or_else(|| duration.map(|ms| format!("{ms} ms")));
     let summary = body
         .as_deref()
-        .map(|body| format!("Model returned no content: no visible content ({body})"))
-        .unwrap_or_else(|| "Model returned no content".into());
-    ("Model returned no content".into(), body, summary)
+        .map(|body| format!("{title}: {body}"))
+        .unwrap_or_else(|| title.to_string());
+    (title.into(), body, summary)
 }
 
 fn text_only_round_text(payload: &Value) -> (String, Option<String>, String) {
@@ -989,14 +1064,6 @@ fn collapse_whitespace(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn is_max_output_stop_reason(reason: &str) -> bool {
-    matches!(
-        reason,
-        "max_tokens" | "max_output_tokens" | "length" | "output_limit"
-    ) || reason.contains("max_output")
-        || reason.contains("max_tokens")
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1006,61 +1073,97 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn provider_round_distinguishes_text_from_tool_requests() {
+    fn assistant_round_recorded_distinguishes_text_from_tool_requests() {
         let context = OperatorPresentationContext::default();
         let text = present_operator_event(
-            "provider_round_completed",
-            &json!({ "text_preview": "thinking", "tool_names": ["ExecCommand"] }),
+            "assistant_round_recorded",
+            &json!({ "text": "thinking", "tool_names": ["ExecCommand"] }),
             "fallback",
             &context,
         );
         assert_eq!(text.visibility, OperatorVisibility::Progress);
         assert_eq!(text.category, OperatorEventCategory::AssistantProgress);
-        assert_eq!(text.summary, "Assistant progress: thinking");
+        assert_eq!(text.summary, "Assistant round: thinking");
 
         let multiline = present_operator_event(
-            "provider_round_completed",
-            &json!({ "text_preview": "thinking\n\nabout\ttools  now" }),
+            "assistant_round_recorded",
+            &json!({ "text": "thinking\n\nabout\ttools  now" }),
             "fallback",
             &context,
         );
         assert_eq!(
             multiline.summary,
-            "Assistant progress: thinking about tools now"
+            "Assistant round: thinking about tools now"
         );
 
         let tools = present_operator_event(
-            "provider_round_completed",
-            &json!({ "text_preview": null, "tool_names": ["ExecCommand", "ReadFile"] }),
+            "assistant_round_recorded",
+            &json!({ "text": null, "tool_names": ["ExecCommand", "ReadFile"] }),
             "fallback",
             &context,
         );
         assert_eq!(
             tools.summary,
-            "Model requested tools: ExecCommand, ReadFile"
-        );
-
-        let max_output = present_operator_event(
-            "provider_round_completed",
-            &json!({ "text_preview": null, "tool_names": [], "stop_reason": "max_output_tokens" }),
-            "fallback",
-            &context,
-        );
-        assert_eq!(
-            max_output.summary,
-            "Output limit reached: requesting continuation"
+            "Assistant requested tools: ExecCommand, ReadFile"
         );
 
         let empty = present_operator_event(
-            "provider_round_completed",
-            &json!({ "text_preview": null, "tool_names": [], "stop_reason": "end_turn" }),
+            "assistant_round_recorded",
+            &json!({ "text": null, "tool_names": [], "stop_reason": "end_turn" }),
             "fallback",
             &context,
         );
         assert_eq!(
             empty.summary,
-            "Model returned no content: no visible content (Stop reason: end_turn)"
+            "Assistant round completed without text (stop=end_turn)"
         );
+    }
+
+    #[test]
+    fn provider_round_completed_presents_provider_telemetry() {
+        let context = OperatorPresentationContext::default();
+        let provider = present_operator_event(
+            "provider_round_completed",
+            &json!({
+                "round": 2,
+                "active_model": "deepseek-chat",
+                "stop_reason": "tool_use",
+                "input_tokens": 12,
+                "output_tokens": 7,
+                "tool_call_count": 1
+            }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(provider.visibility, OperatorVisibility::Progress);
+        assert_eq!(provider.category, OperatorEventCategory::AssistantProgress);
+        assert_eq!(
+            provider.summary,
+            "Provider round 2: model=deepseek-chat; stop=tool_use; 12/7 tokens; tools=1"
+        );
+        assert_eq!(provider.title, "Provider round completed");
+    }
+
+    #[test]
+    fn completed_turn_terminal_is_trace_but_failures_are_turn_results() {
+        let context = OperatorPresentationContext::default();
+        let completed = present_operator_event(
+            "turn_terminal",
+            &json!({ "kind": "completed", "duration_ms": 42 }),
+            "turn completed",
+            &context,
+        );
+        assert_eq!(completed.visibility, OperatorVisibility::Trace);
+        assert_eq!(completed.summary, "Turn completed: 42 ms");
+
+        let aborted = present_operator_event(
+            "turn_terminal",
+            &json!({ "kind": "aborted", "last_assistant_message": "need more input" }),
+            "turn aborted",
+            &context,
+        );
+        assert_eq!(aborted.visibility, OperatorVisibility::TurnResult);
+        assert_eq!(aborted.summary, "Turn aborted: need more input");
     }
 
     #[test]
@@ -1175,6 +1278,18 @@ mod tests {
         assert_eq!(
             presentation.summary,
             "Command started: cargo test -q tui::chat"
+        );
+
+        let background = present_operator_event(
+            "process_execution_requested",
+            &json!({ "surface": "command_task" }),
+            "process_execution_requested",
+            &OperatorPresentationContext::default(),
+        );
+        assert_eq!(background.summary, "Background command started");
+        assert_eq!(
+            background.body.as_deref(),
+            Some("Background command details are available in the task and event logs.")
         );
     }
 }

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -475,6 +475,7 @@ impl RuntimeHandle {
             None,
             false,
         );
+        let diagnostics = self.command_cost_diagnostics_for(&resolved.spec);
         let task = TaskRecord {
             id: task_id.clone(),
             agent_id: agent_id.clone(),
@@ -498,6 +499,8 @@ impl RuntimeHandle {
                 "surface": "command_task",
                 "task_id": task_id,
                 "trust": trust,
+                "cmd_preview": diagnostics.cmd_preview.clone(),
+                "command_cost": diagnostics,
                 "execution": resolved.execution.clone(),
                 "boundary": crate::system::HostLocalBoundary::from_snapshot(&resolved.execution).audit_metadata(),
                 "workdir": resolved.workdir.clone(),

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -82,7 +82,9 @@ async fn runtime_records_text_only_round_observations() {
     assert_eq!(assistant_event.data["round"], 1);
     assert_eq!(assistant_event.data["tool_call_count"], 0);
     assert_eq!(assistant_event.data["text_block_count"], 1);
-    assert!(assistant_event.data["text"]
+    assert!(assistant_event.data.get("text").is_none());
+    assert!(assistant_event.data.get("text_blocks").is_none());
+    assert!(assistant_event.data["text_preview"]
         .as_str()
         .unwrap()
         .contains("runtime split"));

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -73,7 +73,16 @@ async fn runtime_records_text_only_round_observations() {
     assert_eq!(provider_event.data["round"], 1);
     assert_eq!(provider_event.data["tool_call_count"], 0);
     assert_eq!(provider_event.data["text_block_count"], 1);
-    assert!(provider_event.data["text_preview"]
+    assert!(provider_event.data.get("text_preview").is_none());
+
+    let assistant_event = events
+        .iter()
+        .find(|event| event.kind == "assistant_round_recorded")
+        .expect("missing assistant_round_recorded");
+    assert_eq!(assistant_event.data["round"], 1);
+    assert_eq!(assistant_event.data["tool_call_count"], 0);
+    assert_eq!(assistant_event.data["text_block_count"], 1);
+    assert!(assistant_event.data["text"]
         .as_str()
         .unwrap()
         .contains("runtime split"));

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1944,11 +1944,6 @@ impl TurnExecution<'_> {
                     "tool_names": tool_calls.iter().map(|call| call.name.clone()).collect::<Vec<_>>(),
                     "text_block_count": text_blocks.len(),
                     "text_char_count": combined_text.chars().count(),
-                    "text_preview": if combined_text.is_empty() {
-                        None::<String>
-                    } else {
-                        Some(truncate_preview(&combined_text, ROUND_TEXT_PREVIEW_LIMIT))
-                    },
                     "only_sleep_tools": only_sleep_tools,
                     "provider_cache_usage": cache_usage,
                     "prompt_cache_key": effective_prompt.cache_identity.prompt_cache_key.clone(),
@@ -2062,6 +2057,28 @@ impl TurnExecution<'_> {
                         }),
                     )
                 })?;
+            runtime.inner.storage.append_event(&AuditEvent::new(
+                "assistant_round_recorded",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "turn_index": turn_index,
+                    "run_id": run_id,
+                    "round": round,
+                    "stop_reason": stop_reason,
+                    "text": if combined_text.is_empty() {
+                        None::<String>
+                    } else {
+                        Some(combined_text.clone())
+                    },
+                    "text_blocks": text_blocks.clone(),
+                    "text_block_count": text_blocks.len(),
+                    "text_char_count": combined_text.chars().count(),
+                    "tool_call_count": tool_calls.len(),
+                    "tool_names": tool_calls.iter().map(|call| call.name.clone()).collect::<Vec<_>>(),
+                    "has_text": !combined_text.is_empty(),
+                    "has_tool_calls": !tool_calls.is_empty(),
+                }),
+            ))?;
 
             if tool_calls.is_empty() {
                 runtime.inner.storage.append_event(&AuditEvent::new(

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -2065,12 +2065,11 @@ impl TurnExecution<'_> {
                     "run_id": run_id,
                     "round": round,
                     "stop_reason": stop_reason,
-                    "text": if combined_text.is_empty() {
+                    "text_preview": if combined_text.is_empty() {
                         None::<String>
                     } else {
-                        Some(combined_text.clone())
+                        Some(truncate_preview(&combined_text, ROUND_TEXT_PREVIEW_LIMIT))
                     },
-                    "text_blocks": text_blocks.clone(),
                     "text_block_count": text_blocks.len(),
                     "text_char_count": combined_text.chars().count(),
                     "tool_call_count": tool_calls.len(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1288,7 +1288,7 @@ mod tests {
                     event_type: "assistant_round_recorded".into(),
                     projection: None,
                     provenance: None,
-                    payload: json!({ "round": 1, "text": "hidden assistant partial" }),
+                    payload: json!({ "round": 1, "text_preview": "hidden assistant partial" }),
                 },
             },
             &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1278,17 +1278,17 @@ mod tests {
         );
         projection.apply_event(
             AgentStreamEvent {
-                id: "evt-provider".into(),
-                event: "provider_round_completed".into(),
+                id: "evt-assistant".into(),
+                event: "assistant_round_recorded".into(),
                 data: StreamEventEnvelope {
-                    id: "evt-provider".into(),
+                    id: "evt-assistant".into(),
                     seq: 3,
                     ts: Utc::now(),
                     agent_id: "default".into(),
-                    event_type: "provider_round_completed".into(),
+                    event_type: "assistant_round_recorded".into(),
                     projection: None,
                     provenance: None,
-                    payload: json!({ "round": 1, "text_preview": "hidden provider partial" }),
+                    payload: json!({ "round": 1, "text": "hidden assistant partial" }),
                 },
             },
             &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
@@ -1300,7 +1300,7 @@ mod tests {
             .into_iter()
             .flat_map(|line| line.spans.into_iter().map(|span| span.content))
             .collect();
-        assert!(rendered.contains("Assistant hidden provider partial"));
+        assert!(rendered.contains("Assistant hidden assistant partial"));
         assert!(!rendered.contains("Action    Waiting for activity"));
         assert!(!rendered.contains("Current   "));
     }
@@ -1958,7 +1958,7 @@ mod tests {
                     event_type: "provider_round_completed".into(),
                     projection: None,
                     provenance: None,
-                    payload: json!({"text_preview":"older"}),
+                    payload: json!({"round": 1, "stop_reason": "end_turn"}),
                 },
             },
             &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
@@ -1982,7 +1982,7 @@ mod tests {
                         event_type: "provider_round_completed".into(),
                         projection: None,
                         provenance: None,
-                        payload: json!({"text_preview":"newer"}),
+                        payload: json!({"round": 2, "stop_reason": "end_turn"}),
                     },
                 },
                 &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -642,7 +642,7 @@ fn assistant_message_from_event(
             .presentation
             .body
             .clone()
-            .or_else(|| event.payload.get("text").and_then(non_empty_value)),
+            .or_else(|| event.payload.get("text_preview").and_then(non_empty_value)),
         "provider_round_completed" => None,
         _ if is_progress_event(event) => event.presentation.body.clone(),
         _ => None,
@@ -988,7 +988,7 @@ mod tests {
         let assistant = event(
             "assistant_round_recorded",
             "assistant round",
-            json!({ "text": "I will inspect the event path first." }),
+            json!({ "text_preview": "I will inspect the event path first." }),
         );
 
         assert_eq!(

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -637,14 +637,16 @@ fn latest_assistant_message(
 fn assistant_message_from_event(
     event: &crate::tui::projection::ProjectionEventRecord,
 ) -> Option<String> {
-    if !is_progress_event(event) {
-        return None;
+    match event.kind.as_str() {
+        "assistant_round_recorded" => event
+            .presentation
+            .body
+            .clone()
+            .or_else(|| event.payload.get("text").and_then(non_empty_value)),
+        "provider_round_completed" => None,
+        _ if is_progress_event(event) => event.presentation.body.clone(),
+        _ => None,
     }
-    event
-        .presentation
-        .body
-        .clone()
-        .or_else(|| event.payload.get("text_preview").and_then(non_empty_value))
 }
 
 fn is_progress_event(event: &crate::tui::projection::ProjectionEventRecord) -> bool {
@@ -962,7 +964,7 @@ mod tests {
         let empty_round = event(
             "provider_round_completed",
             "provider round completed",
-            json!({ "text_preview": "" }),
+            json!({ "round": 1, "stop_reason": "end_turn" }),
         );
         let command = event(
             "process_execution_requested",
@@ -978,6 +980,20 @@ mod tests {
         assert_eq!(
             latest_action_event(events.as_slice()).map(|event| event.summary.as_str()),
             Some("Command started: cargo test tui::chat")
+        );
+    }
+
+    #[test]
+    fn assistant_round_recorded_is_activity_content() {
+        let assistant = event(
+            "assistant_round_recorded",
+            "assistant round",
+            json!({ "text": "I will inspect the event path first." }),
+        );
+
+        assert_eq!(
+            assistant_message_from_event(&assistant).as_deref(),
+            Some("I will inspect the event path first.")
         );
     }
 }

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -930,7 +930,7 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
         "assistant_round_recorded" => event
             .data
             .payload
-            .get("text")
+            .get("text_preview")
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|text| !text.is_empty())
@@ -1205,7 +1205,7 @@ mod tests {
                     "run_id": "run-1",
                     "turn_index": 1,
                     "round": 1,
-                    "text": "previous turn"
+                    "text_preview": "previous turn"
                 }),
             ),
             &test_log_writer(),
@@ -1228,7 +1228,7 @@ mod tests {
                     "run_id": "run-2",
                     "turn_index": 2,
                     "round": 1,
-                    "text": "current turn"
+                    "text_preview": "current turn"
                 }),
             ),
             &test_log_writer(),

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -338,7 +338,8 @@ impl TuiProjection {
                     self.mark_stale([ProjectionSlice::Session, ProjectionSlice::Agent]);
                 }
             }
-            "provider_round_completed"
+            "assistant_round_recorded"
+            | "provider_round_completed"
             | "text_only_round_observed"
             | "max_output_tokens_recovery"
             | "runtime_error" => {
@@ -926,15 +927,47 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
             .and_then(Value::as_str)
             .map(|branch| format!("exited worktree {branch}"))
             .unwrap_or_else(|| "exited worktree".into()),
-        "provider_round_completed" => event
+        "assistant_round_recorded" => event
             .data
             .payload
-            .get("text_preview")
+            .get("text")
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|text| !text.is_empty())
-            .map(|text| text.to_owned())
-            .unwrap_or_else(|| "provider round completed".into()),
+            .map(trim_summary)
+            .or_else(|| {
+                event
+                    .data
+                    .payload
+                    .get("tool_names")
+                    .and_then(Value::as_array)
+                    .map(|tools| {
+                        tools
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                    .filter(|tools| !tools.trim().is_empty())
+                    .map(|tools| format!("assistant requested tools: {tools}"))
+            })
+            .unwrap_or_else(|| "assistant round recorded".into()),
+        "provider_round_completed" => {
+            let round = event
+                .data
+                .payload
+                .get("round")
+                .and_then(Value::as_u64)
+                .map(|round| format!("round {round}"))
+                .unwrap_or_else(|| "round".into());
+            let stop = event
+                .data
+                .payload
+                .get("stop_reason")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            format!("provider {round} completed: stop={stop}")
+        }
         "text_only_round_observed" => "text-only round observed".into(),
         "tool_executed" => event
             .data
@@ -1136,7 +1169,7 @@ mod tests {
         projection.apply_event(
             sample_event(
                 "provider_round_completed",
-                json!({ "round": 1, "text_preview": "" }),
+                json!({ "round": 1, "stop_reason": "end_turn" }),
             ),
             &test_log_writer(),
         );
@@ -1153,7 +1186,7 @@ mod tests {
                 .event_log()
                 .last()
                 .map(|event| event.summary.as_str()),
-            Some("Model returned no content")
+            Some("Provider round 1: model=model; stop=end_turn; tokens unavailable; tools=0")
         );
     }
 
@@ -1167,12 +1200,12 @@ mod tests {
 
         projection.apply_event(
             sample_event(
-                "provider_round_completed",
+                "assistant_round_recorded",
                 json!({
                     "run_id": "run-1",
                     "turn_index": 1,
                     "round": 1,
-                    "text_preview": "previous turn"
+                    "text": "previous turn"
                 }),
             ),
             &test_log_writer(),
@@ -1190,12 +1223,12 @@ mod tests {
         );
         projection.apply_event(
             sample_event(
-                "provider_round_completed",
+                "assistant_round_recorded",
                 json!({
                     "run_id": "run-2",
                     "turn_index": 2,
                     "round": 1,
-                    "text_preview": "current turn"
+                    "text": "current turn"
                 }),
             ),
             &test_log_writer(),
@@ -1217,10 +1250,7 @@ mod tests {
                 .iter()
                 .map(|event| event.summary.as_str())
                 .collect::<Vec<_>>(),
-            vec![
-                "Assistant progress: current turn",
-                "ExecCommand: cargo test"
-            ]
+            vec!["Assistant round: current turn", "ExecCommand: cargo test"]
         );
     }
 

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -418,7 +418,7 @@ pub async fn control_prompt_records_message_admission_fields() -> Result<()> {
 
     wait_until(|| {
         let messages = runtime.storage().read_recent_messages(10)?;
-        let events = runtime.storage().read_recent_events(20)?;
+        let events = runtime.storage().read_recent_events(200)?;
         Ok(messages.iter().any(|message| {
             message.kind == MessageKind::OperatorPrompt
                 && message.delivery_surface == Some(MessageDeliverySurface::HttpControlPrompt)


### PR DESCRIPTION
## Summary

- add `assistant_round_recorded` as the semantic assistant-progress event for text and tool requests
- keep `provider_round_completed` as provider telemetry only, without `text_preview`
- make TUI working/chat rendering use assistant progress separately from action progress, and hide successful `turn_terminal` from display level 3
- document the event contract split

## Verification

- `cargo test -q --lib`
- `git diff --check`
