### PR TITLE
feat: support linked local skill installs

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -375,7 +375,7 @@ fn templates_root_for_home(home_dir: &Path) -> PathBuf {
     home_dir.join(".agents").join("templates")
 }
 
-fn user_home_dir() -> Result<PathBuf> {
+pub(crate) fn user_home_dir() -> Result<PathBuf> {
     env::var_os("HOME")
         .map(PathBuf::from)
         .filter(|path| !path.as_os_str().is_empty())

--- a/src/http.rs
+++ b/src/http.rs
@@ -1645,8 +1645,10 @@ pub async fn install_skill(
         .await
         .map_err(agent_access_error)?;
     let agent_home = runtime.agent_home();
+    let user_home = state.host.config().home_dir.clone();
     let skill_name =
-        crate::skills::install_skill(&agent_home, &request.kind).map_err(error_response)?;
+        crate::skills::install_skill_with_user_home(&agent_home, Some(&user_home), &request.kind)
+            .map_err(error_response)?;
     runtime
         .append_audit_event(
             "skill_installed",

--- a/src/http.rs
+++ b/src/http.rs
@@ -1645,7 +1645,7 @@ pub async fn install_skill(
         .await
         .map_err(agent_access_error)?;
     let agent_home = runtime.agent_home();
-    let user_home = state.host.config().home_dir.clone();
+    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
     let skill_name =
         crate::skills::install_skill_with_user_home(&agent_home, Some(&user_home), &request.kind)
             .map_err(error_response)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,6 +420,8 @@ enum SkillsCommands {
         #[arg(long)]
         builtin: bool,
         #[arg(long)]
+        copy: bool,
+        #[arg(long)]
         agent: Option<String>,
     },
     Uninstall {
@@ -1404,6 +1406,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         SkillsCommands::Install {
             name_or_path,
             builtin,
+            copy,
             agent,
         } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
@@ -1411,16 +1414,18 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
                 holon::types::SkillInstallKind::Builtin { name: name_or_path }
             } else {
                 let path = std::path::PathBuf::from(&name_or_path);
-                if path.is_absolute() {
-                    if !path.is_dir() {
-                        anyhow::bail!(
-                            "path '{}' does not exist or is not a directory. Use --builtin to install a builtin skill by name.",
-                            path.display()
-                        );
-                    }
-                    holon::types::SkillInstallKind::Local { path }
+                let mode = if copy {
+                    holon::types::SkillInstallMode::Copied
                 } else {
-                    holon::types::SkillInstallKind::Builtin { name: name_or_path }
+                    holon::types::SkillInstallMode::Linked
+                };
+                if path.is_absolute() || path.exists() {
+                    holon::types::SkillInstallKind::Local { path, mode }
+                } else {
+                    holon::types::SkillInstallKind::Named {
+                        name: name_or_path,
+                        mode,
+                    }
                 }
             };
             post_control_json(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1274,6 +1274,22 @@ mod tests {
     }
 
     #[test]
+    fn skills_install_relative_existing_file_stays_named_request() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ghx"), "not a skill directory").unwrap();
+
+        let kind = build_skill_install_kind_from_cwd("ghx", false, dir.path()).unwrap();
+
+        assert_eq!(
+            kind,
+            holon::types::SkillInstallKind::Named {
+                name: "ghx".into(),
+                mode: holon::types::SkillInstallMode::Linked,
+            }
+        );
+    }
+
+    #[test]
     fn unspecified_listen_accepts_explicit_advertise_url() {
         let mut config = test_config();
         let advertise = apply_serve_options(
@@ -1490,7 +1506,7 @@ fn build_skill_install_kind_from_cwd(
         return Ok(holon::types::SkillInstallKind::Local { path, mode });
     }
     let resolved = cwd.join(&path);
-    if resolved.exists() {
+    if resolved.is_dir() {
         Ok(holon::types::SkillInstallKind::Local {
             path: resolved,
             mode,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1241,6 +1241,39 @@ mod tests {
     }
 
     #[test]
+    fn skills_install_relative_existing_path_is_absolutized_before_control_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills/demo");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Demo").unwrap();
+
+        let kind = build_skill_install_kind_from_cwd("skills/demo", false, dir.path()).unwrap();
+
+        assert_eq!(
+            kind,
+            holon::types::SkillInstallKind::Local {
+                path: skill_dir,
+                mode: holon::types::SkillInstallMode::Linked,
+            }
+        );
+    }
+
+    #[test]
+    fn skills_install_unresolved_name_stays_named_request() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let kind = build_skill_install_kind_from_cwd("ghx", true, dir.path()).unwrap();
+
+        assert_eq!(
+            kind,
+            holon::types::SkillInstallKind::Named {
+                name: "ghx".into(),
+                mode: holon::types::SkillInstallMode::Copied,
+            }
+        );
+    }
+
+    #[test]
     fn unspecified_listen_accepts_explicit_advertise_url() {
         let mut config = test_config();
         let advertise = apply_serve_options(
@@ -1413,20 +1446,7 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
             let kind = if builtin {
                 holon::types::SkillInstallKind::Builtin { name: name_or_path }
             } else {
-                let path = std::path::PathBuf::from(&name_or_path);
-                let mode = if copy {
-                    holon::types::SkillInstallMode::Copied
-                } else {
-                    holon::types::SkillInstallMode::Linked
-                };
-                if path.is_absolute() || path.exists() {
-                    holon::types::SkillInstallKind::Local { path, mode }
-                } else {
-                    holon::types::SkillInstallKind::Named {
-                        name: name_or_path,
-                        mode,
-                    }
-                }
+                build_skill_install_kind(&name_or_path, copy)?
             };
             post_control_json(
                 config,
@@ -1444,6 +1464,42 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
             )
             .await
         }
+    }
+}
+
+fn build_skill_install_kind(
+    name_or_path: &str,
+    copy: bool,
+) -> Result<holon::types::SkillInstallKind> {
+    let cwd = std::env::current_dir().context("failed to resolve current directory")?;
+    build_skill_install_kind_from_cwd(name_or_path, copy, &cwd)
+}
+
+fn build_skill_install_kind_from_cwd(
+    name_or_path: &str,
+    copy: bool,
+    cwd: &Path,
+) -> Result<holon::types::SkillInstallKind> {
+    let mode = if copy {
+        holon::types::SkillInstallMode::Copied
+    } else {
+        holon::types::SkillInstallMode::Linked
+    };
+    let path = PathBuf::from(name_or_path);
+    if path.is_absolute() {
+        return Ok(holon::types::SkillInstallKind::Local { path, mode });
+    }
+    let resolved = cwd.join(&path);
+    if resolved.exists() {
+        Ok(holon::types::SkillInstallKind::Local {
+            path: resolved,
+            mode,
+        })
+    } else {
+        Ok(holon::types::SkillInstallKind::Named {
+            name: name_or_path.into(),
+            mode,
+        })
     }
 }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::types::{
@@ -13,6 +13,7 @@ use crate::types::{
 };
 
 const SKILL_ENTRYPOINT: &str = "SKILL.md";
+const INSTALL_METADATA_FILENAME: &str = ".holon-skill-install.json";
 const SKILL_ROOT_SUFFIXES: [&str; 4] = [
     "skills",
     ".agents/skills",
@@ -279,13 +280,17 @@ pub fn install_skill_with_user_home(
     let name = match kind {
         crate::types::SkillInstallKind::Builtin { name } => {
             validate_skill_name(name)?;
-            crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
+            let destination =
+                crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
+            record_install_metadata(&destination, "builtin")?;
             name.clone()
         }
         crate::types::SkillInstallKind::Named { name, mode } => {
             validate_skill_name(name)?;
             if crate::agent_template::builtin_skill_names().contains(&name.as_str()) {
-                crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
+                let destination =
+                    crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
+                record_install_metadata(&destination, "builtin")?;
                 name.clone()
             } else {
                 let path = resolve_user_skill_by_name(user_home, name)?;
@@ -311,6 +316,9 @@ fn materialize_local_skill(
         SkillInstallMode::Linked => materialize_linked_skill_ref(skills_root, &path)?,
         SkillInstallMode::Copied => materialize_copied_skill_ref(skills_root, &path)?,
     };
+    if *mode == SkillInstallMode::Copied {
+        record_install_metadata(&destination, "copied")?;
+    }
     Ok(destination
         .file_name()
         .and_then(|n| n.to_str())
@@ -397,17 +405,20 @@ fn materialize_copied_skill_ref(skills_root: &Path, path: &Path) -> Result<PathB
     let destination = skills_root.join(skill_name);
     if destination.exists() {
         bail!(
-            "template skill destination {} already exists",
+            "local skill destination {} already exists",
             destination.display()
         );
     }
-    copy_dir_all(path, &destination).with_context(|| {
+    if let Err(error) = copy_dir_all(path, &destination).with_context(|| {
         format!(
             "failed to copy local skill ref {} -> {}",
             path.display(),
             destination.display()
         )
-    })?;
+    }) {
+        let _ = fs::remove_dir_all(&destination);
+        return Err(error);
+    }
     Ok(destination)
 }
 
@@ -429,12 +440,35 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
                 )
             })?;
         } else if file_type.is_symlink() {
-            let target = fs::read_link(&src_path)
-                .with_context(|| format!("failed to read symlink {}", src_path.display()))?;
-            create_symlink(&target, &dst_path)?;
+            bail!(
+                "copy mode does not support symlinks inside skill directories: {}",
+                src_path.display()
+            );
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SkillInstallMetadata {
+    install_mode: String,
+}
+
+fn record_install_metadata(destination: &Path, install_mode: &str) -> Result<()> {
+    let payload = serde_json::to_vec_pretty(&SkillInstallMetadata {
+        install_mode: install_mode.into(),
+    })?;
+    fs::write(destination.join(INSTALL_METADATA_FILENAME), payload).with_context(|| {
+        format!(
+            "failed to write install metadata for {}",
+            destination.display()
+        )
+    })
+}
+
+fn read_install_metadata(skill_dir: &Path) -> Option<SkillInstallMetadata> {
+    let content = fs::read(skill_dir.join(INSTALL_METADATA_FILENAME)).ok()?;
+    serde_json::from_slice(&content).ok()
 }
 
 pub fn uninstall_skill(agent_home: &Path, name: &str) -> Result<()> {
@@ -534,6 +568,11 @@ fn installed_skill_view(catalog: SkillCatalogEntry) -> Result<InstalledSkillView
     } else {
         None
     };
+    let install_metadata = if link_target.is_none() {
+        read_install_metadata(skill_dir)
+    } else {
+        None
+    };
     let warning = link_target
         .as_ref()
         .and_then(|target| {
@@ -571,6 +610,20 @@ fn installed_skill_view(catalog: SkillCatalogEntry) -> Result<InstalledSkillView
     Ok(InstalledSkillView {
         install_mode: if link_target.is_some() {
             "linked".into()
+        } else if matches!(
+            install_metadata
+                .as_ref()
+                .map(|metadata| metadata.install_mode.as_str()),
+            Some("builtin")
+        ) {
+            "builtin".into()
+        } else if matches!(
+            install_metadata
+                .as_ref()
+                .map(|metadata| metadata.install_mode.as_str()),
+            Some("copied")
+        ) {
+            "copied".into()
         } else if crate::agent_template::builtin_skill_names()
             .contains(&catalog.skill_id.trim_start_matches("agent:"))
         {
@@ -584,12 +637,12 @@ fn installed_skill_view(catalog: SkillCatalogEntry) -> Result<InstalledSkillView
     })
 }
 
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn create_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::os::unix::fs::symlink(src, dst)
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn create_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
     if src.is_dir() {
         std::os::windows::fs::symlink_dir(src, dst)
@@ -847,6 +900,58 @@ mod tests {
         let installed = list_installed_skills(&agent_home).unwrap();
         assert_eq!(installed[0].install_mode, "copied");
         assert!(installed[0].link_target.is_none());
+    }
+
+    #[test]
+    fn copied_local_skill_named_like_builtin_reports_copied_mode() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("source/ghx");
+        let agent_home = dir.path().join("agent");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join(SKILL_ENTRYPOINT),
+            "---\nname: ghx\ndescription: local ghx\n---\nbody",
+        )
+        .unwrap();
+
+        install_skill_with_user_home(
+            &agent_home,
+            None,
+            &crate::types::SkillInstallKind::Local {
+                path: source,
+                mode: SkillInstallMode::Copied,
+            },
+        )
+        .unwrap();
+
+        let installed = list_installed_skills(&agent_home).unwrap();
+        assert_eq!(installed[0].catalog.name, "ghx");
+        assert_eq!(installed[0].install_mode, "copied");
+    }
+
+    #[test]
+    fn copy_mode_rejects_symlinks_inside_skill_directory() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("source/demo");
+        let agent_home = dir.path().join("agent");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join(SKILL_ENTRYPOINT), "# Demo").unwrap();
+        let target = dir.path().join("target.txt");
+        fs::write(&target, "target").unwrap();
+        create_symlink(&target, &source.join("linked.txt")).unwrap();
+
+        let error = install_skill_with_user_home(
+            &agent_home,
+            None,
+            &crate::types::SkillInstallKind::Local {
+                path: source,
+                mode: SkillInstallMode::Copied,
+            },
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:?}").contains("does not support symlinks"));
+        assert!(!agent_home.join("skills/demo").exists());
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -4,10 +4,12 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
+use serde::Serialize;
 use tracing::warn;
 
 use crate::types::{
-    ActiveSkillRecord, SkillCatalogEntry, SkillRootView, SkillScope, SkillsRuntimeView,
+    ActiveSkillRecord, SkillCatalogEntry, SkillInstallMode, SkillRootView, SkillScope,
+    SkillsRuntimeView,
 };
 
 const SKILL_ENTRYPOINT: &str = "SKILL.md";
@@ -97,6 +99,17 @@ fn select_skill_root(base: Option<&Path>, suffixes: &[&str]) -> Option<PathBuf> 
         }
     }
     None
+}
+
+fn existing_skill_roots(base: Option<&Path>, suffixes: &[&str]) -> Vec<PathBuf> {
+    let Some(base) = base else {
+        return Vec::new();
+    };
+    suffixes
+        .iter()
+        .map(|suffix| base.join(suffix))
+        .filter(|candidate| candidate.is_dir())
+        .collect()
 }
 
 fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<SkillCatalogEntry>> {
@@ -252,6 +265,14 @@ fn validate_skill_name(name: &str) -> Result<()> {
 }
 
 pub fn install_skill(agent_home: &Path, kind: &crate::types::SkillInstallKind) -> Result<String> {
+    install_skill_with_user_home(agent_home, None, kind)
+}
+
+pub fn install_skill_with_user_home(
+    agent_home: &Path,
+    user_home: Option<&Path>,
+    kind: &crate::types::SkillInstallKind,
+) -> Result<String> {
     let skills_root = agent_skills_root(agent_home);
     fs::create_dir_all(&skills_root)
         .with_context(|| format!("failed to create {}", skills_root.display()))?;
@@ -261,17 +282,159 @@ pub fn install_skill(agent_home: &Path, kind: &crate::types::SkillInstallKind) -
             crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
             name.clone()
         }
-        crate::types::SkillInstallKind::Local { path } => {
-            let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            validate_skill_name(file_name)?;
-            let dest = crate::agent_template::materialize_local_skill_ref(&skills_root, path)?;
-            dest.file_name()
-                .and_then(|n| n.to_str())
-                .map(|s| s.to_string())
-                .unwrap_or_default()
+        crate::types::SkillInstallKind::Named { name, mode } => {
+            validate_skill_name(name)?;
+            if crate::agent_template::builtin_skill_names().contains(&name.as_str()) {
+                crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
+                name.clone()
+            } else {
+                let path = resolve_user_skill_by_name(user_home, name)?;
+                materialize_local_skill(&skills_root, &path, mode)?
+            }
+        }
+        crate::types::SkillInstallKind::Local { path, mode } => {
+            materialize_local_skill(&skills_root, path, mode)?
         }
     };
     Ok(name)
+}
+
+fn materialize_local_skill(
+    skills_root: &Path,
+    path: &Path,
+    mode: &SkillInstallMode,
+) -> Result<String> {
+    let path = normalize_local_skill_path(path)?;
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    validate_skill_name(file_name)?;
+    let destination = match mode {
+        SkillInstallMode::Linked => materialize_linked_skill_ref(skills_root, &path)?,
+        SkillInstallMode::Copied => materialize_copied_skill_ref(skills_root, &path)?,
+    };
+    Ok(destination
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_default())
+}
+
+fn normalize_local_skill_path(path: &Path) -> Result<PathBuf> {
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to resolve current directory for local skill path")?
+            .join(path)
+    };
+    if !resolved.is_dir() {
+        bail!("local skill directory does not exist: {}", path.display());
+    }
+    let entrypoint = resolved.join(SKILL_ENTRYPOINT);
+    if !entrypoint.is_file() {
+        bail!(
+            "local skill ref {} does not contain {}",
+            resolved.display(),
+            SKILL_ENTRYPOINT
+        );
+    }
+    Ok(resolved)
+}
+
+fn resolve_user_skill_by_name(user_home: Option<&Path>, name: &str) -> Result<PathBuf> {
+    let mut matches = Vec::new();
+    for root in existing_skill_roots(user_home, &COMPAT_SKILL_ROOT_SUFFIXES) {
+        for skill in load_catalog_for_scope(SkillScope::User, &root)? {
+            let dir_name = skill
+                .path
+                .parent()
+                .and_then(|path| path.file_name())
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            if skill.name == name || dir_name == name {
+                if let Some(skill_dir) = skill.path.parent() {
+                    matches.push(skill_dir.to_path_buf());
+                }
+            }
+        }
+    }
+    matches.sort();
+    matches.dedup();
+    match matches.as_slice() {
+        [path] => Ok(path.clone()),
+        [] => bail!(
+            "skill '{}' is not a builtin skill and was not found in the user-global skill catalog; use an explicit path",
+            name
+        ),
+        paths => bail!(
+            "skill '{}' matched multiple user-global skill directories: {}; use an explicit path",
+            name,
+            paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn materialize_linked_skill_ref(skills_root: &Path, path: &Path) -> Result<PathBuf> {
+    crate::agent_template::materialize_local_skill_ref(skills_root, path)
+}
+
+fn materialize_copied_skill_ref(skills_root: &Path, path: &Path) -> Result<PathBuf> {
+    fs::create_dir_all(skills_root)
+        .with_context(|| format!("failed to create {}", skills_root.display()))?;
+    let skill_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "local skill ref {} has no usable directory name",
+                path.display()
+            )
+        })?;
+    let destination = skills_root.join(skill_name);
+    if destination.exists() {
+        bail!(
+            "template skill destination {} already exists",
+            destination.display()
+        );
+    }
+    copy_dir_all(path, &destination).with_context(|| {
+        format!(
+            "failed to copy local skill ref {} -> {}",
+            path.display(),
+            destination.display()
+        )
+    })?;
+    Ok(destination)
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst).with_context(|| format!("failed to create {}", dst.display()))?;
+    for entry in fs::read_dir(src).with_context(|| format!("failed to read {}", src.display()))? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&src_path, &dst_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&src_path, &dst_path).with_context(|| {
+                format!(
+                    "failed to copy {} -> {}",
+                    src_path.display(),
+                    dst_path.display()
+                )
+            })?;
+        } else if file_type.is_symlink() {
+            let target = fs::read_link(&src_path)
+                .with_context(|| format!("failed to read symlink {}", src_path.display()))?;
+            create_symlink(&target, &dst_path)?;
+        }
+    }
+    Ok(())
 }
 
 pub fn uninstall_skill(agent_home: &Path, name: &str) -> Result<()> {
@@ -300,12 +463,139 @@ pub fn uninstall_skill(agent_home: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<SkillCatalogEntry>> {
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InstalledSkillView {
+    #[serde(flatten)]
+    pub catalog: SkillCatalogEntry,
+    pub install_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_target: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+}
+
+pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<InstalledSkillView>> {
     let skills_root = agent_skills_root(agent_home);
     if !skills_root.is_dir() {
         return Ok(Vec::new());
     }
-    load_catalog_for_scope(SkillScope::Agent, &skills_root)
+    let mut entries = Vec::new();
+    for child in fs::read_dir(&skills_root)
+        .with_context(|| format!("failed to read {}", skills_root.display()))?
+    {
+        let child = child?;
+        let file_type = child.file_type()?;
+        if !file_type.is_dir() && !file_type.is_symlink() {
+            continue;
+        }
+        let skill_name = child.file_name().to_string_lossy().to_string();
+        let skill_path = child.path().join(SKILL_ENTRYPOINT);
+        let catalog = if skill_path.is_file() {
+            let content = fs::read_to_string(&skill_path).with_context(|| {
+                format!("failed to read installed skill {}", skill_path.display())
+            })?;
+            let parsed = parse_skill_metadata(&content);
+            SkillCatalogEntry {
+                skill_id: format!("agent:{skill_name}"),
+                name: parsed.name.unwrap_or_else(|| skill_name.clone()),
+                description: parsed
+                    .description
+                    .unwrap_or_else(|| first_body_paragraph(&content)),
+                path: skill_path,
+                scope: SkillScope::Agent,
+            }
+        } else {
+            SkillCatalogEntry {
+                skill_id: format!("agent:{skill_name}"),
+                name: skill_name.clone(),
+                description: String::new(),
+                path: skill_path,
+                scope: SkillScope::Agent,
+            }
+        };
+        entries.push(installed_skill_view(catalog)?);
+    }
+    entries.sort_by(|left, right| left.catalog.skill_id.cmp(&right.catalog.skill_id));
+    Ok(entries)
+}
+
+fn installed_skill_view(catalog: SkillCatalogEntry) -> Result<InstalledSkillView> {
+    let skill_dir = catalog
+        .path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("skill path {} has no parent", catalog.path.display()))?;
+    let metadata = fs::symlink_metadata(skill_dir)
+        .with_context(|| format!("failed to inspect {}", skill_dir.display()))?;
+    let link_target = if metadata.file_type().is_symlink() {
+        Some(
+            fs::read_link(skill_dir)
+                .with_context(|| format!("failed to read link {}", skill_dir.display()))?,
+        )
+    } else {
+        None
+    };
+    let warning = link_target
+        .as_ref()
+        .and_then(|target| {
+            let target_path = if target.is_absolute() {
+                target.clone()
+            } else {
+                skill_dir
+                    .parent()
+                    .unwrap_or_else(|| Path::new(""))
+                    .join(target)
+            };
+            if !target_path.exists() {
+                Some(format!("link target does not exist: {}", target.display()))
+            } else if !target_path.join(SKILL_ENTRYPOINT).is_file() {
+                Some(format!(
+                    "link target does not contain {}: {}",
+                    SKILL_ENTRYPOINT,
+                    target.display()
+                ))
+            } else {
+                None
+            }
+        })
+        .or_else(|| {
+            if !catalog.path.is_file() {
+                Some(format!(
+                    "installed skill does not contain {}: {}",
+                    SKILL_ENTRYPOINT,
+                    skill_dir.display()
+                ))
+            } else {
+                None
+            }
+        });
+    Ok(InstalledSkillView {
+        install_mode: if link_target.is_some() {
+            "linked".into()
+        } else if crate::agent_template::builtin_skill_names()
+            .contains(&catalog.skill_id.trim_start_matches("agent:"))
+        {
+            "builtin".into()
+        } else {
+            "copied".into()
+        },
+        catalog,
+        link_target,
+        warning,
+    })
+}
+
+#[cfg(unix)]
+fn create_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[cfg(windows)]
+fn create_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if src.is_dir() {
+        std::os::windows::fs::symlink_dir(src, dst)
+    } else {
+        std::os::windows::fs::symlink_file(src, dst)
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -479,5 +769,175 @@ mod tests {
 
         assert_eq!(view.discoverable_skills.len(), 1);
         assert_eq!(view.discoverable_skills[0].name, "good");
+    }
+
+    #[test]
+    fn named_install_links_unique_user_global_skill_for_non_default_agent() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("user");
+        let agent_home = dir.path().join("agent");
+        let source = user_home.join(".agents/skills/global-demo");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join(SKILL_ENTRYPOINT),
+            "---\nname: global-demo\ndescription: global skill\n---\nbody",
+        )
+        .unwrap();
+
+        let installed = install_skill_with_user_home(
+            &agent_home,
+            Some(&user_home),
+            &crate::types::SkillInstallKind::Named {
+                name: "global-demo".into(),
+                mode: SkillInstallMode::Linked,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(installed, "global-demo");
+        let destination = agent_home.join("skills/global-demo");
+        assert!(fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let view = load_skills_runtime_view(
+            SkillVisibility::NonDefaultAgent,
+            Some(&user_home),
+            &agent_home,
+            None,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(view.discoverable_skills.len(), 1);
+        assert_eq!(view.discoverable_skills[0].scope, SkillScope::Agent);
+        assert_eq!(view.discoverable_skills[0].name, "global-demo");
+    }
+
+    #[test]
+    fn local_install_can_copy_skill_directory() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("source/demo");
+        let agent_home = dir.path().join("agent");
+        fs::create_dir_all(source.join("references")).unwrap();
+        fs::write(
+            source.join(SKILL_ENTRYPOINT),
+            "---\nname: demo\ndescription: copied skill\n---\nbody",
+        )
+        .unwrap();
+        fs::write(source.join("references/notes.md"), "notes").unwrap();
+
+        let installed = install_skill_with_user_home(
+            &agent_home,
+            None,
+            &crate::types::SkillInstallKind::Local {
+                path: source.clone(),
+                mode: SkillInstallMode::Copied,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(installed, "demo");
+        let destination = agent_home.join("skills/demo");
+        assert!(destination.join(SKILL_ENTRYPOINT).is_file());
+        assert!(destination.join("references/notes.md").is_file());
+        assert!(!fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let installed = list_installed_skills(&agent_home).unwrap();
+        assert_eq!(installed[0].install_mode, "copied");
+        assert!(installed[0].link_target.is_none());
+    }
+
+    #[test]
+    fn list_installed_skills_reports_builtin_mode() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        install_skill_with_user_home(
+            &agent_home,
+            None,
+            &crate::types::SkillInstallKind::Builtin { name: "ghx".into() },
+        )
+        .unwrap();
+
+        let installed = list_installed_skills(&agent_home).unwrap();
+
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].catalog.name, "ghx");
+        assert_eq!(installed[0].install_mode, "builtin");
+        assert!(installed[0].link_target.is_none());
+        assert!(installed[0].warning.is_none());
+    }
+
+    #[test]
+    fn uninstall_linked_skill_removes_only_agent_local_link() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("source/demo");
+        let agent_home = dir.path().join("agent");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join(SKILL_ENTRYPOINT), "# Demo").unwrap();
+        install_skill_with_user_home(
+            &agent_home,
+            None,
+            &crate::types::SkillInstallKind::Local {
+                path: source.clone(),
+                mode: SkillInstallMode::Linked,
+            },
+        )
+        .unwrap();
+
+        uninstall_skill(&agent_home, "demo").unwrap();
+
+        assert!(source.join(SKILL_ENTRYPOINT).is_file());
+        assert!(!agent_home.join("skills/demo").exists());
+    }
+
+    #[test]
+    fn list_installed_skills_reports_link_mode_and_broken_link_warning() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        let skills_root = agent_home.join("skills");
+        fs::create_dir_all(&skills_root).unwrap();
+        let missing = dir.path().join("missing-skill");
+        create_symlink(&missing, &skills_root.join("missing")).unwrap();
+
+        let installed = list_installed_skills(&agent_home).unwrap();
+
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].catalog.name, "missing");
+        assert_eq!(installed[0].install_mode, "linked");
+        assert_eq!(installed[0].link_target.as_deref(), Some(missing.as_path()));
+        assert!(installed[0]
+            .warning
+            .as_deref()
+            .unwrap_or_default()
+            .contains("link target does not exist"));
+    }
+
+    #[test]
+    fn duplicate_user_global_skill_name_requires_explicit_path() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("user");
+        for root in [".agents/skills", ".codex/skills"] {
+            let source = user_home.join(root).join("demo");
+            fs::create_dir_all(&source).unwrap();
+            fs::write(
+                source.join(SKILL_ENTRYPOINT),
+                "---\nname: demo\ndescription: duplicate\n---\nbody",
+            )
+            .unwrap();
+        }
+
+        let error = install_skill_with_user_home(
+            &dir.path().join("agent"),
+            Some(&user_home),
+            &crate::types::SkillInstallKind::Named {
+                name: "demo".into(),
+                mode: SkillInstallMode::Linked,
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("matched multiple"));
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -574,8 +574,9 @@ impl TuiApp {
                         return Ok(());
                     }
                 };
-                let kind = crate::types::SkillInstallKind::Builtin {
+                let kind = crate::types::SkillInstallKind::Named {
                     name: skill_name.clone(),
+                    mode: crate::types::SkillInstallMode::Linked,
                 };
                 self.client.install_skill(&agent_id, kind).await?;
                 self.status_line = format!("Installed skill: {skill_name}");

--- a/src/types.rs
+++ b/src/types.rs
@@ -674,10 +674,34 @@ pub struct SkillsRuntimeView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillInstallMode {
+    Linked,
+    Copied,
+}
+
+impl Default for SkillInstallMode {
+    fn default() -> Self {
+        Self::Linked
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SkillInstallKind {
-    Builtin { name: String },
-    Local { path: PathBuf },
+    Builtin {
+        name: String,
+    },
+    Named {
+        name: String,
+        #[serde(default)]
+        mode: SkillInstallMode,
+    },
+    Local {
+        path: PathBuf,
+        #[serde(default)]
+        mode: SkillInstallMode,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
Fixes #974.

## Summary

- add `linked` / `copied` install modes for named and local skill installs
- resolve ordinary skill names from the user-global skill catalog for non-default agents while preserving builtin name installs
- default local/user-global installs to agent-local symlinks, with `--copy` for frozen copies
- include installed skill `install_mode`, `link_target`, and broken install warnings in the list API
- switch TUI `/skill-install` to the named install path so global skills can be attached to the selected agent

## Verification

- `cargo fmt`
- `cargo test skills::tests::`
- `cargo check --all-targets`
- `git diff --check`
