### PR TITLE
feat: implement API-backed web search providers (Brave, Tavily, Exa)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,7 @@ pub struct AppConfig {
     pub control_auth_mode: ControlAuthMode,
     pub config_file_path: PathBuf,
     pub stored_config: HolonConfigFile,
+    pub web_config: crate::web::WebConfig,
     pub default_model: ModelRef,
     pub fallback_models: Vec<ModelRef>,
     pub runtime_max_output_tokens: u32,
@@ -389,6 +390,11 @@ pub struct WebProviderConfigFile {
     pub kind: WebProviderKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    /// Named credential profile to load the API key from.
+    /// When set, the profile must exist in the credential store
+    /// and must be of kind `api_key`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_profile: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -560,6 +566,7 @@ impl AppConfig {
             .transpose()?
             .or(stored_config.tui.alternate_screen)
             .unwrap_or(AltScreenMode::Auto);
+        let web_config = crate::web::materialize_web_config(&stored_config.web, &credential_store);
 
         Ok(Self {
             default_agent_id,
@@ -582,6 +589,7 @@ impl AppConfig {
             control_auth_mode,
             config_file_path,
             stored_config,
+            web_config,
             default_model,
             fallback_models,
             runtime_max_output_tokens,
@@ -1426,6 +1434,27 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             default: json!(crate::web::WebSearchConfig::default().max_results),
             allowed_values: vec![],
         },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.kind",
+            kind: "string",
+            description: "Web search provider kind: duck_duck_go, searxng, brave, tavily, exa, perplexity, firecrawl, open_ai_native, anthropic_native, gemini_native.",
+            default: Value::Null,
+            allowed_values: vec!["duck_duck_go", "searxng", "brave", "tavily", "exa", "perplexity", "firecrawl", "open_ai_native", "anthropic_native", "gemini_native"],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.base_url",
+            kind: "string",
+            description: "Optional custom base URL for the web search provider.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.credential_profile",
+            kind: "string",
+            description: "Named credential profile to load the API key from. The profile must be of kind api_key.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
     ]
 }
 
@@ -1572,6 +1601,45 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .max_results
             .map(|value| json!(value))
             .unwrap_or(Value::Null)),
+        "web.providers" => Ok(serde_json::to_value(&config.web.providers)?),
+        key if key.starts_with("web.providers.") => {
+            let name = key.strip_prefix("web.providers.").unwrap();
+            if let Some(provider_name) = name.strip_suffix(".kind") {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .map(|p| Value::String(p.kind.as_str().to_string()))
+                    .unwrap_or(Value::Null));
+            }
+            if let Some(provider_name) = name.strip_suffix(".base_url") {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .and_then(|p| p.base_url.as_ref())
+                    .map(|v| Value::String(v.clone()))
+                    .unwrap_or(Value::Null));
+            }
+            if let Some(provider_name) = name.strip_suffix(".credential_profile") {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .and_then(|p| p.credential_profile.as_ref())
+                    .map(|v| Value::String(v.clone()))
+                    .unwrap_or(Value::Null));
+            }
+            if name.is_empty() {
+                return Err(anyhow!(
+                    "web.providers.<name> requires a non-empty provider name"
+                ));
+            }
+            match config.web.providers.get(name) {
+                Some(provider) => Ok(serde_json::to_value(provider)?),
+                None => Ok(Value::Null),
+            }
+        }
         _ => Err(unknown_config_key(key)),
     }
 }
@@ -1680,6 +1748,63 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
         "web.search.max_results" => {
             config.web.search.max_results = Some(parse_positive_usize_key(key, raw_value)?);
         }
+        key if key.starts_with("web.providers.") && key.ends_with(".kind") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let name = rest.strip_suffix(".kind").unwrap();
+            if name.is_empty() {
+                return Err(anyhow!(
+                    "web.providers.<name>.kind requires a non-empty provider name"
+                ));
+            }
+            let kind: WebProviderKind = serde_json::from_str(&format!("\"{}\"", raw_value.trim()))
+                .with_context(|| format!("invalid web provider kind: {}", raw_value))?;
+            config
+                .web
+                .providers
+                .entry(name.to_string())
+                .or_insert_with(|| WebProviderConfigFile {
+                    kind,
+                    base_url: None,
+                    credential_profile: None,
+                })
+                .kind = kind;
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".base_url") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let name = rest.strip_suffix(".base_url").unwrap();
+            if name.is_empty() {
+                return Err(anyhow!(
+                    "web.providers.<name>.base_url requires a non-empty provider name"
+                ));
+            }
+            let provider = config.web.providers.get_mut(name).ok_or_else(|| {
+                anyhow!("web provider {name} not found; set web.providers.{name}.kind first")
+            })?;
+            let value = raw_value.trim();
+            provider.base_url = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            };
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".credential_profile") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let name = rest.strip_suffix(".credential_profile").unwrap();
+            if name.is_empty() {
+                return Err(anyhow!(
+                    "web.providers.<name>.credential_profile requires a non-empty provider name"
+                ));
+            }
+            let provider = config.web.providers.get_mut(name).ok_or_else(|| {
+                anyhow!("web provider {name} not found; set web.providers.{name}.kind first")
+            })?;
+            let value = raw_value.trim();
+            provider.credential_profile = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            };
+        }
         _ => return Err(unknown_config_key(key)),
     }
     Ok(())
@@ -1734,6 +1859,18 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "web.search.enabled" => config.web.search.enabled = None,
         "web.search.provider" => config.web.search.provider = None,
         "web.search.max_results" => config.web.search.max_results = None,
