### PR TITLE
fix: clear completed blocking task state

### DIFF
--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -672,7 +672,7 @@ impl RuntimeHandle {
             &task_record,
             terminal.status.clone(),
             detail.clone(),
-            !task_record.is_blocking(),
+            true,
             "command_task_terminal_persisted",
         )
         .await?;

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -120,14 +120,19 @@ pub(super) fn resolve_continuation(
         );
     }
 
-    let model_visible = matches!(
-        trigger.kind,
-        ContinuationTriggerKind::OperatorInput
-            | ContinuationTriggerKind::TimerFire
-            | ContinuationTriggerKind::InternalFollowup
-    ) || ((trigger.kind == ContinuationTriggerKind::ExternalEvent
-        || trigger.kind == ContinuationTriggerKind::SystemTick)
-        && trigger.contentful);
+    let terminal_blocking_task_result = trigger.kind == ContinuationTriggerKind::TaskResult
+        && trigger.task_terminal
+        && trigger.task_blocking;
+    let model_visible = terminal_blocking_task_result
+        || matches!(
+            trigger.kind,
+            ContinuationTriggerKind::OperatorInput
+                | ContinuationTriggerKind::TimerFire
+                | ContinuationTriggerKind::InternalFollowup
+        )
+        || ((trigger.kind == ContinuationTriggerKind::ExternalEvent
+            || trigger.kind == ContinuationTriggerKind::SystemTick)
+            && trigger.contentful);
     let class = if model_visible {
         ContinuationClass::LocalContinuation
     } else {
@@ -228,6 +233,22 @@ fn resolve_waiting(
             prior_closure_outcome,
             prior_waiting_reason,
             matched_waiting_reason,
+            evidence,
+        };
+    }
+
+    if trigger.kind == ContinuationTriggerKind::TaskResult
+        && trigger.task_terminal
+        && trigger.task_blocking
+    {
+        evidence.push("terminal_blocking_task_result".to_string());
+        return ContinuationResolution {
+            trigger_kind: trigger.kind,
+            class: ContinuationClass::ResumeOverride,
+            model_visible: true,
+            prior_closure_outcome,
+            prior_waiting_reason,
+            matched_waiting_reason: false,
             evidence,
         };
     }
@@ -359,6 +380,44 @@ mod tests {
         );
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_visible);
+    }
+
+    #[test]
+    fn terminal_blocking_task_result_resumes_without_prior_wait() {
+        let resolution = resolve_continuation(
+            &ClosureDecision {
+                outcome: ClosureOutcome::Completed,
+                waiting_reason: None,
+                work_signal: None,
+                runtime_posture: RuntimePosture::Awake,
+                evidence: vec![],
+            },
+            &ContinuationTrigger {
+                kind: ContinuationTriggerKind::TaskResult,
+                contentful: true,
+                task_terminal: true,
+                task_blocking: true,
+                wake_hint_source: None,
+            },
+        );
+        assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
+        assert!(resolution.model_visible);
+    }
+
+    #[test]
+    fn terminal_blocking_task_result_overrides_mismatched_wait() {
+        let resolution = resolve_continuation(
+            &waiting(WaitingReason::AwaitingExternalChange),
+            &ContinuationTrigger {
+                kind: ContinuationTriggerKind::TaskResult,
+                contentful: true,
+                task_terminal: true,
+                task_blocking: true,
+                wake_hint_source: None,
+            },
+        );
+        assert_eq!(resolution.class, ContinuationClass::ResumeOverride);
+        assert!(resolution.model_visible);
     }
 
     #[test]

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -241,6 +241,8 @@ fn resolve_waiting(
         && trigger.task_terminal
         && trigger.task_blocking
     {
+        // Terminal blocking task state is persisted before TaskResult enqueue, so
+        // resuming here cannot reopen the stale active-task wait that just ended.
         evidence.push("terminal_blocking_task_result".to_string());
         return ContinuationResolution {
             trigger_kind: trigger.kind,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -261,7 +261,11 @@ impl RuntimeHandle {
             .latest_task_records()
             .await?
             .into_iter()
-            .filter(|task| active_task_ids.contains(task.id.as_str()) && task.is_blocking())
+            .filter(|task| {
+                active_task_ids.contains(task.id.as_str())
+                    && task.is_blocking()
+                    && !task_state_reducer::is_terminal_task_status(&task.status)
+            })
             .count())
     }
 
@@ -1085,7 +1089,10 @@ fn active_child_tasks<'a>(
 ) -> Vec<&'a TaskRecord> {
     tasks
         .iter()
-        .filter(|task| active_task_ids.iter().any(|task_id| task_id == &task.id))
+        .filter(|task| {
+            active_task_ids.iter().any(|task_id| task_id == &task.id)
+                && !task_state_reducer::is_terminal_task_status(&task.status)
+        })
         .collect()
 }
 

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -30,9 +30,17 @@ impl RuntimeHandle {
         let continuation_resolution = continuation_trigger
             .as_ref()
             .map(|trigger| resolve_continuation(&prior_closure, trigger));
-        let model_visible = continuation_resolution
-            .as_ref()
-            .is_some_and(|resolution| resolution.model_visible);
+        let model_turn_allowed = {
+            let guard = self.inner.agent.lock().await;
+            !matches!(
+                guard.state.status,
+                AgentStatus::Paused | AgentStatus::Stopped
+            )
+        };
+        let model_visible = model_turn_allowed
+            && continuation_resolution
+                .as_ref()
+                .is_some_and(|resolution| resolution.model_visible);
 
         match message.kind {
             MessageKind::OperatorPrompt

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -42,7 +42,7 @@ pub(super) fn has_blocking_active_tasks(
         tasks
             .iter()
             .find(|task| &task.id == task_id)
-            .is_some_and(TaskRecord::is_blocking)
+            .is_some_and(|task| task.is_blocking() && !is_terminal_task_status(&task.status))
     }))
 }
 
