### PR TITLE
Fix skill install and slash command handling

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -2847,7 +2847,19 @@ fn skill_install_error_response(error: anyhow::Error) -> (StatusCode, Json<Value
                         "stderr": failed.stderr,
                     })),
                 ),
-                Err(error) => error_response(error),
+                Err(error) => match error.downcast::<crate::skills::RemoteSkillInstallTimedOut>() {
+                    Ok(timeout) => (
+                        StatusCode::GATEWAY_TIMEOUT,
+                        Json(json!({
+                            "ok": false,
+                            "code": "remote_skill_install_timeout",
+                            "error": timeout.to_string(),
+                            "package": timeout.package,
+                            "timeout_seconds": timeout.timeout.as_secs(),
+                        })),
+                    ),
+                    Err(error) => error_response(error),
+                },
             },
         },
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -2823,7 +2823,33 @@ fn skill_install_error_response(error: anyhow::Error) -> (StatusCode, Json<Value
                 "hint": "uninstall the existing skill first or choose a different skill name",
             })),
         ),
-        Err(error) => error_response(error),
+        Err(error) => match error.downcast::<crate::skills::SkillManagerUnavailable>() {
+            Ok(unavailable) => (
+                StatusCode::FAILED_DEPENDENCY,
+                Json(json!({
+                    "ok": false,
+                    "code": "skill_manager_unavailable",
+                    "error": unavailable.to_string(),
+                    "manager": unavailable.manager,
+                    "hint": "Install Node.js/npm so `npx skills` is available, or install the skill manually into ~/.agents/skills and link it by name.",
+                })),
+            ),
+            Err(error) => match error.downcast::<crate::skills::RemoteSkillInstallFailed>() {
+                Ok(failed) => (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({
+                        "ok": false,
+                        "code": "remote_skill_install_failed",
+                        "error": failed.to_string(),
+                        "package": failed.package,
+                        "exit_status": failed.status,
+                        "stdout": failed.stdout,
+                        "stderr": failed.stderr,
+                    })),
+                ),
+                Err(error) => error_response(error),
+            },
+        },
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -452,6 +452,10 @@ enum SkillsCommands {
         #[arg(long)]
         builtin: bool,
         #[arg(long)]
+        remote: bool,
+        #[arg(long)]
+        skill: Option<String>,
+        #[arg(long)]
         copy: bool,
         #[arg(long)]
         agent: Option<String>,
@@ -1455,6 +1459,40 @@ mod tests {
     }
 
     #[test]
+    fn skills_install_remote_cli_builds_remote_request() {
+        let cli = Cli::parse_from([
+            "holon",
+            "skills",
+            "install",
+            "vercel-labs/agent-skills",
+            "--remote",
+            "--skill",
+            "pr-review",
+        ]);
+        let Commands::Skills {
+            command:
+                SkillsCommands::Install {
+                    name_or_path,
+                    builtin,
+                    remote,
+                    skill,
+                    copy,
+                    agent,
+                },
+        } = cli.command
+        else {
+            panic!("expected skills install command");
+        };
+
+        assert_eq!(name_or_path, "vercel-labs/agent-skills");
+        assert!(!builtin);
+        assert!(remote);
+        assert_eq!(skill.as_deref(), Some("pr-review"));
+        assert!(!copy);
+        assert_eq!(agent, None);
+    }
+
+    #[test]
     fn unspecified_listen_accepts_explicit_advertise_url() {
         let mut config = test_config();
         let advertise = apply_serve_options(
@@ -2284,13 +2322,32 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
         SkillsCommands::Install {
             name_or_path,
             builtin,
+            remote,
+            skill,
             copy,
             agent,
         } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
             let kind = if builtin {
+                if remote || skill.is_some() {
+                    anyhow::bail!("--builtin cannot be combined with --remote or --skill");
+                }
                 holon::types::SkillInstallKind::Builtin { name: name_or_path }
+            } else if remote {
+                let mode = if copy {
+                    holon::types::SkillInstallMode::Copied
+                } else {
+                    holon::types::SkillInstallMode::Linked
+                };
+                holon::types::SkillInstallKind::Remote {
+                    package: name_or_path,
+                    skill,
+                    mode,
+                }
             } else {
+                if skill.is_some() {
+                    anyhow::bail!("--skill requires --remote");
+                }
                 build_skill_install_kind(&name_or_path, copy)?
             };
             post_control_json(

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::{Command, Output},
+    process::{Command, Output, Stdio},
     time::Duration,
 };
 
@@ -404,6 +404,10 @@ fn command_output_with_timeout(
     command: &mut Command,
     timeout: Duration,
 ) -> std::io::Result<Option<Output>> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     let mut child = command.spawn()?;
     let deadline = std::time::Instant::now() + timeout;
     loop {
@@ -1517,6 +1521,23 @@ mod tests {
         for package in ["vercel-labs/agent-skills", "@scope/package", "agent-skills"] {
             validate_remote_package(package).unwrap();
         }
+    }
+
+    #[test]
+    fn command_output_with_timeout_captures_failed_process_output() {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "read ignored || true; printf captured-stdout; printf captured-stderr >&2; exit 7",
+        ]);
+
+        let output = command_output_with_timeout(&mut command, Duration::from_secs(5))
+            .unwrap()
+            .expect("process should exit before timeout");
+
+        assert_eq!(output.status.code(), Some(7));
+        assert_eq!(bounded_output_excerpt(&output.stdout), "captured-stdout");
+        assert_eq!(bounded_output_excerpt(&output.stderr), "captured-stderr");
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,7 +1,8 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Output},
+    time::Duration,
 };
 
 use anyhow::{bail, Context, Result};
@@ -322,6 +323,25 @@ impl std::fmt::Display for RemoteSkillInstallFailed {
 
 impl std::error::Error for RemoteSkillInstallFailed {}
 
+#[derive(Debug, Clone)]
+pub struct RemoteSkillInstallTimedOut {
+    pub package: String,
+    pub timeout: Duration,
+}
+
+impl std::fmt::Display for RemoteSkillInstallTimedOut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "remote skill install for '{}' timed out after {}s",
+            self.package,
+            self.timeout.as_secs()
+        )
+    }
+}
+
+impl std::error::Error for RemoteSkillInstallTimedOut {}
+
 trait RemoteSkillInstaller {
     fn add_global(&self, package: &str, skill: Option<&str>) -> Result<()>;
 }
