### PR TITLE
fix: persist TUI selected agent

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -255,6 +256,18 @@ impl LocalClient {
             Some(remote) => format!("remote {} auth=bearer", remote.base_url),
             None => "local runtime".into(),
         }
+    }
+
+    pub(crate) fn home_dir(&self) -> &Path {
+        &self.config.home_dir
+    }
+
+    pub(crate) fn default_agent_id(&self) -> &str {
+        &self.config.default_agent_id
+    }
+
+    pub(crate) fn remote_base_url(&self) -> Option<&str> {
+        self.remote.as_ref().map(|remote| remote.base_url.as_str())
     }
 
     pub async fn list_agents(&self) -> Result<Vec<AgentSummary>> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -45,6 +45,7 @@ mod overlay;
 mod projection;
 mod render;
 mod runtime;
+mod state;
 mod view_model;
 
 use app::TuiApp;
@@ -216,6 +217,7 @@ mod tests {
         determine_alt_screen_mode_for_terminal, draw, is_cursor_too_old_error,
         is_operator_origin_value, paragraph_max_scroll, paragraph_max_scroll_unframed,
         projection::{OperatorVisibility, TuiProjection},
+        state::{tui_state_path, TuiClientState},
         view_model::{HeaderViewModel, StatusbarViewModel},
         AgentListChange, ChatScrollState, ComposerState, ConversationCell, OverlayState, TuiApp,
         TuiConnectionState, TuiRuntimeMessage,
@@ -277,6 +279,69 @@ mod tests {
                 temp.join(".codex"),
             ),
         }
