### PR TITLE
Complete scheduler RFC follow-up

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1646,7 +1646,7 @@ fn export_scheduler_fixture(
     write_json_pretty(
         &output.join("agent.json"),
         &serde_json::json!({
-            "current_work_item_id": agent.current_work_item_id,
+            "current_work_item_id": agent.current_work_item_id.clone(),
             "pending_wake_hint_reason": pending_wake_hint_reason,
             "turn_index": agent.turn_index,
             "last_turn_terminal_kind": last_turn_terminal_kind,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeMap,
     ffi::OsString,
+    fs,
     io::Write,
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -30,7 +31,7 @@ use holon::{
     solve::{run_solve, SolveRequest},
     storage::AppStorage,
     tui::run_tui,
-    types::{AuditEvent, ControlAction, TrustLevel},
+    types::{AuditEvent, ControlAction, TimerStatus, TrustLevel, WaitingIntentStatus},
 };
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
@@ -388,6 +389,12 @@ enum DebugCommands {
         limit: usize,
         #[arg(long, default_value_t = 5000)]
         events_limit: usize,
+    },
+    SchedulerFixture {
+        #[arg(long)]
+        agent: Option<String>,
+        #[arg(long)]
+        output: PathBuf,
     },
 }
 
@@ -1316,6 +1323,63 @@ mod tests {
     }
 
     #[test]
+    fn debug_scheduler_fixture_command_parses_agent_and_output() {
+        let cli = Cli::parse_from([
+            "holon",
+            "debug",
+            "scheduler-fixture",
+            "--agent",
+            "pm",
+            "--output",
+            "/tmp/scheduler-case",
+        ]);
+        let Commands::Debug {
+            command: DebugCommands::SchedulerFixture { agent, output },
+        } = cli.command
+        else {
+            panic!("expected debug scheduler-fixture command");
+        };
+        assert_eq!(agent.as_deref(), Some("pm"));
+        assert_eq!(output, PathBuf::from("/tmp/scheduler-case"));
+    }
+
+    #[test]
+    fn export_scheduler_fixture_writes_replay_harness_shape() {
+        let config = test_config();
+        let agent_home = config.data_dir.join("agents/default");
+        let storage = AppStorage::new(&agent_home).unwrap();
+        let mut agent = holon::types::AgentState::new("default");
+        agent.current_work_item_id = Some("work-1".into());
+        storage.write_agent(&agent).unwrap();
+        let mut work_item = holon::types::WorkItemRecord::new(
+            "default",
+            "fixture work",
+            holon::types::WorkItemState::Open,
+        );
+        work_item.id = "work-1".into();
+        work_item.revision = 2;
+        storage.append_work_item(&work_item).unwrap();
+
+        let output = tempfile::tempdir().unwrap();
+        export_scheduler_fixture(&config, None, output.path()).unwrap();
+
+        let agent_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(output.path().join("agent.json")).unwrap())
+                .unwrap();
+        let expected_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(output.path().join("expected.json")).unwrap())
+                .unwrap();
+        assert_eq!(agent_json["current_work_item_id"].as_str(), Some("work-1"));
+        assert_eq!(
+            expected_json["current_work_item_revision"].as_u64(),
+            Some(2)
+        );
+        assert!(output.path().join("ledger/messages.jsonl").exists());
+        assert!(output.path().join("ledger/tools.jsonl").exists());
+        assert!(output.path().join("ledger/transcript.jsonl").exists());
+    }
+
+    #[test]
     fn daemon_start_passes_inline_token_through_env_not_argv() {
         let options = ServeOptions {
             access: ServeAccess::Lan,
@@ -1547,7 +1611,152 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
             limit,
             events_limit,
         } => print_latency_diagnostics(&config, agent, limit, events_limit),
+        DebugCommands::SchedulerFixture { agent, output } => {
+            export_scheduler_fixture(&config, agent, &output)
+        }
     }
+}
+
+fn export_scheduler_fixture(
+    config: &AppConfig,
+    agent: Option<String>,
+    output: &Path,
+) -> Result<()> {
+    let agent_id = agent.unwrap_or_else(|| config.default_agent_id.clone());
+    let agent_home = config.data_dir.join("agents").join(&agent_id);
+    let storage = AppStorage::new(&agent_home)?;
+    let agent = storage.read_agent()?.with_context(|| {
+        format!(
+            "agent state not found for {agent_id} in {}",
+            agent_home.display()
+        )
+    })?;
+    let ledger_dir = output.join("ledger");
+    fs::create_dir_all(&ledger_dir)
+        .with_context(|| format!("failed to create {}", ledger_dir.display()))?;
+
+    let pending_wake_hint_reason = agent
+        .pending_wake_hint
+        .as_ref()
+        .map(|pending| pending.reason.clone());
+    let last_turn_terminal_kind = agent
+        .last_turn_terminal
+        .as_ref()
+        .map(|terminal| terminal.kind.clone());
+    write_json_pretty(
+        &output.join("agent.json"),
+        &serde_json::json!({
+            "current_work_item_id": agent.current_work_item_id,
+            "pending_wake_hint_reason": pending_wake_hint_reason,
+            "turn_index": agent.turn_index,
+            "last_turn_terminal_kind": last_turn_terminal_kind,
+        }),
+    )?;
+
+    let work_queue = storage.work_queue_prompt_projection()?;
+    let active_tasks = storage.latest_active_task_records_for_agent(&agent.id, usize::MAX)?;
+    let has_blocking_active_tasks = active_tasks.iter().any(|task| task.is_blocking());
+    let active_waiting_intents = storage
+        .latest_waiting_intents()?
+        .into_iter()
+        .filter(|intent| {
+            intent.agent_id == agent.id && intent.status == WaitingIntentStatus::Active
+        })
+        .collect::<Vec<_>>();
+    let active_timers = storage
+        .latest_timer_records()?
+        .into_iter()
+        .filter(|timer| timer.agent_id == agent.id && timer.status == TimerStatus::Active)
+        .collect::<Vec<_>>();
+    let replay_message_ids = storage
+        .recovery_snapshot()?
+        .replay_messages
+        .into_iter()
+        .map(|message| message.id)
+        .collect::<Vec<_>>();
+    write_json_pretty(
+        &output.join("expected.json"),
+        &serde_json::json!({
+            "current_work_item_id": work_queue.current.as_ref().map(|item| item.id.clone()),
+            "current_work_item_revision": work_queue.current.as_ref().map(|item| item.revision),
+            "queued_work_items": work_queue.queued_blocked.iter().filter(|item| item.is_runnable()).count(),
+            "active_tasks": active_tasks.len(),
+            "has_blocking_active_tasks": has_blocking_active_tasks,
+            "pending_wake_hint": agent.pending_wake_hint.is_some(),
+            "active_waiting_intents": active_waiting_intents.len(),
+            "active_work_item_waiting_intents": active_waiting_intents.iter().filter(|intent| matches!(intent.scope, holon::types::ExternalTriggerScope::WorkItem)).count(),
+            "active_agent_waiting_intents": active_waiting_intents.iter().filter(|intent| matches!(intent.scope, holon::types::ExternalTriggerScope::Agent)).count(),
+            "active_timers": active_timers.len(),
+            "runtime_error": storage.read_recent_events(128)?.iter().any(|event| event.kind == "runtime_error"),
+            "replay_message_ids": replay_message_ids,
+            "turn_terminal_kind": last_turn_terminal_kind,
+        }),
+    )?;
+
+    write_jsonl(
+        &ledger_dir.join("messages.jsonl"),
+        &storage.read_recent_messages(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("queue_entries.jsonl"),
+        &storage.read_recent_queue_entries(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("events.jsonl"),
+        &storage.read_recent_events(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("tasks.jsonl"),
+        &storage.read_recent_tasks(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("work_items.jsonl"),
+        &storage.read_recent_work_items(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("waiting_intents.jsonl"),
+        &storage.read_recent_waiting_intents(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("timers.jsonl"),
+        &storage.read_recent_timers(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("tools.jsonl"),
+        &storage.read_recent_tool_executions(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("briefs.jsonl"),
+        &storage.read_recent_briefs(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("transcript.jsonl"),
+        &storage.read_recent_transcript(usize::MAX)?,
+    )?;
+    write_jsonl(
+        &ledger_dir.join("external_triggers.jsonl"),
+        &storage.read_recent_external_triggers(usize::MAX)?,
+    )?;
+
+    println!(
+        "Exported scheduler fixture for agent {agent_id} to {}",
+        output.display()
+    );
+    Ok(())
+}
+
+fn write_json_pretty(path: &Path, value: &serde_json::Value) -> Result<()> {
+    let content = serde_json::to_vec_pretty(value)?;
+    fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn write_jsonl<T: serde::Serialize>(path: &Path, values: &[T]) -> Result<()> {
+    let mut content = Vec::new();
+    for value in values {
+        serde_json::to_writer(&mut content, value)?;
+        content.push(b'\n');
+    }
+    fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))
 }
 
 #[derive(Debug, Default)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -907,10 +907,12 @@ impl RuntimeHandle {
                         &state,
                         queue_len,
                     )?;
-                    scheduler::append_scheduler_decision(
-                        &self.inner.storage,
-                        &scheduler::idle_boundary_decision(&projection, "run_loop"),
-                    )?;
+                    let decision = scheduler::decide_next_action(
+                        &projection,
+                        scheduler::SchedulerBoundary::RunLoop,
+                        scheduler::SchedulerInput::Idle,
+                    );
+                    scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                     return Ok(());
                 }
                 RunLoopPoll::Message(message, prior_state, running_state) => {
@@ -929,7 +931,11 @@ impl RuntimeHandle {
                         &idle_snapshot.0,
                         idle_snapshot.1,
                     )?;
-                    let decision = scheduler::idle_boundary_decision(&projection, "run_loop_idle");
+                    let decision = scheduler::decide_next_action(
+                        &projection,
+                        scheduler::SchedulerBoundary::RunLoopIdle,
+                        scheduler::SchedulerInput::Idle,
+                    );
                     if !matches!(
                         decision.kind,
                         scheduler::SchedulerDecisionKind::Sleep

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -162,57 +162,39 @@ impl RuntimeHandle {
 
         match trigger {
             Some(IdleTickTrigger::WorkQueueActive(active)) => {
-                if let Some(decision) =
-                    scheduler::wait_decision_for_projection(&scheduler_projection)
-                {
-                    scheduler::append_scheduler_decision(
-                        &self.inner.storage,
-                        &decision
-                            .boundary("idle_tick")
-                            .evidence("work_queue_tick_blocked_by_wait_fact"),
-                    )?;
-                    return Ok(false);
-                }
-                if suppress_continue_active {
-                    scheduler::append_scheduler_decision(
-                        &self.inner.storage,
-                        &scheduler::SchedulerDecision::new(
-                            scheduler::SchedulerDecisionKind::Noop,
-                            "continue_active_suppressed_after_model_visible_continuation",
-                        )
-                        .boundary("idle_tick")
-                        .liveness_only(true)
-                        .work_item_id(active.id.clone())
-                        .evidence(
-                            "model_visible_continuation_suppresses_duplicate_continue_active",
-                        ),
-                    )?;
-                    return Ok(false);
-                }
-                if let Some(result_brief_id) =
-                    self.duplicate_continue_active_result_brief_id(&active)?
-                {
-                    scheduler::append_scheduler_decision(
-                        &self.inner.storage,
-                        &scheduler::SchedulerDecision::new(
-                            scheduler::SchedulerDecisionKind::Noop,
-                            "duplicate_continue_active",
-                        )
-                        .boundary("idle_tick")
-                        .liveness_only(true)
-                        .work_item_id(active.id.clone())
-                        .evidence("duplicate_tick_suppressed")
-                        .evidence(format!("result_brief_id={result_brief_id}")),
-                    )?;
-                    self.inner.storage.append_event(&AuditEvent::new(
-                        "system_tick_suppressed",
-                        serde_json::json!({
-                            "subsystem": "work_queue",
-                            "reason": "no_new_signal_after_result_brief",
-                            "work_item_id": active.id,
-                            "result_brief_id": result_brief_id,
-                        }),
-                    ))?;
+                let duplicate = self
+                    .duplicate_continue_active_result_brief_id(&active)?
+                    .map(scheduler::SchedulerDuplicateEvidence::ContinueActiveBrief);
+                let decision = scheduler::decide_next_action(
+                    &scheduler_projection,
+                    scheduler::SchedulerBoundary::IdleTick,
+                    scheduler::SchedulerInput::IdleSignal(
+                        scheduler::SchedulerIdleSignal::ContinueActive {
+                            work_item: &active,
+                            suppressed_after_model_visible_continuation: suppress_continue_active,
+                            duplicate: duplicate.clone(),
+                        },
+                    ),
+                );
+                if !matches!(
+                    decision.kind,
+                    scheduler::SchedulerDecisionKind::EmitSystemTick
+                ) {
+                    scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
+                    if let Some(scheduler::SchedulerDuplicateEvidence::ContinueActiveBrief(
+                        result_brief_id,
+                    )) = duplicate
+                    {
+                        self.inner.storage.append_event(&AuditEvent::new(
+                            "system_tick_suppressed",
+                            serde_json::json!({
+                                "subsystem": "work_queue",
+                                "reason": "no_new_signal_after_result_brief",
+                                "work_item_id": active.id,
+                                "result_brief_id": result_brief_id,
+                            }),
+                        ))?;
+                    }
                     return Ok(false);
                 }
                 self.emit_system_tick_from_work_queue(&active, "continue_active")
@@ -220,39 +202,38 @@ impl RuntimeHandle {
                 Ok(true)
             }
             Some(IdleTickTrigger::WorkQueueQueued(queued)) => {
-                if let Some(decision) =
-                    scheduler::wait_decision_for_projection(&scheduler_projection)
-                {
-                    scheduler::append_scheduler_decision(
-                        &self.inner.storage,
-                        &decision
-                            .boundary("idle_tick")
-                            .evidence("work_queue_tick_blocked_by_wait_fact"),
-                    )?;
-                    return Ok(false);
-                }
-                if let Some(message_id) = self.duplicate_queued_available_message_id(&queued)? {
-                    scheduler::append_scheduler_decision(
-                        &self.inner.storage,
-                        &scheduler::SchedulerDecision::new(
-                            scheduler::SchedulerDecisionKind::Noop,
-                            "duplicate_queued_available",
-                        )
-                        .boundary("idle_tick")
-                        .liveness_only(true)
-                        .work_item_id(queued.id.clone())
-                        .evidence("duplicate_tick_suppressed")
-                        .evidence(format!("message_id={message_id}")),
-                    )?;
-                    self.inner.storage.append_event(&AuditEvent::new(
-                        "system_tick_suppressed",
-                        serde_json::json!({
-                            "subsystem": "work_queue",
-                            "reason": "no_new_signal_after_queued_available",
-                            "work_item_id": queued.id,
-                            "message_id": message_id,
-                        }),
-                    ))?;
+                let duplicate = self
+                    .duplicate_queued_available_message_id(&queued)?
+                    .map(scheduler::SchedulerDuplicateEvidence::QueuedAvailableMessage);
+                let decision = scheduler::decide_next_action(
+                    &scheduler_projection,
+                    scheduler::SchedulerBoundary::IdleTick,
+                    scheduler::SchedulerInput::IdleSignal(
+                        scheduler::SchedulerIdleSignal::QueuedAvailable {
+                            work_item: &queued,
+                            duplicate: duplicate.clone(),
+                        },
+                    ),
+                );
+                if !matches!(
+                    decision.kind,
+                    scheduler::SchedulerDecisionKind::EmitSystemTick
+                ) {
+                    scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
+                    if let Some(scheduler::SchedulerDuplicateEvidence::QueuedAvailableMessage(
+                        message_id,
+                    )) = duplicate
+                    {
+                        self.inner.storage.append_event(&AuditEvent::new(
+                            "system_tick_suppressed",
+                            serde_json::json!({
+                                "subsystem": "work_queue",
+                                "reason": "no_new_signal_after_queued_available",
+                                "work_item_id": queued.id,
+                                "message_id": message_id,
+                            }),
+                        ))?;
+                    }
                     return Ok(false);
                 }
                 self.emit_system_tick_from_work_queue(&queued, "queued_available")
@@ -260,18 +241,24 @@ impl RuntimeHandle {
                 Ok(true)
             }
             Some(IdleTickTrigger::WakeHint(pending)) => {
-                if let Some(message_id) = self.duplicate_wake_hint_message_id(&pending)? {
-                    scheduler::append_scheduler_decision(
-                        &self.inner.storage,
-                        &scheduler::SchedulerDecision::new(
-                            scheduler::SchedulerDecisionKind::Noop,
-                            "duplicate_wake_hint",
-                        )
-                        .boundary("idle_tick")
-                        .liveness_only(true)
-                        .evidence("duplicate_wake_hint_suppressed")
-                        .evidence(format!("message_id={message_id}")),
-                    )?;
+                let duplicate = self
+                    .duplicate_wake_hint_message_id(&pending)?
+                    .map(scheduler::SchedulerDuplicateEvidence::WakeHintMessage);
+                let decision = scheduler::decide_next_action(
+                    &scheduler_projection,
+                    scheduler::SchedulerBoundary::IdleTick,
+                    scheduler::SchedulerInput::IdleSignal(
+                        scheduler::SchedulerIdleSignal::WakeHint {
+                            pending: &pending,
+                            duplicate,
+                        },
+                    ),
+                );
+                if !matches!(
+                    decision.kind,
+                    scheduler::SchedulerDecisionKind::EmitSystemTick
+                ) {
+                    scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                     let mut guard = self.inner.agent.lock().await;
                     if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
                         guard.state.pending_wake_hint = None;

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -25,21 +25,20 @@ impl RuntimeHandle {
         let continuation_resolution = continuation_trigger
             .as_ref()
             .map(|trigger| resolve_continuation(&prior_closure, trigger));
-        let model_turn_allowed = {
+        let scheduler_state = {
             let guard = self.inner.agent.lock().await;
-            !matches!(
-                guard.state.status,
-                AgentStatus::Paused | AgentStatus::Stopped
-            )
+            guard.state.clone()
         };
+        let model_turn_allowed = !matches!(
+            scheduler_state.status,
+            AgentStatus::Paused | AgentStatus::Stopped
+        );
         let model_visible = model_turn_allowed
             && continuation_resolution
                 .as_ref()
                 .is_some_and(|resolution| resolution.model_visible);
-        let scheduler_projection = {
-            let guard = self.inner.agent.lock().await;
-            scheduler::SchedulerProjection::from_state(&self.inner.storage, &guard.state)?
-        };
+        let scheduler_projection =
+            scheduler::SchedulerProjection::from_state(&self.inner.storage, &scheduler_state)?;
         let scheduler_decision = scheduler::decide_next_action(
             &scheduler_projection,
             scheduler::SchedulerBoundary::MessageProcessing,

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -36,11 +36,20 @@ impl RuntimeHandle {
             && continuation_resolution
                 .as_ref()
                 .is_some_and(|resolution| resolution.model_visible);
-        scheduler::append_scheduler_decision(
-            &self.inner.storage,
-            &scheduler::message_processing_decision(&message, model_turn_allowed, model_visible)
-                .boundary("message_processing"),
-        )?;
+        let scheduler_projection = {
+            let guard = self.inner.agent.lock().await;
+            scheduler::SchedulerProjection::from_state(&self.inner.storage, &guard.state)?
+        };
+        let scheduler_decision = scheduler::decide_next_action(
+            &scheduler_projection,
+            scheduler::SchedulerBoundary::MessageProcessing,
+            scheduler::SchedulerInput::Message {
+                message: &message,
+                model_turn_allowed,
+                model_visible,
+            },
+        );
+        scheduler::append_scheduler_decision(&self.inner.storage, &scheduler_decision)?;
 
         match message.kind {
             MessageKind::OperatorPrompt

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::runtime::closure::runtime_error_active;
 use crate::storage::{AppStorage, WorkQueuePromptProjection};
 use crate::types::{
-    AgentStatus, MessageEnvelope, TaskRecord, TaskStatus, TimerStatus, WaitingIntentStatus,
-    WorkItemRecord,
+    AgentStatus, MessageEnvelope, PendingWakeHint, TaskRecord, TaskStatus, TimerStatus,
+    TurnTerminalKind, WaitingIntentStatus, WorkItemRecord,
 };
 use chrono::{DateTime, Utc};
 
@@ -22,6 +22,7 @@ pub(crate) struct SchedulerProjection {
     pub active_work_item_waiting_intents: usize,
     pub active_agent_waiting_intents: usize,
     pub active_timers: usize,
+    pub last_turn_terminal: Option<TurnTerminalKind>,
     pub turn_in_progress: bool,
     pub runtime_error: bool,
 }
@@ -31,6 +32,7 @@ pub(crate) struct SchedulerAgentSnapshot {
     status: AgentStatus,
     active_run_id: Option<String>,
     pending_wake_hint: bool,
+    last_turn_terminal: Option<TurnTerminalKind>,
 }
 
 impl SchedulerAgentSnapshot {
@@ -40,6 +42,10 @@ impl SchedulerAgentSnapshot {
             status: state.status.clone(),
             active_run_id: state.current_run_id.clone(),
             pending_wake_hint: state.pending_wake_hint.is_some(),
+            last_turn_terminal: state
+                .last_turn_terminal
+                .as_ref()
+                .map(|terminal| terminal.kind.clone()),
         }
     }
 }
@@ -130,6 +136,7 @@ impl SchedulerProjection {
             active_work_item_waiting_intents,
             active_agent_waiting_intents,
             active_timers,
+            last_turn_terminal: snapshot.last_turn_terminal.clone(),
             turn_in_progress: snapshot.active_run_id.is_some(),
             runtime_error: runtime_error_active(
                 &storage.read_recent_events(64)?,
@@ -186,6 +193,59 @@ pub(crate) struct SchedulerDecision {
     pub evidence: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchedulerBoundary {
+    RunLoop,
+    RunLoopIdle,
+    MessageProcessing,
+    IdleTick,
+}
+
+impl SchedulerBoundary {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::RunLoop => "run_loop",
+            Self::RunLoopIdle => "run_loop_idle",
+            Self::MessageProcessing => "message_processing",
+            Self::IdleTick => "idle_tick",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SchedulerDuplicateEvidence {
+    ContinueActiveBrief(String),
+    QueuedAvailableMessage(String),
+    WakeHintMessage(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SchedulerIdleSignal<'a> {
+    ContinueActive {
+        work_item: &'a WorkItemRecord,
+        suppressed_after_model_visible_continuation: bool,
+        duplicate: Option<SchedulerDuplicateEvidence>,
+    },
+    QueuedAvailable {
+        work_item: &'a WorkItemRecord,
+        duplicate: Option<SchedulerDuplicateEvidence>,
+    },
+    WakeHint {
+        pending: &'a PendingWakeHint,
+        duplicate: Option<SchedulerDuplicateEvidence>,
+    },
+}
+
+pub(crate) enum SchedulerInput<'a> {
+    Idle,
+    Message {
+        message: &'a MessageEnvelope,
+        model_turn_allowed: bool,
+        model_visible: bool,
+    },
+    IdleSignal(SchedulerIdleSignal<'a>),
+}
+
 impl SchedulerDecision {
     pub(crate) fn new(kind: SchedulerDecisionKind, reason: impl Into<String>) -> Self {
         Self {
@@ -237,6 +297,155 @@ impl SchedulerDecision {
     pub(crate) fn evidence(mut self, evidence: impl Into<String>) -> Self {
         self.evidence.push(evidence.into());
         self
+    }
+}
+
+pub(crate) fn decide_next_action(
+    projection: &SchedulerProjection,
+    boundary: SchedulerBoundary,
+    input: SchedulerInput<'_>,
+) -> SchedulerDecision {
+    let boundary_label = boundary.as_str();
+    if matches!(projection.status, AgentStatus::Stopped) {
+        return SchedulerDecision::new(SchedulerDecisionKind::Stop, "stopped")
+            .boundary(boundary_label)
+            .liveness_only(true)
+            .evidence(format!("status={:?}", projection.status));
+    }
+
+    match input {
+        SchedulerInput::Message {
+            message,
+            model_turn_allowed,
+            model_visible,
+        } => message_processing_decision(message, model_turn_allowed, model_visible)
+            .boundary(boundary_label)
+            .evidence(format!("queue_len={}", projection.queue_len))
+            .evidence(format!("turn_in_progress={}", projection.turn_in_progress)),
+        SchedulerInput::IdleSignal(signal) => {
+            decide_idle_signal_action(projection, boundary_label, signal)
+        }
+        SchedulerInput::Idle => idle_boundary_decision(projection, boundary_label),
+    }
+}
+
+fn decide_idle_signal_action(
+    projection: &SchedulerProjection,
+    boundary: &'static str,
+    signal: SchedulerIdleSignal<'_>,
+) -> SchedulerDecision {
+    if matches!(projection.status, AgentStatus::Paused) {
+        return SchedulerDecision::new(SchedulerDecisionKind::Noop, "paused")
+            .boundary(boundary)
+            .liveness_only(true)
+            .evidence(format!("status={:?}", projection.status));
+    }
+    if projection.turn_in_progress {
+        return SchedulerDecision::new(SchedulerDecisionKind::Noop, "turn_in_progress")
+            .boundary(boundary)
+            .liveness_only(true)
+            .evidence(format!("active_run_id={:?}", projection.active_run_id));
+    }
+
+    match signal {
+        SchedulerIdleSignal::WakeHint { pending, duplicate } => {
+            if let Some(SchedulerDuplicateEvidence::WakeHintMessage(message_id)) = duplicate {
+                return SchedulerDecision::new(SchedulerDecisionKind::Noop, "duplicate_wake_hint")
+                    .boundary(boundary)
+                    .liveness_only(true)
+                    .evidence("duplicate_wake_hint_suppressed")
+                    .evidence(format!("message_id={message_id}"))
+                    .evidence(format!(
+                        "idempotency_key={}",
+                        wake_hint_idempotency_key(pending)
+                    ));
+            }
+            SchedulerDecision::new(SchedulerDecisionKind::EmitSystemTick, "wake_hint")
+                .boundary(boundary)
+                .model_visible(true)
+                .evidence("runtime_idle")
+                .evidence("pending_wake_hint")
+                .evidence(format!(
+                    "idempotency_key={}",
+                    wake_hint_idempotency_key(pending)
+                ))
+        }
+        SchedulerIdleSignal::ContinueActive {
+            work_item,
+            suppressed_after_model_visible_continuation,
+            duplicate,
+        } => {
+            if let Some(decision) = wait_decision_for_projection(projection) {
+                return decision
+                    .boundary(boundary)
+                    .evidence("work_queue_tick_blocked_by_wait_fact");
+            }
+            if suppressed_after_model_visible_continuation {
+                return SchedulerDecision::new(
+                    SchedulerDecisionKind::Noop,
+                    "continue_active_suppressed_after_model_visible_continuation",
+                )
+                .boundary(boundary)
+                .liveness_only(true)
+                .work_item_id(work_item.id.clone())
+                .evidence("model_visible_continuation_suppresses_duplicate_continue_active");
+            }
+            if let Some(SchedulerDuplicateEvidence::ContinueActiveBrief(result_brief_id)) =
+                duplicate
+            {
+                return SchedulerDecision::new(
+                    SchedulerDecisionKind::Noop,
+                    "duplicate_continue_active",
+                )
+                .boundary(boundary)
+                .liveness_only(true)
+                .work_item_id(work_item.id.clone())
+                .evidence("duplicate_tick_suppressed")
+                .evidence(format!("result_brief_id={result_brief_id}"));
+            }
+            SchedulerDecision::new(SchedulerDecisionKind::EmitSystemTick, "continue_active")
+                .boundary(boundary)
+                .model_visible(true)
+                .work_item_id(work_item.id.clone())
+                .evidence("runtime_idle")
+                .evidence("work_item_runnable")
+                .evidence(format!(
+                    "idempotency_key={}",
+                    work_queue_tick_idempotency_key(work_item, "continue_active")
+                ))
+        }
+        SchedulerIdleSignal::QueuedAvailable {
+            work_item,
+            duplicate,
+        } => {
+            if let Some(decision) = wait_decision_for_projection(projection) {
+                return decision
+                    .boundary(boundary)
+                    .evidence("work_queue_tick_blocked_by_wait_fact");
+            }
+            if let Some(SchedulerDuplicateEvidence::QueuedAvailableMessage(message_id)) = duplicate
+            {
+                return SchedulerDecision::new(
+                    SchedulerDecisionKind::Noop,
+                    "duplicate_queued_available",
+                )
+                .boundary(boundary)
+                .liveness_only(true)
+                .work_item_id(work_item.id.clone())
+                .evidence("duplicate_tick_suppressed")
+                .evidence(format!("message_id={message_id}"));
+            }
+            SchedulerDecision::new(SchedulerDecisionKind::EmitSystemTick, "queued_available")
+                .boundary(boundary)
+                .model_visible(true)
+                .work_item_id(work_item.id.clone())
+                .evidence("runtime_idle")
+                .evidence("work_item_runnable")
+                .evidence(format!(
+                    "idempotency_key={}",
+                    work_queue_tick_idempotency_key(work_item, "queued_available")
+                ))
+        }
     }
 }
 

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -428,7 +428,11 @@ fn assert_scheduler_fixture(name: &str) {
         "{name}: replay messages"
     );
     if let Some(expected_decision) = expected.decision {
-        let decision = scheduler::idle_boundary_decision(&projection, "fixture");
+        let decision = scheduler::decide_next_action(
+            &projection,
+            scheduler::SchedulerBoundary::RunLoopIdle,
+            scheduler::SchedulerInput::Idle,
+        );
         assert_eq!(
             decision.kind.as_str(),
             expected_decision,
@@ -607,6 +611,111 @@ fn idle_boundary_decision_prefers_controlled_status_over_wait_facts() {
     let decision = scheduler::idle_boundary_decision(&projection, "fixture");
     assert_eq!(decision.kind, scheduler::SchedulerDecisionKind::Stop);
     assert_eq!(decision.reason, "stopped");
+}
+
+#[test]
+fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let mut work_item = WorkItemRecord::new("default", "continue work", WorkItemState::Open);
+    work_item.id = "work-1".into();
+    work_item.revision = 7;
+    storage.append_work_item(&work_item).unwrap();
+
+    let pending = PendingWakeHint {
+        reason: "external update".into(),
+        description: None,
+        source: Some("fixture".into()),
+        scope: Some(ExternalTriggerScope::Agent),
+        waiting_intent_id: None,
+        external_trigger_id: Some("trigger-1".into()),
+        resource: None,
+        body: None,
+        content_type: None,
+        correlation_id: None,
+        causation_id: None,
+        created_at: Utc::now(),
+    };
+    agent.pending_wake_hint = Some(pending.clone());
+    storage.write_agent(&agent).unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let wake_decision = scheduler::decide_next_action(
+        &projection,
+        scheduler::SchedulerBoundary::IdleTick,
+        scheduler::SchedulerInput::IdleSignal(scheduler::SchedulerIdleSignal::WakeHint {
+            pending: &pending,
+            duplicate: None,
+        }),
+    );
+    assert_eq!(
+        wake_decision.kind,
+        scheduler::SchedulerDecisionKind::EmitSystemTick
+    );
+    assert_eq!(wake_decision.reason, "wake_hint");
+
+    storage
+        .append_task(&TaskRecord {
+            id: "blocking-task".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: Some("work-1".into()),
+            summary: Some("fixture task".into()),
+            detail: Some(serde_json::json!({ "wait_policy": "blocking" })),
+            recovery: None,
+        })
+        .unwrap();
+    let blocked_projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let work_queue_decision = scheduler::decide_next_action(
+        &blocked_projection,
+        scheduler::SchedulerBoundary::IdleTick,
+        scheduler::SchedulerInput::IdleSignal(scheduler::SchedulerIdleSignal::ContinueActive {
+            work_item: &work_item,
+            suppressed_after_model_visible_continuation: false,
+            duplicate: None,
+        }),
+    );
+    assert_eq!(
+        work_queue_decision.kind,
+        scheduler::SchedulerDecisionKind::WaitForTask
+    );
+    assert_eq!(work_queue_decision.reason, "blocking_active_tasks");
+}
+
+#[test]
+fn decide_next_action_records_duplicate_tick_evidence() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let mut work_item = WorkItemRecord::new("default", "queued work", WorkItemState::Open);
+    work_item.id = "work-queued".into();
+    work_item.revision = 3;
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+
+    let decision = scheduler::decide_next_action(
+        &projection,
+        scheduler::SchedulerBoundary::IdleTick,
+        scheduler::SchedulerInput::IdleSignal(scheduler::SchedulerIdleSignal::QueuedAvailable {
+            work_item: &work_item,
+            duplicate: Some(
+                scheduler::SchedulerDuplicateEvidence::QueuedAvailableMessage("msg-1".into()),
+            ),
+        }),
+    );
+
+    assert_eq!(decision.kind, scheduler::SchedulerDecisionKind::Noop);
+    assert_eq!(decision.reason, "duplicate_queued_available");
+    assert!(decision
+        .evidence
+        .iter()
+        .any(|entry| entry == "message_id=msg-1"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- centralize scheduler boundary decisions behind `scheduler::decide_next_action`
- route message processing, run-loop idle, and idle tick work-queue decisions through the shared decision reducer
- add scheduler projection coverage for last turn terminal state and duplicate tick evidence
- add `holon debug scheduler-fixture --agent <id> --output <dir>` to export replay-harness-shaped scheduler fixtures

## Validation

- `cargo check`
- `cargo test scheduler --lib`
- `cargo test scheduler_fixture --bin holon`
- `cargo test --workspace -- --test-threads=1`

Note: a first parallel `cargo test --workspace` run exposed an existing env-var race in `config::tests::app_config_honors_explicit_default_agent_env`; the test passed when run directly and the full suite passed serially.
