### PR TITLE
fix: simplify tui header and statusbar

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -45,6 +45,7 @@ mod overlay;
 mod projection;
 mod render;
 mod runtime;
+mod view_model;
 
 use app::TuiApp;
 #[cfg(test)]
@@ -207,6 +208,7 @@ mod tests {
     use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use serde_json::json;
+    use std::path::PathBuf;
     use tokio::sync::mpsc;
 
     use super::{
@@ -214,6 +216,7 @@ mod tests {
         determine_alt_screen_mode_for_terminal, draw, is_cursor_too_old_error,
         is_operator_origin_value, paragraph_max_scroll, paragraph_max_scroll_unframed,
         projection::{OperatorVisibility, TuiProjection},
+        view_model::{HeaderViewModel, StatusbarViewModel},
         AgentListChange, ChatScrollState, ComposerState, ConversationCell, OverlayState, TuiApp,
         TuiConnectionState, TuiRuntimeMessage,
     };
@@ -428,6 +431,160 @@ mod tests {
             "kind": "system",
             "subsystem": "runtime"
         })));
+    }
+
+    #[test]
+    fn header_view_model_shows_agent_status_without_contract() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("holon-dev", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+        app.agents = vec![snapshot.agent.clone()];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let view_model = HeaderViewModel::from_app(&app);
+
+        assert_eq!(view_model.line, "holon-dev  running");
+        assert!(!view_model.line.contains("public/self_owned"));
+        assert!(!view_model.line.contains("public_named"));
+    }
+
+    #[test]
+    fn header_view_model_prefers_operator_waiting_label_and_resume_hint() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        let mut snapshot = sample_snapshot("holon-dev", "evt-0");
+        snapshot.agent.agent.status = AgentStatus::AwakeIdle;
+        snapshot.agent.closure.waiting_reason =
+            Some(crate::types::WaitingReason::AwaitingOperatorInput);
+        snapshot.agent.lifecycle.resume_required = true;
+        app.agents = vec![snapshot.agent.clone()];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let view_model = HeaderViewModel::from_app(&app);
+
+        assert_eq!(
+            view_model.line,
+            "holon-dev  waiting for you · resume required"
+        );
+    }
+
+    #[test]
+    fn statusbar_view_model_shows_workspace_label_execution_root_and_model() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.status_line.clear();
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        let workspace_anchor = home.join("opensource/src/github.com/holon-run/holon");
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.active_workspace_entry = Some(crate::types::ActiveWorkspaceEntry {
+            workspace_id: "ws-random".into(),
+            workspace_anchor: workspace_anchor.clone(),
+            execution_root_id: "canonical_root:ws-random".into(),
+            execution_root: workspace_anchor.clone(),
+            projection_kind: crate::system::WorkspaceProjectionKind::CanonicalRoot,
+            access_mode: crate::system::WorkspaceAccessMode::ExclusiveWrite,
+            cwd: workspace_anchor.clone(),
+            occupancy_id: None,
+            projection_metadata: None,
+        });
+        snapshot.workspace.active_workspace_entry =
+            snapshot.agent.agent.active_workspace_entry.clone();
+        app.agents = vec![snapshot.agent.clone()];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let view_model = StatusbarViewModel::from_app(&app);
+
+        assert!(view_model
+            .context_line
+            .starts_with("holon (~/opensource/src/github.com/holon-run/holon)"));
+        assert!(view_model
+            .context_line
+            .contains("anthropic/claude-sonnet-4-6"));
+        assert!(!view_model.context_line.contains("model:"));
+    }
+
+    #[test]
+    fn statusbar_view_model_uses_workspace_label_for_worktree_execution_root() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.status_line.clear();
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        let workspace_anchor = home.join("opensource/src/github.com/holon-run/holon");
+        let execution_root =
+            home.join("opensource/worktrees/github.com/holon-run/holon/issue-960-working-switch");
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.agent.agent.active_workspace_entry = Some(crate::types::ActiveWorkspaceEntry {
+            workspace_id: "ws-random".into(),
+            workspace_anchor: workspace_anchor.clone(),
+            execution_root_id: format!("git_worktree_root:ws-random:{}", execution_root.display()),
+            execution_root: execution_root.clone(),
+            projection_kind: crate::system::WorkspaceProjectionKind::GitWorktreeRoot,
+            access_mode: crate::system::WorkspaceAccessMode::ExclusiveWrite,
+            cwd: execution_root.clone(),
+            occupancy_id: None,
+            projection_metadata: None,
+        });
+        snapshot.workspace.active_workspace_entry =
+            snapshot.agent.agent.active_workspace_entry.clone();
+        app.agents = vec![snapshot.agent.clone()];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let view_model = StatusbarViewModel::from_app(&app);
+
+        assert!(view_model.context_line.starts_with(
+            "holon (~/opensource/worktrees/github.com/holon-run/holon/issue-960-working-switch)"
+        ));
+        assert!(!view_model
+            .context_line
+            .starts_with("issue-960-working-switch"));
+    }
+
+    #[test]
+    fn statusbar_view_model_prompts_for_active_tasks() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.status_line.clear();
+        let mut snapshot = sample_snapshot("default", "evt-0");
+        snapshot.tasks = vec![crate::types::TaskRecord {
+            id: "task-1".into(),
+            agent_id: "default".into(),
+            kind: crate::types::TaskKind::CommandTask,
+            status: crate::types::TaskStatus::Running,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            summary: Some("cargo test".into()),
+            detail: None,
+            recovery: None,
+        }];
+        app.agents = vec![snapshot.agent.clone()];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let view_model = StatusbarViewModel::from_app(&app);
+
+        assert!(view_model
+            .status_line
+            .contains("1 active task · /tasks to inspect"));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -504,11 +504,12 @@ mod tests {
         app.agents = vec![snapshot.agent.clone()];
         app.projection = Some(TuiProjection::from_snapshot(snapshot));
 
-        let view_model = StatusbarViewModel::from_app(&app);
+        let view_model = StatusbarViewModel::from_app(&app, false);
 
+        assert!(view_model.context_line.starts_with("holon ("));
         assert!(view_model
             .context_line
-            .starts_with("holon (~/opensource/src/github.com/holon-run/holon)"));
+            .contains("opensource/src/github.com/holon-run/holon)"));
         assert!(view_model
             .context_line
             .contains("anthropic/claude-sonnet-4-6"));