@@ -330,8 +350,20 @@ struct NpxRemoteSkillInstaller;
 
 impl RemoteSkillInstaller for NpxRemoteSkillInstaller {
     fn add_global(&self, package: &str, skill: Option<&str>) -> Result<()> {
-        match Command::new("npx").arg("--version").output() {
-            Ok(_) => {}
+        const REMOTE_SKILL_INSTALL_TIMEOUT: Duration = Duration::from_secs(120);
+
+        match command_output_with_timeout(
+            Command::new("npx").arg("--version"),
+            Duration::from_secs(10),
+        ) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return Err(RemoteSkillInstallTimedOut {
+                    package: package.into(),
+                    timeout: Duration::from_secs(10),
+                }
+                .into());
+            }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 return Err(SkillManagerUnavailable {
                     manager: "npx".into(),
@@ -346,9 +378,15 @@ impl RemoteSkillInstaller for NpxRemoteSkillInstaller {
         if let Some(skill) = skill {
             command.args(["--skill", skill]);
         }
-        let output = command
-            .output()
+        let output = command_output_with_timeout(&mut command, REMOTE_SKILL_INSTALL_TIMEOUT)
             .with_context(|| format!("failed to run npx skills add for {package}"))?;
+        let Some(output) = output else {
+            return Err(RemoteSkillInstallTimedOut {
+                package: package.into(),
+                timeout: REMOTE_SKILL_INSTALL_TIMEOUT,
+            }
+            .into());
+        };
         if !output.status.success() {
             return Err(RemoteSkillInstallFailed {
                 package: package.into(),
@@ -359,6 +397,25 @@ impl RemoteSkillInstaller for NpxRemoteSkillInstaller {
             .into());
         }
         Ok(())
+    }
+}
+
+fn command_output_with_timeout(
+    command: &mut Command,
+    timeout: Duration,
+) -> std::io::Result<Option<Output>> {
+    let mut child = command.spawn()?;
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output().map(Some);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(None);
+        }
+        std::thread::sleep(Duration::from_millis(50));
     }
 }
 
@@ -512,6 +569,18 @@ fn install_skill_with_user_home_and_remote_installer(
 fn validate_remote_package(package: &str) -> Result<()> {
     if package.trim().is_empty() {
         bail!("remote skill package must not be empty");
+    }
+    if package.trim() != package {
+        bail!("remote skill package must not contain leading or trailing whitespace");
+    }
+    if package.starts_with('-') {
+        bail!("remote skill package must not start with '-'");
+    }
+    if package
+        .chars()
+        .any(|ch| ch.is_control() || ch.is_ascii_whitespace())
+    {
+        bail!("remote skill package must not contain whitespace or control characters");
     }
     Ok(())
 }
@@ -1429,6 +1498,25 @@ mod tests {
             .downcast_ref::<SkillManagerUnavailable>()
             .expect("missing remote manager should be structured");
         assert_eq!(unavailable.manager, "npx");
+    }
+
+    #[test]
+    fn remote_package_validation_rejects_option_like_and_whitespace_refs() {
+        for package in [
+            "", " ", "--help", "-x", " demo", "demo ", "foo bar", "foo\nbar",
+        ] {
+            assert!(
+                validate_remote_package(package).is_err(),
+                "package should be rejected: {package:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn remote_package_validation_accepts_common_package_refs() {
+        for package in ["vercel-labs/agent-skills", "@scope/package", "agent-skills"] {
+            validate_remote_package(package).unwrap();
+        }
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use anyhow::{bail, Context, Result};
@@ -281,6 +282,132 @@ impl std::fmt::Display for SkillInstallConflict {
 
 impl std::error::Error for SkillInstallConflict {}
 
+#[derive(Debug, Clone)]
+pub struct SkillManagerUnavailable {
+    pub manager: String,
+}
+
+impl std::fmt::Display for SkillManagerUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "remote skill install requires {}", self.manager)
+    }
+}
+
+impl std::error::Error for SkillManagerUnavailable {}
+
+#[derive(Debug, Clone)]
+pub struct RemoteSkillInstallFailed {
+    pub package: String,
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl std::fmt::Display for RemoteSkillInstallFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.status {
+            Some(status) => write!(
+                f,
+                "remote skill install for '{}' failed with exit status {}",
+                self.package, status
+            ),
+            None => write!(
+                f,
+                "remote skill install for '{}' failed before process exit",
+                self.package
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RemoteSkillInstallFailed {}
+
+trait RemoteSkillInstaller {
+    fn add_global(&self, package: &str, skill: Option<&str>) -> Result<()>;
+}
+
+struct NpxRemoteSkillInstaller;
+
+impl RemoteSkillInstaller for NpxRemoteSkillInstaller {
+    fn add_global(&self, package: &str, skill: Option<&str>) -> Result<()> {
+        match Command::new("npx").arg("--version").output() {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(SkillManagerUnavailable {
+                    manager: "npx".into(),
+                }
+                .into());
+            }
+            Err(error) => return Err(error).context("failed to check npx availability"),
+        }
+
+        let mut command = Command::new("npx");
+        command.args(["--yes", "skills", "add", package, "--global", "--yes"]);
+        if let Some(skill) = skill {
+            command.args(["--skill", skill]);
+        }
+        let output = command
+            .output()
+            .with_context(|| format!("failed to run npx skills add for {package}"))?;
+        if !output.status.success() {
+            return Err(RemoteSkillInstallFailed {
+                package: package.into(),
+                status: output.status.code(),
+                stdout: bounded_output_excerpt(&output.stdout),
+                stderr: bounded_output_excerpt(&output.stderr),
+            }
+            .into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct RecordedRemoteSkillInstall {
+    package: String,
+    skill: Option<String>,
+}
+
+#[cfg(test)]
+struct RecordingRemoteSkillInstaller {
+    calls: std::sync::Arc<std::sync::Mutex<Vec<RecordedRemoteSkillInstall>>>,
+}
+
+#[cfg(test)]
+impl RemoteSkillInstaller for RecordingRemoteSkillInstaller {
+    fn add_global(&self, package: &str, skill: Option<&str>) -> Result<()> {
+        self.calls.lock().unwrap().push(RecordedRemoteSkillInstall {
+            package: package.into(),
+            skill: skill.map(str::to_string),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+struct UnavailableRemoteSkillInstaller;
+
+#[cfg(test)]
+impl RemoteSkillInstaller for UnavailableRemoteSkillInstaller {
+    fn add_global(&self, _package: &str, _skill: Option<&str>) -> Result<()> {
+        Err(SkillManagerUnavailable {
+            manager: "npx".into(),
+        }
+        .into())
+    }
+}
+
+fn bounded_output_excerpt(bytes: &[u8]) -> String {
+    const MAX_OUTPUT_BYTES: usize = 2048;
+    let excerpt = if bytes.len() > MAX_OUTPUT_BYTES {
+        &bytes[..MAX_OUTPUT_BYTES]
+    } else {
+        bytes
+    };
+    String::from_utf8_lossy(excerpt).to_string()
+}
+
 /// Validate that a skill name is a single path component with no traversal.
 fn validate_skill_name(name: &str) -> Result<()> {
     if name.is_empty()
@@ -319,6 +446,20 @@ pub fn install_skill_with_user_home(
     user_home: Option<&Path>,
     kind: &crate::types::SkillInstallKind,
 ) -> Result<String> {
+    install_skill_with_user_home_and_remote_installer(
+        agent_home,
+        user_home,
+        kind,
+        &NpxRemoteSkillInstaller,
+    )
+}
+
+fn install_skill_with_user_home_and_remote_installer(
+    agent_home: &Path,
+    user_home: Option<&Path>,
+    kind: &crate::types::SkillInstallKind,
+    remote_installer: &dyn RemoteSkillInstaller,
+) -> Result<String> {
     let skills_root = agent_skills_root(agent_home);
     fs::create_dir_all(&skills_root)
         .with_context(|| format!("failed to create {}", skills_root.display()))?;
@@ -347,8 +488,41 @@ pub fn install_skill_with_user_home(
         crate::types::SkillInstallKind::Local { path, mode } => {
             materialize_local_skill(&skills_root, path, mode)?
         }
+        crate::types::SkillInstallKind::Remote {
+            package,
+            skill,
+            mode,
+        } => {
+            validate_remote_package(package)?;
+            if let Some(skill) = skill {
+                validate_skill_name(skill)?;
+            }
+            remote_installer.add_global(package, skill.as_deref())?;
+            let skill_name = match skill {
+                Some(skill) => skill.as_str(),
+                None => remote_package_default_skill_name(package)?,
+            };
+            let path = resolve_user_skill_by_name(user_home, skill_name)?;
+            materialize_local_skill(&skills_root, &path, mode)?
+        }
     };
     Ok(name)
+}
+
+fn validate_remote_package(package: &str) -> Result<()> {
+    if package.trim().is_empty() {
+        bail!("remote skill package must not be empty");
+    }
+    Ok(())
+}
+
+fn remote_package_default_skill_name(package: &str) -> Result<&str> {
+    package
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("remote skill package has no usable default skill name"))
 }
 
 fn materialize_local_skill(
@@ -397,8 +571,8 @@ fn normalize_local_skill_path(path: &Path) -> Result<PathBuf> {
 }
 
 fn resolve_user_skill_by_name(user_home: Option<&Path>, name: &str) -> Result<PathBuf> {
-    let mut matches = Vec::new();
     for root in existing_skill_roots(user_home, &COMPAT_SKILL_ROOT_SUFFIXES) {
+        let mut root_matches = Vec::new();
         for skill in load_catalog_for_scope(SkillScope::User, &root)? {
             let dir_name = skill
                 .path
@@ -408,29 +582,31 @@ fn resolve_user_skill_by_name(user_home: Option<&Path>, name: &str) -> Result<Pa
                 .unwrap_or("");
             if skill.name == name || dir_name == name {
                 if let Some(skill_dir) = skill.path.parent() {
-                    matches.push(skill_dir.to_path_buf());
+                    root_matches.push(skill_dir.to_path_buf());
                 }
             }
         }
+        root_matches.sort();
+        root_matches.dedup();
+        match root_matches.as_slice() {
+            [] => {}
+            [path] => return Ok(path.clone()),
+            paths => bail!(
+                "skill '{}' matched multiple user-global skill directories under {}: {}; use an explicit path",
+                name,
+                root.display(),
+                paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
     }
-    matches.sort();
-    matches.dedup();
-    match matches.as_slice() {
-        [path] => Ok(path.clone()),
-        [] => bail!(
-            "skill '{}' is not a builtin skill and was not found in the user-global skill catalog; use an explicit path",
-            name
-        ),
-        paths => bail!(
-            "skill '{}' matched multiple user-global skill directories: {}; use an explicit path",
-            name,
-            paths
-                .iter()
-                .map(|path| path.display().to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
-    }
+    bail!(
+        "skill '{}' is not a builtin skill and was not found in the user-global skill catalog; use an explicit path",
+        name
+    )
 }
 
 fn materialize_linked_skill_ref(skills_root: &Path, path: &Path) -> Result<PathBuf> {
@@ -1203,29 +1379,95 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_user_global_skill_name_requires_explicit_path() {
+    fn named_install_prefers_agents_user_global_skill_over_compat_roots() {
         let dir = tempdir().unwrap();
         let user_home = dir.path().join("user");
-        for root in [".agents/skills", ".codex/skills"] {
+        let agent_home = dir.path().join("agent");
+        for (root, description) in [(".agents/skills", "preferred"), (".codex/skills", "compat")] {
             let source = user_home.join(root).join("demo");
             fs::create_dir_all(&source).unwrap();
             fs::write(
                 source.join(SKILL_ENTRYPOINT),
-                "---\nname: demo\ndescription: duplicate\n---\nbody",
+                format!("---\nname: demo\ndescription: {description}\n---\nbody"),
             )
             .unwrap();
         }
 
-        let error = install_skill_with_user_home(
-            &dir.path().join("agent"),
+        let installed = install_skill_with_user_home(
+            &agent_home,
             Some(&user_home),
             &crate::types::SkillInstallKind::Named {
                 name: "demo".into(),
                 mode: SkillInstallMode::Linked,
             },
         )
+        .unwrap();
+
+        assert_eq!(installed, "demo");
+        assert_eq!(
+            fs::read_link(agent_home.join("skills/demo")).unwrap(),
+            user_home.join(".agents/skills/demo")
+        );
+    }
+
+    #[test]
+    fn remote_install_requires_skill_manager() {
+        let dir = tempdir().unwrap();
+        let error = install_skill_with_user_home_and_remote_installer(
+            &dir.path().join("agent"),
+            Some(&dir.path().join("user")),
+            &crate::types::SkillInstallKind::Remote {
+                package: "vercel-labs/agent-skills".into(),
+                skill: Some("demo".into()),
+                mode: SkillInstallMode::Linked,
+            },
+            &UnavailableRemoteSkillInstaller,
+        )
         .unwrap_err();
 
-        assert!(error.to_string().contains("matched multiple"));
+        let unavailable = error
+            .downcast_ref::<SkillManagerUnavailable>()
+            .expect("missing remote manager should be structured");
+        assert_eq!(unavailable.manager, "npx");
+    }
+
+    #[test]
+    fn remote_install_adds_global_skill_non_interactively_then_links_to_agent() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("user");
+        let agent_home = dir.path().join("agent");
+        let source = user_home.join(".agents/skills/demo");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join(SKILL_ENTRYPOINT),
+            "---\nname: demo\ndescription: remote\n---\nbody",
+        )
+        .unwrap();
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let installer = RecordingRemoteSkillInstaller {
+            calls: calls.clone(),
+        };
+
+        let installed = install_skill_with_user_home_and_remote_installer(
+            &agent_home,
+            Some(&user_home),
+            &crate::types::SkillInstallKind::Remote {
+                package: "vercel-labs/agent-skills".into(),
+                skill: Some("demo".into()),
+                mode: SkillInstallMode::Linked,
+            },
+            &installer,
+        )
+        .unwrap();
+
+        assert_eq!(installed, "demo");
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].package, "vercel-labs/agent-skills");
+        assert_eq!(calls[0].skill.as_deref(), Some("demo"));
+        assert_eq!(
+            fs::read_link(agent_home.join("skills/demo")).unwrap(),
+            user_home.join(".agents/skills/demo")
+        );
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -378,16 +378,12 @@ fn paste_single_line_text(text: &str) -> String {
 
 impl TuiApp {
     fn should_treat_enter_as_paste_newline(&self, key: KeyEvent) -> bool {
-        const PASTE_BURST_ENTER_WINDOW: Duration = Duration::from_millis(30);
-
-        let trimmed = self.composer.as_str().trim_start();
-        if key.code != KeyCode::Enter || !key.modifiers.is_empty() || trimmed.is_empty() {
-            return false;
-        }
-        self.composer_key_burst_len > 0
-            && self
-                .composer_key_burst_last_at
-                .is_some_and(|last_at| last_at.elapsed() <= PASTE_BURST_ENTER_WINDOW)
+        should_treat_enter_as_paste_newline_state(
+            self.composer.as_str(),
+            key,
+            self.composer_key_burst_len,
+            self.composer_key_burst_last_at,
+        )
     }
 
     fn record_composer_key_edit(&mut self, action: TuiKeyAction) {
@@ -1293,6 +1289,27 @@ impl TuiApp {
     }
 }
 
+fn should_treat_enter_as_paste_newline_state(
+    composer_text: &str,
+    key: KeyEvent,
+    composer_key_burst_len: usize,
+    composer_key_burst_last_at: Option<Instant>,
+) -> bool {
+    const PASTE_BURST_ENTER_WINDOW: Duration = Duration::from_millis(30);
+
+    let trimmed = composer_text.trim_start();
+    if key.code != KeyCode::Enter
+        || !key.modifiers.is_empty()
+        || trimmed.is_empty()
+        || trimmed.starts_with('/')
+    {
+        return false;
+    }
+    composer_key_burst_len > 0
+        && composer_key_burst_last_at
+            .is_some_and(|last_at| last_at.elapsed() <= PASTE_BURST_ENTER_WINDOW)
+}
+
 fn slash_menu_enter_submission(buffer: &str, selected: SlashCommandSpec) -> String {
     let trimmed = buffer.trim();
     let Some((token, rest)) = trimmed.split_once(char::is_whitespace) else {
@@ -1416,10 +1433,12 @@ impl TuiApp {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_agent_slash_action, parse_composer_submission, slash_command_spec,
-        slash_menu_enter_submission, slash_menu_specs, slash_prompt_lines, AgentSlashAction,
-        ComposerSubmission, SlashCommand,
+        parse_agent_slash_action, parse_composer_submission,
+        should_treat_enter_as_paste_newline_state, slash_command_spec, slash_menu_enter_submission,
+        slash_menu_specs, slash_prompt_lines, AgentSlashAction, ComposerSubmission, SlashCommand,
     };
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::time::Instant;
 
     #[test]
     fn parses_plain_chat_submission() {
@@ -1435,6 +1454,26 @@ mod tests {
             parse_composer_submission("//hello").unwrap(),
             Some(ComposerSubmission::Chat("/hello".into()))
         );
+    }
+
+    #[test]
+    fn paste_newline_heuristic_does_not_intercept_slash_commands() {
+        assert!(!should_treat_enter_as_paste_newline_state(
+            "/skills",
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            1,
+            Some(Instant::now()),
+        ));
+    }
+
+    #[test]
+    fn paste_newline_heuristic_still_applies_to_plain_text_bursts() {
+        assert!(should_treat_enter_as_paste_newline_state(
+            "hello",
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            1,
+            Some(Instant::now()),
+        ));
     }
 
     #[test]

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1301,13 +1301,20 @@ fn should_treat_enter_as_paste_newline_state(
     if key.code != KeyCode::Enter
         || !key.modifiers.is_empty()
         || trimmed.is_empty()
-        || trimmed.starts_with('/')
+        || (trimmed.starts_with('/') && is_complete_slash_command_token(trimmed))
     {
         return false;
     }
     composer_key_burst_len > 0
         && composer_key_burst_last_at
             .is_some_and(|last_at| last_at.elapsed() <= PASTE_BURST_ENTER_WINDOW)
+}
+
+fn is_complete_slash_command_token(trimmed: &str) -> bool {
+    let Some(token) = trimmed.split_whitespace().next() else {
+        return false;
+    };
+    slash_command_spec(token).is_some()
 }
 
 fn slash_menu_enter_submission(buffer: &str, selected: SlashCommandSpec) -> String {

--- a/src/types.rs
+++ b/src/types.rs
@@ -721,6 +721,13 @@ pub enum SkillInstallKind {
         #[serde(default)]
         mode: SkillInstallMode,
     },
+    Remote {
+        package: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        skill: Option<String>,
+        #[serde(default)]
+        mode: SkillInstallMode,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- keep slash commands out of the paste-newline heuristic so `/skills` and other `/...` commands submit reliably
- resolve named user-global skill installs by root priority, preferring `~/.agents/skills` over compatibility roots
- add remote skill install support via non-interactive `npx --yes skills add <package> --global --yes`, plus CLI `--remote --skill` plumbing and structured manager/command errors

Closes #1044
Closes #1048
Closes #1053

## Testing
- `cargo test skill`
- `cargo test paste_newline_heuristic`
- `cargo test skills_install_remote_cli_builds_remote_request`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
