### PR TITLE
feat: project WorkItem plan artifacts in context

### DIFF
--- a/docs/website/guides/work-items.md
+++ b/docs/website/guides/work-items.md
@@ -47,7 +47,7 @@ The key distinction is:
 Each work item can contain:
 
 - **objective** — short statement of the goal
-- **plan** — durable description of the intended approach
+- **plan artifact** — durable markdown file describing the intended approach
 - **plan status** — `draft`, `ready`, or `needs_input`
 - **todo list** — checklist of meaningful progress steps
 - **blocked by** — specific blocker when progress cannot continue
@@ -60,7 +60,7 @@ Typical work-item operations:
 
 - `CreateWorkItem` — create a new tracked objective
 - `PickWorkItem` — make an open item the current focus
-- `UpdateWorkItem` — refine objective, plan, blocker, or todo list
+- `UpdateWorkItem` — refine objective, plan status, blocker, or todo list
 - `ListWorkItems` — inspect current, open, blocked, or completed work
 - `GetWorkItem` — inspect one work item in detail
 - `CompleteWorkItem` — mark the objective done
@@ -69,7 +69,7 @@ Typical work-item operations:
 
 1. Inspect whether the objective already has an open work item
 2. Create one only if the objective has its own lifecycle
-3. Add a durable plan once the acceptance boundary is clear
+3. Edit the durable plan artifact once the acceptance boundary is clear
 4. Update the todo list after material progress
 5. Record blockers explicitly instead of silently broadening scope
 6. Complete the item only after acceptance evidence exists

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -759,6 +759,7 @@ pub fn ensure_agent_home_layout(agent_home: &Path) -> Result<()> {
         agent_home.join("memory"),
         agent_home.join("notes"),
         agent_home.join("work"),
+        agent_home.join("work-items"),
         agent_home.join("skills"),
         agent_home.join(".holon/state"),
         agent_home.join(".holon/ledger"),

--- a/src/context.rs
+++ b/src/context.rs
@@ -222,7 +222,7 @@ pub fn build_context(
             &mut remaining_budget,
             turn_section(
                 "queued_blocked_work_items",
-                render_queued_blocked_work_items(&queued_blocked_items),
+                render_queued_blocked_work_items(&queued_blocked_items, storage.data_dir()),
             ),
         );
     }
@@ -232,7 +232,7 @@ pub fn build_context(
         &mut remaining_budget,
         section(
             "context_contract",
-            "Interpret the memory block with this priority: current work item objective first, durable plan second, todo_list third, working memory delta next, and rolling working memory after that. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as continuity evidence across turns. When sources differ on task scope, treat the current work item's `objective` and `plan` as the ground truth unless the current input explicitly changes it."
+            "Interpret the memory block with this priority: current work item objective first, durable plan artifact second, todo_list third, working memory delta next, and rolling working memory after that. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as continuity evidence across turns. When sources differ on task scope, treat the current work item's `objective` and plan artifact as the ground truth unless the current input explicitly changes it."
                 .to_string(),
         ),
     );
@@ -510,28 +510,9 @@ fn render_current_work_item(work_item: &WorkItemRecord, agent_home: &std::path::
             work_item_plan_status_label(work_item.plan_status)
         ),
     ];
