### PR TITLE
fix: load model availability independently

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,12 +13,14 @@ use crate::{
         AttachWorkspaceRequest, ClearAgentModelRequest, ControlPromptRequest, DebugPromptRequest,
         DetachWorkspaceRequest, ExitWorkspaceRequest, SetAgentModelRequest,
     },
+    model_catalog::BuiltInModelMetadata,
     system::ExecutionSnapshot,
     types::{
         ActiveWorkspaceEntry, AgentListEntry, AgentSummary, BriefRecord,
         ExternalTriggerStateSnapshot, OperatorMessageRecord, OperatorNotificationRecord,
-        TaskRecord, TimerRecord, TranscriptEntry, TrustLevel, TurnTerminalRecord,
-        WaitingIntentRecord, WorkItemRecord, WorkspaceOccupancyRecord, WorktreeSession,
+        ResolvedModelAvailability, TaskRecord, TimerRecord, TranscriptEntry, TrustLevel,
+        TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord, WorkspaceOccupancyRecord,
+        WorktreeSession,
     },
 };
 
@@ -67,6 +69,14 @@ pub struct DebugPromptResponse {
     pub ok: bool,
     pub agent_id: String,
     pub dump: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelsResponse {
+    #[serde(default)]
+    pub available_models: Vec<BuiltInModelMetadata>,
+    #[serde(default)]
+    pub model_availability: Vec<ResolvedModelAvailability>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -280,6 +290,10 @@ impl LocalClient {
 
     pub async fn list_agent_entries(&self) -> Result<Vec<AgentListEntry>> {
         self.get_json("/agents/list").await
+    }
+
+    pub async fn fetch_models(&self) -> Result<ModelsResponse> {
+        self.get_json("/models").await
     }
 
     pub async fn handshake(&self) -> Result<Value> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3263,6 +3263,7 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, MutexGuard};
 
     use serde_json::{json, Value};
     use tempfile::tempdir;
@@ -3283,31 +3284,88 @@ mod tests {
         ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
     };
 
-    struct EnvVarGuard {
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarSnapshot {
         key: &'static str,
         original: Option<std::ffi::OsString>,
     }
 
+    struct EnvVarGuard {
+        snapshots: Vec<EnvVarSnapshot>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
     impl EnvVarGuard {
         fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let original = std::env::var_os(key);
-            std::env::set_var(key, value);
-            Self { key, original }
+            let mut guard = Self::new();
+            guard.set_var(key, value);
+            guard
         }
 
         fn unset(key: &'static str) -> Self {
-            let original = std::env::var_os(key);
+            let mut guard = Self::new();
+            guard.unset_var(key);
+            guard
+        }
+
+        fn unset_many(keys: &[&'static str]) -> Self {
+            let mut guard = Self::new();
+            for key in keys {
+                guard.unset_var(key);
+            }
+            guard
+        }
+
+        fn set_and_unset(
+            set_vars: &[(&'static str, &std::ffi::OsStr)],
+            unset_vars: &[&'static str],
+        ) -> Self {
+            let mut guard = Self::new();
+            for (key, value) in set_vars {
+                guard.set_var(key, value);
+            }
+            for key in unset_vars {
+                guard.unset_var(key);
+            }
+            guard
+        }
+
+        fn new() -> Self {
+            let lock = ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            Self {
+                snapshots: Vec::new(),
+                _lock: lock,
+            }
+        }
+
+        fn set_var(&mut self, key: &'static str, value: impl AsRef<std::ffi::OsStr>) {
+            self.snapshots.push(EnvVarSnapshot {
+                key,
+                original: std::env::var_os(key),
+            });
+            std::env::set_var(key, value);
+        }
+
+        fn unset_var(&mut self, key: &'static str) {
+            self.snapshots.push(EnvVarSnapshot {
+                key,
+                original: std::env::var_os(key),
+            });
             std::env::remove_var(key);
-            Self { key, original }
         }
     }
 
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
-            if let Some(value) = &self.original {
-                std::env::set_var(self.key, value);
-            } else {
-                std::env::remove_var(self.key);
+            for snapshot in self.snapshots.iter().rev() {
+                if let Some(value) = &snapshot.original {
+                    std::env::set_var(snapshot.key, value);
+                } else {
+                    std::env::remove_var(snapshot.key);
+                }
             }
         }
     }
@@ -3414,8 +3472,7 @@ mod tests {
 
     #[test]
     fn config_falls_back_to_settings_values() {
-        let original_value = std::env::var("ANTHROPIC_BASE_URL").ok();
-        std::env::remove_var("ANTHROPIC_BASE_URL");
+        let _base_url_guard = EnvVarGuard::unset("ANTHROPIC_BASE_URL");
 
         let mut settings = HashMap::new();
         settings.insert(
@@ -3425,10 +3482,6 @@ mod tests {
 
         let value = get_config_value("ANTHROPIC_BASE_URL", None, &settings);
         assert_eq!(value.as_deref(), Some("https://example.com"));
-
-        if let Some(orig) = original_value {
-            std::env::set_var("ANTHROPIC_BASE_URL", orig);
-        }
     }
 
     #[test]
@@ -3474,8 +3527,8 @@ mod tests {
 
     #[test]
     fn anthropic_runtime_cache_strategy_defaults_to_claude_code_prompt_cache() {
-        let _strategy_guard = EnvVarGuard::unset("HOLON_ANTHROPIC_CACHE_STRATEGY");
-        let _betas_guard = EnvVarGuard::unset("HOLON_ANTHROPIC_BETAS");
+        let _env_guard =
+            EnvVarGuard::unset_many(&["HOLON_ANTHROPIC_CACHE_STRATEGY", "HOLON_ANTHROPIC_BETAS"]);
 
         let config = resolve_anthropic_context_management_config().unwrap();
 
@@ -3528,17 +3581,11 @@ mod tests {
 
     #[test]
     fn default_holon_home_uses_home_directory() {
-        let original_home = std::env::var("HOME").ok();
-        std::env::set_var("HOME", "/tmp/holon-home-test");
+        let _home_guard = EnvVarGuard::set("HOME", "/tmp/holon-home-test");
         assert_eq!(
             default_holon_home(),
             Path::new("/tmp/holon-home-test/.holon")
         );
-        if let Some(home) = original_home {
-            std::env::set_var("HOME", home);
-        } else {
-            std::env::remove_var("HOME");
-        }
     }
 
     #[test]
@@ -4350,11 +4397,15 @@ mod tests {
     #[test]
     fn config_inspection_loads_provider_state_without_resolved_model() {
         let home = tempdir().unwrap();
-        let _home_guard = EnvVarGuard::set("HOME", home.path());
-        let _model_guard = EnvVarGuard::unset("HOLON_MODEL");
-        let _fallback_guard = EnvVarGuard::unset("HOLON_MODEL_FALLBACKS");
-        let _openai_guard = EnvVarGuard::unset("OPENAI_API_KEY");
-        let _anthropic_guard = EnvVarGuard::unset("ANTHROPIC_AUTH_TOKEN");
+        let _env_guard = EnvVarGuard::set_and_unset(
+            &[("HOME", home.path().as_os_str())],
+            &[
+                "HOLON_MODEL",
+                "HOLON_MODEL_FALLBACKS",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_AUTH_TOKEN",
+            ],
+        );
         let provider_id = ProviderId::parse("custom-openai").unwrap();
         save_persisted_config_at(
             &persisted_config_path(home.path()),

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -377,7 +377,6 @@ impl RuntimeHandle {
             active_task_count,
             model,
             token_usage,
-            model_availability: self.inner.model_availability.clone(),
             closure,
             execution,
             active_workspace_occupancy,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,7 +11,8 @@ use crate::{
     tui_markdown::{render_markdown_text, render_markdown_text_spaced},
     types::{
         AgentListEntry, AgentSummary, BriefRecord, MessageBody, OperatorMessageRecord,
-        OperatorMessageStatus, TaskRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        OperatorMessageStatus, ResolvedModelAvailability, TaskRecord, TranscriptEntry,
+        TranscriptEntryKind, TrustLevel,
     },
 };
 use anyhow::{anyhow, Result};

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -11,6 +11,7 @@ use tokio::{
 pub(super) struct TuiApp {
     pub(super) client: LocalClient,
     pub(super) agents: Vec<AgentSummary>,
+    pub(super) model_availability: Vec<ResolvedModelAvailability>,
     pub(super) briefs: Vec<BriefRecord>,
     pub(super) transcript: Vec<TranscriptEntry>,
     pub(super) optimistic_operator_messages: Vec<OperatorMessageRecord>,
@@ -63,6 +64,7 @@ impl TuiApp {
         Self {
             client,
             agents: Vec::new(),
+            model_availability: Vec::new(),
             briefs: Vec::new(),
             transcript: Vec::new(),
             optimistic_operator_messages: Vec::new(),

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -504,6 +504,7 @@ impl TuiApp {
 
     pub(super) async fn handle_paste(&mut self, text: &str) -> Result<()> {
         let selected_agent = self.selected_agent_summary().cloned();
+        let model_availability = self.model_availability.clone();
         match &mut self.overlay {
             OverlayState::None => {
                 let before = self.composer.as_str().to_string();
@@ -515,6 +516,7 @@ impl TuiApp {
                 filter.push_str(&paste_inline_text(text));
                 *selected = crate::tui::model_picker::clamp_model_picker_selection(
                     selected_agent.as_ref(),
+                    &model_availability,
                     filter,
                     *selected,
                 );
@@ -958,6 +960,7 @@ impl TuiApp {
                     TuiKeyAction::OverlayMoveDown => {
                         let max = crate::tui::model_picker::model_picker_rows(
                             self.selected_agent_summary(),
+                            &self.model_availability,
                             &filter,
                         )
                         .len()
@@ -969,6 +972,7 @@ impl TuiApp {
                         filter.pop();
                         selected = crate::tui::model_picker::clamp_model_picker_selection(
                             self.selected_agent_summary(),
+                            &self.model_availability,
                             &filter,
                             selected,
                         );
@@ -978,6 +982,7 @@ impl TuiApp {
                         filter.push(ch);
                         selected = crate::tui::model_picker::clamp_model_picker_selection(
                             self.selected_agent_summary(),
+                            &self.model_availability,
                             &filter,
                             selected,
                         );
@@ -1304,6 +1309,7 @@ impl TuiApp {
             .to_string();
         let choice = crate::tui::model_picker::selected_model_choice(
             self.selected_agent_summary(),
+            &self.model_availability,
             filter,
             selected,
         )

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -15,14 +15,17 @@ pub(super) struct ModelPickerRow {
     pub(super) available: bool,
 }
 
-pub(super) fn model_picker_rows(agent: Option<&AgentSummary>, filter: &str) -> Vec<ModelPickerRow> {
+pub(super) fn model_picker_rows(
+    agent: Option<&AgentSummary>,
+    model_availability: &[ResolvedModelAvailability],
+    filter: &str,
+) -> Vec<ModelPickerRow> {
     let Some(agent) = agent else {
         return Vec::new();
     };
     let inherit_row = inherit_default_row(agent);
     let query = filter.trim().to_ascii_lowercase();
-    let model_rows = agent
-        .model_availability
+    let model_rows = model_availability
         .iter()
         .filter(|entry| entry.available)
         .map(model_availability_row);
@@ -39,10 +42,11 @@ pub(super) fn model_picker_rows(agent: Option<&AgentSummary>, filter: &str) -> V
 
 pub(super) fn selected_model_choice(
     agent: Option<&AgentSummary>,
+    model_availability: &[ResolvedModelAvailability],
     filter: &str,
     selected: usize,
 ) -> Option<ModelPickerChoice> {
-    model_picker_rows(agent, filter)
+    model_picker_rows(agent, model_availability, filter)
         .into_iter()
         .nth(selected)
         .map(|row| row.choice)
@@ -50,10 +54,11 @@ pub(super) fn selected_model_choice(
 
 pub(super) fn clamp_model_picker_selection(
     agent: Option<&AgentSummary>,
+    model_availability: &[ResolvedModelAvailability],
     filter: &str,
     selected: usize,
 ) -> usize {
-    let len = model_picker_rows(agent, filter).len();
+    let len = model_picker_rows(agent, model_availability, filter).len();
     if len == 0 {
         0
     } else {
@@ -171,6 +176,13 @@ mod tests {
         }
     }
 
+    fn model_availability() -> Vec<ResolvedModelAvailability> {
+        vec![
+            availability("openai/gpt-5.4", "GPT-5.4", true),
+            availability("anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6", false),
+        ]
+    }
+
     fn summary() -> AgentSummary {
         AgentSummary {
             identity: AgentIdentityView {
@@ -205,10 +217,6 @@ mod tests {
                 total_model_rounds: 0,
                 last_turn: None,
             },
-            model_availability: vec![
-                availability("openai/gpt-5.4", "GPT-5.4", true),
-                availability("anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6", false),
-            ],
             closure: ClosureDecision {
                 outcome: ClosureOutcome::Completed,
                 waiting_reason: None,
@@ -244,7 +252,8 @@ mod tests {
     #[test]
     fn picker_rows_include_inherit_and_runtime_availability() {
         let agent = summary();
-        let rows = model_picker_rows(Some(&agent), "");
+        let availability = model_availability();
+        let rows = model_picker_rows(Some(&agent), &availability, "");
         assert_eq!(rows.len(), 2);
         assert!(rows[0].title.contains("inherit runtime default"));
         assert!(rows[1].title.contains("openai/gpt-5.4"));
@@ -254,7 +263,8 @@ mod tests {
     #[test]
     fn picker_rows_filter_by_model_and_label() {
         let agent = summary();
-        let rows = model_picker_rows(Some(&agent), "sonnet");
+        let availability = model_availability();
+        let rows = model_picker_rows(Some(&agent), &availability, "sonnet");
         assert_eq!(rows.len(), 1);
         assert!(rows[0].title.contains("inherit runtime default"));
     }
@@ -262,7 +272,11 @@ mod tests {
     #[test]
     fn picker_selection_clamps_to_filtered_rows() {
         let agent = summary();
-        assert_eq!(clamp_model_picker_selection(Some(&agent), "gpt", 10), 1);
-        assert!(selected_model_choice(Some(&agent), "", 1).is_some());
+        let availability = model_availability();
+        assert_eq!(
+            clamp_model_picker_selection(Some(&agent), &availability, "gpt", 10),
+            1
+        );
+        assert!(selected_model_choice(Some(&agent), &availability, "", 1).is_some());
     }
 }

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -316,7 +316,11 @@ fn draw_model_picker_overlay(frame: &mut Frame<'_>, app: &TuiApp, filter: &str, 
         Paragraph::new(filter_text).block(Block::default().title("Model").borders(Borders::ALL));
     frame.render_widget(filter_widget, layout[0]);
 
-    let rows = crate::tui::model_picker::model_picker_rows(app.selected_agent_summary(), filter);
+    let rows = crate::tui::model_picker::model_picker_rows(
+        app.selected_agent_summary(),
+        &app.model_availability,
+        filter,
+    );
     let items = if rows.is_empty() {
         vec![ListItem::new(
             "No runtime-provided model availability matches the filter",

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -2517,7 +2517,6 @@ mod tests {
                 total_model_rounds: 0,
                 last_turn: None,
             },
-            model_availability: Vec::new(),
             closure: ClosureDecision {
                 outcome: ClosureOutcome::Completed,
                 waiting_reason: None,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1134,7 +1134,6 @@ mod tests {
                 total_model_rounds: 0,
                 last_turn: None,
             },
-            model_availability: Vec::new(),
             closure: ClosureDecision {
                 outcome: ClosureOutcome::Completed,
                 waiting_reason: None,

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -30,6 +30,7 @@ pub(super) enum TuiRuntimeMessage {
         error: String,
     },
     AgentListLoaded(Result<Vec<AgentListEntry>, String>),
+    ModelsLoaded(Result<Vec<ResolvedModelAvailability>, String>),
     SnapshotLoaded {
         request_id: u64,
         target_index: usize,
@@ -66,6 +67,7 @@ pub(super) struct TuiRuntimeCheckpoint {
 
 impl TuiApp {
     pub(super) async fn initialize(&mut self) {
+        self.begin_load_models();
         self.schedule_agent_list_refresh();
         self.begin_load_agents();
     }
@@ -124,6 +126,29 @@ impl TuiApp {
                 .map_err(|err| err.to_string());
             let _ = tx.send(TuiRuntimeMessage::AgentListLoaded(result));
         });
+    }
+
+    pub(super) fn begin_load_models(&mut self) {
+        let client = self.client.clone();
+        let tx = self.runtime_tx.clone();
+        tokio::spawn(async move {
+            let result = client
+                .fetch_models()
+                .await
+                .map(|models| models.model_availability)
+                .map_err(|err| err.to_string());
+            let _ = tx.send(TuiRuntimeMessage::ModelsLoaded(result));
+        });
+    }
+
+    pub(super) fn apply_loaded_models(
+        &mut self,
+        result: Result<Vec<ResolvedModelAvailability>, String>,
+    ) {
+        match result {
+            Ok(model_availability) => self.model_availability = model_availability,
+            Err(error) => self.status_line = format!("Model availability load failed: {error}"),
+        }
     }
 
     pub(super) fn apply_loaded_agents(&mut self, result: Result<Vec<AgentListEntry>, String>) {
@@ -567,6 +592,7 @@ impl TuiApp {
                     self.status_line = format!("Event stream disconnected: {error}");
                 }
                 TuiRuntimeMessage::AgentListLoaded(result) => self.apply_loaded_agents(result),
+                TuiRuntimeMessage::ModelsLoaded(result) => self.apply_loaded_models(result),
                 TuiRuntimeMessage::SnapshotLoaded {
                     request_id,
                     target_index,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -200,7 +200,6 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
             total_model_rounds: 0,
             last_turn: None,
         },
-        model_availability: Vec::new(),
         closure: ClosureDecision {
             outcome: ClosureOutcome::Completed,
             waiting_reason: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3115,8 +3115,6 @@ pub struct AgentSummary {
     pub lifecycle: AgentLifecycleHint,
     pub model: AgentModelState,
     pub token_usage: AgentTokenUsageSummary,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub model_availability: Vec<ResolvedModelAvailability>,
     pub closure: ClosureDecision,
     pub execution: ExecutionSnapshot,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3280,7 +3278,6 @@ impl AgentListEntry {
             identity: self.identity,
             lifecycle: self.lifecycle,
             model: self.model.into_model_state(),
-            model_availability: Vec::new(),
             token_usage: AgentTokenUsageSummary {
                 total: TokenUsage::new(0, 0),
                 total_model_rounds: 0,


### PR DESCRIPTION
## Summary
- add a `/models` client path and TUI-side model availability loading
- keep model availability out of agent summary/status payloads
- preserve explicit default-agent environment configuration behavior

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test
