### PR TITLE
refactor: route run loop messages through scheduler executor

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -37,6 +37,22 @@ impl RuntimeQueue {
             .or_else(|| self.background.pop_front())
     }
 
+    pub fn peek(&self) -> Option<&MessageEnvelope> {
+        self.interrupt
+            .front()
+            .or_else(|| self.next.front())
+            .or_else(|| self.normal.front())
+            .or_else(|| self.background.front())
+    }
+
+    pub fn pop_if_next(&mut self, message_id: &str) -> Option<MessageEnvelope> {
+        if self.peek().is_some_and(|message| message.id == message_id) {
+            self.pop()
+        } else {
+            None
+        }
+    }
+
     pub fn pop_interrupt_operator_prompt(&mut self) -> Option<MessageEnvelope> {
         let position = self.interrupt.iter().position(|message| {
             matches!(
@@ -123,6 +139,22 @@ mod tests {
             queue.pop().unwrap().body,
             MessageBody::Text { text: "n2".into() }
         );
+    }
+
+    #[test]
+    fn peek_and_pop_if_next_use_priority_head() {
+        let mut queue = RuntimeQueue::default();
+        let normal = msg(Priority::Normal, "normal");
+        let interrupt = msg(Priority::Interrupt, "interrupt");
+        let normal_id = normal.id.clone();
+        let interrupt_id = interrupt.id.clone();
+        queue.push(normal);
+        queue.push(interrupt);
+
+        assert_eq!(queue.peek().unwrap().id, interrupt_id);
+        assert!(queue.pop_if_next(&normal_id).is_none());
+        assert_eq!(queue.pop_if_next(&interrupt_id).unwrap().id, interrupt_id);
+        assert_eq!(queue.pop_if_next(&normal_id).unwrap().id, normal_id);
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,6 +12,7 @@ mod operator;
 mod operator_dispatch;
 mod provider_turn;
 mod scheduler;
+mod scheduler_executor;
 mod subagent;
 mod task_state_reducer;
 mod task_supervisor;
@@ -862,46 +863,14 @@ impl RuntimeHandle {
             }
         }
 
-        enum RunLoopPoll {
-            Stopped(AgentState, usize),
-            Message(MessageEnvelope, AgentState, AgentState),
-            Idle,
-        }
-
         loop {
-            let poll = {
-                let mut guard = self.inner.agent.lock().await;
-                if self.inner.shutdown_requested.load(Ordering::SeqCst) {
-                    guard.state.current_run_id = None;
-                    self.inner.storage.write_agent(&guard.state)?;
-                    return Ok(());
-                }
-                if guard.state.status == AgentStatus::Stopped {
-                    RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len())
-                } else if guard.state.status == AgentStatus::Paused {
-                    RunLoopPoll::Idle
-                } else if let Some(message) = guard.queue.pop() {
-                    let run_id = Uuid::new_v4().to_string();
-                    let interrupt_token = CancellationToken::new();
-                    let prior_state = guard.state.clone();
-                    guard.state.pending = guard.queue.len();
-                    scheduler::apply_running_projection(&mut guard.state, run_id.clone());
-                    guard.current_run_interrupt = Some(CurrentRunInterruptHandle {
-                        run_id: run_id.clone(),
-                        token: interrupt_token,
-                        reason: Arc::new(StdMutex::new("operator_interrupted".into())),
-                    });
-                    guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
-                    self.inner.storage.write_agent(&guard.state)?;
-                    let running_state = guard.state.clone();
-                    RunLoopPoll::Message(message, prior_state, running_state)
-                } else {
-                    RunLoopPoll::Idle
-                }
-            };
+            let poll = scheduler_executor::SchedulerDecisionExecutor::new(&self)
+                .poll()
+                .await?;
 
-            let (message, prior_state, running_state) = match poll {
-                RunLoopPoll::Stopped(state, queue_len) => {
+            let scheduled = match poll {
+                scheduler_executor::RunLoopPoll::Shutdown => return Ok(()),
+                scheduler_executor::RunLoopPoll::Stopped(state, queue_len) => {
                     let projection = scheduler::SchedulerProjection::from_state_with_queue_len(
                         &self.inner.storage,
                         &state,
@@ -915,10 +884,8 @@ impl RuntimeHandle {
                     scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                     return Ok(());
                 }
-                RunLoopPoll::Message(message, prior_state, running_state) => {
-                    (message, prior_state, running_state)
-                }
-                RunLoopPoll::Idle => {
+                scheduler_executor::RunLoopPoll::Message(scheduled) => scheduled,
+                scheduler_executor::RunLoopPoll::Idle => {
                     if self.maybe_emit_pending_system_tick(None).await? {
                         continue;
                     }
@@ -965,7 +932,8 @@ impl RuntimeHandle {
                 }
             };
 
-            self.append_state_changed_events(&running_state)?;
+            let message = scheduled.message.clone();
+            self.append_state_changed_events(&scheduled.running_state)?;
             self.inner.storage.append_queue_entry(&QueueEntryRecord {
                 message_id: message.id.clone(),
                 agent_id: message.agent_id.clone(),
@@ -975,8 +943,10 @@ impl RuntimeHandle {
                 updated_at: Utc::now(),
             })?;
 
-            let prior_closure = self.closure_decision_for_state(&prior_state, None).await?;
-            if let Err(err) = self.process_message(message.clone(), prior_closure).await {
+            if let Err(err) = self
+                .process_message_with_plan(scheduled.message, scheduled.dispatch_plan)
+                .await
+            {
                 let interrupted = err.downcast_ref::<CurrentRunInterrupted>().cloned();
                 if let Some(interrupted) = interrupted.as_ref() {
                     self.inner.storage.append_queue_entry(&QueueEntryRecord {

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -1,34 +1,31 @@
 use super::*;
 
+pub(super) struct MessageDispatchPlan {
+    pub(super) prior_closure: ClosureDecision,
+    pub(super) task: Option<TaskRecord>,
+    pub(super) continuation_trigger: Option<ContinuationTrigger>,
+    pub(super) continuation_resolution: Option<ContinuationResolution>,
+    pub(super) model_turn_allowed: bool,
+    pub(super) model_visible: bool,
+}
+
 impl RuntimeHandle {
-    pub(super) async fn process_message(
+    pub(super) fn build_message_dispatch_plan(
         &self,
-        mut message: MessageEnvelope,
+        message: &MessageEnvelope,
         prior_closure: ClosureDecision,
-    ) -> Result<()> {
-        message.normalize_admission_fields();
-        self.inner.storage.append_event(&AuditEvent::new(
-            "message_processing_started",
-            to_json_value(&message),
-        ))?;
+        scheduler_state: &AgentState,
+    ) -> Result<MessageDispatchPlan> {
         let task = match message.kind {
             MessageKind::TaskStatus | MessageKind::TaskResult => {
-                Some(tasks::task_from_message(&message, &message.agent_id)?)
+                Some(tasks::task_from_message(message, &message.agent_id)?)
             }
             _ => None,
         };
-        let continuation_trigger = ContinuationTrigger::from_message(&message, task.as_ref());
-        if let Some(trigger) = continuation_trigger.as_ref() {
-            self.record_continuation_trigger_received(&message, trigger, &prior_closure)
-                .await?;
-        }
+        let continuation_trigger = ContinuationTrigger::from_message(message, task.as_ref());
         let continuation_resolution = continuation_trigger
             .as_ref()
             .map(|trigger| resolve_continuation(&prior_closure, trigger));
-        let scheduler_state = {
-            let guard = self.inner.agent.lock().await;
-            guard.state.clone()
-        };
         let model_turn_allowed = !matches!(
             scheduler_state.status,
             AgentStatus::Paused | AgentStatus::Stopped
@@ -37,6 +34,28 @@ impl RuntimeHandle {
             && continuation_resolution
                 .as_ref()
                 .is_some_and(|resolution| resolution.model_visible);
+
+        Ok(MessageDispatchPlan {
+            prior_closure,
+            task,
+            continuation_trigger,
+            continuation_resolution,
+            model_turn_allowed,
+            model_visible,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(super) async fn process_message(
+        &self,
+        message: MessageEnvelope,
+        prior_closure: ClosureDecision,
+    ) -> Result<()> {
+        let scheduler_state = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.clone()
+        };
+        let plan = self.build_message_dispatch_plan(&message, prior_closure, &scheduler_state)?;
         let scheduler_projection =
             scheduler::SchedulerProjection::from_state(&self.inner.storage, &scheduler_state)?;
         let scheduler_decision = scheduler::decide_next_action(
@@ -44,11 +63,36 @@ impl RuntimeHandle {
             scheduler::SchedulerBoundary::MessageProcessing,
             scheduler::SchedulerInput::Message {
                 message: &message,
-                model_turn_allowed,
-                model_visible,
+                model_turn_allowed: plan.model_turn_allowed,
+                model_visible: plan.model_visible,
             },
         );
         scheduler::append_scheduler_decision(&self.inner.storage, &scheduler_decision)?;
+        self.process_message_with_plan(message, plan).await
+    }
+
+    pub(super) async fn process_message_with_plan(
+        &self,
+        mut message: MessageEnvelope,
+        plan: MessageDispatchPlan,
+    ) -> Result<()> {
+        message.normalize_admission_fields();
+        self.inner.storage.append_event(&AuditEvent::new(
+            "message_processing_started",
+            to_json_value(&message),
+        ))?;
+        let MessageDispatchPlan {
+            prior_closure,
+            task,
+            continuation_trigger,
+            continuation_resolution,
+            model_visible,
+            ..
+        } = plan;
+        if let Some(trigger) = continuation_trigger.as_ref() {
+            self.record_continuation_trigger_received(&message, trigger, &prior_closure)
+                .await?;
+        }
 
         match message.kind {
             MessageKind::OperatorPrompt

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(super) struct MessageDispatchPlan {
     pub(super) prior_closure: ClosureDecision,
-    pub(super) task: Option<TaskRecord>,
+    pub(super) task: Result<Option<TaskRecord>>,
     pub(super) continuation_trigger: Option<ContinuationTrigger>,
     pub(super) continuation_resolution: Option<ContinuationResolution>,
     pub(super) model_turn_allowed: bool,
@@ -18,11 +18,12 @@ impl RuntimeHandle {
     ) -> Result<MessageDispatchPlan> {
         let task = match message.kind {
             MessageKind::TaskStatus | MessageKind::TaskResult => {
-                Some(tasks::task_from_message(message, &message.agent_id)?)
+                tasks::task_from_message(message, &message.agent_id).map(Some)
             }
-            _ => None,
+            _ => Ok(None),
         };
-        let continuation_trigger = ContinuationTrigger::from_message(message, task.as_ref());
+        let continuation_trigger =
+            ContinuationTrigger::from_message(message, task.as_ref().ok().and_then(Option::as_ref));
         let continuation_resolution = continuation_trigger
             .as_ref()
             .map(|trigger| resolve_continuation(&prior_closure, trigger));
@@ -45,7 +46,8 @@ impl RuntimeHandle {
         })
     }
 
-    #[allow(dead_code)]
+    // Tests and direct runtime probes still exercise the per-message entrypoint.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) async fn process_message(
         &self,
         message: MessageEnvelope,
@@ -89,6 +91,7 @@ impl RuntimeHandle {
             model_visible,
             ..
         } = plan;
+        let task = task?;
         if let Some(trigger) = continuation_trigger.as_ref() {
             self.record_continuation_trigger_received(&message, trigger, &prior_closure)
                 .await?;

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -194,6 +194,7 @@ pub(crate) struct SchedulerDecision {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub(crate) enum SchedulerBoundary {
     RunLoop,
     RunLoopIdle,

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -194,10 +194,10 @@ pub(crate) struct SchedulerDecision {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum SchedulerBoundary {
     RunLoop,
     RunLoopIdle,
+    #[allow(dead_code)]
     MessageProcessing,
     IdleTick,
 }

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -33,7 +33,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let candidate = {
             let guard = self.runtime.inner.agent.lock().await;
             if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
-                return self.shutdown(guard).await;
+                return self.shutdown(guard);
             }
             if guard.state.status == AgentStatus::Stopped {
                 return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
@@ -54,7 +54,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         self.prepare_message(candidate).await
     }
 
-    async fn shutdown(
+    fn shutdown(
         &self,
         mut guard: tokio::sync::MutexGuard<'_, RuntimeAgent>,
     ) -> Result<RunLoopPoll> {
@@ -91,7 +91,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let (message, running_state) = {
             let mut guard = self.runtime.inner.agent.lock().await;
             if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
-                return self.shutdown(guard).await;
+                return self.shutdown(guard);
             }
             if matches!(
                 guard.state.status,

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -1,0 +1,139 @@
+use super::message_dispatch::MessageDispatchPlan;
+use super::*;
+
+pub(super) enum RunLoopPoll {
+    Shutdown,
+    Stopped(AgentState, usize),
+    Message(ScheduledMessage),
+    Idle,
+}
+
+pub(super) struct ScheduledMessage {
+    pub(super) message: MessageEnvelope,
+    pub(super) running_state: AgentState,
+    pub(super) dispatch_plan: MessageDispatchPlan,
+}
+
+pub(super) struct SchedulerDecisionExecutor<'a> {
+    runtime: &'a RuntimeHandle,
+}
+
+struct QueueCandidate {
+    message: MessageEnvelope,
+    prior_state: AgentState,
+    queue_len: usize,
+}
+
+impl<'a> SchedulerDecisionExecutor<'a> {
+    pub(super) fn new(runtime: &'a RuntimeHandle) -> Self {
+        Self { runtime }
+    }
+
+    pub(super) async fn poll(&self) -> Result<RunLoopPoll> {
+        let candidate = {
+            let guard = self.runtime.inner.agent.lock().await;
+            if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
+                return self.shutdown(guard).await;
+            }
+            if guard.state.status == AgentStatus::Stopped {
+                return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
+            }
+            if guard.state.status == AgentStatus::Paused {
+                return Ok(RunLoopPoll::Idle);
+            }
+            let Some(message) = guard.queue.peek().cloned() else {
+                return Ok(RunLoopPoll::Idle);
+            };
+            QueueCandidate {
+                message,
+                prior_state: guard.state.clone(),
+                queue_len: guard.queue.len(),
+            }
+        };
+
+        self.prepare_message(candidate).await
+    }
+
+    async fn shutdown(
+        &self,
+        mut guard: tokio::sync::MutexGuard<'_, RuntimeAgent>,
+    ) -> Result<RunLoopPoll> {
+        guard.state.current_run_id = None;
+        self.runtime.inner.storage.write_agent(&guard.state)?;
+        Ok(RunLoopPoll::Shutdown)
+    }
+
+    async fn prepare_message(&self, candidate: QueueCandidate) -> Result<RunLoopPoll> {
+        let prior_closure = self
+            .runtime
+            .closure_decision_for_state(&candidate.prior_state, None)
+            .await?;
+        let dispatch_plan = self.runtime.build_message_dispatch_plan(
+            &candidate.message,
+            prior_closure,
+            &candidate.prior_state,
+        )?;
+        let projection = scheduler::SchedulerProjection::from_state_with_queue_len(
+            &self.runtime.inner.storage,
+            &candidate.prior_state,
+            candidate.queue_len,
+        )?;
+        let decision = scheduler::decide_next_action(
+            &projection,
+            scheduler::SchedulerBoundary::RunLoop,
+            scheduler::SchedulerInput::Message {
+                message: &candidate.message,
+                model_turn_allowed: dispatch_plan.model_turn_allowed,
+                model_visible: dispatch_plan.model_visible,
+            },
+        );
+
+        let (message, running_state) = {
+            let mut guard = self.runtime.inner.agent.lock().await;
+            if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
+                return self.shutdown(guard).await;
+            }
+            if matches!(
+                guard.state.status,
+                AgentStatus::Paused | AgentStatus::Stopped
+            ) {
+                return Ok(if guard.state.status == AgentStatus::Stopped {
+                    RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len())
+                } else {
+                    RunLoopPoll::Idle
+                });
+            }
+            if !guard
+                .queue
+                .peek()
+                .is_some_and(|message| message.id == candidate.message.id)
+            {
+                return Ok(RunLoopPoll::Idle);
+            }
+
+            scheduler::append_scheduler_decision(&self.runtime.inner.storage, &decision)?;
+            let message = guard
+                .queue
+                .pop_if_next(&candidate.message.id)
+                .expect("queue head was just checked");
+            let run_id = Uuid::new_v4().to_string();
+            let interrupt_token = CancellationToken::new();
+            guard.state.pending = guard.queue.len();
+            scheduler::apply_running_projection(&mut guard.state, run_id.clone());
+            guard.current_run_interrupt = Some(CurrentRunInterruptHandle {
+                run_id: run_id.clone(),
+                token: interrupt_token,
+                reason: Arc::new(StdMutex::new("operator_interrupted".into())),
+            });
+            guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
+            self.runtime.inner.storage.write_agent(&guard.state)?;
+            (message, guard.state.clone())
+        };
+
+        Ok(RunLoopPoll::Message(ScheduledMessage {
+            message,
+            running_state,
+            dispatch_plan,
+        }))
+    }
+}

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -97,6 +97,77 @@ async fn runtime_replays_unprocessed_queue_messages_after_restart() {
 }
 
 #[tokio::test]
+async fn runtime_records_scheduler_decision_before_dequeueing_message() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("scheduled")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let message = runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "schedule me".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let events = runtime.storage().read_recent_events(200).unwrap();
+        if events
+            .iter()
+            .any(|event| event.kind == "message_processing_started")
+        {
+            let decision_index = events
+                .iter()
+                .position(|event| {
+                    event.kind == "scheduler_decision"
+                        && event.data["message_id"] == message.id.as_str()
+                        && event.data["boundary"] == "run_loop"
+                })
+                .expect("run loop scheduler decision should be recorded");
+            let processing_index = events
+                .iter()
+                .position(|event| event.kind == "message_processing_started")
+                .expect("message processing should start");
+            assert!(
+                decision_index < processing_index,
+                "scheduler decision should be recorded before message processing starts"
+            );
+            let decision = &events[decision_index];
+            assert_eq!(decision.data["decision"], "StartModelTurn");
+            assert_eq!(decision.data["model_visible"], true);
+            assert!(!events.iter().any(|event| {
+                event.kind == "scheduler_decision"
+                    && event.data["message_id"] == message.id.as_str()
+                    && event.data["boundary"] == "message_processing"
+            }));
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "message was not processed before deadline"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    runtime_task.abort();
+}
+
+#[tokio::test]
 async fn runtime_interrupts_inflight_task_after_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -128,10 +128,9 @@ async fn runtime_records_scheduler_decision_before_dequeueing_message() {
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
         let events = runtime.storage().read_recent_events(200).unwrap();
-        if events
-            .iter()
-            .any(|event| event.kind == "message_processing_started")
-        {
+        if events.iter().any(|event| {
+            event.kind == "message_processing_started" && event.data["id"] == message.id.as_str()
+        }) {
             let decision_index = events
                 .iter()
                 .position(|event| {
@@ -142,7 +141,10 @@ async fn runtime_records_scheduler_decision_before_dequeueing_message() {
                 .expect("run loop scheduler decision should be recorded");
             let processing_index = events
                 .iter()
-                .position(|event| event.kind == "message_processing_started")
+                .position(|event| {
+                    event.kind == "message_processing_started"
+                        && event.data["id"] == message.id.as_str()
+                })
                 .expect("message processing should start");
             assert!(
                 decision_index < processing_index,
@@ -161,6 +163,83 @@ async fn runtime_records_scheduler_decision_before_dequeueing_message() {
         assert!(
             tokio::time::Instant::now() < deadline,
             "message was not processed before deadline"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    runtime_task.abort();
+}
+
+#[tokio::test]
+async fn malformed_task_message_does_not_exit_runtime_loop() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("still running")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let mut malformed = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "bad-task".into(),
+        },
+        TrustLevel::TrustedSystem,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "malformed task result".into(),
+        },
+    );
+    malformed.metadata = Some(serde_json::json!({
+        "task_kind": "child_agent_task",
+        "task_status": "completed",
+    }));
+    let malformed = runtime.enqueue(malformed).await.unwrap();
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "continue after malformed task".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let briefs = runtime.storage().read_recent_briefs(10).unwrap();
+        if briefs
+            .iter()
+            .any(|brief| brief.text.contains("still running"))
+        {
+            let events = runtime.storage().read_recent_events(200).unwrap();
+            assert!(events.iter().any(|event| {
+                event.kind == "runtime_error"
+                    && event.data["message_id"] == malformed.id.as_str()
+                    && event.data["error"]
+                        .as_str()
+                        .is_some_and(|error| error.contains("metadata.task_id"))
+            }));
+            assert!(events.iter().any(|event| {
+                event.kind == "scheduler_decision"
+                    && event.data["message_id"] == malformed.id.as_str()
+                    && event.data["boundary"] == "run_loop"
+            }));
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "runtime did not process the message after malformed task result"
         );
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }


### PR DESCRIPTION
## Summary

Implements step 1 of the scheduler RFC landing plan: route queued run-loop messages through an explicit scheduler decision executor before mutating queue/runtime state.

Changes:
- adds `SchedulerDecisionExecutor` for run-loop polling and queued message execution
- computes the message dispatch plan before dequeue/running-state mutation
- appends the run-loop `scheduler_decision` before queue dequeue/state transition
- reuses the precomputed dispatch plan in message processing to avoid a second scheduler path
- adds queue head helpers and regression coverage for decision-before-processing order

## Validation

- `cargo check --quiet`
- `cargo test scheduler --quiet`
- `cargo test task_recovery --quiet`
- `cargo test queue --quiet`
- `cargo test runtime_records_scheduler_decision_before_dequeueing_message --quiet`
- `cargo test --quiet -- --test-threads=1`

Note: plain parallel `cargo test --quiet` still fails in existing config env-var tests because those tests mutate shared process environment; single-threaded full test passes.
