### PR TITLE
Fix WorkItem focus transition reporting

### DIFF
--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -207,6 +207,7 @@ fn event_category(kind: &str) -> OperatorEventCategory {
         | "turn_started" => OperatorEventCategory::Message,
         "work_item_written"
         | "work_item_picked"
+        | "work_item_focus_released"
         | "work_item_enqueue_requested"
         | "work_item_turn_end_committed"
         | "work_item_turn_end_commit_skipped"
@@ -405,6 +406,9 @@ fn event_text(
         "task_child_spawned" => task_child_spawned_text(payload, fallback_summary),
         "task_input_delivered" => task_input_delivered_text(payload, fallback_summary),
         "work_item_picked" => simple_event_text("Work item picked", work_item_body(payload)),
+        "work_item_focus_released" => {
+            simple_event_text("Work item focus released", work_item_body(payload))
+        }
         "work_item_enqueue_requested" => {
             simple_event_text("Work item enqueue requested", work_item_body(payload))
         }
@@ -1735,6 +1739,7 @@ mod tests {
         "truncated_mutation_tool_call_rejected",
         "work_item_written",
         "work_item_picked",
+        "work_item_focus_released",
         "work_item_enqueue_requested",
         "work_item_turn_end_committed",
         "work_item_turn_end_commit_skipped",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -24,6 +24,8 @@ mod waiting;
 mod workspace;
 mod worktree;
 
+pub use tasks::{PickedWorkItem, WorkItemFocusTransition, WorkItemFocusTransitionWarning};
+
 use std::{
     collections::HashMap,
     fs,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -7,9 +7,10 @@ use crate::types::{
     FailureArtifact, FailureArtifactCategory, SpawnAgentResult, TaskHandle, TaskInputResult,
     TaskKind, TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot,
     TaskStatusSnapshot, TodoItem, ToolArtifactRef, WorkItemDelegationRecord,
-    WorkItemDelegationState, WorkItemPlanStatus, WorkItemRecord, WorkItemState,
+    WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
     CHILD_AGENT_TASK_KIND,
 };
+use serde::Serialize;
 use std::collections::BTreeMap;
 
 const TASK_OUTPUT_POLL_INTERVAL_MS: u64 = 100;
@@ -21,6 +22,32 @@ const SPAWN_AGENT_TASK_LABEL_CHAR_BUDGET: usize = 120;
 struct TaskMessageSnapshot {
     state: TaskStatus,
     text: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorkItemFocusTransitionWarning {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorkItemFocusTransition {
+    pub previous_work_item_id: Option<String>,
+    pub current_work_item_id: String,
+    pub reason: Option<String>,
+    pub previous_readiness: Option<WorkItemReadiness>,
+    pub current_readiness: WorkItemReadiness,
+    pub switch_kind: String,
+    pub current_focus_mode: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<WorkItemFocusTransitionWarning>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PickedWorkItem {
+    pub previous_work_item: Option<WorkItemRecord>,
+    pub current_work_item: WorkItemRecord,
+    pub transition: WorkItemFocusTransition,
 }
 
 fn child_agent_task_detail(workspace_mode: ChildAgentWorkspaceMode) -> serde_json::Value {
@@ -1921,6 +1948,15 @@ impl RuntimeHandle {
         &self,
         work_item_id: String,
     ) -> Result<(Option<WorkItemRecord>, WorkItemRecord)> {
+        let picked = self.pick_work_item_with_reason(work_item_id, None).await?;
+        Ok((picked.previous_work_item, picked.current_work_item))
+    }
+
+    pub async fn pick_work_item_with_reason(
+        &self,
+        work_item_id: String,
+        reason: Option<String>,
+    ) -> Result<PickedWorkItem> {
         let agent_id = self.agent_id().await?;
         let current_id = self.agent_state().await?.current_work_item_id;
         let previous = match current_id.as_deref() {
@@ -1931,7 +1967,38 @@ impl RuntimeHandle {
         if record.state == WorkItemState::Completed {
             return Err(anyhow!("cannot pick completed work item {}", work_item_id));
         }
-        if current_id.as_deref().is_some_and(|id| id != record.id) {
+        let switching = current_id.as_deref().is_some_and(|id| id != record.id);
+        let normalized_reason = reason.and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        });
+        let previous_readiness = previous.as_ref().map(WorkItemRecord::readiness);
+        let current_readiness = record.readiness();
+        let mut warnings = Vec::new();
+        if switching
+            && previous.as_ref().is_some_and(WorkItemRecord::is_runnable)
+            && normalized_reason.is_none()
+        {
+            warnings.push(WorkItemFocusTransitionWarning {
+                code: "missing_pick_reason_for_runnable_focus_switch".into(),
+                message: "PickWorkItem switched away from a runnable current work item without a reason; include reason on future explicit focus overrides.".into(),
+            });
+        }
+        let switch_kind = if !switching {
+            "same_work_item"
+        } else if previous.as_ref().is_some_and(WorkItemRecord::is_runnable) {
+            "explicit_focus_override"
+        } else {
+            "explicit_focus_pick"
+        }
+        .to_string();
+        let current_focus_mode = if record.is_runnable() {
+            "runnable"
+        } else {
+            "inspection"
+        }
+        .to_string();
+        if switching {
             if let Some(previous_id) = current_id.as_deref() {
                 self.cancel_work_item_waiting_intents(previous_id, "active_work_item_switched")
                     .await?;
@@ -1943,15 +2010,35 @@ impl RuntimeHandle {
             guard.state.current_turn_work_item_id = Some(record.id.clone());
             self.inner.storage.write_agent(&guard.state)?;
         }
+        let transition = WorkItemFocusTransition {
+            previous_work_item_id: current_id.clone(),
+            current_work_item_id: record.id.clone(),
+            reason: normalized_reason,
+            previous_readiness,
+            current_readiness,
+            switch_kind,
+            current_focus_mode,
+            warnings,
+        };
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_picked",
             serde_json::json!({
                 "agent_id": agent_id,
-                "previous_work_item_id": current_id,
-                "current_work_item_id": record.id,
+                "previous_work_item_id": transition.previous_work_item_id.clone(),
+                "current_work_item_id": transition.current_work_item_id.clone(),
+                "reason": transition.reason.clone(),
+                "previous_readiness": transition.previous_readiness,
+                "current_readiness": transition.current_readiness,
+                "switch_kind": transition.switch_kind.clone(),
+                "current_focus_mode": transition.current_focus_mode.clone(),
+                "warnings": transition.warnings.clone(),
             }),
         ))?;
-        Ok((previous, record))
+        Ok(PickedWorkItem {
+            previous_work_item: previous,
+            current_work_item: record,
+            transition,
+        })
     }
 
     pub async fn update_work_item_fields(
@@ -1974,6 +2061,13 @@ impl RuntimeHandle {
         let mut record = existing.clone();
         let mut wrote_item = false;
         let previous_objective = record.objective.clone();
+        let focus_release_reason = if blocked_by.as_ref().is_some_and(Option::is_some) {
+            Some("work_item_blocked")
+        } else if plan_status == Some(WorkItemPlanStatus::NeedsInput) {
+            Some("work_item_needs_input")
+        } else {
+            None
+        };
         if let Some(objective) = objective {
             record.objective = objective;
             record.updated_at = Utc::now();
@@ -2020,6 +2114,10 @@ impl RuntimeHandle {
                     "objective_changed": previous_objective != record.objective,
                 }),
             ))?;
+            if let Some(reason) = focus_release_reason {
+                self.release_current_work_item_if_matches(&agent_id, &record, reason)
+                    .await?;
+            }
         }
         if wrote_item {
             self.inner.notify.notify_one();
@@ -2074,14 +2172,8 @@ impl RuntimeHandle {
         self.cancel_work_item_waiting_intents(&record.id, "work_item_completed")
             .await?;
         {
-            let mut guard = self.inner.agent.lock().await;
-            if guard.state.current_work_item_id.as_deref() == Some(record.id.as_str()) {
-                guard.state.current_work_item_id = None;
-            }
-            if guard.state.current_turn_work_item_id.as_deref() == Some(record.id.as_str()) {
-                guard.state.current_turn_work_item_id = None;
-            }
-            self.inner.storage.write_agent(&guard.state)?;
+            self.release_current_work_item_if_matches(&agent_id, &record, "work_item_completed")
+                .await?;
         }
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_written",
@@ -2111,6 +2203,45 @@ impl RuntimeHandle {
             ));
         }
         Ok(record)
+    }
+
+    async fn release_current_work_item_if_matches(
+        &self,
+        agent_id: &str,
+        record: &WorkItemRecord,
+        reason: &str,
+    ) -> Result<bool> {
+        let released = {
+            let mut guard = self.inner.agent.lock().await;
+            let release_current =
+                guard.state.current_work_item_id.as_deref() == Some(record.id.as_str());
+            let release_turn =
+                guard.state.current_turn_work_item_id.as_deref() == Some(record.id.as_str());
+            if !release_current && !release_turn {
+                return Ok(false);
+            }
+            if release_current {
+                guard.state.current_work_item_id = None;
+            }
+            if release_turn {
+                guard.state.current_turn_work_item_id = None;
+            }
+            self.inner.storage.write_agent(&guard.state)?;
+            release_current || release_turn
+        };
+        if released {
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_focus_released",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": record.id.as_str(),
+                    "reason": reason,
+                    "readiness": record.readiness(),
+                    "revision": record.revision,
+                }),
+            ))?;
+        }
+        Ok(released)
     }
 }
 

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::support::*;
-use crate::types::WorkItemPlanStatus;
+use crate::types::{WorkItemPlanStatus, WorkItemReadiness};
 
 fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> TaskRecord {
     TaskRecord {
@@ -2804,4 +2804,279 @@ async fn queued_notification_keeps_working_memory_unfocused_before_pick() {
         .is_none());
 
     runtime_task.abort();
+}
+
+#[tokio::test]
+async fn blocking_current_work_item_releases_focus_and_unblock_does_not_repick() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("wait for dependency".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+
+    let blocked = runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            Some(Some("blocked on review".into())),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(blocked.readiness(), WorkItemReadiness::Blocked);
+    let state = runtime.agent_state().await.unwrap();
+    assert!(state.current_work_item_id.is_none());
+    assert!(state.current_turn_work_item_id.is_none());
+    let events = runtime.storage().read_recent_events(10).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "work_item_focus_released"
+            && event.data["reason"] == "work_item_blocked"
+            && event.data["work_item_id"].as_str() == Some(work.id.as_str())
+    }));
+
+    let unblocked = runtime
+        .update_work_item_fields(work.id.clone(), None, None, None, None, Some(None))
+        .await
+        .unwrap();
+
+    assert_eq!(unblocked.readiness(), WorkItemReadiness::Runnable);
+    let state = runtime.agent_state().await.unwrap();
+    assert!(state.current_work_item_id.is_none());
+    assert!(state.current_turn_work_item_id.is_none());
+}
+
+#[tokio::test]
+async fn update_tool_result_reports_released_blocked_focus() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("block through tool".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+
+    let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+    let (result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "block".into(),
+                name: "UpdateWorkItem".into(),
+                input: serde_json::json!({
+                    "work_item_id": work.id,
+                    "blocked_by": "blocked through tool result",
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+    let payload = result.envelope.result.unwrap();
+    assert_eq!(payload["work_item"]["readiness"].as_str(), Some("blocked"));
+    assert_eq!(payload["work_item"]["is_current"].as_bool(), Some(false));
+    assert_eq!(payload["work_item"]["focus"].as_str(), Some("blocked"));
+    let state = runtime.agent_state().await.unwrap();
+    assert!(state.current_work_item_id.is_none());
+}
+
+#[tokio::test]
+async fn needs_input_current_work_item_releases_focus() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("ask operator".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+
+    let waiting = runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            None,
+            Some(WorkItemPlanStatus::NeedsInput),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(waiting.readiness(), WorkItemReadiness::WaitingForOperator);
+    let state = runtime.agent_state().await.unwrap();
+    assert!(state.current_work_item_id.is_none());
+    assert!(state.current_turn_work_item_id.is_none());
+    let events = runtime.storage().read_recent_events(10).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "work_item_focus_released"
+            && event.data["reason"] == "work_item_needs_input"
+            && event.data["work_item_id"].as_str() == Some(work.id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn pick_blocked_work_item_reports_inspection_focus() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("inspect blocker".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            Some(Some("blocked on external signal".into())),
+        )
+        .await
+        .unwrap();
+
+    let picked = runtime
+        .pick_work_item_with_reason(work.id.clone(), Some("inspect blocker details".into()))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        picked.current_work_item.readiness(),
+        WorkItemReadiness::Blocked
+    );
+    assert_eq!(
+        picked.transition.current_readiness,
+        WorkItemReadiness::Blocked
+    );
+    assert_eq!(picked.transition.current_focus_mode, "inspection");
+    assert!(picked.transition.warnings.is_empty());
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(work.id.as_str())
+    );
+
+    runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            None,
+            None,
+            None,
+            Some(vec![crate::types::TodoItem {
+                text: "inspect blocker evidence".into(),
+                state: crate::types::TodoItemState::InProgress,
+            }]),
+            None,
+        )
+        .await
+        .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(work.id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn pick_without_reason_warns_when_switching_from_runnable_current_work() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let current = runtime
+        .create_work_item("current runnable".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let next = runtime
+        .create_work_item("next runnable".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(current.id.clone()).await.unwrap();
+
+    let picked = runtime
+        .pick_work_item_with_reason(next.id.clone(), None)
+        .await
+        .unwrap();
+
+    assert_eq!(picked.transition.previous_work_item_id, Some(current.id));
+    assert_eq!(
+        picked.transition.previous_readiness,
+        Some(WorkItemReadiness::Runnable)
+    );
+    assert_eq!(picked.transition.switch_kind, "explicit_focus_override");
+    assert_eq!(picked.transition.warnings.len(), 1);
+    assert_eq!(
+        picked.transition.warnings[0].code,
+        "missing_pick_reason_for_runnable_focus_switch"
+    );
+    let events = runtime.storage().read_recent_events(10).unwrap();
+    let event = events
+        .iter()
+        .find(|event| {
+            event.kind == "work_item_picked"
+                && event.data["current_work_item_id"].as_str() == Some(next.id.as_str())
+        })
+        .expect("work_item_picked event");
+    assert_eq!(
+        event.data["warnings"][0]["code"].as_str(),
+        Some("missing_pick_reason_for_runnable_focus_switch")
+    );
 }

--- a/src/tool/tools/pick_work_item.rs
+++ b/src/tool/tools/pick_work_item.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    runtime::RuntimeHandle,
-    tool::helpers::{parse_tool_args, validate_non_empty},
+    runtime::{RuntimeHandle, WorkItemFocusTransition},
+    tool::helpers::{normalize_optional_non_empty, parse_tool_args, validate_non_empty},
     tool::spec::typed_spec,
     types::{ToolCapabilityFamily, TrustLevel, WorkItemRecord},
 };
@@ -18,6 +18,8 @@ pub(crate) const NAME: &str = "PickWorkItem";
 #[serde(deny_unknown_fields)]
 pub(crate) struct PickWorkItemArgs {
     pub(crate) work_item_id: String,
+    #[serde(default)]
+    pub(crate) reason: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -26,6 +28,7 @@ pub(crate) struct PickWorkItemResult {
     pub(crate) previous_work_item: Option<WorkItemRecord>,
     pub(crate) current_work_item: WorkItemRecord,
     pub(crate) current_work_item_id: String,
+    pub(crate) transition: WorkItemFocusTransition,
     pub(crate) binding_note: String,
 }
 
@@ -34,7 +37,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<PickWorkItemArgs>(
             NAME,
-            "Make an existing open work item the current work-item focus for this agent.",
+            "Make an existing open work item the current work-item focus for this agent. Include reason when switching away from runnable current work; blocked work items may be picked for inspection but remain non-runnable.",
         )?,
     })
 }
@@ -47,7 +50,11 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: PickWorkItemArgs = parse_tool_args(NAME, input)?;
     let work_item_id = validate_non_empty(args.work_item_id, NAME, "work_item_id")?;
-    let (previous_work_item, current_work_item) = runtime.pick_work_item(work_item_id).await?;
+    let picked = runtime
+        .pick_work_item_with_reason(work_item_id, normalize_optional_non_empty(args.reason))
+        .await?;
+    let previous_work_item = picked.previous_work_item;
+    let current_work_item = picked.current_work_item;
     let current_work_item_id = current_work_item.id.clone();
     serialize_success(
         NAME,
@@ -55,6 +62,7 @@ pub(crate) async fn execute(
             previous_work_item,
             current_work_item,
             current_work_item_id,
+            transition: picked.transition,
             binding_note: "subsequent tool calls in this turn are bound to the new current work item unless they explicitly specify another work_item_id".into(),
         },
     )


### PR DESCRIPTION
## Summary

Fixes #1097.

This makes WorkItem focus transitions explicit in the runtime:

- releases current WorkItem focus when the current item becomes blocked, needs input, or completed
- keeps unblocking from silently re-picking a WorkItem
- adds optional `PickWorkItem.reason` and structured transition warnings for missing reasons when switching away from runnable current work
- records focus transition metadata on `work_item_picked` and emits `work_item_focus_released` audit events
- reports blocked picks as inspection focus instead of runnable focus

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo test -p holon work_items --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
