### PR TITLE
fix: gate rust warnings in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
   rust:
     name: Rust
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ current source of truth.
 - Use clear conventional commit prefixes: `feat:`, `fix:`, `docs:`, `refactor:`,
   `test:`, `chore:`.
 - Keep early commits narrow. This repository is still defining its core model.
+- Before opening a Rust PR, run `cargo fmt --all -- --check` and
+  `RUSTFLAGS="-D warnings" cargo check --all-targets` for warning-free builds.
 - In PR descriptions, explain which runtime concept changed and why.
 
 ## Migration Notes

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -812,7 +812,7 @@ async fn materialize_skill_ref(
     }
 }
 
-pub fn builtin_skill(name: &str) -> Option<&'static BuiltinSkill> {
+fn builtin_skill(name: &str) -> Option<&'static BuiltinSkill> {
     BUILTIN_SKILLS.iter().find(|skill| skill.name == name)
 }
 

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -58,6 +58,7 @@ pub async fn spawn_raw_http_server_bytes_sequence(responses: Vec<Vec<u8>>) -> St
     format!("http://{}", addr)
 }
 
+#[allow(dead_code)]
 pub async fn spawn_raw_http_server_bytes_sequence_with_delay(
     responses: Vec<(u64, Vec<u8>)>,
 ) -> String {

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -2721,6 +2721,7 @@ pub(crate) fn parse_chat_completion_response(response: Value) -> Result<ParsedOp
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 pub(crate) async fn send_chat_completion_stream_request(
     client: &Client,
     url: String,
@@ -2758,6 +2759,7 @@ pub(crate) async fn send_chat_completion_stream_request(
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 async fn read_chat_completion_stream(response: Response) -> Result<Value> {
     const MAX_STREAMED_EVENTS: usize = 128;
     let mut streamed_events = Vec::new();
@@ -2864,6 +2866,7 @@ async fn read_chat_completion_stream(response: Response) -> Result<Value> {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 fn process_chat_completion_sse_event(
     data_lines: &mut Vec<String>,
 ) -> Result<Option<ChatCompletionSseEvent>> {
@@ -3041,6 +3044,7 @@ pub(crate) fn accumulate_chat_completion_stream_events(events: Vec<Value>) -> Re
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 enum ChatCompletionSseEvent {
     ContentDelta(String),
     ToolCallDelta(Value),

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports)]
+
 pub(crate) use async_trait::async_trait;
 pub(crate) use chrono::Utc;
 pub(crate) use std::path::PathBuf;

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -976,6 +976,7 @@ fn build_turn_local_checkpoint_request(
     }
 }
 
+#[cfg(test)]
 fn build_turn_local_projection(
     prompt_frame: &ProviderPromptFrame,
     rounds: &[TurnRoundRecord],

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,7 +1,7 @@
 use super::overlay::draw_overlay;
-use super::view_model::{
-    render_header_line, render_model_detail, HeaderViewModel, StatusbarViewModel,
-};
+#[cfg(test)]
+use super::view_model::render_header_line;
+use super::view_model::{render_model_detail, HeaderViewModel, StatusbarViewModel};
 use super::*;
 use crate::tui::input::slash_menu_specs;
 use crate::types::{TaskKind, TaskStatus};
@@ -424,6 +424,7 @@ fn display_width(text: &str) -> u16 {
     UnicodeWidthStr::width(text).min(u16::MAX as usize) as u16
 }
 
+#[cfg(test)]
 pub(super) fn render_header(agent: &AgentSummary) -> String {
     render_header_line(agent)
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use std::{
     future::Future,

--- a/tests/support/runtime_compaction.rs
+++ b/tests/support/runtime_compaction.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 // Shared runtime integration fixtures and test implementations.
 // Domain-focused suites in sibling files call into these functions so coverage

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 // Shared runtime integration fixtures and test implementations.
 // Domain-focused suites in sibling files call into these functions so coverage

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 // Shared runtime integration fixtures and test implementations.
 // Domain-focused suites in sibling files call into these functions so coverage

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 // Shared runtime integration fixtures and test implementations.
 // Domain-focused suites in sibling files call into these functions so coverage

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 // Shared runtime integration fixtures and test implementations.
 // Domain-focused suites in sibling files call into these functions so coverage


### PR DESCRIPTION
## Summary
- clean current Rust warnings under `RUSTFLAGS="-D warnings" cargo check --all-targets`
- gate the Rust CI job with `RUSTFLAGS: -D warnings`
- document warning-free pre-PR checks in AGENTS.md

Fixes #993.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets -- --test-threads=1`