### PR TITLE
feat: pass serve options through daemon start

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,18 @@ Start the long-running runtime in the foreground:
 
 ```bash
 holon serve
+holon serve --access lan --host 192.168.1.10 --port 7878 --token-file ~/.config/holon/remote.token
 ```
 
 Manage the runtime as a local daemon:
 
 ```bash
 holon daemon start
+holon daemon start --access lan --host 192.168.1.10 --port 7878 --token-file ~/.config/holon/remote.token
 holon daemon status
 holon daemon logs
 holon daemon stop
+holon daemon restart --access lan --host 192.168.1.10 --port 7878 --token-file ~/.config/holon/remote.token
 ```
 
 Open the local operator console:

--- a/docs/local-operator-troubleshooting.md
+++ b/docs/local-operator-troubleshooting.md
@@ -166,6 +166,19 @@ Use `holon serve` directly when:
 Do not treat `serve` as a different product mode. It is the same long-lived
 runtime that `daemon` manages in the background.
 
+For LAN or tailnet access, prefer `--token-file` over putting a token directly
+on the command line:
+
+```bash
+holon serve --access lan --host 192.168.1.10 --port 7878 --token-file ~/.config/holon/remote.token
+holon daemon start --access lan --host 192.168.1.10 --port 7878 --token-file ~/.config/holon/remote.token
+holon daemon restart --access lan --host 192.168.1.10 --port 7878 --token-file ~/.config/holon/remote.token
+```
+
+`daemon restart` is an explicit stop/start cycle. It accepts the same access
+options as `daemon start`; if no options are supplied, it restarts with the
+configured local defaults.
+
 ## Safe Local Recovery
 
 If the local runtime state seems stale:

--- a/docs/rfcs/remote-tui-access.md
+++ b/docs/rfcs/remote-tui-access.md
@@ -38,11 +38,16 @@ authentication:
 
 ```sh
 holon serve --access lan --host 192.168.1.10 --token-file ~/.config/holon/remote.token
+holon daemon start --access lan --host 192.168.1.10 --token-file ~/.config/holon/remote.token
 holon tui --connect http://192.168.1.10:7878 --token-file ~/.config/holon/remote.token
 
 holon serve --access tailnet --host lab.tailnet.ts.net --token-file ~/.config/holon/remote.token
+holon daemon start --access tailnet --host lab.tailnet.ts.net --token-file ~/.config/holon/remote.token
 holon tui --connect http://lab.tailnet.ts.net:7878 --token-file ~/.config/holon/remote.token
 ```
+
+`holon daemon restart` accepts the same access options as `daemon start` and
+uses them for the replacement background `serve` process.
 
 The lower-level form separates bind and client-visible URLs:
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -495,6 +495,13 @@ Phase-1 commands:
 - `holon daemon restart`
 - `holon daemon logs`
 
+`daemon start` and `daemon restart` accept the same remote-control access
+options as `serve`, including `--access`, `--host`, `--listen`, `--port`,
+`--advertise`, `--token`, and `--token-file`. The daemon lifecycle layer
+validates those options before launch and starts the background `serve` process
+with the same effective options. `--advertise` is also the callback base URL
+that external-trigger capabilities report.
+
 Current contract:
 
 - `serve` remains the only runtime owner mode
@@ -510,6 +517,9 @@ Current contract:
 - stale daemon pid metadata that points to a missing process is also treated as
   recoverable stale state; `daemon restart` must clean it up instead of failing
   hard on `kill -TERM`
+- `daemon restart` is an explicit stop/start cycle using the supplied access
+  options; if no options are supplied, it restarts with the configured local
+  defaults
 - socket-path takeover by an unrelated process fails closed
 - `daemon stop` prefers graceful runtime shutdown through the control surface
   before falling back to process termination

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -520,6 +520,9 @@ Current contract:
 - `daemon restart` is an explicit stop/start cycle using the supplied access
   options; if no options are supplied, it restarts with the configured local
   defaults
