### PR TITLE
fix: harden remote TUI bootstrap recovery

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,7 @@ use crate::{
 const UNIX_CONTROL_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const LOCAL_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const REMOTE_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+const REMOTE_STATE_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(30);
 const REMOTE_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone)]
@@ -563,7 +564,7 @@ impl LocalClient {
     async fn send_http(&self, request: RequestSpec, include_control_auth: bool) -> Result<Vec<u8>> {
         let response = self
             .build_http_request(&request, include_control_auth)
-            .timeout(self.http_request_timeout())
+            .timeout(self.http_request_timeout_for_path(&request.path))
             .send()
             .await
             .with_context(|| format!("failed to send {}", request.path))?;
@@ -592,10 +593,11 @@ impl LocalClient {
         if let Some(last_event_id) = last_event_id {
             builder = builder.header("Last-Event-ID", last_event_id);
         }
-        let response = tokio::time::timeout(self.http_request_timeout(), builder.send())
-            .await
-            .map_err(|_| anyhow!("timed out opening event stream {}", path))?
-            .with_context(|| format!("failed to open event stream {}", path))?;
+        let response =
+            tokio::time::timeout(self.http_request_timeout_for_path(path), builder.send())
+                .await
+                .map_err(|_| anyhow!("timed out opening event stream {}", path))?
+                .with_context(|| format!("failed to open event stream {}", path))?;
         let status = response.status();
         if !status.is_success() {
             let bytes = response.bytes().await?.to_vec();
@@ -640,12 +642,8 @@ impl LocalClient {
         }
     }
 
-    fn http_request_timeout(&self) -> Duration {
-        if self.remote.is_some() {
-            REMOTE_HTTP_REQUEST_TIMEOUT
-        } else {
-            LOCAL_HTTP_REQUEST_TIMEOUT
-        }
+    fn http_request_timeout_for_path(&self, path: &str) -> Duration {
+        http_request_timeout_for_path(self.remote.is_some(), path)
     }
 
     #[cfg(unix)]
@@ -775,6 +773,18 @@ impl LocalClient {
             current_chunk_size: None,
             eof: false,
         })
+    }
+}
+
+fn is_state_bootstrap_path(path: &str) -> bool {
+    path == "/state" || (path.starts_with("/agents/") && path.ends_with("/state"))
+}
+
+fn http_request_timeout_for_path(remote: bool, path: &str) -> Duration {
+    match (remote, is_state_bootstrap_path(path)) {
+        (true, true) => REMOTE_STATE_BOOTSTRAP_TIMEOUT,
+        (true, false) => REMOTE_HTTP_REQUEST_TIMEOUT,
+        (false, _) => LOCAL_HTTP_REQUEST_TIMEOUT,
     }
 }
 
@@ -1242,8 +1252,10 @@ fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>> {
 mod tests {
     use super::{
         authorization_header_value, decode_chunked_body, decode_or_error, event_stream_path,
-        normalize_remote_base_url, parse_http_response, parse_sse_frame, take_next_sse_frame,
-        validate_header_value, validate_unix_request_target, EventStreamRequest, LocalHttpError,
+        http_request_timeout_for_path, is_state_bootstrap_path, normalize_remote_base_url,
+        parse_http_response, parse_sse_frame, take_next_sse_frame, validate_header_value,
+        validate_unix_request_target, EventStreamRequest, LocalHttpError,
+        REMOTE_HTTP_REQUEST_TIMEOUT, REMOTE_STATE_BOOTSTRAP_TIMEOUT,
     };
 
     #[test]
@@ -1258,6 +1270,29 @@ mod tests {
             normalize_remote_base_url("http://example.test:7878/".into()).unwrap(),
             "http://example.test:7878"
         );
+    }
+
+    #[test]
+    fn remote_state_bootstrap_uses_longer_timeout_than_lightweight_calls() {
+        assert_eq!(
+            http_request_timeout_for_path(true, "/agents/default/state"),
+            REMOTE_STATE_BOOTSTRAP_TIMEOUT
+        );
+        assert_eq!(
+            http_request_timeout_for_path(true, "/agents/default/status"),
+            REMOTE_HTTP_REQUEST_TIMEOUT
+        );
+        assert!(REMOTE_STATE_BOOTSTRAP_TIMEOUT > REMOTE_HTTP_REQUEST_TIMEOUT);
+    }
+
+    #[test]
+    fn state_bootstrap_path_detection_is_exact() {
+        assert!(is_state_bootstrap_path("/state"));
+        assert!(is_state_bootstrap_path("/agents/default/state"));
+        assert!(!is_state_bootstrap_path("/agents/default/status"));
+        assert!(!is_state_bootstrap_path(
+            "/agents/default/events?since=evt_1"
+        ));
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -65,6 +65,13 @@ use crate::{
     },
 };
 
+const STATE_BOOTSTRAP_TASK_LIMIT: usize = 40;
+const STATE_BOOTSTRAP_TRANSCRIPT_LIMIT: usize = 40;
+const STATE_BOOTSTRAP_OPERATOR_MESSAGE_LIMIT: usize = 40;
+const STATE_BOOTSTRAP_TASK_DETAIL_STRING_LIMIT: usize = 2048;
+const STATE_BOOTSTRAP_TRANSCRIPT_DATA_STRING_LIMIT: usize = 8192;
+const STATE_BOOTSTRAP_JSON_ARRAY_LIMIT: usize = 64;
+
 #[derive(Clone)]
 pub struct AppState {
     pub host: RuntimeHost,
@@ -876,13 +883,22 @@ pub async fn agent_state(
         })
         .collect();
     let agent = runtime.agent_summary().await.map_err(error_response)?;
-    let tasks = runtime.active_tasks(50).await.map_err(error_response)?;
-    let transcript_tail = runtime
-        .recent_transcript(100)
+    let tasks = runtime
+        .active_tasks(STATE_BOOTSTRAP_TASK_LIMIT)
         .await
-        .map_err(error_response)?;
+        .map_err(error_response)?
+        .into_iter()
+        .map(slim_state_task_record)
+        .collect();
+    let transcript_tail = runtime
+        .recent_transcript(STATE_BOOTSTRAP_TRANSCRIPT_LIMIT)
+        .await
+        .map_err(error_response)?
+        .into_iter()
+        .map(slim_state_transcript_entry)
+        .collect();
     let operator_messages = runtime
-        .recent_operator_messages(100)
+        .recent_operator_messages(STATE_BOOTSTRAP_OPERATOR_MESSAGE_LIMIT)
         .await
         .map_err(error_response)?;
     let briefs_tail = runtime.recent_briefs(24).await.map_err(error_response)?;
@@ -952,6 +968,51 @@ fn sort_state_work_items(work_items: &mut [WorkItemRecord]) {
     });
 }
 
