### PR TITLE
Consolidate sleep and message-admission scheduler posture

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -810,9 +810,11 @@ impl RuntimeHandle {
             guard.state.pending = guard.queue.len();
             guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
             guard.state.total_message_count = self.inner.storage.count_messages()?;
-            scheduler::apply_message_wake_projection(&mut guard.state);
             self.inner.storage.write_agent(&guard.state)?;
         }
+        scheduler_executor::SchedulerDecisionExecutor::new(self)
+            .admit_message_wake(&message)
+            .await?;
 
         self.inner.storage.append_event(&AuditEvent::new(
             "message_admitted",
@@ -901,15 +903,21 @@ impl RuntimeHandle {
                         scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                     }
                     let idle_state = {
-                        let mut guard = self.inner.agent.lock().await;
+                        let guard = self.inner.agent.lock().await;
                         if !matches!(
                             guard.state.status,
                             AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
                         ) && guard.queue.is_empty()
                         {
-                            scheduler::apply_sleep_projection(&mut guard.state, None);
-                            self.inner.storage.write_agent(&guard.state)?;
-                            Some(guard.state.clone())
+                            drop(guard);
+                            Some(
+                                scheduler_executor::SchedulerDecisionExecutor::new(&self)
+                                    .transition_to_sleep(
+                                        None,
+                                        scheduler_executor::SleepTransitionBoundary::RunLoopIdle,
+                                    )
+                                    .await?,
+                            )
                         } else {
                             None
                         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -902,26 +902,9 @@ impl RuntimeHandle {
                     ) {
                         scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                     }
-                    let idle_state = {
-                        let guard = self.inner.agent.lock().await;
-                        if !matches!(
-                            guard.state.status,
-                            AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
-                        ) && guard.queue.is_empty()
-                        {
-                            drop(guard);
-                            Some(
-                                scheduler_executor::SchedulerDecisionExecutor::new(&self)
-                                    .transition_to_sleep(
-                                        None,
-                                        scheduler_executor::SleepTransitionBoundary::RunLoopIdle,
-                                    )
-                                    .await?,
-                            )
-                        } else {
-                            None
-                        }
-                    };
+                    let idle_state = scheduler_executor::SchedulerDecisionExecutor::new(&self)
+                        .transition_run_loop_idle_to_sleep()
+                        .await?;
                     if let Some(idle_state) = idle_state {
                         self.append_state_changed_events(&idle_state)?;
                     }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1015,12 +1015,12 @@ impl RuntimeHandle {
             chrono::Utc::now()
                 + chrono::Duration::milliseconds(i64::try_from(duration_ms).unwrap_or(i64::MAX))
         });
-        let state = {
-            let mut guard = self.inner.agent.lock().await;
-            scheduler::apply_sleep_projection(&mut guard.state, sleeping_until);
-            self.inner.storage.write_agent(&guard.state)?;
-            guard.state.clone()
-        };
+        let state = super::scheduler_executor::SchedulerDecisionExecutor::new(self)
+            .transition_to_sleep(
+                sleeping_until,
+                super::scheduler_executor::SleepTransitionBoundary::LifecycleSleep,
+            )
+            .await?;
         self.append_state_changed_events(&state)?;
         if let (Some(duration_ms), Some(sleeping_until)) = (duration_ms, sleeping_until) {
             self.spawn_session_sleep_wake(duration_ms, sleeping_until);

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -639,11 +639,13 @@ pub(crate) fn apply_running_projection(state: &mut AgentState, run_id: String) {
     state.current_run_id = Some(run_id);
 }
 
-pub(crate) fn apply_message_wake_projection(state: &mut AgentState) {
+pub(crate) fn apply_message_wake_projection(state: &mut AgentState) -> bool {
     if matches!(state.status, AgentStatus::Asleep | AgentStatus::Booting) {
         state.status = AgentStatus::AwakeIdle;
         state.sleeping_until = None;
+        return true;
     }
+    false
 }
 
 pub(crate) fn apply_awaiting_task_projection(state: &mut AgentState) {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -28,6 +28,21 @@ pub(super) struct ShutdownPostureOutcome {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SleepTransitionBoundary {
+    LifecycleSleep,
+    RunLoopIdle,
+}
+
+impl SleepTransitionBoundary {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::LifecycleSleep => "lifecycle_sleep",
+            Self::RunLoopIdle => "run_loop_idle",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct BootstrapRecoveryFacts {
     pub(super) queued_messages: usize,
     pub(super) blocking_active_tasks: usize,
@@ -114,6 +129,54 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             self.runtime.inner.storage.write_agent(&guard.state)?;
         }
         Ok(guard.state.clone())
+    }
+
+    pub(super) async fn transition_to_sleep(
+        &self,
+        sleeping_until: Option<chrono::DateTime<chrono::Utc>>,
+        boundary: SleepTransitionBoundary,
+    ) -> Result<AgentState> {
+        let mut guard = self.runtime.inner.agent.lock().await;
+        let previous_status = guard.state.status.clone();
+        let previous_run_id = guard.state.current_run_id.clone();
+        scheduler::apply_sleep_projection(&mut guard.state, sleeping_until);
+        self.append_posture_decision(
+            boundary.as_str(),
+            "sleep",
+            &previous_status,
+            &guard.state.status,
+            vec![
+                format!("previous_run_id={previous_run_id:?}"),
+                format!("sleeping_until={:?}", guard.state.sleeping_until),
+            ],
+        )?;
+        self.runtime.inner.storage.write_agent(&guard.state)?;
+        Ok(guard.state.clone())
+    }
+
+    pub(super) async fn admit_message_wake(
+        &self,
+        message: &MessageEnvelope,
+    ) -> Result<Option<AgentState>> {
+        let mut guard = self.runtime.inner.agent.lock().await;
+        let previous_status = guard.state.status.clone();
+        let previous_sleeping_until = guard.state.sleeping_until;
+        if !scheduler::apply_message_wake_projection(&mut guard.state) {
+            return Ok(None);
+        }
+        self.append_posture_decision(
+            "message_admission",
+            "message_admission_wake",
+            &previous_status,
+            &guard.state.status,
+            vec![
+                format!("message_id={}", message.id),
+                format!("message_kind={:?}", message.kind),
+                format!("previous_sleeping_until={previous_sleeping_until:?}"),
+            ],
+        )?;
+        self.runtime.inner.storage.write_agent(&guard.state)?;
+        Ok(Some(guard.state.clone()))
     }
 
     pub(super) async fn poll(&self) -> Result<RunLoopPoll> {
@@ -223,6 +286,26 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             dispatch_plan,
             scheduler_decision: decision,
         }))
+    }
+
+    fn append_posture_decision(
+        &self,
+        boundary: &'static str,
+        reason: &'static str,
+        previous_status: &AgentStatus,
+        next_status: &AgentStatus,
+        evidence: Vec<String>,
+    ) -> Result<()> {
+        self.runtime.inner.storage.append_event(&AuditEvent::new(
+            "scheduler_posture_decision",
+            serde_json::json!({
+                "boundary": boundary,
+                "reason": reason,
+                "previous_status": previous_status,
+                "next_status": next_status,
+                "evidence": evidence,
+            }),
+        ))
     }
 }
 

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -154,6 +154,33 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         Ok(guard.state.clone())
     }
 
+    pub(super) async fn transition_run_loop_idle_to_sleep(&self) -> Result<Option<AgentState>> {
+        let mut guard = self.runtime.inner.agent.lock().await;
+        if matches!(
+            guard.state.status,
+            AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
+        ) || !guard.queue.is_empty()
+        {
+            return Ok(None);
+        }
+
+        let previous_status = guard.state.status.clone();
+        let previous_run_id = guard.state.current_run_id.clone();
+        scheduler::apply_sleep_projection(&mut guard.state, None);
+        self.append_posture_decision(
+            SleepTransitionBoundary::RunLoopIdle.as_str(),
+            "sleep",
+            &previous_status,
+            &guard.state.status,
+            vec![
+                format!("previous_run_id={previous_run_id:?}"),
+                format!("sleeping_until={:?}", guard.state.sleeping_until),
+            ],
+        )?;
+        self.runtime.inner.storage.write_agent(&guard.state)?;
+        Ok(Some(guard.state.clone()))
+    }
+
     pub(super) async fn admit_message_wake(
         &self,
         message: &MessageEnvelope,

--- a/src/runtime/test_util.rs
+++ b/src/runtime/test_util.rs
@@ -73,6 +73,8 @@ pub async fn wait_for_emit_at_checkpoint() {
 
 /// Release the checkpoint, allowing the emit thread to continue
 pub fn release_checkpoint() {
-    // Notify the emit thread to continue
-    ALLOW_CONTINUE.notify_one();
+    CHECKPOINT_ENABLED.store(false, Ordering::SeqCst);
+    // Wake every test task that may have observed the global checkpoint while
+    // running filtered tests in parallel.
+    ALLOW_CONTINUE.notify_waiters();
 }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -110,6 +110,232 @@ async fn non_model_reentry_external_events_do_not_run_interactive_turn() {
 }
 
 #[tokio::test]
+async fn run_loop_idle_sleep_records_scheduler_owned_posture_decision() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let runner = tokio::spawn(runtime.clone().run());
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if runtime.agent_state().await.unwrap().status == AgentStatus::Asleep {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("idle runtime should transition to sleep");
+
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision"
+            && event.data["boundary"] == "run_loop_idle"
+            && event.data["reason"] == "sleep"
+            && event.data["next_status"] == "asleep"
+    }));
+    runner.abort();
+}
+
+#[tokio::test]
+async fn explicit_sleep_transition_records_scheduler_owned_posture_decision() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeRunning;
+        guard.state.current_run_id = Some("run-1".into());
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+
+    runtime.transition_to_sleep(None).await.unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::Asleep);
+    assert_eq!(state.current_run_id, None);
+    assert_eq!(state.sleeping_until, None);
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision"
+            && event.data["boundary"] == "lifecycle_sleep"
+            && event.data["reason"] == "sleep"
+            && event.data["previous_status"] == "awake_running"
+            && event.data["next_status"] == "asleep"
+    }));
+}
+
+#[tokio::test]
+async fn message_admission_wakes_asleep_and_booting_agents() {
+    for status in [AgentStatus::Asleep, AgentStatus::Booting] {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        {
+            let mut guard = runtime.inner.agent.lock().await;
+            guard.state.status = status.clone();
+            guard.state.sleeping_until = Some(Utc::now() + chrono::Duration::seconds(60));
+            runtime.storage().write_agent(&guard.state).unwrap();
+        }
+
+        runtime
+            .enqueue(MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                TrustLevel::TrustedOperator,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "wake up".into(),
+                },
+            ))
+            .await
+            .unwrap();
+
+        let state = runtime.agent_state().await.unwrap();
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
+        assert_eq!(state.sleeping_until, None);
+        assert_eq!(state.pending, 1);
+        let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+        assert!(events.iter().any(|event| {
+            event.kind == "message_admitted"
+                && event.data["kind"] == serde_json::json!(MessageKind::OperatorPrompt)
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == "scheduler_posture_decision"
+                && event.data["boundary"] == "message_admission"
+                && event.data["reason"] == "message_admission_wake"
+                && event.data["previous_status"] == serde_json::json!(status)
+                && event.data["next_status"] == "awake_idle"
+        }));
+    }
+}
+
+#[tokio::test]
+async fn message_admission_does_not_wake_stopped_or_paused_agents() {
+    for status in [AgentStatus::Stopped, AgentStatus::Paused] {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(CountingProvider {
+                calls: Mutex::new(0),
+                reply: "unused",
+            }),
+            "default".into(),
+            context_config(),
+        )
+        .unwrap();
+        {
+            let mut guard = runtime.inner.agent.lock().await;
+            guard.state.status = status.clone();
+            runtime.storage().write_agent(&guard.state).unwrap();
+        }
+
+        runtime
+            .enqueue(MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                TrustLevel::TrustedOperator,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "do not wake".into(),
+                },
+            ))
+            .await
+            .unwrap();
+
+        let state = runtime.agent_state().await.unwrap();
+        assert_eq!(state.status, status);
+        assert_eq!(state.pending, 1);
+        let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+        assert!(!events.iter().any(|event| {
+            event.kind == "scheduler_posture_decision"
+                && event.data["boundary"] == "message_admission"
+        }));
+    }
+}
+
+#[tokio::test]
+async fn sleep_wake_task_ignores_stale_sleeping_until() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    runtime.transition_to_sleep(Some(25)).await.unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.sleeping_until = Some(Utc::now() + chrono::Duration::seconds(60));
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let messages = runtime.storage().read_recent_messages(10).unwrap();
+    assert!(!messages.iter().any(|message| {
+        matches!(
+            &message.origin,
+            MessageOrigin::System { subsystem } if subsystem == "sleep_duration"
+        )
+    }));
+    assert_eq!(
+        runtime.agent_state().await.unwrap().status,
+        AgentStatus::Asleep
+    );
+}
+
+#[tokio::test]
 async fn enqueue_normalizes_operator_admission_fields() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -150,6 +150,55 @@ async fn run_loop_idle_sleep_records_scheduler_owned_posture_decision() {
 }
 
 #[tokio::test]