@@ -546,11 +547,12 @@ mod tests {
         app.agents = vec![snapshot.agent.clone()];
         app.projection = Some(TuiProjection::from_snapshot(snapshot));
 
-        let view_model = StatusbarViewModel::from_app(&app);
+        let view_model = StatusbarViewModel::from_app(&app, false);
 
-        assert!(view_model.context_line.starts_with(
-            "holon (~/opensource/worktrees/github.com/holon-run/holon/issue-960-working-switch)"
-        ));
+        assert!(view_model.context_line.starts_with("holon ("));
+        assert!(view_model
+            .context_line
+            .contains("opensource/worktrees/github.com/holon-run/holon/issue-960-working-switch)"));
         assert!(!view_model
             .context_line
             .starts_with("issue-960-working-switch"));
@@ -580,11 +582,33 @@ mod tests {
         app.agents = vec![snapshot.agent.clone()];
         app.projection = Some(TuiProjection::from_snapshot(snapshot));
 
-        let view_model = StatusbarViewModel::from_app(&app);
+        let view_model = StatusbarViewModel::from_app(&app, false);
 
         assert!(view_model
             .status_line
             .contains("1 active task · /tasks to inspect"));
+    }
+
+    #[test]
+    fn statusbar_view_model_prefers_overlay_hint_over_transient_status() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.status_line = "Opened tasks overlay".into();
+        app.overlay = OverlayState::Tasks {
+            selected: 0,
+            detail_scroll: 0,
+        };
+        let snapshot = sample_snapshot("default", "evt-0");
+        app.agents = vec![snapshot.agent.clone()];
+        app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+        let view_model = StatusbarViewModel::from_app(&app, false);
+
+        assert!(view_model.status_line.contains("Tasks:"));
+        assert!(!view_model.status_line.contains("Opened tasks overlay"));
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,5 +1,7 @@
 use super::overlay::draw_overlay;
-use super::view_model::{render_header_line, HeaderViewModel, StatusbarViewModel};
+use super::view_model::{
+    render_header_line, render_model_detail, HeaderViewModel, StatusbarViewModel,
+};
 use super::*;
 use crate::tui::input::slash_menu_specs;
 use crate::types::{TaskKind, TaskStatus};
@@ -23,7 +25,7 @@ pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     draw_header(frame, outer[0], app);
     draw_main_panels(frame, outer[1], app);
     draw_prompt_pane(frame, outer[2], app, &slash_menu);
-    draw_status_bar(frame, outer[3], app);
+    draw_status_bar(frame, outer[3], app, !slash_menu.is_empty());
     draw_overlay(frame, app);
 }
 