-    let plan_path = crate::work_item_plan::plan_path(agent_home, &work_item.id);
-    let plan_artifact = if plan_path.exists() || work_item.plan.is_some() {
-        crate::work_item_plan::ensure_plan_artifact(agent_home, work_item, None).ok()
-    } else {
-        None
-    };
-    if let Some(plan_artifact) = plan_artifact {
-        lines.push(format!("- Plan artifact: {}", plan_artifact.path.display()));
-        lines.push(format!(
-            "- Plan preview complete: {}",
-            plan_artifact.preview_complete
-        ));
-        if !plan_artifact.preview.is_empty() {
-            lines.push("- Plan preview:".to_string());
-            lines.extend(
-                plan_artifact
-                    .preview
-                    .lines()
-                    .map(|line| format!("  {line}")),
-            );
-        }
-    }
+    lines.extend(render_work_item_plan_artifact_lines(
+        work_item, agent_home, "- ",
+    ));
     if !work_item.todo_list.is_empty() {
         lines.push("- Todo list:".to_string());
         lines.extend(work_item.todo_list.iter().map(|item| {
@@ -557,9 +538,12 @@ fn work_item_plan_status_label(status: crate::types::WorkItemPlanStatus) -> &'st
     }
 }
 
-fn render_queued_blocked_work_items(items: &[&WorkItemRecord]) -> String {
+fn render_queued_blocked_work_items(
+    items: &[&WorkItemRecord],
+    agent_home: &std::path::Path,
+) -> String {
     let mut lines = vec!["Queued and blocked work items:".to_string()];
-    lines.extend(items.iter().map(|item| {
+    for item in items {
         let view = match item.readiness() {
             crate::types::WorkItemReadiness::Runnable => "queued",
             crate::types::WorkItemReadiness::WaitingForOperator => "waiting_for_operator",
@@ -570,9 +554,45 @@ fn render_queued_blocked_work_items(items: &[&WorkItemRecord]) -> String {
         if let Some(blocked_by) = item.blocked_by.as_deref() {
             summary.push_str(&format!(" :: blocked_by={blocked_by}"));
         }
-        summary
-    }));
+        lines.push(summary);
+        lines.extend(render_work_item_plan_artifact_lines(
+            item, agent_home, "  - ",
+        ));
+    }
     lines.join("\n")
+}
+
+fn render_work_item_plan_artifact_lines(
+    work_item: &WorkItemRecord,
+    agent_home: &std::path::Path,
+    prefix: &str,
+) -> Vec<String> {
+    let plan_path = crate::work_item_plan::plan_path(agent_home, &work_item.id);
+    let plan_artifact = if plan_path.exists() || work_item.plan.is_some() {
+        crate::work_item_plan::ensure_plan_artifact(agent_home, work_item, None).ok()
+    } else {
+        None
+    };
+    let Some(plan_artifact) = plan_artifact else {
+        return Vec::new();
+    };
+    let mut lines = vec![
+        format!("{prefix}Plan artifact: {}", plan_artifact.path.display()),
+        format!(
+            "{prefix}Plan preview complete: {}",
+            plan_artifact.preview_complete
+        ),
+    ];
+    if !plan_artifact.preview.is_empty() {
+        lines.push(format!("{prefix}Plan preview:"));
+        lines.extend(
+            plan_artifact
+                .preview
+                .lines()
+                .map(|line| format!("  {line}")),
+        );
+    }
+    lines
 }
 
 fn working_memory_is_empty(snapshot: &WorkingMemorySnapshot) -> bool {
@@ -2316,6 +2336,14 @@ mod tests {
         assert!(active_section
             .content
             .contains("storage and recovery foundation"));
+        assert!(active_section.content.contains("Plan artifact:"));
+        assert!(active_section.content.contains("work-items/"));
+        assert!(active_section
+            .content
+            .contains("Plan preview complete: true"));
+        assert!(active_section
+            .content
+            .contains("Persist the work item store and project it into prompts."));
         assert!(active_section
             .content
             .contains("Project active item into prompt"));
@@ -2337,17 +2365,22 @@ mod tests {
             },
         );
 
-        let queued = crate::types::WorkItemRecord::new(
+        let mut queued = crate::types::WorkItemRecord::new(
             "default",
             "Queue follow-up verification",
             crate::types::WorkItemState::Open,
         );
+        queued.plan = Some(format!(
+            "Verify the queued path.\n{}",
+            "queued detail ".repeat(200)
+        ));
         let mut waiting = crate::types::WorkItemRecord::new(
             "default",
             "Wait for operator confirmation",
             crate::types::WorkItemState::Open,
         );
         waiting.blocked_by = Some("needs explicit approval before completion".into());
+        waiting.plan = Some("Wait for the operator answer before retrying.".into());
         let completed = crate::types::WorkItemRecord::new(
             "default",
             "Already finished item",
@@ -2384,6 +2417,11 @@ mod tests {
         assert!(summary
             .content
             .contains("needs explicit approval before completion"));
+        assert!(summary.content.contains("Plan artifact:"));
+        assert!(summary.content.contains("Plan preview:"));
+        assert!(summary.content.contains("Verify the queued path."));
+        assert!(summary.content.contains("Plan preview complete: false"));
+        assert!(summary.content.contains("Plan preview complete: true"));
         assert!(!summary.content.contains("Already finished item"));
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -567,15 +567,12 @@ fn render_work_item_plan_artifact_lines(
     agent_home: &std::path::Path,
     prefix: &str,
 ) -> Vec<String> {
-    let plan_path = crate::work_item_plan::plan_path(agent_home, &work_item.id);
-    let plan_artifact = if plan_path.exists() || work_item.plan.is_some() {
-        crate::work_item_plan::ensure_plan_artifact(agent_home, work_item, None).ok()
-    } else {
-        None
-    };
+    let plan_artifact =
+        crate::work_item_plan::ensure_plan_artifact(agent_home, work_item, None).ok();
     let Some(plan_artifact) = plan_artifact else {
         return Vec::new();
     };
+    let preview_indent = " ".repeat(prefix.chars().count());
     let mut lines = vec![
         format!("{prefix}Plan artifact: {}", plan_artifact.path.display()),
         format!(
@@ -589,7 +586,7 @@ fn render_work_item_plan_artifact_lines(
             plan_artifact
                 .preview
                 .lines()
-                .map(|line| format!("  {line}")),
+                .map(|line| format!("{preview_indent}{line}")),
         );
     }
     lines
@@ -2337,7 +2334,7 @@ mod tests {
             .content
             .contains("storage and recovery foundation"));
         assert!(active_section.content.contains("Plan artifact:"));
-        assert!(active_section.content.contains("work-items/"));
+        assert!(active_section.content.contains("work-items"));
         assert!(active_section
             .content
             .contains("Plan preview complete: true"));

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -369,7 +369,7 @@ fn build_system_sections(
         section(
             "agent_home_contract",
             PromptStability::Stable,
-            "Treat `AgentHome` as the default workspace for agent-local state, not as a replacement for an active project workspace. Treat `agent_home/AGENTS.md` as the long-lived contract for this specific agent, not as a duplicate of the system prompt, tool instructions, workspace/project guidance, or one-off task notes. It should capture durable agent-specific information such as role, standing responsibilities, granted authority, escalation boundaries, and how this agent maintains its own `agent_home`. `AGENTS.md` is loaded guidance; `agent_home/memory/self.md` and `agent_home/memory/operator.md` are curated Markdown memory to search or retrieve on demand. Keep project-scoped work, files, rules, and memory in the active project workspace. `.holon/` under agent_home is runtime-owned state, ledger, index, and cache storage; do not edit it as ordinary agent-authored files. `AGENTS.md` may evolve over time as the operator clarifies the agent's role. Near the end of each turn, quickly check whether the interaction revealed new durable agent-specific information worth preserving there. Update it only when that information is likely to remain useful across future turns or sessions. Do not store transient plans, temporary execution notes, copied project docs, or repeated tool guidance there.".to_string(),
+            "Treat `AgentHome` as the default workspace for agent-local state, not as a replacement for an active project workspace. Treat `agent_home/AGENTS.md` as the long-lived contract for this specific agent, not as a duplicate of the system prompt, tool instructions, workspace/project guidance, or one-off task notes. It should capture durable agent-specific information such as role, standing responsibilities, granted authority, escalation boundaries, and how this agent maintains its own `agent_home`. `AGENTS.md` is loaded guidance; `agent_home/memory/self.md` and `agent_home/memory/operator.md` are curated Markdown memory to search or retrieve on demand. Keep project-scoped work, files, rules, and memory in the active project workspace. `agent_home/work-items/<work_item_id>/plan.md` is the agent-authored durable plan artifact for that WorkItem. `.holon/` under agent_home is runtime-owned state, ledger, index, and cache storage; do not edit it as ordinary agent-authored files. `AGENTS.md` may evolve over time as the operator clarifies the agent's role. Near the end of each turn, quickly check whether the interaction revealed new durable agent-specific information worth preserving there. Update it only when that information is likely to remain useful across future turns or sessions. Do not store transient plans, temporary execution notes, copied project docs, or repeated tool guidance there.".to_string(),
         ),
         section(
             "context_completion",
@@ -1187,6 +1187,12 @@ mod tests {
             .content
             .contains("role, standing responsibilities, granted authority"));
         assert!(section.content.contains("may evolve over time"));
+        assert!(section
+            .content
+            .contains("work-items/<work_item_id>/plan.md"));
+        assert!(section
+            .content
+            .contains("agent-authored durable plan artifact"));
         assert!(section.content.contains("Near the end of each turn"));
         assert!(section.content.contains("Do not store transient plans"));
     }

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -115,7 +115,11 @@ fn render_context_snapshot(
         &[],
         continuation,
     )?;
-    Ok(prompt.rendered_context_attachment)
+    let agent_home = storage.data_dir().display().to_string();
+    Ok(prompt
+        .rendered_context_attachment
+        .replace(&agent_home, "$AGENT_HOME")
+        .replace('\\', "/"))
 }
 
 fn assert_snapshot(actual: &str, expected: &str) {
@@ -235,6 +239,8 @@ Current work item:
 - Readiness: Blocked
 - Objective: Ship prompt snapshot coverage
 - Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_prompt/plan.md
+- Plan preview complete: true
 - Todo list:
   - [in_progress] Capture baseline operator layout
   - [pending] Cover callback and task result surfaces
@@ -563,6 +569,8 @@ Current work item:
 - Readiness: Blocked
 - Objective: Complete snapshot coverage expansion
 - Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_active/plan.md
+- Plan preview complete: true
 - Todo list:
   - [in_progress] Add active work with queued work test
   - [pending] Add post-compaction snapshot tests
@@ -571,6 +579,8 @@ Current work item:
 ## queued_blocked_work_items
 Queued and blocked work items:
 - [blocked] work_queued :: Review and merge PR #485 :: blocked_by=blocked on active work completion
+  - Plan artifact: $AGENT_HOME/work-items/work_queued/plan.md
+  - Plan preview complete: true
 
 ## context_contract
 {CONTEXT_CONTRACT}
@@ -653,6 +663,8 @@ Current work item:
 - Readiness: Blocked
 - Objective: Test delta absence
 - Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_no_delta/plan.md
+- Plan preview complete: true
 - Todo list:
   - [in_progress] Verify delta absence
 - Blocked by: verifying snapshot without delta
@@ -777,6 +789,8 @@ Current work item:
 - Readiness: Blocked
 - Objective: Handle CI callback
 - Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_ci/plan.md
+- Plan preview complete: true
 - Todo list:
   - [completed] Wait for CI callback
   - [in_progress] Process CI result
@@ -895,6 +909,8 @@ Current work item:
 - Readiness: Blocked
 - Objective: External service integration
 - Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_waiting/plan.md
+- Plan preview complete: true
 - Todo list:
   - [in_progress] Wait for rate limit reset
   - [pending] Retry API request
@@ -1039,6 +1055,8 @@ Current work item:
 - Readiness: Blocked
 - Objective: Long-running task with compaction
 - Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_compaction/plan.md
+- Plan preview complete: true
 - Todo list:
   - [completed] Complete initial phase
   - [in_progress] Work on expanded coverage
@@ -1186,6 +1204,8 @@ Current work item:
 - Readiness: Blocked
 - Objective: Test execution and verification
 - Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_test/plan.md
+- Plan preview complete: true
 - Todo list:
   - [completed] Execute cargo test
   - [in_progress] Verify test results

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -46,7 +46,7 @@ Process execution guarantees:
   - secret_isolation: not_enforced
   - child_process_containment: not_enforced"#;
 
-const CONTEXT_CONTRACT: &str = r#"Interpret the memory block with this priority: current work item objective first, durable plan second, todo_list third, working memory delta next, and rolling working memory after that. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as continuity evidence across turns. When sources differ on task scope, treat the current work item's `objective` and `plan` as the ground truth unless the current input explicitly changes it."#;
+const CONTEXT_CONTRACT: &str = r#"Interpret the memory block with this priority: current work item objective first, durable plan artifact second, todo_list third, working memory delta next, and rolling working memory after that. This is an interpretation priority, not a guarantee about section ordering. Use prior briefs and recent tool results as continuity evidence across turns. When sources differ on task scope, treat the current work item's `objective` and plan artifact as the ground truth unless the current input explicitly changes it."#;
 
 fn sample_identity() -> AgentIdentityView {
     AgentIdentityView {


### PR DESCRIPTION
## Summary
- project current and queued/blocked WorkItem plans as AgentHome plan artifact paths plus bounded previews
- clarify AgentHome work-items/ vs runtime-owned .holon/ contract and update work-item guide wording
- cover current and queued/blocked WorkItem context rendering with plan artifact preview assertions

Closes #1093

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test -p holon context --lib
- RUSTFLAGS="-D warnings" cargo test -p holon prompt::tests::system_prompt_includes_agent_home_contract_section --lib
- RUSTFLAGS="-D warnings" cargo test -p holon --test prompt_context_snapshots
- RUSTFLAGS="-D warnings" cargo check --all-targets
