### PR TITLE
perf: slim remote agent list bootstrap

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -624,7 +624,7 @@ without durably persisting public self-owned agents as `stopped`.
 
 ## Agent Inspection Surface Contract
 
-Holon now exposes two different public per-agent inspection surfaces:
+Holon now exposes three different public per-agent inspection surfaces:
 
 - `GET /agents/list`
 - `GET /agents/:agent_id/status`
@@ -642,6 +642,8 @@ Phase-1 contract:
   - intentionally excludes heavy nested collections such as skills, active
     children, waiting intents, triggers, notifications, event tails, and
     loaded AGENTS.md metadata
+  - active workspace entries are kept list-sized and exclude projection
+    metadata such as managed worktree session details
 - `/status`
   - the concise agent-facing summary surface
   - returns one `AgentSummary`

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -626,6 +626,7 @@ without durably persisting public self-owned agents as `stopped`.
 
 Holon now exposes two different public per-agent inspection surfaces:
 
+- `GET /agents/list`
 - `GET /agents/:agent_id/status`
 - `GET /agents/:agent_id/state`
 
@@ -633,6 +634,14 @@ They should not be treated as interchangeable.
 
 Phase-1 contract:
 
+- `/agents/list`
+  - the narrow public agent-list bootstrap surface
+  - returns `Vec<AgentListEntry>`
+  - meant for TUI agent selection and other clients that need to choose an
+    agent without downloading full per-agent runtime projections
+  - intentionally excludes heavy nested collections such as skills, active
+    children, waiting intents, triggers, notifications, event tails, and
+    loaded AGENTS.md metadata
 - `/status`
   - the concise agent-facing summary surface
   - returns one `AgentSummary`

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,10 +15,10 @@ use crate::{
     },
     system::ExecutionSnapshot,
     types::{
-        ActiveWorkspaceEntry, AgentSummary, BriefRecord, ExternalTriggerStateSnapshot,
-        OperatorMessageRecord, OperatorNotificationRecord, TaskRecord, TimerRecord,
-        TranscriptEntry, TrustLevel, TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord,
-        WorkspaceOccupancyRecord, WorktreeSession,
+        ActiveWorkspaceEntry, AgentListEntry, AgentSummary, BriefRecord,
+        ExternalTriggerStateSnapshot, OperatorMessageRecord, OperatorNotificationRecord,
+        TaskRecord, TimerRecord, TranscriptEntry, TrustLevel, TurnTerminalRecord,
+        WaitingIntentRecord, WorkItemRecord, WorkspaceOccupancyRecord, WorktreeSession,
     },
 };
 
