### PR TITLE
fix: keep unix control socket token-free

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -107,12 +107,10 @@ impl AppState {
         host: RuntimeHost,
         runtime_service: Option<RuntimeServiceHandle>,
     ) -> Self {
-        let require_control_token = host
-            .config()
-            .control_token_required(ControlTransportKind::Unix);
+        // Unix control is local IPC; filesystem permissions are the access boundary.
         Self {
             host,
-            require_control_token,
+            require_control_token: false,
             runtime_service,
             advertise_url: None,
         }

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -33,4 +33,7 @@ http_async_tests!(
 );
 
 #[cfg(unix)]
-http_async_tests!(control_prompt_is_open_over_unix_socket_auto,);
+http_async_tests!(
+    control_prompt_is_open_over_unix_socket_auto,
+    control_runtime_status_is_open_over_unix_socket_when_auth_required,
+);

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -28,6 +28,8 @@ use holon::{
 };
 use reqwest::Client;
 use tokio::net::TcpListener;
+#[cfg(unix)]
+use tokio::net::UnixListener;
 use tokio::time::{sleep, Duration, Instant};
 
 use super::{
@@ -324,6 +326,41 @@ pub async fn control_prompt_requires_bearer_token_when_required() -> Result<()> 
     Ok(())
 }
 
+#[cfg(unix)]
+pub async fn control_runtime_status_is_open_over_unix_socket_when_auth_required() -> Result<()> {
+    let config = test_config_with_paths(
+        tempdir().unwrap().keep(),
+        tempdir().unwrap().keep(),
+        "127.0.0.1:0".into(),
+        ControlAuthMode::Required,
+    );
+    std::fs::create_dir_all(&config.workspace_dir)?;
+    init_git_repo(&config.workspace_dir)?;
+    if let Some(parent) = config.socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let host = RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    let runtime_service = RuntimeServiceHandle::new(&config)?;
+    let router: Router = http::router(AppState::for_unix_with_runtime_service(
+        host.clone(),
+        Some(runtime_service),
+    ));
+    let listener = UnixListener::bind(&config.socket_path)?;
+    let socket_path = config.socket_path.clone();
+    let server = tokio::spawn(async move {
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        http::serve_unix(listener, router, rx).await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let response = unix_request(&socket_path, "GET", "/control/runtime/status", &[], None).await?;
+    assert_eq!(response.status, 200);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<()> {
     let config = test_config_with_paths(
         tempdir().unwrap().keep(),
@@ -331,12 +368,28 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         "127.0.0.1:0".into(),
         ControlAuthMode::Required,
     );
-    let (_host, base, server) = spawn_server_with_config(config).await?;
+    std::fs::create_dir_all(&config.workspace_dir)?;
+    init_git_repo(&config.workspace_dir)?;
+    let host = RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    let runtime_service = RuntimeServiceHandle::new(&config)?;
+    let router: Router = http::router(AppState::for_tcp_with_runtime_service(
+        host.clone(),
+        Some(runtime_service),
+    ));
+    let listener = TcpListener::bind(&config.http_addr).await?;
+    let addr = connect_addr(listener.local_addr()?);
+    let base = format!("http://{addr}");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await?;
+        Ok::<_, anyhow::Error>(())
+    });
     let client = reqwest::Client::new();
 
     for path in [
         "/handshake",
         "/",
+        "/control/runtime/status",
         "/agents",
         "/agents/default/status",
         "/agents/default/state",
@@ -373,6 +426,23 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         .send()
         .await?;
     assert!(agents.status().is_success());
+
+    let invalid_runtime_status = client
+        .get(format!("{base}/control/runtime/status"))
+        .bearer_auth("wrong")
+        .send()
+        .await?;
+    assert_eq!(
+        invalid_runtime_status.status(),
+        reqwest::StatusCode::FORBIDDEN
+    );
+
+    let runtime_status = client
+        .get(format!("{base}/control/runtime/status"))
+        .bearer_auth("secret")
+        .send()
+        .await?;
+    assert!(runtime_status.status().is_success());
 
     let denied_enqueue = client
         .post(format!("{base}/enqueue"))


### PR DESCRIPTION
## Summary
- keep Unix socket control state local/token-free even when remote control auth is required
- add regression coverage for Unix `/control/runtime/status` without auth under required auth mode
- extend TCP auth coverage for `/control/runtime/status` missing, invalid, and valid bearer tokens

Fixes #987

## Verification
- cargo test --test http_control control_runtime_status_is_open_over_unix_socket_when_auth_required -- --nocapture
- cargo test --test http_control remote_tcp_surfaces_require_bearer_token_when_required -- --nocapture
- cargo fmt --check
- cargo check --all-targets
