### PR TITLE
fix: stop treating active tasks as scheduler waits

### DIFF
--- a/docs/rfcs/agent-lifecycle-control-posture.md
+++ b/docs/rfcs/agent-lifecycle-control-posture.md
@@ -87,7 +87,7 @@ allowed to perform autonomous work.
 ### Scheduler Posture
 
 The derived operational state of a runnable agent, such as `AwakeIdle`,
-`AwakeRunning`, `AwaitingTask`, or `Asleep`.
+`AwakeRunning`, or `Asleep`.
 
 ### Runtime Ownership
 
@@ -120,7 +120,6 @@ enum AgentStatus {
     Booting,
     AwakeIdle,
     AwakeRunning,
-    AwaitingTask,
     Asleep,
     Stopped,
 }
@@ -148,8 +147,11 @@ It should:
 - derive the next status from scheduler projection:
   - queued message or wake hint available -> runnable `AwakeIdle` before the
     next run-loop decision;
-  - blocking active task -> `AwaitingTask`;
   - no runnable facts -> `AwakeIdle` or `Asleep`, depending on sleep policy.
+
+Active task records are diagnostic and task-result reduction facts, not
+lifecycle posture gates. A running task does not by itself move the scheduler
+into a waiting status.
 
 `Start` may restore runtime-owned in-process handles only when those handles are
 known to still be valid. It must not invent handles for interrupted tasks.

--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -320,7 +320,6 @@ The scheduler should produce one explicit decision at each boundary:
 - `StartModelTurn`
 - `ReduceMessageOnly`
 - `EmitSystemTick`
-- `WaitForTask`
 - `WaitForExternalChange`
 - `WaitForTimer`
 - `WaitForOperator`
@@ -345,19 +344,19 @@ Scheduler decisions should use a fixed priority order.
 2. queued operator interjection input may be inserted into a running turn.
 3. a queued model-reentry message may start a turn when no turn is running.
 4. terminal blocking task result may resume the model-reentry wait it satisfies.
-5. active blocking tasks mean `WaitForTask`.
-6. active waiting intents mean `WaitForExternalChange`.
-7. active timers mean `WaitForTimer`.
-8. pending wake hint means `EmitSystemTick(wake_hint)`.
-9. current runnable work item means `EmitSystemTick(continue_active)` unless an
+5. active waiting intents mean `WaitForExternalChange`.
+6. active timers mean `WaitForTimer`.
+7. pending wake hint means `EmitSystemTick(wake_hint)`.
+8. current runnable work item means `EmitSystemTick(continue_active)` unless an
    idempotency key has already been emitted for the same generation.
-10. queued runnable work item means `EmitSystemTick(queued_available)` unless an
+9. queued runnable work item means `EmitSystemTick(queued_available)` unless an
     idempotency key has already been emitted for the same generation.
-11. no runnable work and no pending inputs means `Sleep` or `StayIdle`,
+10. no runnable work and no pending inputs means `Sleep` or `StayIdle`,
     depending on host mode.
 
-This order intentionally keeps blocking facts above work-queue self-reactivate
-ticks.
+Active task records remain part of the scheduler projection for diagnostics and
+task-result reduction, but active task presence alone is not a waiting fact and
+must not block work-queue self-reactivate ticks.
 
 ## Model Visibility
 
@@ -777,7 +776,7 @@ Implemented by routing the normal run-loop polling path through
 Implemented by converging normal scheduler-sensitive posture writes and
 decision events:
 
-- normal `AwakeRunning`, `AwakeIdle`, `AwaitingTask`, and `Asleep` writes go
+- normal `AwakeRunning`, `AwakeIdle`, and `Asleep` writes go
   through scheduler projection helpers;
 - idle, stopped, work-queue, and wake-hint decisions are recorded as
   `scheduler_decision` events built from `SchedulerDecision`;

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -266,12 +266,6 @@ impl RuntimeHandle {
             }
         }
 
-        let blocking_active_tasks = snapshot
-            .active_tasks
-            .iter()
-            .filter(|task| task.is_blocking())
-            .count();
-
         state
             .active_skills
             .retain(|skill| matches!(skill.activation_state, SkillActivationState::SessionActive));
@@ -284,7 +278,6 @@ impl RuntimeHandle {
             &mut state,
             scheduler_executor::BootstrapRecoveryFacts {
                 queued_messages: queue.len(),
-                blocking_active_tasks,
             },
         );
 

--- a/src/runtime/closure.rs
+++ b/src/runtime/closure.rs
@@ -73,16 +73,6 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
         };
     }
 