@@ -275,6 +275,10 @@ impl LocalClient {
 
     pub async fn list_agents(&self) -> Result<Vec<AgentSummary>> {
         self.get_json("/agents").await
+    }
+
+    pub async fn list_agent_entries(&self) -> Result<Vec<AgentListEntry>> {
+        self.get_json("/agents/list").await
     }
 
     pub async fn handshake(&self) -> Result<Value> {
@@ -564,7 +568,11 @@ impl LocalClient {
             .await
             .with_context(|| format!("failed to send {}", request.path))?;
         let status = response.status();
-        let bytes = response.bytes().await?.to_vec();
+        let bytes = response
+            .bytes()
+            .await
+            .with_context(|| format!("failed to read response body for {}", request.path))?
+            .to_vec();
         decode_or_error(status.as_u16(), bytes, &request.path)
     }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -30,11 +30,12 @@ use crate::{
     storage::AppStorage,
     system::WorkspaceAccessMode,
     types::{
-        AgentIdentityRecord, AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset,
-        AgentRegistryStatus, AgentState, AgentStatus, AgentSummary, AgentVisibility,
-        ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord, ExternalTriggerStatus,
-        OperatorNotificationRecord, RuntimeFailureSummary, TaskRecord, TaskStatus, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WorkspaceEntry, WorkspaceOccupancyRecord,
+        AgentIdentityRecord, AgentIdentityView, AgentKind, AgentListEntry, AgentOwnership,
+        AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus, AgentSummary,
+        AgentVisibility, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
+        ExternalTriggerStatus, OperatorNotificationRecord, RuntimeFailureSummary, TaskRecord,
+        TaskStatus, TranscriptEntry, TranscriptEntryKind, TrustLevel, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -544,6 +545,20 @@ impl RuntimeHost {
         }
         summaries.sort_by(|left, right| left.agent.id.cmp(&right.agent.id));
         Ok(summaries)
+    }
+
+    pub async fn list_agent_entries(&self) -> Result<Vec<AgentListEntry>> {
+        self.ensure_default_agent_identity()?;
+        let mut entries = Vec::new();
+        for identity in self.agent_identity_records()?.into_iter().filter(|record| {
+            record.status == AgentRegistryStatus::Active
+                && record.visibility == AgentVisibility::Public
+        }) {
+            let runtime = self.get_or_create_agent(&identity.agent_id).await?;
+            entries.push(runtime.agent_list_entry().await?);
+        }
+        entries.sort_by(|left, right| left.identity.agent_id.cmp(&right.identity.agent_id));
+        Ok(entries)
     }
 
     pub fn public_agent_activity_snapshots(&self) -> Result<Vec<PublicAgentActivitySnapshot>> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -127,6 +127,7 @@ pub fn router(state: AppState) -> Router {
         .route("/", get(root))
         .route("/handshake", get(handshake))
         .route("/agents", get(list_agents))
+        .route("/agents/list", get(list_agent_entries))
         .route("/agents/:agent_id/enqueue", post(enqueue))
         .route("/agents/:agent_id/status", get(status))
         .route("/agents/:agent_id/briefs", get(briefs))
@@ -568,6 +569,19 @@ pub async fn list_agents(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let agents = state.host.list_agents().await.map_err(error_response)?;
+    Ok(Json(agents))
+}
+
+pub async fn list_agent_entries(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let agents = state
+        .host
+        .list_agent_entries()
+        .await
+        .map_err(error_response)?;
     Ok(Json(agents))
 }
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -388,7 +388,9 @@ impl RuntimeHandle {
             current_run_id: agent.current_run_id,
             waiting_reason: closure.waiting_reason,
             model: (&model).into(),
-            active_workspace_entry: agent.active_workspace_entry,
+            active_workspace_entry: agent
+                .active_workspace_entry
+                .map(crate::types::ActiveWorkspaceEntry::without_projection_metadata),
         })
     }
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -4,9 +4,9 @@ use std::path::{Path, PathBuf};
 use crate::runtime::closure::{derive_closure_decision, runtime_error_active, ClosureFacts};
 use crate::storage::AppStorage;
 use crate::types::{
-    AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason, ChildAgentObservabilitySnapshot,
-    ChildAgentPhase, TaskRecord, TaskStatus, TokenUsage, WaitingReason, WorkItemState,
-    WorktreeSession,
+    AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
+    ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskRecord, TaskStatus, TokenUsage,
+    WaitingReason, WorkItemState, WorktreeSession,
 };
 
 fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBuf> {
@@ -369,6 +369,26 @@ impl RuntimeHandle {
             recent_operator_notifications: self.recent_operator_notifications(10).await?,
             recent_brief_count: self.inner.storage.read_recent_briefs(50)?.len(),
             recent_event_count: self.inner.storage.read_recent_events(100)?.len(),
+        })
+    }
+
+    pub async fn agent_list_entry(&self) -> Result<AgentListEntry> {
+        let agent = self.agent_state().await?;
+        let model = self.model_state_for(&agent);
+        let closure = self.current_closure_decision().await?;
+        let identity = self.agent_identity_view().await?;
+        Ok(AgentListEntry {
+            identity,
+            lifecycle: crate::types::AgentLifecycleHint::from_status(
+                &agent.id,
+                agent.status.clone(),
+            ),
+            status: agent.status,
+            pending: agent.pending,
+            current_run_id: agent.current_run_id,
+            waiting_reason: closure.waiting_reason,
+            model: (&model).into(),
+            active_workspace_entry: agent.active_workspace_entry,
         })
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -224,10 +224,10 @@ mod tests {
         config::{AltScreenMode, AppConfig},
         system::{ExecutionProfile, ExecutionSnapshot},
         types::{
-            AgentIdentityView, AgentKind, AgentLifecycleHint, AgentModelSource, AgentModelState,
-            AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus, AgentSummary,
-            AgentTokenUsageSummary, AgentVisibility, BriefKind, BriefRecord, ChildAgentSummary,
-            ClosureDecision, ClosureOutcome, LoadedAgentsMdView, MessageBody,
+            AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry, AgentModelSource,
+            AgentModelState, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus,
+            AgentSummary, AgentTokenUsageSummary, AgentVisibility, BriefKind, BriefRecord,
+            ChildAgentSummary, ClosureDecision, ClosureOutcome, LoadedAgentsMdView, MessageBody,
             OperatorMessageRecord, OperatorMessageStatus, RuntimePosture, SkillsRuntimeView,
             TokenUsage, TranscriptEntry, TranscriptEntryKind, WaitingIntentSummary,
         },
@@ -2655,6 +2655,32 @@ mod tests {
 
         assert_eq!(change, AgentListChange::Ready);
         assert_eq!(app.selected_agent_id(), Some("beta"));
+        assert!(app.projection.is_some());
+    }
+
+    #[test]
+    fn slim_agent_list_refresh_preserves_selected_projection_summary() {
+        let client = LocalClient::new(test_config()).unwrap();
+        let mut app = TuiApp::new(
+            client,
+            crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+        app.agents = vec![sample_agent_summary("alpha"), sample_agent_summary("beta")];
+        app.selected_agent = 1;
+        app.projection = Some(crate::tui::projection::TuiProjection::from_snapshot(
+            sample_snapshot("beta", "cursor-1"),
+        ));
+
+        let beta_entry = AgentListEntry::from_summary(&sample_agent_summary("beta"));
+        app.apply_loaded_agents(Ok(vec![
+            AgentListEntry::from_summary(&sample_agent_summary("alpha")),
+            beta_entry,
+        ]));
+
+        let selected = app.selected_agent_summary().unwrap();
+        assert_eq!(selected.identity.agent_id, "beta");
+        assert_eq!(selected.recent_event_count, 1);
+        assert_eq!(selected.model.resolved_policy.description, "Sample policy");
         assert!(app.projection.is_some());
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -10,8 +10,8 @@ use crate::{
     system::{workspace_access_mode_label, workspace_projection_label},
     tui_markdown::{render_markdown_text, render_markdown_text_spaced},
     types::{
-        AgentSummary, BriefRecord, MessageBody, OperatorMessageRecord, OperatorMessageStatus,
-        TaskRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        AgentListEntry, AgentSummary, BriefRecord, MessageBody, OperatorMessageRecord,
+        OperatorMessageStatus, TaskRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
     },
 };
 use anyhow::{anyhow, Result};
@@ -2725,7 +2725,7 @@ mod tests {
 
         tokio::time::timeout(std::time::Duration::from_millis(50), app.tick())
             .await
-            .expect("tick should not wait for slow /agents")
+            .expect("tick should not wait for slow /agents/list")
             .unwrap();
 
         assert!(app.agent_list_refresh_in_flight);

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -29,7 +29,7 @@ pub(super) enum TuiRuntimeMessage {
     Disconnected {
         error: String,
     },
-    AgentListLoaded(Result<Vec<AgentSummary>, String>),
+    AgentListLoaded(Result<Vec<AgentListEntry>, String>),
     SnapshotLoaded {
         request_id: u64,
         target_index: usize,
@@ -118,16 +118,19 @@ impl TuiApp {
         let client = self.client.clone();
         let tx = self.runtime_tx.clone();
         tokio::spawn(async move {
-            let result = client.list_agents().await.map_err(|err| err.to_string());
+            let result = client
+                .list_agent_entries()
+                .await
+                .map_err(|err| err.to_string());
             let _ = tx.send(TuiRuntimeMessage::AgentListLoaded(result));
         });
     }
 
-    pub(super) fn apply_loaded_agents(&mut self, result: Result<Vec<AgentSummary>, String>) {
+    pub(super) fn apply_loaded_agents(&mut self, result: Result<Vec<AgentListEntry>, String>) {
         self.agent_list_refresh_in_flight = false;
         self.schedule_agent_list_refresh();
-        let agents = match result {
-            Ok(agents) => agents,
+        let entries = match result {
+            Ok(entries) => entries,
             Err(err) => {
                 if self.agents.is_empty() {
                     self.set_disconnected(format!("failed to list public agents: {err}"));
@@ -137,6 +140,10 @@ impl TuiApp {
                 return;
             }
         };
+        let agents = entries
+            .into_iter()
+            .map(AgentListEntry::into_agent_summary_placeholder)
+            .collect();
         match self.apply_agent_list(agents) {
             AgentListChange::Ready => {}
             AgentListChange::RequiresBootstrap => self.begin_bootstrap_selected_agent(),

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -140,9 +140,22 @@ impl TuiApp {
                 return;
             }
         };
+        let selected_projection_agent = self.projection.as_ref().and_then(|projection| {
+            let selected_agent_id = self.selected_agent_id()?;
+            (projection.agent.identity.agent_id == selected_agent_id)
+                .then(|| projection.agent.clone())
+        });
         let agents = entries
             .into_iter()
-            .map(AgentListEntry::into_agent_summary_placeholder)
+            .map(|entry| {
+                let agent = entry.into_agent_summary_placeholder();
+                if let Some(selected) = selected_projection_agent.as_ref() {
+                    if selected.identity.agent_id == agent.identity.agent_id {
+                        return selected.clone();
+                    }
+                }
+                agent
+            })
             .collect();
         match self.apply_agent_list(agents) {
             AgentListChange::Ready => {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -60,6 +60,13 @@ pub struct ActiveWorkspaceEntry {
     pub projection_metadata: Option<Value>,
 }
 
+impl ActiveWorkspaceEntry {
+    pub fn without_projection_metadata(mut self) -> Self {
+        self.projection_metadata = None;
+        self
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceOccupancyRecord {
     pub occupancy_id: String,
@@ -3179,7 +3186,11 @@ impl AgentListEntry {
             current_run_id: summary.agent.current_run_id.clone(),
             waiting_reason: summary.closure.waiting_reason,
             model: (&summary.model).into(),
-            active_workspace_entry: summary.agent.active_workspace_entry.clone(),
+            active_workspace_entry: summary
+                .agent
+                .active_workspace_entry
+                .clone()
+                .map(ActiveWorkspaceEntry::without_projection_metadata),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3098,6 +3098,171 @@ pub struct AgentSummary {
     pub recent_event_count: usize,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentListModelSummary {
+    pub source: AgentModelSource,
+    pub runtime_default_model: ModelRef,
+    pub effective_model: ModelRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_model: Option<ModelRef>,
+    #[serde(default)]
+    pub fallback_active: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub effective_fallback_models: Vec<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_reasoning_effort: Option<String>,
+}
+
+impl From<&AgentModelState> for AgentListModelSummary {
+    fn from(value: &AgentModelState) -> Self {
+        Self {
+            source: value.source.clone(),
+            runtime_default_model: value.runtime_default_model.clone(),
+            effective_model: value.effective_model.clone(),
+            requested_model: value.requested_model.clone(),
+            active_model: value.active_model.clone(),
+            fallback_active: value.fallback_active,
+            effective_fallback_models: value.effective_fallback_models.clone(),
+            override_model: value.override_model.clone(),
+            override_reasoning_effort: value.override_reasoning_effort.clone(),
+        }
+    }
+}
+
+impl AgentListModelSummary {
+    pub fn into_model_state(self) -> AgentModelState {
+        AgentModelState {
+            source: self.source,
+            runtime_default_model: self.runtime_default_model,
+            effective_model: self.effective_model,
+            requested_model: self.requested_model,
+            active_model: self.active_model,
+            fallback_active: self.fallback_active,
+            effective_fallback_models: self.effective_fallback_models,
+            override_model: self.override_model,
+            override_reasoning_effort: self.override_reasoning_effort,
+            resolved_policy: ResolvedRuntimeModelPolicy::default(),
+            available_models: Vec::new(),
+            model_availability: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentListEntry {
+    pub identity: AgentIdentityView,
+    pub status: AgentStatus,
+    #[serde(default)]
+    pub lifecycle: AgentLifecycleHint,
+    #[serde(default)]
+    pub pending: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub waiting_reason: Option<WaitingReason>,
+    pub model: AgentListModelSummary,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_workspace_entry: Option<ActiveWorkspaceEntry>,
+}
+
+impl AgentListEntry {
+    pub fn from_summary(summary: &AgentSummary) -> Self {
+        Self {
+            identity: summary.identity.clone(),
+            status: summary.agent.status.clone(),
+            lifecycle: summary.lifecycle.clone(),
+            pending: summary.agent.pending,
+            current_run_id: summary.agent.current_run_id.clone(),
+            waiting_reason: summary.closure.waiting_reason,
+            model: (&summary.model).into(),
+            active_workspace_entry: summary.agent.active_workspace_entry.clone(),
+        }
+    }
+
+    pub fn into_agent_summary_placeholder(self) -> AgentSummary {
+        let mut agent = AgentState::new(self.identity.agent_id.clone());
+        agent.status = self.status;
+        agent.pending = self.pending;
+        agent.current_run_id = self.current_run_id;
+        agent.active_workspace_entry = self.active_workspace_entry.clone();
+        agent.model_override = self.model.override_model.clone();
+        agent.model_override_reasoning_effort = self.model.override_reasoning_effort.clone();
+
+        let runtime_posture = if agent.status == AgentStatus::Asleep {
+            RuntimePosture::Sleeping
+        } else {
+            RuntimePosture::Awake
+        };
+        let closure = ClosureDecision {
+            outcome: if self.waiting_reason.is_some() {
+                ClosureOutcome::Waiting
+            } else {
+                ClosureOutcome::Completed
+            },
+            waiting_reason: self.waiting_reason,
+            work_signal: None,
+            runtime_posture,
+            evidence: Vec::new(),
+        };
+        let execution = if let Some(entry) = agent.active_workspace_entry.as_ref() {
+            ExecutionSnapshot {
+                profile: ExecutionProfile::default(),
+                policy: ExecutionProfile::default().policy_snapshot(),
+                attached_workspaces: Vec::new(),
+                workspace_id: Some(entry.workspace_id.clone()),
+                workspace_anchor: entry.workspace_anchor.clone(),
+                execution_root: entry.execution_root.clone(),
+                cwd: entry.cwd.clone(),
+                execution_root_id: Some(entry.execution_root_id.clone()),
+                projection_kind: Some(entry.projection_kind),
+                access_mode: Some(entry.access_mode),
+                worktree_root: None,
+            }
+        } else {
+            ExecutionSnapshot {
+                profile: ExecutionProfile::default(),
+                policy: ExecutionProfile::default().policy_snapshot(),
+                attached_workspaces: Vec::new(),
+                workspace_id: None,
+                workspace_anchor: PathBuf::new(),
+                execution_root: PathBuf::new(),
+                cwd: PathBuf::new(),
+                execution_root_id: None,
+                projection_kind: None,
+                access_mode: None,
+                worktree_root: None,
+            }
+        };
+
+        AgentSummary {
+            identity: self.identity,
+            lifecycle: self.lifecycle,
+            model: self.model.into_model_state(),
+            token_usage: AgentTokenUsageSummary {
+                total: TokenUsage::new(0, 0),
+                total_model_rounds: 0,
+                last_turn: None,
+            },
+            closure,
+            execution,
+            agent,
+            active_workspace_occupancy: None,
+            loaded_agents_md: LoadedAgentsMdView::default(),
+            skills: SkillsRuntimeView::default(),
+            active_children: Vec::new(),
+            active_waiting_intents: Vec::new(),
+            active_external_triggers: Vec::new(),
+            recent_operator_notifications: Vec::new(),
+            recent_brief_count: 0,
+            recent_event_count: 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/http_client.rs
+++ b/tests/http_client.rs
@@ -12,6 +12,7 @@ macro_rules! http_async_tests {
 }
 
 http_async_tests!(
+    agent_list_entries_are_slim_for_tui_bootstrap,
     local_client_over_http_can_read_agent_state_snapshot,
     local_client_over_http_can_stream_events_with_since_query,
     local_client_over_http_can_stream_events_with_last_event_id_header,

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -60,6 +60,51 @@ pub async fn local_client_over_unix_socket_can_poll_without_http_fallback() -> R
     Ok(())
 }
 
+pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+
+    let client = reqwest::Client::new();
+    let payload: serde_json::Value = client
+        .get(format!("{base}/agents/list"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let entry = payload
+        .as_array()
+        .and_then(|entries| entries.first())
+        .expect("agent list should contain default agent");
+    assert_eq!(entry["identity"]["agent_id"], "default");
+    assert!(entry.get("status").is_some());
+    assert!(entry.get("model").is_some());
+
+    for heavy_field in [
+        "skills",
+        "active_children",
+        "active_waiting_intents",
+        "active_external_triggers",
+        "recent_operator_notifications",
+        "loaded_agents_md",
+        "recent_brief_count",
+        "recent_event_count",
+    ] {
+        assert!(
+            entry.get(heavy_field).is_none(),
+            "{heavy_field} should not be present in /agents/list"
+        );
+    }
+
+    let mut config = test_config();
+    config.http_addr = base.trim_start_matches("http://").to_string();
+    let local_client = LocalClient::new(config)?;
+    let entries = local_client.list_agent_entries().await?;
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].identity.agent_id, "default");
+
+    server.abort();
+    Ok(())
+}
+
 #[cfg(unix)]
 pub async fn local_client_over_http_can_read_agent_state_snapshot() -> Result<()> {
     let mut config = test_config();

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -61,7 +61,27 @@ pub async fn local_client_over_unix_socket_can_poll_without_http_fallback() -> R
 }
 
 pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
-    let (_host, base, server) = spawn_server().await?;
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let original_cwd = tempdir()?.keep();
+    let worktree_path = tempdir()?.keep();
+    runtime
+        .enter_worktree(
+            original_cwd,
+            "main".into(),
+            worktree_path,
+            "slim-list-test".into(),
+        )
+        .await?;
+    let state = runtime.agent_state().await?;
+    assert!(
+        state
+            .active_workspace_entry
+            .as_ref()
+            .and_then(|entry| entry.projection_metadata.as_ref())
+            .is_some(),
+        "test setup should seed nested projection metadata"
+    );
 
     let client = reqwest::Client::new();
     let payload: serde_json::Value = client
@@ -77,6 +97,13 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
     assert_eq!(entry["identity"]["agent_id"], "default");
     assert!(entry.get("status").is_some());
     assert!(entry.get("model").is_some());
+    let workspace_entry = entry
+        .get("active_workspace_entry")
+        .expect("active workspace entry should be present");
+    assert!(
+        workspace_entry.get("projection_metadata").is_none(),
+        "projection metadata should not be present in /agents/list"
+    );
 
     for heavy_field in [
         "skills",
@@ -100,6 +127,10 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
     let entries = local_client.list_agent_entries().await?;
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].identity.agent_id, "default");
+    assert!(entries[0]
+        .active_workspace_entry
+        .as_ref()
+        .is_some_and(|entry| entry.projection_metadata.is_none()));
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary
- add a narrow `AgentListEntry`/`AgentListModelSummary` DTO for remote TUI bootstrap
- expose `GET /agents/list` and `LocalClient::list_agent_entries()` while keeping the full `/agents` inspection endpoint intact
- switch TUI agent-list refresh to the slim endpoint, then continue using per-agent state for the selected agent
- document the lightweight list contract and add response-body read context before JSON decode

Fixes #988

## Verification
- `cargo test --test http_client agent_list_entries_are_slim_for_tui_bootstrap -- --nocapture`
- `cargo test remote_tick_does_not_await_slow_agent_list_refresh --lib -- --nocapture`
- `cargo test local_tui_restores_persisted_selected_agent_on_initial_agent_list --lib -- --nocapture`
- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test --test http_client -- --nocapture`