### PR TITLE
feat: support authenticated remote TUI access

### DIFF
--- a/docs/rfcs/remote-tui-access.md
+++ b/docs/rfcs/remote-tui-access.md
@@ -1,0 +1,85 @@
+# Remote TUI Access
+
+Remote TUI access is an explicit control-plane mode for connecting `holon tui`
+to a `holon serve` runtime on another host. The local Unix socket remains the
+default trust path for same-host use.
+
+## Terms
+
+- `listen`: the address the server binds, such as `127.0.0.1:7878` or
+  `0.0.0.0:7878`.
+- `connect`: the URL a TUI client dials, such as `http://lab:7878`.
+- `advertise`: the URL the server reports to clients as its reachable endpoint.
+- `callback_base_url`: the URL external callback registrations should use.
+
+`0.0.0.0` and `::` are valid only as listen addresses. They are not valid
+connect, advertise, or callback URLs because clients cannot route to them.
+
+## Server Modes
+
+Default local mode is loopback only:
+
+```sh
+holon serve
+holon serve --access local
+```
+
+SSH tunnel mode keeps the server loopback-bound and expects the operator to
+forward a port explicitly:
+
+```sh
+holon serve --access tunnel --token-file ~/.config/holon/remote.token
+ssh -L 7878:127.0.0.1:7878 lab
+holon tui --connect http://127.0.0.1:7878 --token-file ~/.config/holon/remote.token
+```
+
+LAN and tailnet modes are explicit remote access modes and require bearer-token
+authentication:
+
+```sh
+holon serve --access lan --host 192.168.1.10 --token-file ~/.config/holon/remote.token
+holon tui --connect http://192.168.1.10:7878 --token-file ~/.config/holon/remote.token
+
+holon serve --access tailnet --host lab.tailnet.ts.net --token-file ~/.config/holon/remote.token
+holon tui --connect http://lab.tailnet.ts.net:7878 --token-file ~/.config/holon/remote.token
+```
+
+The lower-level form separates bind and client-visible URLs:
+
+```sh
+holon serve \
+  --listen 0.0.0.0:7878 \
+  --advertise http://lab.tailnet.ts.net:7878 \
+  --token-file ~/.config/holon/remote.token
+```
+
+## Auth Contract
+
+Any non-loopback TCP bind requires a configured control token. In token-required
+TCP mode, all TUI-visible read, event, and write surfaces require bearer auth,
+including agent lists, state snapshots, transcript/brief/task/timer views, SSE
+event streams, public enqueue, and control actions.
+
+Remote TUI mode must be explicit:
+
+```sh
+holon tui --connect http://host:7878 --token-file ~/.config/holon/remote.token
+```
+
+When `--connect` is present, the client never falls back to the local Unix
+socket or local HTTP default, and it does not implicitly reuse local provider
+credentials. The token must come from `--token`, `--token-file`, or
+`--token-profile`.
+
+## Handshake
+
+Remote clients should call `GET /handshake` first. The response reports:
+
+- control protocol name and version
+- auth mode and whether bearer auth is required
+- runtime capabilities
+- default agent, workspace directory, home directory, listen address, and
+  advertised URL when configured
+
+Auth mismatch, unsupported URLs, missing tokens, and invalid advertise/connect
+URLs should fail before silently falling back to local runtime state.

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,13 @@ const UNIX_CONTROL_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct LocalClient {
     config: AppConfig,
     http: reqwest::Client,
+    remote: Option<RemoteConnection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemoteConnection {
+    base_url: String,
+    token: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -213,11 +220,47 @@ impl LocalClient {
             .connect_timeout(Duration::from_secs(2))
             .build()
             .context("failed to build local control client")?;
-        Ok(Self { config, http })
+        Ok(Self {
+            config,
+            http,
+            remote: None,
+        })
+    }
+
+    pub fn remote(
+        config: AppConfig,
+        base_url: impl Into<String>,
+        token: impl Into<String>,
+    ) -> Result<Self> {
+        let base_url = normalize_remote_base_url(base_url.into())?;
+        let token = token.into();
+        if token.trim().is_empty() {
+            return Err(anyhow!("remote TUI token must not be empty"));
+        }
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .build()
+            .context("failed to build remote control client")?;
+        Ok(Self {
+            config,
+            http,
+            remote: Some(RemoteConnection { base_url, token }),
+        })
+    }
+
+    pub fn connection_summary(&self) -> String {
+        match &self.remote {
+            Some(remote) => format!("remote {} auth=bearer", remote.base_url),
+            None => "local runtime".into(),
+        }
     }
 
     pub async fn list_agents(&self) -> Result<Vec<AgentSummary>> {
         self.get_json("/agents").await
+    }
+
+    pub async fn handshake(&self) -> Result<Value> {
+        self.get_json("/handshake").await
     }
 
     pub async fn runtime_status(&self) -> Result<RuntimeStatusResponse> {
@@ -424,7 +467,7 @@ impl LocalClient {
         let path = event_stream_path(agent_id, &request)?;
 
         #[cfg(unix)]
-        if self.config.socket_path.exists() {
+        if self.remote.is_none() && self.config.socket_path.exists() {
             let socket_error = match self
                 .stream_unix_events(&path, false, request.last_event_id.as_deref())
                 .await
@@ -445,8 +488,12 @@ impl LocalClient {
                 });
         }
 
-        self.stream_http_events(&path, false, request.last_event_id.as_deref())
-            .await
+        self.stream_http_events(
+            &path,
+            self.remote.is_some(),
+            request.last_event_id.as_deref(),
+        )
+        .await
     }
 
     async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
@@ -475,7 +522,7 @@ impl LocalClient {
 
     async fn send(&self, request: RequestSpec, include_control_auth: bool) -> Result<Vec<u8>> {
         #[cfg(unix)]
-        if self.config.socket_path.exists() {
+        if self.remote.is_none() && self.config.socket_path.exists() {
             let socket_error = match self.send_unix(request.clone(), include_control_auth).await {
                 Ok(body) => return Ok(body),
                 Err(err) => err,
@@ -541,14 +588,12 @@ impl LocalClient {
         include_control_auth: bool,
     ) -> reqwest::RequestBuilder {
         let mut builder = match request.method {
-            HttpMethod::Get => self
-                .http
-                .get(format!("http://{}{}", self.config.http_addr, request.path)),
-            HttpMethod::Post => self
-                .http
-                .post(format!("http://{}{}", self.config.http_addr, request.path)),
+            HttpMethod::Get => self.http.get(self.http_url_for(&request.path)),
+            HttpMethod::Post => self.http.post(self.http_url_for(&request.path)),
         };
-        if include_control_auth {
+        if let Some(remote) = &self.remote {
+            builder = builder.bearer_auth(&remote.token);
+        } else if include_control_auth {
             if let Some(token) = &self.config.control_token {
                 builder = builder.bearer_auth(token);
             }
@@ -559,6 +604,14 @@ impl LocalClient {
                 .body(body);
         }
         builder
+    }
+
+    fn http_url_for(&self, path: &str) -> String {
+        if let Some(remote) = &self.remote {
+            format!("{}{}", remote.base_url, path)
+        } else {
+            format!("http://{}{}", self.config.http_addr, path)
+        }
     }
 
     #[cfg(unix)]
@@ -689,6 +742,44 @@ impl LocalClient {
             eof: false,
         })
     }
+}
+
+pub fn normalize_remote_base_url(value: String) -> Result<String> {
+    normalize_http_base_url(value, "remote connect URL")
+}
+
+pub fn normalize_control_base_url(value: String, label: &str) -> Result<String> {
+    normalize_http_base_url(value, label)
+}
+
+fn normalize_http_base_url(value: String, label: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("{label} must not be empty"));
+    }
+    let url =
+        reqwest::Url::parse(trimmed).with_context(|| format!("invalid {label} {trimmed:?}"))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        scheme => return Err(anyhow!("{label} must use http or https, got {scheme}")),
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("{label} must include a host"))?;
+    if url.query().is_some() {
+        return Err(anyhow!("{label} must not include a query string"));
+    }
+    if host == "0.0.0.0" || host == "::" || host.eq_ignore_ascii_case("[::]") {
+        return Err(anyhow!(
+            "{label} must use a client-reachable host, not {host}"
+        ));
+    }
+    let mut normalized = url;
+    normalized.set_fragment(None);
+    if normalized.path() == "/" {
+        normalized.set_path("");
+    }
+    Ok(normalized.as_str().trim_end_matches('/').to_string())
 }
 
 #[derive(Clone)]
@@ -1117,9 +1208,23 @@ fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>> {
 mod tests {
     use super::{
         authorization_header_value, decode_chunked_body, decode_or_error, event_stream_path,
-        parse_http_response, parse_sse_frame, take_next_sse_frame, validate_header_value,
-        validate_unix_request_target, EventStreamRequest, LocalHttpError,
+        normalize_remote_base_url, parse_http_response, parse_sse_frame, take_next_sse_frame,
+        validate_header_value, validate_unix_request_target, EventStreamRequest, LocalHttpError,
     };
+
+    #[test]
+    fn remote_connect_url_rejects_unspecified_hosts() {
+        assert!(normalize_remote_base_url("http://0.0.0.0:7878".into()).is_err());
+        assert!(normalize_remote_base_url("http://[::]:7878".into()).is_err());
+    }
+
+    #[test]
+    fn remote_connect_url_normalizes_trailing_slash() {
+        assert_eq!(
+            normalize_remote_base_url("http://example.test:7878/".into()).unwrap(),
+            "http://example.test:7878"
+        );
+    }
 
     #[test]
     fn parse_http_response_decodes_chunked_body() {

--- a/src/http.rs
+++ b/src/http.rs
@@ -70,6 +70,7 @@ pub struct AppState {
     pub host: RuntimeHost,
     pub require_control_token: bool,
     pub runtime_service: Option<RuntimeServiceHandle>,
+    pub advertise_url: Option<String>,
 }
 
 const CALLBACK_BODY_LIMIT_BYTES: usize = 256 * 1024;
@@ -93,6 +94,7 @@ impl AppState {
             host,
             require_control_token,
             runtime_service,
+            advertise_url: None,
         }
     }
 
@@ -111,13 +113,20 @@ impl AppState {
             host,
             require_control_token,
             runtime_service,
+            advertise_url: None,
         }
+    }
+
+    pub fn with_advertise_url(mut self, advertise_url: Option<String>) -> Self {
+        self.advertise_url = advertise_url;
+        self
     }
 }
 
 pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/", get(root))
+        .route("/handshake", get(handshake))
         .route("/agents", get(list_agents))
         .route("/agents/:agent_id/enqueue", post(enqueue))
         .route("/agents/:agent_id/status", get(status))
@@ -511,16 +520,53 @@ pub struct CreateAgentRequest {
 
 pub async fn root(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     Ok(Json(json!({
         "ok": true,
         "default_agent": state.host.config().default_agent_id,
     })))
 }
 
+pub async fn handshake(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let config = state.host.config();
+    Ok(Json(json!({
+        "ok": true,
+        "protocol": {
+            "name": "holon-control",
+            "version": 1,
+        },
+        "auth": {
+            "mode": if state.require_control_token { "bearer" } else { "local" },
+            "required": state.require_control_token,
+        },
+        "capabilities": [
+            "agents.list",
+            "agents.state",
+            "agents.events",
+            "agents.control",
+            "tui.remote"
+        ],
+        "runtime": {
+            "default_agent": config.default_agent_id,
+            "workspace_dir": config.workspace_dir,
+            "home_dir": config.home_dir,
+            "listen": config.http_addr,
+            "advertise_url": state.advertise_url,
+        }
+    })))
+}
+
 pub async fn list_agents(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let agents = state.host.list_agents().await.map_err(error_response)?;
     Ok(Json(agents))
 }
@@ -588,8 +634,10 @@ pub async fn runtime_shutdown(
 
 pub async fn enqueue_default(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(request): Json<EnqueueRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let agent_id = state.host.config().default_agent_id.clone();
     enqueue_internal(state, agent_id, request, EnqueueIngress::Public).await
 }
@@ -597,8 +645,10 @@ pub async fn enqueue_default(
 pub async fn enqueue(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(request): Json<EnqueueRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     enqueue_internal(state, agent_id, request, EnqueueIngress::Public).await
 }
 
@@ -745,10 +795,12 @@ async fn enqueue_internal(
 
 pub async fn status_default(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     status(
         Path(state.host.config().default_agent_id.clone()),
         State(state),
+        headers,
     )
     .await
 }
@@ -756,7 +808,9 @@ pub async fn status_default(
 pub async fn status(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -768,10 +822,12 @@ pub async fn status(
 
 pub async fn state_default(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     agent_state(
         Path(state.host.config().default_agent_id.clone()),
         State(state),
+        headers,
     )
     .await
 }
@@ -779,7 +835,9 @@ pub async fn state_default(
 pub async fn agent_state(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -938,11 +996,13 @@ mod tests {
 
 pub async fn briefs_default(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     briefs(
         Path(state.host.config().default_agent_id.clone()),
         State(state),
+        headers,
         Query(query),
     )
     .await
@@ -951,8 +1011,10 @@ pub async fn briefs_default(
 pub async fn briefs(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -981,11 +1043,13 @@ pub async fn events_default(
 
 pub async fn transcript_default(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     transcript(
         Path(state.host.config().default_agent_id.clone()),
         State(state),
+        headers,
         Query(query),
     )
     .await
@@ -993,10 +1057,12 @@ pub async fn transcript_default(
 
 pub async fn worktree_summary_default(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     worktree_summary(
         Path(state.host.config().default_agent_id.clone()),
         State(state),
+        headers,
     )
     .await
 }
@@ -1026,7 +1092,7 @@ pub async fn events(
         .await
         .map_err(agent_access_error)?;
     let projection = query.projection.unwrap_or(EventReplayProjection::Operator);
-    if projection == EventReplayProjection::LocalDebug {
+    if state.require_control_token || projection == EventReplayProjection::LocalDebug {
         authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     }
     let initial_event_marker = runtime
@@ -1295,8 +1361,10 @@ fn cursor_too_old(cursor: String) -> (StatusCode, Json<Value>) {
 pub async fn transcript(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -1312,7 +1380,9 @@ pub async fn transcript(
 pub async fn worktree_summary(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -1331,8 +1401,10 @@ pub async fn worktree_summary(
 pub async fn tasks(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -1440,8 +1512,10 @@ pub async fn create_work_item(
 pub async fn timers(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<LimitQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -1494,7 +1568,9 @@ pub async fn create_timer(
 pub async fn list_skills(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -2391,6 +2467,13 @@ fn authorize_control(headers: &HeaderMap, state: &AppState) -> Result<()> {
     let token = &provided[prefix.len()..];
     if token != expected_token {
         return Err(anyhow!("invalid control token"));
+    }
+    Ok(())
+}
+
+fn authorize_remote_access(headers: &HeaderMap, state: &AppState) -> Result<()> {
+    if state.require_control_token {
+        authorize_control(headers, state)?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,21 @@
 use std::{
     io::Write,
+    net::SocketAddr,
     path::{Path, PathBuf},
 };
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use holon::{
-    client::LocalClient,
+    client::{normalize_control_base_url, LocalClient},
     config::{
         built_in_provider_default_config, config_schema, credential_store_path, default_holon_home,
-        get_config_key, list_credential_profiles_at, load_persisted_config_at,
-        persisted_config_path, provider_config_view, provider_config_views,
-        remove_credential_profile_at, save_persisted_config_at, set_config_key,
-        set_credential_profile_at, unset_config_key, validate_provider_config, AppConfig,
-        CredentialKind, CredentialSource, ProviderAuthConfig, ProviderConfigFile, ProviderId,
-        ProviderTransportKind,
+        get_config_key, list_credential_profiles_at, load_credential_store_at,
+        load_persisted_config_at, persisted_config_path, provider_config_view,
+        provider_config_views, remove_credential_profile_at, save_persisted_config_at,
+        set_config_key, set_credential_profile_at, unset_config_key, validate_provider_config,
+        AppConfig, ControlAuthMode, CredentialKind, CredentialSource, ProviderAuthConfig,
+        ProviderConfigFile, ProviderId, ProviderTransportKind,
     },
     daemon::{
         daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
@@ -61,7 +62,20 @@ impl ControlCommandAction {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    Serve,
+    Serve {
+        #[arg(long, value_enum, default_value_t = ServeAccess::Local)]
+        access: ServeAccess,
+        #[arg(long)]
+        host: Option<String>,
+        #[arg(long)]
+        listen: Option<String>,
+        #[arg(long)]
+        advertise: Option<String>,
+        #[arg(long)]
+        token: Option<String>,
+        #[arg(long)]
+        token_file: Option<PathBuf>,
+    },
     Daemon {
         #[command(subcommand)]
         command: DaemonCommands,
@@ -201,11 +215,37 @@ enum Commands {
     Tui {
         #[arg(long)]
         no_alt_screen: bool,
+        #[arg(long)]
+        connect: Option<String>,
+        #[arg(long)]
+        token: Option<String>,
+        #[arg(long)]
+        token_file: Option<PathBuf>,
+        #[arg(long)]
+        token_profile: Option<String>,
     },
     Debug {
         #[command(subcommand)]
         command: DebugCommands,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum ServeAccess {
+    Local,
+    Tunnel,
+    Lan,
+    Tailnet,
+}
+
+#[derive(Debug)]
+struct ServeOptions {
+    access: ServeAccess,
+    host: Option<String>,
+    listen: Option<String>,
+    advertise: Option<String>,
+    token: Option<String>,
+    token_file: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -463,9 +503,44 @@ async fn main() -> Result<()> {
 }
 
 async fn run_runtime_command(command: Commands) -> Result<()> {
+    if let Commands::Tui {
+        no_alt_screen,
+        connect: Some(connect),
+        token,
+        token_file,
+        token_profile,
+    } = command
+    {
+        let config = AppConfig::load_for_config_inspection()?;
+        let token = resolve_remote_token(&config, token, token_file, token_profile)?;
+        let client = LocalClient::remote(config.clone(), connect, token)?;
+        client.handshake().await?;
+        return run_tui(config, no_alt_screen, Some(client)).await;
+    }
+
     let config = AppConfig::load()?;
     match command {
-        Commands::Serve => serve(config).await,
+        Commands::Serve {
+            access,
+            host,
+            listen,
+            advertise,
+            token,
+            token_file,
+        } => {
+            serve(
+                config,
+                ServeOptions {
+                    access,
+                    host,
+                    listen,
+                    advertise,
+                    token,
+                    token_file,
+                },
+            )
+            .await
+        }
         Commands::Daemon { command } => handle_daemon_command(config, command).await,
         Commands::Prompt { text, agent } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
@@ -572,7 +647,14 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         Commands::Agents { command } => handle_agents_command(&config, command).await,
         Commands::Skills { command } => handle_skills_command(&config, command).await,
         Commands::Workspace { command } => handle_workspace_command(&config, command).await,
-        Commands::Tui { no_alt_screen } => run_tui(config, no_alt_screen).await,
+        Commands::Tui {
+            no_alt_screen,
+            connect: None,
+            ..
+        } => run_tui(config, no_alt_screen, None).await,
+        Commands::Tui {
+            connect: Some(_), ..
+        } => unreachable!("remote tui is handled before runtime config load"),
         Commands::Run { .. } => unreachable!("run command is handled separately"),
         Commands::Solve { .. } => unreachable!("solve command is handled separately"),
         Commands::Debug { command } => handle_debug_command(config, command).await,
@@ -670,7 +752,205 @@ async fn run_solve_command(
     Ok(())
 }
 
-async fn serve(config: AppConfig) -> Result<()> {
+fn apply_serve_options(config: &mut AppConfig, options: ServeOptions) -> Result<Option<String>> {
+    let token = resolve_inline_or_file_token(options.token, options.token_file)?;
+    if let Some(token) = token {
+        config.control_token = Some(token);
+    }
+
+    if let Some(listen) = options.listen {
+        config.http_addr = listen;
+    } else if options.access == ServeAccess::Tunnel {
+        config.http_addr = loopback_with_configured_port(&config.http_addr);
+    } else if matches!(options.access, ServeAccess::Lan | ServeAccess::Tailnet) {
+        config.http_addr = default_remote_listen_addr(options.host.as_deref(), &config.http_addr);
+    }
+
+    let advertise_url = match options.advertise {
+        Some(url) => Some(validate_client_visible_url("advertise URL", &url)?),
+        None => match options.access {
+            ServeAccess::Local | ServeAccess::Tunnel => None,
+            ServeAccess::Lan | ServeAccess::Tailnet => {
+                let Some(host) = options
+                    .host
+                    .as_deref()
+                    .filter(|host| !host.trim().is_empty())
+                else {
+                    return Err(anyhow!(
+                        "--access {:?} requires --host or --advertise",
+                        options.access
+                    ));
+                };
+                Some(format!(
+                    "http://{}",
+                    client_visible_host_port(host, &config.http_addr)?
+                ))
+            }
+        },
+    };
+    if let Some(url) = &advertise_url {
+        config.callback_base_url = url.clone();
+    }
+    config.callback_base_url =
+        validate_client_visible_url("callback base URL", &config.callback_base_url)?;
+
+    let non_loopback_tcp = !config.tcp_listener_is_local();
+    if non_loopback_tcp
+        && config
+            .control_token
+            .as_deref()
+            .is_none_or(|token| token.trim().is_empty())
+    {
+        return Err(anyhow!(
+            "non-loopback TCP listen address {} requires --token, --token-file, or HOLON_CONTROL_TOKEN",
+            config.http_addr
+        ));
+    }
+    if matches!(options.access, ServeAccess::Lan | ServeAccess::Tailnet)
+        && config
+            .control_token
+            .as_deref()
+            .is_none_or(|token| token.trim().is_empty())
+    {
+        return Err(anyhow!(
+            "--access {:?} requires --token, --token-file, or HOLON_CONTROL_TOKEN",
+            options.access
+        ));
+    }
+    if non_loopback_tcp || matches!(options.access, ServeAccess::Lan | ServeAccess::Tailnet) {
+        config.control_auth_mode = ControlAuthMode::Required;
+    }
+
+    Ok(advertise_url)
+}
+
+fn default_remote_listen_addr(host: Option<&str>, current: &str) -> String {
+    let port = current
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse::<u16>().ok())
+        .unwrap_or(7878);
+    if let Some(host) = host {
+        if let Ok(addr) = host.parse::<SocketAddr>() {
+            return addr.to_string();
+        }
+        if host.parse::<std::net::IpAddr>().is_ok() {
+            return format!("{host}:{port}");
+        }
+    }
+    format!("0.0.0.0:{port}")
+}
+
+fn loopback_with_configured_port(current: &str) -> String {
+    let port = current
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse::<u16>().ok())
+        .unwrap_or(7878);
+    format!("127.0.0.1:{port}")
+}
+
+fn client_visible_host_port(host: &str, listen: &str) -> Result<String> {
+    let host = host.trim();
+    let listen_port = listen
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse::<u16>().ok())
+        .unwrap_or(7878);
+    let host_port = if host
+        .rsplit_once(':')
+        .is_some_and(|(_, tail)| tail.parse::<u16>().is_ok())
+    {
+        host.to_string()
+    } else {
+        format!("{host}:{listen_port}")
+    };
+    let url = validate_client_visible_url("host URL", &format!("http://{host_port}"))?;
+    let Some(host) = reqwest::Url::parse(&url)
+        .ok()
+        .and_then(|url| url.host_str().map(ToString::to_string))
+    else {
+        return Err(anyhow!("client-visible host must include a host"));
+    };
+    if matches!(host.as_str(), "0.0.0.0" | "::") {
+        return Err(anyhow!(
+            "0.0.0.0/:: is only valid for --listen; provide a client-reachable --host or --advertise"
+        ));
+    }
+    Ok(url.trim_start_matches("http://").to_string())
+}
+
+fn validate_client_visible_url(label: &str, value: &str) -> Result<String> {
+    let normalized = normalize_control_base_url(value.to_string(), label)
+        .with_context(|| format!("invalid {label}"))?;
+    Ok(normalized)
+}
+
+fn resolve_remote_token(
+    config: &AppConfig,
+    token: Option<String>,
+    token_file: Option<PathBuf>,
+    token_profile: Option<String>,
+) -> Result<String> {
+    let token = match (token, token_file, token_profile) {
+        (Some(token), None, None) => token,
+        (None, Some(path), None) => read_token_file(&path)?,
+        (None, None, Some(profile)) => read_token_profile(config, &profile)?,
+        (None, None, None) => {
+            return Err(anyhow!(
+                "remote TUI requires explicit --token, --token-file, or --token-profile"
+            ))
+        }
+        _ => {
+            return Err(anyhow!(
+                "use exactly one of --token, --token-file, or --token-profile for remote TUI"
+            ))
+        }
+    };
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err(anyhow!("remote TUI token must not be empty"));
+    }
+    Ok(token)
+}
+
+fn resolve_inline_or_file_token(
+    token: Option<String>,
+    token_file: Option<PathBuf>,
+) -> Result<Option<String>> {
+    match (token, token_file) {
+        (Some(_), Some(_)) => Err(anyhow!("use only one of --token or --token-file")),
+        (Some(token), None) => Ok(Some(non_empty_token(token)?)),
+        (None, Some(path)) => Ok(Some(non_empty_token(read_token_file(&path)?)?)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn read_token_file(path: &Path) -> Result<String> {
+    std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read token file {}", path.display()))
+}
+
+fn read_token_profile(config: &AppConfig, profile: &str) -> Result<String> {
+    let profile = profile.trim();
+    if profile.is_empty() {
+        return Err(anyhow!("token profile must not be empty"));
+    }
+    let store = load_credential_store_at(&credential_store_path(&config.home_dir))?;
+    store
+        .profiles
+        .get(profile)
+        .map(|entry| entry.material.clone())
+        .ok_or_else(|| anyhow!("token profile {profile:?} was not found"))
+}
+
+fn non_empty_token(token: String) -> Result<String> {
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err(anyhow!("control token must not be empty"));
+    }
+    Ok(token)
+}
+
+async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
+    let advertise_url = apply_serve_options(&mut config, options)?;
     std::fs::create_dir_all(config.agent_root_dir())
         .with_context(|| format!("failed to create {}", config.agent_root_dir().display()))?;
     std::fs::create_dir_all(config.run_dir())
@@ -681,14 +961,17 @@ async fn serve(config: AppConfig) -> Result<()> {
     host.default_runtime().await?;
     let runtime_service = RuntimeServiceHandle::new(&config)?;
 
-    let tcp_router = http::router(AppState::for_tcp_with_runtime_service(
-        host.clone(),
-        Some(runtime_service.clone()),
-    ));
+    let tcp_router = http::router(
+        AppState::for_tcp_with_runtime_service(host.clone(), Some(runtime_service.clone()))
+            .with_advertise_url(advertise_url.clone()),
+    );
     let listener = TcpListener::bind(&config.http_addr)
         .await
         .with_context(|| format!("failed to bind {}", config.http_addr))?;
     println!("Holon listening on {}", listener.local_addr()?);
+    if let Some(advertise_url) = &advertise_url {
+        println!("Holon advertised at {advertise_url}");
+    }
 
     #[cfg(unix)]
     {
@@ -755,6 +1038,115 @@ async fn dump_prompt(
     let prompt = runtime.preview_prompt(text, trust).await?;
     println!("{}", prompt.render_dump());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use holon::config::{provider_registry_for_tests, AltScreenMode, ModelRef};
+
+    fn test_config() -> AppConfig {
+        let home = tempfile::tempdir().unwrap().keep();
+        let workspace = tempfile::tempdir().unwrap().keep();
+        AppConfig {
+            default_agent_id: "default".into(),
+            http_addr: "127.0.0.1:7878".into(),
+            callback_base_url: "http://127.0.0.1:7878".into(),
+            home_dir: home.clone(),
+            data_dir: home.clone(),
+            socket_path: home.join("run").join("holon.sock"),
+            workspace_dir: workspace,
+            context_window_messages: 8,
+            context_window_briefs: 8,
+            compaction_trigger_messages: 10,
+            compaction_keep_recent_messages: 4,
+            prompt_budget_estimated_tokens: 16_384,
+            compaction_trigger_estimated_tokens: 8_192,
+            compaction_keep_recent_estimated_tokens: 2_048,
+            recent_episode_candidates: 12,
+            max_relevant_episodes: 3,
+            control_token: Some("secret".into()),
+            control_auth_mode: ControlAuthMode::Auto,
+            config_file_path: home.join("config.json"),
+            stored_config: Default::default(),
+            default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            fallback_models: Vec::new(),
+            runtime_max_output_tokens: 8192,
+            default_tool_output_tokens: 8_000,
+            max_tool_output_tokens: 64_000,
+            disable_provider_fallback: false,
+            tui_alternate_screen: AltScreenMode::Auto,
+            validated_model_overrides: Default::default(),
+            validated_unknown_model_fallback: None,
+            providers: provider_registry_for_tests(None, Some("dummy"), home.join(".codex")),
+        }
+    }
+
+    #[test]
+    fn tailnet_host_is_client_visible_not_listen_socket() {
+        let mut config = test_config();
+        let advertise = apply_serve_options(
+            &mut config,
+            ServeOptions {
+                access: ServeAccess::Tailnet,
+                host: Some("lab.tailnet.ts.net".into()),
+                listen: None,
+                advertise: None,
+                token: None,
+                token_file: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(config.http_addr, "0.0.0.0:7878");
+        assert_eq!(advertise.as_deref(), Some("http://lab.tailnet.ts.net:7878"));
+        assert_eq!(config.callback_base_url, "http://lab.tailnet.ts.net:7878");
+        assert_eq!(config.control_auth_mode, ControlAuthMode::Required);
+    }
+
+    #[test]
+    fn unspecified_listen_accepts_explicit_advertise_url() {
+        let mut config = test_config();
+        let advertise = apply_serve_options(
+            &mut config,
+            ServeOptions {
+                access: ServeAccess::Lan,
+                host: None,
+                listen: Some("0.0.0.0:7878".into()),
+                advertise: Some("http://lab.example.test:7878".into()),
+                token: None,
+                token_file: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(config.http_addr, "0.0.0.0:7878");
+        assert_eq!(advertise.as_deref(), Some("http://lab.example.test:7878"));
+        assert_eq!(config.callback_base_url, "http://lab.example.test:7878");
+        assert_eq!(config.control_auth_mode, ControlAuthMode::Required);
+    }
+
+    #[test]
+    fn callback_base_url_is_normalized_when_validated() {
+        let mut config = test_config();
+        config.callback_base_url = "http://lab.example.test:7878/#fragment".into();
+
+        let advertise = apply_serve_options(
+            &mut config,
+            ServeOptions {
+                access: ServeAccess::Local,
+                host: None,
+                listen: None,
+                advertise: None,
+                token: None,
+                token_file: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(advertise, None);
+        assert_eq!(config.callback_base_url, "http://lab.example.test:7878");
+    }
 }
 
 async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Result<()> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -66,8 +66,15 @@ use runtime::{is_cursor_too_old_error, AgentListChange};
 use runtime::{TuiConnectionState, TuiRuntimeMessage};
 
 const INPUT_POLL_INTERVAL: Duration = Duration::from_millis(100);
-pub async fn run_tui(config: AppConfig, no_alt_screen: bool) -> Result<()> {
-    let client = LocalClient::new(config.clone())?;
+pub async fn run_tui(
+    config: AppConfig,
+    no_alt_screen: bool,
+    client: Option<LocalClient>,
+) -> Result<()> {
+    let client = match client {
+        Some(client) => client,
+        None => LocalClient::new(config.clone())?,
+    };
     let log_writer = TuiLogWriter::new(config.agent_root_dir())?;
     let mut app = TuiApp::new(client, log_writer);
     app.initialize().await;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -38,6 +38,7 @@ pub(super) struct TuiApp {
 
 impl TuiApp {
     pub(crate) fn new(client: LocalClient, log_writer: TuiLogWriter) -> Self {
+        let connection_summary = client.connection_summary();
         Self {
             client,
             agents: Vec::new(),
@@ -63,7 +64,7 @@ impl TuiApp {
             last_refresh_at: None,
             last_event_at: None,
             display_level: OperatorVisibility::DEFAULT_DISPLAY_LEVEL,
-            status_line: "Connecting to local Holon runtime...".into(),
+            status_line: format!("Connecting to {connection_summary}..."),
             should_quit: false,
             chat_text_cache: RefCell::new(None),
             input_history: Vec::new(),

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -610,7 +610,7 @@ impl TuiApp {
     }
 
     pub(super) fn connection_label(&self) -> String {
-        match &self.connection_state {
+        let state = match &self.connection_state {
             TuiConnectionState::Bootstrapping => "bootstrapping".into(),
             TuiConnectionState::Streaming => "streaming".into(),
             TuiConnectionState::Reconnecting { attempt, .. } => {
@@ -618,7 +618,8 @@ impl TuiApp {
             }
             TuiConnectionState::RefreshRequired { .. } => "refresh-required".into(),
             TuiConnectionState::Disconnected { .. } => "disconnected".into(),
-        }
+        };
+        format!("{state} via {}", self.client.connection_summary())
     }
 
     #[cfg_attr(not(test), allow(dead_code))]

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -17,6 +17,7 @@ http_async_tests!(
     agent_state_route_includes_bootstrap_projection_fields_when_present,
     control_agent_model_override_set_and_clear_updates_status,
     control_prompt_requires_bearer_token_when_required,
+    remote_tcp_surfaces_require_bearer_token_when_required,
     control_wake_records_liveness_only_system_tick_on_loopback_auto,
     control_prompt_requires_bearer_token_for_non_loopback_auto,
     control_prompt_records_message_admission_fields,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -324,6 +324,74 @@ pub async fn control_prompt_requires_bearer_token_when_required() -> Result<()> 
     Ok(())
 }
 
+pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<()> {
+    let config = test_config_with_paths(
+        tempdir().unwrap().keep(),
+        tempdir().unwrap().keep(),
+        "127.0.0.1:0".into(),
+        ControlAuthMode::Required,
+    );
+    let (_host, base, server) = spawn_server_with_config(config).await?;
+    let client = reqwest::Client::new();
+
+    for path in [
+        "/handshake",
+        "/",
+        "/agents",
+        "/agents/default/status",
+        "/agents/default/state",
+        "/agents/default/briefs",
+        "/agents/default/transcript",
+        "/agents/default/tasks",
+        "/agents/default/timers",
+        "/agents/default/worktree-summary",
+        "/agents/default/skills",
+        "/events",
+    ] {
+        let denied = client.get(format!("{base}{path}")).send().await?;
+        assert_eq!(
+            denied.status(),
+            reqwest::StatusCode::FORBIDDEN,
+            "{path} should require bearer auth"
+        );
+    }
+
+    let handshake: serde_json::Value = client
+        .get(format!("{base}/handshake"))
+        .bearer_auth("secret")
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(handshake["protocol"]["version"], 1);
+    assert_eq!(handshake["auth"]["mode"], "bearer");
+    assert_eq!(handshake["runtime"]["default_agent"], "default");
+
+    let agents = client
+        .get(format!("{base}/agents"))
+        .bearer_auth("secret")
+        .send()
+        .await?;
+    assert!(agents.status().is_success());
+
+    let denied_enqueue = client
+        .post(format!("{base}/enqueue"))
+        .json(&serde_json::json!({ "text": "hello" }))
+        .send()
+        .await?;
+    assert_eq!(denied_enqueue.status(), reqwest::StatusCode::FORBIDDEN);
+    let allowed_enqueue = client
+        .post(format!("{base}/enqueue"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({ "text": "hello" }))
+        .send()
+        .await?;
+    assert!(allowed_enqueue.status().is_success());
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn control_wake_records_liveness_only_system_tick_on_loopback_auto() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let runtime = host.default_runtime().await?;


### PR DESCRIPTION
## Summary

Implements #950 by making remote TUI access explicit and authenticated.

- adds `holon serve --access/--host/--listen/--advertise/--token-file` and validates listen vs client-visible URL semantics
- adds `holon tui --connect` with explicit token/token-file/token-profile, remote handshake, and no Unix/local fallback in remote mode
- protects TUI-visible TCP read/event/write surfaces when control auth is required
- adds `GET /handshake` and documents the remote TUI access contract

## Verification

- `cargo check`
- `cargo test remote_connect_url --lib`
- `cargo test remote_tcp_surfaces_require_bearer_token_when_required --test http_control`
- `cargo test --test http_client`

I also ran `cargo test --lib`; it hit two existing local-environment-sensitive failures unrelated to this change: `agent_template::tests::seed_builtin_templates_tolerates_empty_builtin_state_file` and `config::tests::config_inspection_loads_provider_state_without_resolved_model`.

Closes #950