### PR TITLE
Wake sleeping agents for background task results

### DIFF
--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     admission_trigger_kind_for_message_kind, ClosureDecision, ClosureOutcome, ContinuationClass,
     ContinuationResolution, ContinuationTriggerKind, MessageBody, MessageEnvelope, MessageKind,
-    TaskRecord, TaskStatus, WaitingReason,
+    TaskRecord, TaskStatus, TaskWaitPolicy, WaitingReason,
 };
 
 #[derive(Debug, Clone)]
@@ -10,6 +10,7 @@ pub(super) struct ContinuationTrigger {
     pub(super) contentful: bool,
     pub(super) task_terminal: bool,
     pub(super) task_blocking: bool,
+    pub(super) task_wait_policy: Option<TaskWaitPolicy>,
     pub(super) wake_hint_source: Option<String>,
 }
 
@@ -24,6 +25,7 @@ impl ContinuationTrigger {
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: None,
             }),
             MessageKind::WebhookEvent | MessageKind::CallbackEvent | MessageKind::ChannelEvent => {
@@ -32,6 +34,7 @@ impl ContinuationTrigger {
                     contentful: body_is_contentful(&message.body),
                     task_terminal: false,
                     task_blocking: false,
+                    task_wait_policy: None,
                     wake_hint_source: None,
                 })
             }
