### PR TITLE
fix: add warn log for FailFast fallback errors in FallbackProvider

### DIFF
--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -407,6 +407,16 @@ impl AgentProvider for FallbackProvider {
                             transport_diagnostics: provider_transport_diagnostics(&error).cloned(),
                         });
                         last_error = Some(error);
+                        let has_fallback = candidate_index + 1 < self.candidates.len();
+                        warn!(
+                            model_ref = %candidate.model_ref,
+                            attempt,
+                            max_attempts,
+                            failure_kind = classification.kind.as_str(),
+                            disposition = classification.disposition.as_str(),
+                            has_fallback,
+                            "provider turn failed; advancing to fallback"
+                        );
                         break;
                     }
                 }

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -415,7 +415,7 @@ impl AgentProvider for FallbackProvider {
                             failure_kind = classification.kind.as_str(),
                             disposition = classification.disposition.as_str(),
                             has_fallback,
-                            "provider turn failed; advancing to fallback"
+                            "provider turn failed; {}", if has_fallback { "advancing to fallback" } else { "no fallback remaining" }
                         );
                         break;
                     }


### PR DESCRIPTION
## Summary

Fix #1031: FallbackProvider now logs a `warn!` when a provider turn fails with a FailFast error before advancing to the next fallback candidate.

## Problem

In `src/provider/fallback.rs`, the `complete_turn_with_diagnostics` method had two error handling paths:

1. **Retryable errors** (timeout, connection, rate_limited, server_error): logged with `warn!` and retried up to `max_attempts` ✅
2. **FailFast errors** (auth_error, contract_error, 4xx, invalid_response, retries-exhausted): silently pushed to the timeline and advanced to the next candidate with **no log** ❌

This made it impossible to diagnose why deepseek was falling back to GPT without inspecting daemon logs for transport-level errors.

## Fix

Added a `warn!` log in the FailFast path, right before breaking out of the retry loop:

```
warn!(
    model_ref = %candidate.model_ref,
    attempt,
    max_attempts,
    failure_kind = classification.kind.as_str(),
    disposition = classification.disposition.as_str(),
    has_fallback,
    "provider turn failed; advancing to fallback"
);
```

The log includes `has_fallback` to distinguish between "trying next candidate" and "all candidates exhausted."

## Verification

- `cargo check -p holon` — passes
- `cargo test -p holon --lib -- provider` — 212 passed, 0 failed
- `cargo test -p holon --lib -- model_visible_hint` — 3 passed, 0 failed
