### PR TITLE
Defer /agents switching until accept

### DIFF
--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1272,6 +1272,7 @@ impl TuiApp {
         match resolve_key(KeyContext::AgentsOverlay, key) {
             TuiKeyAction::OverlayClose => Ok(()),
             TuiKeyAction::OverlayAccept => {
+                let selected = selected.min(self.agents.len().saturating_sub(1));
                 if let Some(agent_id) = self
                     .agents
                     .get(selected)

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -529,15 +529,6 @@ impl TuiApp {
         Ok(())
     }
 
-    pub(super) async fn move_agent_selection(&mut self, delta: i32) -> Result<()> {
-        let Some(target_index) = self.next_agent_index(delta) else {
-            return Ok(());
-        };
-        self.chat_scroll.follow_tail();
-        self.begin_bootstrap_agent_index(target_index);
-        Ok(())
-    }
-
     async fn submit_prompt_buffer(&mut self) -> Result<()> {
         match parse_composer_submission(self.composer.as_str())? {
             None => Ok(()),
@@ -633,7 +624,9 @@ impl TuiApp {
                 self.status_line = "Opened slash command help".into();
             }
             SlashCommand::Agents => {
-                self.overlay = OverlayState::Agents;
+                self.overlay = OverlayState::Agents {
+                    selected: self.selected_agent,
+                };
                 self.status_line = "Opened agents overlay".into();
             }
             SlashCommand::Events => {
@@ -834,7 +827,9 @@ impl TuiApp {
         let overlay = std::mem::replace(&mut self.overlay, OverlayState::None);
         match overlay {
             OverlayState::None => self.handle_main_key(key).await,
-            OverlayState::Agents => self.handle_agents_overlay_key(key).await,
+            OverlayState::Agents { selected } => {
+                self.handle_agents_overlay_key(key, selected).await
+            }
             OverlayState::Events {
                 selected_event_id,
                 mut detail_scroll,
@@ -1273,30 +1268,33 @@ impl TuiApp {
         }
     }
 
-    async fn handle_agents_overlay_key(&mut self, key: KeyEvent) -> Result<()> {
+    async fn handle_agents_overlay_key(&mut self, key: KeyEvent, selected: usize) -> Result<()> {
         match resolve_key(KeyContext::AgentsOverlay, key) {
             TuiKeyAction::OverlayClose => Ok(()),
             TuiKeyAction::OverlayAccept => {
-                let agent_id = self.selected_agent_id().unwrap_or("").to_string();
-                if !agent_id.is_empty() {
+                if let Some(agent_id) = self
+                    .agents
+                    .get(selected)
+                    .map(|agent| agent.identity.agent_id.clone())
+                {
                     self.status_line = format!("Switching to agent {agent_id}");
-                    self.begin_bootstrap_agent_index(self.selected_agent);
+                    self.begin_bootstrap_agent_index(selected);
                 }
                 self.overlay = OverlayState::None;
                 Ok(())
             }
             TuiKeyAction::OverlayMoveUp => {
-                self.move_agent_selection(-1).await?;
-                self.overlay = OverlayState::Agents;
+                let selected = self.next_agent_index_from(selected, -1).unwrap_or(selected);
+                self.overlay = OverlayState::Agents { selected };
                 Ok(())
             }
             TuiKeyAction::OverlayMoveDown => {
-                self.move_agent_selection(1).await?;
-                self.overlay = OverlayState::Agents;
+                let selected = self.next_agent_index_from(selected, 1).unwrap_or(selected);
+                self.overlay = OverlayState::Agents { selected };
                 Ok(())
             }
             _ => {
-                self.overlay = OverlayState::Agents;
+                self.overlay = OverlayState::Agents { selected };
                 Ok(())
             }
         }

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -119,14 +119,13 @@ fn draw_agents_overlay(frame: &mut Frame<'_>, app: &TuiApp, selected: usize) {
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
     let mut state = ListState::default();
-    if !app.agents.is_empty() {
-        state.select(Some(selected.min(app.agents.len().saturating_sub(1))));
-    }
+    let selected = (!app.agents.is_empty()).then(|| selected.min(app.agents.len() - 1));
+    state.select(selected);
     frame.render_stateful_widget(list, layout[0], &mut state);
 
     let text = app
         .agents
-        .get(selected)
+        .get(selected.unwrap_or(0))
         .map(render::render_summary)
         .unwrap_or_else(|| "No agent selected.".to_string());
     let detail = Paragraph::new(text)

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -8,7 +8,9 @@ pub(super) const MODEL_REASONING_EFFORT_OPTIONS: [&str; 5] =
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum OverlayState {
     None,
-    Agents,
+    Agents {
+        selected: usize,
+    },
     Events {
         selected_event_id: Option<String>,
         detail_scroll: u16,
@@ -49,7 +51,7 @@ pub(super) enum OverlayState {
 pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
     match &app.overlay {
         OverlayState::None => {}
-        OverlayState::Agents => draw_agents_overlay(frame, app),
+        OverlayState::Agents { selected } => draw_agents_overlay(frame, app, *selected),
         OverlayState::Events {
             selected_event_id,
             detail_scroll,
@@ -83,7 +85,7 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
     }
 }
 
-fn draw_agents_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
+fn draw_agents_overlay(frame: &mut Frame<'_>, app: &TuiApp, selected: usize) {
     let popup = centered_rect(92, 80, frame.area());
     let layout = Layout::default()
         .direction(Direction::Horizontal)
@@ -118,12 +120,13 @@ fn draw_agents_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
         .highlight_symbol("> ");
     let mut state = ListState::default();
     if !app.agents.is_empty() {
-        state.select(Some(app.selected_agent));
+        state.select(Some(selected.min(app.agents.len().saturating_sub(1))));
     }
     frame.render_stateful_widget(list, layout[0], &mut state);
 
     let text = app
-        .selected_agent_summary()
+        .agents
+        .get(selected)
         .map(render::render_summary)
         .unwrap_or_else(|| "No agent selected.".to_string());
     let detail = Paragraph::new(text)

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -525,17 +525,18 @@ impl TuiApp {
         }
     }
 
-    pub(super) fn next_agent_index(&self, delta: i32) -> Option<usize> {
+    pub(super) fn next_agent_index_from(&self, selected: usize, delta: i32) -> Option<usize> {
         if self.agents.is_empty() {
             return None;
         }
+        let selected = selected.min(self.agents.len().saturating_sub(1));
 
         Some(if delta > 0 {
-            (self.selected_agent + 1) % self.agents.len()
-        } else if self.selected_agent == 0 {
+            (selected + 1) % self.agents.len()
+        } else if selected == 0 {
             self.agents.len() - 1
         } else {
-            self.selected_agent - 1
+            selected - 1
         })
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -839,6 +839,28 @@ async fn agent_overlay_enter_starts_switch_without_awaiting_snapshot() {
 }
 
 #[tokio::test]
+async fn agent_overlay_enter_clamps_stale_selection() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.agents = vec![sample_agent_summary("alpha"), sample_agent_summary("beta")];
+    app.selected_agent = 0;
+    app.overlay = OverlayState::Agents { selected: 9 };
+    app.connection_state = TuiConnectionState::Streaming;
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(app.overlay, OverlayState::None);
+    assert_eq!(app.status_line, "Bootstrapping agent beta from /state");
+    assert_eq!(app.selected_agent_id(), Some("alpha"));
+    assert!(app.snapshot_refresh_in_flight);
+}
+
+#[tokio::test]
 async fn esc_closes_active_overlay_before_touching_prompt() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -797,11 +797,24 @@ async fn agent_overlay_stays_open_while_navigating() {
         client,
         crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
     );
-    app.overlay = OverlayState::Agents;
+    app.agents = vec![sample_agent_summary("alpha"), sample_agent_summary("beta")];
+    app.selected_agent = 0;
+    app.connection_state = TuiConnectionState::Streaming;
+    app.status_line = "Streaming native events for agent alpha".into();
+    app.overlay = OverlayState::Agents { selected: 0 };
+
     app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
         .await
         .unwrap();
-    assert_eq!(app.overlay, OverlayState::Agents);
+
+    assert_eq!(app.overlay, OverlayState::Agents { selected: 1 });
+    assert_eq!(app.selected_agent_id(), Some("alpha"));
+    assert!(matches!(
+        app.connection_state,
+        TuiConnectionState::Streaming
+    ));
+    assert!(!app.snapshot_refresh_in_flight);
+    assert_eq!(app.status_line, "Streaming native events for agent alpha");
 }
 
 #[tokio::test]
@@ -813,7 +826,7 @@ async fn agent_overlay_enter_starts_switch_without_awaiting_snapshot() {
     );
     app.agents = vec![sample_agent_summary("alpha"), sample_agent_summary("beta")];
     app.selected_agent = 1;
-    app.overlay = OverlayState::Agents;
+    app.overlay = OverlayState::Agents { selected: 1 };
     app.connection_state = TuiConnectionState::Streaming;
 
     app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
@@ -1094,7 +1107,7 @@ async fn slash_menu_enter_runs_selected_command_from_root_menu() {
         .await
         .unwrap();
 
-    assert_eq!(app.overlay, OverlayState::Agents);
+    assert_eq!(app.overlay, OverlayState::Agents { selected: 0 });
     assert_eq!(app.composer.as_str(), "");
 }
 
@@ -2647,7 +2660,7 @@ async fn agent_switch_starts_snapshot_refresh_without_awaiting_network() {
     app.connection_state = TuiConnectionState::Streaming;
     app.status_line = "Streaming native events for agent alpha".into();
 
-    app.move_agent_selection(1).await.unwrap();
+    app.begin_bootstrap_agent_index(1);
 
     assert_eq!(app.selected_agent_id(), Some("alpha"));
     assert!(matches!(

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -159,7 +159,7 @@ fn overlay_hint(app: &TuiApp, slash_visible: bool) -> Option<&'static str> {
     }
     let context = match app.overlay {
         OverlayState::None => return None,
-        OverlayState::Agents => KeyContext::AgentsOverlay,
+        OverlayState::Agents { .. } => KeyContext::AgentsOverlay,
         OverlayState::Events { .. } => KeyContext::EventsOverlay,
         OverlayState::Transcript { .. }
         | OverlayState::AgentState { .. }

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -157,7 +157,7 @@ fn overlay_hint(app: &TuiApp, slash_visible: bool) -> Option<&'static str> {
     if slash_visible {
         return Some(status_hint(KeyContext::SlashMenu, true));
     }
-    let context = match app.overlay {
+    let context = match &app.overlay {
         OverlayState::None => return None,
         OverlayState::Agents { .. } => KeyContext::AgentsOverlay,
         OverlayState::Events { .. } => KeyContext::EventsOverlay,


### PR DESCRIPTION
## Summary
- give the agents overlay its own selected index
- make up/down update only the overlay selection without bootstrapping or changing the active agent
- keep Enter as the only path that closes the overlay and starts the selected agent bootstrap

Closes #1040

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test agent_overlay --lib -- --test-threads=1
- cargo test slash_menu_enter_runs_selected_command_from_root_menu --lib -- --test-threads=1
- cargo test agent_switch_starts_snapshot_refresh_without_awaiting_network --lib -- --test-threads=1
- cargo test tui --lib -- --test-threads=1