### PR TITLE
fix: surface installed skills consistently

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1573,7 +1573,7 @@ pub async fn install_skill(
     let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
     let skill_name =
         crate::skills::install_skill_with_user_home(&agent_home, Some(&user_home), &request.kind)
-            .map_err(error_response)?;
+            .map_err(skill_install_error_response)?;
     runtime
         .append_audit_event(
             "skill_installed",
@@ -2623,6 +2623,23 @@ fn interrupt_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
                 "code": "no_current_run",
                 "error": format!("agent {agent_id} has no current run to interrupt"),
                 "agent_id": agent_id,
+            })),
+        ),
+        Err(error) => error_response(error),
+    }
+}
+
+fn skill_install_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
+    match error.downcast::<crate::skills::SkillInstallConflict>() {
+        Ok(conflict) => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "ok": false,
+                "code": "skill_already_installed",
+                "error": conflict.to_string(),
+                "skill_name": conflict.skill_name,
+                "destination": conflict.destination,
+                "hint": "uninstall the existing skill first or choose a different skill name",
             })),
         ),
         Err(error) => error_response(error),

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -48,7 +48,7 @@ pub fn load_skills_runtime_view(
         }
     }
 
-    if let Some(root) = select_skill_root(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
+    for root in existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
         discoverable_skills.extend(load_catalog_for_scope(SkillScope::Agent, &root)?);
         discovered_roots.push(SkillRootView {
             scope: SkillScope::Agent,
@@ -262,6 +262,25 @@ fn agent_skills_root(agent_home: &Path) -> PathBuf {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SkillInstallConflict {
+    pub skill_name: String,
+    pub destination: PathBuf,
+}
+
+impl std::fmt::Display for SkillInstallConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "skill '{}' is already installed at {}; uninstall it first or choose a different skill name",
+            self.skill_name,
+            self.destination.display()
+        )
+    }
+}
+
+impl std::error::Error for SkillInstallConflict {}
+
 /// Validate that a skill name is a single path component with no traversal.
 fn validate_skill_name(name: &str) -> Result<()> {
     if name.is_empty()
@@ -276,6 +295,19 @@ fn validate_skill_name(name: &str) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn install_destination(skills_root: &Path, skill_name: &str) -> Result<PathBuf> {
+    validate_skill_name(skill_name)?;
+    let destination = skills_root.join(skill_name);
+    if destination.exists() {
+        return Err(SkillInstallConflict {
+            skill_name: skill_name.to_string(),
+            destination,
+        }
+        .into());
+    }
+    Ok(destination)
 }
 
 pub fn install_skill(agent_home: &Path, kind: &crate::types::SkillInstallKind) -> Result<String> {
@@ -293,6 +325,7 @@ pub fn install_skill_with_user_home(
     let name = match kind {
         crate::types::SkillInstallKind::Builtin { name } => {
             validate_skill_name(name)?;
+            let _ = install_destination(&skills_root, name)?;
             let destination =
                 crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
             record_install_metadata(&destination, "builtin")?;
@@ -301,6 +334,7 @@ pub fn install_skill_with_user_home(
         crate::types::SkillInstallKind::Named { name, mode } => {
             validate_skill_name(name)?;
             if crate::agent_template::builtin_skill_names().contains(&name.as_str()) {
+                let _ = install_destination(&skills_root, name)?;
                 let destination =
                     crate::agent_template::materialize_builtin_skill_ref(&skills_root, name)?;
                 record_install_metadata(&destination, "builtin")?;
@@ -325,6 +359,7 @@ fn materialize_local_skill(
     let path = normalize_local_skill_path(path)?;
     let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
     validate_skill_name(file_name)?;
+    let _ = install_destination(skills_root, file_name)?;
     let destination = match mode {
         SkillInstallMode::Linked => materialize_linked_skill_ref(skills_root, &path)?,
         SkillInstallMode::Copied => materialize_copied_skill_ref(skills_root, &path)?,
@@ -522,47 +557,50 @@ pub struct InstalledSkillView {
 }
 
 pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<InstalledSkillView>> {
-    let skills_root = agent_skills_root(agent_home);
-    if !skills_root.is_dir() {
-        return Ok(Vec::new());
-    }
     let mut entries = Vec::new();
-    for child in fs::read_dir(&skills_root)
-        .with_context(|| format!("failed to read {}", skills_root.display()))?
-    {
-        let child = child?;
-        let file_type = child.file_type()?;
-        if !file_type.is_dir() && !file_type.is_symlink() {
-            continue;
+    for skills_root in existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
+        for child in fs::read_dir(&skills_root)
+            .with_context(|| format!("failed to read {}", skills_root.display()))?
+        {
+            let child = child?;
+            let file_type = child.file_type()?;
+            if !file_type.is_dir() && !file_type.is_symlink() {
+                continue;
+            }
+            let skill_name = child.file_name().to_string_lossy().to_string();
+            let skill_path = child.path().join(SKILL_ENTRYPOINT);
+            let catalog = if skill_path.is_file() {
+                let content = fs::read_to_string(&skill_path).with_context(|| {
+                    format!("failed to read installed skill {}", skill_path.display())
+                })?;
+                let parsed = parse_skill_metadata(&content);
+                SkillCatalogEntry {
+                    skill_id: format!("agent:{skill_name}"),
+                    name: parsed.name.unwrap_or_else(|| skill_name.clone()),
+                    description: parsed
+                        .description
+                        .unwrap_or_else(|| first_body_paragraph(&content)),
+                    path: skill_path,
+                    scope: SkillScope::Agent,
+                }
+            } else {
+                SkillCatalogEntry {
+                    skill_id: format!("agent:{skill_name}"),
+                    name: skill_name.clone(),
+                    description: String::new(),
+                    path: skill_path,
+                    scope: SkillScope::Agent,
+                }
+            };
+            entries.push(installed_skill_view(catalog)?);
         }
-        let skill_name = child.file_name().to_string_lossy().to_string();
-        let skill_path = child.path().join(SKILL_ENTRYPOINT);
-        let catalog = if skill_path.is_file() {
-            let content = fs::read_to_string(&skill_path).with_context(|| {
-                format!("failed to read installed skill {}", skill_path.display())
-            })?;
-            let parsed = parse_skill_metadata(&content);
-            SkillCatalogEntry {
-                skill_id: format!("agent:{skill_name}"),
-                name: parsed.name.unwrap_or_else(|| skill_name.clone()),
-                description: parsed
-                    .description
-                    .unwrap_or_else(|| first_body_paragraph(&content)),
-                path: skill_path,
-                scope: SkillScope::Agent,
-            }
-        } else {
-            SkillCatalogEntry {
-                skill_id: format!("agent:{skill_name}"),
-                name: skill_name.clone(),
-                description: String::new(),
-                path: skill_path,
-                scope: SkillScope::Agent,
-            }
-        };
-        entries.push(installed_skill_view(catalog)?);
     }
-    entries.sort_by(|left, right| left.catalog.skill_id.cmp(&right.catalog.skill_id));
+    entries.sort_by(|left, right| {
+        left.catalog
+            .skill_id
+            .cmp(&right.catalog.skill_id)
+            .then_with(|| left.catalog.path.cmp(&right.catalog.path))
+    });
     Ok(entries)
 }
 
@@ -671,7 +709,7 @@ mod tests {
     use crate::types::{SkillActivationSource, SkillActivationState};
 
     #[test]
-    fn uses_first_existing_root_without_merging_fallbacks() {
+    fn agent_skill_discovery_merges_compatible_roots() {
         let dir = tempdir().unwrap();
         let base = dir.path();
         let first_root = base.join("skills");
@@ -693,9 +731,13 @@ mod tests {
             load_skills_runtime_view(SkillVisibility::NonDefaultAgent, None, base, None, &[])
                 .unwrap();
 
-        assert_eq!(view.discovered_roots.len(), 1);
-        assert_eq!(view.discoverable_skills.len(), 1);
-        assert_eq!(view.discoverable_skills[0].name, "alpha");
+        assert_eq!(view.discovered_roots.len(), 2);
+        let names = view
+            .discoverable_skills
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["alpha", "beta"]);
     }
 
     #[test]
@@ -985,6 +1027,51 @@ mod tests {
         assert_eq!(installed[0].install_mode, "builtin");
         assert!(installed[0].link_target.is_none());
         assert!(installed[0].warning.is_none());
+    }
+
+    #[test]
+    fn list_installed_skills_merges_compatible_agent_roots() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        for (root, name) in [("skills", "alpha"), (".codex/skills", "beta")] {
+            let skill_dir = agent_home.join(root).join(name);
+            fs::create_dir_all(&skill_dir).unwrap();
+            fs::write(
+                skill_dir.join(SKILL_ENTRYPOINT),
+                format!("---\nname: {name}\ndescription: installed\n---\nbody"),
+            )
+            .unwrap();
+        }
+
+        let installed = list_installed_skills(&agent_home).unwrap();
+
+        let names = installed
+            .iter()
+            .map(|skill| skill.catalog.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn install_existing_destination_returns_structured_conflict() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        let destination = agent_home.join("skills/ghx");
+        fs::create_dir_all(&destination).unwrap();
+        fs::write(destination.join(SKILL_ENTRYPOINT), "# Existing ghx").unwrap();
+
+        let error = install_skill_with_user_home(
+            &agent_home,
+            None,
+            &crate::types::SkillInstallKind::Builtin { name: "ghx".into() },
+        )
+        .unwrap_err();
+        let conflict = error
+            .downcast_ref::<SkillInstallConflict>()
+            .expect("existing destination should return a structured conflict");
+
+        assert_eq!(conflict.skill_name, "ghx");
+        assert_eq!(conflict.destination, destination);
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -300,7 +300,7 @@ fn validate_skill_name(name: &str) -> Result<()> {
 fn install_destination(skills_root: &Path, skill_name: &str) -> Result<PathBuf> {
     validate_skill_name(skill_name)?;
     let destination = skills_root.join(skill_name);
-    if destination.exists() {
+    if fs::symlink_metadata(&destination).is_ok() {
         return Err(SkillInstallConflict {
             skill_name: skill_name.to_string(),
             destination,
@@ -521,17 +521,29 @@ fn read_install_metadata(skill_dir: &Path) -> Option<SkillInstallMetadata> {
 
 pub fn uninstall_skill(agent_home: &Path, name: &str) -> Result<()> {
     validate_skill_name(name)?;
-    let skills_root = agent_skills_root(agent_home);
-    let destination = skills_root.join(name);
-    // Use symlink_metadata to detect symlinks without following them.
-    let meta = match fs::symlink_metadata(&destination) {
-        Ok(m) => m,
-        Err(_) => {
+    let mut matches = Vec::new();
+    for skills_root in existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
+        let destination = skills_root.join(name);
+        if let Ok(meta) = fs::symlink_metadata(&destination) {
+            matches.push((destination, meta));
+        }
+    }
+    let [(destination, meta)] = matches.as_slice() else {
+        if matches.is_empty() {
             bail!(
                 "skill '{}' is not installed in agent skills directory",
                 name
             );
         }
+        bail!(
+            "skill '{}' is installed in multiple agent skill roots: {}; remove the duplicate directories manually",
+            name,
+            matches
+                .iter()
+                .map(|(path, _)| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
     };
     // Verify this looks like a skill installation by checking for SKILL_ENTRYPOINT.
     if !destination.join(SKILL_ENTRYPOINT).exists() && !meta.is_symlink() {
@@ -559,9 +571,17 @@ pub struct InstalledSkillView {
 pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<InstalledSkillView>> {
     let mut entries = Vec::new();
     for skills_root in existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
-        for child in fs::read_dir(&skills_root)
-            .with_context(|| format!("failed to read {}", skills_root.display()))?
-        {
+        let read_dir = match fs::read_dir(&skills_root) {
+            Ok(read_dir) => read_dir,
+            Err(error) => {
+                warn!(
+                    "skipping unreadable installed skill root {}: {error}",
+                    skills_root.display()
+                );
+                continue;
+            }
+        };
+        for child in read_dir {
             let child = child?;
             let file_type = child.file_type()?;
             if !file_type.is_dir() && !file_type.is_symlink() {
@@ -1075,6 +1095,35 @@ mod tests {
     }
 
     #[test]
+    fn install_existing_broken_symlink_returns_structured_conflict() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        let skills_root = agent_home.join("skills");
+        fs::create_dir_all(&skills_root).unwrap();
+        let destination = skills_root.join("demo");
+        create_symlink(&dir.path().join("missing-demo"), &destination).unwrap();
+        let source = dir.path().join("source/demo");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join(SKILL_ENTRYPOINT), "# Demo").unwrap();
+
+        let error = install_skill_with_user_home(
+            &agent_home,
+            None,
+            &crate::types::SkillInstallKind::Local {
+                path: source,
+                mode: SkillInstallMode::Linked,
+            },
+        )
+        .unwrap_err();
+        let conflict = error
+            .downcast_ref::<SkillInstallConflict>()
+            .expect("dangling destination symlink should return a structured conflict");
+
+        assert_eq!(conflict.skill_name, "demo");
+        assert_eq!(conflict.destination, destination);
+    }
+
+    #[test]
     fn uninstall_linked_skill_removes_only_agent_local_link() {
         let dir = tempdir().unwrap();
         let source = dir.path().join("source/demo");
@@ -1095,6 +1144,40 @@ mod tests {
 
         assert!(source.join(SKILL_ENTRYPOINT).is_file());
         assert!(!agent_home.join("skills/demo").exists());
+    }
+
+    #[test]
+    fn uninstall_skill_searches_compatible_agent_roots() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        let source = dir.path().join("source/demo");
+        let legacy_destination = agent_home.join(".codex/skills/demo");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join(SKILL_ENTRYPOINT), "# Demo").unwrap();
+        fs::create_dir_all(legacy_destination.parent().unwrap()).unwrap();
+        create_symlink(&source, &legacy_destination).unwrap();
+
+        uninstall_skill(&agent_home, "demo").unwrap();
+
+        assert!(source.join(SKILL_ENTRYPOINT).is_file());
+        assert!(!legacy_destination.exists());
+    }
+
+    #[test]
+    fn uninstall_skill_rejects_duplicate_installs_across_roots() {
+        let dir = tempdir().unwrap();
+        let agent_home = dir.path().join("agent");
+        for root in ["skills", ".codex/skills"] {
+            let skill_dir = agent_home.join(root).join("demo");
+            fs::create_dir_all(&skill_dir).unwrap();
+            fs::write(skill_dir.join(SKILL_ENTRYPOINT), "# Demo").unwrap();
+        }
+
+        let error = uninstall_skill(&agent_home, "demo").unwrap_err();
+
+        assert!(error.to_string().contains("multiple agent skill roots"));
+        assert!(agent_home.join("skills/demo").exists());
+        assert!(agent_home.join(".codex/skills/demo").exists());
     }
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -627,8 +627,20 @@ impl TuiApp {
                     name: skill_name.clone(),
                     mode: crate::types::SkillInstallMode::Linked,
                 };
-                self.client.install_skill(&agent_id, kind).await?;
-                self.status_line = format!("Installed skill: {skill_name}");
+                match self.client.install_skill(&agent_id, kind).await {
+                    Ok(_) => self.status_line = format!("Installed skill: {skill_name}"),
+                    Err(error) => {
+                        if error
+                            .downcast_ref::<crate::client::LocalHttpError>()
+                            .is_some_and(|error| error.has_code("skill_already_installed"))
+                        {
+                            self.status_line =
+                                format!("Skill already installed: {skill_name}; uninstall first");
+                        } else {
+                            return Err(error);
+                        }
+                    }
+                }
             }
             SlashCommand::SkillUninstall => {
                 let skill_name = args

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -15,6 +15,8 @@ http_async_tests!(
     control_prompt_is_open_on_loopback_auto,
     agent_state_route_returns_aggregated_snapshot,
     agent_state_route_includes_bootstrap_projection_fields_when_present,
+    list_skills_includes_all_agent_skill_roots,
+    install_skill_existing_destination_returns_conflict,
     control_agent_model_override_set_and_clear_updates_status,
     control_prompt_requires_bearer_token_when_required,
     remote_tcp_surfaces_require_bearer_token_when_required,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -250,6 +250,76 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
     Ok(())
 }
 
+pub async fn list_skills_includes_all_agent_skill_roots() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let agent_home = host.config().data_dir.join("agents/default");
+    for (root, name) in [("skills", "alpha"), (".codex/skills", "beta")] {
+        let skill_dir = agent_home.join(root).join(name);
+        std::fs::create_dir_all(&skill_dir)?;
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: installed\n---\nbody"),
+        )?;
+    }
+
+    let payload: serde_json::Value = Client::new()
+        .get(format!("{base}/agents/default/skills"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let names = payload["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .filter_map(|skill| skill["name"].as_str())
+        .collect::<Vec<_>>();
+
+    assert!(names.contains(&"alpha"));
+    assert!(names.contains(&"beta"));
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn install_skill_existing_destination_returns_conflict() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = Client::new();
+    let payload = serde_json::json!({
+        "kind": {
+            "kind": "builtin",
+            "name": "ghx",
+        }
+    });
+
+    let first = client
+        .post(format!("{base}/control/agents/default/skills/install"))
+        .json(&payload)
+        .send()
+        .await?;
+    assert!(first.status().is_success());
+
+    let second = client
+        .post(format!("{base}/control/agents/default/skills/install"))
+        .json(&payload)
+        .send()
+        .await?;
+    assert_eq!(second.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = second.json().await?;
+    assert_eq!(body["code"], "skill_already_installed");
+    assert!(body["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("uninstall it first"));
+    assert!(body["hint"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("uninstall"));
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn control_agent_model_override_set_and_clear_updates_status() -> Result<()> {
     let mut config = test_config();
     config.default_model = holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap();


### PR DESCRIPTION
## Summary

Fixes #1016.

- Make agent skill discovery and `/agents/{agent_id}/skills` list across all compatible agent-home skill roots instead of only the first selected root.
- Return a structured `409 skill_already_installed` response when `skill-install` targets an existing destination.
- Show an actionable TUI status line when `/skill-install` hits an already-installed skill.

## Verification

- `cargo fmt --all -- --check`
- `cargo test skills::tests::`
- `cargo test --test http_control list_skills_includes_all_agent_skill_roots`
- `cargo test --test http_control install_skill_existing_destination_returns_conflict`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
