### PR TITLE
fix: gate TUI presentation debug logs

### DIFF
--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -177,6 +177,13 @@ Credentials follow the same pattern with `credentials.json`.
 |-----|--------|---------|-------------|
 | `tui.alternate_screen` | `auto`, `always`, `never` | `auto` | Alternate screen buffer behavior |
 
+TUI debug instrumentation is controlled by environment variables:
+
+| Environment variable | Values | Default | Description |
+|----------------------|--------|---------|-------------|
+| `HOLON_TUI_PRESENTATION_LOG` | `1`, `true`, `yes`, `on`, `debug` | unset | Enable `logs/tui/presentation.jsonl` debug logging for stream-driven presentation decisions |
+| `HOLON_TUI_PRESENTATION_LOG_MAX_BYTES` | positive integer bytes | `5242880` | Rotate the presentation debug log when it reaches this size |
+
 ## Web Fetch/Search Settings
 
 | Key | Type | Default | Description |

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,7 +1,6 @@
 use super::chat::CachedChatText;
 use super::state::{tui_state_path, TuiClientState};
 use super::*;
-use std::cell::RefCell;
 use std::path::PathBuf;
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
@@ -50,8 +49,7 @@ pub(super) struct TuiApp {
     pub(super) display_mode: OperatorDisplayMode,
     pub(crate) status_line: String,
     pub(super) should_quit: bool,
-    pub(super) chat_text_cache: RefCell<Option<CachedChatText>>,
-    pub(super) presentation_log_signature: RefCell<Option<String>>,
+    pub(super) chat_text_cache: std::cell::RefCell<Option<CachedChatText>>,
     pub(super) input_history: Vec<String>,
     pub(super) history_index: Option<usize>,
     pub(super) log_writer: TuiLogWriter,
@@ -107,8 +105,7 @@ impl TuiApp {
             display_mode: OperatorDisplayMode::DEFAULT,
             status_line: format!("Connecting to {connection_summary}..."),
             should_quit: false,
-            chat_text_cache: RefCell::new(None),
-            presentation_log_signature: RefCell::new(None),
+            chat_text_cache: std::cell::RefCell::new(None),
             input_history: Vec::new(),
             history_index: None,
             log_writer,

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -1,7 +1,6 @@
 use super::*;
-use crate::operator_event::OperatorEventCategory;
 use crate::presentation::{PresentationItem, PresentationReducer, Renderable};
-use crate::tui::projection::ProjectionEventRecord;
+use crate::tui::projection::{is_presentation_reducer_event, ProjectionEventRecord};
 use crossterm::event::KeyCode;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -216,10 +215,7 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
             .event_log()
             .iter()
             .cloned()
-            .filter(|e| {
-                e.kind != "message_enqueued"
-                    && !matches!(e.presentation.category, OperatorEventCategory::StateSync)
-            })
+            .filter(is_presentation_reducer_event)
             .collect();
 
         let mut reducer = PresentationReducer::new();

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -225,7 +225,6 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
         let mut reducer = PresentationReducer::new();
         let mut timed_items = reducer.reduce(events.as_slice());
         timed_items.extend(reducer.flush());
-        log_presentation_decisions(app, events.as_slice(), timed_items.as_slice());
 
         for timed in &timed_items {
             if timed.item.is_visible_at(level) {
@@ -248,30 +247,6 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
         cells.push(active_item);
     }
     cells
-}
-
-fn log_presentation_decisions(
-    app: &TuiApp,
-    events: &[ProjectionEventRecord],
-    timed_items: &[crate::presentation::TimedItem],
-) {
-    if events.is_empty() || timed_items.is_empty() {
-        return;
-    }
-    let signature = events
-        .last()
-        .map(|event| format!("{}:{}", events.len(), event.id))
-        .unwrap_or_default();
-    {
-        let mut logged = app.presentation_log_signature.borrow_mut();
-        if logged.as_deref() == Some(signature.as_str()) {
-            return;
-        }
-        *logged = Some(signature);
-    }
-    if let Err(error) = app.log_writer.write_presentation_items(events, timed_items) {
-        tracing::warn!("failed to persist TUI presentation log: {error}");
-    }
 }
 
 fn projection_brief_ids(app: &TuiApp) -> std::collections::BTreeSet<String> {

--- a/src/tui/logging.rs
+++ b/src/tui/logging.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 use std::sync::Arc;
 use std::{
+    env,
     fs::{self, OpenOptions},
     io::{BufWriter, Write},
     path::{Path, PathBuf},
@@ -14,9 +15,15 @@ use serde_json::Value;
 use super::projection::ProjectionEventRecord;
 use crate::presentation::{PresentationItem, Renderable, RenderedCell, TimedItem};
 
+const PRESENTATION_LOG_ENV: &str = "HOLON_TUI_PRESENTATION_LOG";
+const PRESENTATION_LOG_MAX_BYTES_ENV: &str = "HOLON_TUI_PRESENTATION_LOG_MAX_BYTES";
+const DEFAULT_PRESENTATION_LOG_MAX_BYTES: u64 = 5 * 1024 * 1024;
+
 #[derive(Debug, Clone)]
 pub(crate) struct TuiLogWriter {
     root: PathBuf,
+    presentation_logging_enabled: bool,
+    presentation_log_max_bytes: u64,
     #[cfg(test)]
     _tempdir: Option<Arc<tempfile::TempDir>>,
 }
@@ -28,6 +35,8 @@ impl TuiLogWriter {
             .with_context(|| format!("failed to create {}", root.display()))?;
         Ok(Self {
             root,
+            presentation_logging_enabled: presentation_logging_enabled_from_env(),
+            presentation_log_max_bytes: presentation_log_max_bytes_from_env(),
             #[cfg(test)]
             _tempdir: None,
         })
@@ -41,15 +50,36 @@ impl TuiLogWriter {
             .with_context(|| format!("failed to create {}", root.display()))?;
         Ok(Self {
             root,
+            presentation_logging_enabled: false,
+            presentation_log_max_bytes: DEFAULT_PRESENTATION_LOG_MAX_BYTES,
             _tempdir: Some(tempdir),
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_temp_with_presentation_logging(max_bytes: u64) -> Result<Self> {
+        let mut writer = Self::new_temp()?;
+        writer.presentation_logging_enabled = true;
+        writer.presentation_log_max_bytes = max_bytes;
+        Ok(writer)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
     }
 
     pub(crate) fn write_event(&self, event: &ProjectionEventRecord) -> Result<()> {
         if is_error_log_event(&event.kind) {
             append_jsonl(
                 &self.root.join("errors.jsonl"),
-                &PersistedErrorLogRecord::from_event(event),
+                &PersistedTuiEventLogRecord::from_event(event),
+            )?;
+        }
+        if is_turn_log_event(&event.kind) {
+            append_jsonl(
+                &self.root.join("turns.jsonl"),
+                &PersistedTuiEventLogRecord::from_event(event),
             )?;
         }
 
@@ -61,29 +91,24 @@ impl TuiLogWriter {
         reducer_events: &[ProjectionEventRecord],
         items: &[TimedItem],
     ) -> Result<()> {
+        if !self.presentation_logging_enabled || items.is_empty() {
+            return Ok(());
+        }
         let path = self.root.join("presentation.jsonl");
-        let mut writer = BufWriter::new(
-            OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&path)
-                .with_context(|| format!("failed to open {}", path.display()))?,
-        );
         for item in items {
             let line = serde_json::to_string(&PersistedPresentationLogRecord::from_timed_item(
                 reducer_events,
                 item,
             ))?;
-            writeln!(writer, "{line}")?;
+            append_bounded_jsonl_line(&path, &line, self.presentation_log_max_bytes)?;
         }
-        writer.flush()?;
 
         Ok(())
     }
 }
 
 #[derive(Debug, Serialize)]
-struct PersistedErrorLogRecord<'a> {
+struct PersistedTuiEventLogRecord<'a> {
     ts: DateTime<Utc>,
     event_id: &'a str,
     seq: u64,
@@ -92,7 +117,7 @@ struct PersistedErrorLogRecord<'a> {
     payload: &'a Value,
 }
 
-impl<'a> PersistedErrorLogRecord<'a> {
+impl<'a> PersistedTuiEventLogRecord<'a> {
     fn from_event(event: &'a ProjectionEventRecord) -> Self {
         Self {
             ts: event.ts,
@@ -224,7 +249,25 @@ fn presentation_item_kind(item: &PresentationItem) -> &'static str {
 }
 
 fn is_error_log_event(kind: &str) -> bool {
-    matches!(kind, "runtime_error" | "turn_terminal")
+    matches!(kind, "runtime_error")
+}
+
+fn is_turn_log_event(kind: &str) -> bool {
+    matches!(kind, "turn_terminal")
+}
+
+fn presentation_logging_enabled_from_env() -> bool {
+    env::var(PRESENTATION_LOG_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes" | "on" | "debug"))
+}
+
+fn presentation_log_max_bytes_from_env() -> u64 {
+    env::var(PRESENTATION_LOG_MAX_BYTES_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PRESENTATION_LOG_MAX_BYTES)
 }
 
 fn append_jsonl<T: Serialize>(path: &Path, value: &T) -> Result<()> {
@@ -235,6 +278,46 @@ fn append_jsonl<T: Serialize>(path: &Path, value: &T) -> Result<()> {
         .with_context(|| format!("failed to open {}", path.display()))?;
     let line = serde_json::to_string(value)?;
     writeln!(file, "{line}")?;
+    Ok(())
+}
+
+fn append_bounded_jsonl_line(path: &Path, line: &str, max_bytes: u64) -> Result<()> {
+    let incoming_bytes = line.len() as u64 + 1;
+    if path
+        .metadata()
+        .map(|metadata| metadata.len().saturating_add(incoming_bytes) > max_bytes)
+        .unwrap_or(false)
+    {
+        rotate_jsonl(path)?;
+    }
+    let mut writer = BufWriter::new(
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?,
+    );
+    writeln!(writer, "{line}")?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn rotate_jsonl(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let rotated = path.with_extension("jsonl.1");
+    if rotated.exists() {
+        fs::remove_file(&rotated)
+            .with_context(|| format!("failed to remove {}", rotated.display()))?;
+    }
+    fs::rename(path, &rotated).with_context(|| {
+        format!(
+            "failed to rotate {} to {}",
+            path.display(),
+            rotated.display()
+        )
+    })?;
     Ok(())
 }
 
@@ -249,8 +332,48 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn presentation_log_records_display_decisions_without_raw_conversation_log() {
+    fn presentation_log_is_disabled_by_default() {
         let writer = TuiLogWriter::new_temp().unwrap();
+        let event = ProjectionEventRecord {
+            id: "evt_1".into(),
+            seq: 7,
+            ts: Utc::now(),
+            kind: "brief_created".into(),
+            lane: ProjectionEventLane::Timeline,
+            summary: "completed work".into(),
+            presentation: OperatorEventPresentation {
+                visibility: OperatorVisibility::TurnResult,
+                category: OperatorEventCategory::Brief,
+                title: "Holon".into(),
+                body: Some("completed work".into()),
+                summary: "completed work".into(),
+                source_event_kind: "brief_created".into(),
+            },
+            payload: json!({ "id": "brief_1", "text": "completed work" }),
+        };
+        let item = TimedItem {
+            ts: event.ts,
+            item: PresentationItem::AssistantResult {
+                brief_id: Some("brief_1".into()),
+                body: "completed work".into(),
+                outcome: Outcome::Success,
+            },
+        };
+
+        writer
+            .write_event(&event)
+            .and_then(|_| writer.write_presentation_items(std::slice::from_ref(&event), &[item]))
+            .unwrap();
+
+        assert!(
+            !writer.root.join("presentation.jsonl").exists(),
+            "presentation logging is debug instrumentation and must default off"
+        );
+    }
+
+    #[test]
+    fn presentation_log_records_display_decisions_without_raw_conversation_log_when_enabled() {
+        let writer = TuiLogWriter::new_temp_with_presentation_logging(4096).unwrap();
         let event = ProjectionEventRecord {
             id: "evt_1".into(),
             seq: 7,
@@ -303,7 +426,7 @@ mod tests {
 
     #[test]
     fn presentation_log_marks_lower_display_levels_hidden() {
-        let writer = TuiLogWriter::new_temp().unwrap();
+        let writer = TuiLogWriter::new_temp_with_presentation_logging(4096).unwrap();
         let event = ProjectionEventRecord {
             id: "evt_debug".into(),
             seq: 9,
@@ -339,5 +462,105 @@ mod tests {
         assert_eq!(record["displays"][0]["decision"], "hidden");
         assert_eq!(record["displays"][1]["decision"], "hidden");
         assert_eq!(record["displays"][2]["decision"], "shown");
+    }
+
+    #[test]
+    fn presentation_log_rotates_when_enabled_debug_log_reaches_limit() {
+        let writer = TuiLogWriter::new_temp_with_presentation_logging(1800).unwrap();
+        let event = ProjectionEventRecord {
+            id: "evt_debug".into(),
+            seq: 9,
+            ts: Utc::now(),
+            kind: "provider_round_completed".into(),
+            lane: ProjectionEventLane::Debug,
+            summary: "provider completed".into(),
+            presentation: OperatorEventPresentation {
+                visibility: OperatorVisibility::Trace,
+                category: OperatorEventCategory::Trace,
+                title: "Provider".into(),
+                body: None,
+                summary: "provider completed".into(),
+                source_event_kind: "provider_round_completed".into(),
+            },
+            payload: json!({ "model": "test-model" }),
+        };
+        let item = TimedItem {
+            ts: event.ts,
+            item: PresentationItem::GenericEvent {
+                kind: "provider_round_completed".into(),
+                summary: "provider completed".into(),
+            },
+        };
+
+        for _ in 0..8 {
+            writer
+                .write_presentation_items(std::slice::from_ref(&event), std::slice::from_ref(&item))
+                .unwrap();
+        }
+
+        let path = writer.root.join("presentation.jsonl");
+        let rotated = writer.root.join("presentation.jsonl.1");
+        assert!(path.exists());
+        assert!(rotated.exists());
+        assert!(path.metadata().unwrap().len() <= writer.presentation_log_max_bytes);
+        assert!(rotated.metadata().unwrap().len() <= writer.presentation_log_max_bytes);
+    }
+
+    #[test]
+    fn turn_terminal_records_are_routed_to_turns_not_errors() {
+        let writer = TuiLogWriter::new_temp().unwrap();
+        let event = ProjectionEventRecord {
+            id: "evt_terminal".into(),
+            seq: 10,
+            ts: Utc::now(),
+            kind: "turn_terminal".into(),
+            lane: ProjectionEventLane::Debug,
+            summary: "turn completed".into(),
+            presentation: OperatorEventPresentation {
+                visibility: OperatorVisibility::Trace,
+                category: OperatorEventCategory::Trace,
+                title: "Turn".into(),
+                body: None,
+                summary: "turn completed".into(),
+                source_event_kind: "turn_terminal".into(),
+            },
+            payload: json!({ "kind": "completed" }),
+        };
+
+        writer.write_event(&event).unwrap();
+
+        assert!(!writer.root.join("errors.jsonl").exists());
+        let line = fs::read_to_string(writer.root.join("turns.jsonl")).unwrap();
+        let record: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(record["kind"], "turn_terminal");
+    }
+
+    #[test]
+    fn runtime_errors_are_routed_to_errors_not_turns() {
+        let writer = TuiLogWriter::new_temp().unwrap();
+        let event = ProjectionEventRecord {
+            id: "evt_error".into(),
+            seq: 11,
+            ts: Utc::now(),
+            kind: "runtime_error".into(),
+            lane: ProjectionEventLane::Debug,
+            summary: "runtime failed".into(),
+            presentation: OperatorEventPresentation {
+                visibility: OperatorVisibility::Trace,
+                category: OperatorEventCategory::Trace,
+                title: "Runtime".into(),
+                body: None,
+                summary: "runtime failed".into(),
+                source_event_kind: "runtime_error".into(),
+            },
+            payload: json!({ "error": "failed" }),
+        };
+
+        writer.write_event(&event).unwrap();
+
+        assert!(!writer.root.join("turns.jsonl").exists());
+        let line = fs::read_to_string(writer.root.join("errors.jsonl")).unwrap();
+        let record: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(record["kind"], "runtime_error");
     }
 }

--- a/src/tui/logging.rs
+++ b/src/tui/logging.rs
@@ -95,13 +95,16 @@ impl TuiLogWriter {
             return Ok(());
         }
         let path = self.root.join("presentation.jsonl");
-        for item in items {
-            let line = serde_json::to_string(&PersistedPresentationLogRecord::from_timed_item(
-                reducer_events,
-                item,
-            ))?;
-            append_bounded_jsonl_line(&path, &line, self.presentation_log_max_bytes)?;
-        }
+        let lines = items
+            .iter()
+            .map(|item| {
+                serde_json::to_string(&PersistedPresentationLogRecord::from_timed_item(
+                    reducer_events,
+                    item,
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        append_bounded_jsonl_lines(&path, lines.as_slice(), self.presentation_log_max_bytes)?;
 
         Ok(())
     }
@@ -281,24 +284,40 @@ fn append_jsonl<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     Ok(())
 }
 
-fn append_bounded_jsonl_line(path: &Path, line: &str, max_bytes: u64) -> Result<()> {
-    let incoming_bytes = line.len() as u64 + 1;
-    if path
-        .metadata()
-        .map(|metadata| metadata.len().saturating_add(incoming_bytes) > max_bytes)
-        .unwrap_or(false)
-    {
-        rotate_jsonl(path)?;
+fn append_bounded_jsonl_lines(path: &Path, lines: &[String], max_bytes: u64) -> Result<()> {
+    let mut current_size = path.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+    let mut writer: Option<BufWriter<std::fs::File>> = None;
+
+    for line in lines {
+        let incoming_bytes = line.len() as u64 + 1;
+        if incoming_bytes > max_bytes {
+            continue;
+        }
+        if current_size.saturating_add(incoming_bytes) > max_bytes {
+            if let Some(mut open_writer) = writer.take() {
+                open_writer.flush()?;
+            }
+            rotate_jsonl(path)?;
+            current_size = 0;
+        }
+        if writer.is_none() {
+            writer = Some(BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                    .with_context(|| format!("failed to open {}", path.display()))?,
+            ));
+        }
+        if let Some(open_writer) = writer.as_mut() {
+            writeln!(open_writer, "{line}")?;
+        }
+        current_size += incoming_bytes;
     }
-    let mut writer = BufWriter::new(
-        OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .with_context(|| format!("failed to open {}", path.display()))?,
-    );
-    writeln!(writer, "{line}")?;
-    writer.flush()?;
+
+    if let Some(mut open_writer) = writer {
+        open_writer.flush()?;
+    }
     Ok(())
 }
 
@@ -504,6 +523,41 @@ mod tests {
         assert!(rotated.exists());
         assert!(path.metadata().unwrap().len() <= writer.presentation_log_max_bytes);
         assert!(rotated.metadata().unwrap().len() <= writer.presentation_log_max_bytes);
+    }
+
+    #[test]
+    fn presentation_log_drops_single_records_larger_than_limit() {
+        let writer = TuiLogWriter::new_temp_with_presentation_logging(128).unwrap();
+        let event = ProjectionEventRecord {
+            id: "evt_large".into(),
+            seq: 9,
+            ts: Utc::now(),
+            kind: "provider_round_completed".into(),
+            lane: ProjectionEventLane::Debug,
+            summary: "provider completed".repeat(100),
+            presentation: OperatorEventPresentation {
+                visibility: OperatorVisibility::Trace,
+                category: OperatorEventCategory::Trace,
+                title: "Provider".into(),
+                body: None,
+                summary: "provider completed".repeat(100),
+                source_event_kind: "provider_round_completed".into(),
+            },
+            payload: json!({ "model": "test-model" }),
+        };
+        let item = TimedItem {
+            ts: event.ts,
+            item: PresentationItem::GenericEvent {
+                kind: "provider_round_completed".into(),
+                summary: "provider completed".repeat(100),
+            },
+        };
+
+        writer
+            .write_presentation_items(std::slice::from_ref(&event), std::slice::from_ref(&item))
+            .unwrap();
+
+        assert!(!writer.root.join("presentation.jsonl").exists());
     }
 
     #[test]

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -231,6 +231,18 @@ impl TuiProjection {
                 tracing::warn!("failed to persist TUI log event: {error}");
             }
         }
+        if is_presentation_reducer_event(&record) {
+            let timed_items = self
+                .presentation_reducer
+                .reduce(std::slice::from_ref(&record));
+            if let Err(error) = log_writer
+                .write_presentation_items(std::slice::from_ref(&record), timed_items.as_slice())
+            {
+                if !TUI_LOG_WRITE_WARNED.swap(true, Ordering::Relaxed) {
+                    tracing::warn!("failed to persist TUI presentation log: {error}");
+                }
+            }
+        }
         self.cursor = Some(event.id.clone());
 
         match event.data.event_type.as_str() {
@@ -1163,6 +1175,14 @@ pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
     is_durable_operator_event_kind(kind)
 }
 
+fn is_presentation_reducer_event(event: &ProjectionEventRecord) -> bool {
+    event.kind != "message_enqueued"
+        && !matches!(
+            event.presentation.category,
+            OperatorEventCategory::StateSync
+        )
+}
+
 fn is_activity_reset_kind(kind: &str) -> bool {
     is_activity_reset_event_kind(kind)
 }
@@ -1504,6 +1524,45 @@ mod tests {
             projection.durable_conversation_events().next().is_none(),
             "events_tail should seed the raw inspector, not durable conversation history"
         );
+    }
+
+    #[test]
+    fn stream_event_writes_enabled_presentation_debug_log_incrementally() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let writer =
+            crate::tui::logging::TuiLogWriter::new_temp_with_presentation_logging(4096).unwrap();
+
+        projection.apply_event(
+            sample_event(
+                "assistant_round_recorded",
+                json!({ "round": 1, "text_preview": "streamed assistant progress" }),
+            ),
+            &writer,
+        );
+
+        let line = std::fs::read_to_string(writer.root().join("presentation.jsonl")).unwrap();
+        let record: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(record["item_kind"], "assistant_progress");
+        assert_eq!(
+            record["reducer_event_ids"],
+            json!(["evt-assistant_round_recorded"])
+        );
+    }
+
+    #[test]
+    fn stream_event_does_not_write_presentation_debug_log_by_default() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let writer = crate::tui::logging::TuiLogWriter::new_temp().unwrap();
+
+        projection.apply_event(
+            sample_event(
+                "assistant_round_recorded",
+                json!({ "round": 1, "text_preview": "streamed assistant progress" }),
+            ),
+            &writer,
+        );
+
+        assert!(!writer.root().join("presentation.jsonl").exists());
     }
 
     #[test]

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -38,7 +38,8 @@ const TIMER_TAIL_LIMIT: usize = 50;
 const EVENT_LOG_LIMIT: usize = 256;
 const EVENT_HISTORY_LOG_LIMIT: usize = 4096;
 const DURABLE_CONVERSATION_LOG_LIMIT: usize = 256;
-static TUI_LOG_WRITE_WARNED: AtomicBool = AtomicBool::new(false);
+static TUI_EVENT_LOG_WRITE_WARNED: AtomicBool = AtomicBool::new(false);
+static TUI_PRESENTATION_LOG_WRITE_WARNED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum ProjectionSlice {
@@ -227,7 +228,7 @@ impl TuiProjection {
             );
         }
         if let Err(error) = log_writer.write_event(&record) {
-            if !TUI_LOG_WRITE_WARNED.swap(true, Ordering::Relaxed) {
+            if !TUI_EVENT_LOG_WRITE_WARNED.swap(true, Ordering::Relaxed) {
                 tracing::warn!("failed to persist TUI log event: {error}");
             }
         }
@@ -235,10 +236,15 @@ impl TuiProjection {
             let timed_items = self
                 .presentation_reducer
                 .reduce(std::slice::from_ref(&record));
-            if let Err(error) = log_writer
-                .write_presentation_items(std::slice::from_ref(&record), timed_items.as_slice())
+            let (reducer_events, log_items) = presentation_debug_items_for_event(
+                self.event_log.as_slice(),
+                &record,
+                timed_items.as_slice(),
+            );
+            if let Err(error) =
+                log_writer.write_presentation_items(reducer_events.as_slice(), log_items.as_slice())
             {
-                if !TUI_LOG_WRITE_WARNED.swap(true, Ordering::Relaxed) {
+                if !TUI_PRESENTATION_LOG_WRITE_WARNED.swap(true, Ordering::Relaxed) {
                     tracing::warn!("failed to persist TUI presentation log: {error}");
                 }
             }
@@ -1171,16 +1177,48 @@ fn operator_message_from_enqueued(message: &MessageEnvelope) -> OperatorMessageR
     }
 }
 
-pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
-    is_durable_operator_event_kind(kind)
-}
-
-fn is_presentation_reducer_event(event: &ProjectionEventRecord) -> bool {
+pub(crate) fn is_presentation_reducer_event(event: &ProjectionEventRecord) -> bool {
     event.kind != "message_enqueued"
         && !matches!(
             event.presentation.category,
             OperatorEventCategory::StateSync
         )
+}
+
+pub(crate) fn is_durable_conversation_kind(kind: &str) -> bool {
+    is_durable_operator_event_kind(kind)
+}
+
+fn presentation_debug_items_for_event(
+    event_log: &[ProjectionEventRecord],
+    record: &ProjectionEventRecord,
+    timed_items: &[crate::presentation::TimedItem],
+) -> (
+    Vec<ProjectionEventRecord>,
+    Vec<crate::presentation::TimedItem>,
+) {
+    if record.kind == "process_execution_requested" {
+        return (Vec::new(), Vec::new());
+    }
+    if matches!(
+        record.kind.as_str(),
+        "tool_executed" | "tool_execution_failed"
+    ) {
+        if let Some(previous) = event_log
+            .iter()
+            .rev()
+            .nth(1)
+            .filter(|event| event.kind == "process_execution_requested")
+        {
+            let reducer_events = vec![previous.clone(), record.clone()];
+            let mut reducer = crate::presentation::PresentationReducer::new();
+            let items = reducer.reduce(reducer_events.as_slice());
+            if !items.is_empty() {
+                return (reducer_events, items);
+            }
+        }
+    }
+    (vec![record.clone()], timed_items.to_vec())
 }
 
 fn is_activity_reset_kind(kind: &str) -> bool {
@@ -1546,6 +1584,42 @@ mod tests {
         assert_eq!(
             record["reducer_event_ids"],
             json!(["evt-assistant_round_recorded"])
+        );
+    }
+
+    #[test]
+    fn presentation_debug_log_uses_adjacent_command_window() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let writer =
+            crate::tui::logging::TuiLogWriter::new_temp_with_presentation_logging(4096).unwrap();
+
+        projection.apply_event(
+            sample_event(
+                "process_execution_requested",
+                json!({ "exec_command_cmd": "cargo test" }),
+            ),
+            &writer,
+        );
+        projection.apply_event(
+            sample_event(
+                "tool_executed",
+                json!({
+                    "tool_name": "ExecCommand",
+                    "exec_command_cmd": "cargo test",
+                    "duration_ms": 12,
+                    "exit_status": 0,
+                    "stdout_preview": "ok"
+                }),
+            ),
+            &writer,
+        );
+
+        let line = std::fs::read_to_string(writer.root().join("presentation.jsonl")).unwrap();
+        let record: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(record["item_kind"], "command_executed");
+        assert_eq!(
+            record["reducer_event_ids"],
+            json!(["evt-process_execution_requested", "evt-tool_executed"])
         );
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -290,6 +290,32 @@ fn operator_origin_detection_accepts_structured_origin() {
 }
 
 #[test]
+fn collect_chat_items_does_not_write_presentation_debug_log() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let log_writer =
+        crate::tui::logging::TuiLogWriter::new_temp_with_presentation_logging(4096).unwrap();
+    let mut app = TuiApp::new(client, log_writer);
+    let mut snapshot = sample_snapshot("default", "evt-assistant");
+    snapshot.events_tail = vec![StreamEventEnvelope {
+        id: "evt-assistant".into(),
+        seq: 1,
+        ts: Utc::now(),
+        agent_id: "default".into(),
+        event_type: "assistant_round_recorded".into(),
+        projection: None,
+        provenance: None,
+        payload: json!({ "round": 1, "text_preview": "history progress" }),
+    }];
+    app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+    let first = collect_chat_items(&app);
+    let second = collect_chat_items(&app);
+
+    assert_eq!(first, second);
+    assert!(!app.log_writer.root().join("presentation.jsonl").exists());
+}
+
+#[test]
 fn header_view_model_shows_agent_status_without_contract() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(


### PR DESCRIPTION
Closes #1086

## Summary
- gate `logs/tui/presentation.jsonl` behind `HOLON_TUI_PRESENTATION_LOG`, defaulting debug presentation logging off
- move presentation debug writes from `collect_chat_items` to stream-event projection updates so bootstrap/history/display recomputation does not duplicate log records
- route `turn_terminal` records to `turns.jsonl`, keep `errors.jsonl` for `runtime_error`, and rotate enabled presentation logs by size
- document the TUI debug env vars

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test -p holon tui::logging --lib`
- `RUSTFLAGS="-D warnings" cargo test -p holon tui::projection --lib`
- `RUSTFLAGS="-D warnings" cargo test -p holon collect_chat_items_does_not_write_presentation_debug_log --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `RUSTFLAGS="-D warnings" cargo test -p holon tui:: --lib`