@@ -75,8 +77,8 @@ fn draw_prompt_pane(frame: &mut Frame<'_>, area: Rect, app: &TuiApp, slash_menu:
     }
 }
 
-fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
-    let view_model = StatusbarViewModel::from_app(app);
+fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp, slash_visible: bool) {
+    let view_model = StatusbarViewModel::from_app(app, slash_visible);
     let text = format!("{}\n{}", view_model.context_line, view_model.status_line);
     let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::TOP));
     frame.render_widget(paragraph, area);
@@ -653,34 +655,7 @@ pub(super) fn render_task_detail(task: &TaskRecord) -> String {
 }
 
 pub(super) fn render_model_status(agent: &AgentSummary) -> String {
-    let model = agent
-        .model
-        .active_model
-        .as_ref()
-        .unwrap_or(&agent.model.effective_model);
-    if agent.model.fallback_active {
-        let requested = agent
-            .model
-            .requested_model
-            .as_ref()
-            .unwrap_or(&agent.model.effective_model);
-        return format!(
-            "model: {} (fallback from {})",
-            model.as_string(),
-            requested.as_string()
-        );
-    }
-    if agent.model.override_model.is_some() {
-        if let Some(effort) = agent.model.override_reasoning_effort.as_deref() {
-            return format!(
-                "model: {} (agent override, effort={})",
-                model.as_string(),
-                effort
-            );
-        }
-        return format!("model: {} (agent override)", model.as_string());
-    }
-    format!("model: {}", model.as_string())
+    format!("model: {}", render_model_detail(agent))
 }
 
 pub(super) fn render_summary(agent: &AgentSummary) -> String {
@@ -1189,7 +1164,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_status_line_uses_compact_status_bar_height() {
+    fn status_bar_uses_fixed_two_line_height() {
         assert_eq!(status_bar_height(), 3);
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,7 +1,7 @@
 use super::overlay::draw_overlay;
+use super::view_model::{render_header_line, HeaderViewModel, StatusbarViewModel};
 use super::*;
 use crate::tui::input::slash_menu_specs;
-use crate::tui::keymap::{status_hint, KeyContext};
 use crate::types::{TaskKind, TaskStatus};
 use unicode_width::UnicodeWidthStr;
 
@@ -9,7 +9,7 @@ pub(super) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     let area = frame.area();
     let slash_menu = slash_menu_lines(app);
     let prompt_height = prompt_pane_height(app.composer.as_str(), slash_menu.len(), area.width);
-    let status_height = status_bar_height(&app.status_line);
+    let status_height = status_bar_height();
     let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -32,11 +32,8 @@ fn draw_main_panels(frame: &mut Frame<'_>, area: Rect, app: &mut TuiApp) {
 }
 
 fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
-    let text = match app.selected_agent_summary() {
-        Some(agent) => render_header(agent),
-        None => "No agent selected.".to_string(),
-    };
-    let paragraph = Paragraph::new(text)
+    let view_model = HeaderViewModel::from_app(app);
+    let paragraph = Paragraph::new(view_model.line)
         .block(Block::default().borders(Borders::BOTTOM))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
@@ -79,33 +76,8 @@ fn draw_prompt_pane(frame: &mut Frame<'_>, area: Rect, app: &TuiApp, slash_menu:
 }
 
 fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &TuiApp) {
-    let slash_visible =
-        matches!(app.overlay, OverlayState::None) && !slash_menu_lines(app).is_empty();
-    let context = match app.overlay {
-        OverlayState::None => KeyContext::Main,
-        OverlayState::Agents => KeyContext::AgentsOverlay,
-        OverlayState::Events { .. } => KeyContext::EventsOverlay,
-        OverlayState::Transcript { .. }
-        | OverlayState::AgentState { .. }
-        | OverlayState::DebugPromptView { .. }
-        | OverlayState::HelpView { .. } => KeyContext::ScrollOverlay,
-        OverlayState::Tasks { .. } => KeyContext::TasksOverlay,
-        OverlayState::ModelPicker { .. } => KeyContext::ModelPicker,
-        OverlayState::ModelEffortPicker { .. } => KeyContext::ModelEffortPicker,
-        OverlayState::DebugPromptInput { .. } => KeyContext::DebugPromptInput,
-    };
-    let help = status_hint(context, slash_visible);
-
-    let connection = app.connection_label();
-    let model = app
-        .selected_agent_summary()
-        .map(render_model_status)
-        .unwrap_or_else(|| "model: <no agent selected>".into());
-    let text = if app.status_line.trim().is_empty() {
-        format!("{help}\n{connection}  {model}")
-    } else {
-        format!("{help}\n{connection}  {model}\n{}", app.status_line)
-    };
+    let view_model = StatusbarViewModel::from_app(app);
+    let text = format!("{}\n{}", view_model.context_line, view_model.status_line);
     let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::TOP));
     frame.render_widget(paragraph, area);
 }