@@ -40,6 +43,7 @@ impl ContinuationTrigger {
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: None,
             }),
             MessageKind::InternalFollowup => Some(Self {
@@ -47,6 +51,7 @@ impl ContinuationTrigger {
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: None,
             }),
             MessageKind::SystemTick => Some(Self {
@@ -54,6 +59,7 @@ impl ContinuationTrigger {
                 contentful: system_tick_is_contentful(message),
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: message
                     .metadata
                     .as_ref()
@@ -77,6 +83,7 @@ impl ContinuationTrigger {
                     })
                     .unwrap_or(false),
                 task_blocking: task.map(TaskRecord::is_blocking).unwrap_or(false),
+                task_wait_policy: task.map(TaskRecord::wait_policy),
                 wake_hint_source: None,
             }),
             MessageKind::TaskStatus
@@ -104,6 +111,9 @@ pub(super) fn resolve_continuation(
     if trigger.task_blocking {
         evidence.push("task_blocking".to_string());
     }
+    if trigger.task_wait_policy == Some(TaskWaitPolicy::Background) {
+        evidence.push("task_background".to_string());
+    }
     if let Some(source) = trigger.wake_hint_source.as_ref() {
         evidence.push(format!("wake_hint_source={source}"));
     }
@@ -120,10 +130,9 @@ pub(super) fn resolve_continuation(
         );
     }
 
-    let terminal_blocking_task_result = trigger.kind == ContinuationTriggerKind::TaskResult
-        && trigger.task_terminal
-        && trigger.task_blocking;
-    let model_reentry = terminal_blocking_task_result
+    let terminal_task_result =
+        trigger.kind == ContinuationTriggerKind::TaskResult && trigger.task_terminal;
+    let model_reentry = terminal_task_result
         || matches!(
             trigger.kind,
             ContinuationTriggerKind::OperatorInput
@@ -185,7 +194,7 @@ fn resolve_waiting(
     let override_allowed = trigger.kind == ContinuationTriggerKind::OperatorInput;
     if expected {
         let model_reentry = match trigger.kind {
-            ContinuationTriggerKind::TaskResult => trigger.task_terminal && trigger.task_blocking,
+            ContinuationTriggerKind::TaskResult => trigger.task_terminal,
             ContinuationTriggerKind::ExternalEvent => trigger.contentful,
             ContinuationTriggerKind::SystemTick => trigger.contentful,
             _ => true,
@@ -237,13 +246,10 @@ fn resolve_waiting(
         };
     }
 
-    if trigger.kind == ContinuationTriggerKind::TaskResult
-        && trigger.task_terminal
-        && trigger.task_blocking
-    {
-        // Terminal blocking task state is persisted before TaskResult enqueue, so
+    if trigger.kind == ContinuationTriggerKind::TaskResult && trigger.task_terminal {
+        // Terminal task state is persisted before TaskResult enqueue, so
         // resuming here cannot reopen the stale active-task wait that just ended.
-        evidence.push("terminal_blocking_task_result".to_string());
+        evidence.push("terminal_task_result".to_string());
         return ContinuationResolution {
             trigger_kind: trigger.kind,
             class: ContinuationClass::ResumeOverride,
@@ -323,6 +329,7 @@ mod tests {
                 contentful: true,
                 task_terminal: true,
                 task_blocking: true,
+                task_wait_policy: Some(TaskWaitPolicy::Blocking),
                 wake_hint_source: None,
             },
         );
@@ -339,6 +346,7 @@ mod tests {
                 contentful: false,
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: Some("callback".into()),
             },
         );
@@ -355,6 +363,7 @@ mod tests {
                 contentful: true,
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );
@@ -377,6 +386,7 @@ mod tests {
                 contentful: false,
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );
@@ -399,11 +409,39 @@ mod tests {
                 contentful: true,
                 task_terminal: true,
                 task_blocking: true,
+                task_wait_policy: Some(TaskWaitPolicy::Blocking),
                 wake_hint_source: None,
             },
         );
         assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
         assert!(resolution.model_reentry);
+    }
+
+    #[test]
+    fn terminal_background_task_result_resumes_without_prior_wait() {
+        let resolution = resolve_continuation(
+            &ClosureDecision {
+                outcome: ClosureOutcome::Completed,
+                waiting_reason: None,
+                work_signal: None,
+                runtime_posture: RuntimePosture::Sleeping,
+                evidence: vec![],
+            },
+            &ContinuationTrigger {
+                kind: ContinuationTriggerKind::TaskResult,
+                contentful: true,
+                task_terminal: true,
+                task_blocking: false,
+                task_wait_policy: Some(TaskWaitPolicy::Background),
+                wake_hint_source: None,
+            },
+        );
+        assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
+        assert!(resolution.model_reentry);
+        assert!(resolution
+            .evidence
+            .iter()
+            .any(|entry| entry == "task_background"));
     }
 
     #[test]
@@ -415,6 +453,7 @@ mod tests {
                 contentful: true,
                 task_terminal: true,
                 task_blocking: true,
+                task_wait_policy: Some(TaskWaitPolicy::Blocking),
                 wake_hint_source: None,
             },
         );
@@ -431,6 +470,7 @@ mod tests {
                 contentful: false,
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );
@@ -448,6 +488,7 @@ mod tests {
                 contentful: true,
                 task_terminal: false,
                 task_blocking: false,
+                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -16,6 +16,7 @@ macro_rules! runtime_async_tests {
 
 runtime_async_tests!(
     background_task_rejoins_main_session,
+    background_command_task_result_wakes_sleeping_agent_for_model_reentry,
     stop_task_cancels_running_background_task,
     tool_use_round_trip_executes_and_returns_result,
     file_tools_can_modify_workspace_and_reenter_context,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -21,8 +21,7 @@ use holon::{
     ingress::{WakeDisposition, WakeHint},
     policy::validate_message_kind_for_origin,
     provider::{
-        AgentProvider, ConversationMessage, ModelBlock, ProviderTurnRequest, ProviderTurnResponse,
-        StubProvider,
+        AgentProvider, ModelBlock, ProviderTurnRequest, ProviderTurnResponse, StubProvider,
     },
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     tool::{ToolCall, ToolError, ToolRegistry, ToolResult},
@@ -43,9 +42,9 @@ use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 
 use crate::support::runtime_helpers::{
-    aggressive_compaction_config, git, init_git_repo, operator_transport_binding,
-    parse_tool_result_payload, parse_tool_result_value, test_config, wait_for_worktree_presence,
-    wait_until, wait_until_async, wait_until_async_for,
+    aggressive_compaction_config, delegated_prompt_text, git, init_git_repo,
+    operator_transport_binding, parse_tool_result_payload, parse_tool_result_value, test_config,
+    wait_for_worktree_presence, wait_until, wait_until_async, wait_until_async_for,
 };
 use crate::support::runtime_providers::{
     DelayedTextProvider, DelegatedBoundaryProvider, FileEditingProvider, LongShellProvider,
@@ -61,6 +60,62 @@ use crate::support::{
 
 // ============================================================================
 // Runtime tasks domain test support
+
+struct SleepThenRecordTaskResultProvider {
+    requests: Mutex<Vec<String>>,
+}
+
+impl SleepThenRecordTaskResultProvider {
+    fn new() -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn captured_requests(&self) -> Vec<String> {
+        self.requests.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl AgentProvider for SleepThenRecordTaskResultProvider {
+    async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let prompt_text = delegated_prompt_text(&request);
+        let mut requests = self.requests.lock().await;
+        requests.push(prompt_text);
+        let call = requests.len();
+        drop(requests);
+
+        match call {
+            1 => Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::ToolUse {
+                    id: "sleep-1".into(),
+                    name: "Sleep".into(),
+                    input: json!({
+                        "reason": "wait for background command result"
+                    }),
+                }],
+                stop_reason: None,
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_usage: None,
+                request_diagnostics: None,
+            }),
+            2 => Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text {
+                    text: "background command result observed".into(),
+                }],
+                stop_reason: None,
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_usage: None,
+                request_diagnostics: None,
+            }),
+            _ => anyhow::bail!("unexpected provider call {call}"),
+        }
+    }
+}
+
 pub async fn background_task_rejoins_main_session() -> Result<()> {
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
@@ -108,6 +163,90 @@ pub async fn background_task_rejoins_main_session() -> Result<()> {
             .any(|record| record.id == task.id
                 && record.status == holon::types::TaskStatus::Completed)
     );
+    Ok(())
+}
+
+pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reentry() -> Result<()> {
+    let provider = Arc::new(SleepThenRecordTaskResultProvider::new());
+    let host = RuntimeHost::new_with_provider(test_config(), provider.clone())?;
+    let runtime = host.default_runtime().await?;
+
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "sleep until the background command finishes".into(),
+            },
+        ))
+        .await?;
+
+    wait_until_async(|| {
+        let runtime = runtime.clone();
+        let provider = provider.clone();
+        async move {
+            let state = runtime.agent_state().await?;
+            Ok(
+                state.status == AgentStatus::Asleep
+                    && provider.captured_requests().await.len() == 1,
+            )
+        }
+    })
+    .await?;
+
+    let task = runtime
+        .schedule_command_task(
+            "background wake task".into(),
+            CommandTaskSpec {
+                cmd: "printf background_done".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: Some(256),
+                accepts_input: false,
+                continue_on_result: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    wait_until_async(|| {
+        let provider = provider.clone();
+        async move { Ok(provider.captured_requests().await.len() >= 2) }
+    })
+    .await?;
+
+    let requests = provider.captured_requests().await;
+    let reentry_prompt = requests
+        .get(1)
+        .expect("background task result should trigger model reentry");
+    assert!(
+        reentry_prompt.contains("background_done"),
+        "task result output should be visible to model: {reentry_prompt}"
+    );
+    let state = runtime.agent_state().await?;
+    assert!(state
+        .last_continuation
+        .as_ref()
+        .is_some_and(|continuation| {
+            continuation.trigger_kind == holon::types::ContinuationTriggerKind::TaskResult
+                && continuation.model_reentry
+                && continuation
+                    .evidence
+                    .iter()
+                    .any(|entry| entry == "task_background")
+        }));
+    let tasks = runtime.storage().latest_task_records()?;
+    assert!(tasks.iter().any(|record| {
+        record.id == task.id
+            && record.status == TaskStatus::Completed
+            && record.wait_policy() == holon::types::TaskWaitPolicy::Background
+    }));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- route terminal background command task results as local continuations that reenter the model
- preserve task wait-policy evidence in continuation decisions
- add regression coverage for a sleeping agent waking on a completed background command task result

Closes #1069

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test terminal_background_task_result_resumes_without_prior_wait --lib -- --test-threads=1
- cargo test background_command_task_result_wakes_sleeping_agent_for_model_reentry --test runtime_tasks -- --test-threads=1
- cargo test continuation --lib -- --test-threads=1
- cargo test --test runtime_tasks -- --test-threads=1
- cargo test --all-targets -- --test-threads=1