+fn slim_state_task_record(mut task: TaskRecord) -> TaskRecord {
+    if let Some(detail) = task.detail.take() {
+        task.detail = Some(slim_state_json_value(
+            detail,
+            STATE_BOOTSTRAP_TASK_DETAIL_STRING_LIMIT,
+        ));
+    }
+    task
+}
+
+fn slim_state_transcript_entry(mut entry: TranscriptEntry) -> TranscriptEntry {
+    entry.data = slim_state_json_value(entry.data, STATE_BOOTSTRAP_TRANSCRIPT_DATA_STRING_LIMIT);
+    entry
+}
+
+fn slim_state_json_value(value: Value, string_limit: usize) -> Value {
+    match value {
+        Value::String(text) => Value::String(truncate_state_bootstrap_string(&text, string_limit)),
+        Value::Array(items) => Value::Array(
+            items
+                .into_iter()
+                .take(STATE_BOOTSTRAP_JSON_ARRAY_LIMIT)
+                .map(|item| slim_state_json_value(item, string_limit))
+                .collect(),
+        ),
+        Value::Object(object) => Value::Object(
+            object
+                .into_iter()
+                .map(|(key, value)| (key, slim_state_json_value(value, string_limit)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn truncate_state_bootstrap_string(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    if limit <= 3 {
+        return text.chars().take(limit).collect();
+    }
+    format!("{}...", text.chars().take(limit - 3).collect::<String>())
+}
+
 fn state_work_item_rank(item: &WorkItemRecord) -> u8 {
     match item.state {
         WorkItemState::Open if item.blocked_by.is_none() => 0,
@@ -971,9 +1032,16 @@ fn state_workspace_snapshot(agent: &AgentSummary) -> StateWorkspaceSnapshot {
 
 #[cfg(test)]
 mod tests {
-    use super::sort_state_work_items;
-    use crate::types::{WorkItemRecord, WorkItemState};
+    use super::{
+        sort_state_work_items, STATE_BOOTSTRAP_JSON_ARRAY_LIMIT,
+        STATE_BOOTSTRAP_TASK_DETAIL_STRING_LIMIT, STATE_BOOTSTRAP_TRANSCRIPT_DATA_STRING_LIMIT,
+    };
+    use crate::types::{
+        TaskKind, TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkItemRecord,
+        WorkItemState,
+    };
     use chrono::{Duration, Utc};
+    use serde_json::json;
 
     #[test]
     fn state_sort_preserves_queue_display_order() {
@@ -1016,6 +1084,67 @@ mod tests {
                 waiting.objective.as_str(),
                 "completed",
             ]
+        );
+    }
+
+    #[test]
+    fn state_bootstrap_slims_large_task_detail_and_transcript_data() {
+        let now = chrono::Utc::now();
+        let task = TaskRecord {
+            id: "task-1".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("large task".into()),
+            detail: Some(json!({
+                "cmd": "printf test",
+                "output_path": "/tmp/output.log",
+                "output_summary": "x".repeat(STATE_BOOTSTRAP_TASK_DETAIL_STRING_LIMIT + 64),
+                "lines": (0..(STATE_BOOTSTRAP_JSON_ARRAY_LIMIT + 10)).collect::<Vec<_>>()
+            })),
+            recovery: None,
+        };
+        let slimmed = super::slim_state_task_record(task);
+        let detail = slimmed.detail.expect("detail");
+        assert_eq!(detail["cmd"], "printf test");
+        assert_eq!(detail["output_path"], "/tmp/output.log");
+        assert!(
+            detail["output_summary"]
+                .as_str()
+                .expect("summary")
+                .chars()
+                .count()
+                <= STATE_BOOTSTRAP_TASK_DETAIL_STRING_LIMIT
+        );
+        assert_eq!(
+            detail["lines"].as_array().expect("lines").len(),
+            STATE_BOOTSTRAP_JSON_ARRAY_LIMIT
+        );
+
+        let entry = TranscriptEntry {
+            id: "entry-1".into(),
+            agent_id: "default".into(),
+            created_at: now,
+            kind: TranscriptEntryKind::ToolResults,
+            round: Some(1),
+            related_message_id: None,
+            stop_reason: None,
+            input_tokens: None,
+            output_tokens: None,
+            data: json!({"content": "y".repeat(STATE_BOOTSTRAP_TRANSCRIPT_DATA_STRING_LIMIT + 64)}),
+        };
+        let slimmed_entry = super::slim_state_transcript_entry(entry);
+        assert!(
+            slimmed_entry.data["content"]
+                .as_str()
+                .expect("content")
+                .chars()
+                .count()
+                <= STATE_BOOTSTRAP_TRANSCRIPT_DATA_STRING_LIMIT
         );
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1004,13 +1004,28 @@ fn slim_state_json_value(value: Value, string_limit: usize) -> Value {
 }
 
 fn truncate_state_bootstrap_string(text: &str, limit: usize) -> String {
-    if text.chars().count() <= limit {
-        return text.to_string();
+    if limit == 0 {
+        return String::new();
     }
-    if limit <= 3 {
-        return text.chars().take(limit).collect();
+
+    let truncated_char_limit = limit.saturating_sub(3);
+    let mut truncate_at = None;
+    for (index, (byte_index, _)) in text.char_indices().enumerate() {
+        if limit <= 3 {
+            if index == limit {
+                return text[..byte_index].to_string();
+            }
+        } else {
+            if index == truncated_char_limit {
+                truncate_at = Some(byte_index);
+            }
+            if index == limit {
+                let byte_index = truncate_at.unwrap_or(byte_index);
+                return format!("{}...", &text[..byte_index]);
+            }
+        }
     }
-    format!("{}...", text.chars().take(limit - 3).collect::<String>())
+    text.to_string()
 }
 
 fn state_work_item_rank(item: &WorkItemRecord) -> u8 {
@@ -1145,6 +1160,28 @@ mod tests {
                 .chars()
                 .count()
                 <= STATE_BOOTSTRAP_TRANSCRIPT_DATA_STRING_LIMIT
+        );
+    }
+
+    #[test]
+    fn state_bootstrap_string_truncation_preserves_total_budget() {
+        assert_eq!(super::truncate_state_bootstrap_string("abcdef", 0), "");
+        assert_eq!(super::truncate_state_bootstrap_string("abcdef", 2), "ab");
+        assert_eq!(
+            super::truncate_state_bootstrap_string("abcdef", 6),
+            "abcdef"
+        );
+        assert_eq!(
+            super::truncate_state_bootstrap_string("abcdefg", 6),
+            "abc..."
+        );
+        assert_eq!(
+            super::truncate_state_bootstrap_string("你好世界", 3),
+            "你好世"
+        );
+        assert_eq!(
+            super::truncate_state_bootstrap_string("你好世界a", 4),
+            "你..."
         );
     }
 }

--- a/tests/http_events.rs
+++ b/tests/http_events.rs
@@ -19,6 +19,7 @@ http_async_tests!(
     events_route_operator_projection_preserves_assistant_round_payload,
     events_route_operator_projection_preserves_workspace_payload,
     state_snapshot_seeds_projected_events_tail_and_stream_resumes_after_cursor,
+    state_snapshot_bounds_large_projection_fields,
     events_route_local_debug_projection_requires_control_auth,
     events_route_with_missing_cursor_returns_refresh_hint,
 );

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -22,8 +22,8 @@ use holon::{
         AdmissionContext, AgentStatus, AuditEvent, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin,
-        OperatorDeliveryStatus, TodoItem, TodoItemState, TrustLevel, WaitingIntentStatus,
-        WorkItemState,
+        OperatorDeliveryStatus, TaskKind, TaskRecord, TaskStatus, TodoItem, TodoItemState,
+        TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentStatus, WorkItemState,
     },
 };
 use reqwest::Client;
@@ -515,6 +515,81 @@ pub async fn events_route_local_debug_projection_requires_control_auth() -> Resu
         .send()
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn state_snapshot_bounds_large_projection_fields() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let now = chrono::Utc::now();
+
+    runtime.storage().append_task(&TaskRecord {
+        id: "large-task".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Running,
+        created_at: now,
+        updated_at: now,
+        parent_message_id: None,
+        work_item_id: None,
+        summary: Some("large task".into()),
+        detail: Some(serde_json::json!({
+            "output_path": "/tmp/large-task.log",
+            "output_summary": "x".repeat(12_000),
+            "lines": (0..120).collect::<Vec<_>>()
+        })),
+        recovery: None,
+    })?;
+    runtime
+        .storage()
+        .append_transcript_entry(&TranscriptEntry::new(
+            "default",
+            TranscriptEntryKind::ToolResults,
+            Some(1),
+            None,
+            serde_json::json!({ "content": "y".repeat(20_000) }),
+        ))?;
+
+    let snapshot: serde_json::Value = reqwest::Client::new()
+        .get(format!("{base}/agents/default/state"))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let task = snapshot["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["id"] == "large-task"))
+        .expect("large task should be present");
+    assert_eq!(task["detail"]["output_path"], "/tmp/large-task.log");
+    assert!(
+        task["detail"]["output_summary"]
+            .as_str()
+            .expect("task summary")
+            .chars()
+            .count()
+            <= 2048
+    );
+    assert_eq!(task["detail"]["lines"].as_array().expect("lines").len(), 64);
+
+    let transcript = snapshot["transcript_tail"]
+        .as_array()
+        .and_then(|entries| {
+            entries
+                .iter()
+                .find(|entry| entry["data"]["content"].as_str().is_some())
+        })
+        .expect("large transcript should be present");
+    assert!(
+        transcript["data"]["content"]
+            .as_str()
+            .expect("transcript content")
+            .chars()
+            .count()
+            <= 8192
+    );
 
     server.abort();
     Ok(())


### PR DESCRIPTION
Fixes #1005.

## Summary
- give remote `/state` bootstrap requests a longer first-party timeout while keeping lightweight remote calls on the short timeout
- bound `/state` bootstrap payloads for active task detail, transcript data, and operator-message window size so large runtime records do not make remote TUI selection appear stuck
- keep existing `cursor_too_old` recovery behavior covered while adding a regression for large projection fields

## Verification
- `cargo fmt --all -- --check`
- `cargo test state_snapshot_bounds_large_projection_fields`
- `cargo test state_snapshot_seeds_projected_events_tail_and_stream_resumes_after_cursor`
- `cargo test cursor_`
- `cargo test remote_state_bootstrap_uses_longer_timeout_than_lightweight_calls`
- `cargo test state_bootstrap_path_detection_is_exact`
- `cargo test state_bootstrap_slims_large_task_detail_and_transcript_data`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
