### PR TITLE
fix: refresh WorkItem plan artifact snapshots

### DIFF
--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -89,25 +89,32 @@ impl RuntimeHandle {
             }
             None => None,
         };
-        let wrote_new_snapshot =
+        let mut refreshed = latest.clone();
+        let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+            self.agent_home().as_path(),
+            &mut refreshed,
+        )?;
+        let work_item_state_changed =
             latest.state == WorkItemState::Open && latest.blocked_by != blocked_by;
+        let wrote_new_snapshot = work_item_state_changed || plan_artifact_changed;
         let committed = if wrote_new_snapshot {
             let record = crate::types::WorkItemRecord {
-                id: latest.id.clone(),
-                agent_id: latest.agent_id.clone(),
-                workspace_id: latest.workspace_id.clone(),
                 revision: latest.revision + 1,
-                objective: latest.objective.clone(),
-                state: latest.state.clone(),
-                plan_status: latest.plan_status,
-                plan: latest.plan.clone(),
-                todo_list: latest.todo_list.clone(),
                 blocked_by,
-                result_summary: latest.result_summary.clone(),
-                created_at: latest.created_at,
                 updated_at: chrono::Utc::now(),
+                ..refreshed
             };
             self.inner.storage.append_work_item(&record)?;
+            if plan_artifact_changed {
+                self.inner.storage.append_event(&AuditEvent::new(
+                    "work_item_plan_artifact_refreshed",
+                    serde_json::json!({
+                        "work_item_id": record.id.clone(),
+                        "revision": record.revision,
+                        "plan_artifact": record.plan_artifact.clone(),
+                    }),
+                ))?;
+            }
             self.inner.storage.append_event(&AuditEvent::new(
                 "work_item_written",
                 serde_json::json!({
@@ -128,6 +135,8 @@ impl RuntimeHandle {
                 "work_item_id": committed.id,
                 "committed_state": committed.state,
                 "wrote_new_snapshot": wrote_new_snapshot,
+                "plan_artifact_changed": plan_artifact_changed,
+                "work_item_state_changed": work_item_state_changed,
                 "closure": closure,
             }),
         ))?;

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1892,11 +1892,11 @@ impl RuntimeHandle {
         if let Some(plan_status) = plan_status {
             record.plan_status = plan_status;
         }
-        crate::work_item_plan::ensure_plan_artifact(
+        record.plan_artifact = Some(crate::work_item_plan::ensure_plan_artifact(
             self.agent_home().as_path(),
             &record,
             plan.as_deref(),
-        )?;
+        )?);
         record.plan = None;
         record.todo_list = todo_list;
         record.workspace_id = self
@@ -1995,20 +1995,22 @@ impl RuntimeHandle {
             wrote_item = true;
         }
         if wrote_item {
-            if record.plan.is_some() {
-                let plan_path =
-                    crate::work_item_plan::plan_path(self.agent_home().as_path(), &record.id);
-                if !plan_path.exists() {
-                    crate::work_item_plan::ensure_plan_artifact(
-                        self.agent_home().as_path(),
-                        &record,
-                        None,
-                    )?;
-                }
-                record.plan = None;
-            }
+            let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+                self.agent_home().as_path(),
+                &mut record,
+            )?;
             record.revision = existing.revision + 1;
             self.inner.storage.append_work_item(&record)?;
+            if plan_artifact_changed && record.plan_artifact != existing.plan_artifact {
+                self.inner.storage.append_event(&AuditEvent::new(
+                    "work_item_plan_artifact_refreshed",
+                    serde_json::json!({
+                        "work_item_id": record.id.clone(),
+                        "revision": record.revision,
+                        "plan_artifact": record.plan_artifact.clone(),
+                    }),
+                ))?;
+            }
             self.inner.storage.append_event(&AuditEvent::new(
                 "work_item_written",
                 serde_json::json!({
@@ -2035,7 +2037,7 @@ impl RuntimeHandle {
         if existing.state == WorkItemState::Completed {
             return Ok(existing);
         }
-        let record = WorkItemRecord {
+        let mut record = WorkItemRecord {
             revision: existing.revision + 1,
             state: WorkItemState::Completed,
             blocked_by: None,
@@ -2043,7 +2045,21 @@ impl RuntimeHandle {
             updated_at: Utc::now(),
             ..existing
         };
+        let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+            self.agent_home().as_path(),
+            &mut record,
+        )?;
         self.inner.storage.append_work_item(&record)?;
+        if plan_artifact_changed {
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_plan_artifact_refreshed",
+                serde_json::json!({
+                    "work_item_id": record.id.clone(),
+                    "revision": record.revision,
+                    "plan_artifact": record.plan_artifact.clone(),
+                }),
+            ))?;
+        }
         if let Some(result_summary) = result_summary {
             self.inner
                 .storage

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -35,6 +35,7 @@ fn work_item_record_revision_defaults_for_old_records() {
     });
     let record: WorkItemRecord = serde_json::from_value(value).unwrap();
     assert_eq!(record.revision, 1);
+    assert!(record.plan_artifact.is_none());
 }
 
 #[tokio::test]
@@ -616,6 +617,182 @@ async fn work_item_plan_artifact_refreshes_after_direct_file_edit() {
         .as_str()
         .unwrap()
         .contains("expanded plan line"));
+}
+
+#[tokio::test]
+async fn turn_end_refreshes_changed_work_item_plan_artifact_snapshot() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item(
+            "Refresh artifact at turn end".into(),
+            Some(WorkItemPlanStatus::Ready),
+            Some("initial plan".into()),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let original_artifact = work.plan_artifact.clone().unwrap();
+    let plan_path = original_artifact.path.clone();
+    std::fs::write(&plan_path, "changed plan body").unwrap();
+    bind_turn_to_work_item(&runtime, &work.id).await;
+
+    let committed = runtime
+        .maybe_commit_turn_end_work_item_transition()
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(committed.id, work.id);
+    assert_eq!(committed.revision, work.revision + 1);
+    assert_eq!(committed.plan_status, WorkItemPlanStatus::Ready);
+    assert_ne!(
+        committed.plan_artifact.as_ref().unwrap().hash,
+        original_artifact.hash
+    );
+    assert_eq!(
+        committed.plan_artifact.as_ref().unwrap().preview,
+        "changed plan body"
+    );
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    assert_eq!(
+        latest.plan_artifact.as_ref().unwrap().hash,
+        committed.plan_artifact.as_ref().unwrap().hash
+    );
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "work_item_plan_artifact_refreshed"
+            && event.data["work_item_id"].as_str() == Some(work.id.as_str())));
+}
+
+#[tokio::test]
+async fn turn_end_work_item_plan_artifact_refresh_is_noop_when_unchanged() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item(
+            "Keep unchanged artifact stable".into(),
+            Some(WorkItemPlanStatus::NeedsInput),
+            Some("unchanged plan".into()),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    bind_turn_to_work_item(&runtime, &work.id).await;
+
+    let committed = runtime
+        .maybe_commit_turn_end_work_item_transition()
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(committed.revision, work.revision);
+    assert_eq!(committed.plan_status, WorkItemPlanStatus::NeedsInput);
+    assert_eq!(committed.plan_artifact, work.plan_artifact);
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    assert_eq!(latest.revision, work.revision);
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(!events
+        .iter()
+        .any(|event| event.kind == "work_item_plan_artifact_refreshed"));
+}
+
+#[tokio::test]
+async fn turn_end_work_item_plan_artifact_refresh_rejects_missing_existing_artifact() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item(
+            "Reject missing artifact".into(),
+            Some(WorkItemPlanStatus::Ready),
+            Some("plan that should not disappear".into()),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let plan_path = work.plan_artifact.as_ref().unwrap().path.clone();
+    std::fs::remove_file(&plan_path).unwrap();
+    bind_turn_to_work_item(&runtime, &work.id).await;
+
+    let error = runtime
+        .maybe_commit_turn_end_work_item_transition()
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("missing plan artifact"));
+    assert!(!plan_path.exists());
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    assert_eq!(latest.revision, work.revision);
+}
+
+#[tokio::test]
+async fn complete_work_item_refreshes_latest_plan_artifact_snapshot() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item(
+            "Complete with latest artifact".into(),
+            Some(WorkItemPlanStatus::Ready),
+            Some("initial completion plan".into()),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let plan_path = work.plan_artifact.as_ref().unwrap().path.clone();
+    std::fs::write(&plan_path, "completion plan after direct edit").unwrap();
+    let expected = crate::work_item_plan::describe_plan_artifact(&plan_path).unwrap();
+
+    let completed = runtime
+        .complete_work_item(work.id.clone(), Some("done".into()))
+        .await
+        .unwrap();
+
+    assert_eq!(completed.state, WorkItemState::Completed);
+    assert_eq!(completed.plan_status, WorkItemPlanStatus::Ready);
+    assert_eq!(completed.plan_artifact.as_ref(), Some(&expected));
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    assert_eq!(latest.plan_artifact.as_ref(), Some(&expected));
 }
 
 #[tokio::test]

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -85,8 +85,15 @@ pub(crate) async fn view_for_record(
 ) -> Result<WorkItemView> {
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
-    let plan_artifact =
-        crate::work_item_plan::ensure_plan_artifact(runtime.agent_home().as_path(), &record, None)?;
+    let mut record = record;
+    crate::work_item_plan::refresh_plan_artifact_metadata(
+        runtime.agent_home().as_path(),
+        &mut record,
+    )?;
+    let plan_artifact = record
+        .plan_artifact
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("missing plan artifact for work item {}", record.id))?;
     let todo_list = if include_todo_list {
         record.todo_list.clone()
     } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -2652,6 +2652,8 @@ pub struct WorkItemRecord {
     pub plan_status: WorkItemPlanStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_artifact: Option<WorkItemPlanArtifact>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub todo_list: Vec<TodoItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2678,6 +2680,7 @@ impl WorkItemRecord {
             state,
             plan_status: WorkItemPlanStatus::Draft,
             plan: None,
+            plan_artifact: None,
             todo_list: Vec::new(),
             blocked_by: None,
             result_summary: None,

--- a/src/work_item_plan.rs
+++ b/src/work_item_plan.rs
@@ -41,6 +41,26 @@ pub(crate) fn ensure_plan_artifact(
     describe_plan_artifact(&path)
 }
 
+pub(crate) fn refresh_plan_artifact_metadata(
+    agent_home: &Path,
+    record: &mut WorkItemRecord,
+) -> Result<bool> {
+    let previous = record.plan_artifact.clone();
+    let had_inline_plan = record.plan.is_some();
+    let path = plan_path(agent_home, &record.id);
+    if !path.exists() && record.plan.is_none() && record.plan_artifact.is_some() {
+        anyhow::bail!(
+            "missing plan artifact {} for work item {}",
+            path.display(),
+            record.id
+        );
+    }
+    let artifact = ensure_plan_artifact(agent_home, record, None)?;
+    record.plan = None;
+    record.plan_artifact = Some(artifact);
+    Ok(had_inline_plan || record.plan_artifact != previous)
+}
+
 pub(crate) fn describe_plan_artifact(path: &Path) -> Result<WorkItemPlanArtifact> {
     let mut file =
         File::open(path).with_context(|| format!("failed to open {}", path.display()))?;


### PR DESCRIPTION
Closes #1094.

## Summary

- Persist `plan_artifact` metadata on `WorkItemRecord` snapshots while keeping legacy records backward compatible.
- Refresh plan artifact metadata through the shared helper for read views, explicit updates, turn-end commits, and completion.
- Append `work_item_plan_artifact_refreshed` audit events when a changed artifact descriptor is persisted.
- Keep `plan_status` independent from direct plan file edits.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test -p holon work_item_plan_artifact --lib`
- `RUSTFLAGS="-D warnings" cargo test -p holon complete_work_item_refreshes_latest_plan_artifact_snapshot --lib`
- `RUSTFLAGS="-D warnings" cargo test -p holon work_items --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