+- `daemon restart` performs full process replacement; durable runtime state is
+  recovered through storage, but in-flight provider turns and transient process
+  state are interrupted
 - socket-path takeover by an unrelated process fails closed
 - `daemon stop` prefers graceful runtime shutdown through the control surface
   before falling back to process termination

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12,8 +12,9 @@ pub use lifecycle::{
 pub(crate) use service::runtime_activity_message;
 pub use service::{
     runtime_activity_summary, RuntimeActivityState, RuntimeActivitySummary,
-    RuntimeAgentOverrideSummary, RuntimeConfigSurface, RuntimeServiceHandle,
-    RuntimeServiceMetadata, RuntimeShutdownResponse, RuntimeStartupSurface, RuntimeStatusResponse,
+    RuntimeAgentOverrideSummary, RuntimeConfigSurface, RuntimeControlAuthMode,
+    RuntimeServiceHandle, RuntimeServiceMetadata, RuntimeShutdownResponse, RuntimeStartupSurface,
+    RuntimeStatusResponse,
 };
 pub use state::{
     cleanup_daemon_state, config_fingerprint, daemon_logs, daemon_paths, load_daemon_metadata,

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     fs,
     process::{Child, Command, Stdio},
     time::Duration,
@@ -113,7 +114,8 @@ pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
 
 pub async fn daemon_start(
     config: &AppConfig,
-    serve_args: &[String],
+    serve_args: &[OsString],
+    control_token_env: Option<&str>,
 ) -> Result<DaemonLifecycleResult> {
     let current_fingerprint = config_fingerprint(config)?;
     match probe_runtime(config).await {
@@ -170,14 +172,17 @@ pub async fn daemon_start(
         .try_clone()
         .with_context(|| format!("failed to clone {}", log_path.display()))?;
     let exe = std::env::current_exe().context("failed to resolve current holon executable")?;
-    let mut child = Command::new(exe)
+    let mut command = Command::new(exe);
+    command
         .arg("serve")
         .args(serve_args)
         .stdin(Stdio::null())
         .stdout(Stdio::from(log))
-        .stderr(Stdio::from(log_err))
-        .spawn()
-        .context("failed to spawn 'holon serve'")?;
+        .stderr(Stdio::from(log_err));
+    if let Some(token) = control_token_env {
+        command.env("HOLON_CONTROL_TOKEN", token);
+    }
+    let mut child = command.spawn().context("failed to spawn 'holon serve'")?;
 
     let deadline = tokio::time::Instant::now() + START_TIMEOUT;
     loop {
@@ -400,10 +405,11 @@ Probe error: {details}",
 
 pub async fn daemon_restart(
     config: &AppConfig,
-    serve_args: &[String],
+    serve_args: &[OsString],
+    control_token_env: Option<&str>,
 ) -> Result<DaemonLifecycleResult> {
     let _ = daemon_stop(config).await?;
-    let started = daemon_start(config, serve_args).await?;
+    let started = daemon_start(config, serve_args, control_token_env).await?;
     Ok(DaemonLifecycleResult {
         ok: true,
         action: DaemonLifecycleAction::Restart,

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -111,7 +111,10 @@ pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
     }
 }
 
-pub async fn daemon_start(config: &AppConfig) -> Result<DaemonLifecycleResult> {
+pub async fn daemon_start(
+    config: &AppConfig,
+    serve_args: &[String],
+) -> Result<DaemonLifecycleResult> {
     let current_fingerprint = config_fingerprint(config)?;
     match probe_runtime(config).await {
         ProbeRuntime::Running(status) => {
@@ -122,8 +125,9 @@ pub async fn daemon_start(config: &AppConfig) -> Result<DaemonLifecycleResult> {
                 ));
             }
             if status.config_fingerprint != current_fingerprint {
+                let details = effective_config_mismatch_summary(config, &status);
                 return Err(anyhow!(
-                    "runtime is already running with a different effective config; use 'holon daemon restart' to replace it"
+                    "runtime is already running with a different effective config; use 'holon daemon restart' to replace it; differing config: {details}"
                 ));
             }
             let mut status = daemon_status(config).await?;
@@ -168,6 +172,7 @@ pub async fn daemon_start(config: &AppConfig) -> Result<DaemonLifecycleResult> {
     let exe = std::env::current_exe().context("failed to resolve current holon executable")?;
     let mut child = Command::new(exe)
         .arg("serve")
+        .args(serve_args)
         .stdin(Stdio::null())
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err))
@@ -179,21 +184,22 @@ pub async fn daemon_start(config: &AppConfig) -> Result<DaemonLifecycleResult> {
         match probe_runtime(config).await {
             ProbeRuntime::Running(status) => {
                 if status.config_fingerprint != current_fingerprint {
+                    let details = effective_config_mismatch_summary(config, &status);
                     best_effort_cleanup_spawned_start(config, &mut child).await;
                     let _ = persist_daemon_lifecycle_failure(
-                    config,
-                    &RuntimeFailureSummary {
-                        occurred_at: Utc::now(),
-                        summary:
-                            "daemon start failed because runtime reported a different effective config fingerprint"
-                                .into(),
-                        phase: RuntimeFailurePhase::Startup,
-                        detail_hint: Some(daemon_log_hint()),
-                        failure_artifact: None,
-                    },
-                );
+                        config,
+                        &RuntimeFailureSummary {
+                            occurred_at: Utc::now(),
+                            summary: format!(
+                                "daemon start failed because runtime reported a different effective config fingerprint: {details}"
+                            ),
+                            phase: RuntimeFailurePhase::Startup,
+                            detail_hint: Some(daemon_log_hint()),
+                            failure_artifact: None,
+                        },
+                    );
                     return Err(anyhow!(
-                        "runtime started but reported a different effective config fingerprint; {}",
+                        "runtime started but reported a different effective config fingerprint; differing config: {details}; {}",
                         daemon_log_hint()
                     ));
                 }
@@ -392,9 +398,12 @@ Probe error: {details}",
     })
 }
 
-pub async fn daemon_restart(config: &AppConfig) -> Result<DaemonLifecycleResult> {
+pub async fn daemon_restart(
+    config: &AppConfig,
+    serve_args: &[String],
+) -> Result<DaemonLifecycleResult> {
     let _ = daemon_stop(config).await?;
-    let started = daemon_start(config).await?;
+    let started = daemon_start(config, serve_args).await?;
     Ok(DaemonLifecycleResult {
         ok: true,
         action: DaemonLifecycleAction::Restart,
@@ -418,8 +427,9 @@ pub async fn ensure_serve_preflight(config: &AppConfig) -> Result<()> {
                     config.home_dir.display()
                 ));
             }
+            let details = effective_config_mismatch_summary(config, &status);
             return Err(anyhow!(
-                "runtime is already running with a different effective config; stop or restart it explicitly"
+                "runtime is already running with a different effective config; stop or restart it explicitly; differing config: {details}"
             ));
         }
         ProbeRuntime::Stopped {
@@ -526,8 +536,9 @@ async fn wait_for_startup_stability(
                     ));
                 }
                 if status.config_fingerprint != expected_fingerprint {
+                    let details = effective_config_mismatch_summary(config, &status);
                     return Err(anyhow!(
-                        "runtime config fingerprint changed during startup stabilization"
+                        "runtime config fingerprint changed during startup stabilization; differing config: {details}"
                     ));
                 }
             }
@@ -571,6 +582,125 @@ async fn wait_for_shutdown(config: &AppConfig, timeout: Duration) -> Result<()> 
             return Err(anyhow!("timed out waiting for runtime shutdown"));
         }
         tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+pub(crate) fn effective_config_mismatch_summary(
+    config: &AppConfig,
+    status: &RuntimeStatusResponse,
+) -> String {
+    let mut differences = Vec::new();
+    push_diff(
+        &mut differences,
+        "home_dir",
+        config.home_dir.display().to_string(),
+        status.home_dir.display().to_string(),
+    );
+    push_diff(
+        &mut differences,
+        "socket_path",
+        config.socket_path.display().to_string(),
+        status.socket_path.display().to_string(),
+    );
+    push_diff(
+        &mut differences,
+        "http_addr",
+        config.http_addr.clone(),
+        status.http_addr.clone(),
+    );
+
+    if let Some(startup) = &status.startup_surface {
+        push_diff(
+            &mut differences,
+            "workspace_dir",
+            config.workspace_dir.display().to_string(),
+            startup.workspace_dir.display().to_string(),
+        );
+        push_diff(
+            &mut differences,
+            "default_agent_id",
+            config.default_agent_id.clone(),
+            startup.default_agent_id.clone(),
+        );
+        push_diff(
+            &mut differences,
+            "callback_base_url",
+            config.callback_base_url.clone(),
+            startup.callback_base_url.clone(),
+        );
+        push_diff(
+            &mut differences,
+            "control_auth_mode",
+            format!("{:?}", config.control_auth_mode),
+            format!("{:?}", startup.control_auth_mode),
+        );
+        push_diff(
+            &mut differences,
+            "control_token_configured",
+            config.control_token.is_some().to_string(),
+            startup.control_token_configured.to_string(),
+        );
+    } else {
+        differences.push("startup_surface missing from runtime status".into());
+    }
+
+    if let Some(runtime) = &status.runtime_surface {
+        push_diff(
+            &mut differences,
+            "model.default",
+            config.default_model.as_string(),
+            runtime.model_default.clone(),
+        );
+        push_diff(
+            &mut differences,
+            "model.fallbacks",
+            config
+                .fallback_models
+                .iter()
+                .map(|model| model.as_string())
+                .collect::<Vec<_>>()
+                .join(","),
+            runtime.model_fallbacks.join(","),
+        );
+        push_diff(
+            &mut differences,
+            "runtime_max_output_tokens",
+            config.runtime_max_output_tokens.to_string(),
+            runtime.runtime_max_output_tokens.to_string(),
+        );
+        push_diff(
+            &mut differences,
+            "default_tool_output_tokens",
+            config.default_tool_output_tokens.to_string(),
+            runtime.default_tool_output_tokens.to_string(),
+        );
+        push_diff(
+            &mut differences,
+            "max_tool_output_tokens",
+            config.max_tool_output_tokens.to_string(),
+            runtime.max_tool_output_tokens.to_string(),
+        );
+        push_diff(
+            &mut differences,
+            "disable_provider_fallback",
+            config.provider_fallback_disabled().to_string(),
+            runtime.disable_provider_fallback.to_string(),
+        );
+    } else {
+        differences.push("runtime_surface missing from runtime status".into());
+    }
+
+    if differences.is_empty() {
+        "fingerprint differed, but no field-level difference was available from runtime status"
+            .into()
+    } else {
+        differences.join("; ")
+    }
+}
+
+fn push_diff(differences: &mut Vec<String>, key: &str, expected: String, actual: String) {
+    if expected != actual {
+        differences.push(format!("{key} expected={expected:?} actual={actual:?}"));
     }
 }
 

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -51,6 +51,7 @@ pub struct RuntimeStartupSurface {
     pub socket_path: PathBuf,
     pub workspace_dir: PathBuf,
     pub default_agent_id: String,
+    pub callback_base_url: String,
     pub control_token_configured: bool,
     pub control_auth_mode: RuntimeControlAuthMode,
 }

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -51,6 +51,7 @@ pub struct RuntimeStartupSurface {
     pub socket_path: PathBuf,
     pub workspace_dir: PathBuf,
     pub default_agent_id: String,
+    #[serde(default)]
     pub callback_base_url: String,
     pub control_token_configured: bool,
     pub control_auth_mode: RuntimeControlAuthMode,

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -1,4 +1,4 @@
-use super::lifecycle::{probe_runtime, ProbeRuntime};
+use super::lifecycle::{effective_config_mismatch_summary, probe_runtime, ProbeRuntime};
 use super::state::{
     persist_last_runtime_failure, DAEMON_LOG_TAIL_LINE_CHAR_LIMIT, DAEMON_LOG_TAIL_READ_BYTE_LIMIT,
 };
@@ -6,7 +6,8 @@ use super::{
     clear_persisted_daemon_lifecycle_failures, config_fingerprint, daemon_log_hint, daemon_logs,
     daemon_paths, daemon_status, daemon_stop, load_last_runtime_failure,
     persist_daemon_lifecycle_failure, runtime_activity_summary, DaemonLifecycleState,
-    RuntimeActivityState, RuntimeServiceMetadata, RuntimeStatusResponse,
+    RuntimeActivityState, RuntimeConfigSurface, RuntimeControlAuthMode, RuntimeServiceMetadata,
+    RuntimeStartupSurface, RuntimeStatusResponse,
 };
 use crate::config::{provider_registry_for_tests, AppConfig, ModelRef, ProviderId};
 use crate::{
@@ -233,6 +234,49 @@ fn runtime_status_response_decodes_without_activity_field() {
     let decoded: RuntimeStatusResponse = serde_json::from_value(payload).unwrap();
     assert_eq!(decoded.pid, 42);
     assert!(decoded.activity.is_none());
+}
+
+#[test]
+fn effective_config_mismatch_summary_lists_actionable_differences() {
+    let mut expected = test_config();
+    expected.http_addr = "0.0.0.0:7878".into();
+    expected.callback_base_url = "http://192.168.1.10:7878".into();
+    expected.control_auth_mode = crate::config::ControlAuthMode::Required;
+
+    let mut actual_surface = RuntimeConfigSurface::new(&expected);
+    actual_surface.runtime_max_output_tokens = expected.runtime_max_output_tokens;
+    let status = RuntimeStatusResponse {
+        ok: true,
+        healthy: true,
+        pid: 42,
+        home_dir: expected.home_dir.clone(),
+        socket_path: expected.socket_path.clone(),
+        http_addr: "127.0.0.1:7878".into(),
+        started_at: Utc::now(),
+        config_fingerprint: "actual".into(),
+        activity: None,
+        startup_surface: Some(RuntimeStartupSurface {
+            home_dir: expected.home_dir.clone(),
+            socket_path: expected.socket_path.clone(),
+            workspace_dir: expected.workspace_dir.clone(),
+            default_agent_id: expected.default_agent_id.clone(),
+            callback_base_url: "http://127.0.0.1:7878".into(),
+            control_token_configured: false,
+            control_auth_mode: RuntimeControlAuthMode::Auto,
+        }),
+        runtime_surface: Some(actual_surface),
+        agent_model_overrides: Vec::new(),
+        last_failure: None,
+    };
+
+    let summary = effective_config_mismatch_summary(&expected, &status);
+    assert!(summary.contains("http_addr expected=\"0.0.0.0:7878\" actual=\"127.0.0.1:7878\""));
+    assert!(summary.contains(
+        "callback_base_url expected=\"http://192.168.1.10:7878\" actual=\"http://127.0.0.1:7878\""
+    ));
+    assert!(summary.contains("control_auth_mode expected=\"Required\" actual=\"Auto\""));
+    assert!(summary.contains("control_token_configured expected=\"true\" actual=\"false\""));
+    assert!(!summary.contains("secret"));
 }
 
 #[tokio::test]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -237,6 +237,36 @@ fn runtime_status_response_decodes_without_activity_field() {
 }
 
 #[test]
+fn runtime_status_response_decodes_startup_surface_without_callback_base_url() {
+    let payload = serde_json::json!({
+        "ok": true,
+        "healthy": true,
+        "pid": 42,
+        "home_dir": "/tmp/holon",
+        "socket_path": "/tmp/holon.sock",
+        "http_addr": "127.0.0.1:1234",
+        "started_at": "2026-04-15T00:00:00Z",
+        "config_fingerprint": "abc123",
+        "startup_surface": {
+            "home_dir": "/tmp/holon",
+            "socket_path": "/tmp/holon.sock",
+            "workspace_dir": "/tmp/workspace",
+            "default_agent_id": "main",
+            "control_token_configured": false,
+            "control_auth_mode": "auto"
+        }
+    });
+    let decoded: RuntimeStatusResponse = serde_json::from_value(payload).unwrap();
+    assert_eq!(
+        decoded
+            .startup_surface
+            .expect("startup surface should decode")
+            .callback_base_url,
+        ""
+    );
+}
+
+#[test]
 fn effective_config_mismatch_summary_lists_actionable_differences() {
     let mut expected = test_config();
     expected.http_addr = "0.0.0.0:7878".into();

--- a/src/http.rs
+++ b/src/http.rs
@@ -599,6 +599,7 @@ pub async fn runtime_status(
         socket_path: config.socket_path.clone(),
         workspace_dir: config.workspace_dir.clone(),
         default_agent_id: config.default_agent_id.clone(),
+        callback_base_url: config.callback_base_url.clone(),
         control_token_configured: config.control_token.is_some(),
         control_auth_mode: config.control_auth_mode.into(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     io::Write,
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -743,7 +744,9 @@ fn apply_serve_options(config: &mut AppConfig, options: ServeOptions) -> Result<
     }
 
     if options.listen.is_some() && options.port.is_some() {
-        return Err(anyhow!("use only one of --listen or --port"));
+        return Err(anyhow!(
+            "use only one of --listen or --port; use --listen ADDRESS:PORT for full control or --port with --host for a port-only override"
+        ));
     }
 
     if let Some(listen) = options.listen {
@@ -950,35 +953,45 @@ fn non_empty_token(token: String) -> Result<String> {
     Ok(token)
 }
 
-fn serve_args_for_options(options: &ServeOptions) -> Vec<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DaemonServeLaunchOptions {
+    args: Vec<OsString>,
+    control_token_env: Option<String>,
+}
+
+fn serve_args_for_options(options: &ServeOptions) -> DaemonServeLaunchOptions {
     let mut args = vec![
-        "--access".into(),
-        options
-            .access
-            .to_possible_value()
-            .expect("serve access should have clap value")
-            .get_name()
-            .to_string(),
+        OsString::from("--access"),
+        OsString::from(
+            options
+                .access
+                .to_possible_value()
+                .expect("serve access should have clap value")
+                .get_name(),
+        ),
     ];
     if let Some(host) = &options.host {
-        args.extend(["--host".into(), host.clone()]);
+        args.extend([OsString::from("--host"), OsString::from(host)]);
     }
     if let Some(listen) = &options.listen {
-        args.extend(["--listen".into(), listen.clone()]);
+        args.extend([OsString::from("--listen"), OsString::from(listen)]);
     }
     if let Some(port) = options.port {
-        args.extend(["--port".into(), port.to_string()]);
+        args.extend([OsString::from("--port"), OsString::from(port.to_string())]);
     }
     if let Some(advertise) = &options.advertise {
-        args.extend(["--advertise".into(), advertise.clone()]);
-    }
-    if let Some(token) = &options.token {
-        args.extend(["--token".into(), token.clone()]);
+        args.extend([OsString::from("--advertise"), OsString::from(advertise)]);
     }
     if let Some(token_file) = &options.token_file {
-        args.extend(["--token-file".into(), token_file.display().to_string()]);
+        args.extend([
+            OsString::from("--token-file"),
+            token_file.as_os_str().to_os_string(),
+        ]);
     }
-    args
+    DaemonServeLaunchOptions {
+        args,
+        control_token_env: options.token.clone(),
+    }
 }
 
 async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
@@ -1183,19 +1196,46 @@ mod tests {
         };
 
         assert_eq!(options.access, ServeAccess::Lan);
+        let serve_launch = serve_args_for_options(&options);
         assert_eq!(
-            serve_args_for_options(&options),
+            serve_launch.args,
             vec![
-                "--access",
-                "lan",
-                "--host",
-                "192.168.1.10",
-                "--port",
-                "8787",
-                "--token-file",
-                "/tmp/holon.token",
+                OsString::from("--access"),
+                OsString::from("lan"),
+                OsString::from("--host"),
+                OsString::from("192.168.1.10"),
+                OsString::from("--port"),
+                OsString::from("8787"),
+                OsString::from("--token-file"),
+                OsString::from("/tmp/holon.token"),
             ]
         );
+        assert_eq!(serve_launch.control_token_env, None);
+    }
+
+    #[test]
+    fn daemon_start_passes_inline_token_through_env_not_argv() {
+        let options = ServeOptions {
+            access: ServeAccess::Lan,
+            host: Some("192.168.1.10".into()),
+            listen: None,
+            port: None,
+            advertise: None,
+            token: Some("secret-token".into()),
+            token_file: None,
+        };
+
+        let serve_launch = serve_args_for_options(&options);
+        assert_eq!(
+            serve_launch.control_token_env.as_deref(),
+            Some("secret-token")
+        );
+        let token_flag = OsString::from("--token");
+        let token_value = OsString::from("secret-token");
+        assert!(!serve_launch
+            .args
+            .iter()
+            .any(|arg| arg == &token_flag || arg == &token_value));
     }
 
     #[test]
@@ -1257,17 +1297,31 @@ async fn handle_daemon_command(config: AppConfig, command: DaemonCommands) -> Re
     let value = match command {
         DaemonCommands::Start { options } => {
             let mut config = config;
-            let serve_args = serve_args_for_options(&options);
+            let serve_launch = serve_args_for_options(&options);
             apply_serve_options(&mut config, options)?;
-            serde_json::to_value(daemon_start(&config, &serve_args).await?)?
+            serde_json::to_value(
+                daemon_start(
+                    &config,
+                    &serve_launch.args,
+                    serve_launch.control_token_env.as_deref(),
+                )
+                .await?,
+            )?
         }
         DaemonCommands::Stop => serde_json::to_value(daemon_stop(&config).await?)?,
         DaemonCommands::Status => serde_json::to_value(daemon_status(&config).await?)?,
         DaemonCommands::Restart { options } => {
             let mut config = config;
-            let serve_args = serve_args_for_options(&options);
+            let serve_launch = serve_args_for_options(&options);
             apply_serve_options(&mut config, options)?;
-            serde_json::to_value(daemon_restart(&config, &serve_args).await?)?
+            serde_json::to_value(
+                daemon_restart(
+                    &config,
+                    &serve_launch.args,
+                    serve_launch.control_token_env.as_deref(),
+                )
+                .await?,
+            )?
         }
         DaemonCommands::Logs { tail } => serde_json::to_value(daemon_logs(&config, tail)?)?,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use holon::{
     client::{normalize_control_base_url, LocalClient},
     config::{
@@ -63,18 +63,8 @@ impl ControlCommandAction {
 #[derive(Debug, Subcommand)]
 enum Commands {
     Serve {
-        #[arg(long, value_enum, default_value_t = ServeAccess::Local)]
-        access: ServeAccess,
-        #[arg(long)]
-        host: Option<String>,
-        #[arg(long)]
-        listen: Option<String>,
-        #[arg(long)]
-        advertise: Option<String>,
-        #[arg(long)]
-        token: Option<String>,
-        #[arg(long)]
-        token_file: Option<PathBuf>,
+        #[command(flatten)]
+        options: ServeOptions,
     },
     Daemon {
         #[command(subcommand)]
@@ -238,13 +228,21 @@ enum ServeAccess {
     Tailnet,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Args)]
 struct ServeOptions {
+    #[arg(long, value_enum, default_value_t = ServeAccess::Local)]
     access: ServeAccess,
+    #[arg(long)]
     host: Option<String>,
+    #[arg(long)]
     listen: Option<String>,
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..))]
+    port: Option<u16>,
+    #[arg(long)]
     advertise: Option<String>,
+    #[arg(long)]
     token: Option<String>,
+    #[arg(long)]
     token_file: Option<PathBuf>,
 }
 
@@ -335,10 +333,16 @@ enum ConfigCredentialCommands {
 
 #[derive(Debug, Subcommand)]
 enum DaemonCommands {
-    Start,
+    Start {
+        #[command(flatten)]
+        options: ServeOptions,
+    },
     Stop,
     Status,
-    Restart,
+    Restart {
+        #[command(flatten)]
+        options: ServeOptions,
+    },
     Logs {
         #[arg(long, default_value_t = 80)]
         tail: usize,
@@ -520,27 +524,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
 
     let config = AppConfig::load()?;
     match command {
-        Commands::Serve {
-            access,
-            host,
-            listen,
-            advertise,
-            token,
-            token_file,
-        } => {
-            serve(
-                config,
-                ServeOptions {
-                    access,
-                    host,
-                    listen,
-                    advertise,
-                    token,
-                    token_file,
-                },
-            )
-            .await
-        }
+        Commands::Serve { options } => serve(config, options).await,
         Commands::Daemon { command } => handle_daemon_command(config, command).await,
         Commands::Prompt { text, agent } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
@@ -758,12 +742,19 @@ fn apply_serve_options(config: &mut AppConfig, options: ServeOptions) -> Result<
         config.control_token = Some(token);
     }
 
+    if options.listen.is_some() && options.port.is_some() {
+        return Err(anyhow!("use only one of --listen or --port"));
+    }
+
     if let Some(listen) = options.listen {
         config.http_addr = listen;
     } else if options.access == ServeAccess::Tunnel {
-        config.http_addr = loopback_with_configured_port(&config.http_addr);
+        config.http_addr = loopback_with_configured_port(&config.http_addr, options.port);
     } else if matches!(options.access, ServeAccess::Lan | ServeAccess::Tailnet) {
-        config.http_addr = default_remote_listen_addr(options.host.as_deref(), &config.http_addr);
+        config.http_addr =
+            default_remote_listen_addr(options.host.as_deref(), &config.http_addr, options.port);
+    } else if options.port.is_some() {
+        config.http_addr = loopback_with_configured_port(&config.http_addr, options.port);
     }
 
     let advertise_url = match options.advertise {
@@ -824,10 +815,17 @@ fn apply_serve_options(config: &mut AppConfig, options: ServeOptions) -> Result<
     Ok(advertise_url)
 }
 
-fn default_remote_listen_addr(host: Option<&str>, current: &str) -> String {
-    let port = current
-        .rsplit_once(':')
-        .and_then(|(_, port)| port.parse::<u16>().ok())
+fn default_remote_listen_addr(
+    host: Option<&str>,
+    current: &str,
+    explicit_port: Option<u16>,
+) -> String {
+    let port = explicit_port
+        .or_else(|| {
+            current
+                .rsplit_once(':')
+                .and_then(|(_, port)| port.parse::<u16>().ok())
+        })
         .unwrap_or(7878);
     if let Some(host) = host {
         if let Ok(addr) = host.parse::<SocketAddr>() {
@@ -840,10 +838,13 @@ fn default_remote_listen_addr(host: Option<&str>, current: &str) -> String {
     format!("0.0.0.0:{port}")
 }
 
-fn loopback_with_configured_port(current: &str) -> String {
-    let port = current
-        .rsplit_once(':')
-        .and_then(|(_, port)| port.parse::<u16>().ok())
+fn loopback_with_configured_port(current: &str, explicit_port: Option<u16>) -> String {
+    let port = explicit_port
+        .or_else(|| {
+            current
+                .rsplit_once(':')
+                .and_then(|(_, port)| port.parse::<u16>().ok())
+        })
         .unwrap_or(7878);
     format!("127.0.0.1:{port}")
 }
@@ -947,6 +948,37 @@ fn non_empty_token(token: String) -> Result<String> {
         return Err(anyhow!("control token must not be empty"));
     }
     Ok(token)
+}
+
+fn serve_args_for_options(options: &ServeOptions) -> Vec<String> {
+    let mut args = vec![
+        "--access".into(),
+        options
+            .access
+            .to_possible_value()
+            .expect("serve access should have clap value")
+            .get_name()
+            .to_string(),
+    ];
+    if let Some(host) = &options.host {
+        args.extend(["--host".into(), host.clone()]);
+    }
+    if let Some(listen) = &options.listen {
+        args.extend(["--listen".into(), listen.clone()]);
+    }
+    if let Some(port) = options.port {
+        args.extend(["--port".into(), port.to_string()]);
+    }
+    if let Some(advertise) = &options.advertise {
+        args.extend(["--advertise".into(), advertise.clone()]);
+    }
+    if let Some(token) = &options.token {
+        args.extend(["--token".into(), token.clone()]);
+    }
+    if let Some(token_file) = &options.token_file {
+        args.extend(["--token-file".into(), token_file.display().to_string()]);
+    }
+    args
 }
 
 async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
@@ -1091,6 +1123,7 @@ mod tests {
                 access: ServeAccess::Tailnet,
                 host: Some("lab.tailnet.ts.net".into()),
                 listen: None,
+                port: None,
                 advertise: None,
                 token: None,
                 token_file: None,
@@ -1105,6 +1138,67 @@ mod tests {
     }
 
     #[test]
+    fn lan_port_updates_listen_and_advertise_urls() {
+        let mut config = test_config();
+        let advertise = apply_serve_options(
+            &mut config,
+            ServeOptions {
+                access: ServeAccess::Lan,
+                host: Some("192.168.1.10".into()),
+                listen: None,
+                port: Some(8787),
+                advertise: None,
+                token: None,
+                token_file: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(config.http_addr, "192.168.1.10:8787");
+        assert_eq!(advertise.as_deref(), Some("http://192.168.1.10:8787"));
+        assert_eq!(config.callback_base_url, "http://192.168.1.10:8787");
+        assert_eq!(config.control_auth_mode, ControlAuthMode::Required);
+    }
+
+    #[test]
+    fn daemon_start_accepts_and_forwards_serve_options() {
+        let cli = Cli::parse_from([
+            "holon",
+            "daemon",
+            "start",
+            "--access",
+            "lan",
+            "--host",
+            "192.168.1.10",
+            "--port",
+            "8787",
+            "--token-file",
+            "/tmp/holon.token",
+        ]);
+        let Commands::Daemon {
+            command: DaemonCommands::Start { options },
+        } = cli.command
+        else {
+            panic!("expected daemon start command");
+        };
+
+        assert_eq!(options.access, ServeAccess::Lan);
+        assert_eq!(
+            serve_args_for_options(&options),
+            vec![
+                "--access",
+                "lan",
+                "--host",
+                "192.168.1.10",
+                "--port",
+                "8787",
+                "--token-file",
+                "/tmp/holon.token",
+            ]
+        );
+    }
+
+    #[test]
     fn unspecified_listen_accepts_explicit_advertise_url() {
         let mut config = test_config();
         let advertise = apply_serve_options(
@@ -1113,6 +1207,7 @@ mod tests {
                 access: ServeAccess::Lan,
                 host: None,
                 listen: Some("0.0.0.0:7878".into()),
+                port: None,
                 advertise: Some("http://lab.example.test:7878".into()),
                 token: None,
                 token_file: None,
@@ -1137,6 +1232,7 @@ mod tests {
                 access: ServeAccess::Local,
                 host: None,
                 listen: None,
+                port: None,
                 advertise: None,
                 token: None,
                 token_file: None,
@@ -1159,10 +1255,20 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
 
 async fn handle_daemon_command(config: AppConfig, command: DaemonCommands) -> Result<()> {
     let value = match command {
-        DaemonCommands::Start => serde_json::to_value(daemon_start(&config).await?)?,
+        DaemonCommands::Start { options } => {
+            let mut config = config;
+            let serve_args = serve_args_for_options(&options);
+            apply_serve_options(&mut config, options)?;
+            serde_json::to_value(daemon_start(&config, &serve_args).await?)?
+        }
         DaemonCommands::Stop => serde_json::to_value(daemon_stop(&config).await?)?,
         DaemonCommands::Status => serde_json::to_value(daemon_status(&config).await?)?,
-        DaemonCommands::Restart => serde_json::to_value(daemon_restart(&config).await?)?,
+        DaemonCommands::Restart { options } => {
+            let mut config = config;
+            let serve_args = serve_args_for_options(&options);
+            apply_serve_options(&mut config, options)?;
+            serde_json::to_value(daemon_restart(&config, &serve_args).await?)?
+        }
         DaemonCommands::Logs { tail } => serde_json::to_value(daemon_logs(&config, tail)?)?,
     };
     print_json(&value)

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -831,6 +831,10 @@ pub async fn runtime_status_route_reports_runtime_metadata() -> Result<()> {
         payload["startup_surface"]["default_agent_id"],
         config.default_agent_id
     );
+    assert_eq!(
+        payload["startup_surface"]["callback_base_url"],
+        config.callback_base_url
+    );
     assert_eq!(payload["startup_surface"]["control_token_configured"], true);
     assert_eq!(payload["startup_surface"]["control_auth_mode"], "auto");
     assert_eq!(


### PR DESCRIPTION
## Summary

Fixes #970.

- Reuses the `serve` network/auth option surface for `daemon start` and `daemon restart`, including `--access`, `--host`, `--listen`, `--port`, `--advertise`, `--token`, and `--token-file`.
- Applies the effective serve config before daemon launch and forwards the same options to the managed background `serve` process.
- Adds actionable daemon fingerprint mismatch diagnostics that list concrete effective-config differences without printing token material.
- Exposes `callback_base_url` in runtime startup status so mismatch diagnostics can compare advertised callback URLs.
- Updates CLI docs/RFC notes for LAN daemon startup and restart semantics.

## Verification

- `cargo fmt`
- `git diff --check`
- `cargo check --all-targets`
- `cargo test --bin holon lan_port_updates_listen_and_advertise_urls -- --test-threads=1`
- `cargo test --bin holon daemon_start_accepts_and_forwards_serve_options -- --test-threads=1`
- `cargo test --lib effective_config_mismatch_summary_lists_actionable_differences -- --test-threads=1`
- `cargo test --test http_control runtime_status_route_reports_runtime_metadata -- --test-threads=1`
- `cargo test --all-targets -- --test-threads=1`
