### PR TITLE
feat: add agent lifecycle slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Inspect state:
 
 ```bash
 holon status
-holon agents
+holon agent list
 holon transcript --limit 50
 ```
 

--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -143,7 +143,7 @@ When you start Holon, it automatically creates a **default agent** in `~/.holon/
 Create a specialized agent for a specific role:
 
 ```bash
-cargo run -- agents create reviewer --template holon-reviewer
+cargo run -- agent create reviewer --template holon-reviewer
 ```
 
 This creates a new agent in `~/.holon/agents/reviewer/` initialized with the holon-reviewer template.
@@ -154,19 +154,19 @@ Templates provide reusable agent configurations:
 
 ```bash
 # Use a builtin template by ID
-cargo run -- agents create docs-helper --template holon-developer
+cargo run -- agent create docs-helper --template holon-developer
 
 # Use a local template path
-cargo run -- agents create custom --template /path/to/template
+cargo run -- agent create custom --template /path/to/template
 
 # Use a GitHub template URL
-cargo run -- agents create github-agent --template https://github.com/owner/repo/tree/main/template-path
+cargo run -- agent create github-agent --template https://github.com/owner/repo/tree/main/template-path
 ```
 
 ### List agents
 
 ```bash
-cargo run -- agents
+cargo run -- agent list
 ```
 
 ### Switch agents in the TUI
@@ -232,7 +232,7 @@ cargo run -- config set model.default "anthropic/claude-sonnet-4-6"
 An agent can override the default model:
 
 ```bash
-cargo run -- agents model set "anthropic/claude-sonnet-4-6" --agent reviewer
+cargo run -- agent model set "anthropic/claude-sonnet-4-6" reviewer
 ```
 
 See [Configuration reference](/reference/configuration.md) for more details on agent model overrides.

--- a/docs/website/guides/quick-examples.md
+++ b/docs/website/guides/quick-examples.md
@@ -27,13 +27,13 @@ holon run --json "List files in the current directory"
 Create a named agent that persists across sessions:
 
 ```bash
-holon agents create reviewer
+holon agent create reviewer
 ```
 
 Create an agent from a built-in template:
 
 ```bash
-holon agents create reviewer --template holon-reviewer
+holon agent create reviewer --template holon-reviewer
 ```
 
 Then interact with it:
@@ -53,13 +53,13 @@ holon config set model.default "deepseek-anthropic/deepseek-v4-pro"
 Set a per-agent model override:
 
 ```bash
-holon agents model set "anthropic/claude-sonnet-4-6" --agent reviewer
+holon agent model set "anthropic/claude-sonnet-4-6" reviewer
 ```
 
 Check which model an agent uses:
 
 ```bash
-holon agents model get --agent reviewer
+holon agent model get reviewer
 ```
 
 ## 4. Run as a Background Daemon
@@ -187,7 +187,7 @@ holon run --workspace-root /path/to/project "Analyze this codebase"
 ## 10. Create an Agent with a Custom Workspace
 
 ```bash
-holon agents create my-builder
+holon agent create my-builder
 holon run --agent my-builder --workspace-root /path/to/project "Build the project"
 ```
 

--- a/docs/website/guides/troubleshooting.md
+++ b/docs/website/guides/troubleshooting.md
@@ -103,7 +103,7 @@ This shows which models are available, which credentials are configured, and det
 
 1. Check agent exists:
    ```bash
-   holon agents model get --agent my-agent
+   holon agent model get my-agent
    ```
 
 2. Try running with a fresh one-shot:
@@ -116,13 +116,13 @@ This shows which models are available, which credentials are configured, and det
 Check if the agent has a per-agent model override:
 
 ```bash
-holon agents model get --agent my-agent
+holon agent model get my-agent
 ```
 
 Clear the override to fall back to the global default:
 
 ```bash
