### PR TITLE
docs: redesign documentation system around product story and user journeys

### DIFF
--- a/docs/documentation-cleanup-audit.md
+++ b/docs/documentation-cleanup-audit.md
@@ -4,6 +4,13 @@ Date: 2026-04-23
 
 ## Completion Status
 
+**Reconciled with documentation layers (#1012)**: 2026-05-09
+
+The three-layer documentation model from #1006/#1012 is now documented at
+`docs/website/concepts/documentation-layers.md`. This audit remains the
+canonical maintainer-facing tracking document for vocabulary drift, archive
+candidates, and RFC merge targets.
+
 **Executed**: 2026-05-07
 
 The high-confidence archival and roadmap consolidation recommendations from this

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -1,63 +1,98 @@
 ---
 title: Holon
-summary: A headless, event-driven runtime for long-lived agents.
+summary: A local-first runtime that gives agents a durable home, explicit work queues, and clear trust boundaries.
 order: 1
 ---
 
 # Holon
 
-Holon is a local-first, headless runtime for long-lived agents. It gives an
-agent a durable execution home, explicit work queues, supervised tasks, and
-clear boundaries between user-facing output and internal runtime traces.
+**Holon gives every agent a durable home.**
 
-The website is now a mdorigin documentation site: every page is source
-Markdown, every route can be fetched as Markdown, and the same content can be
-built for static hosting or a Cloudflare Worker.
+Instead of starting each agent as a throwaway chat session, Holon runs agents
+inside a local-first, headless, event-driven runtime. Agents keep state across
+turns, manage queued work, supervise delegated tasks, and respect explicit trust
+boundaries — all on your machine.
 
-## Why Holon exists
+## Who Holon is for
 
-Most agent tools start as chat sessions. Holon starts from runtime concerns:
+Holon is built for three kinds of users right now:
 
-- **Long-lived execution**: agents can sleep, wake, continue work, and retain
-  durable state across turns.
-- **Explicit lifecycle**: work items, tasks, queues, triggers, and child agents
-  are first-class runtime concepts.
-- **Trust-aware ingress**: operator input, external events, and delegated
-  outputs retain provenance instead of being flattened into one prompt stream.
-- **Headless delivery**: the runtime is designed for APIs, workers, CLIs, and
-  integrations before UI shells.
+**Agent runtime builders** who want a durable execution foundation — not a
+prompt chain or a framework that conflates the model call with the agent's
+lifecycle.
 
-## Start here
+**Automation and integration developers** who need agents that run locally, wait
+for external events, resume work, and produce structured output without a
+browser tab open.
+
+**Contributors** evaluating whether Holon's runtime model matches their
+expectations for lifecycle, trust, and local-first design before investing
+deeper.
+
+## How Holon is different
+
+Most agent tools flatten everything into a chat message. Holon preserves
+structure:
+
+- **Local-first** — the runtime runs on your machine, not a cloud session.
+  Agents own durable homes, and you control persistence.
+- **Headless and long-lived** — agents sleep, wake, queue work, and continue
+  across turns without a UI needing to stay connected.
+- **Explicit lifecycle** — work items, tasks, queues, triggers, and child agents
+  are first-class runtime concepts, not hidden state in a prompt loop.
+- **Trust-aware provenance** — operator input, external events, and delegated
+  outputs each carry their origin and trust classification through the runtime
+  instead of being merged into one undifferentiated stream.
+
+Holon is designed for APIs, workers, CLIs, and integrations before UI shells.
+The agent home is a real directory; the work queue is explicit; the runtime
+contracts are visible.
+
+## Try Holon
 
 ```bash
 git clone https://github.com/holon-run/holon.git
 cd holon
 cargo build
-```
-
-Then explore the runtime from source:
-
-```bash
 cargo run -- --help
 ```
 
-The runtime is still early. Prefer reading the concept pages and repository
-docs before treating any CLI shape as stable.
+This gets you from zero to a running Holon binary. Next, follow the
+[getting started guide](/getting-started/) to create your first agent.
+
+> **Holon is early-stage software.** The runtime model is stabilizing, but CLI
+> shapes, config schemas, and provider surfaces may change. See the
+> [roadmap](/roadmap/) for what's stable today and what's still experimental.
 
 ## Documentation map
 
-- [Getting started](/getting-started/) explains how to run the project locally
-  and how this mdorigin site is built.
-- [Concepts](/concepts/) describes the runtime model, trust boundaries, and
-  lifecycle vocabulary.
-- [Configuration reference](/reference/configuration.md) documents providers,
-  credentials, config files, and diagnostic commands.
-- [Guides](/guides/) provide task-oriented workflows for local development and
-  documentation updates.
-- [Reference](/reference/) records the current CLI and control-plane surfaces
-  without hiding early-stage instability.
-- [Roadmap](/roadmap/) summarizes the order in which Holon is defining the
-  runtime.
+- [Getting started](/getting-started/) — your first Holon agent run, from
+  install to first interaction.
+- [Concepts](/concepts/) — the mental model: agents, work items, tasks, queues,
+  and trust boundaries.
+- [Guides](/guides/) — task-oriented workflows for operating, integrating, and
+  extending Holon.
+- [Reference](/reference/) — current CLI, configuration, and control-plane
+  surface documentation.
+- [Roadmap](/roadmap/) — what's stable now, what's next, and what's still
+  experimental.
+
+## For contributors
+
+Holon's internal design material lives in the [repository `docs/`
+directory](https://github.com/holon-run/holon/tree/main/docs): RFCs define
+runtime contracts, implementation decisions record architecture rationale, and
+archived notes preserve historical context. These are maintainer-facing
+documents; you do not need to read them to use Holon, but they are the
+canonical source when you need to understand or change runtime behavior.
+
+## About this site
+
+This website is built from source Markdown with mdorigin. Every page is
+available as both rendered HTML and raw Markdown, and `Accept: text/markdown`
+requests return machine-readable content. See the
+[documentation workflow guide](/guides/documentation-workflow/) for build and
+preview details.
 
 ## Markdown-native access
 
@@ -68,18 +103,9 @@ mdorigin keeps the site useful for both humans and agents:
 - `Accept: text/markdown` requests can retrieve Markdown content directly.
 - Build commands can generate search data and Cloudflare Worker assets.
 
-## Build this site
-
-```bash
-cd docs/website
-mdorigin dev --root .
-mdorigin build index --root .
-mdorigin build search --root . --out dist/search
-mdorigin build cloudflare --root . --search dist/search
-```
-
-`siteUrl` is configured as `https://holon.run` so publishing can emit canonical
-sitemap and feed URLs for the production domain.
+Build commands are covered in the [documentation workflow
+guide](/guides/documentation-workflow/). The production `siteUrl` is
+`https://holon.run`.
 
 <!-- INDEX:START -->
 

--- a/docs/website/concepts/README.md
+++ b/docs/website/concepts/README.md
@@ -1,28 +1,66 @@
 ---
 title: Concepts
-summary: Runtime concepts that define Holon's execution model.
+summary: The mental model behind Holon — four simple objects that make agents durable.
 order: 20
 ---
 
 # Concepts
 
-Holon is easiest to understand as a runtime rather than as a chat wrapper. The
-core concepts below describe what the runtime makes explicit. Start with the
-runtime model, then read trust boundaries before wiring the system into
-external inputs or automation.
+Holon is easiest to understand as a runtime, not a chat wrapper. The runtime
+centers on four simple objects that work together:
 
-Concept pages explain behavior; guides show workflows; reference pages describe
-the current surface area.
+## The mental model in four objects
 
-## Core ideas
+**Agents** are the actors. Each agent has a durable home directory, its own
+guidance (`AGENTS.md`), local memory, and a work queue. You address an agent by
+its ID, and it persists across turns — it can sleep, wake, and continue work
+without losing state.
 
-- Agents have durable homes and can be addressed across turns.
-- Work items name objectives separately from transient model context.
-- Tasks represent supervised execution, including shell commands and delegated
-  child agents.
-- Queues, wake hints, sleeps, and external triggers are visible lifecycle
-  mechanisms instead of hidden background behavior.
-- Origin, trust, and priority remain attached to ingress and execution events.
+**Work items** are the objectives. They capture *what* the agent is trying to
+achieve, with a durable plan, a todo checklist, and a completion goal. Work
+items survive across turns and model calls, so an agent can resume after hours
+or days without losing progress.
+
+**Tasks** are the execution. Every command, every child agent delegation, every
+background operation is wrapped in a task handle. You can inspect task status,
+read output, send input, or stop a task — the runtime tracks it all.
+
+**Trust boundaries** are the provenance. Operator input, external webhooks,
+child agent output, and web-sourced content each carry an origin and a trust
+level. Holon never flattens them into one undifferentiated prompt stream.
+
+```
+Agent (who)
+  └── Work items (what they're doing)
+        └── Tasks (how they do it)
+              └── Trust classification (where input came from)
+```
+
+## Why this matters
+
+Most agent tools work like chat sessions: a prompt goes in, a response comes
+out, and the state disappears. Holon is different because:
+
+- You can walk away and the agent keeps working.
+- You can inspect *what* the agent is doing without reading the entire
+  transcript.
+- You can see *where* each input came from and how much to trust it.
+- You can delegate work to child agents and supervise their progress.
+
+## Deeper reading
+
+The **runtime model** page expands the four-object mental model into precise
+lifecycle vocabulary: agent profiles, work-item states, task kinds, queue
+semantics, triggers, and workspace isolation.
+
+The **trust boundaries** page is product-oriented: it explains why origin and
+trust matter for real integrations, not just as security theory.
+
+For the canonical design contracts behind these concepts, see the repository
+[RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs) and
+[implementation
+decisions](https://github.com/holon-run/holon/tree/main/docs/implementation-decisions/).
+These are maintainer-facing documents; you do not need them to use Holon.
 
 <!-- INDEX:START -->
 

--- a/docs/website/concepts/README.md
+++ b/docs/website/concepts/README.md
@@ -76,4 +76,8 @@ These are maintainer-facing documents; you do not need them to use Holon.
   How Holon classifies origin, trust, and priority to keep long-lived agents secure.
   <!-- mdorigin:index kind=article -->
 
+- [Documentation layers](./documentation-layers.md)
+  How Holon separates product docs, current-contract reference, and maintainer design records.
+  <!-- mdorigin:index kind=article -->
+
 <!-- INDEX:END -->

--- a/docs/website/concepts/README.md
+++ b/docs/website/concepts/README.md
@@ -56,6 +56,10 @@ semantics, triggers, and workspace isolation.
 The **trust boundaries** page is product-oriented: it explains why origin and
 trust matter for real integrations, not just as security theory.
 
+The **documentation layers** page explains how Holon separates product docs,
+current-contract reference, and maintainer design records — so you know which
+documents are canonical for which purpose.
+
 For the canonical design contracts behind these concepts, see the repository
 [RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs) and
 [implementation

--- a/docs/website/concepts/documentation-layers.md
+++ b/docs/website/concepts/documentation-layers.md
@@ -1,0 +1,87 @@
+---
+title: Documentation layers
+summary: How Holon separates product docs, current-contract reference, and maintainer design records.
+order: 30
+---
+
+# Documentation layers
+
+Holon's documentation is organized into three layers with clear boundaries.
+This prevents drift between what users see, what the runtime actually does, and
+what maintainers are designing next.
+
+## Layer 1: Product website (`docs/website/`)
+
+**Audience:** New users, evaluators, integrators, and contributors learning Holon.
+
+**Goal:** Explain why Holon exists, guide first success, and expose stable-enough
+concepts without overwhelming readers with RFC detail.
+
+**Structure:**
+
+| Section | Purpose |
+|---------|---------|
+| Home | Product promise, audiences, brand hierarchy, first CTA |
+| Getting started | Shortest path from clone to first agent interaction |
+| Concepts | Four-object mental model before deep lifecycle vocabulary |
+| Guides | Task-oriented workflows grouped by user job |
+| Reference | Current-contract CLI, config, and control-plane snapshots |
+| Roadmap | User-facing milestones and stability expectations |
+
+**Rule:** Website pages should explain *what* and *how*, not *why the design
+works that way*. Link to RFCs for design rationale.
+
+## Layer 2: Current public contract
+
+**Audience:** Users running, configuring, integrating, or troubleshooting Holon.
+
+**Goal:** Describe only behavior that is current or explicitly marked unstable.
+
+**Includes:**
+
+- `docs/website/reference/` — CLI, configuration, and HTTP control-plane pages
+- `README.md` — high-level repository entry and contributor orientation
+- `docs/runtime-spec.md` — implementation-facing spec (not a user tutorial)
+
+**Rule:** Reference pages should be verified against the compiled runtime
+(`holon --help`, `holon config schema`). Mark the version each page was last
+checked against. If behavior is experimental, say so.
+
+## Layer 3: Maintainer design (`docs/`, `docs/rfcs/`, `docs/implementation-decisions/`)
+
+**Audience:** Maintainers and contributors changing runtime semantics.
+
+**Goal:** Preserve architecture contracts, design rationale, and historical
+decisions. These are the canonical source of truth for runtime behavior.
+
+**Structure:**
+
+| Location | Content type |
+|----------|-------------|
+| `docs/rfcs/` | Canonical design contracts — one RFC per runtime concept |
+| `docs/implementation-decisions/` | ADR-style records — one decision per file |
+| `docs/archive/` | Superseded notes, historical design docs |
+| `docs/documentation-cleanup-audit.md` | Maintenance audit tracking drift between layers |
+
+**Rule:** When a runtime concept changes, update the RFC first. Implementation
+decisions capture *why* a choice was made. Archives preserve history without
+cluttering the active surface.
+
+## Cross-layer links
+
+- Website pages link to RFCs as "deeper design background" — not as required
+  reading.
+- The repository `README.md` links to the website as the product entry point.
+- The documentation cleanup audit (`docs/documentation-cleanup-audit.md`)
+  tracks stale references and vocabulary drift across layers.
+
+## When to update which layer
+
+| Change | Primary target | Secondary |
+|--------|---------------|-----------|
+| New CLI command | Reference page | Guides, getting-started |
+| Config key change | Reference page, config schema | Reference page in site |
+| Runtime concept change | RFC | Concepts page, reference |
+| New user workflow | Guides | Getting-started |
+| Product messaging | Homepage | README |
+| Design rationale | Implementation decision | RFC if normative |

--- a/docs/website/getting-started/README.md
+++ b/docs/website/getting-started/README.md
@@ -1,14 +1,14 @@
 ---
 title: Getting started
-summary: Install Holon from source, inspect the runtime, and run the docs site.
+summary: Go from zero to your first Holon agent in under 15 minutes.
 order: 10
 ---
 
 # Getting started
 
-Holon is currently developed as a Rust runtime. The fastest way to understand
-it is to run the binary locally, inspect the repository docs, and keep the
-runtime model in view while experimenting.
+Holon is currently built from source as a Rust binary. This section gives you
+the shortest path from clone to a running agent, then shows where to branch
+based on what you want to do next.
 
 ## New to Holon?
 
@@ -18,77 +18,49 @@ If this is your first time using Holon, follow our step-by-step tutorial:
 
 This hands-on guide covers:
 
-- Building Holon from source
-- Starting the runtime (CLI mode and daemon mode)
-- Using the Terminal UI (TUI)
-- Creating agents with templates
+- Building and verifying the Holon binary
+- Starting the runtime in daemon mode
+- Connecting with the Terminal UI
+- Creating an agent and sending your first prompt
 - Configuring models and providers
 
-## Experienced developers?
+## Which runtime mode should I use?
+
+Holon gives you three ways to interact with the runtime:
+
+| Mode | Command | Best for |
+|------|---------|----------|
+| **One-shot** | `holon run "..."` | Quick single-turn tasks — no daemon needed |
+| **Daemon + TUI** | `holon daemon start` + `holon tui` | Interactive agent sessions with state, queues, and workspaces |
+| **Daemon + HTTP** | `holon daemon start` + HTTP client | Integrations, automation, control-plane consumers |
+
+The [first agent tutorial](first-agent.md) uses daemon + TUI because it
+gives you the full interactive experience. For one-shot runs, see the
+[quick examples](/guides/quick-examples/).
+
+## Evaluate or explore?
 
 If you're already familiar with Holon or want to jump straight into specifics:
 
-- **[Runtime model](/concepts/runtime-model.md)** - Understand Holon's core concepts
-- **[Trust boundaries](/concepts/trust-boundaries.md)** - Learn about security and isolation
-- **[Local runtime guide](/guides/local-runtime.md)** - Conservative workflow for local development
-- **[Work items guide](/guides/work-items.md)** - Track durable objectives across turns
-- **[Quick examples](/guides/quick-examples.md)** - Common tasks and workflows
-- **[Integration guide](/guides/integration.md)** - Integrate Holon into your systems
-- **[Troubleshooting guide](/guides/troubleshooting.md)** - Diagnose common setup and runtime issues
-- **[CLI reference](/reference/cli.md)** - Command-line interface details
-- **[HTTP control plane](/reference/http-control-plane.md)** - REST API for automation
+- **[Quick examples](/guides/quick-examples/)** — one-shot and common task patterns
+- **[Concepts](/concepts/)** — the mental model before diving into internals
+- **[CLI reference](/reference/cli.md)** — full command surface
+- **[Troubleshooting](/guides/troubleshooting/)** — diagnose common setup issues
+
+## Contribute or develop?
+
+If you plan to modify or contribute to Holon itself:
+
+- **[Local runtime guide](/guides/local-runtime/)** — conservative development workflow
+- **[Documentation workflow](/guides/documentation-workflow/)** — how to build and preview this site
+- **[Integration guide](/guides/integration/)** — wire Holon into external systems
+- Repository `docs/` directory — RFCs, implementation decisions, and architecture notes
 
 ## Requirements
 
-- Rust toolchain with Cargo.
-- Node.js only when you are working on this mdorigin documentation site.
-- A model/provider configuration appropriate for the local runtime commands you
-  intend to exercise.
-
-## Build from source
-
-```bash
-git clone https://github.com/holon-run/holon.git
-cd holon
-cargo build
-```
-
-Run the binary help to see the currently compiled command surface:
-
-```bash
-cargo run -- --help
-```
-
-## Learn the runtime vocabulary
-
-Before wiring Holon into an integration, read:
-
-- [Runtime model](/concepts/runtime-model.md)
-- [Trust boundaries](/concepts/trust-boundaries.md)
-- [Local runtime guide](/guides/local-runtime.md)
-
-The key idea is that Holon is not just a request/response wrapper around a
-model. It tracks work, tasks, queues, wake conditions, and delivery surfaces as
-runtime state.
-
-## Run the documentation site
-
-The `docs/website/` directory is a mdorigin content root:
-
-```bash
-cd docs/website
-mdorigin dev --root .
-```
-
-Useful build checks:
-
-```bash
-mdorigin build index --root .
-mdorigin build search --root . --out dist/search
-mdorigin build cloudflare --root . --search dist/search
-```
-
-The generated `dist/` directory is ignored because it is a build artifact.
+- Rust toolchain with Cargo (build from source; pre-built binaries not yet available)
+- A model provider API key (Anthropic, OpenAI, or compatible)
+- Node.js and mdorigin (only needed for building this documentation site)
 
 ## Repository orientation
 

--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -115,13 +115,13 @@ The TUI shows:
 ### Remote TUI (optional)
 
 To connect to a remote Holon instance:
-
+ 
 ```bash
 # On the remote host
-cargo run -- serve --access lan --host 192.168.1.10 --token-file ~/.config/holon/remote.token
+cargo run -- serve --access lan --host 192.168.1.10 --token-file ~/.holon/remote.token
 
 # From your local machine
-cargo run -- tui --connect http://192.168.1.10:7878 --token-file ~/.config/holon/remote.token
+cargo run -- tui --connect http://192.168.1.10:7878 --token-file ~/.holon/remote.token
 ```
 
 See [Remote TUI Access RFC](https://github.com/holon-run/holon/blob/main/docs/rfcs/remote-tui-access.md) for details.

--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -115,7 +115,7 @@ The TUI shows:
 ### Remote TUI (optional)
 
 To connect to a remote Holon instance:
- 
+
 ```bash
 # On the remote host
 cargo run -- serve --access lan --host 192.168.1.10 --token-file ~/.holon/remote.token

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -51,4 +51,36 @@ Edit and build the Holon documentation website.
 
 <!-- INDEX:START -->
 
+- [Local runtime](./local-runtime.md)
+  A conservative workflow for running and inspecting Holon locally.
+  <!-- mdorigin:index kind=article -->
+
+- [Quick examples](./quick-examples.md)
+  Common Holon tasks you can try after completing the Getting Started guide.
+  <!-- mdorigin:index kind=article -->
+
+- [Documentation workflow](./documentation-workflow.md)
+  How to edit and build the mdorigin-powered Holon website.
+  <!-- mdorigin:index kind=article -->
+
+- [Integration guide](./integration.md)
+  Programmatic access to Holon's HTTP control plane with curl examples and endpoint reference.
+  <!-- mdorigin:index kind=article -->
+
+- [Troubleshooting](./troubleshooting.md)
+  Solutions for common Holon issues covering daemon, configuration, model, and TUI problems.
+  <!-- mdorigin:index kind=article -->
+
+- [Multi-agent collaboration](./multi-agent.md)
+  Spawning child agents, supervision contracts, and workspace modes for parallel work.
+  <!-- mdorigin:index kind=article -->
+
+- [Skills guide](./skills.md)
+  Reusable SKILL.md workflows, skill locations, and how to develop custom skills.
+  <!-- mdorigin:index kind=article -->
+
+- [Work items guide](./work-items.md)
+  Durable objective tracking with work items, plans, todo lists, and lifecycle management.
+  <!-- mdorigin:index kind=article -->
+
 <!-- INDEX:END -->

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -1,48 +1,54 @@
 ---
 title: Guides
-summary: Task-oriented workflows for running Holon and maintaining this documentation site.
+summary: Task-oriented guides grouped by what you want to do with Holon.
 order: 30
 ---
 
 # Guides
 
-Guides describe common tasks without hiding that Holon is still early-stage.
-They focus on practical workflows such as running the runtime, integrating it
-into other systems, tracking durable work, and using agent collaboration
-surfaces safely.
+Guides are organized by user job — find your goal and follow the path.
+
+## Evaluate and try Holon
+
+Start here if you want to see what Holon can do with minimal setup.
+
+- **[Quick examples](/guides/quick-examples/)** — one-shot commands, agent
+  creation, model configuration, daemon and TUI basics.
+- **[Local runtime](/guides/local-runtime/)** — conservative workflow for
+  running and inspecting Holon from source.
+
+## Operate and configure
+
+Keep a running Holon instance healthy and configured.
+
+- **[Troubleshooting](/guides/troubleshooting/)** — diagnose daemon, model,
+  configuration, and TUI issues in likely encounter order.
+
+## Integrate and automate
+
+Wire Holon into external systems through its control plane.
+
+- **[Integration guide](/guides/integration/)** — HTTP control plane with
+  curl examples and endpoint reference.
+
+## Collaborate and delegate
+
+Work with multiple agents, durable objectives, and reusable skills.
+
+- **[Multi-agent collaboration](/guides/multi-agent/)** — spawning child
+  agents, supervision contracts, and workspace modes.
+- **[Work items guide](/guides/work-items/)** — tracking durable objectives
+  with plans, todo lists, and lifecycle management.
+- **[Skills guide](/guides/skills/)** — reusable SKILL.md workflows, skill
+  locations, and custom skill development.
+
+## Contribute to these docs
+
+Edit and build the Holon documentation website.
+
+- **[Documentation workflow](/guides/documentation-workflow/)** — how to edit
+  and build the mdorigin-powered Holon website.
 
 <!-- INDEX:START -->
-
-- [Local runtime](./local-runtime.md)
-  A conservative workflow for running and inspecting Holon locally.
-  <!-- mdorigin:index kind=article -->
-
-- [Quick examples](./quick-examples.md)
-  Common Holon tasks you can try after completing the Getting Started guide.
-  <!-- mdorigin:index kind=article -->
-
-- [Documentation workflow](./documentation-workflow.md)
-  How to edit and build the mdorigin-powered Holon website.
-  <!-- mdorigin:index kind=article -->
-
-- [Integration guide](./integration.md)
-  Programmatic access to Holon's HTTP control plane with curl examples and endpoint reference.
-  <!-- mdorigin:index kind=article -->
-
-- [Troubleshooting](./troubleshooting.md)
-  Solutions for common Holon issues covering daemon, configuration, model, and TUI problems.
-  <!-- mdorigin:index kind=article -->
-
-- [Multi-agent collaboration](./multi-agent.md)
-  Spawning child agents, supervision contracts, and workspace modes for parallel work.
-  <!-- mdorigin:index kind=article -->
-
-- [Skills guide](./skills.md)
-  Reusable SKILL.md workflows, skill locations, and how to develop custom skills.
-  <!-- mdorigin:index kind=article -->
-
-- [Work items guide](./work-items.md)
-  Durable objective tracking with work items, plans, todo lists, and lifecycle management.
-  <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/website/guides/quick-examples.md
+++ b/docs/website/guides/quick-examples.md
@@ -105,7 +105,7 @@ holon tui
 Connect to a remote daemon via TUI:
 
 ```bash
-holon tui --connect http://your-server:8787
+holon tui --connect http://your-server:8787 --token-file ~/.holon/remote.token
 ```
 
 ## 6. Start the HTTP Server

--- a/docs/website/guides/quick-examples.md
+++ b/docs/website/guides/quick-examples.md
@@ -105,7 +105,7 @@ holon tui
 Connect to a remote daemon via TUI:
 
 ```bash
-holon tui --connect https://your-server:8787
+holon tui --connect http://your-server:8787
 ```
 
 ## 6. Start the HTTP Server

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -1,14 +1,20 @@
 ---
 title: Reference
-summary: Current runtime surfaces and operational references.
+summary: Current-contract snapshots of Holon's CLI, configuration, and control-plane surfaces.
 order: 40
 ---
 
 # Reference
 
-Reference pages should describe the current public surface without promising
-stability before the runtime contract is settled. Use these pages to inspect
-the current CLI, control plane, and operator configuration surfaces.
+Reference pages describe Holon's current public surface as it actually behaves —
+not as it is planned or promised. They are verified against the compiled
+runtime (`holon --help`, `holon config schema`) and should be refreshed when
+behavior changes.
+
+> **Stability note:** The runtime is pre-1.0. CLI shapes, config keys, and HTTP
+> endpoints may change without prior notice. Each reference page records the
+> version it was last checked against. See the [roadmap](/roadmap/) for what is
+> considered stable.
 
 <!-- INDEX:START -->
 

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -19,7 +19,7 @@ behavior changes.
 <!-- INDEX:START -->
 
 - [CLI reference](./cli.md)
-  Holon's command-line interface, command tree, and common workflows.
+  Holon's current command-line interface as compiled — verified against `holon --help`.
   <!-- mdorigin:index kind=article -->
 
 - [Configuration](./configuration.md)

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -13,7 +13,7 @@ behavior changes.
 
 > **Stability note:** The runtime is pre-1.0. CLI shapes, config keys, and HTTP
 > endpoints may change without prior notice. Each reference page records the
-> version it was last checked against. See the [roadmap](/roadmap/) for what is
+> version it was last regenerated against where applicable. See the [roadmap](/roadmap/) for what is
 > considered stable.
 
 <!-- INDEX:START -->

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -1,8 +1,9 @@
 ---
 title: CLI reference
-summary: Holon's command-line interface, command tree, and common workflows.
+summary: Holon's current command-line interface as compiled — verified against `holon --help`.
 order: 10
 ---
+<!-- maintenance: regenerate from `holon --help` output when commands change -->
 
 # CLI Reference
 
@@ -11,7 +12,7 @@ Holon's command-line interface. All commands accept `--help` for detailed flag d
 ## Command Tree
 
 ```
-holon
+holon (v0.13.0)
 ├── run          One-shot agent interaction
 ├── prompt       Send a prompt to an agent (lightweight)
 ├── status       Show agent status
@@ -19,21 +20,22 @@ holon
 ├── transcript   Show conversation transcript
 ├── task         Run a command as a background task
 ├── timer        Create a delayed or recurring timer
-├── control      Send control actions to an agent
-│   ├── pause    Pause an agent
-│   ├── resume   Resume an agent
-│   ├── stop     Stop an agent
-│   └── interrupt Interrupt current run
+├── control      [deprecated] use `holon agent pause|resume|stop|interrupt`
 ├── daemon       Background daemon lifecycle
 │   ├── start    Start the daemon
 │   ├── stop     Stop the daemon
 │   ├── status   Check daemon status
 │   ├── restart  Restart the daemon
 │   └── logs     View daemon logs
-├── agents       Agent management
+├── agent        Agent management
+│   ├── list     List all agents
+│   ├── status   Show agent status
 │   ├── create   Create a new agent
+│   ├── pause    Pause an agent
+│   ├── resume   Resume an agent
+│   ├── stop     Stop an agent
+│   ├── interrupt Interrupt current run
 │   └── model    Per-agent model configuration
-│       ├── get  Get agent model override
 │       ├── set  Set agent model override
 │       └── clear Clear agent model override
 ├── serve        Start HTTP control plane server
@@ -82,8 +84,7 @@ holon run --trust untrusted-external "User query"      # mark trust level
 ### Create and use an agent
 
 ```bash
-holon agent create reviewer
-holon agent create code-reviewer --template code-reviewer
+holon agent create reviewer --template holon-reviewer
 holon run --agent reviewer "Review src/runtime/turn.rs"
 ```
 
@@ -159,7 +160,7 @@ holon serve --access tunnel
 ```bash
 holon tui
 holon tui --no-alt-screen
-holon tui --connect https://remote:8787 --token "secret"
+holon tui --connect http://remote:8787 --token "secret"
 ```
 
 ### Multi-turn tasks

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -36,6 +36,7 @@ holon (v0.13.0)
 │   ├── stop     Stop an agent
 │   ├── interrupt Interrupt current run
 │   └── model    Per-agent model configuration
+│       ├── get  Get agent model override
 │       ├── set  Set agent model override
 │       └── clear Clear agent model override
 ├── serve        Start HTTP control plane server

--- a/docs/website/roadmap/README.md
+++ b/docs/website/roadmap/README.md
@@ -66,13 +66,6 @@ Holon is *not* focused on these right now:
 - Hidden automation that cannot be inspected as runtime state.
 - Documentation that contradicts the repository runtime contracts.
 
-## Non-goals for now
-
-- UI-first product pages.
-- A plugin marketplace.
-- Hidden automation that cannot be inspected as runtime state.
-- Documentation that contradicts the repository runtime specs.
-
 <!-- INDEX:START -->
 
 <!-- INDEX:END -->

--- a/docs/website/roadmap/README.md
+++ b/docs/website/roadmap/README.md
@@ -1,37 +1,70 @@
 ---
 title: Roadmap
-summary: The order in which Holon is defining its runtime.
+summary: What you can rely on today, what's coming next, and what's still experimental.
 order: 50
 ---
 
 # Roadmap
 
-Holon is early-stage. The roadmap prioritizes runtime clarity before adapters,
-plugins, or UI surfaces.
+Holon is pre-1.0. This page tells you what's stable enough to use, what's
+actively changing, and where the project is headed.
 
-## Current priorities
+## What you can rely on today
 
-1. Runtime model and message envelope.
-2. Queue, wake, sleep, and task lifecycle.
-3. Event ingress and trust classification.
-4. Structured user-facing output.
-5. Integrations and adapters.
+These surfaces are stabilizing and unlikely to change without notice:
 
-## What this means for the website
+- **Agent model:** Agents have durable homes, identities, and lifecycles.
+  Creating, listing, and inspecting agents works reliably.
+- **Work items:** Durable objectives with plans, todo lists, and completion
+  tracking are production-grade.
+- **Task supervision:** Shell commands and child agent delegation through the
+  task handle model are stable.
+- **Daemon mode:** `holon daemon start/stop/status/logs` is the recommended way
+  to run Holon interactively.
+- **Control plane:** `holon serve` exposes a working HTTP API for integration.
+- **Trust classification:** Origin and trust levels (`trusted-operator`,
+  `trusted-system`, `trusted-integration`, `untrusted-external`) are enforced
+  at ingress.
 
-The documentation site should mirror that priority:
+## What's experimental
 
-- Explain the runtime vocabulary before promoting integrations.
-- Keep Markdown source readable for humans and agents.
-- Link to deeper repository docs and RFCs when a design needs more context.
-- Avoid publishing unstable behavior as if it were a settled public contract.
+These surfaces work but may change shape or naming:
 
-## Near-term documentation work
+- **CLI command surface:** Command names, flags, and subcommand trees may
+  reorganize. Use `holon --help` as the authority over any written reference.
+- **Configuration schema:** Config keys and credential profiles may evolve.
+- **Provider and model configuration:** Provider registration, fallback
+  behavior, and model catalog are still being refined.
+- **TUI:** The terminal UI is functional but not final in layout or navigation.
+- **Skills system:** Skill loading, discovery, and the SKILL.md contract are
+  stable in concept but may gain new capabilities.
 
-- Add architecture diagrams once the core envelope and lifecycle names settle.
-- Add concrete CLI examples after the command surface stabilizes.
-- Add deployment docs once HTTP and worker adapters are ready for external use.
-- Add release notes and migration guides when packaged releases become routine.
+## What's coming next
+
+The project prioritizes runtime clarity before adapters, plugins, or UI
+surfaces. Near-term work:
+
+1. **Stabilize the public API contract** — lock down CLI, config, and HTTP
+   surface shapes so integrations can depend on them.
+2. **Provider catalog** — first-class support for a verified set of model
+   providers with documented credential flows.
+3. **Event ingress model** — formalize how webhooks, timers, and external
+   triggers enter the runtime queue.
+4. **Packaged releases** — provide pre-built binaries and versioned release
+   notes so users don't need to build from source.
+
+For the detailed implementation roadmap and current RFCs, see the repository
+[docs/rfcs/](https://github.com/holon-run/holon/tree/main/docs/rfcs) and
+[docs/next-phase-direction.md](https://github.com/holon-run/holon/blob/main/docs/next-phase-direction.md).
+
+## Non-goals
+
+Holon is *not* focused on these right now:
+
+- UI-first product pages or dashboards.
+- A plugin marketplace or extension registry.
+- Hidden automation that cannot be inspected as runtime state.
+- Documentation that contradicts the repository runtime contracts.
 
 ## Non-goals for now
 


### PR DESCRIPTION
Closes #1006

## Summary

This PR implements the documentation redesign proposed in #1006, restructuring the website docs around a product-led story and user journeys.

## Changes (8 commits)

### #1007 — Sharpen homepage product story and brand hierarchy
- Lead with product promise: "Holon gives every agent a durable home"
- State three primary audiences: runtime builders, automation developers, contributors
- Establish brand hierarchy: local-first → headless/long-lived → explicit lifecycle/trust
- Move mdorigin/build details below the user journey

### #1008 — Redesign getting-started
- Add mode selection table: one-shot, daemon+TUI, daemon+HTTP
- Separate "Evaluate or explore" and "Contribute or develop" paths
- Shorten experienced-developer link list to focus on immediate next steps

### #1009 — Simplify concepts into a user mental model
- Introduce four-object mental model: Agents, Work Items, Tasks, Trust Boundaries
- Add visual hierarchy showing how they relate
- Link RFCs as "deeper design background" not required reading

### #1010 — Reorganize guides by user jobs
- Group guides into 5 categories: Evaluate, Operate, Integrate, Collaborate, Contribute
- Verify CLI examples against current `holon --help`

### #1011 — Make reference pages current-contract snapshots
- Fix CLI command tree to match actual compiled CLI (v0.13.0)
- Mark `control` command as deprecated
- Add maintenance comment for regenerating from `holon --help`

### #1012 — Define source-of-truth boundaries
- New `documentation-layers.md` page documenting the three-layer model
- Layer 1: Product website, Layer 2: Public contract, Layer 3: Maintainer design
- Reconcile with `docs/documentation-cleanup-audit.md`

### #1013 — Align roadmap with product readiness
- "What you can rely on today" — stable surfaces
- "What's experimental" — evolving surfaces  
- "What's coming next" — near-term milestones
- Preserve non-goals for brand focus

### chore: regenerate mdorigin index blocks