@@ -289,6 +289,21 @@ mod tests {
         assert!(has_blocking_active_tasks(&storage, &active_task_ids).unwrap());
         let no_blocking = vec!["background".to_string()];
         assert!(!has_blocking_active_tasks(&storage, &no_blocking).unwrap());
+    }
+
+    #[test]
+    fn has_blocking_active_tasks_ignores_terminal_stale_active_ids() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage
+            .append_task(&task("stale", TaskStatus::Running, true))
+            .unwrap();
+        storage
+            .append_task(&task("stale", TaskStatus::Completed, true))
+            .unwrap();
+
+        let active_task_ids = vec!["stale".to_string()];
+        assert!(!has_blocking_active_tasks(&storage, &active_task_ids).unwrap());
     }
 
     #[tokio::test]

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -44,15 +44,15 @@ fn spawn_agent_task_label(initial_message: &str) -> String {
     crate::tool::helpers::truncate_text(&label, SPAWN_AGENT_TASK_LABEL_CHAR_BUDGET)
 }
 
-fn task_status_from_label(status: &str) -> TaskStatus {
+fn task_status_label(status: &TaskStatus) -> &'static str {
     match status {
-        "running" => TaskStatus::Running,
-        "cancelling" => TaskStatus::Cancelling,
-        "completed" => TaskStatus::Completed,
-        "failed" => TaskStatus::Failed,
-        "cancelled" => TaskStatus::Cancelled,
-        "interrupted" => TaskStatus::Interrupted,
-        _ => TaskStatus::Queued,
+        TaskStatus::Queued => "queued",
+        TaskStatus::Running => "running",
+        TaskStatus::Cancelling => "cancelling",
+        TaskStatus::Completed => "completed",
+        TaskStatus::Failed => "failed",
+        TaskStatus::Cancelled => "cancelled",
+        TaskStatus::Interrupted => "interrupted",
     }
 }
 
