### PR TITLE
feat: implement runtime scheduler contract

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -10,6 +10,7 @@ For a short architecture map and reading path, see
 
 - [Agent Control Plane Model](./agent-control-plane-model.md)
 - [Agent Profile Model](./agent-profile-model.md)
+- [Runtime Scheduler Contract](./runtime-scheduler-contract.md)
 - [Result Closure](./result-closure.md)
 - [Continuation Trigger](./continuation-trigger.md)
 - [Objective, Delta, and Acceptance Boundary](./objective-delta-and-acceptance-boundary.md)

--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -495,21 +495,29 @@ Queued messages are durable scheduler inputs.
 Restart behavior should be explicit:
 
 - `Queued` messages replay;
-- `Dequeued` messages replay only if the previous run did not reach a terminal
-  boundary;
+- `Dequeued` messages may replay at the message level when the previous run did
+  not reach a terminal boundary;
 - `Processed`, `Interrupted`, `Dropped`, and `Interjected` messages do not
   replay as normal queued messages.
 
-The current replay behavior should be characterized by tests before it changes.
+Holon should not replay prior tool calls as a recovery mechanism. Tool calls
+are model-driven. After a restart, the runtime may replay the dequeued message
+so the model can inspect current state and decide what to do next, but the
+runtime must not automatically execute tool calls that were recorded before the
+restart.
 
-Open question:
+The scheduler contract is therefore:
 
-- should a `Dequeued` message replay after a provider/tool side effect but
-  before `Processed`, or should Holon persist a run checkpoint that prevents
-  duplicate side effects?
+- replay is message-level, not tool-call-level;
+- prior assistant rounds, tool executions, task records, work items, and briefs
+  should be visible enough for the next model turn to recover;
+- duplicate prevention means the runtime does not re-execute an already
+  recorded tool call id by itself;
+- if a side effect happened but no durable tool record exists, the scheduler
+  cannot reliably infer it and should not pretend otherwise.
 
-Until that is resolved, tools that can cause side effects should remain
-auditable and preferably idempotent or recoverable.
+This keeps side-effect recovery model-guided through observable evidence rather
+than scheduler-owned semantic replay.
 
 ## Context And Compaction Contract
 
@@ -739,18 +747,134 @@ Required scenarios:
 - compaction does not rewrite scheduler truth;
 - ledger replay can explain the final scheduler projection.
 
-## Open Questions
+## Decisions
 
-- Should `AgentState.status` eventually be fully derived, or should it remain a
-  cached projection with strict consistency checks?
-- What is the durable generation marker for WorkItem idempotency: `updated_at`,
-  append sequence, or an explicit revision?
-- How should Holon prevent duplicate side effects when a `Dequeued` message
-  replays after a crash?
-- Should task-to-work-item association become a first-class `TaskRecord` field
-  or remain in detail metadata?
-- Should scheduler replay fixtures live under `tests/fixtures/scheduler/` or
-  be generated from real `.holon/ledger` directories?
+### `AgentState.status` Remains A Cached Projection
+
+`AgentState.status` should remain persisted for fast TUI, API, and recovery
+reads.
+
+It should not remain a shared authority that unrelated modules mutate
+independently. The scheduler should become the only writer for status-like
+runtime posture. Tests should be able to rebuild the scheduler projection from
+durable ledgers and compare it with the cached agent state.
+
+This avoids making every status read expensive while still preventing hidden
+state drift.
+
+### WorkItem Idempotency Uses Explicit Revision
+
+Work-item idempotency should use an explicit revision or generation field, not
+`updated_at`.
+
+`updated_at` is useful for display and ordering, but it is too weak as a
+scheduler idempotency key. It can be affected by clock precision, imports,
+fixtures, and non-semantic writes.
+
+The preferred direction is:
+
+```rust
+struct WorkItemRecord {
+    revision: u64,
+    // existing fields...
+}
+```
+
+Every new WorkItem snapshot increments `revision`. Work-queue tick keys should
+then use:
+
+```text
+work_queue:continue_active:<work_item_id>:<revision>
+work_queue:queued_available:<work_item_id>:<revision>
+```
+
+If Holon later introduces ledger-wide sequence numbers, WorkItem revision can
+still remain the work-item-local semantic generation.
+
+### Dequeued Replay Is Message-Level
+
+Holon should replay `Dequeued` messages at the message level, not at the
+tool-call level.
+
+The runtime should not try to classify every tool as safe or unsafe to replay.
+Tools are model-invoked, and the model can inspect current state before
+deciding whether to call a tool again. Runtime-owned automatic replay of old
+tool calls would be both hard to classify and easy to get wrong.
+
+The decision is:
+
+- replaying a dequeued message may cause a new model turn;
+- old tool call ids are never automatically re-executed by scheduler recovery;
+- visible ledger evidence is the recovery mechanism;
+- if no durable record exists for a side effect, the scheduler cannot
+  reconstruct it reliably.
+
+This keeps replay simple and avoids introducing a premature side-effect
+classification system into the scheduler.
+
+### Task-To-WorkItem Association Becomes First-Class
+
+Task records should gain a first-class optional work-item association.
+
+Recommended shape:
+
+```rust
+struct TaskRecord {
+    work_item_id: Option<String>,
+    // existing fields...
+}
+```
+
+This lets Holon answer scheduler questions directly:
+
+- which WorkItem is this blocking task related to?
+- can this WorkItem complete while unrelated tasks are still running?
+- should this task result satisfy the current wait?
+- how should `/tasks` and state snapshots group active work?
+
+During migration, old records may continue to expose work-item association from
+`detail.work_item_id` as a fallback. New records should write the first-class
+field.
+
+### Scheduler Replay Fixtures Live Under `tests/fixtures/scheduler`
+
+Scheduler replay fixtures should live under:
+
+```text
+tests/fixtures/scheduler/
+```
+
+Each fixture should preserve the minimum ledger subset needed to rebuild a
+scheduler projection:
+
+```text
+tests/fixtures/scheduler/<case>/
+  agent.json
+  ledger/
+    messages.jsonl
+    queue_entries.jsonl
+    events.jsonl
+    tasks.jsonl
+    work_items.jsonl
+    waiting_intents.jsonl
+    timers.jsonl
+    tools.jsonl
+    briefs.jsonl
+  expected.json
+```
+
+Real `.holon/ledger` directories should be convertible into this fixture shape
+through a debug/export command, but committed tests should use stable,
+repository-local fixtures.
+
+## Deferred Follow-Up
+
+Tools may later expose a lightweight side-effect level such as `read_only`,
+`workspace_mutation`, `external_mutation`, or `unknown` for diagnostics and
+prompt guidance.
+
+That belongs with tool contract work, not this scheduler RFC. Scheduler
+recovery must not depend on it.
 
 ## Related RFCs
 