-    if facts.active_blocking_tasks > 0 {
-        return ClosureDecision {
-            outcome: ClosureOutcome::Waiting,
-            waiting_reason: Some(WaitingReason::AwaitingTaskResult),
-            work_signal: None,
-            runtime_posture,
-            evidence,
-        };
-    }
-
     if facts.active_waiting_intents > 0 {
         return ClosureDecision {
             outcome: ClosureOutcome::Waiting,
@@ -232,17 +222,18 @@ mod tests {
     }
 
     #[test]
-    fn blocking_tasks_map_to_awaiting_task_result() {
+    fn blocking_tasks_are_metadata_not_waiting_reason() {
         let decision = derive_closure_decision(&ClosureFacts {
             active_blocking_tasks: 2,
             ..facts()
         });
 
-        assert_eq!(decision.outcome, ClosureOutcome::Waiting);
-        assert_eq!(
-            decision.waiting_reason,
-            Some(WaitingReason::AwaitingTaskResult)
-        );
+        assert_eq!(decision.outcome, ClosureOutcome::Completed);
+        assert_eq!(decision.waiting_reason, None);
+        assert!(decision
+            .evidence
+            .iter()
+            .any(|item| item == "active_blocking_tasks=2"));
     }
 
     #[test]
@@ -355,7 +346,7 @@ mod tests {
     #[test]
     fn waiting_conditions_override_runnable_work() {
         let decision = derive_closure_decision(&ClosureFacts {
-            active_blocking_tasks: 1,
+            active_waiting_intents: 1,
             work_signal: Some(WorkReactivationSignal {
                 work_item_id: "work-1".into(),
                 state: WorkItemState::Open,
@@ -367,9 +358,29 @@ mod tests {
         assert_eq!(decision.outcome, ClosureOutcome::Waiting);
         assert_eq!(
             decision.waiting_reason,
-            Some(WaitingReason::AwaitingTaskResult)
+            Some(WaitingReason::AwaitingExternalChange)
         );
         assert_eq!(decision.work_signal, None);
+    }
+
+    #[test]
+    fn blocking_tasks_do_not_override_runnable_work() {
+        let decision = derive_closure_decision(&ClosureFacts {
+            active_blocking_tasks: 1,
+            work_signal: Some(WorkReactivationSignal {
+                work_item_id: "work-1".into(),
+                state: WorkItemState::Open,
+                reactivation_mode: WorkReactivationMode::ContinueActive,
+            }),
+            ..facts()
+        });
+
+        assert_eq!(decision.outcome, ClosureOutcome::Continuable);
+        assert_eq!(decision.waiting_reason, None);
+        assert!(decision
+            .evidence
+            .iter()
+            .any(|item| item == "active_blocking_tasks=1"));
     }
 
     #[test]

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -535,20 +535,6 @@ pub(crate) fn idle_noop_decision(projection: &SchedulerProjection) -> SchedulerD
 pub(crate) fn wait_decision_for_projection(
     projection: &SchedulerProjection,
 ) -> Option<SchedulerDecision> {
-    if projection.has_blocking_active_tasks {
-        let mut decision =
-            SchedulerDecision::new(SchedulerDecisionKind::WaitForTask, "blocking_active_tasks")
-                .liveness_only(true)
-                .evidence(format!("active_tasks={}", projection.active_tasks.len()));
-        if let Some(task) = projection
-            .active_tasks
-            .iter()
-            .find(|task| task.is_blocking())
-        {
-            decision = decision.task_id(task.id.clone());
-        }
-        return Some(decision);
-    }
     if projection.active_waiting_intents > 0 {
         return Some(
             SchedulerDecision::new(
@@ -613,7 +599,7 @@ pub(crate) fn is_terminal_task_status(status: &TaskStatus) -> bool {
 
 pub(crate) fn projected_status_for_idle(
     state: &AgentState,
-    storage: &AppStorage,
+    _storage: &AppStorage,
 ) -> Result<AgentStatus> {
     if matches!(
         state.status,
@@ -621,11 +607,7 @@ pub(crate) fn projected_status_for_idle(
     ) {
         return Ok(state.status.clone());
     }
-    if SchedulerProjection::from_state(storage, state)?.has_blocking_active_tasks {
-        Ok(AgentStatus::AwaitingTask)
-    } else {
-        Ok(AgentStatus::AwakeIdle)
-    }
+    Ok(AgentStatus::AwakeIdle)
 }
 
 pub(crate) fn apply_idle_projection(state: &mut AgentState, storage: &AppStorage) -> Result<()> {
@@ -646,10 +628,6 @@ pub(crate) fn apply_message_wake_projection(state: &mut AgentState) -> bool {
         return true;
     }
     false
-}
-
-pub(crate) fn apply_awaiting_task_projection(state: &mut AgentState) {
-    state.status = AgentStatus::AwaitingTask;
 }
 
 pub(crate) fn apply_sleep_projection(

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_recovery_with_blocking_tasks_becomes_idle() {
+    fn bootstrap_recovery_without_runnable_facts_becomes_idle() {
         let mut state = bootstrap_state(AgentStatus::Booting);
         assert!(apply_bootstrap_recovered_projection(
             &mut state,

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -45,7 +45,6 @@ impl SleepTransitionBoundary {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct BootstrapRecoveryFacts {
     pub(super) queued_messages: usize,
-    pub(super) blocking_active_tasks: usize,
 }
 
 pub(super) struct ScheduledMessage {
@@ -107,23 +106,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
     }
 
     pub(super) async fn bootstrap_recovered(&self) -> Result<AgentState> {
-        let agent_id = {
-            let guard = self.runtime.inner.agent.lock().await;
-            guard.state.id.clone()
-        };
-        let blocking_active_tasks = self
-            .runtime
-            .inner
-            .storage
-            .latest_active_task_records_for_agent(&agent_id, usize::MAX)?
-            .into_iter()
-            .filter(|task| task.is_blocking())
-            .count();
-
         let mut guard = self.runtime.inner.agent.lock().await;
         let facts = BootstrapRecoveryFacts {
             queued_messages: guard.queue.len(),
-            blocking_active_tasks,
         };
         if apply_bootstrap_recovered_projection(&mut guard.state, facts) {
             self.runtime.inner.storage.write_agent(&guard.state)?;
@@ -350,8 +335,6 @@ pub(super) fn apply_bootstrap_recovered_projection(
 
     if state.pending > 0 || facts.queued_messages > 0 || state.pending_wake_hint.is_some() {
         state.status = AgentStatus::AwakeIdle;
-    } else if facts.blocking_active_tasks > 0 {
-        state.status = AgentStatus::AwaitingTask;
     } else if matches!(
         state.status,
         AgentStatus::Booting | AgentStatus::AwakeRunning | AgentStatus::AwaitingTask
@@ -378,26 +361,20 @@ mod tests {
         state.pending = 1;
         assert!(apply_bootstrap_recovered_projection(
             &mut state,
-            BootstrapRecoveryFacts {
-                queued_messages: 1,
-                blocking_active_tasks: 0,
-            },
+            BootstrapRecoveryFacts { queued_messages: 1 },
         ));
         assert_eq!(state.status, AgentStatus::AwakeIdle);
         assert_eq!(state.current_run_id, None);
     }
 
     #[test]
-    fn bootstrap_recovery_with_blocking_tasks_becomes_awaiting_task() {
+    fn bootstrap_recovery_with_blocking_tasks_becomes_idle() {
         let mut state = bootstrap_state(AgentStatus::Booting);
         assert!(apply_bootstrap_recovered_projection(
             &mut state,
-            BootstrapRecoveryFacts {
-                queued_messages: 0,
-                blocking_active_tasks: 2,
-            },
+            BootstrapRecoveryFacts { queued_messages: 0 },
         ));
-        assert_eq!(state.status, AgentStatus::AwaitingTask);
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
     }
 
     #[test]
@@ -407,10 +384,7 @@ mod tests {
             state.current_run_id = Some("run-1".into());
             assert!(!apply_bootstrap_recovered_projection(
                 &mut state,
-                BootstrapRecoveryFacts {
-                    queued_messages: 1,
-                    blocking_active_tasks: 1,
-                },
+                BootstrapRecoveryFacts { queued_messages: 1 },
             ));
             assert_eq!(state.status, status);
             assert_eq!(state.current_run_id.as_deref(), Some("run-1"));
@@ -423,10 +397,7 @@ mod tests {
         state.current_run_id = Some("run-1".into());
         assert!(apply_bootstrap_recovered_projection(
             &mut state,
-            BootstrapRecoveryFacts {
-                queued_messages: 0,
-                blocking_active_tasks: 0,
-            },
+            BootstrapRecoveryFacts { queued_messages: 0 },
         ));
         assert_eq!(state.status, AgentStatus::AwakeIdle);
         assert_eq!(state.current_run_id, None);

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -58,8 +58,6 @@ impl RuntimeHandle {
             ) {
                 if guard.state.current_run_id.is_none() {
                     scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
-                } else if task.is_blocking() && !is_terminal_task_status(&task.status) {
-                    scheduler::apply_awaiting_task_projection(&mut guard.state);
                 }
             }
             self.inner.storage.write_agent(&guard.state)?;
@@ -339,7 +337,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_terminal_task_updates_are_visible_in_ledger_projection_and_blocking_state() {
+    async fn non_terminal_task_updates_are_visible_without_scheduler_wait() {
         let runtime = runtime();
 
         runtime
@@ -350,7 +348,7 @@ mod tests {
         let active_tasks = runtime.active_tasks(10).await.unwrap();
         assert!(active_tasks.iter().any(|task| task.id == "task-1"));
         let state = runtime.agent_state().await.unwrap();
-        assert_eq!(state.status, AgentStatus::AwaitingTask);
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
     }
 
     #[tokio::test]
@@ -378,7 +376,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn terminal_result_falls_back_to_awake_idle_only_when_no_blocking_tasks_remain() {
+    async fn terminal_result_keeps_scheduler_idle_with_other_running_tasks() {
         let runtime = runtime();
         runtime
             .reduce_task_status_message(scheduler_blocking_task("task-1", TaskStatus::Running))
@@ -399,7 +397,7 @@ mod tests {
             .await
             .unwrap();
         let state = runtime.agent_state().await.unwrap();
-        assert_eq!(state.status, AgentStatus::AwaitingTask);
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
         let active_tasks = runtime.active_tasks(10).await.unwrap();
         assert!(!active_tasks.iter().any(|task| task.id == "task-1"));
         assert!(active_tasks.iter().any(|task| task.id == "task-2"));

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -788,11 +788,12 @@ fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts()
             duplicate: None,
         }),
     );
+    assert!(blocked_projection.has_blocking_active_tasks);
     assert_eq!(
         work_queue_decision.kind,
-        scheduler::SchedulerDecisionKind::WaitForTask
+        scheduler::SchedulerDecisionKind::EmitSystemTick
     );
-    assert_eq!(work_queue_decision.reason, "blocking_active_tasks");
+    assert_eq!(work_queue_decision.reason, "continue_active");
 }
 
 #[test]

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1107,7 +1107,7 @@ async fn turn_end_work_item_commit_preserves_existing_blocker_on_failed_turn() {
 }
 
 #[tokio::test]
-async fn turn_end_work_item_commit_moves_bound_item_to_waiting_when_runtime_is_waiting() {
+async fn turn_end_work_item_commit_does_not_block_bound_item_for_active_task_presence() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -1132,10 +1132,7 @@ async fn turn_end_work_item_commit_moves_bound_item_to_waiting_when_runtime_is_w
 
     assert_eq!(committed.id, work_item_id);
     assert_eq!(committed.state, WorkItemState::Open);
-    assert_eq!(
-        committed.blocked_by.as_deref(),
-        Some("Waiting on a task result.")
-    );
+    assert_eq!(committed.blocked_by.as_deref(), None);
 }
 
 #[tokio::test]

--- a/tests/fixtures/scheduler/blocking_task/expected.json
+++ b/tests/fixtures/scheduler/blocking_task/expected.json
@@ -9,6 +9,6 @@
   "active_work_item_waiting_intents": 0,
   "active_agent_waiting_intents": 0,
   "active_timers": 0,
-  "decision": "WaitForTask",
-  "decision_reason": "blocking_active_tasks"
+  "decision": "Sleep",
+  "decision_reason": "no_pending_scheduler_facts"
 }


### PR DESCRIPTION
## Summary
- stop active blocking tasks from producing scheduler wait decisions or AwaitingTask idle posture
- keep active tasks as diagnostic/task-result facts while allowing runnable work ticks
- update closure, bootstrap recovery, scheduler fixtures, and RFC docs for the new posture boundary

Closes #1064

## Tests
- cargo fmt --all -- --check
- cargo test scheduler --lib -- --test-threads=1
- cargo test closure --lib -- --test-threads=1
- cargo test task_state_reducer --lib -- --test-threads=1
- cargo test runtime_state --lib -- --test-threads=1
- cargo test --test runtime_tasks background_command_task_result_wakes_sleeping_agent_for_model_reentry -- --test-threads=1
- cargo test --test runtime_tasks command_task_result_is_canonical_follow_up_on_completion -- --test-threads=1
- RUSTFLAGS="-D warnings" cargo check --all-targets