+async fn run_loop_idle_sleep_rechecks_queue_before_transition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeIdle;
+        guard.queue.push(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "queued while idle".into(),
+            },
+        ));
+        guard.state.pending = guard.queue.len();
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+
+    let transition = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .transition_run_loop_idle_to_sleep()
+        .await
+        .unwrap();
+
+    assert!(transition.is_none());
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::AwakeIdle);
+    assert_eq!(state.pending, 1);
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(!events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision" && event.data["boundary"] == "run_loop_idle"
+    }));
+}
+
+#[tokio::test]
 async fn explicit_sleep_transition_records_scheduler_owned_posture_decision() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -12,7 +12,7 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use holon::{
-    client::{EventStreamRequest, LocalClient},
+    client::{AgentStreamEvent, EventStreamRequest, LocalClient, LocalEventStream},
     config::{AppConfig, ControlAuthMode},
     daemon::RuntimeServiceHandle,
     host::RuntimeHost,
@@ -43,6 +43,18 @@ use super::{
     spawn_server_with_runtime_config, spawn_unix_server, tempdir, test_config,
     test_config_with_paths, wait_until, ParsedSseEvent,
 };
+
+async fn next_message_admitted_event(stream: &mut LocalEventStream) -> Result<AgentStreamEvent> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = stream.next_event().await?;
+            if event.event == "message_admitted" {
+                return Ok(event);
+            }
+        }
+    })
+    .await?
+}
 
 pub async fn local_client_over_unix_socket_can_poll_without_http_fallback() -> Result<()> {
     let config = test_config();
@@ -192,7 +204,7 @@ pub async fn local_client_over_http_can_stream_events_with_since_query() -> Resu
             },
         )
         .await?;