+        key if key.starts_with("web.providers.") => {
+            let name = key.strip_prefix("web.providers.").unwrap();
+            if name.is_empty() {
+                return Err(anyhow!(
+                    "web.providers.<name> requires a non-empty provider name"
+                ));
+            }
+            if config.web.providers.remove(name).is_none() {
+                return Err(anyhow!("web provider {name} not found"));
+            }
+            return Ok(());
+        }
         _ => return Err(unknown_config_key(key)),
     }
     Ok(())
@@ -3063,6 +3200,9 @@ fn unknown_config_key(key: &str) -> anyhow::Error {
     if is_startup_only_config_key(key) {
         return startup_only_config_key_error(key);
     }
+    if key.starts_with("web.providers.") {
+        return anyhow!("unknown web providers config key {key}; supported fields: .kind, .base_url, .credential_profile; use web.providers.<name>.kind to create a provider first");
+    }
     let supported = config_schema()
         .into_iter()
         .map(|entry| entry.key)
@@ -3188,6 +3328,7 @@ mod tests {
                 Some("anthropic-token"),
                 PathBuf::from("/tmp/codex-home"),
             ),
+            web_config: crate::web::WebConfig::default(),
         };
         TestAppConfigFixture {
             _home_dir: home_dir,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1756,8 +1756,9 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                     "web.providers.<name>.kind requires a non-empty provider name"
                 ));
             }
-            let kind: WebProviderKind = serde_json::from_str(&format!("\"{}\"", raw_value.trim()))
-                .with_context(|| format!("invalid web provider kind: {}", raw_value))?;
+            let kind: WebProviderKind =
+                serde_json::from_value(serde_json::Value::String(raw_value.trim().to_string()))
+                    .with_context(|| format!("invalid web provider kind: {}", raw_value))?;
             config
                 .web
                 .providers
@@ -1859,6 +1860,33 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "web.search.enabled" => config.web.search.enabled = None,
         "web.search.provider" => config.web.search.provider = None,
         "web.search.max_results" => config.web.search.max_results = None,
