### PR TITLE
feat: clarify skill activation monitoring

### DIFF
--- a/docs/rfcs/skill-discovery-and-activation.md
+++ b/docs/rfcs/skill-discovery-and-activation.md
@@ -49,11 +49,31 @@ Skill discovery should not drift with shell cwd.
 
 ## Activation Model
 
-Phase-1 activation should be explicit and inspectable. Holon should record:
+Phase-1 activation should be explicit and inspectable. Discovery alone only
+means a skill's catalog metadata is available to prompt context; it must not
+emit activation events or mark the skill active.
+
+Holon records one user-visible activation event, `skill_activated`, when a
+discovered skill is touched in a way that loads or uses the skill:
 
 - which skill ids were activated
+- which skill name was activated
 - which source path each one came from
 - whether activation came from agent scope or workspace scope
+- why the skill was loaded (`read_skill_md`, `run_skill_script`, or the
+  reserved `prompt_injection`)
+- the turn index and current run id when available
+
+The v1 runtime monitors:
+
+- tool reads of a discovered skill's `SKILL.md`
+- successful shell commands that reference a discovered skill's `SKILL.md`
+- successful shell commands, including command batches, that reference
+  `scripts/*` under a discovered skill root
+
+Successful turn completion promotes current `turn_active` skills to
+`session_active` in state only; it does not emit a second user-visible
+promotion event.
 
 ## Prompt And Resume Behavior
 

--- a/docs/rfcs/skill-discovery-and-activation.md
+++ b/docs/rfcs/skill-discovery-and-activation.md
@@ -58,17 +58,26 @@ discovered skill is touched in a way that loads or uses the skill:
 
 - which skill ids were activated
 - which skill name was activated
-- which source path each one came from
+- which path triggered activation
+- which `SKILL.md` entrypoint the activated skill came from
 - whether activation came from agent scope or workspace scope
 - why the skill was loaded (`read_skill_md`, `run_skill_script`, or the
   reserved `prompt_injection`)
 - the turn index and current run id when available
 
+In the event payload, `path` is the triggering path. For
+`load_reason=read_skill_md`, it is the discovered `SKILL.md`. For
+`load_reason=run_skill_script`, it is the matching `scripts/*` path when the
+runtime can identify one, otherwise the skill's `scripts` directory.
+`entrypoint_path` always points at the skill's `SKILL.md`.
+
 The v1 runtime monitors:
 
 - tool reads of a discovered skill's `SKILL.md`
 - successful shell commands that reference a discovered skill's `SKILL.md`
-- successful shell commands, including command batches, that reference
+- successful shell command-batch items that completed and reference a
+  discovered skill's `SKILL.md`
+- successful shell commands, including completed command-batch items, that reference
   `scripts/*` under a discovered skill root
 
 Successful turn completion promotes current `turn_active` skills to

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -789,12 +789,20 @@ Prompt context includes catalog metadata and active-skill metadata, but not raw
 System prompt guidance tells the agent that if a listed skill matches the task,
 it should open that skill's `SKILL.md` before following the workflow.
 
-Activation is currently minimal and file-based:
+Activation is currently minimal and file-based. Discovery alone does not mark a
+skill active and does not emit an activation event:
 
-- reading a discovered catalog entry's `SKILL.md` marks that skill
-  `turn_active`
+- reading a discovered catalog entry's `SKILL.md` marks that skill `turn_active`
+  and emits `skill_activated` with `load_reason=read_skill_md`
+- a successful command or command batch that references that `SKILL.md` does the
+  same
+- a successful command or command batch that references `scripts/*` under a
+  discovered skill root marks the skill `turn_active` and emits
+  `skill_activated` with `load_reason=run_skill_script`
+- `prompt_injection` is reserved as a future `load_reason` for runtime-driven
+  `SKILL.md` prompt injection
 - successful turn completion promotes current turn-active skills to
-  `session_active`
+  `session_active` without emitting a separate promotion event
 - resumed session-active skills are restored into runtime state as `restored`
 
 This keeps skill behavior inspectable without adding a dedicated activation

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -805,6 +805,11 @@ skill active and does not emit an activation event:
   `session_active` without emitting a separate promotion event
 - resumed session-active skills are restored into runtime state as `restored`
 
