### PR TITLE
fix: clear legacy inline WorkItem plan snapshots

### DIFF
--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1995,9 +1995,7 @@ impl RuntimeHandle {
             wrote_item = true;
         }
         if wrote_item {
-            let plan_path =
-                crate::work_item_plan::plan_path(self.agent_home().as_path(), &record.id);
-            if record.plan.is_some() || plan_path.exists() {
+            if record.plan.is_some() {
                 crate::work_item_plan::ensure_plan_artifact(
                     self.agent_home().as_path(),
                     &record,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1995,6 +1995,16 @@ impl RuntimeHandle {
             wrote_item = true;
         }
         if wrote_item {
+            let plan_path =
+                crate::work_item_plan::plan_path(self.agent_home().as_path(), &record.id);
+            if record.plan.is_some() || plan_path.exists() {
+                crate::work_item_plan::ensure_plan_artifact(
+                    self.agent_home().as_path(),
+                    &record,
+                    None,
+                )?;
+                record.plan = None;
+            }
             record.revision = existing.revision + 1;
             self.inner.storage.append_work_item(&record)?;
             self.inner.storage.append_event(&AuditEvent::new(

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1996,11 +1996,15 @@ impl RuntimeHandle {
         }
         if wrote_item {
             if record.plan.is_some() {
-                crate::work_item_plan::ensure_plan_artifact(
-                    self.agent_home().as_path(),
-                    &record,
-                    None,
-                )?;
+                let plan_path =
+                    crate::work_item_plan::plan_path(self.agent_home().as_path(), &record.id);
+                if !plan_path.exists() {
+                    crate::work_item_plan::ensure_plan_artifact(
+                        self.agent_home().as_path(),
+                        &record,
+                        None,
+                    )?;
+                }
                 record.plan = None;
             }
             record.revision = existing.revision + 1;

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -727,6 +727,57 @@ async fn update_work_item_can_refine_objective() {
 }
 
 #[tokio::test]
+async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let mut legacy = WorkItemRecord::new("default", "Migrate inline plan", WorkItemState::Open);
+    legacy.id = "legacy-plan-item".into();
+    legacy.plan = Some("Keep this legacy plan body in the artifact.".into());
+    runtime.inner.storage.append_work_item(&legacy).unwrap();
+
+    let updated = runtime
+        .update_work_item_fields(
+            legacy.id.clone(),
+            Some("Migrate inline plan without copying it".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.revision, legacy.revision + 1);
+    assert!(updated.plan.is_none());
+    let latest = runtime.latest_work_item(&legacy.id).await.unwrap().unwrap();
+    assert!(latest.plan.is_none());
+    assert_eq!(latest.objective, "Migrate inline plan without copying it");
+
+    let plan_path = crate::work_item_plan::plan_path(runtime.agent_home().as_path(), &legacy.id);
+    assert_eq!(
+        std::fs::read_to_string(&plan_path).unwrap(),
+        "Keep this legacy plan body in the artifact."
+    );
+    let artifact = crate::work_item_plan::describe_plan_artifact(&plan_path).unwrap();
+    assert_eq!(
+        artifact.preview,
+        "Keep this legacy plan body in the artifact."
+    );
+    assert!(artifact.preview_complete);
+}
+
+#[tokio::test]
 async fn update_work_item_can_refine_objective_and_todo_list_together() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -775,6 +775,38 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
         "Keep this legacy plan body in the artifact."
     );
     assert!(artifact.preview_complete);
+
+    let mut legacy_with_artifact =
+        WorkItemRecord::new("default", "Keep existing artifact", WorkItemState::Open);
+    legacy_with_artifact.id = "legacy-plan-item-with-artifact".into();
+    legacy_with_artifact.plan = Some("Stale inline plan body.".into());
+    runtime
+        .inner
+        .storage
+        .append_work_item(&legacy_with_artifact)
+        .unwrap();
+    let existing_plan_path =
+        crate::work_item_plan::plan_path(runtime.agent_home().as_path(), &legacy_with_artifact.id);
+    std::fs::create_dir_all(existing_plan_path.parent().unwrap()).unwrap();
+    std::fs::write(&existing_plan_path, "Existing artifact body.").unwrap();
+
+    let updated_with_artifact = runtime
+        .update_work_item_fields(
+            legacy_with_artifact.id.clone(),
+            Some("Keep artifact while clearing inline plan".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(updated_with_artifact.plan.is_none());
+    assert_eq!(
+        std::fs::read_to_string(&existing_plan_path).unwrap(),
+        "Existing artifact body."
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- materialize a WorkItem plan artifact before appending an updated legacy inline-plan record
- clear the inline `WorkItemRecord.plan` field on the new snapshot after artifact materialization
- add a regression test that verifies the updated snapshot has `plan: None` while the artifact preview still contains the legacy body

Closes #1105

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo test -p holon update_work_item_materializes_and_clears_legacy_inline_plan --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets
