### PR TITLE
fix: seed TUI events from state snapshot

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -109,6 +109,8 @@ pub struct AgentStateSnapshot {
     pub execution: Option<ExecutionSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub brief: Option<BriefRecord>,
+    #[serde(default)]
+    pub events_tail: Vec<StreamEventEnvelope>,
     pub cursor: Option<String>,
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -75,6 +75,7 @@ pub struct AppState {
 
 const CALLBACK_BODY_LIMIT_BYTES: usize = 256 * 1024;
 const DEFAULT_EVENT_STREAM_WINDOW: usize = 128;
+const DEFAULT_STATE_EVENTS_TAIL_LIMIT: usize = DEFAULT_EVENT_STREAM_WINDOW;
 const MAX_EVENT_STREAM_WINDOW: usize = 512;
 const EVENT_STREAM_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -409,6 +410,7 @@ struct AgentStateSnapshot {
     execution: Option<ExecutionSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     brief: Option<BriefRecord>,
+    events_tail: Vec<StreamEventEnvelope>,
     cursor: Option<String>,
 }
 
@@ -843,13 +845,23 @@ pub async fn agent_state(
         .get_public_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
-    let cursor = runtime
-        .recent_events(1)
+    let events_tail_raw = runtime
+        .recent_events(DEFAULT_STATE_EVENTS_TAIL_LIMIT)
         .await
-        .map_err(error_response)?
-        .into_iter()
-        .next()
-        .map(|event| event.id);
+        .map_err(error_response)?;
+    let cursor = events_tail_raw.last().map(|event| event.id.clone());
+    let events_tail = events_tail_raw
+        .iter()
+        .enumerate()
+        .map(|(seq, event)| {
+            stream_event_envelope(
+                seq as u64,
+                &agent_id,
+                event,
+                EventReplayProjection::Operator,
+            )
+        })
+        .collect();
     let agent = runtime.agent_summary().await.map_err(error_response)?;
     let tasks = runtime.recent_tasks(50).await.map_err(error_response)?;
     let transcript_tail = runtime
@@ -902,6 +914,7 @@ pub async fn agent_state(
         execution: Some(execution),
         workspace,
         brief,
+        events_tail,
         cursor,
     }))
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -393,6 +393,7 @@ mod tests {
             workspace: StateWorkspaceSnapshot::default(),
             execution: None,
             brief: None,
+            events_tail: Vec::new(),
             cursor: Some(cursor.into()),
         }
     }

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -94,8 +94,9 @@ impl TuiProjection {
     pub(crate) fn from_snapshot(snapshot: AgentStateSnapshot) -> Self {
         let external_triggers = snapshot.external_triggers;
         let operator_notifications = snapshot.operator_notifications;
+        let events_tail = snapshot.events_tail;
 
-        Self {
+        let mut projection = Self {
             agent: snapshot.agent,
             session: snapshot.session,
             tasks: snapshot.tasks,
@@ -112,7 +113,9 @@ impl TuiProjection {
             stale_slices: BTreeSet::new(),
             event_log: Vec::new(),
             durable_conversation_log: Vec::new(),
-        }
+        };
+        projection.seed_event_log(events_tail);
+        projection
     }
 
     pub(crate) fn reset_from_snapshot(&mut self, snapshot: AgentStateSnapshot) {
@@ -128,24 +131,8 @@ impl TuiProjection {
     }
 
     pub(crate) fn apply_event(&mut self, event: AgentStreamEvent, log_writer: &TuiLogWriter) {
-        let fallback_summary = summarize_event(&event);
         let presentation_context = self.operator_presentation_context();
-        let presentation = present_operator_event(
-            &event.data.event_type,
-            &event.data.payload,
-            &fallback_summary,
-            &presentation_context,
-        );
-        let record = ProjectionEventRecord {
-            id: event.id.clone(),
-            seq: event.data.seq,
-            ts: event.data.ts,
-            kind: event.data.event_type.clone(),
-            lane: classify_event_lane(&presentation),
-            summary: presentation.summary.clone(),
-            presentation,
-            payload: event.data.payload.clone(),
-        };
+        let record = projection_event_record_from_stream_event(&event, &presentation_context);
         push_limited(&mut self.event_log, record.clone(), EVENT_LOG_LIMIT);
         if is_durable_conversation_kind(&record.kind) {
             push_limited(
@@ -402,6 +389,24 @@ impl TuiProjection {
             }
             "message_admitted" | "control_applied" => {}
             _ => {}
+        }
+    }
+
+    fn seed_event_log(&mut self, events_tail: Vec<crate::client::StreamEventEnvelope>) {
+        for envelope in events_tail {
+            let event = AgentStreamEvent {
+                id: envelope.id.clone(),
+                event: envelope.event_type.clone(),
+                data: envelope,
+            };
+            let presentation_context = self.operator_presentation_context();
+            let record = projection_event_record_from_stream_event(&event, &presentation_context);
+            push_limited(&mut self.event_log, record, EVENT_LOG_LIMIT);
+        }
+        if let Some(last_event) = self.event_log.last() {
+            if self.cursor.is_none() {
+                self.cursor = Some(last_event.id.clone());
+            }
         }
     }
 
@@ -824,6 +829,29 @@ fn classify_event_lane(presentation: &OperatorEventPresentation) -> ProjectionEv
     }
 }
 
+fn projection_event_record_from_stream_event(
+    event: &AgentStreamEvent,
+    presentation_context: &OperatorPresentationContext,
+) -> ProjectionEventRecord {
+    let fallback_summary = summarize_event(event);
+    let presentation = present_operator_event(
+        &event.data.event_type,
+        &event.data.payload,
+        &fallback_summary,
+        presentation_context,
+    );
+    ProjectionEventRecord {
+        id: event.id.clone(),
+        seq: event.data.seq,
+        ts: event.data.ts,
+        kind: event.data.event_type.clone(),
+        lane: classify_event_lane(&presentation),
+        summary: presentation.summary.clone(),
+        presentation,
+        payload: event.data.payload.clone(),
+    }
+}
+
 fn summarize_event(event: &AgentStreamEvent) -> String {
     match event.data.event_type.as_str() {
         "message_enqueued" => decode_payload::<MessageEnvelope>(&event.data.payload)
@@ -1077,6 +1105,48 @@ mod tests {
         assert_eq!(
             projection.external_triggers.len(),
             snapshot.external_triggers.len()
+        );
+    }
+
+    #[test]
+    fn projection_bootstrap_seeds_raw_event_log_from_snapshot_tail() {
+        let mut snapshot = sample_snapshot();
+        snapshot.events_tail = vec![StreamEventEnvelope {
+            id: "evt-tail-1".into(),
+            seq: 0,
+            ts: Utc::now(),
+            agent_id: "default".into(),
+            event_type: "assistant_round_recorded".into(),
+            projection: Some(json!({
+                "name": "operator",
+                "raw_payload_included": false,
+                "redactions": ["internal_detail_payload"],
+            })),
+            provenance: None,
+            payload: json!({
+                "redacted": true,
+                "stop_reason": "tool_use",
+                "tool_names": ["ExecCommand"],
+                "tool_call_count": 1,
+                "has_tool_calls": true,
+            }),
+        }];
+        snapshot.cursor = Some("evt-tail-1".into());
+
+        let projection = TuiProjection::from_snapshot(snapshot);
+
+        assert_eq!(projection.event_log().len(), 1);
+        assert_eq!(
+            projection
+                .event_log()
+                .last()
+                .map(|event| event.summary.as_str()),
+            Some("Assistant requested tools: ExecCommand")
+        );
+        assert_eq!(projection.cursor.as_deref(), Some("evt-tail-1"));
+        assert!(
+            projection.durable_conversation_events().next().is_none(),
+            "events_tail should seed the raw inspector, not durable conversation history"
         );
     }
 
@@ -1987,6 +2057,7 @@ mod tests {
             },
             execution: None,
             brief: None,
+            events_tail: Vec::new(),
             cursor: Some("evt-bootstrap".into()),
         }
     }

--- a/tests/http_events.rs
+++ b/tests/http_events.rs
@@ -17,6 +17,7 @@ http_async_tests!(
     events_route_preserves_replay_provenance,
     events_route_operator_projection_redacts_trace_payload,
     events_route_operator_projection_preserves_assistant_round_progress,
+    state_snapshot_seeds_projected_events_tail_and_stream_resumes_after_cursor,
     events_route_local_debug_projection_requires_control_auth,
     events_route_with_missing_cursor_returns_refresh_hint,
 );

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -339,6 +339,87 @@ pub async fn events_route_operator_projection_preserves_assistant_round_progress
     Ok(())
 }
 
+pub async fn state_snapshot_seeds_projected_events_tail_and_stream_resumes_after_cursor(
+) -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    runtime.storage().append_event(&AuditEvent::new(
+        "assistant_round_recorded",
+        serde_json::json!({
+            "agent_id": "default",
+            "run_id": "run-state",
+            "turn_index": 3,
+            "round": 1,
+            "stop_reason": "tool_use",
+            "text_preview": null,
+            "tool_names": ["ExecCommand"],
+            "tool_call_count": 1,
+            "has_text": false,
+            "has_tool_calls": true,
+            "raw_text": "debug-only assistant body",
+        }),
+    ))?;
+
+    let snapshot: serde_json::Value = client
+        .get(format!("{base}/agents/default/state"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let events_tail = snapshot["events_tail"]
+        .as_array()
+        .expect("events_tail should be an array");
+    let tail_cursor = events_tail
+        .last()
+        .and_then(|event| event["id"].as_str())
+        .expect("events_tail should include at least one event");
+    assert_eq!(snapshot["cursor"], tail_cursor);
+    let assistant_tail = events_tail
+        .iter()
+        .find(|event| event["type"] == "assistant_round_recorded")
+        .expect("events_tail should include the appended assistant round");
+    assert_eq!(assistant_tail["projection"]["name"], "operator");
+    assert_eq!(
+        assistant_tail["projection"]["raw_payload_included"],
+        serde_json::json!(false)
+    );
+    assert_eq!(assistant_tail["payload"]["stop_reason"], "tool_use");
+    assert_eq!(
+        assistant_tail["payload"]["tool_names"],
+        serde_json::json!(["ExecCommand"])
+    );
+    assert!(!serde_json::to_string(assistant_tail)?.contains("debug-only assistant body"));
+
+    let cursor = snapshot["cursor"]
+        .as_str()
+        .expect("cursor should be present")
+        .to_string();
+    runtime.storage().append_event(&AuditEvent::new(
+        "tool_executed",
+        serde_json::json!({
+            "agent_id": "default",
+            "tool_name": "ReadFile",
+            "task_id": "task-tail",
+        }),
+    ))?;
+
+    let mut stream = client
+        .get(format!(
+            "{base}/agents/default/events?since={cursor}&projection=operator"
+        ))
+        .send()
+        .await?;
+    let replayed =
+        tokio::time::timeout(Duration::from_secs(5), read_next_sse_event(&mut stream)).await??;
+    assert_eq!(replayed.event, "tool_executed");
+    assert_ne!(replayed._id, cursor);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn events_route_local_debug_projection_requires_control_auth() -> Result<()> {
     let config = test_config_with_paths(
         tempdir()?.keep(),


### PR DESCRIPTION
## Summary

- add an operator-projected `events_tail` to `/agents/:id/state` using the existing event replay projection boundary
- seed the TUI `/events` raw inspector from the snapshot tail without promoting it into durable conversation history
- preserve snapshot cursor semantics so SSE resumes after the newest snapshot event and add regression coverage

Fixes #956.

## Verification

- `cargo fmt`
- `cargo test projection_bootstrap_seeds_raw_event_log_from_snapshot_tail --lib -- --test-threads=1`
- `cargo test state_snapshot_seeds_projected_events_tail_and_stream_resumes_after_cursor --test http_events -- --test-threads=1`
- `cargo test --all-targets -- --test-threads=1`