### PR TITLE
Fix remote TUI review follow-ups

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -584,10 +584,9 @@ impl LocalClient {
         if let Some(last_event_id) = last_event_id {
             builder = builder.header("Last-Event-ID", last_event_id);
         }
-        let response = builder
-            .timeout(self.http_request_timeout())
-            .send()
+        let response = tokio::time::timeout(self.http_request_timeout(), builder.send())
             .await
+            .map_err(|_| anyhow!("timed out opening event stream {}", path))?
             .with_context(|| format!("failed to open event stream {}", path))?;
         let status = response.status();
         if !status.is_success() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2364,6 +2364,71 @@ mod tests {
         assert_eq!(app.transcript[0].id, "persisted-transcript-entry");
     }
 
+    #[tokio::test]
+    async fn snapshot_refresh_preserves_sse_only_transcript_entries() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.agents = vec![sample_agent_summary("default")];
+        app.selected_agent = 0;
+        app.projection = Some(TuiProjection::from_snapshot(sample_snapshot(
+            "default", "cursor-1",
+        )));
+        app.transcript = vec![TranscriptEntry {
+            id: "stream-only-entry".into(),
+            agent_id: "default".into(),
+            created_at: Utc::now(),
+            kind: TranscriptEntryKind::AssistantRound,
+            round: Some(1),
+            related_message_id: None,
+            stop_reason: None,
+            input_tokens: None,
+            output_tokens: None,
+            data: json!({
+                "body": { "type": "text", "text": "streamed only" }
+            }),
+        }];
+        app.snapshot_refresh_request_id = 1;
+
+        app.apply_snapshot_result(
+            1,
+            0,
+            "default".into(),
+            None,
+            Ok(sample_snapshot("default", "cursor-2")),
+        );
+
+        assert!(app
+            .transcript
+            .iter()
+            .any(|entry| entry.id == "stream-only-entry"));
+    }
+
+    #[test]
+    fn snapshot_refresh_failure_updates_status_line() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.agents = vec![sample_agent_summary("default")];
+        app.selected_agent = 0;
+        app.snapshot_refresh_request_id = 7;
+
+        app.apply_snapshot_result(7, 0, "default".into(), None, Err("network down".into()));
+
+        assert_eq!(
+            app.status_line,
+            "Snapshot refresh failed for default: network down"
+        );
+        assert!(matches!(
+            app.connection_state,
+            TuiConnectionState::RefreshRequired { .. }
+        ));
+    }
+
     #[test]
     fn chat_text_keeps_long_brief_content() {
         let client = LocalClient::new(test_config()).unwrap();

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -474,7 +474,6 @@ impl TuiApp {
             }
             SlashCommand::Refresh => {
                 self.overlay = OverlayState::None;
-                self.status_line = "Refreshing selected agent from /state".into();
                 self.begin_bootstrap_selected_agent();
             }
             SlashCommand::ClearStatus => {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -358,9 +358,9 @@ impl TuiApp {
                     self.restore_runtime_checkpoint(checkpoint);
                     self.status_line = format!("Failed to switch to agent {agent_id}: {err}");
                 } else {
-                    self.schedule_refresh(format!(
-                        "failed to bootstrap {agent_id} from /state: {err}"
-                    ));
+                    let reason = format!("failed to bootstrap {agent_id} from /state: {err}");
+                    self.schedule_refresh(reason.clone());
+                    self.status_line = format!("Snapshot refresh failed for {agent_id}: {err}");
                 }
                 return;
             }
@@ -371,6 +371,7 @@ impl TuiApp {
             if let Some(previous) = self.projection.as_mut() {
                 projection.inherit_recent_event_logs_from(previous);
             }
+            merge_transcript_tail(&mut projection.transcript_tail, &self.transcript);
         }
         let cursor = projection.cursor.clone();
 
@@ -798,6 +799,18 @@ fn transcript_merge_key(entry: &TranscriptEntry) -> &str {
         .related_message_id
         .as_deref()
         .unwrap_or(entry.id.as_str())
+}
+
+fn merge_transcript_tail(persisted: &mut Vec<TranscriptEntry>, streamed: &[TranscriptEntry]) {
+    for entry in streamed {
+        let key = transcript_merge_key(entry);
+        if !persisted
+            .iter()
+            .any(|persisted| transcript_merge_key(persisted) == key)
+        {
+            persisted.push(entry.clone());
+        }
+    }
 }
 
 fn find_agent_index(agents: &[AgentSummary], agent_id: &str) -> Option<usize> {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -359,7 +359,7 @@ impl TuiApp {
                     self.status_line = format!("Failed to switch to agent {agent_id}: {err}");
                 } else {
                     let reason = format!("failed to bootstrap {agent_id} from /state: {err}");
-                    self.schedule_refresh(reason.clone());
+                    self.schedule_refresh(reason);
                     self.status_line = format!("Snapshot refresh failed for {agent_id}: {err}");
                 }
                 return;
@@ -601,17 +601,7 @@ impl TuiApp {
         let merged_transcript = if is_streaming && !self.transcript.is_empty() {
             // Start with HTTP response, then add any SSE-only messages not yet in HTTP response
             let mut merged = projection.transcript_tail.clone();
-            for entry in &self.transcript {
-                let key = transcript_merge_key(entry);
-                // /state uses persisted ids while SSE entries can be synthetic.
-                // related_message_id is the stable identity once persistence catches up.
-                if !merged
-                    .iter()
-                    .any(|persisted| transcript_merge_key(persisted) == key)
-                {
-                    merged.push(entry.clone());
-                }
-            }
+            merge_transcript_tail(&mut merged, &self.transcript);
             merged
         } else {
             projection.transcript_tail.clone()


### PR DESCRIPTION
Follow-up to #983. Addresses review feedback that landed after the original PR had already merged.

Summary:
- scope remote TUI SSE timeout to the stream open/header phase so long-lived event streams are not killed by the short refresh timeout
- preserve SSE-only transcript entries when a same-agent /state snapshot refresh arrives
- show snapshot refresh failures explicitly and remove the redundant /refresh status assignment

Verification:
- cargo fmt --check
- cargo test snapshot_refresh -- --nocapture
- cargo test streaming_transcript_merge_dedupes_persisted_message_by_related_message_id -- --nocapture
- cargo check --all-targets
