### PR TITLE
fix: rename default local agent to main

### DIFF
--- a/docs/agent-types-and-default-agent.md
+++ b/docs/agent-types-and-default-agent.md
@@ -23,7 +23,8 @@ callbacks, and agent creation will keep drifting.
 
 ## Short Answer
 
-`Holon` should use `default agent` as the primary term, not `root agent`.
+`Holon` should use `default agent` as the role term, not `root agent`.
+The default local agent id is `main`.
 
 `Holon` should also treat `agent` as the primary runtime primitive and describe
 other distinctions with explicit axes instead of one overloaded role list.
@@ -41,7 +42,7 @@ And each agent should also have explicit lifecycle properties:
 
 The main rules are:
 
-- `default` means default entrypoint, not elevated authority
+- `main` is the default local agent id, not elevated authority
 - `child` means parent provenance, not necessarily persistence
 - `delegated execution` is best understood as a child-agent lifecycle pattern,
   not a separate runtime primitive
@@ -83,7 +84,8 @@ agents.
 
 ## Naming Decision
 
-`Holon` should use `default agent` as the user-facing and runtime term.
+`Holon` should use `default agent` as the role term and `main` as the default
+local agent id.
 
 It should not use `root agent` as the primary term.
 
@@ -91,8 +93,8 @@ Reason:
 
 - `root` strongly implies elevated privilege
 - `Holon` does not intend the default agent to bypass trust or execution rules
-- the implementation already uses `default_agent_id`, so `default agent` keeps
-  naming aligned with current runtime state
+- `main` is a stronger durable identity than `default`, while `default agent`
+  remains the role name for the omitted-`--agent` route
 
 `root` may still be used for unrelated concepts such as root directories or
 root tasks, but not as the primary agent-role term.
@@ -241,7 +243,7 @@ This RFC distinguishes two cases:
 
 - `default agent` and `named agent`
   - should use meaningful, operator-facing ids
-  - examples: `default`, `release-bot`
+  - examples: `main`, `release-bot`
 - `child agent`
   - should normally use runtime-generated ids
   - the exact id format is an implementation detail
@@ -264,6 +266,8 @@ be cleaned up after closure according to later policy.
 The first routing rules should be:
 
 - commands that omit `--agent` target the `default agent`
+- when `HOLON_AGENT_ID` is not set, the default agent id is `main`
+- `HOLON_AGENT_ID` explicitly overrides the default agent id
 - explicitly named public agents target that agent and only that agent
 - `holon run` without `--agent` should execute on a temporary ephemeral agent
 - `holon run --agent <id>` should execute on that named persistent agent
@@ -365,8 +369,8 @@ These questions matter, but they do not block the first model.
 
 ## Decision
 
-`Holon` should use `default agent` as the primary term for the host's default
-operator-facing agent.
+`Holon` should use `default agent` as the role term for the host's default
+operator-facing agent, and `main` as the default local agent id.
 
 It should treat `agent` as the primary runtime primitive and model other
 distinctions with explicit kinds and lifecycle axes:

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -817,6 +817,8 @@ The current first-pass profile presets are:
 Routing rules:
 
 - omitted agent targeting still resolves to the default agent
+- when `HOLON_AGENT_ID` is not set, the default agent id is `main`
+- `HOLON_AGENT_ID` explicitly overrides the default agent id
 - explicitly targeting a non-default public agent does not auto-create it
 - public named agents must be created explicitly through control surfaces
 - `holon run` without `--agent` uses a temporary private agent

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,6 +126,8 @@ pub struct AppConfig {
     pub providers: ProviderRegistry,
 }
 