@@ -274,12 +246,8 @@ fn prompt_pane_height(buffer: &str, slash_menu_rows: usize, pane_width: u16) -> 
     pane_rows.clamp(3, u32::from(MAX_PROMPT_PANE_HEIGHT)) as u16
 }
 
-fn status_bar_height(status_line: &str) -> u16 {
-    if status_line.trim().is_empty() {
-        3
-    } else {
-        4
-    }
+fn status_bar_height() -> u16 {
+    3
 }
 
 fn render_prompt_buffer(buffer: &str) -> String {
@@ -334,7 +302,7 @@ fn render_prompt_text(buffer: &str, slash_menu: &[Line<'static>]) -> Text<'stati
     ]))
 }
 
-fn slash_menu_lines(app: &TuiApp) -> Vec<Line<'static>> {
+pub(super) fn slash_menu_lines(app: &TuiApp) -> Vec<Line<'static>> {
     if app.overlay != OverlayState::None {
         return Vec::new();
     }
@@ -455,16 +423,7 @@ fn display_width(text: &str) -> u16 {
 }
 
 pub(super) fn render_header(agent: &AgentSummary) -> String {
-    let mut line = format!(
-        "{}  {:?}  {}",
-        agent.identity.agent_id,
-        agent.agent.status,
-        agent.identity.contract_badge()
-    );
-    if agent.lifecycle.resume_required {
-        line.push_str("  resume required");
-    }
-    line
+    render_header_line(agent)
 }
 
 pub(super) fn render_projection_event_summary(
@@ -1036,9 +995,10 @@ mod tests {
     }
 
     #[test]
-    fn render_header_uses_agent_contract_badge() {
+    fn render_header_uses_agent_status_without_identity_contract() {
         let rendered = render_header(&sample_agent_summary());
-        assert!(rendered.contains("public/self_owned (public_named)"));
+        assert_eq!(rendered, "default  idle");
+        assert!(!rendered.contains("public/self_owned (public_named)"));
     }
 
     #[test]
@@ -1230,8 +1190,7 @@ mod tests {
 
     #[test]
     fn empty_status_line_uses_compact_status_bar_height() {
-        assert_eq!(status_bar_height(""), 3);
-        assert_eq!(status_bar_height("Action failed"), 4);
+        assert_eq!(status_bar_height(), 3);
     }
 
     fn task(status: TaskStatus, kind: TaskKind, detail: Option<Value>) -> TaskRecord {

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -1,0 +1,222 @@
+use std::path::{Path, PathBuf};
+
+use crate::types::{AgentStatus, AgentSummary, WaitingReason, AGENT_HOME_WORKSPACE_ID};
+
+use super::{
+    keymap::{status_hint, KeyContext},
+    overlay::OverlayState,
+    TuiApp,
+};
+
+pub(super) struct HeaderViewModel {
+    pub(super) line: String,
+}
+
+impl HeaderViewModel {
+    pub(super) fn from_app(app: &TuiApp) -> Self {
+        let line = app
+            .selected_agent_summary()
+            .map(render_header_line)
+            .unwrap_or_else(|| "No agent selected.".to_string());
+        Self { line }
+    }
+}
+
+pub(super) struct StatusbarViewModel {
+    pub(super) context_line: String,
+    pub(super) status_line: String,
+}
+
+impl StatusbarViewModel {
+    pub(super) fn from_app(app: &TuiApp) -> Self {
+        let context_line = format!("{} · {}", execution_root_summary(app), model_summary(app));
+        let status_line = statusbar_detail(app);
+        Self {
+            context_line,
+            status_line,
+        }
+    }
+}
+
+pub(super) fn render_header_line(agent: &AgentSummary) -> String {
+    let mut line = format!("{}  {}", agent.identity.agent_id, agent_status_label(agent));
+    if agent.lifecycle.resume_required {
+        line.push_str(" · resume required");
+    }
+    line
+}
+
+fn agent_status_label(agent: &AgentSummary) -> &'static str {
+    if agent.closure.waiting_reason == Some(WaitingReason::AwaitingOperatorInput) {
+        return "waiting for you";
+    }
+    match agent.agent.status {
+        AgentStatus::Booting => "booting",
+        AgentStatus::AwakeIdle => "idle",
+        AgentStatus::AwakeRunning => "running",
+        AgentStatus::AwaitingTask => "waiting for task",
+        AgentStatus::Asleep => "sleeping",
+        AgentStatus::Paused => "paused",
+        AgentStatus::Stopped => "stopped",
+    }
+}
+
+fn execution_root_summary(app: &TuiApp) -> String {
+    let active_entry = app
+        .projection
+        .as_ref()
+        .and_then(|projection| projection.workspace.active_workspace_entry.as_ref())
+        .or_else(|| {
+            app.selected_agent_summary()
+                .and_then(|agent| agent.agent.active_workspace_entry.as_ref())
+        });
+    let Some(entry) = active_entry else {
+        return "workspace not ready".into();
+    };
+    let label = workspace_label(
+        entry.workspace_id.as_str(),
+        entry.workspace_anchor.as_path(),
+    );
+    format!("{} ({})", label, shorten_home_path(&entry.execution_root))
+}
+
+fn workspace_label(workspace_id: &str, workspace_anchor: &Path) -> String {
+    if workspace_id == AGENT_HOME_WORKSPACE_ID {
+        return AGENT_HOME_WORKSPACE_ID.to_string();
+    }
+    workspace_anchor
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("workspace")
+        .to_string()
+}
+
+fn shorten_home_path(path: &Path) -> String {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    shorten_home_path_with_home(path, home.as_deref())
+}
+
+fn shorten_home_path_with_home(path: &Path, home: Option<&Path>) -> String {
+    if let Some(home) = home {
+        if let Ok(relative) = path.strip_prefix(home) {
+            if relative.as_os_str().is_empty() {
+                return "~".into();
+            }
+            return format!("~/{}", relative.display());
+        }
+    }
+    path.display().to_string()
+}
+
+fn model_summary(app: &TuiApp) -> String {
+    app.selected_agent_summary()
+        .map(agent_model_summary)
+        .unwrap_or_else(|| "<no model>".into())
+}
+
+fn agent_model_summary(agent: &AgentSummary) -> String {
+    let model = agent
+        .model
+        .active_model
+        .as_ref()
+        .unwrap_or(&agent.model.effective_model);
+    if agent.model.fallback_active {
+        let requested = agent
+            .model
+            .requested_model
+            .as_ref()
+            .unwrap_or(&agent.model.effective_model);
+        return format!(
+            "{} (fallback from {})",
+            model.as_string(),
+            requested.as_string()
+        );
+    }
+    if agent.model.override_model.is_some() {
+        if let Some(effort) = agent.model.override_reasoning_effort.as_deref() {
+            return format!("{} (agent override, effort={})", model.as_string(), effort);
+        }
+        return format!("{} (agent override)", model.as_string());
+    }
+    model.as_string()
+}
+
+fn statusbar_detail(app: &TuiApp) -> String {
+    let status_line = app.status_line.trim();
+    let detail = (!status_line.is_empty())
+        .then(|| status_line.to_string())
+        .or_else(|| app.connection_detail().map(ToString::to_string))
+        .or_else(|| overlay_hint(app).map(ToString::to_string))
+        .or_else(|| active_tasks_hint(app))
+        .unwrap_or_else(|| "Type / for commands · /help for shortcuts".into());
+    format!("{} · {}", app.connection_label(), detail)
+}
+
+fn overlay_hint(app: &TuiApp) -> Option<&'static str> {
+    let slash_visible = matches!(app.overlay, OverlayState::None)
+        && !super::render::slash_menu_lines(app).is_empty();
+    if slash_visible {
+        return Some(status_hint(KeyContext::SlashMenu, true));
+    }
+    let context = match app.overlay {
+        OverlayState::None => return None,
+        OverlayState::Agents => KeyContext::AgentsOverlay,
+        OverlayState::Events { .. } => KeyContext::EventsOverlay,
+        OverlayState::Transcript { .. }
+        | OverlayState::AgentState { .. }
+        | OverlayState::DebugPromptView { .. }
+        | OverlayState::HelpView { .. } => KeyContext::ScrollOverlay,
+        OverlayState::Tasks { .. } => KeyContext::TasksOverlay,
+        OverlayState::ModelPicker { .. } => KeyContext::ModelPicker,
+        OverlayState::ModelEffortPicker { .. } => KeyContext::ModelEffortPicker,
+        OverlayState::DebugPromptInput { .. } => KeyContext::DebugPromptInput,
+    };
+    Some(status_hint(context, false))
+}
+
+fn active_tasks_hint(app: &TuiApp) -> Option<String> {
+    let count = app
+        .projection
+        .as_ref()
+        .map(|projection| projection.tasks.len())
+        .unwrap_or(0);
+    match count {
+        0 => None,
+        1 => Some("1 active task · /tasks to inspect".into()),
+        count => Some(format!("{count} active tasks · /tasks to inspect")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{shorten_home_path_with_home, workspace_label};
+    use crate::types::AGENT_HOME_WORKSPACE_ID;
+    use std::path::Path;
+
+    #[test]
+    fn workspace_label_uses_anchor_name_not_random_workspace_id() {
+        assert_eq!(
+            workspace_label(
+                "ws-123456",
+                Path::new("/Users/example/opensource/src/github.com/holon-run/holon")
+            ),
+            "holon"
+        );
+        assert_eq!(
+            workspace_label(AGENT_HOME_WORKSPACE_ID, Path::new("/tmp/default")),
+            "agent_home"
+        );
+    }
+
+    #[test]
+    fn shorten_home_path_uses_tilde_for_home_relative_paths() {
+        assert_eq!(
+            shorten_home_path_with_home(
+                Path::new("/Users/example/opensource/holon"),
+                Some(Path::new("/Users/example"))
+            ),
+            "~/opensource/holon"
+        );
+    }
+}

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -28,9 +28,9 @@ pub(super) struct StatusbarViewModel {
 }
 
 impl StatusbarViewModel {
-    pub(super) fn from_app(app: &TuiApp) -> Self {
+    pub(super) fn from_app(app: &TuiApp, slash_visible: bool) -> Self {
         let context_line = format!("{} · {}", execution_root_summary(app), model_summary(app));
-        let status_line = statusbar_detail(app);
+        let status_line = statusbar_detail(app, slash_visible);
         Self {
             context_line,
             status_line,
@@ -111,11 +111,11 @@ fn shorten_home_path_with_home(path: &Path, home: Option<&Path>) -> String {
 
 fn model_summary(app: &TuiApp) -> String {
     app.selected_agent_summary()
-        .map(agent_model_summary)
+        .map(render_model_detail)
         .unwrap_or_else(|| "<no model>".into())
 }
 
-fn agent_model_summary(agent: &AgentSummary) -> String {
+pub(super) fn render_model_detail(agent: &AgentSummary) -> String {
     let model = agent
         .model
         .active_model
@@ -142,20 +142,18 @@ fn agent_model_summary(agent: &AgentSummary) -> String {
     model.as_string()
 }
 
-fn statusbar_detail(app: &TuiApp) -> String {
+fn statusbar_detail(app: &TuiApp, slash_visible: bool) -> String {
     let status_line = app.status_line.trim();
-    let detail = (!status_line.is_empty())
-        .then(|| status_line.to_string())
+    let detail = overlay_hint(app, slash_visible)
+        .map(ToString::to_string)
+        .or_else(|| (!status_line.is_empty()).then(|| status_line.to_string()))
         .or_else(|| app.connection_detail().map(ToString::to_string))
-        .or_else(|| overlay_hint(app).map(ToString::to_string))
         .or_else(|| active_tasks_hint(app))
         .unwrap_or_else(|| "Type / for commands · /help for shortcuts".into());
     format!("{} · {}", app.connection_label(), detail)
 }
 
-fn overlay_hint(app: &TuiApp) -> Option<&'static str> {
-    let slash_visible = matches!(app.overlay, OverlayState::None)
-        && !super::render::slash_menu_lines(app).is_empty();
+fn overlay_hint(app: &TuiApp, slash_visible: bool) -> Option<&'static str> {
     if slash_visible {
         return Some(status_hint(KeyContext::SlashMenu, true));
     }


### PR DESCRIPTION
## Summary

- Extract `HeaderViewModel` and `StatusbarViewModel` for TUI header/statusbar rendering.
- Simplify the header to agent id plus human-readable status, with no identity contract badge.
- Make the statusbar a fixed two-line view: workspace label + execution root + model on line one, connection/detail hints on line two.
- Show active task count in the transient detail area when no higher-priority status/overlay hint is present.

## Testing

- `cargo test -q view_model --lib`
- `cargo test -q tui::render --lib`
- `cargo test -q --lib -- --test-threads=1`
- `git diff --check`

Note: `cargo test -q --lib` without `--test-threads=1` hit 3 unrelated shared-state/concurrency failures in `agent_template` and `config`; the same failed tests pass individually and the full lib suite passes serially.