+    }
+
+    #[test]
+    fn local_tui_restores_persisted_selected_agent_on_initial_agent_list() {
+        let config = test_config();
+        let state_path = config.home_dir.join("state").join("tui").join("local.json");
+        TuiClientState::new("beta").save(&state_path).unwrap();
+        let client = LocalClient::new(config).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+
+        let change = app.apply_agent_list(vec![
+            sample_agent_summary("default"),
+            sample_agent_summary("beta"),
+        ]);
+
+        assert_eq!(change, AgentListChange::RequiresBootstrap);
+        assert_eq!(app.selected_agent_id(), Some("beta"));
+    }
+
+    #[test]
+    fn missing_persisted_agent_falls_back_to_default_agent() {
+        let config = test_config();
+        let state_path = config.home_dir.join("state").join("tui").join("local.json");
+        TuiClientState::new("missing").save(&state_path).unwrap();
+        let client = LocalClient::new(config).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+
+        app.apply_agent_list(vec![
+            sample_agent_summary("alpha"),
+            sample_agent_summary("default"),
+        ]);
+
+        assert_eq!(app.selected_agent_id(), Some("default"));
+    }
+
+    #[test]
+    fn remote_tui_state_scope_uses_hashed_connect_target_without_token() {
+        let config = test_config();
+        let client =
+            LocalClient::remote(config, "http://example.test:7878/", "top-secret-token").unwrap();
+        let path = tui_state_path(&client);
+        let filename = path.file_name().unwrap().to_string_lossy();
+
+        assert!(filename.starts_with("remote-"));
+        assert!(filename.ends_with(".json"));
+        assert!(!filename.contains("example"));
+        assert!(!filename.contains("top-secret-token"));
+
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.record_selected_agent("beta");
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("beta"));
+        assert!(!raw.contains("top-secret-token"));
+        assert!(!raw.contains("example.test"));
     }
 
     fn sample_agent_summary(agent_id: &str) -> AgentSummary {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,8 @@
 use super::chat::CachedChatText;
+use super::state::{tui_state_path, TuiClientState};
 use super::*;
 use std::cell::RefCell;
+use std::path::PathBuf;
 use tokio::{sync::mpsc, task::JoinHandle};
 
 pub(super) struct TuiApp {
@@ -19,6 +21,8 @@ pub(super) struct TuiApp {
     pub(super) refresh_deadline: Option<Instant>,
     pub(super) reconnect_attempt: u32,
     pub(super) selected_agent: usize,
+    pub(super) preferred_agent_id: Option<String>,
+    pub(super) state_path: PathBuf,
     pub(super) chat_scroll: ChatScrollState,
     pub(super) chat_max_scroll: u16,
     pub(super) composer: ComposerState,
@@ -39,6 +43,10 @@ pub(super) struct TuiApp {
 impl TuiApp {
     pub(crate) fn new(client: LocalClient, log_writer: TuiLogWriter) -> Self {
         let connection_summary = client.connection_summary();
+        let state_path = tui_state_path(&client);
+        let preferred_agent_id = TuiClientState::load(&state_path)
+            .ok()
+            .map(|state| state.last_selected_agent_id);
         Self {
             client,
             agents: Vec::new(),
@@ -55,6 +63,8 @@ impl TuiApp {
             refresh_deadline: None,
             reconnect_attempt: 0,
             selected_agent: 0,
+            preferred_agent_id,
+            state_path,
             chat_scroll: ChatScrollState::new(),
             chat_max_scroll: 0,
             composer: ComposerState::new(),

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -1,4 +1,5 @@
 use super::projection::ProjectionSlice;
+use super::state::TuiClientState;
 use super::*;
 use crate::client::{AgentStreamEvent, EventStreamRequest, LocalEventStream, LocalHttpError};
 use tokio::sync::mpsc;
@@ -132,11 +133,14 @@ impl TuiApp {
         });
 
         self.selected_agent = previously_selected
-            .and_then(|agent_id| {
-                agents
-                    .iter()
-                    .position(|agent| agent.identity.agent_id == agent_id)
+            .as_deref()
+            .and_then(|agent_id| find_agent_index(&agents, agent_id))
+            .or_else(|| {
+                self.preferred_agent_id
+                    .as_deref()
+                    .and_then(|agent_id| find_agent_index(&agents, agent_id))
             })
+            .or_else(|| find_agent_index(&agents, self.client.default_agent_id()))
             .unwrap_or_else(|| self.selected_agent.min(agents.len().saturating_sub(1)));
         self.agents = agents;
 
@@ -303,6 +307,7 @@ impl TuiApp {
 
         self.stop_stream_task();
         self.selected_agent = target_index;
+        self.record_selected_agent(&agent_id);
         self.projection = Some(projection);
         self.apply_projection_view();
         self.last_refresh_at = Some(Local::now());
@@ -360,6 +365,17 @@ impl TuiApp {
                 }
                 Ok(())
             }
+        }
+    }
+
+    pub(super) fn record_selected_agent(&mut self, agent_id: &str) {
+        self.preferred_agent_id = Some(agent_id.to_string());
+        if let Err(err) = TuiClientState::new(agent_id).save(&self.state_path) {
+            tracing::warn!(
+                error = %err,
+                path = %self.state_path.display(),
+                "failed to persist TUI selected agent"
+            );
         }
     }
 
@@ -664,6 +680,12 @@ fn transcript_merge_key(entry: &TranscriptEntry) -> &str {
         .related_message_id
         .as_deref()
         .unwrap_or(entry.id.as_str())
+}
+
+fn find_agent_index(agents: &[AgentSummary], agent_id: &str) -> Option<usize> {
+    agents
+        .iter()
+        .position(|agent| agent.identity.agent_id == agent_id)
 }
 
 impl Drop for TuiApp {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,0 +1,77 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::client::LocalClient;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct TuiClientState {
+    pub(super) last_selected_agent_id: String,
+    pub(super) updated_at: DateTime<Utc>,
+}
+
+impl TuiClientState {
+    pub(super) fn new(last_selected_agent_id: impl Into<String>) -> Self {
+        Self {
+            last_selected_agent_id: last_selected_agent_id.into(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    pub(super) fn load(path: &Path) -> Result<Self> {
+        let bytes = fs::read(path)
+            .with_context(|| format!("failed to read TUI state {}", path.display()))?;
+        serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to decode TUI state {}", path.display()))
+    }
+
+    pub(super) fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create TUI state dir {}", parent.display()))?;
+        }
+        let bytes = serde_json::to_vec_pretty(self)?;
+        fs::write(path, bytes)
+            .with_context(|| format!("failed to write TUI state {}", path.display()))
+    }
+}
+
+pub(super) fn tui_state_path(client: &LocalClient) -> PathBuf {
+    let filename = match client.remote_base_url() {
+        Some(base_url) => format!("remote-{}.json", short_sha256_hex(base_url)),
+        None => "local.json".to_string(),
+    };
+    client.home_dir().join("state").join("tui").join(filename)
+}
+
+fn short_sha256_hex(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    digest
+        .iter()
+        .take(12)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_round_trip_preserves_selected_agent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state").join("tui").join("local.json");
+        let state = TuiClientState::new("agent-beta");
+
+        state.save(&path).unwrap();
+        let loaded = TuiClientState::load(&path).unwrap();
+
+        assert_eq!(loaded.last_selected_agent_id, "agent-beta");
+    }
+}


### PR DESCRIPTION
## Summary
- persist TUI last selected agent under `$HOLON_HOME/state/tui/` per connection scope
- restore persisted agent on initial agent-list load, with default/first-agent fallback
- hash remote connect target for state filename and keep token/URL details out of state contents

Fixes #976

## Verification
- cargo test tui::tests::
- cargo test tui::state::tests::
- cargo check --all-targets
- git diff --check