+        key if key.starts_with("web.providers.") && key.ends_with(".kind") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let name = rest.strip_suffix(".kind").unwrap();
+            if let Some(provider) = config.web.providers.get_mut(name) {
+                provider.kind = WebProviderKind::DuckDuckGo;
+            } else {
+                return Err(anyhow!("web provider {name} not found"));
+            }
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".base_url") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let name = rest.strip_suffix(".base_url").unwrap();
+            if let Some(provider) = config.web.providers.get_mut(name) {
+                provider.base_url = None;
+            } else {
+                return Err(anyhow!("web provider {name} not found"));
+            }
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".credential_profile") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let name = rest.strip_suffix(".credential_profile").unwrap();
+            if let Some(provider) = config.web.providers.get_mut(name) {
+                provider.credential_profile = None;
+            } else {
+                return Err(anyhow!("web provider {name} not found"));
+            }
+        }
         key if key.starts_with("web.providers.") => {
             let name = key.strip_prefix("web.providers.").unwrap();
             if name.is_empty() {
@@ -3171,6 +3199,11 @@ fn config_uses_credential_profiles(config: &HolonConfigFile) -> bool {
         .providers
         .values()
         .any(|provider| provider.auth.source == CredentialSource::AuthProfile)
+        || config
+            .web
+            .providers
+            .values()
+            .any(|p| p.credential_profile.is_some())
 }
 
 fn is_startup_only_config_key(key: &str) -> bool {

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -56,6 +56,7 @@ fn test_config() -> AppConfig {
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
         providers: provider_registry_for_tests(None, Some("dummy"), home.path().join(".codex")),
+        web_config: crate::web::WebConfig::default(),
     }
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -1529,6 +1529,7 @@ mod tests {
                 anthropic_token,
                 PathBuf::from("/tmp/missing-codex-home"),
             ),
+            web_config: crate::web::WebConfig::default(),
         };
         ProviderConfigFixture {
             _home: home,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1158,6 +1158,7 @@ mod tests {
             validated_model_overrides: Default::default(),
             validated_unknown_model_fallback: None,
             providers: provider_registry_for_tests(None, Some("dummy"), home.join(".codex")),
+            web_config: holon::web::WebConfig::default(),
         }
     }
 

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -282,6 +282,7 @@ mod tests {
                 Some("anthropic-token"),
                 PathBuf::new(),
             ),
+            web_config: crate::web::WebConfig::default(),
         };
         TestConfigFixture {
             _home_dir: home_dir,

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -296,6 +296,7 @@ pub fn test_config(
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
         providers: provider_registry_for_tests(openai_key, anthropic_token, codex_home),
+        web_config: crate::web::WebConfig::default(),
     };
     ProviderTestFixture {
         _home_dir: home_dir,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -126,7 +126,7 @@ impl RuntimeHandle {
             model_availability,
             config.default_tool_output_tokens as u64,
             config.max_tool_output_tokens as u64,
-            crate::web::WebConfig::from(&config.stored_config.web),
+            config.web_config.clone(),
             Some(ProviderReconfigurator { config }),
             Some(host_bridge),
         )

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -73,6 +73,7 @@ fn test_config() -> AppConfig {
             Some("dummy"),
             temp.join(".codex"),
         ),
+        web_config: crate::web::WebConfig::default(),
     }
 }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,3 +1,5 @@
+use crate::config::CredentialStoreFile;
+
 pub mod fetch;
 pub mod policy;
 pub mod search;
@@ -115,6 +117,10 @@ impl From<&crate::config::WebSearchConfigFile> for WebSearchConfig {
 pub struct WebProviderConfig {
     pub kind: WebProviderKind,
     pub base_url: Option<String>,
+    /// Resolved API key from a credential profile (for API-backed providers).
+    /// Empty when no credential profile is configured.
+    #[serde(skip)]
+    pub api_key: String,
 }
 
 impl From<&crate::config::WebProviderConfigFile> for WebProviderConfig {
@@ -122,7 +128,39 @@ impl From<&crate::config::WebProviderConfigFile> for WebProviderConfig {
         Self {
             kind: value.kind,
             base_url: value.base_url.clone(),
+            api_key: String::new(),
         }
+    }
+}
+
+/// Materialize a resolved WebConfig from the file config and credential store.
+pub fn materialize_web_config(
+    file: &crate::config::WebConfigFile,
+    credential_store: &CredentialStoreFile,
+) -> WebConfig {
+    WebConfig {
+        fetch: WebFetchConfig::from(&file.fetch),
+        search: WebSearchConfig::from(&file.search),
+        providers: file
+            .providers
+            .iter()
+            .map(|(id, provider)| {
+                let api_key = provider
+                    .credential_profile
+                    .as_deref()
+                    .and_then(|profile| credential_store.profiles.get(profile))
+                    .map(|entry| entry.material.clone())
+                    .unwrap_or_default();
+                (
+                    id.clone(),
+                    WebProviderConfig {
+                        kind: provider.kind,
+                        base_url: provider.base_url.clone(),
+                        api_key,
+                    },
+                )
+            })
+            .collect(),
     }
 }
 
@@ -139,4 +177,98 @@ pub enum WebProviderKind {
     OpenAiNative,
     AnthropicNative,
     GeminiNative,
+}
+
+impl WebProviderKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WebProviderKind::DuckDuckGo => "duck_duck_go",
+            WebProviderKind::Searxng => "searxng",
+            WebProviderKind::Brave => "brave",
+            WebProviderKind::Tavily => "tavily",
+            WebProviderKind::Exa => "exa",
+            WebProviderKind::Perplexity => "perplexity",
+            WebProviderKind::Firecrawl => "firecrawl",
+            WebProviderKind::OpenAiNative => "open_ai_native",
+            WebProviderKind::AnthropicNative => "anthropic_native",
+            WebProviderKind::GeminiNative => "gemini_native",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CredentialProfileFile, CredentialStoreFile, WebProviderConfigFile};
+    use std::collections::BTreeMap;
+
+    fn credential_store_with(profile: &str, material: &str) -> CredentialStoreFile {
+        let mut profiles = BTreeMap::new();
+        profiles.insert(
+            profile.to_string(),
+            CredentialProfileFile {
+                kind: crate::config::CredentialKind::ApiKey,
+                material: material.to_string(),
+            },
+        );
+        CredentialStoreFile { profiles }
+    }
+
+    #[test]
+    fn materialize_resolves_api_key_from_credential_profile() {
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "my_brave".to_string(),
+            WebProviderConfigFile {
+                kind: WebProviderKind::Brave,
+                base_url: None,
+                credential_profile: Some("brave_key".to_string()),
+            },
+        );
+        let file = crate::config::WebConfigFile {
+            fetch: Default::default(),
+            search: Default::default(),
+            providers,
+        };
+        let store = credential_store_with("brave_key", "test-api-key-123");
+        let config = materialize_web_config(&file, &store);
+        let provider = config.providers.get("my_brave").unwrap();
+        assert_eq!(provider.api_key, "test-api-key-123");
+        assert_eq!(provider.kind, WebProviderKind::Brave);
+    }
+
+    #[test]
+    fn materialize_empty_api_key_without_credential_profile() {
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "my_tavily".to_string(),
+            WebProviderConfigFile {
+                kind: WebProviderKind::Tavily,
+                base_url: None,
+                credential_profile: None,
+            },
+        );
+        let file = crate::config::WebConfigFile {
+            fetch: Default::default(),
+            search: Default::default(),
+            providers,
+        };
+        let store = CredentialStoreFile::default();
+        let config = materialize_web_config(&file, &store);
+        let provider = config.providers.get("my_tavily").unwrap();
+        assert!(provider.api_key.is_empty());
+    }
+
+    #[test]
+    fn materialize_missing_credential_profile_yields_empty_key() {
+        let file = crate::config::WebConfigFile::default();
+        // File with no providers but credential_profile references a non-existent profile
+        let store = credential_store_with("other", "irrelevant");
+        let config = materialize_web_config(&file, &store);
+        assert!(config.providers.is_empty());
+        // Default WebConfig has no providers
+        let default = WebConfig::default();
+        assert!(default.providers.is_empty());
+        assert_eq!(default.search.provider, "auto");
+    }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -148,7 +148,12 @@ pub fn materialize_web_config(
                 let api_key = provider
                     .credential_profile
                     .as_deref()
-                    .and_then(|profile| credential_store.profiles.get(profile))
+                    .and_then(|profile| {
+                        credential_store
+                            .profiles
+                            .get(profile)
+                            .filter(|entry| entry.kind == crate::config::CredentialKind::ApiKey)
+                    })
                     .map(|entry| entry.material.clone())
                     .unwrap_or_default();
                 (
@@ -261,14 +266,54 @@ mod tests {
 
     #[test]
     fn materialize_missing_credential_profile_yields_empty_key() {
-        let file = crate::config::WebConfigFile::default();
-        // File with no providers but credential_profile references a non-existent profile
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "my_brave".to_string(),
+            WebProviderConfigFile {
+                kind: WebProviderKind::Brave,
+                base_url: None,
+                credential_profile: Some("missing_profile".to_string()),
+            },
+        );
+        let file = crate::config::WebConfigFile {
+            fetch: Default::default(),
+            search: Default::default(),
+            providers,
+        };
+        // Credential store does not contain "missing_profile"
         let store = credential_store_with("other", "irrelevant");
         let config = materialize_web_config(&file, &store);
-        assert!(config.providers.is_empty());
-        // Default WebConfig has no providers
-        let default = WebConfig::default();
-        assert!(default.providers.is_empty());
-        assert_eq!(default.search.provider, "auto");
+        let provider = config.providers.get("my_brave").unwrap();
+        assert!(provider.api_key.is_empty());
+    }
+
+    #[test]
+    fn materialize_non_api_key_credential_kind_yields_empty_key() {
+        let mut providers = BTreeMap::new();
+        providers.insert(
+            "my_brave".to_string(),
+            WebProviderConfigFile {
+                kind: WebProviderKind::Brave,
+                base_url: None,
+                credential_profile: Some("session_token".to_string()),
+            },
+        );
+        let file = crate::config::WebConfigFile {
+            fetch: Default::default(),
+            search: Default::default(),
+            providers,
+        };
+        // Profile exists but kind is SessionToken, not ApiKey
+        let mut store = CredentialStoreFile::default();
+        store.profiles.insert(
+            "session_token".to_string(),
+            crate::config::CredentialProfileFile {
+                kind: crate::config::CredentialKind::SessionToken,
+                material: "some-session-hash".to_string(),
+            },
+        );
+        let config = materialize_web_config(&file, &store);
+        let provider = config.providers.get("my_brave").unwrap();
+        assert!(provider.api_key.is_empty());
     }
 }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -86,14 +86,46 @@ pub async fn search(request: WebSearchRequest, config: &WebConfig) -> Result<Web
                 WebProviderKind::DuckDuckGo => {
                     duckduckgo_search(&request.query, max_results, &config.fetch).await?
                 }
-                kind => {
-                    return Err(search_error(
-                        "provider_unavailable",
-                        format!("WebSearch provider kind `{kind:?}` is reserved for API-backed or native provider support"),
-                        provider_id,
-                        "configure a duckduckgo or searxng provider for this Holon version",
-                    ));
-                }
+                kind => match kind {
+                    WebProviderKind::Brave => {
+                        brave_search(
+                            &request.query,
+                            max_results,
+                            provider_id,
+                            provider_config,
+                            &config.fetch,
+                        )
+                        .await?
+                    }
+                    WebProviderKind::Tavily => {
+                        tavily_search(
+                            &request.query,
+                            max_results,
+                            provider_id,
+                            provider_config,
+                            &config.fetch,
+                        )
+                        .await?
+                    }
+                    WebProviderKind::Exa => {
+                        exa_search(
+                            &request.query,
+                            max_results,
+                            provider_id,
+                            provider_config,
+                            &config.fetch,
+                        )
+                        .await?
+                    }
+                    kind => {
+                        return Err(search_error(
+                                "provider_unavailable",
+                                format!("WebSearch provider kind `{kind:?}` is reserved for future provider support"),
+                                provider_id,
+                                "configure a duckduckgo, searxng, brave, tavily, or exa provider for this Holon version",
+                            ));
+                    }
+                },
             }
         }
     };
