### PR TITLE
Fix remote TUI refreshes blocking local input

### DIFF
--- a/docs/rfcs/remote-tui-access.md
+++ b/docs/rfcs/remote-tui-access.md
@@ -88,3 +88,25 @@ Remote clients should call `GET /handshake` first. The response reports:
 
 Auth mismatch, unsupported URLs, missing tokens, and invalid advertise/connect
 URLs should fail before silently falling back to local runtime state.
+
+## Client Responsiveness
+
+The first-party TUI must keep terminal input and drawing local. Remote
+control-plane refreshes are allowed to update local connection state, but they
+must not be awaited by the main input/render loop.
+
+In remote mode, the TUI treats these operations as background work:
+
+- public agent list refreshes
+- selected-agent `/state` bootstrap and forced refresh
+- SSE open and reconnect attempts
+
+The main loop consumes completed background results and stream events from a
+local runtime channel. A slow LAN, tailnet hop, unavailable server, or stalled
+SSE connect should therefore surface as loading, stale, reconnecting, or
+disconnected state instead of freezing text entry, cursor movement, or basic
+redraws.
+
+Remote HTTP request setup should use shorter connect and request-open timeouts
+than same-host local control requests. Long-lived SSE reads may remain open
+after the initial response has been established.

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,6 +23,9 @@ use crate::{
 };
 
 const UNIX_CONTROL_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCAL_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const REMOTE_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+const REMOTE_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone)]
 pub struct LocalClient {
@@ -241,7 +244,7 @@ impl LocalClient {
             return Err(anyhow!("remote TUI token must not be empty"));
         }
         let http = reqwest::Client::builder()
-            .connect_timeout(Duration::from_secs(5))
+            .connect_timeout(REMOTE_HTTP_CONNECT_TIMEOUT)
             .build()
             .context("failed to build remote control client")?;
         Ok(Self {
@@ -556,7 +559,7 @@ impl LocalClient {
     async fn send_http(&self, request: RequestSpec, include_control_auth: bool) -> Result<Vec<u8>> {
         let response = self
             .build_http_request(&request, include_control_auth)
-            .timeout(Duration::from_secs(10))
+            .timeout(self.http_request_timeout())
             .send()
             .await
             .with_context(|| format!("failed to send {}", request.path))?;
@@ -582,6 +585,7 @@ impl LocalClient {
             builder = builder.header("Last-Event-ID", last_event_id);
         }
         let response = builder
+            .timeout(self.http_request_timeout())
             .send()
             .await
             .with_context(|| format!("failed to open event stream {}", path))?;
@@ -626,6 +630,14 @@ impl LocalClient {
             format!("{}{}", remote.base_url, path)
         } else {
             format!("http://{}{}", self.config.http_addr, path)
+        }
+    }
+
+    fn http_request_timeout(&self) -> Duration {
+        if self.remote.is_some() {
+            REMOTE_HTTP_REQUEST_TIMEOUT
+        } else {
+            LOCAL_HTTP_REQUEST_TIMEOUT
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -206,12 +206,6 @@ impl Drop for TerminalCleanupGuard {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use serde_json::json;
-    use std::path::PathBuf;
-    use tokio::sync::mpsc;
-
     use super::{
         build_chat_text, centered_rect_rows, chat_text, collect_chat_items,
         determine_alt_screen_mode_for_terminal, draw, is_cursor_too_old_error,
@@ -238,8 +232,12 @@ mod tests {
             TokenUsage, TranscriptEntry, TranscriptEntryKind, WaitingIntentSummary,
         },
     };
+    use chrono::Utc;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::text::{Line, Text};
     use ratatui::{backend::TestBackend, layout::Rect, Terminal};
+    use serde_json::json;
+    use std::path::PathBuf;
 
     fn test_config() -> AppConfig {
         let temp = tempfile::tempdir().unwrap().keep();
@@ -931,7 +929,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn agent_overlay_enter_keeps_open_on_failed_switch() {
+    async fn agent_overlay_enter_starts_switch_without_awaiting_snapshot() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(
             client,
@@ -942,16 +940,13 @@ mod tests {
         app.overlay = OverlayState::Agents;
         app.connection_state = TuiConnectionState::Streaming;
 
-        let err = app
-            .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert_eq!(app.overlay, OverlayState::Agents);
-        assert_eq!(
-            app.status_line,
-            format!("Failed to switch to agent beta: {err}")
-        );
+        assert_eq!(app.overlay, OverlayState::None);
+        assert_eq!(app.status_line, "Bootstrapping agent beta from /state");
+        assert!(app.snapshot_refresh_in_flight);
     }
 
     #[tokio::test]
@@ -2477,9 +2472,8 @@ mod tests {
             client,
             crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
         );
-        let (tx, rx) = mpsc::unbounded_channel();
+        let tx = app.runtime_tx.clone();
         app.connection_state = TuiConnectionState::Streaming;
-        app.stream_messages = Some(rx);
 
         tx.send(TuiRuntimeMessage::Disconnected {
             error: "socket closed".into(),
@@ -2541,8 +2535,7 @@ mod tests {
             "default", "cursor-1",
         )));
         app.connection_state = TuiConnectionState::Streaming;
-        let (tx, rx) = mpsc::unbounded_channel();
-        app.stream_messages = Some(rx);
+        let tx = app.runtime_tx.clone();
 
         tx.send(TuiRuntimeMessage::Event(AgentStreamEvent {
             id: "evt-stale".into(),
@@ -2634,7 +2627,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_agent_switch_keeps_existing_selection() {
+    async fn agent_switch_starts_snapshot_refresh_without_awaiting_network() {
         let client = LocalClient::new(test_config()).unwrap();
         let mut app = TuiApp::new(
             client,
@@ -2645,18 +2638,93 @@ mod tests {
         app.connection_state = TuiConnectionState::Streaming;
         app.status_line = "Streaming native events for agent alpha".into();
 
-        let err = app.move_agent_selection(1).await.unwrap_err();
+        app.move_agent_selection(1).await.unwrap();
 
-        assert!(err.to_string().contains("/agents/beta/state"));
         assert_eq!(app.selected_agent_id(), Some("alpha"));
         assert!(matches!(
             app.connection_state,
-            TuiConnectionState::Streaming
+            TuiConnectionState::Bootstrapping
         ));
-        assert_eq!(
-            app.status_line,
-            format!("Failed to switch to agent beta: {err}")
+        assert!(app.snapshot_refresh_in_flight);
+        assert_eq!(app.status_line, "Bootstrapping agent beta from /state");
+    }
+
+    #[tokio::test]
+    async fn remote_tick_does_not_await_slow_agent_list_refresh() {
+        let client = slow_remote_client().await;
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
         );
+        app.agent_list_refresh_deadline = Some(std::time::Instant::now());
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), app.tick())
+            .await
+            .expect("tick should not wait for slow /agents")
+            .unwrap();
+
+        assert!(app.agent_list_refresh_in_flight);
+    }
+
+    #[tokio::test]
+    async fn remote_tick_does_not_await_slow_snapshot_refresh() {
+        let client = slow_remote_client().await;
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.agents = vec![sample_agent_summary("default")];
+        app.selected_agent = 0;
+        app.schedule_refresh("test refresh".into());
+        app.refresh_deadline = Some(std::time::Instant::now());
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), app.tick())
+            .await
+            .expect("tick should not wait for slow /state")
+            .unwrap();
+
+        assert!(app.snapshot_refresh_in_flight);
+        assert!(matches!(
+            app.connection_state,
+            TuiConnectionState::Bootstrapping
+        ));
+    }
+
+    #[tokio::test]
+    async fn remote_tick_does_not_await_slow_event_stream_reconnect() {
+        let client = slow_remote_client().await;
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.agents = vec![sample_agent_summary("default")];
+        app.selected_agent = 0;
+        app.projection = Some(TuiProjection::from_snapshot(sample_snapshot(
+            "default", "cursor-1",
+        )));
+        app.schedule_reconnect("test reconnect".into());
+        app.reconnect_deadline = Some(std::time::Instant::now());
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), app.tick())
+            .await
+            .expect("tick should not wait for slow event stream reconnect")
+            .unwrap();
+
+        assert!(app.stream_connect_in_flight);
+    }
+
+    async fn slow_remote_client() -> LocalClient {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((socket, _peer)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _socket = socket;
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                });
+            }
+        });
+        LocalClient::remote(test_config(), format!("http://{addr}"), "secret").unwrap()
     }
 
     fn test_app() -> TuiApp {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,10 @@ use super::state::{tui_state_path, TuiClientState};
 use super::*;
 use std::cell::RefCell;
 use std::path::PathBuf;
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    task::JoinHandle,
+};
 
 pub(super) struct TuiApp {
     pub(super) client: LocalClient,
@@ -14,11 +17,17 @@ pub(super) struct TuiApp {
     pub(super) tasks: Vec<TaskRecord>,
     pub(super) projection: Option<TuiProjection>,
     pub(super) connection_state: TuiConnectionState,
-    pub(super) stream_messages: Option<mpsc::UnboundedReceiver<TuiRuntimeMessage>>,
+    pub(super) runtime_tx: UnboundedSender<TuiRuntimeMessage>,
+    pub(super) runtime_messages: UnboundedReceiver<TuiRuntimeMessage>,
     pub(super) stream_task: Option<JoinHandle<()>>,
     pub(super) agent_list_refresh_deadline: Option<Instant>,
     pub(super) reconnect_deadline: Option<Instant>,
     pub(super) refresh_deadline: Option<Instant>,
+    pub(super) agent_list_refresh_in_flight: bool,
+    pub(super) snapshot_refresh_in_flight: bool,
+    pub(super) stream_connect_in_flight: bool,
+    pub(super) snapshot_refresh_request_id: u64,
+    pub(super) stream_connect_request_id: u64,
     pub(super) reconnect_attempt: u32,
     pub(super) selected_agent: usize,
     pub(super) preferred_agent_id: Option<String>,
@@ -47,6 +56,7 @@ impl TuiApp {
         let preferred_agent_id = TuiClientState::load(&state_path)
             .ok()
             .map(|state| state.last_selected_agent_id);
+        let (runtime_tx, runtime_messages) = mpsc::unbounded_channel();
         Self {
             client,
             agents: Vec::new(),
@@ -56,11 +66,17 @@ impl TuiApp {
             tasks: Vec::new(),
             projection: None,
             connection_state: TuiConnectionState::Bootstrapping,
-            stream_messages: None,
+            runtime_tx,
+            runtime_messages,
             stream_task: None,
             agent_list_refresh_deadline: None,
             reconnect_deadline: None,
             refresh_deadline: None,
+            agent_list_refresh_in_flight: false,
+            snapshot_refresh_in_flight: false,
+            stream_connect_in_flight: false,
+            snapshot_refresh_request_id: 0,
+            stream_connect_request_id: 0,
             reconnect_attempt: 0,
             selected_agent: 0,
             preferred_agent_id,

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -341,7 +341,8 @@ impl TuiApp {
             return Ok(());
         };
         self.chat_scroll.follow_tail();
-        self.bootstrap_agent_index(target_index).await
+        self.begin_bootstrap_agent_index(target_index);
+        Ok(())
     }
 
     async fn submit_prompt_buffer(&mut self) -> Result<()> {
@@ -474,7 +475,7 @@ impl TuiApp {
             SlashCommand::Refresh => {
                 self.overlay = OverlayState::None;
                 self.status_line = "Refreshing selected agent from /state".into();
-                self.bootstrap_selected_agent().await?;
+                self.begin_bootstrap_selected_agent();
             }
             SlashCommand::ClearStatus => {
                 self.overlay = OverlayState::None;
@@ -515,7 +516,7 @@ impl TuiApp {
                 self.client.interrupt_current_run(&agent_id, run_id).await?;
                 self.overlay = OverlayState::None;
                 self.status_line = format!("Interrupted current run for {agent_id}");
-                let _ = self.bootstrap_selected_agent().await;
+                self.begin_bootstrap_selected_agent();
             }
             SlashCommand::Agent => {
                 let requested_agent_id = args
@@ -532,8 +533,8 @@ impl TuiApp {
                         )
                     })?;
                 self.overlay = OverlayState::None;
-                self.bootstrap_agent_index(target_index).await?;
-                self.status_line = format!("Switched to agent {requested_agent_id}");
+                self.begin_bootstrap_agent_index(target_index);
+                self.status_line = format!("Switching to agent {requested_agent_id}");
             }
             SlashCommand::Skills => {
                 let agent_id = match self.selected_agent_id() {
@@ -1026,20 +1027,12 @@ impl TuiApp {
             TuiKeyAction::OverlayClose => Ok(()),
             TuiKeyAction::OverlayAccept => {
                 let agent_id = self.selected_agent_id().unwrap_or("").to_string();
-                match self.bootstrap_agent_index(self.selected_agent).await {
-                    Ok(()) => {
-                        self.overlay = OverlayState::None;
-                        Ok(())
-                    }
-                    Err(err) => {
-                        if !agent_id.is_empty() {
-                            self.status_line =
-                                format!("Failed to switch to agent {agent_id}: {err}");
-                        }
-                        self.overlay = OverlayState::Agents;
-                        Err(err)
-                    }
+                if !agent_id.is_empty() {
+                    self.status_line = format!("Switching to agent {agent_id}");
+                    self.begin_bootstrap_agent_index(self.selected_agent);
                 }
+                self.overlay = OverlayState::None;
+                Ok(())
             }
             TuiKeyAction::OverlayMoveUp => {
                 self.move_agent_selection(-1).await?;
@@ -1076,7 +1069,7 @@ impl TuiApp {
                 self.status_line =
                     format!("Cleared model override for {agent_id}; inheriting runtime default");
                 self.overlay = OverlayState::None;
-                self.bootstrap_selected_agent().await?;
+                self.begin_bootstrap_selected_agent();
             }
             crate::tui::model_picker::ModelPickerChoice::Model { model } => {
                 self.overlay = OverlayState::ModelEffortPicker {
@@ -1117,7 +1110,7 @@ impl TuiApp {
             .unwrap_or_default();
         self.status_line = format!("Set model override for {agent_id} to {model}{suffix}");
         self.overlay = OverlayState::None;
-        self.bootstrap_selected_agent().await?;
+        self.begin_bootstrap_selected_agent();
         Ok(())
     }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -1,7 +1,9 @@
 use super::projection::ProjectionSlice;
 use super::state::TuiClientState;
 use super::*;
-use crate::client::{AgentStreamEvent, EventStreamRequest, LocalEventStream, LocalHttpError};
+use crate::client::{
+    AgentStateSnapshot, AgentStreamEvent, EventStreamRequest, LocalEventStream, LocalHttpError,
+};
 use tokio::sync::mpsc;
 
 const STREAM_RECONNECT_DELAY: Duration = Duration::from_secs(1);
@@ -22,10 +24,29 @@ pub(super) enum TuiConnectionState {
     Disconnected { reason: String },
 }
 
-#[derive(Debug)]
 pub(super) enum TuiRuntimeMessage {
     Event(AgentStreamEvent),
-    Disconnected { error: String },
+    Disconnected {
+        error: String,
+    },
+    AgentListLoaded(Result<Vec<AgentSummary>, String>),
+    SnapshotLoaded {
+        request_id: u64,
+        target_index: usize,
+        agent_id: String,
+        checkpoint: Option<TuiRuntimeCheckpoint>,
+        result: Result<AgentStateSnapshot, String>,
+    },
+    EventStreamOpened {
+        request_id: u64,
+        agent_id: String,
+        result: Result<LocalEventStream, EventStreamOpenError>,
+    },
+}
+
+pub(super) struct EventStreamOpenError {
+    message: String,
+    cursor_too_old: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,7 +57,7 @@ pub(super) enum AgentListChange {
 }
 
 #[derive(Debug, Clone)]
-struct TuiRuntimeCheckpoint {
+pub(super) struct TuiRuntimeCheckpoint {
     connection_state: TuiConnectionState,
     reconnect_deadline: Option<Instant>,
     refresh_deadline: Option<Instant>,
@@ -46,15 +67,7 @@ struct TuiRuntimeCheckpoint {
 impl TuiApp {
     pub(super) async fn initialize(&mut self) {
         self.schedule_agent_list_refresh();
-        if let Err(err) = self.load_agents().await {
-            self.set_disconnected(format!("failed to list public agents: {err}"));
-            return;
-        }
-        if self.agents.is_empty() {
-            self.set_disconnected("no public agents are available".into());
-            return;
-        }
-        let _ = self.bootstrap_selected_agent().await;
+        self.begin_load_agents();
     }
 
     pub(super) async fn tick(&mut self) -> Result<()> {
@@ -64,14 +77,7 @@ impl TuiApp {
             .agent_list_refresh_deadline
             .is_some_and(|deadline| Instant::now() >= deadline)
         {
-            self.schedule_agent_list_refresh();
-            if let Err(err) = self.refresh_public_agents().await {
-                if self.agents.is_empty() {
-                    self.set_disconnected(format!("failed to refresh public agents: {err}"));
-                } else {
-                    self.status_line = format!("Public agent refresh failed: {err}");
-                }
-            }
+            self.begin_load_agents();
         }
 
         match self.connection_state.clone() {
@@ -80,9 +86,7 @@ impl TuiApp {
                     .refresh_deadline
                     .is_some_and(|deadline| Instant::now() >= deadline)
                 {
-                    if let Err(err) = self.bootstrap_selected_agent().await {
-                        self.schedule_refresh(format!("snapshot refresh failed: {err}"));
-                    }
+                    self.begin_bootstrap_selected_agent();
                 }
             }
             TuiConnectionState::Reconnecting { .. } => {
@@ -90,7 +94,7 @@ impl TuiApp {
                     .reconnect_deadline
                     .is_some_and(|deadline| Instant::now() >= deadline)
                 {
-                    self.connect_event_stream().await?;
+                    self.begin_connect_event_stream();
                 }
             }
             TuiConnectionState::Bootstrapping
@@ -101,20 +105,43 @@ impl TuiApp {
         Ok(())
     }
 
-    pub(super) async fn load_agents(&mut self) -> Result<()> {
-        let agents = self.client.list_agents().await?;
-        let _ = self.apply_agent_list(agents);
-        Ok(())
+    pub(super) fn begin_load_agents(&mut self) {
+        if self.agent_list_refresh_in_flight {
+            return;
+        }
+        self.agent_list_refresh_in_flight = true;
+        self.agent_list_refresh_deadline = None;
+        if self.agents.is_empty() {
+            self.connection_state = TuiConnectionState::Bootstrapping;
+            self.status_line = "Loading public agents".into();
+        }
+        let client = self.client.clone();
+        let tx = self.runtime_tx.clone();
+        tokio::spawn(async move {
+            let result = client.list_agents().await.map_err(|err| err.to_string());
+            let _ = tx.send(TuiRuntimeMessage::AgentListLoaded(result));
+        });
     }
 
-    pub(super) async fn refresh_public_agents(&mut self) -> Result<()> {
-        let agents = self.client.list_agents().await?;
+    pub(super) fn apply_loaded_agents(&mut self, result: Result<Vec<AgentSummary>, String>) {
+        self.agent_list_refresh_in_flight = false;
+        self.schedule_agent_list_refresh();
+        let agents = match result {
+            Ok(agents) => agents,
+            Err(err) => {
+                if self.agents.is_empty() {
+                    self.set_disconnected(format!("failed to list public agents: {err}"));
+                } else {
+                    self.status_line = format!("Public agent refresh failed: {err}");
+                }
+                return;
+            }
+        };
         match self.apply_agent_list(agents) {
-            AgentListChange::Ready => Ok(()),
-            AgentListChange::RequiresBootstrap => self.bootstrap_selected_agent().await,
+            AgentListChange::Ready => {}
+            AgentListChange::RequiresBootstrap => self.begin_bootstrap_selected_agent(),
             AgentListChange::Empty => {
                 self.set_disconnected("no public agents are available".into());
-                Ok(())
             }
         }
     }
@@ -264,26 +291,67 @@ impl TuiApp {
         self.refresh_deadline = None;
         self.reconnect_deadline = None;
         self.reconnect_attempt = 0;
+        self.snapshot_refresh_in_flight = false;
+        self.stream_connect_in_flight = false;
+        self.snapshot_refresh_request_id = self.snapshot_refresh_request_id.saturating_add(1);
+        self.stream_connect_request_id = self.stream_connect_request_id.saturating_add(1);
     }
 
-    pub(super) async fn bootstrap_selected_agent(&mut self) -> Result<()> {
-        self.bootstrap_agent_index(self.selected_agent).await
+    pub(super) fn begin_bootstrap_selected_agent(&mut self) {
+        self.begin_bootstrap_agent_index(self.selected_agent);
     }
 
-    pub(super) async fn bootstrap_agent_index(&mut self, target_index: usize) -> Result<()> {
-        let agent_id = self
+    pub(super) fn begin_bootstrap_agent_index(&mut self, target_index: usize) {
+        let Some(agent_id) = self
             .agents
             .get(target_index)
             .map(|agent| agent.identity.agent_id.clone())
-            .ok_or_else(|| anyhow!("no agent selected"))?;
+        else {
+            self.status_line = "No agent selected".into();
+            return;
+        };
         let switching_agents = target_index != self.selected_agent;
         let checkpoint = switching_agents.then(|| self.runtime_checkpoint());
         self.refresh_deadline = None;
         self.reconnect_deadline = None;
+        self.snapshot_refresh_in_flight = true;
+        self.snapshot_refresh_request_id = self.snapshot_refresh_request_id.saturating_add(1);
+        let request_id = self.snapshot_refresh_request_id;
         self.connection_state = TuiConnectionState::Bootstrapping;
         self.status_line = format!("Bootstrapping agent {agent_id} from /state");
+        let client = self.client.clone();
+        let tx = self.runtime_tx.clone();
+        tokio::spawn({
+            let agent_id = agent_id.clone();
+            async move {
+                let result = client
+                    .agent_state_snapshot(&agent_id)
+                    .await
+                    .map_err(|err| err.to_string());
+                let _ = tx.send(TuiRuntimeMessage::SnapshotLoaded {
+                    request_id,
+                    target_index,
+                    agent_id,
+                    checkpoint,
+                    result,
+                });
+            }
+        });
+    }
 
-        let snapshot = match self.client.agent_state_snapshot(&agent_id).await {
+    pub(super) fn apply_snapshot_result(
+        &mut self,
+        request_id: u64,
+        target_index: usize,
+        agent_id: String,
+        checkpoint: Option<TuiRuntimeCheckpoint>,
+        result: Result<AgentStateSnapshot, String>,
+    ) {
+        if request_id != self.snapshot_refresh_request_id {
+            return;
+        }
+        self.snapshot_refresh_in_flight = false;
+        let snapshot = match result {
             Ok(snapshot) => snapshot,
             Err(err) => {
                 if let Some(checkpoint) = checkpoint {
@@ -294,9 +362,10 @@ impl TuiApp {
                         "failed to bootstrap {agent_id} from /state: {err}"
                     ));
                 }
-                return Err(err);
+                return;
             }
         };
+        let switching_agents = target_index != self.selected_agent;
         let mut projection = TuiProjection::from_snapshot(snapshot);
         if !switching_agents {
             if let Some(previous) = self.projection.as_mut() {
@@ -316,31 +385,66 @@ impl TuiApp {
         self.reconnect_deadline = None;
         self.status_line = format!("Bootstrapped agent {agent_id} from /state");
 
-        self.connect_event_stream_for(agent_id, cursor).await
+        self.begin_connect_event_stream_for(agent_id, cursor);
     }
 
-    pub(super) async fn connect_event_stream(&mut self) -> Result<()> {
-        let agent_id = self
-            .selected_agent_id()
-            .ok_or_else(|| anyhow!("no agent selected"))?
-            .to_string();
+    pub(super) fn begin_connect_event_stream(&mut self) {
+        let Some(agent_id) = self.selected_agent_id().map(ToString::to_string) else {
+            self.status_line = "No agent selected".into();
+            return;
+        };
         let since = self
             .projection
             .as_ref()
             .and_then(|projection| projection.cursor.clone());
-        self.connect_event_stream_for(agent_id, since).await
+        self.begin_connect_event_stream_for(agent_id, since);
     }
 
-    pub(super) async fn connect_event_stream_for(
+    pub(super) fn begin_connect_event_stream_for(
         &mut self,
         agent_id: String,
         since: Option<String>,
-    ) -> Result<()> {
+    ) {
+        self.stream_connect_in_flight = true;
+        self.stream_connect_request_id = self.stream_connect_request_id.saturating_add(1);
+        let request_id = self.stream_connect_request_id;
+        self.reconnect_deadline = None;
         let request = EventStreamRequest {
             since,
             ..Default::default()
         };
-        match self.client.stream_agent_events(&agent_id, request).await {
+        let client = self.client.clone();
+        let tx = self.runtime_tx.clone();
+        tokio::spawn({
+            let agent_id = agent_id.clone();
+            async move {
+                let result = client
+                    .stream_agent_events(&agent_id, request)
+                    .await
+                    .map_err(|err| EventStreamOpenError {
+                        cursor_too_old: is_cursor_too_old_error(&err),
+                        message: err.to_string(),
+                    });
+                let _ = tx.send(TuiRuntimeMessage::EventStreamOpened {
+                    request_id,
+                    agent_id,
+                    result,
+                });
+            }
+        });
+    }
+
+    pub(super) fn apply_event_stream_opened(
+        &mut self,
+        request_id: u64,
+        agent_id: String,
+        result: Result<LocalEventStream, EventStreamOpenError>,
+    ) {
+        if request_id != self.stream_connect_request_id {
+            return;
+        }
+        self.stream_connect_in_flight = false;
+        match result {
             Ok(stream) => {
                 self.spawn_stream_task(stream);
                 self.connection_state = TuiConnectionState::Streaming;
@@ -348,24 +452,20 @@ impl TuiApp {
                 self.reconnect_deadline = None;
                 self.refresh_deadline = None;
                 self.status_line.clear();
-                Ok(())
+            }
+            Err(err) if err.cursor_too_old => {
+                self.schedule_refresh(format!(
+                    "replay cursor expired for {agent_id}; rebuilding from /state"
+                ));
+                self.status_line =
+                    format!("Replay cursor expired for {agent_id}; resetting from /state");
             }
             Err(err) => {
-                let message = err.to_string();
-                if is_cursor_too_old_error(&err) {
-                    self.schedule_refresh(format!(
-                        "replay cursor expired for {agent_id}; rebuilding from /state"
-                    ));
-                    self.status_line =
-                        format!("Replay cursor expired for {agent_id}; resetting from /state");
-                } else {
-                    self.schedule_reconnect(message.clone());
-                    self.status_line =
-                        format!("Event stream disconnected for {agent_id}: {message}");
-                }
-                Ok(())
+                self.schedule_reconnect(err.message.clone());
+                self.status_line =
+                    format!("Event stream disconnected for {agent_id}: {}", err.message);
             }
-        }
+        };
     }
 
     pub(super) fn record_selected_agent(&mut self, agent_id: &str) {
@@ -395,7 +495,7 @@ impl TuiApp {
 
     pub(super) fn spawn_stream_task(&mut self, mut stream: LocalEventStream) {
         self.stop_stream_task();
-        let (tx, rx) = mpsc::unbounded_channel();
+        let tx = self.runtime_tx.clone();
         let task = tokio::spawn(async move {
             loop {
                 match stream.next_event().await {
@@ -413,7 +513,6 @@ impl TuiApp {
                 }
             }
         });
-        self.stream_messages = Some(rx);
         self.stream_task = Some(task);
     }
 
@@ -421,22 +520,18 @@ impl TuiApp {
         if let Some(task) = self.stream_task.take() {
             task.abort();
         }
-        self.stream_messages = None;
     }
 
     pub(super) fn process_runtime_messages(&mut self) -> bool {
         let mut disconnected = false;
         loop {
-            let message = match self.stream_messages.as_mut() {
-                Some(receiver) => match receiver.try_recv() {
-                    Ok(message) => Some(message),
-                    Err(mpsc::error::TryRecvError::Empty) => None,
-                    Err(mpsc::error::TryRecvError::Disconnected) => {
-                        disconnected = true;
-                        None
-                    }
-                },
-                None => None,
+            let message = match self.runtime_messages.try_recv() {
+                Ok(message) => Some(message),
+                Err(mpsc::error::TryRecvError::Empty) => None,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    disconnected = true;
+                    None
+                }
             };
 
             let Some(message) = message else {
@@ -450,6 +545,25 @@ impl TuiApp {
                     self.schedule_reconnect(error.clone());
                     self.status_line = format!("Event stream disconnected: {error}");
                 }
+                TuiRuntimeMessage::AgentListLoaded(result) => self.apply_loaded_agents(result),
+                TuiRuntimeMessage::SnapshotLoaded {
+                    request_id,
+                    target_index,
+                    agent_id,
+                    checkpoint,
+                    result,
+                } => self.apply_snapshot_result(
+                    request_id,
+                    target_index,
+                    agent_id,
+                    checkpoint,
+                    result,
+                ),
+                TuiRuntimeMessage::EventStreamOpened {
+                    request_id,
+                    agent_id,
+                    result,
+                } => self.apply_event_stream_opened(request_id, agent_id, result),
             }
         }
 
@@ -603,6 +717,10 @@ impl TuiApp {
         self.stop_stream_task();
         self.refresh_deadline = None;
         self.reconnect_deadline = None;
+        self.snapshot_refresh_in_flight = false;
+        self.stream_connect_in_flight = false;
+        self.snapshot_refresh_request_id = self.snapshot_refresh_request_id.saturating_add(1);
+        self.stream_connect_request_id = self.stream_connect_request_id.saturating_add(1);
         self.connection_state = TuiConnectionState::Disconnected {
             reason: reason.clone(),
         };


### PR DESCRIPTION
Fixes #972.

## Summary

- moves remote TUI agent-list refresh, selected-agent /state bootstrap, and SSE open/reconnect work onto background tasks
- has the main TUI loop consume completed background results from a local runtime channel instead of awaiting remote requests
- ignores stale snapshot/SSE-open completions when newer requests supersede them
- shortens remote HTTP connect/request-open timeouts and records the responsiveness contract in the remote TUI RFC

## Verification

- cargo check --all-targets
- cargo test tui::tests:: -- --nocapture
