### PR TITLE
fix: preserve assistant round replay fields

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1316,6 +1316,10 @@ fn event_replay_provenance(payload: &Value) -> EventReplayProvenance {
 }
 
 fn redacted_operator_replay_payload(event: &AuditEvent) -> Value {
+    if event.kind == "assistant_round_recorded" {
+        return redacted_assistant_round_replay_payload(event);
+    }
+
     let mut payload = serde_json::Map::new();
     payload.insert("redacted".to_string(), Value::Bool(true));
     payload.insert(
@@ -1334,6 +1338,35 @@ fn redacted_operator_replay_payload(event: &AuditEvent) -> Value {
         "status",
         "kind",
         "tool_name",
+    ] {
+        if let Some(value) = clone_payload_field(&event.data, field) {
+            payload.insert(field.to_string(), value);
+        }
+    }
+    Value::Object(payload)
+}
+
+fn redacted_assistant_round_replay_payload(event: &AuditEvent) -> Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert("redacted".to_string(), Value::Bool(true));
+    payload.insert(
+        "redaction_reason".to_string(),
+        Value::String("assistant_round_operator_projection".to_string()),
+    );
+    payload.insert("summary".to_string(), Value::String(event.kind.clone()));
+    for field in [
+        "agent_id",
+        "run_id",
+        "turn_index",
+        "round",
+        "stop_reason",
+        "text_preview",
+        "text_block_count",
+        "text_char_count",
+        "tool_call_count",
+        "tool_names",
+        "has_text",
+        "has_tool_calls",
     ] {
         if let Some(value) = clone_payload_field(&event.data, field) {
             payload.insert(field.to_string(), value);

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1318,6 +1318,56 @@ mod tests {
     }
 
     #[test]
+    fn assistant_round_operator_projection_renders_progress_fields() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+
+        projection.apply_event(
+            sample_event(
+                "assistant_round_recorded",
+                json!({
+                    "redacted": true,
+                    "stop_reason": "tool_use",
+                    "text_preview": null,
+                    "tool_names": ["ExecCommand", "ReadFile"],
+                    "tool_call_count": 2,
+                    "has_tool_calls": true,
+                }),
+            ),
+            &test_log_writer(),
+        );
+        assert_eq!(
+            projection
+                .event_log()
+                .last()
+                .map(|event| event.summary.as_str()),
+            Some("Assistant requested tools: ExecCommand, ReadFile")
+        );
+
+        projection.apply_event(
+            sample_event(
+                "assistant_round_recorded",
+                json!({
+                    "redacted": true,
+                    "stop_reason": "end_turn",
+                    "text_preview": null,
+                    "tool_names": [],
+                    "tool_call_count": 0,
+                    "has_text": false,
+                    "has_tool_calls": false,
+                }),
+            ),
+            &test_log_writer(),
+        );
+        assert_eq!(
+            projection
+                .event_log()
+                .last()
+                .map(|event| event.summary.as_str()),
+            Some("Assistant round completed without text (stop=end_turn)")
+        );
+    }
+
+    #[test]
     fn transient_activity_events_do_not_force_state_refresh() {
         let mut projection = TuiProjection::from_snapshot(sample_snapshot());
 

--- a/tests/http_events.rs
+++ b/tests/http_events.rs
@@ -16,6 +16,7 @@ http_async_tests!(
     events_route_supports_last_event_id_header_and_rfc3339_ts,
     events_route_preserves_replay_provenance,
     events_route_operator_projection_redacts_trace_payload,
+    events_route_operator_projection_preserves_assistant_round_progress,
     events_route_local_debug_projection_requires_control_auth,
     events_route_with_missing_cursor_returns_refresh_hint,
 );

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -252,6 +252,93 @@ pub async fn events_route_operator_projection_redacts_trace_payload() -> Result<
     Ok(())
 }
 
+pub async fn events_route_operator_projection_preserves_assistant_round_progress() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    client
+        .post(format!("{base}/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": "assistant round projection bootstrap" }))
+        .send()
+        .await?;
+    wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
+
+    let bootstrap: serde_json::Value = client
+        .get(format!("{base}/agents/default/state"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let cursor = bootstrap["cursor"]
+        .as_str()
+        .expect("cursor should be present")
+        .to_string();
+
+    runtime.storage().append_event(&AuditEvent::new(
+        "assistant_round_recorded",
+        serde_json::json!({
+            "agent_id": "default",
+            "run_id": "run-1",
+            "turn_index": 7,
+            "round": 2,
+            "stop_reason": "tool_use",
+            "text_preview": "I will inspect the files.",
+            "text_block_count": 1,
+            "text_char_count": 25,
+            "tool_call_count": 2,
+            "tool_names": ["ExecCommand", "ReadFile"],
+            "has_text": true,
+            "has_tool_calls": true,
+            "raw_text": "full assistant text should stay out of operator replay",
+            "provider_trace": { "secret": "debug-only" },
+        }),
+    ))?;
+
+    let mut stream = client
+        .get(format!(
+            "{base}/agents/default/events?since={cursor}&projection=operator"
+        ))
+        .send()
+        .await?;
+    let replayed =
+        tokio::time::timeout(Duration::from_secs(5), read_next_sse_event(&mut stream)).await??;
+
+    assert_eq!(replayed.event, "assistant_round_recorded");
+    assert_eq!(replayed.data["type"], "assistant_round_recorded");
+    assert_eq!(replayed.data["projection"]["name"], "operator");
+    assert_eq!(
+        replayed.data["projection"]["raw_payload_included"],
+        serde_json::json!(false)
+    );
+    assert_eq!(replayed.data["payload"]["redacted"], true);
+    assert_eq!(replayed.data["payload"]["agent_id"], "default");
+    assert_eq!(replayed.data["payload"]["run_id"], "run-1");
+    assert_eq!(replayed.data["payload"]["turn_index"], 7);
+    assert_eq!(replayed.data["payload"]["round"], 2);
+    assert_eq!(replayed.data["payload"]["stop_reason"], "tool_use");
+    assert_eq!(
+        replayed.data["payload"]["text_preview"],
+        "I will inspect the files."
+    );
+    assert_eq!(replayed.data["payload"]["text_block_count"], 1);
+    assert_eq!(replayed.data["payload"]["text_char_count"], 25);
+    assert_eq!(replayed.data["payload"]["tool_call_count"], 2);
+    assert_eq!(
+        replayed.data["payload"]["tool_names"],
+        serde_json::json!(["ExecCommand", "ReadFile"])
+    );
+    assert_eq!(replayed.data["payload"]["has_text"], true);
+    assert_eq!(replayed.data["payload"]["has_tool_calls"], true);
+
+    let replayed_text = serde_json::to_string(&replayed.data)?;
+    assert!(!replayed_text.contains("full assistant text"));
+    assert!(!replayed_text.contains("debug-only"));
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn events_route_local_debug_projection_requires_control_auth() -> Result<()> {
     let config = test_config_with_paths(
         tempdir()?.keep(),


### PR DESCRIPTION
Closes #958

## Summary
- preserve operator-safe assistant_round_recorded fields during default operator event replay
- keep full assistant/debug payloads redacted while retaining bounded progress metadata
- cover TUI/operator rendering for tool-only and known-stop assistant rounds

## Verification
- cargo test events_route_operator_projection_preserves_assistant_round_progress --test http_events -- --test-threads=1
- cargo test assistant_round_operator_projection_renders_progress_fields --lib -- --test-threads=1
- cargo test assistant_round_recorded_distinguishes_text_from_tool_requests --lib -- --test-threads=1
- cargo test --all-targets -- --test-threads=1