@@ -223,6 +255,346 @@ async fn searxng_search(
             "SearXNG returned no parseable search results",
             provider_id,
             "check the SearXNG instance or use provider=duckduckgo",
+        ));
+    }
+    Ok(results)
+}
+
+async fn brave_search(
+    query: &str,
+    max_results: usize,
+    provider_id: &str,
+    provider: &WebProviderConfig,
+    fetch_config: &WebFetchConfig,
+) -> Result<Vec<WebSearchResult>> {
+    let api_key = &provider.api_key;
+    if api_key.is_empty() {
+        return Err(search_error(
+            "provider_unavailable",
+            "Brave Search requires an API key (set credential_profile on the provider)",
+            provider_id,
+            "add a credential_profile with an api_key in the credential store",
+        ));
+    }
+    let client = Client::builder().timeout(timeout(fetch_config)).build()?;
+    let base_url = provider
+        .base_url
+        .as_deref()
+        .unwrap_or("https://api.search.brave.com");
+    let url = format!(
+        "{}/res/v1/web/search?q={}&count={}",
+        base_url.trim_end_matches('/'),
+        form_urlencoded::byte_serialize(query.as_bytes()).collect::<String>(),
+        max_results.min(20),
+    );
+    let response = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .header("Accept-Encoding", "gzip")
+        .header("X-Subscription-Token", api_key.as_str())
+        .send()
+        .await
+        .map_err(|error| {
+            search_error(
+                "network_failed",
+                format!("Brave Search request failed: {error}"),
+                provider_id,
+                "retry later or check the API key",
+            )
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
+            "provider_unavailable"
+        } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            "rate_limited"
+        } else {
+            "network_failed"
+        };
+        return Err(search_error(
+            kind,
+            format!("Brave Search returned HTTP {status}"),
+            provider_id,
+            "check the API key or retry later",
+        ));
+    }
+    let body = response.text().await.map_err(|error| {
+        search_error(
+            "network_failed",
+            format!("Brave Search response failed: {error}"),
+            provider_id,
+            "retry later",
+        )
+    })?;
+    let payload: serde_json::Value = serde_json::from_str(&body).map_err(|error| {
+        search_error(
+            "parse_failed",
+            format!("Brave Search returned invalid JSON: {error}"),
+            provider_id,
+            "check the API key or retry later",
+        )
+    })?;
+    let results = payload
+        .get("web")
+        .and_then(|web| web.get("results"))
+        .and_then(|results| results.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let title = entry.get("title")?.as_str()?.trim().to_string();
+            let url = entry.get("url")?.as_str()?.trim().to_string();
+            if title.is_empty() || url.is_empty() {
+                return None;
+            }
+            Some(WebSearchResult {
+                title,
+                url,
+                snippet: entry
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty()),
+                source: provider_id.to_string(),
+                published_at: None,
+            })
+        })
+        .take(max_results)
+        .collect::<Vec<_>>();
+    if results.is_empty() {
+        return Err(search_error(
+            "parse_failed",
+            "Brave Search returned no parseable search results",
+            provider_id,
+            "try a different query or check the API subscription",
+        ));
+    }
+    Ok(results)
+}
+
+async fn tavily_search(
+    query: &str,
+    max_results: usize,
+    provider_id: &str,
+    provider: &WebProviderConfig,
+    fetch_config: &WebFetchConfig,
+) -> Result<Vec<WebSearchResult>> {
+    let api_key = &provider.api_key;
+    if api_key.is_empty() {
+        return Err(search_error(
+            "provider_unavailable",
+            "Tavily requires an API key (set credential_profile on the provider)",
+            provider_id,
+            "add a credential_profile with an api_key in the credential store",
+        ));
+    }
+    let client = Client::builder().timeout(timeout(fetch_config)).build()?;
+    let body = serde_json::json!({
+        "query": query,
+        "api_key": api_key,
+        "max_results": max_results.min(20),
+        "search_depth": "basic",
+    });
+    let base_url = provider
+        .base_url
+        .as_deref()
+        .unwrap_or("https://api.tavily.com");
+    let response = client
+        .post(format!("{}/search", base_url.trim_end_matches('/')))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| {
+            search_error(
+                "network_failed",
+                format!("Tavily request failed: {error}"),
+                provider_id,
+                "retry later or check the API key",
+            )
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
+            "provider_unavailable"
+        } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            "rate_limited"
+        } else {
+            "network_failed"
+        };
+        return Err(search_error(
+            kind,
+            format!("Tavily returned HTTP {status}"),
+            provider_id,
+            "check the API key or retry later",
+        ));
+    }
+    let body = response.text().await.map_err(|error| {
+        search_error(
+            "network_failed",
+            format!("Tavily response failed: {error}"),
+            provider_id,
+            "retry later",
+        )
+    })?;
+    let payload: serde_json::Value = serde_json::from_str(&body).map_err(|error| {
+        search_error(
+            "parse_failed",
+            format!("Tavily returned invalid JSON: {error}"),
+            provider_id,
+            "check the API key or retry later",
+        )
+    })?;
+    let results = payload
+        .get("results")
+        .and_then(|results| results.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let title = entry.get("title")?.as_str()?.trim().to_string();
+            let url = entry.get("url")?.as_str()?.trim().to_string();
+            if title.is_empty() || url.is_empty() {
+                return None;
+            }
+            Some(WebSearchResult {
+                title,
+                url,
+                snippet: entry
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty()),
+                source: provider_id.to_string(),
+                published_at: None,
+            })
+        })
+        .take(max_results)
+        .collect::<Vec<_>>();
+    if results.is_empty() {
+        return Err(search_error(
+            "parse_failed",
+            "Tavily returned no parseable search results",
+            provider_id,
+            "try a different query or check the API subscription",
+        ));
+    }
+    Ok(results)
+}
+
+async fn exa_search(
+    query: &str,
+    max_results: usize,
+    provider_id: &str,
+    provider: &WebProviderConfig,
+    fetch_config: &WebFetchConfig,
+) -> Result<Vec<WebSearchResult>> {
+    let api_key = &provider.api_key;
+    if api_key.is_empty() {
+        return Err(search_error(
+            "provider_unavailable",
+            "Exa requires an API key (set credential_profile on the provider)",
+            provider_id,
+            "add a credential_profile with an api_key in the credential store",
+        ));
+    }
+    let client = Client::builder().timeout(timeout(fetch_config)).build()?;
+    let body = serde_json::json!({
+        "query": query,
+        "numResults": max_results.min(25),
+        "type": "auto",
+    });
+    let base_url = provider.base_url.as_deref().unwrap_or("https://api.exa.ai");
+    let response = client
+        .post(format!("{}/search", base_url.trim_end_matches('/')))
+        .header("Content-Type", "application/json")
+        .header("x-api-key", api_key.as_str())
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| {
+            search_error(
+                "network_failed",
+                format!("Exa request failed: {error}"),
+                provider_id,
+                "retry later or check the API key",
+            )
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
+            "provider_unavailable"
+        } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            "rate_limited"
+        } else {
+            "network_failed"
+        };
+        return Err(search_error(
+            kind,
+            format!("Exa returned HTTP {status}"),
+            provider_id,
+            "check the API key or retry later",
+        ));
+    }
+    let body = response.text().await.map_err(|error| {
+        search_error(
+            "network_failed",
+            format!("Exa response failed: {error}"),
+            provider_id,
+            "retry later",
+        )
+    })?;
+    let payload: serde_json::Value = serde_json::from_str(&body).map_err(|error| {
+        search_error(
+            "parse_failed",
+            format!("Exa returned invalid JSON: {error}"),
+            provider_id,
+            "check the API key or retry later",
+        )
+    })?;
+    let results = payload
+        .get("results")
+        .and_then(|results| results.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let title = entry
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let url = entry
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if title.is_empty() || url.is_empty() {
+                return None;
+            }
+            Some(WebSearchResult {
+                title,
+                url,
+                snippet: entry
+                    .get("text")
+                    .and_then(|v| v.as_str())
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty()),
+                source: provider_id.to_string(),
+                published_at: entry
+                    .get("publishedDate")
+                    .and_then(|v| v.as_str())
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty()),
+            })
+        })
+        .take(max_results)
+        .collect::<Vec<_>>();
+    if results.is_empty() {
+        return Err(search_error(
+            "parse_failed",
+            "Exa returned no parseable search results",
+            provider_id,
+            "try a different query or check the API subscription",
         ));
     }
     Ok(results)
