### PR TITLE
docs: fix mdorigin YAML frontmatter parsing error in first-agent.md

### DIFF
--- a/docs/website/concepts/README.md
+++ b/docs/website/concepts/README.md
@@ -27,11 +27,11 @@ the current surface area.
 <!-- INDEX:START -->
 
 - [Runtime model](./runtime-model.md)
-  How Holon separates agents, work items, tasks, queues, and delivery.
+  Agents, tasks, work items, workspaces, and the execution loop that make up Holon's runtime.
   <!-- mdorigin:index kind=article -->
 
 - [Trust boundaries](./trust-boundaries.md)
-  How Holon preserves provenance across operator input, external events, and delegated output.
+  How Holon classifies origin, trust, and priority to keep long-lived agents secure.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/getting-started/README.md
+++ b/docs/website/getting-started/README.md
@@ -101,4 +101,8 @@ The generated `dist/` directory is ignored because it is a build artifact.
 
 <!-- INDEX:START -->
 
+- [Create your first agent](./first-agent.md)
+  From zero to your first Holon agent: build, start, TUI basics, create an agent, and configure models.
+  <!-- mdorigin:index kind=article -->
+
 <!-- INDEX:END -->

--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -1,6 +1,6 @@
 ---
 title: Create your first agent
-summary: From zero to your first Holon agent: build, start, TUI basics, create an agent, and configure models.
+summary: "From zero to your first Holon agent: build, start, TUI basics, create an agent, and configure models."
 order: 20
 ---
 

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -13,36 +13,36 @@ surfaces safely.
 
 <!-- INDEX:START -->
 
-- [Quick examples](./quick-examples.md)
-  Common CLI workflows for creating agents, running tasks, and configuring the runtime.
-  <!-- mdorigin:index kind=article -->
-
-- [Integration](./integration.md)
-  How to connect external systems to Holon's HTTP control plane.
-  <!-- mdorigin:index kind=article -->
-
-- [Troubleshooting](./troubleshooting.md)
-  How to diagnose startup, configuration, model, and TUI issues.
-  <!-- mdorigin:index kind=article -->
-
-- [Multi-agent collaboration](./multi-agent.md)
-  How to delegate work to child agents and supervise the resulting task handles.
-  <!-- mdorigin:index kind=article -->
-
-- [Skills](./skills.md)
-  How reusable `SKILL.md` workflows are discovered, installed, and applied.
-  <!-- mdorigin:index kind=article -->
-
-- [Work items](./work-items.md)
-  How to track durable objectives, plans, blockers, and completion state.
-  <!-- mdorigin:index kind=article -->
-
 - [Local runtime](./local-runtime.md)
   A conservative workflow for running and inspecting Holon locally.
   <!-- mdorigin:index kind=article -->
 
+- [Quick examples](./quick-examples.md)
+  Common Holon tasks you can try after completing the Getting Started guide.
+  <!-- mdorigin:index kind=article -->
+
 - [Documentation workflow](./documentation-workflow.md)
   How to edit and build the mdorigin-powered Holon website.
+  <!-- mdorigin:index kind=article -->
+
+- [Integration guide](./integration.md)
+  Programmatic access to Holon's HTTP control plane with curl examples and endpoint reference.
+  <!-- mdorigin:index kind=article -->
+
+- [Troubleshooting](./troubleshooting.md)
+  Solutions for common Holon issues covering daemon, configuration, model, and TUI problems.
+  <!-- mdorigin:index kind=article -->
+
+- [Multi-agent collaboration](./multi-agent.md)
+  Spawning child agents, supervision contracts, and workspace modes for parallel work.
+  <!-- mdorigin:index kind=article -->
+
+- [Skills guide](./skills.md)
+  Reusable SKILL.md workflows, skill locations, and how to develop custom skills.
+  <!-- mdorigin:index kind=article -->
+
+- [Work items guide](./work-items.md)
+  Durable objective tracking with work items, plans, todo lists, and lifecycle management.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -12,12 +12,12 @@ the current CLI, control plane, and operator configuration surfaces.
 
 <!-- INDEX:START -->
 
-- [Configuration](./configuration.md)
-  File locations, config keys, credentials, provider setup, and diagnostics.
+- [CLI reference](./cli.md)
+  Holon's command-line interface, command tree, and common workflows.
   <!-- mdorigin:index kind=article -->
 
-- [CLI](./cli.md)
-  How to inspect and use the current Holon command-line surface.
+- [Configuration](./configuration.md)
+  Holon configuration files, keys, credentials, environment variables, and diagnostics.
   <!-- mdorigin:index kind=article -->
 
 - [HTTP control plane](./http-control-plane.md)


### PR DESCRIPTION
## Summary

Fix mdorigin deployment failure caused by YAML frontmatter parsing error.

## Root Cause

The `docs/website/getting-started/first-agent.md` frontmatter had an unquoted colon in the `summary` field:

```yaml
summary: From zero to your first Holon agent: build, start, TUI basics, create an agent, and configure models.
```

YAML interprets the colon as a key-value separator, causing `mdorigin build index` to fail with:

```
incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 3, column 45
```

## Changes

- **`first-agent.md`**: Quoted the `summary` value containing a colon
- **`concepts/README.md`**, **`getting-started/README.md`**, **`guides/README.md`**, **`reference/README.md`**: Updated auto-generated `INDEX` blocks to reflect current frontmatter summaries (generated by `mdorigin build index`)

## Verification

Local `mdorigin build index` now passes successfully:

```
$ npm --prefix .tools run build:index
updated 6 index file(s)
skipped 2 directories without index.md
```

## Related

- Previous PR: #999
- CI failure: https://github.com/holon-run/holon/actions/runs/25566932764/job/75052634184
