### PR TITLE
fix: show active task snapshots by default

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -863,7 +863,7 @@ pub async fn agent_state(
         })
         .collect();
     let agent = runtime.agent_summary().await.map_err(error_response)?;
-    let tasks = runtime.recent_tasks(50).await.map_err(error_response)?;
+    let tasks = runtime.active_tasks(50).await.map_err(error_response)?;
     let transcript_tail = runtime
         .recent_transcript(100)
         .await
@@ -1458,7 +1458,7 @@ pub async fn tasks(
         .map_err(agent_access_error)?;
     Ok(Json(
         runtime
-            .recent_tasks(query.limit.unwrap_or(50))
+            .active_tasks(query.limit.unwrap_or(50))
             .await
             .map_err(error_response)?,
     ))

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -610,18 +610,11 @@ async fn active_new_task_ids(
     let mut active = Vec::new();
     for task_id in task_ids {
         let snapshot = runtime.task_output(task_id, false, 0).await?;
-        if is_active_task_status(&snapshot.task.status) {
+        if crate::storage::is_active_task_status(&snapshot.task.status) {
             active.push(task_id.clone());
         }
     }
     Ok(active)
-}
-
-fn is_active_task_status(state: &TaskStatus) -> bool {
-    matches!(
-        state,
-        TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling
-    )
 }
 
 async fn settle_stopped_tasks(
@@ -636,7 +629,7 @@ async fn settle_stopped_tasks(
                 break;
             };
             let snapshot = runtime.task_output(task_id, false, 0).await?;
-            if !is_active_task_status(&snapshot.task.status) {
+            if !crate::storage::is_active_task_status(&snapshot.task.status) {
                 break;
             }
 
@@ -653,7 +646,7 @@ async fn settle_stopped_tasks(
             }
 
             let waited = runtime.task_output(task_id, true, remaining_ms).await?;
-            if !is_active_task_status(&waited.task.status) {
+            if !crate::storage::is_active_task_status(&waited.task.status) {
                 break;
             }
         }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -380,6 +380,10 @@ impl RuntimeHandle {
         self.inner.storage.read_recent_tasks(limit)
     }
 
+    pub async fn active_tasks(&self, limit: usize) -> Result<Vec<TaskRecord>> {
+        self.inner.storage.latest_active_task_records(limit)
+    }
+
     pub async fn recent_transcript(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
         self.inner.storage.read_recent_transcript(limit)
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, ContextEpisodeRecord,
     DeliverySummaryRecord, ExternalTriggerRecord, MessageEnvelope, OperatorDeliveryRecord,
-    OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord, TaskRecord,
+    OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord, TaskRecord, TaskStatus,
     TimerRecord, ToolExecutionRecord, TranscriptEntry, WaitingIntentRecord,
     WorkItemDelegationRecord, WorkItemDelegationState, WorkItemRecord, WorkItemState,
     WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
@@ -430,6 +430,45 @@ impl AppStorage {
         Ok(latest.into_values().collect())
     }
 
+    pub fn latest_active_task_records(&self, limit: usize) -> Result<Vec<TaskRecord>> {
+        if limit == 0 || !self.tasks_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut seen = std::collections::BTreeSet::<String>::new();
+        let mut pending_recovery = std::collections::BTreeMap::<String, usize>::new();
+        let mut records = Vec::<TaskRecord>::new();
+
+        scan_jsonl_reverse::<TaskRecord, _>(&self.tasks_path, |record| {
+            if let Some(index) = pending_recovery.get(&record.id).copied() {
+                if records[index].recovery.is_none() {
+                    records[index].recovery = record.recovery.clone();
+                }
+                if records[index].recovery.is_some() {
+                    pending_recovery.remove(&record.id);
+                }
+            }
+
+            if seen.contains(&record.id) {
+                return records.len() < limit || !pending_recovery.is_empty();
+            }
+            seen.insert(record.id.clone());
+
+            if records.len() < limit && is_active_task_status(&record.status) {
+                records.push(record);
+                let index = records.len() - 1;
+                if records[index].recovery.is_none() {
+                    pending_recovery.insert(records[index].id.clone(), index);
+                }
+            }
+
+            records.len() < limit || !pending_recovery.is_empty()
+        })?;
+
+        records.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        Ok(records)
+    }
+
     pub fn latest_task_record(&self, task_id: &str) -> Result<Option<TaskRecord>> {
         if !self.tasks_path.exists() {
             return Ok(None);
@@ -723,18 +762,7 @@ impl AppStorage {
             .collect::<Vec<_>>();
         replay_messages.sort_by(|left, right| left.created_at.cmp(&right.created_at));
 
-        let active_tasks = self
-            .latest_task_records()?
-            .into_iter()
-            .filter(|record| {
-                matches!(
-                    record.status,
-                    crate::types::TaskStatus::Queued
-                        | crate::types::TaskStatus::Running
-                        | crate::types::TaskStatus::Cancelling
-                )
-            })
-            .collect();
+        let active_tasks = self.latest_active_task_records(usize::MAX)?;
         let active_timers = self
             .latest_timer_records()?
             .into_iter()
@@ -789,6 +817,13 @@ fn append_jsonl<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     let line = serde_json::to_string(value)?;
     writeln!(file, "{line}")?;
     Ok(())
+}
+
+pub(crate) fn is_active_task_status(status: &TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling
+    )
 }
 
 fn read_recent_jsonl<T: DeserializeOwned>(path: &Path, limit: usize) -> Result<Vec<T>> {
@@ -882,6 +917,63 @@ where
     parse_jsonl_match(&prefix, path, &mut matches)
 }
 
+fn scan_jsonl_reverse<T, F>(path: &Path, mut visit: F) -> Result<()>
+where
+    T: DeserializeOwned,
+    F: FnMut(T) -> bool,
+{
+    if !path.exists() {
+        return Ok(());
+    }
+
+    const CHUNK_SIZE: u64 = 8192;
+    let mut file =
+        fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut cursor = file.seek(SeekFrom::End(0))?;
+    let mut prefix = Vec::new();
+
+    while cursor > 0 {
+        let read_len = cursor.min(CHUNK_SIZE);
+        cursor -= read_len;
+        file.seek(SeekFrom::Start(cursor))?;
+
+        let mut chunk = vec![0; read_len as usize];
+        file.read_exact(&mut chunk)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        chunk.extend_from_slice(&prefix);
+
+        let mut line_end = chunk.len();
+        for idx in (0..chunk.len()).rev() {
+            if chunk[idx] != b'\n' {
+                continue;
+            }
+            if !parse_jsonl_visit(&chunk[(idx + 1)..line_end], path, &mut visit)? {
+                return Ok(());
+            }
+            line_end = idx;
+        }
+        prefix = chunk[..line_end].to_vec();
+    }
+
+    let _ = parse_jsonl_visit(&prefix, path, &mut visit)?;
+    Ok(())
+}
+
+fn parse_jsonl_visit<T, F>(line: &[u8], path: &Path, visit: &mut F) -> Result<bool>
+where
+    T: DeserializeOwned,
+    F: FnMut(T) -> bool,
+{
+    let line = std::str::from_utf8(line)
+        .with_context(|| format!("failed to decode UTF-8 from {}", path.display()))?;
+    if line.trim().is_empty() {
+        return Ok(true);
+    }
+    let record: T = serde_json::from_str(line)
+        .with_context(|| format!("failed to decode line from {}", path.display()))?;
+    Ok(visit(record))
+}
+
 fn parse_jsonl_match<T, F>(line: &[u8], path: &Path, matches: &mut F) -> Result<Option<T>>
 where
     T: DeserializeOwned,
@@ -957,8 +1049,8 @@ mod tests {
 
     use crate::types::{
         AgentState, AgentStatus, EpisodeBoundaryReason, Priority, QueueEntryRecord,
-        QueueEntryStatus, TodoItem, TodoItemState, TranscriptEntry, TranscriptEntryKind,
-        WorkItemState,
+        QueueEntryStatus, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TodoItem,
+        TodoItemState, TranscriptEntry, TranscriptEntryKind, TrustLevel, WorkItemState,
     };
 
     use super::*;
@@ -975,6 +1067,119 @@ mod tests {
         assert_eq!(restored.status, AgentStatus::Asleep);
         assert!(dir.path().join(".holon/state/agent.json").is_file());
         assert!(!dir.path().join("agent.json").exists());
+    }
+
+    #[test]
+    fn latest_active_task_records_reduce_by_id_and_filter_terminal_tasks() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+        let task = |id: &str, status: TaskStatus, offset: i64| TaskRecord {
+            id: id.into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: status.clone(),
+            created_at: now + chrono::Duration::seconds(offset),
+            updated_at: now + chrono::Duration::seconds(offset),
+            parent_message_id: None,
+            summary: Some(format!("{id} {status:?}")),
+            detail: None,
+            recovery: None,
+        };
+
+        storage
+            .append_task(&task("completed-after-queue", TaskStatus::Queued, 0))
+            .unwrap();
+        storage
+            .append_task(&task("running", TaskStatus::Running, 1))
+            .unwrap();
+        storage
+            .append_task(&task("completed-after-queue", TaskStatus::Completed, 2))
+            .unwrap();
+        storage
+            .append_task(&task("cancelling", TaskStatus::Cancelling, 3))
+            .unwrap();
+
+        let active = storage.latest_active_task_records(10).unwrap();
+        let rendered = active
+            .iter()
+            .map(|task| (task.id.as_str(), task.status.clone()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            rendered,
+            vec![
+                ("cancelling", TaskStatus::Cancelling),
+                ("running", TaskStatus::Running)
+            ]
+        );
+    }
+
+    #[test]
+    fn latest_active_task_records_applies_limit_after_reverse_reduction() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+
+        for index in 0..5 {
+            storage
+                .append_task(&TaskRecord {
+                    id: format!("task-{index}"),
+                    agent_id: "default".into(),
+                    kind: TaskKind::CommandTask,
+                    status: TaskStatus::Running,
+                    created_at: now + chrono::Duration::seconds(index),
+                    updated_at: now + chrono::Duration::seconds(index),
+                    parent_message_id: None,
+                    summary: None,
+                    detail: None,
+                    recovery: None,
+                })
+                .unwrap();
+        }
+
+        let active = storage.latest_active_task_records(2).unwrap();
+        let ids = active
+            .iter()
+            .map(|task| task.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, vec!["task-4", "task-3"]);
+    }
+
+    #[test]
+    fn latest_active_task_records_preserves_recovery_from_older_snapshot() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+        let mut task = TaskRecord {
+            id: "task-recovery".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            summary: None,
+            detail: None,
+            recovery: Some(TaskRecoverySpec::SubagentTask {
+                summary: "recover".into(),
+                prompt: "resume with artifact".into(),
+                trust: TrustLevel::TrustedOperator,
+            }),
+        };
+        storage.append_task(&task).unwrap();
+
+        task.updated_at = now + chrono::Duration::seconds(1);
+        task.recovery = None;
+        storage.append_task(&task).unwrap();
+
+        let active = storage.latest_active_task_records(1).unwrap();
+        assert_eq!(active.len(), 1);
+        assert!(matches!(
+            active[0].recovery,
+            Some(TaskRecoverySpec::SubagentTask { .. })
+        ));
     }
 
     #[test]

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -262,7 +262,7 @@ fn draw_tasks_overlay(frame: &mut Frame<'_>, app: &TuiApp, selected: usize, deta
     frame.render_widget(Clear, popup);
 
     let items = if app.tasks.is_empty() {
-        vec![ListItem::new("No tasks")]
+        vec![ListItem::new("No active tasks")]
     } else {
         app.tasks
             .iter()
@@ -287,7 +287,7 @@ fn draw_tasks_overlay(frame: &mut Frame<'_>, app: &TuiApp, selected: usize, deta
         .rev()
         .nth(selected)
         .map(render::render_task_detail)
-        .unwrap_or_else(|| "No task selected.".to_string());
+        .unwrap_or_else(|| "No active task selected.".to_string());
     let detail = Paragraph::new(detail_text)
         .block(Block::default().title("Task Detail").borders(Borders::ALL))
         .scroll((detail_scroll, 0))

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -95,11 +95,12 @@ impl TuiProjection {
         let external_triggers = snapshot.external_triggers;
         let operator_notifications = snapshot.operator_notifications;
         let events_tail = snapshot.events_tail;
+        let tasks = active_tasks_for_projection(snapshot.tasks);
 
         let mut projection = Self {
             agent: snapshot.agent,
             session: snapshot.session,
-            tasks: snapshot.tasks,
+            tasks,
             transcript_tail: snapshot.transcript_tail,
             operator_messages: snapshot.operator_messages,
             briefs_tail: snapshot.briefs_tail,
@@ -196,9 +197,7 @@ impl TuiProjection {
             }
             "task_created" | "task_status_updated" | "task_result_received" => {
                 if let Some(task) = decode_payload::<TaskRecord>(&event.data.payload) {
-                    push_limited_sorted(&mut self.tasks, task, TASK_TAIL_LIMIT, |left, right| {
-                        left.updated_at.cmp(&right.updated_at)
-                    });
+                    upsert_active_task(&mut self.tasks, task);
                     self.stale_slices.remove(&ProjectionSlice::Tasks);
                 } else {
                     self.mark_stale([ProjectionSlice::Tasks]);
@@ -752,6 +751,28 @@ where
     }
 }
 
+fn upsert_active_task(tasks: &mut Vec<TaskRecord>, task: TaskRecord) {
+    tasks.retain(|existing| existing.id != task.id);
+    if crate::storage::is_active_task_status(&task.status) {
+        push_limited_sorted(tasks, task, TASK_TAIL_LIMIT, |left, right| {
+            left.updated_at.cmp(&right.updated_at)
+        });
+    }
+}
+
+fn active_tasks_for_projection(tasks: Vec<TaskRecord>) -> Vec<TaskRecord> {
+    let mut tasks = tasks
+        .into_iter()
+        .filter(|task| crate::storage::is_active_task_status(&task.status))
+        .collect::<Vec<_>>();
+    // TUI keeps tasks oldest-first internally because the overlay reverses them for display.
+    tasks.sort_by(|left, right| left.updated_at.cmp(&right.updated_at));
+    if tasks.len() > TASK_TAIL_LIMIT {
+        tasks.drain(0..(tasks.len() - TASK_TAIL_LIMIT));
+    }
+    tasks
+}
+
 fn upsert_work_item(items: &mut Vec<WorkItemRecord>, item: WorkItemRecord) {
     if let Some(index) = items.iter().position(|existing| existing.id == item.id) {
         items[index] = item;
@@ -1045,7 +1066,9 @@ fn trim_summary(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{OperatorVisibility, ProjectionEventLane, ProjectionSlice, TuiProjection};
+    use super::{
+        OperatorVisibility, ProjectionEventLane, ProjectionSlice, TuiProjection, TASK_TAIL_LIMIT,
+    };
     use crate::{
         client::{
             AgentStateSnapshot, AgentStreamEvent, StateSessionSnapshot, StateWorkspaceSnapshot,
@@ -1756,7 +1779,7 @@ mod tests {
         let mut projection = TuiProjection::from_snapshot(sample_snapshot());
         let mut task = sample_task();
         task.id = "task-stream".into();
-        task.status = TaskStatus::Completed;
+        task.status = TaskStatus::Running;
         task.updated_at = Utc::now();
 
         let mut work_item = WorkItemRecord::new("default", "queued delivery", WorkItemState::Open);
@@ -1785,6 +1808,100 @@ mod tests {
             .work_items
             .iter()
             .any(|record| record.id == "work-stream" && record.state == WorkItemState::Open));
+    }
+
+    #[test]
+    fn projection_upserts_active_tasks_and_removes_terminal_updates() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        projection.tasks.clear();
+        let mut task = sample_task();
+        task.id = "task-active".into();
+        task.status = TaskStatus::Queued;
+
+        projection.apply_event(
+            sample_event("task_created", serde_json::to_value(&task).unwrap()),
+            &test_log_writer(),
+        );
+        assert_eq!(projection.tasks.len(), 1);
+        assert_eq!(projection.tasks[0].status, TaskStatus::Queued);
+
+        task.status = TaskStatus::Running;
+        task.summary = Some("running latest".into());
+        task.updated_at = task.updated_at + chrono::Duration::seconds(1);
+        projection.apply_event(
+            sample_event("task_status_updated", serde_json::to_value(&task).unwrap()),
+            &test_log_writer(),
+        );
+        assert_eq!(projection.tasks.len(), 1);
+        assert_eq!(
+            projection.tasks[0].summary.as_deref(),
+            Some("running latest")
+        );
+        assert_eq!(projection.tasks[0].status, TaskStatus::Running);
+
+        task.status = TaskStatus::Completed;
+        task.updated_at = task.updated_at + chrono::Duration::seconds(1);
+        projection.apply_event(
+            sample_event("task_result_received", serde_json::to_value(&task).unwrap()),
+            &test_log_writer(),
+        );
+        assert!(projection.tasks.is_empty());
+    }
+
+    #[test]
+    fn projection_bootstrap_keeps_only_active_tasks_in_chronological_order() {
+        let mut old_running = sample_task();
+        old_running.id = "old-running".into();
+        old_running.status = TaskStatus::Running;
+        old_running.updated_at = Utc::now() - chrono::Duration::seconds(10);
+
+        let mut completed = sample_task();
+        completed.id = "completed".into();
+        completed.status = TaskStatus::Completed;
+        completed.updated_at = Utc::now() - chrono::Duration::seconds(5);
+
+        let mut new_running = sample_task();
+        new_running.id = "new-running".into();
+        new_running.status = TaskStatus::Running;
+        new_running.updated_at = Utc::now();
+
+        let mut snapshot = sample_snapshot();
+        snapshot.tasks = vec![new_running, completed, old_running];
+
+        let projection = TuiProjection::from_snapshot(snapshot);
+        let task_ids = projection
+            .tasks
+            .iter()
+            .map(|task| task.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(task_ids, vec!["old-running", "new-running"]);
+    }
+
+    #[test]
+    fn projection_bootstrap_bounds_active_tasks() {
+        let now = Utc::now();
+        let mut snapshot = sample_snapshot();
+        snapshot.tasks = (0..(TASK_TAIL_LIMIT + 5))
+            .map(|index| {
+                let mut task = sample_task();
+                task.id = format!("task-{index}");
+                task.status = TaskStatus::Running;
+                task.updated_at = now + chrono::Duration::seconds(index as i64);
+                task
+            })
+            .collect();
+
+        let projection = TuiProjection::from_snapshot(snapshot);
+        let task_ids = projection
+            .tasks
+            .iter()
+            .map(|task| task.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(projection.tasks.len(), TASK_TAIL_LIMIT);
+        assert_eq!(task_ids.first().copied(), Some("task-5"));
+        assert_eq!(task_ids.last().copied(), Some("task-54"));
     }
 
     #[test]

--- a/tests/http_tasks.rs
+++ b/tests/http_tasks.rs
@@ -16,6 +16,7 @@ http_async_tests!(
     create_task_route_rejects_unknown_prompt_field,
     create_command_task_route_no_longer_denies_integration_trust,
     create_command_task_route_accepts_command_request,
+    tasks_and_state_routes_return_active_latest_tasks_only,
     create_work_item_route_persists_queued_item_without_message_ingress,
     create_work_item_route_does_not_replace_existing_active_item,
     create_work_item_route_rejects_empty_objective_with_bad_request,

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -22,8 +22,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
-        WorkItemState,
+        OperatorDeliveryStatus, TaskKind, TaskRecord, TaskStatus, TodoItem, TodoItemState,
+        TrustLevel, WaitingIntentStatus, WorkItemState,
     },
 };
 use reqwest::Client;
@@ -152,6 +152,69 @@ pub async fn create_command_task_route_accepts_command_request() -> Result<()> {
     let detail = task.detail.unwrap_or_default();
     assert_eq!(detail["cmd"], "printf route_command_ok");
     assert!(detail["output_path"].as_str().is_some());
+    server.abort();
+    Ok(())
+}
+
+pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+    let now = chrono::Utc::now();
+    let task = |id: &str, status: TaskStatus, offset: i64| TaskRecord {
+        id: id.into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: status.clone(),
+        created_at: now + chrono::Duration::seconds(offset),
+        updated_at: now + chrono::Duration::seconds(offset),
+        parent_message_id: None,
+        summary: Some(format!("{id} {status:?}")),
+        detail: None,
+        recovery: None,
+    };
+
+    runtime
+        .storage()
+        .append_task(&task("task-terminal", TaskStatus::Queued, 0))?;
+    runtime
+        .storage()
+        .append_task(&task("task-running", TaskStatus::Running, 1))?;
+    runtime
+        .storage()
+        .append_task(&task("task-terminal", TaskStatus::Completed, 2))?;
+    runtime
+        .storage()
+        .append_task(&task("task-cancelling", TaskStatus::Cancelling, 3))?;
+
+    let tasks: serde_json::Value = client
+        .get(format!("{base}/agents/default/tasks"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let task_ids = tasks
+        .as_array()
+        .expect("/tasks should return an array")
+        .iter()
+        .map(|task| task["id"].as_str().unwrap_or_default())
+        .collect::<Vec<_>>();
+    assert_eq!(task_ids, vec!["task-cancelling", "task-running"]);
+
+    let snapshot: serde_json::Value = client
+        .get(format!("{base}/agents/default/state"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let state_task_ids = snapshot["tasks"]
+        .as_array()
+        .expect("/state.tasks should return an array")
+        .iter()
+        .map(|task| task["id"].as_str().unwrap_or_default())
+        .collect::<Vec<_>>();
+    assert_eq!(state_task_ids, vec!["task-cancelling", "task-running"]);
+
     server.abort();
     Ok(())
 }


### PR DESCRIPTION
## Summary

- make `/state.tasks` and `/tasks` return active latest task snapshots by default
- reduce task records by task id before filtering terminal states from operator-facing surfaces
- update TUI task projection to upsert active tasks and remove terminal updates

Closes #957

## Verification

- `cargo test tasks_and_state_routes_return_active_latest_tasks_only --test http_tasks -- --test-threads=1`
- `cargo test latest_active_task_records_reduce_by_id_and_filter_terminal_tasks --lib -- --test-threads=1`
- `cargo test projection_upserts_active_tasks_and_removes_terminal_updates --lib -- --test-threads=1`
- `cargo test projection_bootstrap_keeps_only_active_tasks_in_chronological_order --lib -- --test-threads=1`
- `cargo test --all-targets -- --test-threads=1`
- `git diff --check`