@@ -214,23 +214,27 @@ impl RuntimeHandle {
                 .run_subagent_prompt(&agent_id, &prompt, &trust)
                 .await;
             let (text, status) = match subagent_result {
-                Ok(text) => (text, "completed"),
-                Err(err) => (format!("child agent failed: {err:#}"), "failed"),
+                Ok(text) => (text, TaskStatus::Completed),
+                Err(err) => (format!("child agent failed: {err:#}"), TaskStatus::Failed),
             };
+            let status_label = task_status_label(&status);
 
-            let terminal_task = task_with_status(
-                &task_record,
-                task_status_from_label(status),
-                task_record.detail.clone(),
-            );
-            let _ = runtime
+            let terminal_task = task_with_status(&task_record, status, task_record.detail.clone());
+            if let Err(error) = runtime
                 .persist_task_status_direct(&terminal_task, "task_status_updated")
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    task_id = %terminal_task.id,
+                    error = %error,
+                    "failed to persist terminal task status before task result"
+                );
+            }
             let result_message = MessageEnvelope {
                 metadata: Some(serde_json::json!({
                     "task_id": task_record.id,
                     "task_kind": task_record.kind,
-                    "task_status": status,
+                    "task_status": status_label,
                     "task_summary": task_record.summary,
                     "task_detail": task_record.detail,
                     "task_recovery": task_record.recovery,
@@ -520,7 +524,7 @@ impl RuntimeHandle {
 
             let (mut text, status, mut task_detail, worktree_path): (
                 String,
-                &str,
+                TaskStatus,
                 serde_json::Value,
                 Option<(PathBuf, String, Vec<String>)>,
             ) = match subagent_result {
@@ -536,7 +540,11 @@ impl RuntimeHandle {
                     });
                     (
                         worktree::format_worktree_task_result(&result),
-                        if result.failed { "failed" } else { "completed" },
+                        if result.failed {
+                            TaskStatus::Failed
+                        } else {
+                            TaskStatus::Completed
+                        },
                         {
                             let mut detail = task_record
                                 .detail
@@ -550,7 +558,7 @@ impl RuntimeHandle {
                 }
                 Err(err) => (
                     format!("worktree child agent failed: {err:#}"),
-                    "failed",
+                    TaskStatus::Failed,
                     task_record
                         .detail
                         .clone()
@@ -572,10 +580,11 @@ impl RuntimeHandle {
                 }
             }
 
+            let status_label = task_status_label(&status);
             let mut metadata = serde_json::json!({
                 "task_id": task_record.id,
                 "task_kind": task_record.kind,
-                "task_status": status,
+                "task_status": status_label,
                 "task_summary": task_record.summary,
                 "task_detail": task_detail.clone(),
                 "task_recovery": task_record.recovery,
@@ -583,14 +592,17 @@ impl RuntimeHandle {
             if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
                 metadata["worktree"] = worktree;
             }
-            let terminal_task = task_with_status(
-                &task_record,
-                task_status_from_label(status),
-                Some(task_detail.clone()),
-            );
-            let _ = runtime
+            let terminal_task = task_with_status(&task_record, status, Some(task_detail.clone()));
+            if let Err(error) = runtime
                 .persist_task_status_direct(&terminal_task, "task_status_updated")
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    task_id = %terminal_task.id,
+                    error = %error,
+                    "failed to persist terminal task status before task result"
+                );
+            }
             let result_message = MessageEnvelope {
                 metadata: Some(metadata),
                 ..MessageEnvelope::new(
@@ -731,9 +743,16 @@ impl RuntimeHandle {
                         TaskStatus::Failed,
                         task_record.detail.clone(),
                     );
-                    let _ = runtime
+                    if let Err(error) = runtime
                         .persist_task_status_direct(&failed_task, "task_status_updated")
-                        .await;
+                        .await
+                    {
+                        tracing::warn!(
+                            task_id = %failed_task.id,
+                            error = %error,
+                            "failed to persist terminal task status before task result"
+                        );
+                    }
                     let _ = runtime.enqueue(result_message).await;
                     runtime
                         .inner
@@ -918,20 +937,12 @@ impl RuntimeHandle {
         let (mut text, status, mut task_detail) = match result {
             Ok(result) => (
                 result.text,
-                match result.status {
-                    TaskStatus::Completed => "completed",
-                    TaskStatus::Failed => "failed",
-                    TaskStatus::Cancelled => "cancelled",
-                    TaskStatus::Interrupted => "interrupted",
-                    TaskStatus::Cancelling => "cancelling",
-                    TaskStatus::Running => "running",
-                    TaskStatus::Queued => "queued",
-                },
+                result.status,
                 result.task_detail.unwrap_or(task_detail_for_result.clone()),
             ),
             Err(err) => (
                 format!("child agent failed: {err:#}"),
-                "failed",
+                TaskStatus::Failed,
                 task_detail_for_result,
             ),
         };
@@ -963,7 +974,7 @@ impl RuntimeHandle {
                         worktree_path: path.clone(),
                         worktree_branch: branch.clone(),
                         changed_files: changed_files.clone(),
-                        failed: status == "failed",
+                        failed: status == TaskStatus::Failed,
                     });
                     if let Ok(Some(cleanup)) = self
                         .cleanup_task_owned_worktree_in_detail(
@@ -997,10 +1008,11 @@ impl RuntimeHandle {
             ))?;
         }
 
+        let status_label = task_status_label(&status);
         let mut metadata = serde_json::json!({
             "task_id": task_record.id,
             "task_kind": task_record.kind,
-            "task_status": status,
+            "task_status": status_label,
             "task_summary": task_record.summary,
             "task_recovery": task_record.recovery,
             "task_detail": task_detail.clone(),
@@ -1014,14 +1026,17 @@ impl RuntimeHandle {
         if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
             metadata["worktree"] = worktree;
         }
-        let terminal_task = task_with_status(
-            &task_record,
-            task_status_from_label(status),
-            Some(task_detail.clone()),
-        );
-        let _ = self
+        let terminal_task = task_with_status(&task_record, status, Some(task_detail.clone()));
+        if let Err(error) = self
             .persist_task_status_direct(&terminal_task, "task_status_updated")
-            .await;
+            .await
+        {
+            tracing::warn!(
+                task_id = %terminal_task.id,
+                error = %error,
+                "failed to persist terminal task status before task result"
+            );
+        }
         let result_message = MessageEnvelope {
             metadata: Some(metadata),
             ..MessageEnvelope::new(

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -44,6 +44,37 @@ fn spawn_agent_task_label(initial_message: &str) -> String {
     crate::tool::helpers::truncate_text(&label, SPAWN_AGENT_TASK_LABEL_CHAR_BUDGET)
 }
 
+fn task_status_from_label(status: &str) -> TaskStatus {
+    match status {
+        "running" => TaskStatus::Running,
+        "cancelling" => TaskStatus::Cancelling,
+        "completed" => TaskStatus::Completed,
+        "failed" => TaskStatus::Failed,
+        "cancelled" => TaskStatus::Cancelled,
+        "interrupted" => TaskStatus::Interrupted,
+        _ => TaskStatus::Queued,
+    }
+}
+
+fn task_with_status(
+    task: &TaskRecord,
+    status: TaskStatus,
+    detail: Option<serde_json::Value>,
+) -> TaskRecord {
+    TaskRecord {
+        id: task.id.clone(),
+        agent_id: task.agent_id.clone(),
+        kind: task.kind.clone(),
+        status,
+        created_at: task.created_at,
+        updated_at: Utc::now(),
+        parent_message_id: task.parent_message_id.clone(),
+        summary: task.summary.clone(),
+        detail,
+        recovery: task.recovery.clone(),
+    }
+}
+
 impl RuntimeHandle {
     pub(crate) fn supports_child_agent_spawning(&self) -> bool {
         self.inner.host_bridge.is_some()
@@ -187,6 +218,14 @@ impl RuntimeHandle {
                 Err(err) => (format!("child agent failed: {err:#}"), "failed"),
             };
 
+            let terminal_task = task_with_status(
+                &task_record,
+                task_status_from_label(status),
+                task_record.detail.clone(),
+            );
+            let _ = runtime
+                .persist_task_status_direct(&terminal_task, "task_status_updated")
+                .await;
             let result_message = MessageEnvelope {
                 metadata: Some(serde_json::json!({
                     "task_id": task_record.id,
@@ -538,12 +577,20 @@ impl RuntimeHandle {
                 "task_kind": task_record.kind,
                 "task_status": status,
                 "task_summary": task_record.summary,
-                "task_detail": task_detail,
+                "task_detail": task_detail.clone(),
                 "task_recovery": task_record.recovery,
             });
             if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
                 metadata["worktree"] = worktree;
             }
+            let terminal_task = task_with_status(
+                &task_record,
+                task_status_from_label(status),
+                Some(task_detail.clone()),
+            );
+            let _ = runtime
+                .persist_task_status_direct(&terminal_task, "task_status_updated")
+                .await;
             let result_message = MessageEnvelope {
                 metadata: Some(metadata),
                 ..MessageEnvelope::new(
@@ -679,6 +726,14 @@ impl RuntimeHandle {
                             AdmissionContext::RuntimeOwned,
                         )
                     };
+                    let failed_task = task_with_status(
+                        &task_record,
+                        TaskStatus::Failed,
+                        task_record.detail.clone(),
+                    );
+                    let _ = runtime
+                        .persist_task_status_direct(&failed_task, "task_status_updated")
+                        .await;
                     let _ = runtime.enqueue(result_message).await;
                     runtime
                         .inner
@@ -815,7 +870,7 @@ impl RuntimeHandle {
                 "task_status": "running",
                 "task_summary": task_record.summary,
                 "task_recovery": task_record.recovery,
-                "task_detail": task_detail,
+                "task_detail": task_detail.clone(),
             })),
             ..MessageEnvelope::new(
                 agent_id.clone(),
@@ -948,7 +1003,7 @@ impl RuntimeHandle {
             "task_status": status,
             "task_summary": task_record.summary,
             "task_recovery": task_record.recovery,
-            "task_detail": task_detail,
+            "task_detail": task_detail.clone(),
         });
         if let Some(delegation) = delegation.as_ref() {
             metadata["delegation_id"] = serde_json::json!(delegation.delegation_id.clone());
@@ -959,6 +1014,14 @@ impl RuntimeHandle {
         if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
             metadata["worktree"] = worktree;
         }
+        let terminal_task = task_with_status(
+            &task_record,
+            task_status_from_label(status),
+            Some(task_detail.clone()),
+        );
+        let _ = self
+            .persist_task_status_direct(&terminal_task, "task_status_updated")
+            .await;
         let result_message = MessageEnvelope {
             metadata: Some(metadata),
             ..MessageEnvelope::new(

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -43,6 +43,7 @@ runtime_async_tests!(
     command_task_output_truncation_preserves_path_artifact_reference,
     command_task_stop_cancels_running_command,
     background_command_task_persists_terminal_state_while_runtime_paused,
+    blocking_command_task_clears_active_state_while_runtime_paused,
     command_task_result_is_canonical_follow_up_on_completion,
     task_result_rejoin_preserves_runtime_provenance_not_operator_authority,
     blocking_command_task_sets_awaiting_task_closure,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -1710,6 +1710,45 @@ pub async fn background_command_task_persists_terminal_state_while_runtime_pause
     Ok(())
 }
 
+pub async fn blocking_command_task_clears_active_state_while_runtime_paused() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    let runtime = host.default_runtime().await?;
+    runtime.control(ControlAction::Pause).await?;
+
+    let task = runtime
+        .schedule_command_task(
+            "blocking complete while paused".into(),
+            holon::types::CommandTaskSpec {
+                cmd: "printf blocking_paused_ok".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: Some(256),
+                accepts_input: false,
+                continue_on_result: true,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    wait_until(|| {
+        let tasks = runtime.storage().latest_task_records()?;
+        let state = runtime.storage().read_agent()?.expect("agent should exist");
+        Ok(tasks.iter().any(|record| {
+            record.id == task.id && record.status == holon::types::TaskStatus::Completed
+        }) && !state.active_task_ids.contains(&task.id))
+    })
+    .await?;
+
+    let state = runtime.agent_state().await?;
+    assert_eq!(state.status, AgentStatus::Paused);
+    assert!(!state.active_task_ids.contains(&task.id));
+    Ok(())
+}
+
 pub async fn command_task_result_is_canonical_follow_up_on_completion() -> Result<()> {
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;


### PR DESCRIPTION
## Summary

Fixes #1000.

This fixes agents getting stuck in `AwaitingTask` after blocking tasks complete by making terminal task state explicit before task result re-entry, and by treating stale terminal task IDs as non-blocking during recovery/inspection.

## Changes

- Persist terminal state for blocking command tasks so completed command task IDs are removed from `active_task_ids` immediately.
- Persist terminal state for child/subagent task completion and spawn-failure paths before enqueueing `TaskResult`.
- Treat terminal task records as non-blocking when computing active blocking task state and active child observability.
- Let terminal blocking `TaskResult` resume the model even if prior closure state was missing or mismatched, while still preventing paused/stopped agents from starting provider turns.
- Add regression coverage for stale terminal active IDs and paused-runtime blocking command completion.

## Verification

- `cargo fmt --check && git diff --check`
- `cargo test continuation --lib -- --nocapture`
- `cargo test task_state_reducer --lib -- --nocapture`
- `cargo test runtime_state --lib -- --nocapture`
- `cargo test --test runtime_tasks -- --nocapture`
- `cargo test --test runtime_subagents -- --nocapture`
- `cargo test --lib config::tests::app_config_honors_explicit_default_agent_env -- --nocapture`
- `cargo test --lib config::tests::config_inspection_loads_provider_state_without_resolved_model -- --nocapture`
