### PR TITLE
refactor: converge scheduler event and posture paths

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::types::{MessageEnvelope, MessageKind, MessageOrigin, Priority, TrustLevel};
+use crate::types::{MessageEnvelope, Priority};
 
 #[derive(Debug, Default, Clone)]
 pub struct RuntimeQueue {
@@ -53,24 +53,14 @@ impl RuntimeQueue {
         }
     }
 
-    pub fn pop_interrupt_operator_prompt(&mut self) -> Option<MessageEnvelope> {
-        let position = self.interrupt.iter().position(|message| {
-            matches!(
-                (
-                    &message.kind,
-                    &message.origin,
-                    &message.trust,
-                    &message.priority,
-                ),
-                (
-                    MessageKind::OperatorPrompt,
-                    MessageOrigin::Operator { .. },
-                    TrustLevel::TrustedOperator,
-                    Priority::Interrupt,
-                )
-            )
-        })?;
-        self.interrupt.remove(position)
+    pub fn pop_next_matching(
+        &mut self,
+        mut predicate: impl FnMut(&MessageEnvelope) -> bool,
+    ) -> Option<MessageEnvelope> {
+        pop_matching_from(&mut self.interrupt, &mut predicate)
+            .or_else(|| pop_matching_from(&mut self.next, &mut predicate))
+            .or_else(|| pop_matching_from(&mut self.normal, &mut predicate))
+            .or_else(|| pop_matching_from(&mut self.background, &mut predicate))
     }
 
     pub fn len(&self) -> usize {
@@ -80,6 +70,14 @@ impl RuntimeQueue {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+}
+
+fn pop_matching_from(
+    queue: &mut VecDeque<MessageEnvelope>,
+    predicate: &mut impl FnMut(&MessageEnvelope) -> bool,
+) -> Option<MessageEnvelope> {
+    let position = queue.iter().position(predicate)?;
+    queue.remove(position)
 }
 
 #[cfg(test)]
@@ -158,14 +156,26 @@ mod tests {
     }
 
     #[test]
-    fn pop_interrupt_operator_prompt_only_drains_trusted_operator_interrupts() {
+    fn pop_next_matching_uses_priority_order() {
         let mut queue = RuntimeQueue::default();
         queue.push(msg(Priority::Interrupt, "webhook"));
         queue.push(operator_msg(Priority::Normal, "normal-operator"));
         queue.push(operator_msg(Priority::Interrupt, "interrupt-operator"));
 
         assert_eq!(
-            queue.pop_interrupt_operator_prompt().unwrap().body,
+            queue
+                .pop_next_matching(|message| {
+                    matches!(
+                        (&message.kind, &message.origin, &message.trust),
+                        (
+                            MessageKind::OperatorPrompt,
+                            MessageOrigin::Operator { .. },
+                            TrustLevel::TrustedOperator,
+                        )
+                    )
+                })
+                .unwrap()
+                .body,
             MessageBody::Text {
                 text: "interrupt-operator".into()
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -810,13 +810,7 @@ impl RuntimeHandle {
             guard.state.pending = guard.queue.len();
             guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
             guard.state.total_message_count = self.inner.storage.count_messages()?;
-            if matches!(
-                guard.state.status,
-                AgentStatus::Asleep | AgentStatus::Booting
-            ) {
-                guard.state.status = AgentStatus::AwakeIdle;
-                guard.state.sleeping_until = None;
-            }
+            scheduler::apply_message_wake_projection(&mut guard.state);
             self.inner.storage.write_agent(&guard.state)?;
         }
 

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -197,6 +197,7 @@ impl RuntimeHandle {
                     }
                     return Ok(false);
                 }
+                scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                 self.emit_system_tick_from_work_queue(&active, "continue_active")
                     .await?;
                 Ok(true)
@@ -236,6 +237,7 @@ impl RuntimeHandle {
                     }
                     return Ok(false);
                 }
+                scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                 self.emit_system_tick_from_work_queue(&queued, "queued_available")
                     .await?;
                 Ok(true)
@@ -266,6 +268,7 @@ impl RuntimeHandle {
                     }
                     return Ok(false);
                 }
+                scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                 self.emit_system_tick_from_wake_hint(&pending).await?;
 
                 #[cfg(test)]
@@ -398,6 +401,44 @@ impl RuntimeHandle {
             .map(|message| message.id))
     }
 
+    pub(super) async fn emit_system_tick_from_wake_hint_with_decision(
+        &self,
+        pending: &PendingWakeHint,
+    ) -> Result<bool> {
+        let (snapshot, queue_len) = {
+            let guard = self.inner.agent.lock().await;
+            (
+                scheduler::SchedulerAgentSnapshot::from_state(&guard.state),
+                guard.queue.len(),
+            )
+        };
+        let projection = scheduler::SchedulerProjection::from_snapshot_with_queue_len(
+            &self.inner.storage,
+            &snapshot,
+            queue_len,
+        )?;
+        let duplicate = self
+            .duplicate_wake_hint_message_id(pending)?
+            .map(scheduler::SchedulerDuplicateEvidence::WakeHintMessage);
+        let decision = scheduler::decide_next_action(
+            &projection,
+            scheduler::SchedulerBoundary::IdleTick,
+            scheduler::SchedulerInput::IdleSignal(scheduler::SchedulerIdleSignal::WakeHint {
+                pending,
+                duplicate,
+            }),
+        );
+        scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
+        if !matches!(
+            decision.kind,
+            scheduler::SchedulerDecisionKind::EmitSystemTick
+        ) {
+            return Ok(false);
+        }
+        self.emit_system_tick_from_wake_hint(pending).await?;
+        Ok(true)
+    }
+
     fn has_work_signal_after(
         &self,
         work_item: &crate::types::WorkItemRecord,
@@ -506,18 +547,6 @@ impl RuntimeHandle {
         let correlation_id = pending.correlation_id.clone();
         let causation_id = pending.causation_id.clone();
         let idempotency_key = scheduler::wake_hint_idempotency_key(pending);
-        scheduler::append_scheduler_decision(
-            &self.inner.storage,
-            &scheduler::SchedulerDecision::new(
-                scheduler::SchedulerDecisionKind::EmitSystemTick,
-                "wake_hint",
-            )
-            .boundary("idle_tick")
-            .model_visible(true)
-            .evidence("runtime_idle")
-            .evidence("pending_wake_hint")
-            .evidence(format!("idempotency_key={idempotency_key}")),
-        )?;
         let mut message = MessageEnvelope::new(
             self.agent_id().await?,
             MessageKind::SystemTick,
@@ -574,19 +603,6 @@ impl RuntimeHandle {
         reason: &str,
     ) -> Result<()> {
         let idempotency_key = scheduler::work_queue_tick_idempotency_key(work_item, reason);
-        scheduler::append_scheduler_decision(
-            &self.inner.storage,
-            &scheduler::SchedulerDecision::new(
-                scheduler::SchedulerDecisionKind::EmitSystemTick,
-                reason,
-            )
-            .boundary("idle_tick")
-            .model_visible(true)
-            .work_item_id(work_item.id.clone())
-            .evidence("runtime_idle")
-            .evidence("work_item_runnable")
-            .evidence(format!("idempotency_key={idempotency_key}")),
-        )?;
         let mut message = MessageEnvelope::new(
             self.agent_id().await?,
             MessageKind::SystemTick,

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -2,8 +2,9 @@ use super::*;
 use crate::runtime::closure::runtime_error_active;
 use crate::storage::{AppStorage, WorkQueuePromptProjection};
 use crate::types::{
-    AgentStatus, MessageEnvelope, PendingWakeHint, TaskRecord, TaskStatus, TimerStatus,
-    TurnTerminalKind, WaitingIntentStatus, WorkItemRecord,
+    AgentStatus, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint, Priority,
+    TaskRecord, TaskStatus, TimerStatus, TrustLevel, TurnTerminalKind, WaitingIntentStatus,
+    WorkItemRecord,
 };
 use chrono::{DateTime, Utc};
 
@@ -636,6 +637,17 @@ pub(crate) fn apply_running_projection(state: &mut AgentState, run_id: String) {
     state.current_run_id = Some(run_id);
 }
 
+pub(crate) fn apply_message_wake_projection(state: &mut AgentState) {
+    if matches!(state.status, AgentStatus::Asleep | AgentStatus::Booting) {
+        state.status = AgentStatus::AwakeIdle;
+        state.sleeping_until = None;
+    }
+}
+
+pub(crate) fn apply_awaiting_task_projection(state: &mut AgentState) {
+    state.status = AgentStatus::AwaitingTask;
+}
+
 pub(crate) fn apply_sleep_projection(
     state: &mut AgentState,
     sleeping_until: Option<DateTime<Utc>>,
@@ -643,6 +655,23 @@ pub(crate) fn apply_sleep_projection(
     state.status = AgentStatus::Asleep;
     state.current_run_id = None;
     state.sleeping_until = sleeping_until;
+}
+
+pub(crate) fn is_interrupt_priority_operator_input(message: &MessageEnvelope) -> bool {
+    matches!(
+        (
+            &message.kind,
+            &message.origin,
+            &message.trust,
+            &message.priority,
+        ),
+        (
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { .. },
+            TrustLevel::TrustedOperator,
+            Priority::Interrupt,
+        )
+    )
 }
 
 pub(crate) fn active_task_blocks_work_item_completion(

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -59,7 +59,7 @@ impl RuntimeHandle {
                 if guard.state.current_run_id.is_none() {
                     scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
                 } else if task.is_blocking() && !is_terminal_task_status(&task.status) {
-                    guard.state.status = AgentStatus::AwaitingTask;
+                    scheduler::apply_awaiting_task_projection(&mut guard.state);
                 }
             }
             self.inner.storage.write_agent(&guard.state)?;

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -769,3 +769,51 @@ fn scheduler_decision_append_dedupes_identical_latest_event() {
     assert_eq!(events[0].kind, "scheduler_decision");
     assert_eq!(events[0].data["boundary"].as_str(), Some("fixture"));
 }
+
+#[test]
+fn interrupt_operator_classifier_requires_trusted_interrupt_operator_prompt() {
+    let trusted_interrupt = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        TrustLevel::TrustedOperator,
+        Priority::Interrupt,
+        MessageBody::Text {
+            text: "interrupt".into(),
+        },
+    );
+    assert!(scheduler::is_interrupt_priority_operator_input(
+        &trusted_interrupt
+    ));
+
+    let normal_operator = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        TrustLevel::TrustedOperator,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "normal".into(),
+        },
+    );
+    assert!(!scheduler::is_interrupt_priority_operator_input(
+        &normal_operator
+    ));
+
+    let webhook_interrupt = MessageEnvelope::new(
+        "default",
+        MessageKind::WebhookEvent,
+        MessageOrigin::Webhook {
+            source: "test".into(),
+            event_type: None,
+        },
+        TrustLevel::TrustedIntegration,
+        Priority::Interrupt,
+        MessageBody::Text {
+            text: "webhook".into(),
+        },
+    );
+    assert!(!scheduler::is_interrupt_priority_operator_input(
+        &webhook_interrupt
+    ));
+}

--- a/src/runtime/tests/wake_hints.rs
+++ b/src/runtime/tests/wake_hints.rs
@@ -49,6 +49,89 @@ async fn runtime_emits_pending_wake_hint_as_system_tick_on_restart() {
 }
 
 #[tokio::test]
+async fn recovered_duplicate_wake_hint_clears_pending_without_new_tick() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let pending = PendingWakeHint {
+        reason: "restart duplicate wake".into(),
+        description: None,
+        scope: None,
+        waiting_intent_id: None,
+        external_trigger_id: None,
+        source: Some("test".into()),
+        resource: None,
+        body: None,
+        content_type: None,
+        correlation_id: Some("dup-corr".into()),
+        causation_id: None,
+        created_at: Utc::now(),
+    };
+    let idempotency_key = scheduler::wake_hint_idempotency_key(&pending);
+    let mut agent = AgentState::new("default");
+    agent.status = AgentStatus::AwakeIdle;
+    agent.pending_wake_hint = Some(pending);
+    storage.write_agent(&agent).unwrap();
+
+    let mut duplicate = MessageEnvelope::new(
+        "default",
+        MessageKind::SystemTick,
+        MessageOrigin::System {
+            subsystem: "wake_hint".into(),
+        },
+        TrustLevel::TrustedSystem,
+        Priority::Next,
+        MessageBody::Text {
+            text: "wake hint: restart duplicate wake".into(),
+        },
+    );
+    duplicate.metadata = Some(serde_json::json!({
+        "wake_hint": {
+            "idempotency_key": idempotency_key,
+            "reason": "restart duplicate wake",
+        }
+    }));
+    storage.append_message(&duplicate).unwrap();
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("wake done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    runtime.emit_recovered_pending_wake_hint().await.unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    assert!(state.pending_wake_hint.is_none());
+    let messages = runtime.storage().read_recent_messages(10).unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|message| {
+                matches!(
+                    (&message.kind, &message.origin),
+                    (MessageKind::SystemTick, MessageOrigin::System { subsystem })
+                        if subsystem == "wake_hint"
+                )
+            })
+            .count(),
+        1,
+        "duplicate recovered wake hint must not enqueue another system tick"
+    );
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "scheduler_decision"
+            && event.data["decision"] == "Noop"
+            && event.data["reason"] == "duplicate_wake_hint"
+    }));
+}
+
+#[tokio::test]
 async fn triggered_wake_hint_records_scheduler_decision_before_tick() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/wake_hints.rs
+++ b/src/runtime/tests/wake_hints.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use super::support::*;
+use crate::ingress::{WakeDisposition, WakeHint};
 
 #[tokio::test]
 async fn runtime_emits_pending_wake_hint_as_system_tick_on_restart() {
@@ -45,6 +46,61 @@ async fn runtime_emits_pending_wake_hint_as_system_tick_on_restart() {
         .any(|message| message.kind == MessageKind::SystemTick
             && message.authority_class == AuthorityClass::RuntimeInstruction));
     runtime_task.abort();
+}
+
+#[tokio::test]
+async fn triggered_wake_hint_records_scheduler_decision_before_tick() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("wake done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let disposition = runtime
+        .submit_wake_hint(WakeHint {
+            agent_id: "default".into(),
+            reason: "immediate wake".into(),
+            description: None,
+            source: Some("test".into()),
+            scope: None,
+            waiting_intent_id: None,
+            external_trigger_id: None,
+            resource: None,
+            body: Some(MessageBody::Text {
+                text: "wake body".into(),
+            }),
+            content_type: None,
+            correlation_id: Some("corr".into()),
+            causation_id: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(disposition, WakeDisposition::Triggered);
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    let decision_index = events
+        .iter()
+        .position(|event| {
+            event.kind == "scheduler_decision"
+                && event.data["decision"] == "EmitSystemTick"
+                && event.data["reason"] == "wake_hint"
+        })
+        .expect("wake hint scheduler decision should be recorded");
+    let tick_index = events
+        .iter()
+        .position(|event| event.kind == "system_tick_emitted")
+        .expect("wake hint tick should be emitted");
+    assert!(
+        decision_index < tick_index,
+        "scheduler decision should be recorded before tick emission"
+    );
 }
 
 #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 use super::{
-    combine_text_history, is_max_output_stop_reason, message_dispatch::message_text,
+    combine_text_history, is_max_output_stop_reason, message_dispatch::message_text, scheduler,
     CurrentRunInterrupted, RuntimeHandle,
 };
 
@@ -1461,7 +1461,10 @@ impl RuntimeHandle {
         let mut messages = Vec::new();
         {
             let mut guard = self.inner.agent.lock().await;
-            while let Some(message) = guard.queue.pop_interrupt_operator_prompt() {
+            while let Some(message) = guard
+                .queue
+                .pop_next_matching(scheduler::is_interrupt_priority_operator_input)
+            {
                 guard.state.pending = guard.queue.len();
                 messages.push(message);
             }

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -72,7 +72,10 @@ impl RuntimeHandle {
         ))?;
 
         if trigger_now {
-            if let Err(err) = self.emit_system_tick_from_wake_hint(&pending).await {
+            if let Err(err) = self
+                .emit_system_tick_from_wake_hint_with_decision(&pending)
+                .await
+            {
                 let mut guard = self.inner.agent.lock().await;
                 if guard.state.pending_wake_hint.is_none() {
                     guard.state.pending_wake_hint = Some(pending);
@@ -91,11 +94,15 @@ impl RuntimeHandle {
             guard.state.pending_wake_hint.clone()
         };
         if let Some(pending) = pending_wake {
-            self.emit_system_tick_from_wake_hint(&pending).await?;
-            let mut guard = self.inner.agent.lock().await;
-            if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
-                guard.state.pending_wake_hint = None;
-                self.inner.storage.write_agent(&guard.state)?;
+            if self
+                .emit_system_tick_from_wake_hint_with_decision(&pending)
+                .await?
+            {
+                let mut guard = self.inner.agent.lock().await;
+                if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
+                    guard.state.pending_wake_hint = None;
+                    self.inner.storage.write_agent(&guard.state)?;
+                }
             }
         }
         Ok(())

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -94,15 +94,12 @@ impl RuntimeHandle {
             guard.state.pending_wake_hint.clone()
         };
         if let Some(pending) = pending_wake {
-            if self
-                .emit_system_tick_from_wake_hint_with_decision(&pending)
-                .await?
-            {
-                let mut guard = self.inner.agent.lock().await;
-                if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
-                    guard.state.pending_wake_hint = None;
-                    self.inner.storage.write_agent(&guard.state)?;
-                }
+            self.emit_system_tick_from_wake_hint_with_decision(&pending)
+                .await?;
+            let mut guard = self.inner.agent.lock().await;
+            if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
+                guard.state.pending_wake_hint = None;
+                self.inner.storage.write_agent(&guard.state)?;
             }
         }
         Ok(())

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -155,7 +155,7 @@ async fn wait_for_worktree(
     let task_id = task.id.clone();
     let summary = task.summary.clone().unwrap_or_default();
     let storage = runtime.storage().clone();
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + Duration::from_secs(30);
 
     loop {
         let events = storage.read_recent_events(200)?;


### PR DESCRIPTION
## Summary

Implements step 2 of the scheduler RFC landing plan: converge scheduler event emission and normal posture transitions.

Changes:
- moves system-tick `scheduler_decision` recording to the decision call sites, so emit helpers only construct/enqueue messages
- routes immediate/recovered wake-hint ticks through the same idle-tick scheduler decision path
- adds scheduler-owned helpers for queue wake and awaiting-task posture projection
- moves interrupt-priority operator interjection classification into scheduler code while preserving the turn-loop safe-point drain
- replaces the special queue interjection popper with a generic priority-ordered predicate scan

## Validation

- `cargo check --quiet`
- `cargo test scheduler --quiet`
- `cargo test wake_hints --quiet`
- `cargo test queue --quiet`
- `cargo test --quiet -- --test-threads=1`
