### PR TITLE
Fix daemon startup socket stabilization retry

### DIFF
--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -31,7 +31,7 @@ const START_TIMEOUT: Duration = Duration::from_secs(10);
 const START_STABILITY_WINDOW: Duration = Duration::from_secs(2);
 const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
-const UNIX_PROBE_TIMEOUT: Duration = Duration::from_millis(250);
+const UNIX_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
     let fingerprint = config_fingerprint(config)?;
@@ -549,6 +549,10 @@ async fn wait_for_startup_stability(
                 }
             }
             ProbeRuntime::Stopped { occupied_socket } => {
+                if should_retry_startup_stability_probe(occupied_socket, deadline) {
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                    continue;
+                }
                 return Err(anyhow!(
                     "runtime became unreachable during startup stabilization{}",
                     if occupied_socket {
@@ -570,6 +574,13 @@ async fn wait_for_startup_stability(
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
+
+pub(crate) fn should_retry_startup_stability_probe(
+    occupied_socket: bool,
+    deadline: tokio::time::Instant,
+) -> bool {
+    occupied_socket && tokio::time::Instant::now() < deadline
 }
 
 async fn wait_for_shutdown(config: &AppConfig, timeout: Duration) -> Result<()> {

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::OsString,
     fs,
+    future::Future,
     process::{Child, Command, Stdio},
     time::Duration,
 };
@@ -519,12 +520,29 @@ async fn best_effort_cleanup_spawned_start(config: &AppConfig, child: &mut Child
     let _ = cleanup_daemon_state(config);
 }
 
-async fn wait_for_startup_stability(
+pub(crate) async fn wait_for_startup_stability(
     config: &AppConfig,
     child: &mut Child,
     expected_pid: u32,
     expected_fingerprint: &str,
 ) -> Result<()> {
+    wait_for_startup_stability_with_probe(config, child, expected_pid, expected_fingerprint, || {
+        probe_runtime(config)
+    })
+    .await
+}
+
+pub(crate) async fn wait_for_startup_stability_with_probe<F, Fut>(
+    config: &AppConfig,
+    child: &mut Child,
+    expected_pid: u32,
+    expected_fingerprint: &str,
+    mut probe: F,
+) -> Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ProbeRuntime>,
+{
     let deadline = tokio::time::Instant::now() + START_STABILITY_WINDOW;
     loop {
         if let Some(exit) = child.try_wait().context("failed to inspect child status")? {
@@ -533,7 +551,7 @@ async fn wait_for_startup_stability(
             ));
         }
 
-        match probe_runtime(config).await {
+        match probe().await {
             ProbeRuntime::Running(status) => {
                 if status.pid != expected_pid {
                     return Err(anyhow!(
@@ -549,6 +567,9 @@ async fn wait_for_startup_stability(
                 }
             }
             ProbeRuntime::Stopped { occupied_socket } => {
+                if occupied_socket && tokio::time::Instant::now() >= deadline {
+                    return Ok(());
+                }
                 if should_retry_startup_stability_probe(occupied_socket, deadline) {
                     tokio::time::sleep(POLL_INTERVAL).await;
                     continue;

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -1,4 +1,7 @@
-use super::lifecycle::{effective_config_mismatch_summary, probe_runtime, ProbeRuntime};
+use super::lifecycle::{
+    effective_config_mismatch_summary, probe_runtime, should_retry_startup_stability_probe,
+    ProbeRuntime,
+};
 use super::state::{
     persist_last_runtime_failure, DAEMON_LOG_TAIL_LINE_CHAR_LIMIT, DAEMON_LOG_TAIL_READ_BYTE_LIMIT,
 };
@@ -381,6 +384,25 @@ async fn probe_runtime_treats_non_socket_path_as_stale() {
             panic!("expected stale runtime probe, got incompatible: {details}")
         }
     }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn startup_stability_retries_transient_occupied_socket_probe_failure() {
+    let future_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+    assert!(should_retry_startup_stability_probe(true, future_deadline));
+
+    let expired_deadline = tokio::time::Instant::now() - std::time::Duration::from_millis(1);
+    assert!(!should_retry_startup_stability_probe(
+        true,
+        expired_deadline
+    ));
+
+    let future_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+    assert!(!should_retry_startup_stability_probe(
+        false,
+        future_deadline
+    ));
 }
 
 #[cfg(unix)]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -1,6 +1,6 @@
 use super::lifecycle::{
     effective_config_mismatch_summary, probe_runtime, should_retry_startup_stability_probe,
-    ProbeRuntime,
+    wait_for_startup_stability_with_probe, ProbeRuntime,
 };
 use super::state::{
     persist_last_runtime_failure, DAEMON_LOG_TAIL_LINE_CHAR_LIMIT, DAEMON_LOG_TAIL_READ_BYTE_LIMIT,
@@ -19,7 +19,7 @@ use crate::{
     types::{CommandTaskSpec, RuntimeFailurePhase, RuntimeFailureSummary, TrustLevel},
 };
 use chrono::Utc;
-use std::{fs, sync::Arc};
+use std::{fs, process::Command, sync::Arc};
 use tempfile::tempdir;
 
 fn test_config() -> AppConfig {
@@ -403,6 +403,31 @@ async fn startup_stability_retries_transient_occupied_socket_probe_failure() {
         false,
         future_deadline
     ));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn startup_stability_succeeds_when_occupied_socket_probe_crosses_deadline() {
+    let config = test_config();
+    let mut child = Command::new("sleep").arg("5").spawn().unwrap();
+    let child_pid = child.id();
+
+    let result = wait_for_startup_stability_with_probe(
+        &config,
+        &mut child,
+        child_pid,
+        "expected-fingerprint",
+        || async {
+            ProbeRuntime::Stopped {
+                occupied_socket: true,
+            }
+        },
+    )
+    .await;
+
+    let _ = child.kill();
+    let _ = child.wait();
+    result.unwrap();
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- retry transient occupied Unix control socket probe failures during daemon startup stabilization
- increase the Unix status probe timeout to avoid killing a runtime that is still producing status
- add a daemon startup stabilization regression test for the retry boundary

## Testing
- `cargo test startup_stability_retries_transient_occupied_socket_probe_failure`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