-holon agents model clear --agent my-agent
+holon agent model clear my-agent
 ```
 
 ## Configuration Issues

--- a/docs/website/legacy-static/index.html
+++ b/docs/website/legacy-static/index.html
@@ -123,7 +123,7 @@ cargo run -- run "Summarize the current workspace"
 
 # Inspect CLI surfaces
 cargo run -- --help
-cargo run -- agents --help</code></pre>
+cargo run -- agent --help</code></pre>
                     </div>
                     <div class="quickstart-note">
                         <strong>Status:</strong> The Rust runtime is now the main development line. Release packaging

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -82,18 +82,27 @@ holon run --trust untrusted-external "User query"      # mark trust level
 ### Create and use an agent
 
 ```bash
-holon agents create reviewer
-holon agents create code-reviewer --template code-reviewer
+holon agent create reviewer
+holon agent create code-reviewer --template code-reviewer
 holon run --agent reviewer "Review src/runtime/turn.rs"
+```
+
+### Agent lifecycle
+
+```bash
+holon agent pause reviewer
+holon agent resume reviewer
+holon agent stop reviewer
+holon agent interrupt reviewer
 ```
 
 ### Model selection
 
 ```bash
 holon config set model.default "deepseek-anthropic/deepseek-v4-pro"
-holon agents model set "anthropic/claude-sonnet-4-6" --agent reviewer
-holon agents model get --agent reviewer
-holon agents model clear --agent reviewer
+holon agent model set "anthropic/claude-sonnet-4-6" reviewer
+holon agent model get reviewer
+holon agent model clear reviewer
 ```
 
 ### Daemon management
@@ -200,7 +209,7 @@ holon run --agent builder --workspace-root /path/to/project "Fix build errors"
 | `--listen <ADDR>` | Listen address |
 | `--token <TOKEN>` | Auth token |
 
-### `holon agents create` options
+### `holon agent create` options
 
 | Option | Description |
 |--------|-------------|

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -145,7 +145,7 @@ This shows each model's availability, credential status, provider, transport, an
 Each agent can override the default model:
 
 ```bash