-    let first_event = tokio::time::timeout(Duration::from_secs(5), stream.next_event()).await??;
+    let first_event = next_message_admitted_event(&mut stream).await?;
     assert_eq!(first_event.event, "message_admitted");
     assert_eq!(first_event.data.event_type, "message_admitted");
     assert_eq!(
@@ -247,7 +259,7 @@ pub async fn local_client_over_http_can_stream_events_with_last_event_id_header(
             },
         )
         .await?;
-    let first_event = tokio::time::timeout(Duration::from_secs(5), stream.next_event()).await??;
+    let first_event = next_message_admitted_event(&mut stream).await?;
     assert_eq!(first_event.event, "message_admitted");
     assert_eq!(first_event.data.event_type, "message_admitted");
 
@@ -298,7 +310,7 @@ pub async fn local_client_over_unix_socket_can_stream_events_with_since_query() 
             },
         )
         .await?;
-    let first_event = tokio::time::timeout(Duration::from_secs(5), stream.next_event()).await??;
+    let first_event = next_message_admitted_event(&mut stream).await?;
     assert_eq!(first_event.event, "message_admitted");
     assert_eq!(first_event.data.event_type, "message_admitted");
 
@@ -336,7 +348,7 @@ pub async fn local_client_over_unix_socket_can_stream_events_with_last_event_id_
             },
         )
         .await?;
