### PR TITLE
fix: release workspace occupancy on stop

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -2755,6 +2755,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stop_releases_active_workspace_occupancy() {
+        let (_home, host) = test_host();
+        let workspace_home = tempdir().unwrap();
+        let workspace_path = workspace_home.path().to_path_buf();
+        let workspace = host.ensure_workspace_entry(workspace_path.clone()).unwrap();
+        let runtime = host.default_runtime().await.unwrap();
+        runtime.attach_workspace(&workspace).await.unwrap();
+        runtime
+            .enter_workspace(
+                &workspace,
+                WorkspaceProjectionKind::CanonicalRoot,
+                WorkspaceAccessMode::ExclusiveWrite,
+                Some(workspace_path.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let occupancy_id = runtime
+            .agent_state()
+            .await
+            .unwrap()
+            .active_workspace_entry
+            .as_ref()
+            .and_then(|entry| entry.occupancy_id.clone())
+            .expect("exclusive workspace should acquire occupancy");
+        runtime.control(ControlAction::Stop).await.unwrap();
+
+        let stopped = runtime.agent_state().await.unwrap();
+        assert_eq!(stopped.status, AgentStatus::Stopped);
+        assert!(
+            stopped.active_workspace_entry.is_none(),
+            "stopped agents should not keep an active workspace entry"
+        );
+        let released = host
+            .workspace_occupancy_by_id(&occupancy_id)
+            .unwrap()
+            .expect("occupancy record should remain queryable");
+        assert!(
+            released.released_at.is_some(),
+            "stop should release the workspace occupancy"
+        );
+
+        host.create_named_agent("peer", None).await.unwrap();
+        let peer = host.get_public_agent("peer").await.unwrap();
+        peer.attach_workspace(&workspace).await.unwrap();
+        peer.enter_workspace(
+            &workspace,
+            WorkspaceProjectionKind::CanonicalRoot,
+            WorkspaceAccessMode::ExclusiveWrite,
+            Some(workspace_path),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
     async fn resume_respawns_stopped_persistent_agent_runtime_loop() {
         let (_home, host) = test_host();
         let agent_id = host.config().default_agent_id.clone();

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -180,8 +180,11 @@ impl RuntimeHandle {
                     occupancy_to_release = guard
                         .state
                         .active_workspace_entry
-                        .take()
-                        .and_then(|entry| entry.occupancy_id);
+                        .as_ref()
+                        .and_then(|entry| entry.occupancy_id.clone());
+                    if occupancy_to_release.is_none() {
+                        guard.state.active_workspace_entry = None;
+                    }
                 }
             }
             guard.state.current_run_id = None;
@@ -189,8 +192,25 @@ impl RuntimeHandle {
             occupancy_to_release
         };
         if let Some(occupancy_id) = occupancy_to_release.as_deref() {
-            if let Some(bridge) = self.inner.host_bridge.as_ref() {
-                let _ = bridge.release_workspace_occupancy(occupancy_id).await?;
+            let bridge = self.inner.host_bridge.as_ref().ok_or_else(|| {
+                anyhow!(
+                    "cannot release workspace occupancy {} without host bridge",
+                    occupancy_id
+                )
+            })?;
+            let _ = bridge.release_workspace_occupancy(occupancy_id).await?;
+            {
+                let mut guard = self.inner.agent.lock().await;
+                let should_clear = guard
+                    .state
+                    .active_workspace_entry
+                    .as_ref()
+                    .and_then(|entry| entry.occupancy_id.as_deref())
+                    == Some(occupancy_id);
+                if should_clear {
+                    guard.state.active_workspace_entry = None;
+                    self.inner.storage.write_agent(&guard.state)?;
+                }
             }
         }
         self.inner.storage.append_event(&AuditEvent::new(

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -169,15 +169,29 @@ impl RuntimeHandle {
     }
 
     pub async fn control(&self, action: ControlAction) -> Result<()> {
-        {
+        let occupancy_to_release = {
+            let mut occupancy_to_release = None;
             let mut guard = self.inner.agent.lock().await;
             match action {
                 ControlAction::Pause => guard.state.status = AgentStatus::Paused,
                 ControlAction::Resume => guard.state.status = AgentStatus::AwakeIdle,
-                ControlAction::Stop => guard.state.status = AgentStatus::Stopped,
+                ControlAction::Stop => {
+                    guard.state.status = AgentStatus::Stopped;
+                    occupancy_to_release = guard
+                        .state
+                        .active_workspace_entry
+                        .take()
+                        .and_then(|entry| entry.occupancy_id);
+                }
             }
             guard.state.current_run_id = None;
             self.inner.storage.write_agent(&guard.state)?;
+            occupancy_to_release
+        };
+        if let Some(occupancy_id) = occupancy_to_release.as_deref() {
+            if let Some(bridge) = self.inner.host_bridge.as_ref() {
+                let _ = bridge.release_workspace_occupancy(occupancy_id).await?;
+            }
         }
         self.inner.storage.append_event(&AuditEvent::new(
             "control_applied",


### PR DESCRIPTION
## Summary

Fixes #1014.

Stops now release any active workspace occupancy and clear the stopped agent's active workspace entry, so a stopped agent no longer holds an exclusive workspace lock.

## Verification

- `cargo fmt --all -- --check`
- `cargo test host::tests::stop_releases_active_workspace_occupancy`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
