### PR TITLE
fix: isolate legacy subagent task compatibility

### DIFF
--- a/docs/rfcs/task-surface-narrowing.md
+++ b/docs/rfcs/task-surface-narrowing.md
@@ -280,7 +280,8 @@ Without breaking the surface yet:
 - describe `command_task` as the primary task-control object
 - describe `child_agent_task` as the unified supervised child-agent task
 - describe `subagent_task` and `worktree_subagent_task` as legacy record names
-  that map to `workspace_mode=inherit` and `workspace_mode=worktree`
+  that map to `workspace_mode=inherit` and `workspace_mode=worktree` for
+  persistence compatibility only, without scheduler blocking semantics
 - describe `sleep_job` as transitional delayed-reactivation language
 - describe `TaskStatus` as the preferred task metadata snapshot
 - describe `TaskGet` as a removable legacy detail shape rather than the long-

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2231,6 +2231,18 @@ type TaskRecoverySpec =
       trust: TrustLevel
       workspace_mode: 'inherit' | 'worktree'
     }
+  | {
+      kind: 'subagent_task' // legacy, persistence compatibility only
+      summary: string
+      prompt: string
+      trust: TrustLevel
+    }
+  | {
+      kind: 'worktree_subagent_task' // legacy, persistence compatibility only
+      summary: string
+      prompt: string
+      trust: TrustLevel
+    }
   | { kind: 'command_task'; summary: string; spec: CommandTaskSpec; trust: TrustLevel }
 ```
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2218,7 +2218,9 @@ type TaskKind =
 
 Legacy stored task records may still deserialize `subagent_task` and
 `worktree_subagent_task`. New records should only emit `command_task`,
-`child_agent_task`, or `sleep_job`.
+`child_agent_task`, or `sleep_job`. The legacy child-agent names are
+persistence-compatibility only and do not participate in scheduler blocking
+decisions, even when older detail payloads contain `wait_policy=blocking`.
 
 ```ts
 type TaskRecoverySpec =