+For `skill_activated`, `path` is the triggering activation path. It is the
+discovered `SKILL.md` for `read_skill_md`, and the matching `scripts/*` path
+for `run_skill_script` when one can be identified. `entrypoint_path` always
+points at the activated skill's `SKILL.md`.
+
 This keeps skill behavior inspectable without adding a dedicated activation
 control surface in v0.
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -54,7 +54,10 @@ use crate::{
     prompt::{build_effective_prompt, EffectivePrompt},
     provider::{provider_attempt_timeline, AgentProvider, ModelBlock},
     queue::RuntimeQueue,
-    skills::{find_skill_by_entrypoint, load_skills_runtime_view, SkillVisibility},
+    skills::{
+        find_skill_by_entrypoint, find_skill_by_script_path, load_skills_runtime_view,
+        SkillVisibility,
+    },
     storage::{to_json_value, AppStorage, PollActivityMarker},
     system::{
         EffectiveExecution, ExecutionScopeKind, ExecutionSnapshot, LocalSystem,
@@ -71,9 +74,9 @@ use crate::{
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
         Priority, QueueEntryRecord, QueueEntryStatus, ResolvedModelAvailability,
         RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
-        SkillActivationState, SkillsRuntimeView, TaskKind, TaskRecord, TaskRecoverySpec,
-        TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
+        SkillActivationState, SkillCatalogEntry, SkillLoadReason, SkillsRuntimeView, TaskKind,
+        TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
+        TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
         WaitingIntentSummary, WorkItemState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
     web::WebConfig,
@@ -664,9 +667,10 @@ impl RuntimeHandle {
         input: &serde_json::Value,
     ) -> Result<()> {
         match tool_name {
-            "Read" => {
+            "Read" | "ReadFile" => {
                 if let Some(file_path) = input.get("file_path").and_then(|value| value.as_str()) {
-                    self.record_skill_read_activation(file_path).await?;
+                    self.record_skill_read_activation(file_path, SkillLoadReason::ReadSkillMd)
+                        .await?;
                 }
             }
             "ExecCommand" => {
@@ -674,12 +678,25 @@ impl RuntimeHandle {
                     self.record_skill_command_activation(command).await?;
                 }
             }
+            "ExecCommandBatch" => {
+                if let Some(items) = input.get("items").and_then(|value| value.as_array()) {
+                    for item in items {
+                        if let Some(command) = item.get("cmd").and_then(|value| value.as_str()) {
+                            self.record_skill_command_activation(command).await?;
+                        }
+                    }
+                }
+            }
             _ => {}
         }
         Ok(())
     }
 
-    pub(crate) async fn record_skill_read_activation(&self, file_path: &str) -> Result<()> {
+    pub(crate) async fn record_skill_read_activation(
+        &self,
+        file_path: &str,
+        load_reason: SkillLoadReason,
+    ) -> Result<()> {
         let execution = self
             .effective_execution(ExecutionScopeKind::AgentTurn)
             .await?;
@@ -690,15 +707,16 @@ impl RuntimeHandle {
         };
         let identity = self.agent_identity_view().await?;
         let skills = self.skills_runtime_view_for_state(&state_snapshot, &identity)?;
-        let Some(skill) = find_skill_by_entrypoint(&skills.discoverable_skills, &resolved_path)
+        let Some(skill) = skill_for_activation_path(&skills.discoverable_skills, &resolved_path)
         else {
             return Ok(());
         };
         let mut guard = self.inner.agent.lock().await;
         let turn_index = guard.state.turn_index;
         let agent_id = guard.state.id.clone();
+        let run_id = guard.state.current_run_id.clone();
 
-        if let Some(existing) = guard
+        let repeated = if let Some(existing) = guard
             .state
             .active_skills
             .iter_mut()
@@ -707,6 +725,7 @@ impl RuntimeHandle {
             existing.activation_state = SkillActivationState::TurnActive;
             existing.activation_source = SkillActivationSource::ImplicitFromCatalog;
             existing.activated_at_turn = turn_index;
+            true
         } else {
             guard
                 .state
@@ -721,18 +740,23 @@ impl RuntimeHandle {
                     activation_state: SkillActivationState::TurnActive,
                     activated_at_turn: turn_index,
                 });
-        }
+            false
+        };
         self.inner.storage.write_agent(&guard.state)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "skill_activated",
             serde_json::json!({
                 "agent_id": agent_id,
                 "skill_id": skill.skill_id,
+                "skill_name": skill.name,
                 "path": skill.path,
                 "scope": skill.scope,
                 "activation_source": SkillActivationSource::ImplicitFromCatalog,
                 "activation_state": SkillActivationState::TurnActive,
+                "load_reason": load_reason,
                 "turn_index": turn_index,
+                "run_id": run_id,
+                "repeated": repeated,
             }),
         ))?;
         Ok(())
@@ -752,7 +776,8 @@ impl RuntimeHandle {
         for skill in skills.discoverable_skills {
             if command_mentions_path(command, &skill.path) {
                 let skill_path = skill.path.to_string_lossy().into_owned();
-                self.record_skill_read_activation(&skill_path).await?;
+                self.record_skill_read_activation(&skill_path, SkillLoadReason::ReadSkillMd)
+                    .await?;
                 continue;
             }
 
@@ -762,7 +787,34 @@ impl RuntimeHandle {
             {
                 if command_mentions_path(command, relative_to_workspace) {
                     let skill_path = skill.path.to_string_lossy().into_owned();
-                    self.record_skill_read_activation(&skill_path).await?;
+                    self.record_skill_read_activation(&skill_path, SkillLoadReason::ReadSkillMd)
+                        .await?;
+                    continue;
+                }
+            }
+
+            if let Some(skill_root) = skill.path.parent() {
+                let scripts_root = skill_root.join("scripts");
+                if command_mentions_path(command, &scripts_root) {
+                    let script_path = scripts_root.to_string_lossy().into_owned();
+                    self.record_skill_read_activation(
+                        &script_path,
+                        SkillLoadReason::RunSkillScript,
+                    )
+                    .await?;
+                    continue;
+                }
+                if let Ok(relative_to_workspace) =
+                    scripts_root.strip_prefix(execution.workspace.workspace_anchor())
+                {
+                    if command_mentions_path(command, relative_to_workspace) {
+                        let script_path = scripts_root.to_string_lossy().into_owned();
+                        self.record_skill_read_activation(
+                            &script_path,
+                            SkillLoadReason::RunSkillScript,
+                        )
+                        .await?;
+                    }
                 }
             }
         }
@@ -1020,6 +1072,13 @@ impl RuntimeHandle {
 fn command_mentions_path(command: &str, path: &Path) -> bool {
     let display = path.to_string_lossy();
     command.contains(display.as_ref())
+}
+
+fn skill_for_activation_path<'a>(
+    skills: &'a [SkillCatalogEntry],
+    path: &Path,
+) -> Option<&'a SkillCatalogEntry> {
+    find_skill_by_entrypoint(skills, path).or_else(|| find_skill_by_script_path(skills, path))
 }
 
 #[cfg(test)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -24,6 +24,7 @@ mod worktree;
 
 use std::{
     collections::HashMap,
+    fs,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -63,21 +64,22 @@ use crate::{
         EffectiveExecution, ExecutionScopeKind, ExecutionSnapshot, LocalSystem,
         WorkspaceAccessMode, WorkspaceProjectionKind, WorkspaceView,
     },
-    tool::ToolRegistry,
+    tool::{ToolRegistry, ToolResult},
     types::{
         ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView, AgentKind, AgentState,
         AgentStatus, AgentSummary, AuditEvent, BriefRecord, CallbackDeliveryMode,
         CallbackDeliveryPayload, CallbackDeliveryResult, CallbackIngressDisposition,
         CancelWaitingResult, ClosureDecision, ContinuationResolution, ControlAction,
-        ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerScope,
-        ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
-        Priority, QueueEntryRecord, QueueEntryStatus, ResolvedModelAvailability,
-        RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
-        SkillActivationState, SkillCatalogEntry, SkillLoadReason, SkillsRuntimeView, TaskKind,
-        TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
-        TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
-        WaitingIntentSummary, WorkItemState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
+        ExecCommandBatchItemStatus, ExecCommandBatchResult, ExternalTriggerCapability,
+        ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus, ExternalTriggerSummary,
+        LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
+        MessageOrigin, PendingWakeHint, Priority, QueueEntryRecord, QueueEntryStatus,
+        ResolvedModelAvailability, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
+        SkillActivationSource, SkillActivationState, SkillCatalogEntry, SkillLoadReason,
+        SkillsRuntimeView, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord,
+        TimerStatus, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        WaitingIntentRecord, WaitingIntentStatus, WaitingIntentSummary, WorkItemState,
+        WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
     web::WebConfig,
 };
@@ -665,6 +667,7 @@ impl RuntimeHandle {
         &self,
         tool_name: &str,
         input: &serde_json::Value,
+        result: &ToolResult,
     ) -> Result<()> {
         match tool_name {
             "Read" | "ReadFile" => {
@@ -679,10 +682,12 @@ impl RuntimeHandle {
                 }
             }
             "ExecCommandBatch" => {
-                if let Some(items) = input.get("items").and_then(|value| value.as_array()) {
-                    for item in items {
-                        if let Some(command) = item.get("cmd").and_then(|value| value.as_str()) {
-                            self.record_skill_command_activation(command).await?;
+                if let Some(batch) = result.envelope.result.as_ref().and_then(|value| {
+                    serde_json::from_value::<ExecCommandBatchResult>(value.clone()).ok()
+                }) {
+                    for item in batch.items {
+                        if matches!(item.status, ExecCommandBatchItemStatus::Completed) {
+                            self.record_skill_command_activation(&item.cmd).await?;
                         }
                     }
                 }
@@ -749,7 +754,8 @@ impl RuntimeHandle {
                 "agent_id": agent_id,
                 "skill_id": skill.skill_id,
                 "skill_name": skill.name,
-                "path": skill.path,
+                "path": resolved_path,
+                "entrypoint_path": skill.path,
                 "scope": skill.scope,
                 "activation_source": SkillActivationSource::ImplicitFromCatalog,
                 "activation_state": SkillActivationState::TurnActive,
@@ -774,48 +780,12 @@ impl RuntimeHandle {
         let skills = self.skills_runtime_view_for_state(&state_snapshot, &identity)?;
 
         for skill in skills.discoverable_skills {
-            if command_mentions_path(command, &skill.path) {
-                let skill_path = skill.path.to_string_lossy().into_owned();
-                self.record_skill_read_activation(&skill_path, SkillLoadReason::ReadSkillMd)
-                    .await?;
-                continue;
-            }
-
-            if let Ok(relative_to_workspace) = skill
-                .path
-                .strip_prefix(execution.workspace.workspace_anchor())
+            if let Some((activation_path, load_reason)) =
+                command_skill_activation(command, &skill, execution.workspace.workspace_anchor())
             {
-                if command_mentions_path(command, relative_to_workspace) {
-                    let skill_path = skill.path.to_string_lossy().into_owned();
-                    self.record_skill_read_activation(&skill_path, SkillLoadReason::ReadSkillMd)
-                        .await?;
-                    continue;
-                }
-            }
-
-            if let Some(skill_root) = skill.path.parent() {
-                let scripts_root = skill_root.join("scripts");
-                if command_mentions_path(command, &scripts_root) {
-                    let script_path = scripts_root.to_string_lossy().into_owned();
-                    self.record_skill_read_activation(
-                        &script_path,
-                        SkillLoadReason::RunSkillScript,
-                    )
+                let activation_path = activation_path.to_string_lossy().into_owned();
+                self.record_skill_read_activation(&activation_path, load_reason)
                     .await?;
-                    continue;
-                }
-                if let Ok(relative_to_workspace) =
-                    scripts_root.strip_prefix(execution.workspace.workspace_anchor())
-                {
-                    if command_mentions_path(command, relative_to_workspace) {
-                        let script_path = scripts_root.to_string_lossy().into_owned();
-                        self.record_skill_read_activation(
-                            &script_path,
-                            SkillLoadReason::RunSkillScript,
-                        )
-                        .await?;
-                    }
-                }
             }
         }
         Ok(())
@@ -1072,6 +1042,71 @@ impl RuntimeHandle {
 fn command_mentions_path(command: &str, path: &Path) -> bool {
     let display = path.to_string_lossy();
     command.contains(display.as_ref())
+}
+
+fn command_skill_activation(
+    command: &str,
+    skill: &SkillCatalogEntry,
+    workspace_anchor: &Path,
+) -> Option<(PathBuf, SkillLoadReason)> {
+    if command_mentions_path(command, &skill.path)
+        || skill
+            .path
+            .strip_prefix(workspace_anchor)
+            .map(|relative| command_mentions_path(command, relative))
+            .unwrap_or(false)
+    {
+        return Some((skill.path.clone(), SkillLoadReason::ReadSkillMd));
+    }
+
+    let skill_root = skill.path.parent()?;
+    let scripts_root = skill_root.join("scripts");
+    for script_path in script_paths_under(&scripts_root) {
+        if command_mentions_path(command, &script_path)
+            || script_path
+                .strip_prefix(workspace_anchor)
+                .map(|relative| command_mentions_path(command, relative))
+                .unwrap_or(false)
+        {
+            return Some((script_path, SkillLoadReason::RunSkillScript));
+        }
+    }
+
+    if command_mentions_path(command, &scripts_root)
+        || scripts_root
+            .strip_prefix(workspace_anchor)
+            .map(|relative| command_mentions_path(command, relative))
+            .unwrap_or(false)
+    {
+        return Some((scripts_root, SkillLoadReason::RunSkillScript));
+    }
+
+    None
+}
+
+fn script_paths_under(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    collect_script_paths(root, &mut paths);
+    paths
+}
+
+fn collect_script_paths(path: &Path, paths: &mut Vec<PathBuf>) {
+    let Ok(metadata) = fs::metadata(path) else {
+        return;
+    };
+    if metadata.is_file() {
+        paths.push(path.to_path_buf());
+        return;
+    }
+    if !metadata.is_dir() {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        collect_script_paths(&entry.path(), paths);
+    }
 }
 
 fn skill_for_activation_path<'a>(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::support::*;
-use crate::types::AuthorityClass;
+use crate::types::{AuthorityClass, SkillLoadReason};
 
 struct BlockingProvider {
     started: Arc<tokio::sync::Notify>,
@@ -1321,9 +1321,141 @@ async fn reading_discovered_skill_marks_it_active_and_promotes_on_success() {
     assert_eq!(skill.activated_at_turn, state.turn_index);
 
     let events = runtime.storage().read_recent_events(20).unwrap();
-    assert!(events.iter().any(|event| {
-        event.kind == "skill_activated" && event.data["skill_id"] == "workspace:demo"
-    }));
+    let activation = events
+        .iter()
+        .find(|event| event.kind == "skill_activated" && event.data["skill_id"] == "workspace:demo")
+        .expect("skill_activated event should be recorded");
+    assert_eq!(activation.data["skill_name"], "demo");
+    assert_eq!(activation.data["load_reason"], "read_skill_md");
+    assert_eq!(
+        activation.data["activation_source"],
+        "implicit_from_catalog"
+    );
+    assert_eq!(activation.data["repeated"], false);
+    assert!(activation.data.get("run_id").is_some());
+}
+
+#[tokio::test]
+async fn batch_command_reading_discovered_skill_marks_it_active() {
+    let (_dir, _workspace, runtime) = run_skill_activation_probe(
+        Arc::new(SkillActivationCommandProvider::new(
+            "ExecCommandBatch",
+            serde_json::json!({
+                "items": [
+                    {
+                        "cmd": "sed -n '1,8p' .agents/skills/demo/SKILL.md",
+                        "workdir": "."
+                    }
+                ]
+            }),
+        )),
+        false,
+    )
+    .await;
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.active_skills.len(), 1);
+    assert_eq!(state.active_skills[0].skill_id, "workspace:demo");
+
+    let activation = skill_activation_event(&runtime, "workspace:demo");
+    assert_eq!(activation.data["skill_name"], "demo");
+    assert_eq!(activation.data["load_reason"], "read_skill_md");
+}
+
+#[tokio::test]
+async fn command_running_skill_script_marks_it_active_with_script_reason() {
+    let (_dir, _workspace, runtime) = run_skill_activation_probe(
+        Arc::new(SkillActivationCommandProvider::new(
+            "ExecCommand",
+            serde_json::json!({
+                "cmd": "sh .agents/skills/demo/scripts/run.sh",
+                "workdir": "."
+            }),
+        )),
+        true,
+    )
+    .await;
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.active_skills.len(), 1);
+    assert_eq!(state.active_skills[0].skill_id, "workspace:demo");
+
+    let activation = skill_activation_event(&runtime, "workspace:demo");
+    assert_eq!(activation.data["skill_name"], "demo");
+    assert_eq!(
+        activation.data["load_reason"],
+        serde_json::json!(SkillLoadReason::RunSkillScript)
+    );
+}
+
+async fn run_skill_activation_probe(
+    provider: Arc<dyn AgentProvider>,
+    include_script: bool,
+) -> (TempDir, TempDir, RuntimeHandle) {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let skill_dir = workspace.path().join(".agents/skills/demo");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: demo skill\n---\nFollow the demo workflow.",
+    )
+    .unwrap();
+    if include_script {
+        std::fs::create_dir_all(skill_dir.join("scripts")).unwrap();
+        std::fs::write(skill_dir.join("scripts/run.sh"), "printf script-ran\n").unwrap();
+    }
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        ContextConfig {
+            prompt_budget_estimated_tokens: 65536,
+            compaction_keep_recent_estimated_tokens: 4096,
+            ..context_config()
+        },
+    )
+    .unwrap();
+
+    runtime
+        .begin_interactive_turn_for_test(None, None)
+        .await
+        .unwrap();
+    let prompt = runtime
+        .preview_prompt(
+            "use the demo skill".to_string(),
+            TrustLevel::TrustedOperator,
+        )
+        .await
+        .unwrap();
+    let outcome = runtime
+        .run_agent_loop(
+            "default",
+            TrustLevel::TrustedOperator,
+            prompt,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+    runtime.promote_turn_active_skills().await.unwrap();
+    assert_eq!(outcome.terminal_kind, TurnTerminalKind::Completed);
+    (dir, workspace, runtime)
+}
+
+fn skill_activation_event(runtime: &RuntimeHandle, skill_id: &str) -> AuditEvent {
+    runtime
+        .storage()
+        .read_recent_events(20)
+        .unwrap()
+        .into_iter()
+        .find(|event| event.kind == "skill_activated" && event.data["skill_id"] == skill_id)
+        .expect("skill_activated event should be recorded")
 }
 
 #[test]

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1327,6 +1327,11 @@ async fn reading_discovered_skill_marks_it_active_and_promotes_on_success() {
         .expect("skill_activated event should be recorded");
     assert_eq!(activation.data["skill_name"], "demo");
     assert_eq!(activation.data["load_reason"], "read_skill_md");
+    assert!(activation.data["path"]
+        .as_str()
+        .unwrap()
+        .ends_with(".agents/skills/demo/SKILL.md"));
+    assert_eq!(activation.data["path"], activation.data["entrypoint_path"]);
     assert_eq!(
         activation.data["activation_source"],
         "implicit_from_catalog"
@@ -1360,6 +1365,7 @@ async fn batch_command_reading_discovered_skill_marks_it_active() {
     let activation = skill_activation_event(&runtime, "workspace:demo");
     assert_eq!(activation.data["skill_name"], "demo");
     assert_eq!(activation.data["load_reason"], "read_skill_md");
+    assert_eq!(activation.data["path"], activation.data["entrypoint_path"]);
 }
 
 #[tokio::test]
@@ -1386,6 +1392,44 @@ async fn command_running_skill_script_marks_it_active_with_script_reason() {
         activation.data["load_reason"],
         serde_json::json!(SkillLoadReason::RunSkillScript)
     );
+    assert!(activation.data["path"]
+        .as_str()
+        .unwrap()
+        .ends_with(".agents/skills/demo/scripts/run.sh"));
+    assert!(activation.data["entrypoint_path"]
+        .as_str()
+        .unwrap()
+        .ends_with(".agents/skills/demo/SKILL.md"));
+}
+
+#[tokio::test]
+async fn batch_skipped_skill_command_does_not_mark_skill_active() {
+    let (_dir, _workspace, runtime) = run_skill_activation_probe(
+        Arc::new(SkillActivationCommandProvider::new(
+            "ExecCommandBatch",
+            serde_json::json!({
+                "stop_on_error": true,
+                "items": [
+                    {
+                        "cmd": "false",
+                        "workdir": "."
+                    },
+                    {
+                        "cmd": "cat .agents/skills/demo/SKILL.md",
+                        "workdir": "."
+                    }
+                ]
+            }),
+        )),
+        false,
+    )
+    .await;
+
+    let state = runtime.agent_state().await.unwrap();
+    assert!(state.active_skills.is_empty());
+
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(!events.iter().any(|event| event.kind == "skill_activated"));
 }
 
 async fn run_skill_activation_probe(

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -774,6 +774,12 @@ pub(crate) struct SkillReadProvider {
     pub(crate) calls: Mutex<usize>,
 }
 
+pub(crate) struct SkillActivationCommandProvider {
+    pub(crate) calls: Mutex<usize>,
+    pub(crate) tool_name: &'static str,
+    pub(crate) input: serde_json::Value,
+}
+
 pub(crate) struct CountingProvider {
     pub(crate) calls: Mutex<usize>,
     pub(crate) reply: &'static str,
@@ -791,6 +797,16 @@ impl SkillReadProvider {
     pub(crate) fn new() -> Self {
         Self {
             calls: Mutex::new(0),
+        }
+    }
+}
+
+impl SkillActivationCommandProvider {
+    pub(crate) fn new(tool_name: &'static str, input: serde_json::Value) -> Self {
+        Self {
+            calls: Mutex::new(0),
+            tool_name,
+            input,
         }
     }
 }
@@ -881,6 +897,34 @@ impl AgentProvider for SkillReadProvider {
             }],
             _ => vec![ModelBlock::Text {
                 text: "Skill loaded and applied.".into(),
+            }],
+        };
+
+        Ok(ProviderTurnResponse {
+            blocks,
+            stop_reason: None,
+            input_tokens: 20,
+            output_tokens: 20,
+            cache_usage: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
+#[async_trait]
+impl AgentProvider for SkillActivationCommandProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+
+        let blocks = match *calls {
+            1 => vec![ModelBlock::ToolUse {
+                id: "activate-skill".into(),
+                name: self.tool_name.into(),
+                input: self.input.clone(),
+            }],
+            _ => vec![ModelBlock::Text {
+                text: "Skill activation observed.".into(),
             }],
         };
 

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -2403,7 +2403,11 @@ impl TurnExecution<'_> {
                         runtime.inner.storage.append_tool_execution(&record)?;
                         if matches!(record.status, crate::types::ToolExecutionStatus::Success) {
                             runtime
-                                .record_skill_tool_activation(&record.tool_name, &record.input)
+                                .record_skill_tool_activation(
+                                    &record.tool_name,
+                                    &record.input,
+                                    &result,
+                                )
                                 .await?;
                         }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -91,6 +91,19 @@ pub fn find_skill_by_entrypoint<'a>(
     skills.iter().find(|entry| entry.path == path)
 }
 
+pub fn find_skill_by_script_path<'a>(
+    skills: &'a [SkillCatalogEntry],
+    path: &Path,
+) -> Option<&'a SkillCatalogEntry> {
+    skills.iter().find(|entry| {
+        entry
+            .path
+            .parent()
+            .map(|skill_root| path.starts_with(skill_root.join("scripts")))
+            .unwrap_or(false)
+    })
+}
+
 fn select_skill_root(base: Option<&Path>, suffixes: &[&str]) -> Option<PathBuf> {
     let base = base?;
     for suffix in suffixes {

--- a/src/types.rs
+++ b/src/types.rs
@@ -493,6 +493,14 @@ pub enum SkillActivationState {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum SkillLoadReason {
+    ReadSkillMd,
+    RunSkillScript,
+    PromptInjection,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum ClosureOutcome {
     Completed,
     Continuable,


### PR DESCRIPTION
## Summary

Closes #973.

- clarify the skill activation contract in the RFC and runtime spec
- add `SkillLoadReason` and enrich `skill_activated` events with skill name, load reason, run id, turn index, and repeated status
- monitor `ExecCommandBatch` commands and skill `scripts/*` command references in addition to `SKILL.md` reads
- keep promotion to `session_active` as a state-only update with no separate user-visible event

## Verification

- `cargo fmt`
- `cargo test skill_marks_it_active`
- `cargo test command_running_skill_script_marks_it_active_with_script_reason`
- `cargo check --all-targets`
- `git diff --check`