@@ -437,5 +809,280 @@ mod tests {
         let error = normalize_max_results(Some(0), 5).unwrap_err();
         let tool_error = ToolError::from_anyhow(&error);
         assert_eq!(tool_error.kind, "invalid_tool_input");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Integration tests against mock HTTP servers for API-backed providers
+    // ---------------------------------------------------------------------------
+
+    fn test_provider(kind: WebProviderKind, base_url: &str) -> WebProviderConfig {
+        WebProviderConfig {
+            kind,
+            base_url: Some(base_url.to_string()),
+            api_key: "test-key-123".to_string(),
+        }
+    }
+
+    fn test_fetch_config() -> WebFetchConfig {
+        WebFetchConfig::default()
+    }
+
+    fn brave_results_json() -> serde_json::Value {
+        serde_json::json!({
+            "web": {
+                "results": [
+                    {
+                        "title": "Brave Search",
+                        "url": "https://search.brave.com",
+                        "description": "Brave Search engine"
+                    },
+                    {
+                        "title": "Brave Browser",
+                        "url": "https://brave.com",
+                        "description": "Privacy-focused browser"
+                    }
+                ]
+            }
+        })
+    }
+
+    fn tavily_results_json() -> serde_json::Value {
+        serde_json::json!({
+            "results": [
+                {
+                    "title": "Tavily Search",
+                    "url": "https://tavily.com",
+                    "content": "AI-powered search API"
+                },
+                {
+                    "title": "Tavily Docs",
+                    "url": "https://docs.tavily.com",
+                    "content": "Documentation for Tavily API"
+                }
+            ]
+        })
+    }
+
+    fn exa_results_json() -> serde_json::Value {
+        serde_json::json!({
+            "results": [
+                {
+                    "title": "Exa Search",
+                    "url": "https://exa.ai",
+                    "snippet": "Semantic search engine"
+                },
+                {
+                    "title": "Exa Docs",
+                    "url": "https://docs.exa.ai",
+                    "snippet": "Exa API documentation"
+                }
+            ]
+        })
+    }
+
+    fn empty_results_json() -> serde_json::Value {
+        serde_json::json!({ "results": [] })
+    }
+
+    fn empty_brave_results_json() -> serde_json::Value {
+        serde_json::json!({ "web": { "results": [] } })
+    }
+
+    #[tokio::test]
+    async fn brave_search_integration_success() {
+        let router = axum::Router::new().route(
+            "/res/v1/web/search",
+            axum::routing::get(|| async { axum::Json(brave_results_json()) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Brave, &base_url);
+        let results = brave_search("test", 5, "brave_test", &provider, &test_fetch_config())
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Brave Search");
+        assert_eq!(results[0].url, "https://search.brave.com");
+        assert_eq!(results[0].snippet.as_deref(), Some("Brave Search engine"));
+        assert_eq!(results[0].source, "brave_test");
+        assert_eq!(results[1].title, "Brave Browser");
+    }
+
+    #[tokio::test]
+    async fn tavily_search_integration_success() {
+        let router = axum::Router::new().route(
+            "/search",
+            axum::routing::post(|| async { axum::Json(tavily_results_json()) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Tavily, &base_url);
+        let results = tavily_search("test", 5, "tavily_test", &provider, &test_fetch_config())
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Tavily Search");
+        assert_eq!(results[1].title, "Tavily Docs");
+    }
+
+    #[tokio::test]
+    async fn exa_search_integration_success() {
+        let router = axum::Router::new().route(
+            "/search",
+            axum::routing::post(|| async { axum::Json(exa_results_json()) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Exa, &base_url);
+        let results = exa_search("test", 5, "exa_test", &provider, &test_fetch_config())
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Exa Search");
+        assert_eq!(results[0].url, "https://exa.ai");
+    }
+
+    #[tokio::test]
+    async fn brave_search_empty_results_is_error() {
+        let router = axum::Router::new().route(
+            "/res/v1/web/search",
+            axum::routing::get(|| async { axum::Json(empty_brave_results_json()) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Brave, &base_url);
+        let err = brave_search("test", 5, "brave_test", &provider, &test_fetch_config())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("no parseable search results"),
+            "expected empty results error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn brave_search_http_401_is_error() {
+        let router = axum::Router::new().route(
+            "/res/v1/web/search",
+            axum::routing::get(|| async { axum::http::StatusCode::UNAUTHORIZED }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Brave, &base_url);
+        let err = brave_search("test", 5, "brave_test", &provider, &test_fetch_config())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("HTTP 401"),
+            "expected HTTP 401 error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn brave_search_http_429_is_error() {
+        let router = axum::Router::new().route(
+            "/res/v1/web/search",
+            axum::routing::get(|| async { axum::http::StatusCode::TOO_MANY_REQUESTS }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Brave, &base_url);
+        let err = brave_search("test", 5, "brave_test", &provider, &test_fetch_config())
+            .await
+            .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&err);
+        assert_eq!(tool_error.kind, "rate_limited");
+    }
+
+    #[tokio::test]
+    async fn brave_search_missing_api_key_is_error() {
+        let provider = WebProviderConfig {
+            kind: WebProviderKind::Brave,
+            base_url: Some("http://localhost:1".to_string()),
+            api_key: String::new(),
+        };
+        let err = brave_search("test", 5, "brave_test", &provider, &test_fetch_config())
+            .await
+            .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&err);
+        assert_eq!(tool_error.kind, "provider_unavailable");
+        assert!(
+            format!("{err}").contains("API key"),
+            "expected API key error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tavily_search_invalid_json_is_error() {
+        let router =
+            axum::Router::new().route("/search", axum::routing::post(|| async { "not json" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Tavily, &base_url);
+        let err = tavily_search("test", 5, "tavily_test", &provider, &test_fetch_config())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("invalid JSON"),
+            "expected invalid JSON error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exa_search_empty_results_is_error() {
+        let router = axum::Router::new().route(
+            "/search",
+            axum::routing::post(|| async { axum::Json(empty_results_json()) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Exa, &base_url);
+        let err = exa_search("test", 5, "exa_test", &provider, &test_fetch_config())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("no parseable search results"),
+            "expected empty results error, got: {err}"
+        );
     }
 }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use chrono::Utc;
-use reqwest::{Client, StatusCode};
+use reqwest::{Client, Response, StatusCode};
 use serde::Serialize;
 use serde_json::json;
 use url::{form_urlencoded, Url};
@@ -290,7 +290,6 @@ async fn brave_search(
     let response = client
         .get(&url)
         .header("Accept", "application/json")
-        .header("Accept-Encoding", "gzip")
         .header("X-Subscription-Token", api_key.as_str())
         .send()
         .await
@@ -318,14 +317,7 @@ async fn brave_search(
             "check the API key or retry later",
         ));
     }
-    let body = response.text().await.map_err(|error| {
-        search_error(
-            "network_failed",
-            format!("Brave Search response failed: {error}"),
-            provider_id,
-            "retry later",
-        )
-    })?;
+    let body = read_search_response(response, provider_id).await?;
     let payload: serde_json::Value = serde_json::from_str(&body).map_err(|error| {
         search_error(
             "parse_failed",
@@ -428,14 +420,7 @@ async fn tavily_search(
             "check the API key or retry later",
         ));
     }
-    let body = response.text().await.map_err(|error| {
-        search_error(
-            "network_failed",
-            format!("Tavily response failed: {error}"),
-            provider_id,
-            "retry later",
-        )
-    })?;
+    let body = read_search_response(response, provider_id).await?;
     let payload: serde_json::Value = serde_json::from_str(&body).map_err(|error| {
         search_error(
             "parse_failed",
@@ -534,14 +519,7 @@ async fn exa_search(
             "check the API key or retry later",
         ));
     }
-    let body = response.text().await.map_err(|error| {
-        search_error(
-            "network_failed",
-            format!("Exa response failed: {error}"),
-            provider_id,
-            "retry later",
-        )
-    })?;
+    let body = read_search_response(response, provider_id).await?;
     let payload: serde_json::Value = serde_json::from_str(&body).map_err(|error| {
         search_error(
             "parse_failed",
@@ -667,6 +645,40 @@ async fn send_search_text(request: reqwest::RequestBuilder, provider: &str) -> R
             "parse_failed",
             format!("WebSearch provider `{provider}` returned non-UTF-8 text: {error}"),
             provider,
+            "configure another WebSearch provider",
+        )
+    })
+}
+
+/// Read a search response body with a byte limit, using chunked streaming to
+/// avoid unbounded memory use when an API endpoint returns an unexpectedly
+/// large payload.
+async fn read_search_response(response: Response, provider_id: &str) -> Result<String> {
+    let mut bytes = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        search_error(
+            "network_failed",
+            format!("{provider_id} response failed: {error}"),
+            provider_id,
+            "retry later or configure another WebSearch provider",
+        )
+    })? {
+        if bytes.len() + chunk.len() > SEARCH_RESPONSE_BYTES {
+            return Err(search_error(
+                "response_too_large",
+                format!("{provider_id} response exceeded the byte limit"),
+                provider_id,
+                "narrow the query or configure another WebSearch provider",
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    String::from_utf8(bytes).map_err(|error| {
+        search_error(
+            "parse_failed",
+            format!("{provider_id} returned non-UTF-8 text: {error}"),
+            provider_id,
             "configure another WebSearch provider",
         )
     })
@@ -869,12 +881,12 @@ mod tests {
                 {
                     "title": "Exa Search",
                     "url": "https://exa.ai",
-                    "snippet": "Semantic search engine"
+                    "text": "Semantic search engine"
                 },
                 {
                     "title": "Exa Docs",
                     "url": "https://docs.exa.ai",
-                    "snippet": "Exa API documentation"
+                    "text": "Exa API documentation"
                 }
             ]
         })
@@ -955,6 +967,11 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].title, "Exa Search");
         assert_eq!(results[0].url, "https://exa.ai");
+        assert_eq!(
+            results[0].snippet.as_deref(),
+            Some("Semantic search engine")
+        );
+        assert_eq!(results[1].snippet.as_deref(), Some("Exa API documentation"));
     }
 
     #[tokio::test]
@@ -1084,5 +1101,57 @@ mod tests {
             format!("{err}").contains("no parseable search results"),
             "expected empty results error, got: {err}"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Real API integration tests (opt-in, requires API keys)
+    // ---------------------------------------------------------------------------
+
+    /// Real Brave Search API integration test.
+    /// Set BRAVE_API_KEY env var to run: BRAVE_API_KEY=... cargo test brave_search_live -- --ignored
+    #[tokio::test]
+    #[ignore = "requires BRAVE_API_KEY env var and network access"]
+    async fn brave_search_live_integration() {
+        let api_key = std::env::var("BRAVE_API_KEY").ok();
+        if api_key.is_none() {
+            eprintln!("SKIP: BRAVE_API_KEY not set");
+            return;
+        }
+        let api_key = api_key.unwrap();
+        assert!(!api_key.is_empty(), "BRAVE_API_KEY is empty");
+
+        let provider = WebProviderConfig {
+            kind: WebProviderKind::Brave,
+            base_url: None, // use default https://api.search.brave.com
+            api_key,
+        };
+        let fetch_config = test_fetch_config();
+
+        let results = brave_search(
+            "Rust programming language",
+            3,
+            "brave_live",
+            &provider,
+            &fetch_config,
+        )
+        .await
+        .expect("Brave live search should succeed");
+
+        eprintln!("Brave live search returned {} results", results.len());
+        for (i, r) in results.iter().enumerate() {
+            eprintln!(
+                "  [{i}] title={} url={} snippet={:?}",
+                r.title, r.url, r.snippet
+            );
+        }
+        assert!(
+            !results.is_empty(),
+            "Brave live search should return at least 1 result"
+        );
+        assert!(
+            !results[0].title.is_empty(),
+            "first result should have a title"
+        );
+        assert!(!results[0].url.is_empty(), "first result should have a url");
     }
 }

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -51,6 +51,7 @@ fn test_config() -> AppConfig {
             Some("dummy"),
             home_dir.join(".codex"),
         ),
+        web_config: holon::web::WebConfig::default(),
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -171,6 +171,7 @@ impl TestConfigBuilder {
                 Some("dummy"),
                 data_dir.join(".codex"),
             ),
+            web_config: holon::web::WebConfig::default(),
         }
     }
 }

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -53,6 +53,7 @@ fn test_config() -> AppConfig {
             Some("dummy"),
             home_dir.join(".codex"),
         ),
+        web_config: holon::web::WebConfig::default(),
     }
 }
 

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -52,6 +52,7 @@ fn test_config() -> AppConfig {
             Some("dummy"),
             home_dir.join(".codex"),
         ),
+        web_config: holon::web::WebConfig::default(),
     }
 }
 

--- a/tests/wt203_task_owned_worktree_cleanup.rs
+++ b/tests/wt203_task_owned_worktree_cleanup.rs
@@ -51,6 +51,7 @@ fn test_config() -> AppConfig {
             Some("dummy"),
             home_dir.join(".codex"),
         ),
+        web_config: holon::web::WebConfig::default(),
     }
 }
 

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -52,6 +52,7 @@ fn test_config() -> AppConfig {
             Some("dummy"),
             home_dir.join(".codex"),
         ),
+        web_config: holon::web::WebConfig::default(),
     }
 }
 

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -52,6 +52,7 @@ fn test_config() -> AppConfig {
             Some("dummy"),
             home_dir.join(".codex"),
         ),