@@ -2231,6 +2233,11 @@ type TaskRecoverySpec =
     }
   | { kind: 'command_task'; summary: string; spec: CommandTaskSpec; trust: TrustLevel }
 ```
+
+Legacy `subagent_task` and `worktree_subagent_task` recovery specs may still be
+accepted while reading old persisted records so the runtime can recover
+supervised child identity and workspace mode. They are not emitted for new
+records and do not imply scheduler blocking.
 
 ### Recovery Behavior
 

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -862,6 +862,63 @@ fn scheduler_decision_event_records_evidence_and_bindings() {
 }
 
 #[test]
+fn legacy_child_agent_task_kinds_do_not_gate_scheduler_wait_for_task() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let now = Utc::now();
+
+    for (id, kind, recovery) in [
+        (
+            "legacy-inherited",
+            TaskKind::SubagentTask,
+            TaskRecoverySpec::SubagentTask {
+                summary: "legacy inherited".into(),
+                prompt: "resume".into(),
+                trust: TrustLevel::TrustedOperator,
+            },
+        ),
+        (
+            "legacy-worktree",
+            TaskKind::WorktreeSubagentTask,
+            TaskRecoverySpec::WorktreeSubagentTask {
+                summary: "legacy worktree".into(),
+                prompt: "resume".into(),
+                trust: TrustLevel::TrustedOperator,
+            },
+        ),
+    ] {
+        storage
+            .append_task(&TaskRecord {
+                id: id.into(),
+                agent_id: "default".into(),
+                kind,
+                status: TaskStatus::Running,
+                created_at: now,
+                updated_at: now,
+                parent_message_id: None,
+                work_item_id: None,
+                summary: Some("legacy child task".into()),
+                detail: Some(serde_json::json!({ "wait_policy": "blocking" })),
+                recovery: Some(recovery),
+            })
+            .unwrap();
+    }
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    assert_eq!(projection.active_tasks.len(), 2);
+    assert!(!projection.has_blocking_active_tasks);
+
+    let decision = scheduler::decide_next_action(
+        &projection,
+        scheduler::SchedulerBoundary::RunLoopIdle,
+        scheduler::SchedulerInput::Idle,
+    );
+    assert_ne!(decision.kind, scheduler::SchedulerDecisionKind::WaitForTask);
+}
+
+#[test]
 fn scheduler_decision_append_dedupes_identical_latest_event() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new(dir.path()).unwrap();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1263,7 +1263,7 @@ mod tests {
     }
 
     #[test]
-    fn latest_active_task_records_preserves_recovery_from_older_snapshot() {
+    fn latest_active_task_records_preserves_current_child_agent_recovery_from_older_snapshot() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
         let now = Utc::now();
@@ -1278,10 +1278,11 @@ mod tests {
             work_item_id: None,
             summary: None,
             detail: None,
-            recovery: Some(TaskRecoverySpec::SubagentTask {
+            recovery: Some(TaskRecoverySpec::ChildAgentTask {
                 summary: "recover".into(),
                 prompt: "resume with artifact".into(),
                 trust: TrustLevel::TrustedOperator,
+                workspace_mode: crate::types::ChildAgentWorkspaceMode::Inherit,
             }),
         };
         storage.append_task(&task).unwrap();
@@ -1294,7 +1295,7 @@ mod tests {
         assert_eq!(active.len(), 1);
         assert!(matches!(
             active[0].recovery,
-            Some(TaskRecoverySpec::SubagentTask { .. })
+            Some(TaskRecoverySpec::ChildAgentTask { .. })
         ));
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -634,6 +634,10 @@ impl TaskKind {
             Self::ChildAgentTask | Self::SubagentTask | Self::WorktreeSubagentTask
         )
     }
+
+    pub fn is_legacy_child_agent_compat(self) -> bool {
+        matches!(self, Self::SubagentTask | Self::WorktreeSubagentTask)
+    }
 }
 
 impl std::fmt::Display for TaskKind {
@@ -1994,6 +1998,15 @@ pub struct TaskRecord {
 
 impl TaskRecord {
     pub fn wait_policy(&self) -> TaskWaitPolicy {
+        if self.kind.is_legacy_child_agent_compat()
+            || self
+                .recovery
+                .as_ref()
+                .is_some_and(TaskRecoverySpec::is_legacy_child_agent_compat)
+        {
+            return TaskWaitPolicy::Background;
+        }
+
         self.detail
             .as_ref()
             .and_then(|detail| detail.get("wait_policy"))
@@ -2512,6 +2525,13 @@ fn task_detail_value<'a>(detail: &'a Option<Value>, key: &str) -> Option<&'a Val
 }
 
 impl TaskRecoverySpec {
+    pub fn is_legacy_child_agent_compat(&self) -> bool {
+        matches!(
+            self,
+            TaskRecoverySpec::SubagentTask { .. } | TaskRecoverySpec::WorktreeSubagentTask { .. }
+        )
+    }
+
     pub fn child_agent_workspace_mode(&self) -> Option<ChildAgentWorkspaceMode> {
         match self {
             TaskRecoverySpec::ChildAgentTask { workspace_mode, .. } => Some(*workspace_mode),
@@ -2526,8 +2546,8 @@ impl TaskRecoverySpec {
     pub fn wait_policy(&self) -> TaskWaitPolicy {
         match self {
             TaskRecoverySpec::ChildAgentTask { .. } => TaskWaitPolicy::Blocking,
-            TaskRecoverySpec::SubagentTask { .. } => TaskWaitPolicy::Blocking,
-            TaskRecoverySpec::WorktreeSubagentTask { .. } => TaskWaitPolicy::Blocking,
+            TaskRecoverySpec::SubagentTask { .. } => TaskWaitPolicy::Background,
+            TaskRecoverySpec::WorktreeSubagentTask { .. } => TaskWaitPolicy::Background,
             TaskRecoverySpec::CommandTask { spec, .. } => {
                 if spec.continue_on_result {
                     TaskWaitPolicy::Blocking
@@ -3459,6 +3479,47 @@ mod tests {
             task.child_agent_workspace_mode(),
             Some(ChildAgentWorkspaceMode::Worktree)
         );
+        assert_eq!(task.wait_policy(), TaskWaitPolicy::Background);
+        assert!(!task.is_blocking());
+    }
+
+    #[test]
+    fn legacy_child_agent_compat_records_do_not_block_scheduler() {
+        let now = Utc::now();
+        for (kind, recovery) in [
+            (
+                TaskKind::SubagentTask,
+                TaskRecoverySpec::SubagentTask {
+                    summary: "legacy inherited".into(),
+                    prompt: "resume".into(),
+                    trust: TrustLevel::TrustedOperator,
+                },
+            ),
+            (
+                TaskKind::WorktreeSubagentTask,
+                TaskRecoverySpec::WorktreeSubagentTask {
+                    summary: "legacy worktree".into(),
+                    prompt: "resume".into(),
+                    trust: TrustLevel::TrustedOperator,
+                },
+            ),
+        ] {
+            let task = TaskRecord {
+                id: format!("task-{kind}"),
+                agent_id: "default".into(),
+                kind,
+                status: TaskStatus::Running,
+                created_at: now,
+                updated_at: now,
+                parent_message_id: None,
+                work_item_id: None,
+                summary: None,
+                detail: Some(serde_json::json!({ "wait_policy": "blocking" })),
+                recovery: Some(recovery),
+            };
+            assert_eq!(task.wait_policy(), TaskWaitPolicy::Background);
+            assert!(!task.is_blocking());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep legacy `subagent_task` and `worktree_subagent_task` readable as persistence compatibility only
- prevent legacy child-agent task kind/recovery records from contributing scheduler blocking wait policy
- update runtime docs/RFC text to mark legacy names as compatibility-only
- rewrite the storage recovery regression around current `child_agent_task` recovery

Fixes #1066.

## Verification

- `cargo fmt --all -- --check`
- `cargo test legacy_child_agent --lib -- --test-threads=1`
- `cargo test latest_active_task_records_preserves_current_child_agent_recovery_from_older_snapshot --lib -- --test-threads=1`
- `cargo test legacy_task_kind_records_deserialize_without_losing_workspace_mode --lib -- --test-threads=1`
- `cargo test scheduler --lib -- --test-threads=1`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