-    let first_event = tokio::time::timeout(Duration::from_secs(5), stream.next_event()).await??;
+    let first_event = next_message_admitted_event(&mut stream).await?;
     assert_eq!(first_event.event, "message_admitted");
     assert_eq!(first_event.data.event_type, "message_admitted");
 

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -42,6 +42,21 @@ use super::{
     test_config, test_config_with_paths, wait_until, ParsedSseEvent,
 };
 
+async fn next_sse_event_kind(
+    stream: &mut reqwest::Response,
+    event_kind: &str,
+) -> Result<ParsedSseEvent> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = read_next_sse_event(stream).await?;
+            if event.event == event_kind {
+                return Ok(event);
+            }
+        }
+    })
+    .await?
+}
+
 pub async fn events_route_supports_cursor_replay() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let runtime = host.default_runtime().await?;
@@ -74,8 +89,7 @@ pub async fn events_route_supports_cursor_replay() -> Result<()> {
         .get(format!("{base}/agents/default/events?since={cursor}"))
         .send()
         .await?;
-    let first_event =
-        tokio::time::timeout(Duration::from_secs(5), read_next_sse_event(&mut stream)).await??;
+    let first_event = next_sse_event_kind(&mut stream, "message_admitted").await?;
     assert_eq!(first_event.event, "message_admitted");
     assert_eq!(first_event.data["type"], "message_admitted");
 
@@ -117,8 +131,7 @@ pub async fn events_route_supports_last_event_id_header_and_rfc3339_ts() -> Resu
         .header("Last-Event-ID", cursor)
         .send()
         .await?;
-    let replayed =
-        tokio::time::timeout(Duration::from_secs(5), read_next_sse_event(&mut stream)).await??;
+    let replayed = next_sse_event_kind(&mut stream, "message_admitted").await?;
     assert_eq!(replayed.event, "message_admitted");
     assert!(replayed.data["ts"].is_string());
     assert!(chrono::DateTime::parse_from_rfc3339(
@@ -163,8 +176,7 @@ pub async fn events_route_preserves_replay_provenance() -> Result<()> {
         .get(format!("{base}/agents/default/events?since={cursor}"))
         .send()
         .await?;
-    let replayed =
-        tokio::time::timeout(Duration::from_secs(5), read_next_sse_event(&mut stream)).await??;
+    let replayed = next_sse_event_kind(&mut stream, "message_admitted").await?;
     assert_eq!(replayed.event, "message_admitted");
     assert_eq!(replayed.data["type"], "message_admitted");
     assert_eq!(replayed.data["provenance"]["origin"]["kind"], "operator");


### PR DESCRIPTION
## Summary

Closes #1061.

- Move sleep posture mutation behind `SchedulerDecisionExecutor::transition_to_sleep` for explicit sleep and run-loop idle sleep.
- Move message-admission wake posture mutation behind `SchedulerDecisionExecutor::admit_message_wake` while keeping message and queue ledger writes in `enqueue()`.
- Add scheduler posture evidence for sleep and message-admission wake transitions, plus focused regressions for asleep/booting wake, stopped/paused gates, run-loop sleep, explicit sleep, and stale sleep wake tasks.
- Fix the wake checkpoint test helper so `cargo test wake --quiet` does not hang when filtered wake tests run in parallel.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test scheduler --quiet`
- `cargo test sleep --quiet`
- `cargo test wake --quiet`
- `cargo test --test http_control --quiet`
- `cargo test --lib --quiet -- --test-threads=1`