--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -1,0 +1,762 @@
+---
+title: RFC: Runtime Scheduler Contract
+date: 2026-05-08
+status: draft
+---
+
+# RFC: Runtime Scheduler Contract
+
+## Summary
+
+Holon's scheduler should become an explicit runtime contract instead of an
+emergent behavior spread across queue handling, task reducers, work-item
+reactivation, waiting intents, turn execution, and context compaction.
+
+The direction is:
+
+- scheduler decisions are derived from typed runtime facts;
+- `AgentState.status` is a projection, not an authority by itself;
+- task, work-item, waiting, wake, and compaction transitions have explicit
+  boundaries;
+- every scheduler-sensitive transition is testable through pure reducers and
+  replayable ledger fixtures.
+
+This RFC does not propose a large rewrite as the first step. It defines the
+contract Holon should converge toward and the tests that should guard the
+existing implementation while it is refactored.
+
+## Problem
+
+Holon is headless, event-driven, and long-lived. Scheduler bugs therefore have
+a disproportionate impact on user experience:
+
+- the agent may appear stuck while useful work is available;
+- the agent may keep re-entering itself with duplicate work-queue ticks;
+- completed tasks may continue to block progress;
+- work items may drift after compaction;
+- restarts may replay work in surprising ways;
+- the TUI and API may disagree about what the agent is waiting on.
+
+Recent task-completion fixes exposed the underlying design issue: scheduling
+state is currently written from several places. Queue dequeue, message
+processing, task transitions, command-task runners, work-item tools, system
+ticks, control actions, and shutdown paths can all mutate pieces of the same
+runtime posture.
+
+That makes local fixes possible, but it makes global correctness hard to
+reason about.
+
+## Goals
+
+- define one scheduler vocabulary for runtime inputs, decisions, and
+  projections;
+- make wake/sleep/wait/task/work-item behavior explainable from runtime facts;
+- make scheduler behavior reproducible from append-only ledgers;
+- prevent terminal tasks, completed work items, stale waits, or repeated ticks
+  from corrupting the active runtime posture;
+- keep context compaction from becoming an implicit scheduler mechanism;
+- preserve existing public behavior while giving future refactors a clear
+  target.
+
+## Non-goals
+
+- do not replace the provider turn loop in this RFC;
+- do not redefine the WorkItem schema beyond scheduler-relevant boundaries;
+- do not make the model the authority for closure or completion;
+- do not introduce a UI-first plan mode;
+- do not require remote provider compaction to become part of Holon's local
+  scheduler state;
+- do not remove append-only runtime ledgers.
+
+## Terms
+
+### Message
+
+A queued ingress unit. Messages include operator prompts, task results, timer
+ticks, system ticks, callback events, channel events, and internal follow-ups.
+
+Messages are inputs to scheduling. They are not themselves proof that a model
+turn should run.
+
+### Turn
+
+One conversational execution pass with a provider. A turn may contain multiple
+provider/tool rounds.
+
+Turns own:
+
+- provider request construction;
+- assistant round recording;
+- tool execution inside the turn;
+- turn-local compaction and checkpoints;
+- a terminal record.
+
+Turns do not own:
+
+- high-level work identity;
+- background task truth;
+- long-lived wait truth.
+
+### Task
+
+A concrete operational execution unit such as a command task or supervised
+child-agent task.
+
+Tasks own:
+
+- operational lifecycle;
+- output retrieval;
+- terminal result delivery;
+- cancellation and restart recovery.
+
+Tasks do not own high-level objective state.
+
+### WorkItem
+
+The goal-oriented unit of ongoing work.
+
+Work items own:
+
+- objective;
+- durable plan;
+- todo list;
+- work-level blocker;
+- completion summary.
+
+Work items are scheduler inputs, but they should not be hidden scheduler state.
+
+### Waiting Intent
+
+A durable future-condition record, usually anchored to a work item.
+
+Waiting intents explain why progress depends on a timer, callback, external
+change, or operator input.
+
+### Wake Hint
+
+A liveness signal that tells the runtime to reconsider scheduling. A wake hint
+does not automatically become rich model-visible content.
+
+### Closure
+
+The derived outcome of current runtime facts:
+
+- completed;
+- continuable;
+- failed;
+- waiting.
+
+Closure is evidence-driven and remains separate from runtime posture.
+
+### Runtime Posture
+
+The runtime's execution stance:
+
+- booting;
+- awake idle;
+- awake running;
+- awaiting task;
+- asleep;
+- paused;
+- stopped.
+
+Posture is a projection of scheduler facts plus control state.
+
+## Scheduler Inputs
+
+The scheduler should consume typed inputs. Current code may still receive these
+inputs through existing modules, but scheduler-sensitive mutations should be
+mapped into this vocabulary.
+
+### Message Inputs
+
+- `MessageQueued`
+- `MessageDequeued`
+- `MessageProcessed`
+- `MessageInterrupted`
+- `MessageDropped`
+
+Required fields:
+
+- `message_id`
+- `message_kind`
+- `priority`
+- `origin`
+- `trust`
+- `work_item_id`
+- `task_id`
+- `correlation_id`
+- `causation_id`
+
+### Turn Inputs
+
+- `TurnStarted`
+- `ProviderRoundCompleted`
+- `AssistantRoundRecorded`
+- `ToolRoundCompleted`
+- `TurnTerminal`
+- `TurnInterrupted`
+- `TurnBaselineOverBudget`
+
+Required fields:
+
+- `turn_index`
+- `run_id`
+- `message_id`
+- `terminal_kind`
+- `last_assistant_message`
+- `checkpoint`
+- token and timing diagnostics when available
+
+### Task Inputs
+
+- `TaskCreated`
+- `TaskRunning`
+- `TaskCancelling`
+- `TaskCompleted`
+- `TaskFailed`
+- `TaskCancelled`
+- `TaskInterrupted`
+- `TaskResultQueued`
+- `TaskResultDelivered`
+
+Required fields:
+
+- `task_id`
+- `task_kind`
+- `task_status`
+- `wait_policy`
+- `work_item_id` when known
+- `recovery`
+- `summary`
+- terminal detail when available
+
+### WorkItem Inputs
+
+- `WorkItemCreated`
+- `WorkItemPicked`
+- `WorkItemUpdated`
+- `WorkItemBlocked`
+- `WorkItemUnblocked`
+- `WorkItemCompleted`
+- `WorkItemDelegated`
+- `WorkItemDelegationCompleted`
+
+Required fields:
+
+- `work_item_id`
+- `state`
+- `readiness`
+- `objective`
+- `plan_status`
+- `blocked_by`
+- generation or updated-at marker
+
+### Waiting Inputs
+
+- `WaitingIntentCreated`
+- `WaitingIntentTriggered`
+- `WaitingIntentCancelled`
+- `TimerCreated`
+- `TimerFired`
+- `TimerCompleted`
+- `WakeHintSubmitted`
+- `WakeHintCoalesced`
+- `WakeHintIgnored`
+
+Required fields:
+
+- `waiting_intent_id`
+- `scope`
+- `work_item_id`
+- `source`
+- `resource`
+- `delivery_mode`
+- `trigger_count`
+
+### Control Inputs
+
+- `PauseRequested`
+- `ResumeRequested`
+- `StopRequested`
+- `ShutdownRequested`
+- `RuntimeRestarted`
+
+Control inputs are authoritative for posture. They should not erase task,
+work-item, or waiting facts.
+
+## Scheduler State
+
+The scheduler state should be a derived projection over durable facts, not a
+second independent source of truth.
+
+Recommended shape:
+
+```rust
+struct SchedulerState {
+    control_posture: ControlPosture,
+    queue: QueueProjection,
+    active_run: Option<RunProjection>,
+    active_tasks: Vec<TaskProjection>,
+    active_work_item: Option<WorkItemProjection>,
+    queued_work_items: Vec<WorkItemProjection>,
+    waiting_intents: Vec<WaitingIntentProjection>,
+    timers: Vec<TimerProjection>,
+    pending_wake_hint: Option<WakeHintProjection>,
+    last_turn_terminal: Option<TurnTerminalProjection>,
+    runtime_error: Option<RuntimeErrorProjection>,
+}
+```
+
+The important point is not this exact struct. The important point is that the
+scheduler decision can be derived from one explicit projection.
+
+## Scheduler Decisions
+
+The scheduler should produce one explicit decision at each boundary:
+
+- `StartModelTurn`
+- `ReduceMessageOnly`
+- `EmitSystemTick`
+- `WaitForTask`
+- `WaitForExternalChange`
+- `WaitForTimer`
+- `WaitForOperator`
+- `Sleep`
+- `StayIdle`
+- `Stop`
+- `Noop`
+
+Decisions should include evidence:
+
+- which facts caused the decision;
+- which message or work item is involved;
+- whether the decision is model-visible;
+- whether it is a liveness-only decision;
+- whether any input was ignored as mismatched.
+
+## Decision Priority
+
+Scheduler decisions should use a fixed priority order.
+
+1. `stopped` or shutdown means `Stop`.
+2. `paused` means no model turn starts.
+3. queued interrupt operator input may interrupt a running turn.
+4. a queued model-visible message may start a turn when no turn is running.
+5. terminal blocking task result may resume the model-visible wait it satisfies.
+6. active blocking tasks mean `WaitForTask`.
+7. active waiting intents mean `WaitForExternalChange`.
+8. active timers mean `WaitForTimer`.
+9. current runnable work item means `EmitSystemTick(continue_active)` unless an
+   idempotency key has already been emitted for the same generation.
+10. queued runnable work item means `EmitSystemTick(queued_available)` unless an
+    idempotency key has already been emitted for the same generation.
+11. pending wake hint means `EmitSystemTick(wake_hint)`.
+12. no runnable work and no pending inputs means `Sleep` or `StayIdle`,
+    depending on host mode.
+
+This order intentionally keeps blocking facts above work-queue self-reactivate
+ticks.
+
+## Model Visibility
+
+Not every scheduler input should run a provider turn.
+
+Model-visible inputs:
+
+- operator prompt;
+- contentful external event;
+- timer tick with contentful resume text;
+- runtime-owned internal follow-up intended for the model;
+- terminal blocking task result.
+
+Liveness-only inputs:
+
+- wake hint without contentful body;
+- non-terminal task status;
+- duplicate work-queue tick;
+- control-plane state updates;
+- task result that does not satisfy the current wait and does not require model
+  re-entry.
+
+The continuation-trigger contract remains the source for the waiting matrix.
+This RFC adds the scheduler-level requirement that mismatched triggers must be
+recorded and must not silently satisfy an unrelated wait.
+
+## Task Contract
+
+Task transitions must be monotonic:
+
+```text
+queued -> running -> cancelling -> terminal
+queued -> terminal
+running -> terminal
+```
+
+Terminal statuses are:
+
+- completed;
+- failed;
+- cancelled;
+- interrupted.
+
+Invariants:
+
+- terminal tasks must not remain in the active task set;
+- terminal task records outrank stale non-terminal task messages;
+- task result delivery must not reopen a terminal task;
+- a non-terminal task status is not model-visible by itself;
+- blocking task truth is derived from latest task records, not from stale
+  active id lists alone;
+- task completion should be persisted before the corresponding model-visible
+  task result is queued.
+
+Recommended implementation boundary:
+
+- all task lifecycle writes should go through one `TaskTransition` reducer;
+- command tasks, child-agent tasks, and worktree child tasks should not each
+  hand-roll `append_task + active_task_ids + status` updates.
+
+## WorkItem Contract
+
+WorkItem scheduling should use readiness:
+
+- completed work is not runnable;
+- blocked work is not runnable;
+- `needs_input` is waiting for operator input;
+- open, unblocked work is runnable.
+
+Invariants:
+
+- completed work items cannot become current;
+- queued work items must not replace current work implicitly;
+- a work-queue `queued_available` tick must not mutate current work;
+- completing a work item clears it from current focus;
+- completing a work item cancels work-item-scoped waiting intents;
+- work-item completion should be blocked only by relevant blocking tasks once
+  task-to-work-item association is available.
+
+`current_work_item_id` and `current_turn_work_item_id` should remain distinct:
+
+- current work item is the durable active focus;
+- current turn binding is a scoped association for one real model turn.
+
+Turn-end work-item commits should only run for a real turn boundary. Reducing a
+non-model-visible message should not accidentally rewrite a work item's blocker
+state.
+
+## Work Queue Tick Contract
+
+Work queue ticks are runtime-generated messages used to make runnable work
+model-visible.
+
+They must be idempotent.
+
+Recommended idempotency keys:
+
+```text
+work_queue:continue_active:<work_item_id>:<work_item_generation>
+work_queue:queued_available:<work_item_id>:<work_item_generation>
+wake_hint:<waiting_intent_id_or_source>:<trigger_generation>
+```
+
+The current heuristic of scanning recent messages, briefs, tool executions, and
+events is useful as a guardrail, but the scheduler contract should move toward
+explicit idempotency keys.
+
+Invariants:
+
+- a work-queue tick is emitted only when the runtime is idle enough to process
+  it;
+- a model-visible continuation suppresses immediate duplicate
+  `continue_active`;
+- a wake hint has priority over work-queue ticks when both are pending;
+- duplicate suppression records evidence, not just silence.
+
+## Waiting Contract
+
+Waiting belongs to the waiting plane.
+
+Invariants:
+
+- `awaiting_operator_input` is satisfied by operator input;
+- `awaiting_task_result` is satisfied by a terminal blocking task result;
+- `awaiting_timer` is satisfied by a timer fire;
+- `awaiting_external_change` is satisfied by a contentful external event or a
+  wake hint tied to an active waiting condition;
+- mismatched triggers are liveness-only unless explicitly allowed to override;
+- switching the active work item cancels stale work-item-scoped waits;
+- agent-scoped waits are not cancelled merely because active work switches.
+
+## Queue And Restart Contract
+
+Queued messages are durable scheduler inputs.
+
+Restart behavior should be explicit:
+
+- `Queued` messages replay;
+- `Dequeued` messages replay only if the previous run did not reach a terminal
+  boundary;
+- `Processed`, `Interrupted`, `Dropped`, and `Interjected` messages do not
+  replay as normal queued messages.
+
+The current replay behavior should be characterized by tests before it changes.
+
+Open question:
+
+- should a `Dequeued` message replay after a provider/tool side effect but
+  before `Processed`, or should Holon persist a run checkpoint that prevents
+  duplicate side effects?
+
+Until that is resolved, tools that can cause side effects should remain
+auditable and preferably idempotent or recoverable.
+
+## Context And Compaction Contract
+
+Compaction must not become an implicit scheduler authority.
+
+### Cross-Turn Context Compaction
+
+Cross-turn compaction keeps prompt history bounded across messages.
+
+It may update:
+
+- compacted message count;
+- working-memory compression epoch;
+- context summary when working memory is not active.
+
+It must not decide:
+
+- whether a task is active;
+- whether a work item is complete;
+- whether the runtime should wake.
+
+### Turn-Local Compaction
+
+Turn-local compaction keeps one provider/tool turn within the prompt budget.
+
+It may create:
+
+- deterministic round recaps;
+- checkpoint prompts;
+- checkpoint terminal records;
+- baseline-over-budget terminal records.
+
+It must not replace:
+
+- WorkItem plan;
+- task records;
+- waiting intents;
+- closure derivation.
+
+### Provider Context Management
+
+Provider context management is a provider-window optimization.
+
+It must not become:
+
+- Holon's semantic memory;
+- scheduler state;
+- a replacement for WorkItem plan or local checkpoint evidence.
+
+## Closure Relationship
+
+The scheduler should consume closure decisions, but closure should also be
+derived from scheduler facts.
+
+Expected precedence:
+
+1. runtime error;
+2. operator-input wait;
+3. active blocking tasks;
+4. active waiting intents;
+5. active timers;
+6. active turn in progress;
+7. failed terminal turn;
+8. runnable work signal;
+9. completed terminal turn;
+10. no waiting condition.
+
+The result-closure RFC remains the semantic contract. This scheduler RFC
+defines how facts enter that closure derivation and how closure affects the
+next decision.
+
+## Event And Ledger Requirements
+
+Every scheduler decision should be explainable from durable records.
+
+Required ledger classes:
+
+- messages;
+- queue entries;
+- events;
+- transcript;
+- tasks;
+- work items;
+- waiting intents;
+- timers;
+- tool executions;
+- briefs.
+
+Recommended new event:
+
+```json
+{
+  "kind": "scheduler_decision",
+  "data": {
+    "decision": "EmitSystemTick",
+    "reason": "continue_active",
+    "model_visible": false,
+    "work_item_id": "work_...",
+    "message_id": null,
+    "evidence": [
+      "runtime_idle",
+      "current_work_item_runnable",
+      "no_duplicate_tick_for_generation"
+    ]
+  }
+}
+```
+
+The event should be generated from the scheduler projection, not hand-written
+separately in each feature path.
+
+## Test Strategy
+
+The test plan should have four layers.
+
+### Pure Reducer Tests
+
+These should not boot a runtime.
+
+Coverage:
+
+- continuation matrix;
+- closure priority;
+- task status monotonicity;
+- WorkItem readiness;
+- work-queue tick idempotency;
+- pause/stop gating;
+- restart replay classification.
+
+### Runtime Boundary Tests
+
+These should run focused runtime instances with stub providers.
+
+Coverage:
+
+- queue -> dequeued -> processed transitions;
+- provider turn started only when allowed;
+- non-model-visible task status does not start a turn;
+- terminal blocking task result resumes the expected wait;
+- paused runtime persists task terminal state but does not start a provider
+  turn;
+- system tick generation does not duplicate across idle loops.
+
+### Ledger Replay Tests
+
+These should rebuild `SchedulerState` from saved ledger fixtures and assert the
+same final projection.
+
+Coverage:
+
+- terminal task persisted before task result enqueue;
+- Dequeued message replay after restart;
+- pending wake hint recovery;
+- current work item with queued follow-up;
+- blocked work item with active waiting intent;
+- turn-local baseline-over-budget terminal record.
+
+### Scenario Tests
+
+These should cover end-to-end flows that combine mechanisms.
+
+Required scenarios:
+
+- task result rejoin after cross-turn compaction preserves current work truth;
+- queued work item notification after compaction does not focus the queued
+  item;
+- wake hint after compaction preserves provenance;
+- turn-local checkpoint followed by WorkItem update invalidates the checkpoint
+  anchor;
+- completing one work item is not blocked by an unrelated task once task
+  association exists;
+- interrupt operator prompt during a long provider/tool turn preserves
+  side-effect evidence and queue status.
+
+## Incremental Implementation Plan
+
+### Phase 1: Contract And Characterization
+
+- land this RFC;
+- add a `SchedulerProjection` read-only builder from current storage and agent
+  state;
+- emit `scheduler_decision` diagnostics without changing behavior;
+- add pure invariant tests for terminal tasks, pause/stop gating, work-item
+  readiness, and duplicate work-queue ticks.
+
+### Phase 2: Task Transition Unification
+
+- introduce `TaskTransition`;
+- move command task and child task terminal persistence through the same path;
+- enforce terminal active-task cleanup in one place;
+- add restart and out-of-order task-message tests.
+
+### Phase 3: Work Queue Idempotency
+
+- add explicit work-queue tick idempotency keys;
+- replace broad recent-ledger scans with generation-aware checks;
+- keep old scans temporarily as diagnostics.
+
+### Phase 4: Turn Binding Cleanup
+
+- separate durable current work from scoped turn binding;
+- make turn-end WorkItem commit require a real model turn terminal;
+- prevent non-model-visible reductions from mutating WorkItem blockers.
+
+### Phase 5: Replay Harness
+
+- add fixture-based scheduler replay tests;
+- convert future "agent seems stuck" reports into ledger fixtures before
+  patching;
+- use replay mismatches to guide further reducer extraction.
+
+## Invariants Checklist
+
+- stopped runtime does not process messages;
+- paused runtime does not start model turns;
+- current run id exists only while a run is active;
+- terminal tasks are absent from active task ids;
+- stale non-terminal task updates do not reopen terminal tasks;
+- blocking task closure is based on latest non-terminal blocking tasks;
+- completed work items are never runnable;
+- queued work items do not become current without an explicit pick;
+- `needs_input` work items wait for operator input;
+- duplicate work-queue ticks are suppressed with durable evidence;
+- wake hints are liveness signals unless made contentful by trigger policy;
+- mismatched continuation triggers do not satisfy unrelated waiting reasons;
+- turn-end WorkItem commits run only for real turn terminals;
+- compaction does not rewrite scheduler truth;
+- ledger replay can explain the final scheduler projection.
+
+## Open Questions
+
+- Should `AgentState.status` eventually be fully derived, or should it remain a
+  cached projection with strict consistency checks?
+- What is the durable generation marker for WorkItem idempotency: `updated_at`,
+  append sequence, or an explicit revision?
+- How should Holon prevent duplicate side effects when a `Dequeued` message
+  replays after a crash?
+- Should task-to-work-item association become a first-class `TaskRecord` field
+  or remain in detail metadata?
+- Should scheduler replay fixtures live under `tests/fixtures/scheduler/` or
+  be generated from real `.holon/ledger` directories?
+
+## Related RFCs
+
+- [Result Closure](./result-closure.md)
+- [Continuation Trigger](./continuation-trigger.md)
+- [Work Item Runtime Model](./work-item-runtime-model.md)
+- [Waiting Plane And Reactivation](./waiting-plane-and-reactivation.md)
+- [Turn-Local Context Compaction](./turn-local-context-compaction.md)
+- [OpenAI Remote Compaction Boundary](./openai-remote-compaction.md)