-holon agents model set "anthropic/claude-sonnet-4-6" --agent reviewer
+holon agent model set "anthropic/claude-sonnet-4-6" reviewer
 ```
 
 The override is stored in the agent's own configuration, not the global `model.default`.

--- a/src/client.rs
+++ b/src/client.rs
@@ -360,6 +360,21 @@ impl LocalClient {
         .await
     }
 
+    pub async fn control_agent(
+        &self,
+        agent_id: &str,
+        action: crate::types::ControlAction,
+    ) -> Result<Value> {
+        self.post_control_json(
+            &format!("/control/agents/{agent_id}/control"),
+            &crate::http::ControlRequest {
+                action,
+                trust: Some(TrustLevel::TrustedOperator),
+            },
+        )
+        .await
+    }
+
     pub async fn attach_workspace(
         &self,
         agent_id: &str,
@@ -1313,7 +1328,7 @@ mod tests {
     fn decode_or_error_includes_code_and_hint_for_stopped_agent() {
         let err = decode_or_error(
             409,
-            br#"{"ok":false,"error":"agent default is stopped; resume first","code":"agent_stopped","hint":"resume with `holon control resume --agent default`"}"#.to_vec(),
+            br#"{"ok":false,"error":"agent default is stopped; resume first","code":"agent_stopped","hint":"resume with `holon agent resume default`"}"#.to_vec(),
             "/control/agents/default/prompt",
         )
         .unwrap_err();
@@ -1323,11 +1338,11 @@ mod tests {
         assert!(typed.has_code("agent_stopped"));
         assert_eq!(
             typed.hint.as_deref(),
-            Some("resume with `holon control resume --agent default`")
+            Some("resume with `holon agent resume default`")
         );
         assert!(rendered.contains("agent default is stopped; resume first"));
         assert!(rendered.contains("[agent_stopped]"));
-        assert!(rendered.contains("Hint: resume with `holon control resume --agent default`"));
+        assert!(rendered.contains("Hint: resume with `holon agent resume default`"));
     }
 
     #[test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -428,7 +428,7 @@ impl RuntimeHost {
                     Some(_) => {}
                     None => {
                         return Err(anyhow!(
-                            "agent {} not found; create it first with 'holon agents create {}'",
+                            "agent {} not found; create it first with 'holon agent create {}'",
                             agent_id,
                             agent_id
                         ));

--- a/src/http.rs
+++ b/src/http.rs
@@ -2733,7 +2733,7 @@ fn stopped_agent_conflict(
 ) -> (StatusCode, Json<Value>) {
     let agent_id = agent_id.into();
     let hint = format!(
-        "resume with `holon control resume --agent {}` or POST /control/agents/{}/control with JSON body {{\"action\":\"resume\"}}",
+        "resume with `holon agent resume {}` or POST /control/agents/{}/control with JSON body {{\"action\":\"resume\"}}",
         agent_id, agent_id
     );
     (

--- a/src/main.rs
+++ b/src/main.rs
@@ -2059,15 +2059,8 @@ async fn control_agent_lifecycle(
     action: ControlAction,
 ) -> Result<()> {
     let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
-    post_control_json(
-        config,
-        &format!("/control/agents/{agent}/control"),
-        &ControlRequest {
-            action,
-            trust: Some(TrustLevel::TrustedOperator),
-        },
-    )
-    .await
+    let client = LocalClient::new(config.clone())?;
+    print_json(&client.control_agent(&agent, action).await?)
 }
 
 async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,14 +129,16 @@ enum Commands {
         #[arg(long)]
         agent: Option<String>,
     },
+    #[command(about = "Deprecated: use `holon agent pause|resume|stop|interrupt [agent-id]`")]
     Control {
         action: ControlCommandAction,
         #[arg(long)]
         agent: Option<String>,
     },
-    Agents {
+    #[command(alias = "agents")]
+    Agent {
         #[command(subcommand)]
-        command: Option<AgentsCommands>,
+        command: Option<AgentCommands>,
     },
     Skills {
         #[command(subcommand)]
@@ -390,11 +392,27 @@ enum DebugCommands {
 }
 
 #[derive(Debug, Subcommand)]
-enum AgentsCommands {
+enum AgentCommands {
+    List,
+    Status {
+        agent_id: Option<String>,
+    },
     Create {
         agent_id: String,
         #[arg(long)]
         template: Option<String>,
+    },
+    Pause {
+        agent_id: Option<String>,
+    },
+    Resume {
+        agent_id: Option<String>,
+    },
+    Stop {
+        agent_id: Option<String>,
+    },
+    Interrupt {
+        agent_id: Option<String>,
     },
     Model {
         #[command(subcommand)]
@@ -405,17 +423,14 @@ enum AgentsCommands {
 #[derive(Debug, Subcommand)]
 enum AgentModelCommands {
     Get {
-        #[arg(long)]
-        agent: Option<String>,
+        agent_id: Option<String>,
     },
     Set {
         model: String,
-        #[arg(long)]
-        agent: Option<String>,
+        agent_id: Option<String>,
     },
     Clear {
-        #[arg(long)]
-        agent: Option<String>,
+        agent_id: Option<String>,
     },
 }
 
@@ -641,7 +656,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
             )
             .await
         }
-        Commands::Agents { command } => handle_agents_command(&config, command).await,
+        Commands::Agent { command } => handle_agent_command(&config, command).await,
         Commands::Skills { command } => handle_skills_command(&config, command).await,
         Commands::Workspace { command } => handle_workspace_command(&config, command).await,
         Commands::Tui {
@@ -1223,6 +1238,81 @@ mod tests {
             ]
         );
         assert_eq!(serve_launch.control_token_env, None);
+    }
+
+    #[test]
+    fn agent_lifecycle_commands_parse_with_optional_agent_id() {
+        let cli = Cli::parse_from(["holon", "agent", "pause"]);
+        let Commands::Agent {
+            command: Some(AgentCommands::Pause { agent_id }),
+        } = cli.command
+        else {
+            panic!("expected agent pause command");
+        };
+        assert_eq!(agent_id, None);
+
+        let cli = Cli::parse_from(["holon", "agent", "resume", "foo"]);
+        let Commands::Agent {
+            command: Some(AgentCommands::Resume { agent_id }),
+        } = cli.command
+        else {
+            panic!("expected agent resume command");
+        };
+        assert_eq!(agent_id.as_deref(), Some("foo"));
+
+        let cli = Cli::parse_from(["holon", "agent", "stop", "foo"]);
+        let Commands::Agent {
+            command: Some(AgentCommands::Stop { agent_id }),
+        } = cli.command
+        else {
+            panic!("expected agent stop command");
+        };
+        assert_eq!(agent_id.as_deref(), Some("foo"));
+
+        let cli = Cli::parse_from(["holon", "agent", "interrupt", "foo"]);
+        let Commands::Agent {
+            command: Some(AgentCommands::Interrupt { agent_id }),
+        } = cli.command
+        else {
+            panic!("expected agent interrupt command");
+        };
+        assert_eq!(agent_id.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn agent_model_commands_use_positional_agent_id() {
+        let cli = Cli::parse_from(["holon", "agent", "model", "get", "foo"]);
+        let Commands::Agent {
+            command:
+                Some(AgentCommands::Model {
+                    command: AgentModelCommands::Get { agent_id },
+                }),
+        } = cli.command
+        else {
+            panic!("expected agent model get command");
+        };
+        assert_eq!(agent_id.as_deref(), Some("foo"));
+
+        let cli = Cli::parse_from(["holon", "agent", "model", "set", "openai/gpt-5.1", "foo"]);
+        let Commands::Agent {
+            command:
+                Some(AgentCommands::Model {
+                    command: AgentModelCommands::Set { model, agent_id },
+                }),
+        } = cli.command
+        else {
+            panic!("expected agent model set command");
+        };
+        assert_eq!(model, "openai/gpt-5.1");
+        assert_eq!(agent_id.as_deref(), Some("foo"));
+
+        let cli = Cli::parse_from(["holon", "agents", "list"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Agent {
+                command: Some(AgentCommands::List)
+            }
+        ));
     }
 
     #[test]
@@ -1898,13 +1988,18 @@ async fn handle_workspace_command(config: &AppConfig, command: WorkspaceCommands
     }
 }
 
-async fn handle_agents_command(config: &AppConfig, command: Option<AgentsCommands>) -> Result<()> {
+async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>) -> Result<()> {
     match command {
-        None => {
+        None | Some(AgentCommands::List) => {
             let client = LocalClient::new(config.clone())?;
             print_json(&serde_json::to_value(client.list_agents().await?)?)
         }
-        Some(AgentsCommands::Create { agent_id, template }) => {
+        Some(AgentCommands::Status { agent_id }) => {
+            let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
+            let client = LocalClient::new(config.clone())?;
+            print_json(&serde_json::to_value(client.agent_status(&agent).await?)?)
+        }
+        Some(AgentCommands::Create { agent_id, template }) => {
             post_control_json(
                 config,
                 &format!("/control/agents/{agent_id}/create"),
@@ -1915,25 +2010,64 @@ async fn handle_agents_command(config: &AppConfig, command: Option<AgentsCommand
             )
             .await
         }
-        Some(AgentsCommands::Model { command }) => {
+        Some(AgentCommands::Pause { agent_id }) => {
+            control_agent_lifecycle(config, agent_id, ControlAction::Pause).await
+        }
+        Some(AgentCommands::Resume { agent_id }) => {
+            control_agent_lifecycle(config, agent_id, ControlAction::Resume).await
+        }
+        Some(AgentCommands::Stop { agent_id }) => {
+            control_agent_lifecycle(config, agent_id, ControlAction::Stop).await
+        }
+        Some(AgentCommands::Interrupt { agent_id }) => {
+            let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
+            post_control_json(
+                config,
+                &format!("/control/agents/{agent}/current-run/interrupt"),
+                &http::InterruptCurrentRunRequest {
+                    run_id: None,
+                    mode: Some("pause_after_abort".into()),
+                    trust: Some(TrustLevel::TrustedOperator),
+                },
+            )
+            .await
+        }
+        Some(AgentCommands::Model { command }) => {
             let client = LocalClient::new(config.clone())?;
             match command {
-                AgentModelCommands::Get { agent } => {
-                    let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+                AgentModelCommands::Get { agent_id } => {
+                    let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
                     let summary = client.agent_status(&agent).await?;
                     print_json(&serde_json::to_value(summary.model)?)
                 }
-                AgentModelCommands::Set { model, agent } => {
-                    let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+                AgentModelCommands::Set { model, agent_id } => {
+                    let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
                     print_json(&client.set_agent_model_override(&agent, model, None).await?)
                 }
-                AgentModelCommands::Clear { agent } => {
-                    let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+                AgentModelCommands::Clear { agent_id } => {
+                    let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
                     print_json(&client.clear_agent_model_override(&agent).await?)
                 }
             }
         }
     }
+}
+
+async fn control_agent_lifecycle(
+    config: &AppConfig,
+    agent_id: Option<String>,
+    action: ControlAction,
+) -> Result<()> {
+    let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());
+    post_control_json(
+        config,
+        &format!("/control/agents/{agent}/control"),
+        &ControlRequest {
+            action,
+            trust: Some(TrustLevel::TrustedOperator),
+        },
+    )
+    .await
 }
 
 async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> Result<()> {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -34,6 +34,16 @@ enum ComposerSubmission {
 enum SlashArgRule {
     None,
     ExactlyOne,
+    Agent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AgentSlashAction {
+    Switch(String),
+    Control {
+        action: crate::types::ControlAction,
+        agent_id: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -132,9 +142,9 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 16] = [
     },
     SlashCommandSpec {
         name: "/agent",
-        description: "switch to agent by id",
-        usage: "/agent <agent-id>",
-        arg_rule: SlashArgRule::ExactlyOne,
+        description: "switch or control an agent",
+        usage: "/agent <agent-id>|pause [agent-id]|resume [agent-id]|stop [agent-id]",
+        arg_rule: SlashArgRule::Agent,
         command: SlashCommand::Agent,
     },
     SlashCommandSpec {
@@ -191,6 +201,49 @@ fn slash_command_argument_error(spec: SlashCommandSpec, args: usize) -> anyhow::
                 spec.usage
             )
         }
+        SlashArgRule::Agent => anyhow!(
+            "{0} expects an agent id or lifecycle action; usage: {1}",
+            spec.name,
+            spec.usage
+        ),
+    }
+}
+
+fn parse_agent_slash_action(args: &[String]) -> Result<AgentSlashAction> {
+    let Some(first) = args.first() else {
+        return Err(anyhow!(
+            "/agent requires an agent id or lifecycle action; usage: /agent <agent-id>|pause [agent-id]|resume [agent-id]|stop [agent-id]"
+        ));
+    };
+    match first.as_str() {
+        "pause" | "resume" | "stop" => {
+            if args.len() > 2 {
+                return Err(anyhow!(
+                    "/agent {first} accepts at most one agent id; usage: /agent {first} [agent-id]"
+                ));
+            }
+            let action = match first.as_str() {
+                "pause" => crate::types::ControlAction::Pause,
+                "resume" => crate::types::ControlAction::Resume,
+                "stop" => crate::types::ControlAction::Stop,
+                _ => unreachable!("matched lifecycle action"),
+            };
+            Ok(AgentSlashAction::Control {
+                action,
+                agent_id: args.get(1).cloned(),
+            })
+        }
+        "status" | "interrupt" | "list" | "model" | "wake" => Err(anyhow!(
+            "/agent {first} is not supported in the TUI yet; use /help for supported commands"
+        )),
+        _ => {
+            if args.len() != 1 {
+                return Err(anyhow!(
+                    "/agent expects exactly one agent id for switching; usage: /agent <agent-id>"
+                ));
+            }
+            Ok(AgentSlashAction::Switch(first.clone()))
+        }
     }
 }
 
@@ -241,6 +294,9 @@ fn parse_composer_submission(buffer: &str) -> Result<Option<ComposerSubmission>>
         }
         SlashArgRule::ExactlyOne if args.len() != 1 => {
             return Err(slash_command_argument_error(slash_command_spec, args.len()));
+        }
+        SlashArgRule::Agent => {
+            parse_agent_slash_action(&args)?;
         }
         SlashArgRule::None | SlashArgRule::ExactlyOne => {}
     }
@@ -566,24 +622,42 @@ impl TuiApp {
                 self.status_line = format!("Interrupted current run for {agent_id}");
                 self.begin_bootstrap_selected_agent();
             }
-            SlashCommand::Agent => {
-                let requested_agent_id = args
-                    .into_iter()
-                    .next()
-                    .expect("slash command /agent requires one argument");
-                let target_index = self
-                    .agents
-                    .iter()
-                    .position(|agent| agent.identity.agent_id == requested_agent_id)
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "unknown agent '{requested_agent_id}'; use /agents to inspect valid ids"
-                        )
-                    })?;
-                self.overlay = OverlayState::None;
-                self.begin_bootstrap_agent_index(target_index);
-                self.status_line = format!("Switching to agent {requested_agent_id}");
-            }
+            SlashCommand::Agent => match parse_agent_slash_action(&args)? {
+                AgentSlashAction::Switch(requested_agent_id) => {
+                    let target_index = self
+                            .agents
+                            .iter()
+                            .position(|agent| agent.identity.agent_id == requested_agent_id)
+                            .ok_or_else(|| {
+                                anyhow!(
+                                    "unknown agent '{requested_agent_id}'; use /agents to inspect valid ids"
+                                )
+                            })?;
+                    self.overlay = OverlayState::None;
+                    self.begin_bootstrap_agent_index(target_index);
+                    self.status_line = format!("Switching to agent {requested_agent_id}");
+                }
+                AgentSlashAction::Control { action, agent_id } => {
+                    let agent_id = agent_id
+                        .or_else(|| self.selected_agent_id().map(ToString::to_string))
+                        .ok_or_else(|| anyhow!("no agent selected"))?;
+                    self.client.control_agent(&agent_id, action.clone()).await?;
+                    self.overlay = OverlayState::None;
+                    self.status_line = format!(
+                        "{} agent {agent_id}",
+                        match action {
+                            crate::types::ControlAction::Pause => "Paused",
+                            crate::types::ControlAction::Resume => "Resumed",
+                            crate::types::ControlAction::Stop => "Stopped",
+                        }
+                    );
+                    if self.selected_agent_id() == Some(agent_id.as_str()) {
+                        self.begin_bootstrap_selected_agent();
+                    } else {
+                        self.schedule_agent_list_refresh();
+                    }
+                }
+            },
             SlashCommand::Skills => {
                 let agent_id = match self.selected_agent_id() {
                     Some(id) => id.to_string(),
@@ -1335,8 +1409,9 @@ impl TuiApp {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_composer_submission, slash_command_spec, slash_menu_enter_submission,
-        slash_menu_specs, slash_prompt_lines, ComposerSubmission, SlashCommand,
+        parse_agent_slash_action, parse_composer_submission, slash_command_spec,
+        slash_menu_enter_submission, slash_menu_specs, slash_prompt_lines, AgentSlashAction,
+        ComposerSubmission, SlashCommand,
     };
 
     #[test]
@@ -1389,6 +1464,27 @@ mod tests {
             ))
         );
         assert_eq!(
+            parse_composer_submission("/agent pause").unwrap(),
+            Some(ComposerSubmission::Slash(
+                SlashCommand::Agent,
+                vec!["pause".into()]
+            ))
+        );
+        assert_eq!(
+            parse_composer_submission("/agent resume foo").unwrap(),
+            Some(ComposerSubmission::Slash(
+                SlashCommand::Agent,
+                vec!["resume".into(), "foo".into()]
+            ))
+        );
+        assert_eq!(
+            parse_composer_submission("/agent stop").unwrap(),
+            Some(ComposerSubmission::Slash(
+                SlashCommand::Agent,
+                vec!["stop".into()]
+            ))
+        );
+        assert_eq!(
             parse_composer_submission("/display 4").unwrap(),
             Some(ComposerSubmission::Slash(
                 SlashCommand::Display,
@@ -1412,7 +1508,9 @@ mod tests {
     #[test]
     fn slash_commands_require_arguments_for_agent() {
         let err = parse_composer_submission("/agent").unwrap_err();
-        assert!(err.to_string().contains("requires one argument"));
+        assert!(err
+            .to_string()
+            .contains("requires an agent id or lifecycle action"));
     }
 
     #[test]
@@ -1424,7 +1522,40 @@ mod tests {
     #[test]
     fn slash_commands_reject_too_many_arguments() {
         let err = parse_composer_submission("/agent default extra").unwrap_err();
-        assert!(err.to_string().contains("expects exactly one argument"));
+        assert!(err
+            .to_string()
+            .contains("expects exactly one agent id for switching"));
+        let err = parse_composer_submission("/agent pause default extra").unwrap_err();
+        assert!(err.to_string().contains("accepts at most one agent id"));
+    }
+
+    #[test]
+    fn agent_slash_lifecycle_actions_map_to_control_actions() {
+        assert_eq!(
+            parse_agent_slash_action(&["pause".into()]).unwrap(),
+            AgentSlashAction::Control {
+                action: crate::types::ControlAction::Pause,
+                agent_id: None,
+            }
+        );
+        assert_eq!(
+            parse_agent_slash_action(&["resume".into(), "foo".into()]).unwrap(),
+            AgentSlashAction::Control {
+                action: crate::types::ControlAction::Resume,
+                agent_id: Some("foo".into()),
+            }
+        );
+        assert_eq!(
+            parse_agent_slash_action(&["stop".into()]).unwrap(),
+            AgentSlashAction::Control {
+                action: crate::types::ControlAction::Stop,
+                agent_id: None,
+            }
+        );
+        assert_eq!(
+            parse_agent_slash_action(&["default".into()]).unwrap(),
+            AgentSlashAction::Switch("default".into())
+        );
     }
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -143,7 +143,8 @@ const SLASH_COMMAND_SPECS: [SlashCommandSpec; 16] = [
     SlashCommandSpec {
         name: "/agent",
         description: "switch or control an agent",
-        usage: "/agent <agent-id>|pause [agent-id]|resume [agent-id]|stop [agent-id]",
+        usage:
+            "/agent <agent-id>|switch <agent-id>|pause [agent-id]|resume [agent-id]|stop [agent-id]",
         arg_rule: SlashArgRule::Agent,
         command: SlashCommand::Agent,
     },
@@ -233,8 +234,16 @@ fn parse_agent_slash_action(args: &[String]) -> Result<AgentSlashAction> {
                 agent_id: args.get(1).cloned(),
             })
         }
+        "switch" => {
+            if args.len() != 2 {
+                return Err(anyhow!(
+                    "/agent switch expects exactly one agent id; usage: /agent switch <agent-id>"
+                ));
+            }
+            Ok(AgentSlashAction::Switch(args[1].clone()))
+        }
         "status" | "interrupt" | "list" | "model" | "wake" => Err(anyhow!(
-            "/agent {first} is not supported in the TUI yet; use /help for supported commands"
+            "/agent {first} is not supported in the TUI yet; use /agent switch {first} to select an agent with that id"
         )),
         _ => {
             if args.len() != 1 {
@@ -1485,6 +1494,13 @@ mod tests {
             ))
         );
         assert_eq!(
+            parse_composer_submission("/agent switch pause").unwrap(),
+            Some(ComposerSubmission::Slash(
+                SlashCommand::Agent,
+                vec!["switch".into(), "pause".into()]
+            ))
+        );
+        assert_eq!(
             parse_composer_submission("/display 4").unwrap(),
             Some(ComposerSubmission::Slash(
                 SlashCommand::Display,
@@ -1527,6 +1543,10 @@ mod tests {
             .contains("expects exactly one agent id for switching"));
         let err = parse_composer_submission("/agent pause default extra").unwrap_err();
         assert!(err.to_string().contains("accepts at most one agent id"));
+        let err = parse_composer_submission("/agent switch").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("switch expects exactly one agent id"));
     }
 
     #[test]
@@ -1556,6 +1576,12 @@ mod tests {
             parse_agent_slash_action(&["default".into()]).unwrap(),
             AgentSlashAction::Switch("default".into())
         );
+        assert_eq!(
+            parse_agent_slash_action(&["switch".into(), "pause".into()]).unwrap(),
+            AgentSlashAction::Switch("pause".into())
+        );
+        let err = parse_agent_slash_action(&["status".into()]).unwrap_err();
+        assert!(err.to_string().contains("use /agent switch status"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3090,7 +3090,7 @@ impl AgentLifecycleHint {
                 operator_hint: Some(
                     "agent is administratively stopped; resume before new prompts or wakes".into(),
                 ),
-                resume_cli_hint: Some(format!("holon control resume --agent {agent_id}")),
+                resume_cli_hint: Some(format!("holon agent resume {agent_id}")),
                 resume_control_path: Some(format!("/control/agents/{agent_id}/control")),
             };
         }

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -729,7 +729,7 @@ pub async fn stopped_status_includes_lifecycle_resume_guidance() -> Result<()> {
     assert_eq!(payload["lifecycle"]["wake_requires_resume"], true);
     assert_eq!(
         payload["lifecycle"]["resume_cli_hint"],
-        "holon control resume --agent default"
+        "holon agent resume default"
     );
     assert_eq!(
         payload["lifecycle"]["resume_control_path"],
@@ -774,7 +774,7 @@ pub async fn control_wake_rejects_stopped_agent_with_resume_guidance() -> Result
     assert!(payload["hint"]
         .as_str()
         .unwrap_or_default()
-        .contains("holon control resume --agent default"));
+        .contains("holon agent resume default"));
 
     let events = runtime.storage().read_recent_events(20)?;
     assert!(!events.iter().any(|event| event.kind == "wake_requested"));


### PR DESCRIPTION
Fixes #1002.

## Summary
- add TUI `/agent pause|resume|stop [agent-id]` lifecycle commands backed by the existing control-plane action endpoint
- add the singular CLI namespace `holon agent list|status|create|pause|resume|stop|interrupt|model ...`, with `holon agents` kept as an alias and `holon control ...` marked deprecated
- update stopped-agent resume hints and user-facing docs to prefer `holon agent ...`

## Verification
- `cargo fmt --all -- --check`
- `cargo test tui::input::tests`
- `cargo test agent_lifecycle_commands_parse_with_optional_agent_id`
- `cargo test agent_model_commands_use_positional_agent_id`
- `cargo test tui::`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
