### PR TITLE
feat: adopt parent workspace for git worktree paths

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2542,6 +2542,12 @@ With `path`, it:
 5. Binds `workspace_id`, `execution_root`, `execution_root_id`, and `cwd`
 6. Persists the active workspace state for recovery across restarts
 
+When `path` points at an existing git worktree whose parent repository is
+already attached to the agent, Holon keeps the parent repository's
+`workspace_id` and `workspace_anchor`, adopts the worktree path as an external
+execution root, and returns guidance to use `mode = "isolated"` with that
+`workspace_id` for runtime-managed worktree lifecycle.
+
 With `workspace_id`, it activates a known attached workspace without discovery.
 `workspace_id = "agent_home"` returns to the built-in AgentHome fallback.
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -27,6 +27,22 @@ fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBu
     Ok(selected_cwd)
 }
 
+pub(crate) struct ExistingGitWorktreeWorkspace {
+    pub(crate) workspace: WorkspaceEntry,
+    pub(crate) worktree_root: PathBuf,
+    pub(crate) suggested_isolation_label: Option<String>,
+}
+
+fn workspace_paths_match(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
 impl RuntimeHandle {
     pub(super) async fn maybe_commit_turn_end_work_item_transition(
         &self,
@@ -728,6 +744,36 @@ impl RuntimeHandle {
         Ok(workspace)
     }
 
+    pub(crate) async fn attached_workspace_for_existing_git_worktree(
+        &self,
+        path: &Path,
+    ) -> Result<Option<ExistingGitWorktreeWorkspace>> {
+        let Some(detected) = crate::system::workspace::detect_existing_git_worktree(path)? else {
+            return Ok(None);
+        };
+        let state = self.agent_state().await?;
+        let known = self.inner.storage.latest_workspace_entries()?;
+        let Some(workspace) = known.into_iter().find(|entry| {
+            workspace_paths_match(&entry.workspace_anchor, &detected.parent_workspace_anchor)
+                && state
+                    .attached_workspaces
+                    .iter()
+                    .any(|id| id == &entry.workspace_id)
+        }) else {
+            return Ok(None);
+        };
+        let suggested_isolation_label = detected
+            .worktree_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(ToString::to_string);
+        Ok(Some(ExistingGitWorktreeWorkspace {
+            workspace,
+            worktree_root: detected.worktree_root,
+            suggested_isolation_label,
+        }))
+    }
+
     pub(crate) async fn workspace_entry_for_use(
         &self,
         workspace_id: &str,
@@ -982,6 +1028,147 @@ impl RuntimeHandle {
                 "boundary": crate::system::HostLocalBoundary::from_parts(
                     &self.agent_state().await?.execution_profile,
                     Some(projection_kind),
+                    Some(access_mode),
+                    Some(execution_root_id),
+                ).audit_metadata(),
+            }),
+        ))?;
+        Ok(())
+    }
+
+    pub async fn enter_existing_git_worktree(
+        &self,
+        workspace: &WorkspaceEntry,
+        worktree_root: PathBuf,
+        access_mode: WorkspaceAccessMode,
+        cwd: Option<PathBuf>,
+    ) -> Result<()> {
+        let agent_id = self.agent_id().await?;
+        let existing_state = self.agent_state().await?;
+        if existing_state
+            .active_workspace_entry
+            .as_ref()
+            .is_some_and(|entry| entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot)
+        {
+            return Err(anyhow!(
+                "agent {} is already using an isolated execution root; use UseWorkspace with a direct workspace before entering another git worktree root",
+                agent_id
+            ));
+        }
+        if !existing_state
+            .attached_workspaces
+            .iter()
+            .any(|id| id == &workspace.workspace_id)
+        {
+            return Err(anyhow!(
+                "workspace {} is not attached to agent {}",
+                workspace.workspace_id,
+                existing_state.id
+            ));
+        }
+        crate::system::ensure_workspace_projection_allowed(
+            &crate::system::HostLocalBoundary::from_parts(
+                &existing_state.execution_profile,
+                existing_state
+                    .active_workspace_entry
+                    .as_ref()
+                    .map(|entry| entry.projection_kind),
+                existing_state
+                    .active_workspace_entry
+                    .as_ref()
+                    .map(|entry| entry.access_mode),
+                existing_state
+                    .active_workspace_entry
+                    .as_ref()
+                    .map(|entry| entry.execution_root_id.clone()),
+            ),
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            "enter_existing_git_worktree",
+        )?;
+
+        let execution_root = crate::system::workspace::normalize_path(&worktree_root)?;
+        let selected_cwd = resolve_enter_cwd(&execution_root, cwd.as_deref())?;
+        let execution_root_id = Self::build_execution_root_id(
+            &workspace.workspace_id,
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            &execution_root,
+        )?;
+        let occupancy = if let Some(bridge) = self.inner.host_bridge.as_ref() {
+            bridge
+                .acquire_workspace_occupancy(
+                    &workspace.workspace_id,
+                    &execution_root_id,
+                    &agent_id,
+                    access_mode,
+                )
+                .await?
+        } else {
+            None
+        };
+        let entry = ActiveWorkspaceEntry {
+            workspace_id: workspace.workspace_id.clone(),
+            workspace_anchor: workspace.workspace_anchor.clone(),
+            execution_root_id: execution_root_id.clone(),
+            execution_root: execution_root.clone(),
+            projection_kind: WorkspaceProjectionKind::GitWorktreeRoot,
+            access_mode,
+            cwd: selected_cwd.clone(),
+            occupancy_id: occupancy.as_ref().map(|record| record.occupancy_id.clone()),
+            projection_metadata: Some(serde_json::json!({
+                "detected_kind": "existing_git_worktree",
+                "ownership": "external",
+                "worktree_root": execution_root,
+            })),
+        };
+        let previous_occupancy_id = existing_state
+            .active_workspace_entry
+            .as_ref()
+            .and_then(|existing_entry| existing_entry.occupancy_id.clone());
+        let new_occupancy_id = entry.occupancy_id.clone();
+
+        let write_result: Result<()> = async {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state.active_workspace_entry = Some(entry.clone());
+            guard.state.worktree_session = None;
+            self.inner.storage.write_agent(&guard.state)?;
+            self.inner.storage.mark_memory_index_dirty()?;
+            Ok(())
+        }
+        .await;
+        if let Err(error) = write_result {
+            if let Some(occupancy_id) = new_occupancy_id.as_deref() {
+                if previous_occupancy_id.as_deref() != Some(occupancy_id) {
+                    if let Some(bridge) = self.inner.host_bridge.as_ref() {
+                        let _ = bridge.release_workspace_occupancy(occupancy_id).await;
+                    }
+                }
+            }
+            return Err(error);
+        }
+        if let Some(previous_occupancy_id) = previous_occupancy_id.as_deref() {
+            if new_occupancy_id.as_deref() != Some(previous_occupancy_id) {
+                if let Some(bridge) = self.inner.host_bridge.as_ref() {
+                    let _ = bridge
+                        .release_workspace_occupancy(previous_occupancy_id)
+                        .await?;
+                }
+            }
+        }
+        self.inner.storage.append_event(&AuditEvent::new(
+            "workspace_entered",
+            serde_json::json!({
+                "workspace_id": workspace.workspace_id,
+                "workspace_anchor": workspace.workspace_anchor,
+                "execution_root_id": execution_root_id,
+                "execution_root": execution_root,
+                "projection_kind": WorkspaceProjectionKind::GitWorktreeRoot,
+                "access_mode": access_mode,
+                "cwd": selected_cwd,
+                "detected_kind": "existing_git_worktree",
+                "ownership": "external",
+                "boundary": crate::system::HostLocalBoundary::from_parts(
+                    &self.agent_state().await?.execution_profile,
+                    Some(WorkspaceProjectionKind::GitWorktreeRoot),
                     Some(access_mode),
                     Some(execution_root_id),
                 ).audit_metadata(),

--- a/src/system/workspace.rs
+++ b/src/system/workspace.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{anyhow, Result};
 use thiserror::Error;
@@ -37,6 +40,78 @@ pub struct WorkspaceView {
     execution_root_id: Option<String>,
     access_mode: Option<WorkspaceAccessMode>,
     worktree_root: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExistingGitWorktree {
+    pub worktree_root: PathBuf,
+    pub parent_workspace_anchor: PathBuf,
+    pub gitdir: PathBuf,
+}
+
+pub fn detect_existing_git_worktree(path: &Path) -> Result<Option<ExistingGitWorktree>> {
+    let normalized_path = normalize_path(path)?;
+    let mut candidate = normalized_path.as_path();
+    loop {
+        let git_file = candidate.join(".git");
+        if git_file.is_file() {
+            let content = fs::read_to_string(&git_file)?;
+            let Some(gitdir_value) = content.trim().strip_prefix("gitdir:") else {
+                return Ok(None);
+            };
+            let gitdir = normalize_path(&resolve_gitdir(candidate, gitdir_value.trim()))?;
+            let Some(parent_workspace_anchor) =
+                parent_workspace_anchor_from_worktree_gitdir(&gitdir)
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(ExistingGitWorktree {
+                worktree_root: candidate.to_path_buf(),
+                parent_workspace_anchor,
+                gitdir,
+            }));
+        }
+        if git_file.is_dir() {
+            return Ok(None);
+        }
+        let Some(parent) = candidate.parent() else {
+            return Ok(None);
+        };
+        candidate = parent;
+    }
+}
+
+fn resolve_gitdir(worktree_root: &Path, gitdir: &str) -> PathBuf {
+    let gitdir = PathBuf::from(gitdir);
+    if gitdir.is_absolute() {
+        gitdir
+    } else {
+        worktree_root.join(gitdir)
+    }
+}
+
+fn parent_workspace_anchor_from_worktree_gitdir(gitdir: &Path) -> Option<PathBuf> {
+    let mut components = gitdir.components();
+    let mut anchor = PathBuf::new();
+    while let Some(component) = components.next() {
+        if component.as_os_str() == ".git" {
+            let Some(worktrees) = components.next() else {
+                return None;
+            };
+            if worktrees.as_os_str() != "worktrees" {
+                return None;
+            }
+            if components.next().is_none() {
+                return None;
+            }
+            if components.next().is_some() {
+                return None;
+            }
+            return Some(anchor);
+        }
+        anchor.push(component.as_os_str());
+    }
+    None
 }
 
 impl WorkspaceView {
@@ -240,5 +315,47 @@ mod tests {
     fn normalize_path_preserves_root_when_parent_dir_appears_at_root() {
         let normalized = normalize_path(Path::new("/../etc")).unwrap();
         assert_eq!(normalized, PathBuf::from("/etc"));
+    }
+
+    #[test]
+    fn detects_existing_git_worktree_from_gitdir_file() {
+        let dir = tempdir().unwrap();
+        let parent = dir.path().join("repo");
+        let worktree = dir.path().join("repo-worktree");
+        std::fs::create_dir_all(parent.join(".git").join("worktrees").join("repo-worktree"))
+            .unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            format!(
+                "gitdir: {}\n",
+                parent
+                    .join(".git")
+                    .join("worktrees")
+                    .join("repo-worktree")
+                    .display()
+            ),
+        )
+        .unwrap();
+
+        let detected = detect_existing_git_worktree(&worktree).unwrap().unwrap();
+        assert_eq!(detected.worktree_root, worktree);
+        assert_eq!(detected.parent_workspace_anchor, parent);
+    }
+
+    #[test]
+    fn does_not_treat_submodule_gitdir_file_as_worktree() {
+        let dir = tempdir().unwrap();
+        let parent = dir.path().join("repo");
+        let submodule = parent.join("vendor").join("lib");
+        std::fs::create_dir_all(parent.join(".git").join("modules").join("vendor/lib")).unwrap();
+        std::fs::create_dir_all(&submodule).unwrap();
+        std::fs::write(
+            submodule.join(".git"),
+            "gitdir: ../../.git/modules/vendor/lib\n",
+        )
+        .unwrap();
+
+        assert!(detect_existing_git_worktree(&submodule).unwrap().is_none());
     }
 }

--- a/src/tool/tools/use_workspace.rs
+++ b/src/tool/tools/use_workspace.rs
@@ -144,9 +144,54 @@ pub(crate) async fn execute(
         }
     } else if let Some(path) = path {
         let path = validate_non_empty(path, NAME, "path")?;
-        let workspace = runtime
-            .ensure_workspace_entry_for_path(PathBuf::from(&path))
-            .await?;
+        let path = PathBuf::from(&path);
+        if projection_kind == WorkspaceProjectionKind::CanonicalRoot {
+            if let Some(existing_worktree) = runtime
+                .attached_workspace_for_existing_git_worktree(&path)
+                .await?
+            {
+                let default_cwd = crate::system::workspace::normalize_path(&path)?;
+                runtime
+                    .enter_existing_git_worktree(
+                        &existing_worktree.workspace,
+                        existing_worktree.worktree_root,
+                        access_mode,
+                        cwd.or(Some(default_cwd)),
+                    )
+                    .await?;
+                let snapshot = runtime.execution_snapshot().await?;
+                let projection_kind_label = workspace_projection_kind_label(
+                    snapshot
+                        .projection_kind
+                        .unwrap_or(WorkspaceProjectionKind::GitWorktreeRoot),
+                );
+                let access_mode_label = workspace_access_mode_kind_label(access_mode);
+                let isolation_label = existing_worktree
+                    .suggested_isolation_label
+                    .unwrap_or_else(|| "worktree".into());
+                return serialize_success(
+                    NAME,
+                    &UseWorkspaceResult {
+                        workspace_id: snapshot
+                            .workspace_id
+                            .unwrap_or_else(|| AGENT_HOME_WORKSPACE_ID.to_string()),
+                        workspace_anchor: snapshot.workspace_anchor,
+                        execution_root: snapshot.execution_root,
+                        cwd: snapshot.cwd,
+                        mode: mode_arg_label(mode).to_string(),
+                        projection_kind: projection_kind_label.to_string(),
+                        access_mode: access_mode_label.to_string(),
+                        summary_text: Some(format!(
+                            "detected an existing git worktree for workspace {}; using it as an external execution root. Prefer UseWorkspace with {{\"workspace_id\":\"{}\",\"mode\":\"isolated\",\"isolation_label\":\"{}\"}} so the runtime manages lifecycle.",
+                            existing_worktree.workspace.workspace_id,
+                            existing_worktree.workspace.workspace_id,
+                            isolation_label
+                        )),
+                    },
+                );
+            }
+        }
+        let workspace = runtime.ensure_workspace_entry_for_path(path).await?;
         runtime.attach_workspace(&workspace).await?;
         runtime
             .enter_workspace(&workspace, projection_kind, access_mode, cwd, branch_name)

--- a/tests/runtime_workspace_worktree.rs
+++ b/tests/runtime_workspace_worktree.rs
@@ -17,6 +17,7 @@ macro_rules! runtime_async_tests {
 runtime_async_tests!(
     task_output_returns_worktree_subagent_result_text,
     enter_worktree_tool_switches_workspace_and_restores_on_reload,
+    use_workspace_path_adopts_attached_parent_for_existing_git_worktree,
     enter_workspace_conflict_preserves_existing_occupancy,
     detach_workspace_persists_empty_binding_across_restart,
     enter_worktree_projection_honors_requested_cwd,

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -163,6 +163,88 @@ pub async fn enter_worktree_tool_switches_workspace_and_restores_on_reload() -> 
     Ok(())
 }
 
+pub async fn use_workspace_path_adopts_attached_parent_for_existing_git_worktree() -> Result<()> {
+    let config = test_config();
+    let workspace = config.workspace_dir.clone();
+    std::fs::create_dir_all(&workspace)?;
+    init_git_repo(&workspace)?;
+    let external_worktree = workspace
+        .parent()
+        .expect("workspace should have parent")
+        .join(format!("manual-worktree-{}", uuid::Uuid::new_v4().simple()));
+    git(
+        &workspace,
+        &[
+            "worktree",
+            "add",
+            external_worktree.to_str().expect("utf8 worktree path"),
+            "-b",
+            "manual-worktree",
+        ],
+    )?;
+
+    let host = RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("unused")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+    let original_workspace_id = runtime
+        .agent_state()
+        .await?
+        .active_workspace_entry
+        .as_ref()
+        .map(|entry| entry.workspace_id.clone())
+        .expect("default workspace should be active");
+
+    let (result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-use-existing-worktree".into(),
+                name: "UseWorkspace".into(),
+                input: json!({ "path": external_worktree }),
+            },
+        )
+        .await?;
+    let value = parse_tool_result_payload(&result)?;
+
+    assert_eq!(value["workspace_id"], original_workspace_id);
+    assert_eq!(
+        PathBuf::from(value["workspace_anchor"].as_str().unwrap()),
+        workspace
+    );
+    assert_eq!(
+        PathBuf::from(value["execution_root"].as_str().unwrap()),
+        external_worktree
+    );
+    assert_eq!(value["projection_kind"], "git_worktree_root");
+    let summary = result.summary_text().unwrap_or_default();
+    assert!(summary.contains("detected an existing git worktree"));
+    assert!(summary.contains("\"mode\":\"isolated\""));
+
+    let state = runtime.agent_state().await?;
+    let active = state
+        .active_workspace_entry
+        .expect("external worktree should be active");
+    assert_eq!(active.workspace_id, original_workspace_id);
+    assert_eq!(active.workspace_anchor, workspace);
+    assert_eq!(active.execution_root, external_worktree);
+    assert_eq!(
+        active.projection_kind,
+        WorkspaceProjectionKind::GitWorktreeRoot
+    );
+    assert!(state.worktree_session.is_none());
+    assert_eq!(
+        active
+            .projection_metadata
+            .as_ref()
+            .and_then(|metadata| metadata["ownership"].as_str()),
+        Some("external")
+    );
+    Ok(())
+}
+
 pub async fn enter_workspace_conflict_preserves_existing_occupancy() -> Result<()> {
     let config = test_config();
     let workspace = config.workspace_dir.clone();


### PR DESCRIPTION
Closes #1049

## Summary
- detect existing git worktree `.git` files and map them back to an attached parent workspace
- let `UseWorkspace(path=...)` adopt the external worktree as a `git_worktree_root` execution root while preserving the parent `workspace_id`
- document the behavior and cover both positive worktree detection and submodule non-detection

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test -p holon system::workspace --lib
- RUSTFLAGS="-D warnings" cargo test --test runtime_workspace_worktree -- --test-threads=1
- RUSTFLAGS="-D warnings" cargo check --all-targets