+pub const DEFAULT_LOCAL_AGENT_ID: &str = "main";
+
 pub type ProviderRegistry = BTreeMap<ProviderId, ProviderRuntimeConfig>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -458,7 +460,8 @@ impl AppConfig {
         let workspace_dir = env::var("HOLON_WORKSPACE_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-        let default_agent_id = env::var("HOLON_AGENT_ID").unwrap_or_else(|_| "default".into());
+        let default_agent_id =
+            env::var("HOLON_AGENT_ID").unwrap_or_else(|_| DEFAULT_LOCAL_AGENT_ID.into());
         let context_window_messages = env::var("HOLON_CONTEXT_WINDOW_MESSAGES")
             .ok()
             .and_then(|value| value.parse().ok())
@@ -3073,7 +3076,7 @@ mod tests {
         AnthropicContextManagementConfig, AppConfig, ControlAuthMode, CredentialKind,
         CredentialSource, CredentialStoreFile, HolonConfigFile, ModelConfigFile, ModelRef,
         ProviderAuthConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
-        ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog,
+        ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
     };
 
     struct EnvVarGuard {
@@ -3160,6 +3163,48 @@ mod tests {
             _workspace_dir: workspace_dir,
             config,
         }
+    }
+
+    #[test]
+    fn app_config_defaults_unset_agent_env_to_main_agent() {
+        let dir = tempdir().unwrap();
+        let _agent_guard = EnvVarGuard::unset("HOLON_AGENT_ID");
+        save_persisted_config_at(
+            &persisted_config_path(dir.path()),
+            &HolonConfigFile {
+                model: ModelConfigFile {
+                    default: Some("openai/gpt-5.4".into()),
+                    ..ModelConfigFile::default()
+                },
+                ..HolonConfigFile::default()
+            },
+        )
+        .unwrap();
+
+        let config = AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap();
+
+        assert_eq!(config.default_agent_id, DEFAULT_LOCAL_AGENT_ID);
+    }
+
+    #[test]
+    fn app_config_honors_explicit_default_agent_env() {
+        let dir = tempdir().unwrap();
+        let _agent_guard = EnvVarGuard::set("HOLON_AGENT_ID", "release-bot");
+        save_persisted_config_at(
+            &persisted_config_path(dir.path()),
+            &HolonConfigFile {
+                model: ModelConfigFile {
+                    default: Some("openai/gpt-5.4".into()),
+                    ..ModelConfigFile::default()
+                },
+                ..HolonConfigFile::default()
+            },
+        )
+        .unwrap();
+
+        let config = AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap();
+
+        assert_eq!(config.default_agent_id, "release-bot");
     }
 
     #[test]

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -281,13 +281,7 @@ fn latest_public_runtime_failure(config: &AppConfig) -> Result<Option<RuntimeFai
                 && record.visibility == AgentVisibility::Public
         })
     {
-        let primary = config.agent_root_dir().join(&identity.agent_id);
-        let legacy = config.data_dir.join("sessions").join(&identity.agent_id);
-        let storage = AppStorage::new(if primary.exists() || !legacy.exists() {
-            primary
-        } else {
-            legacy
-        })?;
+        let storage = AppStorage::new(config.agent_root_dir().join(&identity.agent_id))?;
         let failure = storage
             .read_agent()?
             .and_then(|agent| agent.last_runtime_failure);

--- a/src/host.rs
+++ b/src/host.rs
@@ -1063,13 +1063,7 @@ impl RuntimeHost {
     }
 
     pub(crate) fn agent_data_dir(&self, agent_id: &str) -> PathBuf {
-        let primary = self.config().data_dir.join("agents").join(agent_id);
-        let legacy = self.config().data_dir.join("sessions").join(agent_id);
-        if primary.exists() || !legacy.exists() {
-            primary
-        } else {
-            legacy
-        }
+        self.config().data_dir.join("agents").join(agent_id)
     }
 
     pub(crate) fn is_temporary_agent_id(agent_id: &str) -> bool {
@@ -1634,6 +1628,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn agent_data_dir_uses_agents_directory_without_sessions_compat() {
+        let (_home, host) = test_host();
+        let legacy = host
+            .config()
+            .data_dir
+            .join("sessions")
+            .join(&host.config().default_agent_id);
+        std::fs::create_dir_all(&legacy).unwrap();
+
+        assert_eq!(
+            host.agent_data_dir(&host.config().default_agent_id),
+            host.config()
+                .data_dir
+                .join("agents")
+                .join(&host.config().default_agent_id)
+        );
+    }
+
     #[tokio::test]
     async fn spawn_public_named_preserves_existing_runtime_state() {
         let fixture = provider_test_config(Some("dummy-token"));
@@ -1687,7 +1700,10 @@ mod tests {
             .expect("public named identity should exist");
         assert_eq!(identity.parent_agent_id, None);
         assert_eq!(identity.delegated_from_task_id, None);
-        assert_eq!(identity.lineage_parent_agent_id.as_deref(), Some("default"));
+        assert_eq!(
+            identity.lineage_parent_agent_id.as_deref(),
+            Some(host.config().default_agent_id.as_str())
+        );
 
         let summary = host
             .get_public_agent("release-bot")
@@ -1698,7 +1714,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             summary.identity.lineage_parent_agent_id.as_deref(),
-            Some("default")
+            Some(host.config().default_agent_id.as_str())
         );
     }
 
@@ -1880,7 +1896,7 @@ mod tests {
         );
         assert_eq!(
             bootstrap.metadata.as_ref().unwrap()["creator_agent_id"],
-            "default"
+            host.config().default_agent_id
         );
         assert!(bootstrap
             .metadata


### PR DESCRIPTION
Closes #968

## Summary
- change the implicit local default agent id from `default` to `main`, while keeping `HOLON_AGENT_ID` as the explicit override
- remove the old `.holon/sessions/<agent_id>` compatibility lookup for agent storage and daemon runtime failure reporting
- update current docs to distinguish the `default agent` role from the `main` local identity

## Verification
- `cargo test app_config_ --lib -- --test-threads=1`
- `cargo test agent_data_dir_uses_agents_directory_without_sessions_compat --lib -- --test-threads=1`
- `cargo test daemon_status_surfaces_persisted_last_failure_when_runtime_stopped --lib -- --test-threads=1`
- `cargo test --all-targets -- --test-threads=1`