+        web_config: holon::web::WebConfig::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

Implements API-backed web search providers for Brave Search API, Tavily, and Exa, completing the `WebProviderKind` enum entries that were previously stubbed as "reserved for future".

## Changes

### Core implementation (`src/web/search.rs`)

- **`brave_search`**: Brave Search API integration with proper error handling, result parsing, and snippet extraction
- **`tavily_search`**: Tavily Search API integration with structured result mapping  
- **`exa_search`**: Exa Search API integration with content extraction
- Updated `search()` dispatch to route to API-backed providers via their `base_url` (with fallback to official defaults)

### Configuration (`src/config.rs`, `src/web/mod.rs`)

- `WebProviderConfig` now supports `credential_profile` for API key resolution
- `materialize_web_config()` resolves API keys from the credential store at config load time
- `WebProviderKind::as_str()` helper for serialization
- `set_config_key` / `get_config_key` / `unset_config_key` support `web.providers.<name>.*` paths
- `config_schema` entries for web provider configuration keys

### Bootstrap (`src/runtime/bootstrap.rs`)

- Uses materialized `web_config` (with resolved API keys) instead of raw config

### AppConfig compat

All existing `AppConfig` construction sites (tests, daemon, host, TUI, provider, worktree tests) updated with `web_config: WebConfig::default()`.

## Usage

```json
{
  "web": {
    "search": { "enabled": true, "provider": "my_brave" },
    "providers": {
      "my_brave": {
        "kind": "brave",
        "credential_profile": "brave_key"
      }
    }
  }
}
```

```bash
holon credential set brave_key api_key --stdin
holon config set web.providers.my_brave.kind brave
holon config set web.providers.my_brave.credential_profile brave_key
holon config set web.search.provider my_brave
```

## Verification

- ✅ `cargo check --all-targets` + `RUSTFLAGS="-D warnings"` — zero warnings
- ✅ `cargo fmt --all -- --check` — passes
- ✅ `cargo test --lib` — 1016 passed (12 search tests: 3 existing + 9 new integration tests)
- ✅ 3 new `materialize_web_config` unit tests pass