--- a/src/host.rs
+++ b/src/host.rs
@@ -2204,6 +2204,7 @@ mod tests {
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
                 parent_message_id: None,
+                work_item_id: None,
                 summary: Some("delegated child".into()),
                 detail: Some(serde_json::json!({
                     "child_agent_id": "child_test",
@@ -2265,6 +2266,7 @@ mod tests {
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
                 parent_message_id: None,
+                work_item_id: None,
                 summary: Some("delegated child".into()),
                 detail: Some(serde_json::json!({
                     "child_agent_id": "child_recover",
@@ -2491,6 +2493,7 @@ mod tests {
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
                 parent_message_id: None,
+                work_item_id: None,
                 summary: Some("delegated child".into()),
                 detail: Some(serde_json::json!({
                     "child_agent_id": "child_stop",

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -1150,6 +1150,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: None,
             detail: None,
             recovery: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -11,6 +11,7 @@ mod message_dispatch;
 mod operator;
 mod operator_dispatch;
 mod provider_turn;
+mod scheduler;
 mod subagent;
 mod task_state_reducer;
 mod task_supervisor;

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -689,12 +689,12 @@ impl RuntimeHandle {
         let result_message = MessageEnvelope {
             metadata: Some({
                 serde_json::json!({
-                "task_id": task_record.id,
-                "task_kind": task_record.kind,
-                "task_status": status_label,
-                "task_summary": task_record.summary,
-                "task_detail": detail.clone(),
-                "task_recovery": task_record.recovery,
+                    "task_id": task_record.id,
+                    "task_kind": task_record.kind,
+                    "task_status": status_label,
+                    "task_summary": task_record.summary,
+                    "task_detail": detail.clone(),
+                    "task_recovery": task_record.recovery,
                     "work_item_id": task_record.work_item_id.clone(),
                 })
             }),

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -476,6 +476,7 @@ impl RuntimeHandle {
             false,
         );
         let diagnostics = self.command_cost_diagnostics_for(&resolved.spec);
+        let work_item_id = self.task_work_item_binding().await;
         let task = TaskRecord {
             id: task_id.clone(),
             agent_id: agent_id.clone(),
@@ -484,6 +485,7 @@ impl RuntimeHandle {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
             parent_message_id: None,
+            work_item_id,
             summary: Some(summary.clone()),
             detail: Some(detail),
             recovery: Some(TaskRecoverySpec::CommandTask {
@@ -693,6 +695,7 @@ impl RuntimeHandle {
                 "task_summary": task_record.summary,
                 "task_detail": detail.clone(),
                 "task_recovery": task_record.recovery,
+                    "work_item_id": task_record.work_item_id.clone(),
                 })
             }),
             ..MessageEnvelope::new(
@@ -777,6 +780,7 @@ impl RuntimeHandle {
                 created_at: task_record.created_at,
                 updated_at: chrono::Utc::now(),
                 parent_message_id: None,
+                work_item_id: task_record.work_item_id.clone(),
                 summary: task_record.summary.clone(),
                 detail: Some(command_task_detail(
                     resolved,
@@ -812,6 +816,7 @@ impl RuntimeHandle {
                         false,
                     ),
                     "task_recovery": task_record.recovery,
+                    "work_item_id": task_record.work_item_id.clone(),
                 })),
                 ..MessageEnvelope::new(
                     agent_id.to_string(),
@@ -914,6 +919,7 @@ impl RuntimeHandle {
             created_at: task_record.created_at,
             updated_at: chrono::Utc::now(),
             parent_message_id: None,
+            work_item_id: task_record.work_item_id.clone(),
             summary: task_record.summary.clone(),
             detail: Some(detail),
             recovery: task_record.recovery.clone(),
@@ -1439,6 +1445,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some(summary.into()),
             detail: Some(command_task_detail(
                 resolved,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -34,6 +34,14 @@ impl RuntimeHandle {
         let (turn_index, work_item_id) = {
             let mut guard = self.inner.agent.lock().await;
             let turn_index = guard.state.turn_index;
+            let turn_completed = guard
+                .state
+                .last_turn_terminal
+                .as_ref()
+                .is_some_and(|record| record.turn_index == turn_index);
+            if !turn_completed {
+                return Ok(None);
+            }
             let work_item_id = guard.state.current_turn_work_item_id.take();
             self.inner.storage.write_agent(&guard.state)?;
             (turn_index, work_item_id)
@@ -72,6 +80,7 @@ impl RuntimeHandle {
                 id: latest.id.clone(),
                 agent_id: latest.agent_id.clone(),
                 workspace_id: latest.workspace_id.clone(),
+                revision: latest.revision + 1,
                 objective: latest.objective.clone(),
                 state: latest.state.clone(),
                 plan_status: latest.plan_status,
@@ -1234,6 +1243,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: None,
             detail: None,
             recovery: None,

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -275,6 +275,7 @@ impl RuntimeHandle {
             .storage
             .read_recent_messages(CONTINUE_ACTIVE_SIGNAL_SCAN_LIMIT)?
             .into_iter()
+            .rev()
             .filter(|message| {
                 matches!(
                     (&message.kind, &message.origin),

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -210,6 +210,11 @@ impl RuntimeHandle {
         &self,
         work_item: &crate::types::WorkItemRecord,
     ) -> Result<Option<String>> {
+        if let Some(message_id) = self.duplicate_work_queue_tick_message_id(
+            &scheduler::work_queue_tick_idempotency_key(work_item, "queued_available"),
+        )? {
+            return Ok(Some(message_id));
+        }
         let recent_messages = self
             .inner
             .storage
@@ -239,6 +244,11 @@ impl RuntimeHandle {
         &self,
         work_item: &crate::types::WorkItemRecord,
     ) -> Result<Option<String>> {
+        if let Some(message_id) = self.duplicate_work_queue_tick_message_id(
+            &scheduler::work_queue_tick_idempotency_key(work_item, "continue_active"),
+        )? {
+            return Ok(Some(message_id));
+        }
         let recent_briefs = self
             .inner
             .storage
@@ -254,6 +264,34 @@ impl RuntimeHandle {
         }
 
         Ok(Some(result_brief.id.clone()))
+    }
+
+    fn duplicate_work_queue_tick_message_id(
+        &self,
+        idempotency_key: &str,
+    ) -> Result<Option<String>> {
+        Ok(self
+            .inner
+            .storage
+            .read_recent_messages(CONTINUE_ACTIVE_SIGNAL_SCAN_LIMIT)?
+            .into_iter()
+            .filter(|message| {
+                matches!(
+                    (&message.kind, &message.origin),
+                    (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                        if subsystem == "work_queue"
+                )
+            })
+            .find(|message| {
+                message
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("work_queue"))
+                    .and_then(|metadata| metadata.get("idempotency_key"))
+                    .and_then(|value| value.as_str())
+                    == Some(idempotency_key)
+            })
+            .map(|message| message.id))
     }
 
     fn has_work_signal_after(
@@ -417,6 +455,7 @@ impl RuntimeHandle {
         work_item: &crate::types::WorkItemRecord,
         reason: &str,
     ) -> Result<()> {
+        let idempotency_key = scheduler::work_queue_tick_idempotency_key(work_item, reason);
         let mut message = MessageEnvelope::new(
             self.agent_id().await?,
             MessageKind::SystemTick,
@@ -440,7 +479,9 @@ impl RuntimeHandle {
         message.metadata = Some(serde_json::json!({
             "work_queue": {
                 "reason": reason,
+                "idempotency_key": idempotency_key,
                 "work_item_id": work_item.id,
+                "work_item_revision": work_item.revision,
                 "objective": work_item.objective,
                 "state": work_item.state,
                 "runtime_switched_current_item": false,
@@ -934,6 +975,46 @@ mod tests {
                 && event.data["reason"] == "no_new_signal_after_queued_available"
                 && event.data["work_item_id"] == queued_id
         }));
+    }
+
+    #[test]
+    fn queued_system_tick_idempotency_key_includes_work_item_revision() {
+        let test_runtime = test_runtime();
+        set_agent_idle(&test_runtime);
+
+        let queued = add_queued_work_item(&test_runtime, "wi-queued", "queued-target");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert!(rt
+            .block_on(test_runtime.runtime.maybe_emit_pending_system_tick(None))
+            .unwrap());
+        clear_queue(&test_runtime);
+
+        let first_ticks = get_emitted_system_ticks(&test_runtime);
+        assert_eq!(
+            first_ticks[0].1["idempotency_key"].as_str(),
+            Some("work_queue:queued_available:wi-queued:1")
+        );
+
+        let mut updated = queued.clone();
+        updated.revision += 1;
+        updated.updated_at = chrono::Utc::now();
+        test_runtime
+            .runtime
+            .inner
+            .storage
+            .append_work_item(&updated)
+            .unwrap();
+
+        assert!(rt
+            .block_on(test_runtime.runtime.maybe_emit_pending_system_tick(None))
+            .unwrap());
+        let ticks = get_emitted_system_ticks(&test_runtime);
+        assert_eq!(ticks.len(), 2);
+        assert_eq!(
+            ticks[1].1["idempotency_key"].as_str(),
+            Some("work_queue:queued_available:wi-queued:2")
+        );
     }
 
     #[test]

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -11,11 +11,6 @@ impl RuntimeHandle {
             "message_processing_started",
             to_json_value(&message),
         ))?;
-        if let Some(work_item_id) = message.work_item_id.as_deref() {
-            let mut guard = self.inner.agent.lock().await;
-            guard.state.current_turn_work_item_id = Some(work_item_id.to_string());
-        }
-
         let task = match message.kind {
             MessageKind::TaskStatus | MessageKind::TaskResult => {
                 Some(tasks::task_from_message(&message, &message.agent_id)?)
@@ -51,6 +46,11 @@ impl RuntimeHandle {
             | MessageKind::ChannelEvent
             | MessageKind::InternalFollowup => {
                 if model_visible {
+                    if let Some(work_item_id) = message.work_item_id.as_deref() {
+                        let mut guard = self.inner.agent.lock().await;
+                        guard.state.current_turn_work_item_id = Some(work_item_id.to_string());
+                        self.inner.storage.write_agent(&guard.state)?;
+                    }
                     self.process_interactive_message(
                         &message,
                         continuation_resolution.as_ref(),
@@ -100,15 +100,7 @@ impl RuntimeHandle {
                 AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
             );
             if status_mutable {
-                guard.state.status = if task_state_reducer::has_blocking_active_tasks(
-                    &self.inner.storage,
-                    &guard.state.active_task_ids,
-                )? {
-                    AgentStatus::AwaitingTask
-                } else {
-                    AgentStatus::AwakeIdle
-                };
-                guard.state.current_run_id = None;
+                scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
             }
             if status_mutable || matches!(message.kind, MessageKind::TaskResult) {
                 self.inner.storage.write_agent(&guard.state)?;

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -27,7 +27,11 @@ impl SchedulerProjection {
             active_tasks,
             has_blocking_active_tasks,
             current_work_item: work_queue.current,
-            queued_work_items: work_queue.queued_blocked.len(),
+            queued_work_items: work_queue
+                .queued_blocked
+                .iter()
+                .filter(|item| item.blocked_by.is_none())
+                .count(),
             pending_wake_hint: state.pending_wake_hint.is_some(),
         })
     }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1,0 +1,108 @@
+use super::*;
+use crate::storage::AppStorage;
+use crate::types::{AgentStatus, TaskRecord, TaskStatus, WorkItemRecord};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SchedulerProjection {
+    pub active_tasks: Vec<TaskRecord>,
+    pub has_blocking_active_tasks: bool,
+    pub current_work_item: Option<WorkItemRecord>,
+    pub queued_work_items: usize,
+    pub pending_wake_hint: bool,
+}
+
+impl SchedulerProjection {
+    pub(crate) fn from_state(storage: &AppStorage, state: &AgentState) -> Result<Self> {
+        let latest_tasks = storage.latest_task_records()?;
+        let active_tasks = state
+            .active_task_ids
+            .iter()
+            .filter_map(|task_id| latest_tasks.iter().find(|task| &task.id == task_id))
+            .filter(|task| is_active_task_status(&task.status))
+            .cloned()
+            .collect::<Vec<_>>();
+        let has_blocking_active_tasks = active_tasks.iter().any(TaskRecord::is_blocking);
+        let work_queue = storage.work_queue_prompt_projection()?;
+        Ok(Self {
+            active_tasks,
+            has_blocking_active_tasks,
+            current_work_item: work_queue.current,
+            queued_work_items: work_queue.queued_blocked.len(),
+            pending_wake_hint: state.pending_wake_hint.is_some(),
+        })
+    }
+}
+
+pub(crate) fn is_terminal_task_status(status: &TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::Completed
+            | TaskStatus::Failed
+            | TaskStatus::Cancelled
+            | TaskStatus::Interrupted
+    )
+}
+
+pub(crate) fn is_active_task_status(status: &TaskStatus) -> bool {
+    !is_terminal_task_status(status)
+}
+
+pub(crate) fn projected_status_for_idle(
+    state: &AgentState,
+    storage: &AppStorage,
+) -> Result<AgentStatus> {
+    if matches!(
+        state.status,
+        AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
+    ) {
+        return Ok(state.status.clone());
+    }
+    if SchedulerProjection::from_state(storage, state)?.has_blocking_active_tasks {
+        Ok(AgentStatus::AwaitingTask)
+    } else {
+        Ok(AgentStatus::AwakeIdle)
+    }
+}
+
+pub(crate) fn apply_idle_projection(state: &mut AgentState, storage: &AppStorage) -> Result<()> {
+    state.status = projected_status_for_idle(state, storage)?;
+    state.current_run_id = None;
+    Ok(())
+}
+
+pub(crate) fn active_task_blocks_work_item_completion(
+    task: &TaskRecord,
+    work_item_id: &str,
+) -> bool {
+    if !task.is_blocking() || is_terminal_task_status(&task.status) {
+        return false;
+    }
+    match task.effective_work_item_id() {
+        Some(id) => id == work_item_id,
+        None => true,
+    }
+}
+
+pub(crate) fn has_completion_blocking_task_for_work_item(
+    storage: &AppStorage,
+    active_task_ids: &[String],
+    work_item_id: &str,
+) -> Result<bool> {
+    if active_task_ids.is_empty() {
+        return Ok(false);
+    }
+    let tasks = storage.latest_task_records()?;
+    Ok(active_task_ids.iter().any(|task_id| {
+        tasks
+            .iter()
+            .find(|task| &task.id == task_id)
+            .is_some_and(|task| active_task_blocks_work_item_completion(task, work_item_id))
+    }))
+}
+
+pub(crate) fn work_queue_tick_idempotency_key(work_item: &WorkItemRecord, reason: &str) -> String {
+    format!(
+        "work_queue:{}:{}:{}",
+        reason, work_item.id, work_item.revision
+    )
+}

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -1,13 +1,7 @@
-use super::*;
+use super::{scheduler, *};
 
 pub(super) fn is_terminal_task_status(status: &TaskStatus) -> bool {
-    matches!(
-        status,
-        TaskStatus::Completed
-            | TaskStatus::Failed
-            | TaskStatus::Cancelled
-            | TaskStatus::Interrupted
-    )
+    scheduler::is_terminal_task_status(status)
 }
 
 pub(super) fn should_ignore_task_update(storage: &AppStorage, task: &TaskRecord) -> Result<bool> {
@@ -47,33 +41,35 @@ pub(super) fn has_blocking_active_tasks(
 }
 
 impl RuntimeHandle {
-    pub(super) async fn reduce_task_status_message(&self, task: TaskRecord) -> Result<()> {
-        if should_ignore_task_update(&self.inner.storage, &task)? {
+    pub(super) async fn persist_task_transition(
+        &self,
+        task: &TaskRecord,
+        event_kind: &'static str,
+    ) -> Result<()> {
+        if should_ignore_task_update(&self.inner.storage, task)? {
             return Ok(());
         }
 
-        self.inner.storage.append_task(&task)?;
+        self.inner.storage.append_task(task)?;
         {
             let mut guard = self.inner.agent.lock().await;
-            if !guard.state.active_task_ids.contains(&task.id) {
+            if is_terminal_task_status(&task.status) {
+                guard.state.active_task_ids.retain(|id| id != &task.id);
+            } else if !guard.state.active_task_ids.contains(&task.id) {
                 guard.state.active_task_ids.push(task.id.clone());
             }
-            if task.is_blocking()
-                && !matches!(
-                    guard.state.status,
-                    AgentStatus::Paused | AgentStatus::Stopped
-                )
-            {
-                guard.state.status = AgentStatus::AwaitingTask;
-            }
-            guard.state.current_run_id = None;
+            scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
             self.inner.storage.write_agent(&guard.state)?;
         }
-        self.inner.storage.append_event(&AuditEvent::new(
-            "task_status_updated",
-            to_json_value(&task),
-        ))?;
+        self.inner
+            .storage
+            .append_event(&AuditEvent::new(event_kind, to_json_value(task)))?;
         Ok(())
+    }
+
+    pub(super) async fn reduce_task_status_message(&self, task: TaskRecord) -> Result<()> {
+        self.persist_task_transition(&task, "task_status_updated")
+            .await
     }
 
     pub(super) async fn reduce_task_result_message(
@@ -86,44 +82,8 @@ impl RuntimeHandle {
         if should_ignore_task_update(&self.inner.storage, &task)? {
             return Ok(());
         }
-
-        self.inner.storage.append_task(&task)?;
-        {
-            let mut guard = self.inner.agent.lock().await;
-            if is_terminal_task_status(&task.status) {
-                guard.state.active_task_ids.retain(|id| id != &task.id);
-                if !matches!(
-                    guard.state.status,
-                    AgentStatus::Paused | AgentStatus::Stopped
-                ) {
-                    guard.state.status = if has_blocking_active_tasks(
-                        &self.inner.storage,
-                        &guard.state.active_task_ids,
-                    )? {
-                        AgentStatus::AwaitingTask
-                    } else {
-                        AgentStatus::AwakeIdle
-                    };
-                }
-            } else {
-                if !guard.state.active_task_ids.contains(&task.id) {
-                    guard.state.active_task_ids.push(task.id.clone());
-                }
-                if task.is_blocking()
-                    && !matches!(
-                        guard.state.status,
-                        AgentStatus::Paused | AgentStatus::Stopped
-                    )
-                {
-                    guard.state.status = AgentStatus::AwaitingTask;
-                }
-            }
-            guard.state.current_run_id = None;
-        }
-        self.inner.storage.append_event(&AuditEvent::new(
-            "task_result_received",
-            to_json_value(&task),
-        ))?;
+        self.persist_task_transition(&task, "task_result_received")
+            .await?;
 
         let task_status_label = match task.status {
             TaskStatus::Completed => "completed",
@@ -195,6 +155,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some(format!("task {id}")),
             detail: blocking.then(|| json!({ "wait_policy": "blocking" })),
             recovery: None,
@@ -304,6 +265,20 @@ mod tests {
 
         let active_task_ids = vec!["stale".to_string()];
         assert!(!has_blocking_active_tasks(&storage, &active_task_ids).unwrap());
+    }
+
+    #[test]
+    fn task_record_work_item_id_falls_back_to_detail_for_old_records() {
+        let mut record = task("task-1", TaskStatus::Running, true);
+        record.detail = Some(serde_json::json!({
+            "wait_policy": "blocking",
+            "work_item_id": "work-old",
+        }));
+
+        assert_eq!(record.effective_work_item_id(), Some("work-old"));
+
+        record.work_item_id = Some("work-new".into());
+        assert_eq!(record.effective_work_item_id(), Some("work-new"));
     }
 
     #[tokio::test]

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -111,6 +111,15 @@ impl RuntimeHandle {
                 let brief = brief::make_task_result(&message.agent_id, &task.id, &result_text);
                 self.persist_brief(&brief).await?;
             }
+            if let Some(work_item_id) = message
+                .work_item_id
+                .clone()
+                .or_else(|| task.effective_work_item_id().map(ToString::to_string))
+            {
+                let mut guard = self.inner.agent.lock().await;
+                guard.state.current_turn_work_item_id = Some(work_item_id);
+                self.inner.storage.write_agent(&guard.state)?;
+            }
             self.process_interactive_message(
                 message,
                 continuation_resolution,
@@ -361,6 +370,24 @@ mod tests {
         }));
         let transcript = runtime.storage().read_recent_transcript(10).unwrap();
         assert!(transcript.is_empty());
+    }
+
+    #[tokio::test]
+    async fn model_visible_task_result_binds_turn_to_work_item() {
+        let runtime = runtime();
+        let mut task = task("task-1", TaskStatus::Completed, false);
+        task.work_item_id = Some("work-1".into());
+        let mut message = task_result_message("task-1");
+        message.work_item_id = Some("work-1".into());
+
+        runtime
+            .reduce_task_result_message(&message, task, true, None)
+            .await
+            .unwrap();
+
+        let state = runtime.agent_state().await.unwrap();
+        assert_eq!(state.current_turn_work_item_id.as_deref(), Some("work-1"));
+        assert!(state.last_turn_terminal.is_some());
     }
 
     #[tokio::test]

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1,6 +1,5 @@
 use super::message_dispatch::message_text;
 use super::*;
-use crate::runtime::task_state_reducer::has_blocking_active_tasks;
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
@@ -69,6 +68,7 @@ fn task_with_status(
         created_at: task.created_at,
         updated_at: Utc::now(),
         parent_message_id: task.parent_message_id.clone(),
+        work_item_id: task.work_item_id.clone(),
         summary: task.summary.clone(),
         detail,
         recovery: task.recovery.clone(),
@@ -76,6 +76,15 @@ fn task_with_status(
 }
 
 impl RuntimeHandle {
+    pub(super) async fn task_work_item_binding(&self) -> Option<String> {
+        let guard = self.inner.agent.lock().await;
+        guard
+            .state
+            .current_turn_work_item_id
+            .clone()
+            .or_else(|| guard.state.current_work_item_id.clone())
+    }
+
     pub(crate) fn supports_child_agent_spawning(&self) -> bool {
         self.inner.host_bridge.is_some()
     }
@@ -130,6 +139,7 @@ impl RuntimeHandle {
         self.ensure_background_tasks_allowed(CHILD_AGENT_TASK_KIND)
             .await?;
         let agent_id = self.agent_id().await?;
+        let work_item_id = self.task_work_item_binding().await;
         let workspace_mode = ChildAgentWorkspaceMode::Inherit;
         let recovery = TaskRecoverySpec::ChildAgentTask {
             summary: summary.clone(),
@@ -145,6 +155,7 @@ impl RuntimeHandle {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id,
             summary: Some(summary.clone()),
             detail: Some(child_agent_task_detail(workspace_mode)),
             recovery: Some(recovery),
@@ -187,6 +198,7 @@ impl RuntimeHandle {
                     "task_summary": task_record.summary,
                     "task_detail": task_record.detail,
                     "task_recovery": task_record.recovery,
+                    "work_item_id": task_record.work_item_id.clone(),
                 })),
                 ..MessageEnvelope::new(
                     agent_id.clone(),
@@ -238,6 +250,7 @@ impl RuntimeHandle {
                     "task_summary": task_record.summary,
                     "task_detail": task_record.detail,
                     "task_recovery": task_record.recovery,
+                    "work_item_id": task_record.work_item_id.clone(),
                 })),
                 ..MessageEnvelope::new(
                     agent_id,
@@ -465,6 +478,7 @@ impl RuntimeHandle {
             CHILD_AGENT_TASK_KIND,
         )?;
         let agent_id = self.agent_id().await?;
+        let work_item_id = self.task_work_item_binding().await;
         let recovery = TaskRecoverySpec::ChildAgentTask {
             summary: summary.clone(),
             prompt: prompt.clone(),
@@ -479,6 +493,7 @@ impl RuntimeHandle {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id,
             summary: Some(summary.clone()),
             detail: Some(child_agent_task_detail(workspace_mode)),
             recovery: Some(recovery),
@@ -588,6 +603,7 @@ impl RuntimeHandle {
                 "task_summary": task_record.summary,
                 "task_detail": task_detail.clone(),
                 "task_recovery": task_record.recovery,
+                    "work_item_id": task_record.work_item_id.clone(),
             });
             if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
                 metadata["worktree"] = worktree;
@@ -714,13 +730,14 @@ impl RuntimeHandle {
                 Err(err) => {
                     let result_message = MessageEnvelope {
                         metadata: Some(serde_json::json!({
-                            "task_id": task_record.id,
-                            "task_kind": task_record.kind,
-                            "task_status": "failed",
-                            "task_summary": task_record.summary,
-                            "task_detail": task_record.detail,
-                            "task_recovery": task_record.recovery,
-                        })),
+                                "task_id": task_record.id,
+                                "task_kind": task_record.kind,
+                                "task_status": "failed",
+                                "task_summary": task_record.summary,
+                                "task_detail": task_record.detail,
+                                "task_recovery": task_record.recovery,
+                        "work_item_id": task_record.work_item_id.clone(),
+                            })),
                         ..MessageEnvelope::new(
                             agent_id.clone(),
                             MessageKind::TaskResult,
@@ -827,6 +844,7 @@ impl RuntimeHandle {
         }
 
         let agent_id = self.agent_id().await?;
+        let work_item_id = self.task_work_item_binding().await;
         let recovery = TaskRecoverySpec::ChildAgentTask {
             summary: summary.clone(),
             prompt,
@@ -841,6 +859,7 @@ impl RuntimeHandle {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id,
             summary: Some(summary),
             detail: Some(child_agent_task_detail(workspace_mode)),
             recovery: Some(recovery),
@@ -889,6 +908,7 @@ impl RuntimeHandle {
                 "task_status": "running",
                 "task_summary": task_record.summary,
                 "task_recovery": task_record.recovery,
+                    "work_item_id": task_record.work_item_id.clone(),
                 "task_detail": task_detail.clone(),
             })),
             ..MessageEnvelope::new(
@@ -1015,6 +1035,7 @@ impl RuntimeHandle {
             "task_status": status_label,
             "task_summary": task_record.summary,
             "task_recovery": task_record.recovery,
+                    "work_item_id": task_record.work_item_id.clone(),
             "task_detail": task_detail.clone(),
         });
         if let Some(delegation) = delegation.as_ref() {
@@ -1159,43 +1180,7 @@ impl RuntimeHandle {
         task: &TaskRecord,
         event_kind: &'static str,
     ) -> Result<()> {
-        self.inner.storage.append_task(task)?;
-        {
-            let mut guard = self.inner.agent.lock().await;
-            if is_terminal_task_status(&task.status) {
-                guard.state.active_task_ids.retain(|id| id != &task.id);
-                if !matches!(
-                    guard.state.status,
-                    AgentStatus::Paused | AgentStatus::Stopped
-                ) {
-                    guard.state.status = if has_blocking_active_tasks(
-                        &self.inner.storage,
-                        &guard.state.active_task_ids,
-                    )? {
-                        AgentStatus::AwaitingTask
-                    } else {
-                        AgentStatus::AwakeIdle
-                    };
-                }
-            } else {
-                if !guard.state.active_task_ids.contains(&task.id) {
-                    guard.state.active_task_ids.push(task.id.clone());
-                }
-                if task.is_blocking()
-                    && !matches!(
-                        guard.state.status,
-                        AgentStatus::Paused | AgentStatus::Stopped
-                    )
-                {
-                    guard.state.status = AgentStatus::AwaitingTask;
-                }
-            }
-            self.inner.storage.write_agent(&guard.state)?;
-        }
-        self.inner
-            .storage
-            .append_event(&AuditEvent::new(event_kind, to_json_value(task)))?;
-        Ok(())
+        self.persist_task_transition(task, event_kind).await
     }
 
     async fn persist_interrupted_tasks(&self, tasks: Vec<TaskRecord>) -> Result<Vec<TaskRecord>> {
@@ -1223,6 +1208,7 @@ impl RuntimeHandle {
                 created_at: task.created_at,
                 updated_at: Utc::now(),
                 parent_message_id: None,
+                work_item_id: task.work_item_id.clone(),
                 summary: task.summary.clone(),
                 detail: Some(detail),
                 recovery: task.recovery.clone(),
@@ -1585,6 +1571,7 @@ impl RuntimeHandle {
                 .unwrap_or_else(Utc::now),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: existing.as_ref().and_then(|task| task.work_item_id.clone()),
             summary: existing
                 .as_ref()
                 .and_then(|task| task.summary.clone())
@@ -1985,6 +1972,7 @@ impl RuntimeHandle {
             wrote_item = true;
         }
         if wrote_item {
+            record.revision = existing.revision + 1;
             self.inner.storage.append_work_item(&record)?;
             self.inner.storage.append_event(&AuditEvent::new(
                 "work_item_written",
@@ -2014,7 +2002,11 @@ impl RuntimeHandle {
         }
         let has_blocking_tasks = {
             let guard = self.inner.agent.lock().await;
-            has_blocking_active_tasks(&self.inner.storage, &guard.state.active_task_ids)?
+            scheduler::has_completion_blocking_task_for_work_item(
+                &self.inner.storage,
+                &guard.state.active_task_ids,
+                &work_item_id,
+            )?
         };
         if has_blocking_tasks {
             return Err(anyhow!(
@@ -2023,6 +2015,7 @@ impl RuntimeHandle {
             ));
         }
         let record = WorkItemRecord {
+            revision: existing.revision + 1,
             state: WorkItemState::Completed,
             blocked_by: None,
             result_summary: result_summary.clone(),
@@ -2172,6 +2165,11 @@ pub(super) fn task_from_message(message: &MessageEnvelope, agent_id: &str) -> Re
         created_at: Utc::now(),
         updated_at: Utc::now(),
         parent_message_id: Some(message.id.clone()),
+        work_item_id: metadata
+            .and_then(|value| value.get("work_item_id"))
+            .and_then(|value| value.as_str())
+            .map(ToString::to_string)
+            .or_else(|| message.work_item_id.clone()),
         summary,
         detail: metadata.and_then(|value| value.get("task_detail")).cloned(),
         recovery: metadata

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -603,7 +603,7 @@ impl RuntimeHandle {
                 "task_summary": task_record.summary,
                 "task_detail": task_detail.clone(),
                 "task_recovery": task_record.recovery,
-                    "work_item_id": task_record.work_item_id.clone(),
+                "work_item_id": task_record.work_item_id.clone(),
             });
             if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
                 metadata["worktree"] = worktree;
@@ -730,14 +730,14 @@ impl RuntimeHandle {
                 Err(err) => {
                     let result_message = MessageEnvelope {
                         metadata: Some(serde_json::json!({
-                                "task_id": task_record.id,
-                                "task_kind": task_record.kind,
-                                "task_status": "failed",
-                                "task_summary": task_record.summary,
-                                "task_detail": task_record.detail,
-                                "task_recovery": task_record.recovery,
-                        "work_item_id": task_record.work_item_id.clone(),
-                            })),
+                            "task_id": task_record.id,
+                            "task_kind": task_record.kind,
+                            "task_status": "failed",
+                            "task_summary": task_record.summary,
+                            "task_detail": task_record.detail,
+                            "task_recovery": task_record.recovery,
+                            "work_item_id": task_record.work_item_id.clone(),
+                        })),
                         ..MessageEnvelope::new(
                             agent_id.clone(),
                             MessageKind::TaskResult,
@@ -908,7 +908,7 @@ impl RuntimeHandle {
                 "task_status": "running",
                 "task_summary": task_record.summary,
                 "task_recovery": task_record.recovery,
-                    "work_item_id": task_record.work_item_id.clone(),
+                "work_item_id": task_record.work_item_id.clone(),
                 "task_detail": task_detail.clone(),
             })),
             ..MessageEnvelope::new(
@@ -1035,7 +1035,7 @@ impl RuntimeHandle {
             "task_status": status_label,
             "task_summary": task_record.summary,
             "task_recovery": task_record.recovery,
-                    "work_item_id": task_record.work_item_id.clone(),
+            "work_item_id": task_record.work_item_id.clone(),
             "task_detail": task_detail.clone(),
         });
         if let Some(delegation) = delegation.as_ref() {

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -786,6 +786,7 @@ async fn cancelling_task_ignores_late_running_status_update() {
         created_at: Utc::now(),
         updated_at: Utc::now(),
         parent_message_id: None,
+        work_item_id: None,
         summary: Some("regression task".into()),
         detail: Some(serde_json::json!({
             "task_status": "cancelling",
@@ -836,6 +837,7 @@ async fn latest_task_list_entries_return_compact_projection() {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some("watch logs".into()),
             detail: Some(serde_json::json!({
                 "wait_policy": "blocking",

--- a/src/runtime/tests/mod.rs
+++ b/src/runtime/tests/mod.rs
@@ -1,5 +1,6 @@
 mod agent_and_tools;
 mod runtime_state;
+mod scheduler;
 mod support;
 mod task_recovery;
 mod timers;

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -962,6 +962,7 @@ async fn task_result_routes_through_reduction_and_follow_up_behavior() {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some("task running".into()),
             detail: Some(serde_json::json!({ "wait_policy": "blocking" })),
             recovery: None,

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1,0 +1,108 @@
+use super::super::*;
+use super::support::*;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct SchedulerFixture {
+    agent: AgentFixture,
+    work_items: Vec<WorkItemFixture>,
+    tasks: Vec<TaskFixture>,
+}
+
+#[derive(Deserialize)]
+struct AgentFixture {
+    current_work_item_id: Option<String>,
+    active_task_ids: Vec<String>,
+    pending_wake_hint_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct WorkItemFixture {
+    id: String,
+    objective: String,
+    state: WorkItemState,
+    revision: u64,
+}
+
+#[derive(Deserialize)]
+struct TaskFixture {
+    id: String,
+    status: TaskStatus,
+    wait_policy: String,
+    work_item_id: Option<String>,
+}
+
+#[test]
+fn scheduler_projection_replays_fixture_facts() {
+    let fixture: SchedulerFixture =
+        serde_json::from_str(include_str!("../../../tests/fixtures/scheduler/basic.json")).unwrap();
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+
+    let mut agent = AgentState::new("default");
+    agent.current_work_item_id = fixture.agent.current_work_item_id;
+    agent.active_task_ids = fixture.agent.active_task_ids;
+    if let Some(reason) = fixture.agent.pending_wake_hint_reason {
+        agent.pending_wake_hint = Some(PendingWakeHint {
+            reason,
+            description: None,
+            scope: None,
+            waiting_intent_id: None,
+            external_trigger_id: None,
+            source: Some("fixture".into()),
+            resource: None,
+            body: None,
+            content_type: None,
+            correlation_id: None,
+            causation_id: None,
+            created_at: Utc::now(),
+        });
+    }
+    storage.write_agent(&agent).unwrap();
+
+    for item in fixture.work_items {
+        let mut record = WorkItemRecord::new("default", item.objective, item.state);
+        record.id = item.id;
+        record.revision = item.revision;
+        storage.append_work_item(&record).unwrap();
+    }
+    for task in fixture.tasks {
+        storage
+            .append_task(&TaskRecord {
+                id: task.id,
+                agent_id: "default".into(),
+                kind: TaskKind::CommandTask,
+                status: task.status,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                parent_message_id: None,
+                work_item_id: task.work_item_id,
+                summary: Some("fixture task".into()),
+                detail: Some(serde_json::json!({
+                    "wait_policy": task.wait_policy,
+                })),
+                recovery: None,
+            })
+            .unwrap();
+    }
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    assert_eq!(
+        projection
+            .current_work_item
+            .as_ref()
+            .map(|item| item.id.as_str()),
+        Some("work-active")
+    );
+    assert_eq!(
+        projection
+            .current_work_item
+            .as_ref()
+            .map(|item| item.revision),
+        Some(3)
+    );
+    assert_eq!(projection.queued_work_items, 1);
+    assert_eq!(projection.active_tasks.len(), 1);
+    assert!(projection.has_blocking_active_tasks);
+    assert!(projection.pending_wake_hint);
+}

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -196,6 +196,7 @@ pub(crate) async fn mark_blocking_task(runtime: &RuntimeHandle, task_id: &str) {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some("blocking command".into()),
             detail: Some(serde_json::json!({
                 "wait_policy": "blocking"

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -110,6 +110,7 @@ async fn runtime_interrupts_inflight_task_after_restart() {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some("recoverable command".into()),
             detail: None,
             recovery: Some(TaskRecoverySpec::CommandTask {

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2,6 +2,41 @@ use super::super::*;
 use super::support::*;
 use crate::types::WorkItemPlanStatus;
 
+fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> TaskRecord {
+    TaskRecord {
+        id: task_id.into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Running,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: work_item_id.map(ToString::to_string),
+        summary: Some("blocking command".into()),
+        detail: Some(serde_json::json!({
+            "wait_policy": "blocking",
+            "work_item_id": work_item_id,
+        })),
+        recovery: None,
+    }
+}
+
+#[test]
+fn work_item_record_revision_defaults_for_old_records() {
+    let value = serde_json::json!({
+        "id": "work-old",
+        "agent_id": "default",
+        "workspace_id": "agent_home",
+        "objective": "old record",
+        "state": "open",
+        "plan_status": "draft",
+        "created_at": Utc::now(),
+        "updated_at": Utc::now(),
+    });
+    let record: WorkItemRecord = serde_json::from_value(value).unwrap();
+    assert_eq!(record.revision, 1);
+}
+
 #[tokio::test]
 async fn work_item_query_tools_return_current_open_done_views() {
     let dir = tempdir().unwrap();
@@ -161,6 +196,103 @@ async fn work_item_query_tools_return_current_open_done_views() {
         fallback_payload["work_items"][0]["id"].as_str(),
         Some(active.id.as_str())
     );
+}
+
+#[tokio::test]
+async fn work_item_revision_increments_on_updates_and_completion() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let created = runtime
+        .create_work_item("revision contract".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    assert_eq!(created.revision, 1);
+
+    let updated = runtime
+        .update_work_item_fields(
+            created.id.clone(),
+            None,
+            Some(WorkItemPlanStatus::Ready),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.revision, 2);
+
+    let completed = runtime
+        .complete_work_item(updated.id.clone(), Some("done".into()))
+        .await
+        .unwrap();
+    assert_eq!(completed.revision, 3);
+}
+
+#[tokio::test]
+async fn work_item_completion_blocks_only_related_or_unscoped_blocking_tasks() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let target = runtime
+        .create_work_item("target".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let other = runtime
+        .create_work_item("other".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let unrelated_task = blocking_task_for_work_item("task-other", Some(&other.id));
+    runtime.storage().append_task(&unrelated_task).unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.active_task_ids = vec![unrelated_task.id.clone()];
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let completed = runtime
+        .complete_work_item(target.id.clone(), Some("target done".into()))
+        .await
+        .unwrap();
+    assert_eq!(completed.id, target.id);
+
+    let blocked = runtime
+        .create_work_item("blocked".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let unscoped_task = blocking_task_for_work_item("task-unscoped", None);
+    runtime.storage().append_task(&unscoped_task).unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.active_task_ids = vec![unscoped_task.id.clone()];
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let err = runtime
+        .complete_work_item(blocked.id.clone(), Some("too early".into()))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("cannot complete work item"));
 }
 
 #[tokio::test]
@@ -824,6 +956,58 @@ async fn turn_end_work_item_commit_defaults_completed_turn_to_active() {
         .unwrap()
         .current_turn_work_item_id
         .is_none());
+}
+
+#[tokio::test]
+async fn turn_end_work_item_commit_ignores_unfinished_turn_binding() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("no terminal yet".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.turn_index = 7;
+        guard.state.current_turn_work_item_id = Some(work.id.clone());
+        guard.state.last_turn_terminal = None;
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let committed = runtime
+        .maybe_commit_turn_end_work_item_transition()
+        .await
+        .unwrap();
+    assert!(committed.is_none());
+    assert_eq!(
+        runtime
+            .agent_state()
+            .await
+            .unwrap()
+            .current_turn_work_item_id
+            .as_deref(),
+        Some(work.id.as_str())
+    );
+    assert_eq!(
+        runtime
+            .latest_work_item(&work.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .revision,
+        1
+    );
 }
 
 #[tokio::test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1082,6 +1082,7 @@ mod tests {
             created_at: now + chrono::Duration::seconds(offset),
             updated_at: now + chrono::Duration::seconds(offset),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some(format!("{id} {status:?}")),
             detail: None,
             recovery: None,
@@ -1131,6 +1132,7 @@ mod tests {
                     created_at: now + chrono::Duration::seconds(index),
                     updated_at: now + chrono::Duration::seconds(index),
                     parent_message_id: None,
+                    work_item_id: None,
                     summary: None,
                     detail: None,
                     recovery: None,
@@ -1160,6 +1162,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             parent_message_id: None,
+            work_item_id: None,
             summary: None,
             detail: None,
             recovery: Some(TaskRecoverySpec::SubagentTask {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -638,6 +638,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some("cargo test".into()),
             detail: None,
             recovery: None,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -2410,6 +2410,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             parent_message_id: None,
+            work_item_id: None,
             summary: Some("demo task".into()),
             detail: Some(json!({ "wait_policy": "blocking" })),
             recovery: None,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1207,6 +1207,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             parent_message_id: None,
+            work_item_id: None,
             summary: Some("sample task".into()),
             detail,
             recovery: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,10 @@ fn default_agent_home_workspace_id() -> String {
     AGENT_HOME_WORKSPACE_ID.to_string()
 }
 
+fn default_work_item_revision() -> u64 {
+    1
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceEntry {
     pub workspace_id: String,
@@ -1970,6 +1974,8 @@ pub struct TaskRecord {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub parent_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
     pub summary: Option<String>,
     #[serde(default)]
     pub detail: Option<Value>,
@@ -1997,6 +2003,15 @@ impl TaskRecord {
 
     pub fn is_child_agent_task(&self) -> bool {
         self.kind.is_child_agent()
+    }
+
+    pub fn effective_work_item_id(&self) -> Option<&str> {
+        self.work_item_id.as_deref().or_else(|| {
+            self.detail
+                .as_ref()
+                .and_then(|detail| detail.get("work_item_id"))
+                .and_then(Value::as_str)
+        })
     }
 
     pub fn child_agent_workspace_mode(&self) -> Option<ChildAgentWorkspaceMode> {
@@ -2565,6 +2580,8 @@ pub struct WorkItemRecord {
     pub agent_id: String,
     #[serde(default = "default_agent_home_workspace_id")]
     pub workspace_id: String,
+    #[serde(default = "default_work_item_revision")]
+    pub revision: u64,
     pub objective: String,
     pub state: WorkItemState,
     pub plan_status: WorkItemPlanStatus,
@@ -2591,6 +2608,7 @@ impl WorkItemRecord {
             id: format!("work_{}", Uuid::new_v4().simple()),
             agent_id: agent_id.into(),
             workspace_id: AGENT_HOME_WORKSPACE_ID.to_string(),
+            revision: 1,
             objective: objective.into(),
             state,
             plan_status: WorkItemPlanStatus::Draft,

--- a/tests/fixtures/scheduler/basic.json
+++ b/tests/fixtures/scheduler/basic.json
@@ -1,0 +1,29 @@
+{
+  "agent": {
+    "current_work_item_id": "work-active",
+    "active_task_ids": ["task-active"],
+    "pending_wake_hint_reason": "fixture wake"
+  },
+  "work_items": [
+    {
+      "id": "work-active",
+      "objective": "continue active fixture work",
+      "state": "open",
+      "revision": 3
+    },
+    {
+      "id": "work-queued",
+      "objective": "queued fixture work",
+      "state": "open",
+      "revision": 1
+    }
+  ],
+  "tasks": [
+    {
+      "id": "task-active",
+      "status": "running",
+      "wait_policy": "blocking",
+      "work_item_id": "work-active"
+    }
+  ]
+}

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -169,6 +169,7 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
         created_at: now + chrono::Duration::seconds(offset),
         updated_at: now + chrono::Duration::seconds(offset),
         parent_message_id: None,
+        work_item_id: None,
         summary: Some(format!("{id} {status:?}")),
         detail: None,
         recovery: None,


### PR DESCRIPTION
## Summary

- add the runtime scheduler contract RFC and implement the first concrete scheduler projection module
- persist WorkItem revisions and first-class TaskRecord work_item_id bindings with compatibility fallbacks
- centralize task transition projection, scope work-item completion blockers, and prevent unfinished/non-model-visible turns from committing WorkItem state
- add work-queue tick idempotency keys and scheduler replay fixture coverage

## Validation

- `cargo fmt --check`
- `cargo test -q --lib scheduler`
- `cargo test -q --lib work_items`
- `cargo test -q --lib memory_refresh`
- `cargo test -q --lib task_state_reducer`
- `cargo test -q --lib task_recovery`
- `cargo test -q --test runtime_tasks`
- `cargo test -q --lib -- --test-threads=1`

Note: plain parallel `cargo test -q --lib` exposed an existing config-test environment race; the same failing config tests pass individually, and the full lib suite passes with `--test-threads=1`.
