### PR TITLE
feat: enable gzip for web requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -344,6 +362,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -516,6 +560,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -707,6 +761,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "flate2",
  "hyper",
  "hyper-util",
  "libc",
@@ -1165,6 +1220,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1885,6 +1950,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,13 +2225,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ hyper = { version = "1.5", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["server-auto", "tokio", "service", "http1", "http2"] }
 libc = "0.2"
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["gzip", "json", "rustls-tls"], default-features = false }
 rusqlite = { version = "0.31", features = ["bundled"] }
 pulldown-cmark = "0.13"
 portable-pty = "0.9"
@@ -40,6 +40,7 @@ uuid = { version = "1.11", features = ["serde", "v4"] }
 twox-hash = { version = "2.1.2", features = ["std"] }
 
 [dev-dependencies]
+flate2 = "1.0"
 tempfile = "3.14"
 proptest = "1.6"
 

--- a/src/web/fetch.rs
+++ b/src/web/fetch.rs
@@ -254,6 +254,16 @@ pub fn error_result(tool_name: &str, error: ToolError) -> crate::tool::ToolResul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        body::Body,
+        http::{
+            header::{CONTENT_ENCODING, CONTENT_TYPE},
+            HeaderValue,
+        },
+        response::Response,
+    };
+    use flate2::{write::GzEncoder, Compression};
+    use std::io::Write;
 
     #[test]
     fn html_extraction_removes_tags() {
@@ -269,5 +279,56 @@ mod tests {
         let wrapped = external_content_wrapper(&url, "hello");
         assert!(wrapped.contains("external_content"));
         assert!(wrapped.contains("untrusted"));
+    }
+
+    #[tokio::test]
+    async fn fetch_decodes_gzip_response_before_text_extraction() {
+        let body = gzip_bytes("compressed fetch body");
+        let router = axum::Router::new().route(
+            "/page",
+            axum::routing::get(move || {
+                let body = body.clone();
+                async move { gzip_response(body, "text/plain") }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+
+        let mut config = WebFetchConfig::default();
+        config.allowed_hosts = vec![format!("127.0.0.1:{}", addr.port())];
+        let response = fetch(
+            WebFetchRequest {
+                url: format!("http://{addr}/page"),
+                max_chars: None,
+                extract_mode: ExtractMode::Auto,
+            },
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert!(response.text.contains("compressed fetch body"));
+        assert_eq!(response.bytes_read, "compressed fetch body".len());
+        assert!(!response.truncated);
+    }
+
+    fn gzip_bytes(text: &str) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(text.as_bytes()).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn gzip_response(body: Vec<u8>, content_type: &'static str) -> Response {
+        let mut response = Response::new(Body::from(body));
+        response
+            .headers_mut()
+            .insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static(content_type));
+        response
     }
 }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -788,6 +788,16 @@ fn search_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        body::Body,
+        http::{
+            header::{CONTENT_ENCODING, CONTENT_TYPE},
+            HeaderValue,
+        },
+        response::Response,
+    };
+    use flate2::{write::GzEncoder, Compression};
+    use std::io::Write;
 
     #[test]
     fn parses_duckduckgo_lite_links() {
@@ -923,6 +933,62 @@ mod tests {
         assert_eq!(results[0].snippet.as_deref(), Some("Brave Search engine"));
         assert_eq!(results[0].source, "brave_test");
         assert_eq!(results[1].title, "Brave Browser");
+    }
+
+    #[tokio::test]
+    async fn brave_search_decodes_gzip_json_response() {
+        let body = gzip_json(&brave_results_json());
+        let router = axum::Router::new().route(
+            "/res/v1/web/search",
+            axum::routing::get(move || {
+                let body = body.clone();
+                async move { gzip_response(body, "application/json") }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{}", addr);
+
+        let provider = test_provider(WebProviderKind::Brave, &base_url);
+        let results = brave_search("test", 5, "brave_test", &provider, &test_fetch_config())
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Brave Search");
+    }
+
+    #[tokio::test]
+    async fn search_response_limit_applies_after_gzip_decode() {
+        let body = gzip_text(&"x".repeat(SEARCH_RESPONSE_BYTES + 1));
+        let router = axum::Router::new().route(
+            "/search",
+            axum::routing::get(move || {
+                let body = body.clone();
+                async move { gzip_response(body, "text/plain") }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+
+        let response = Client::builder()
+            .timeout(timeout(&test_fetch_config()))
+            .build()
+            .unwrap()
+            .get(format!("http://{addr}/search"))
+            .send()
+            .await
+            .unwrap();
+        let error = read_search_response(response, "gzip_test")
+            .await
+            .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "response_too_large");
     }
 
     #[tokio::test]
@@ -1153,5 +1219,26 @@ mod tests {
             "first result should have a title"
         );
         assert!(!results[0].url.is_empty(), "first result should have a url");
+    }
+
+    fn gzip_json(value: &serde_json::Value) -> Vec<u8> {
+        gzip_text(&value.to_string())
+    }
+
+    fn gzip_text(text: &str) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(text.as_bytes()).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn gzip_response(body: Vec<u8>, content_type: &'static str) -> Response {
+        let mut response = Response::new(Body::from(body));
+        response
+            .headers_mut()
+            .insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static(content_type));
+        response
     }
 }


### PR DESCRIPTION
## Summary

- enable reqwest gzip support in the shared dependency feature set
- add gzip response coverage for WebFetch text extraction
- add gzip JSON and decompressed-size-limit coverage for WebSearch provider responses

Fixes #1047.

## Verification

- `cargo fmt --all -- --check`
- `cargo test web:: --lib -- --test-threads=1`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
