### PR TITLE
feat: project WorkItem-centered memory

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::Result;
 
 use crate::{
@@ -7,10 +9,11 @@ use crate::{
     tool::helpers::truncate_text,
     types::{
         AdmissionContext, AgentState, AuthorityClass, BriefRecord, ContextEpisodeRecord,
-        ContinuationClass, ContinuationResolution, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TodoItemState,
-        ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord,
-        WaitingIntentStatus, WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot,
+        ContinuationClass, ContinuationResolution, ExternalTriggerScope, MessageBody,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView,
+        TodoItemState, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        WaitingIntentRecord, WaitingIntentStatus, WorkItemRecord, WorkingMemoryDelta,
+        WorkingMemorySnapshot,
     },
 };
 
@@ -65,6 +68,8 @@ pub fn build_context(
     let active_waiting_intents = storage
         .latest_waiting_intents()?
         .into_iter()
+        .filter(|intent| intent.agent_id == agent.id)
+        .filter(|intent| intent.scope == ExternalTriggerScope::WorkItem)
         .filter(|intent| intent.status == WaitingIntentStatus::Active)
         .collect::<Vec<_>>();
     let episodes = storage.read_recent_context_episodes(config.recent_episode_candidates)?;
@@ -232,8 +237,12 @@ pub fn build_context(
     }
 
     if work_queue_projection.has_non_current_candidates() {
-        let candidates =
-            render_work_item_candidates(&work_queue_projection, storage, storage.data_dir())?;
+        let candidates = render_work_item_candidates(
+            &work_queue_projection,
+            storage,
+            &agent.id,
+            storage.data_dir(),
+        )?;
         if let Some(content) = candidates {
             push_budgeted_section(
                 &mut sections,
@@ -588,6 +597,7 @@ fn render_current_work_item_process_trace(
     for brief in briefs
         .iter()
         .rev()
+        .filter(|brief| brief.agent_id == work_item.agent_id)
         .filter(|brief| brief.work_item_id.as_deref() == Some(work_item.id.as_str()))
         .take(3)
     {
@@ -601,6 +611,7 @@ fn render_current_work_item_process_trace(
     for tool in tools
         .iter()
         .rev()
+        .filter(|tool| tool.agent_id == work_item.agent_id)
         .filter(|tool| tool.work_item_id.as_deref() == Some(work_item.id.as_str()))
         .take(4)
     {
@@ -614,6 +625,7 @@ fn render_current_work_item_process_trace(
     for entry in transcript
         .iter()
         .rev()
+        .filter(|entry| entry.agent_id == work_item.agent_id)
         .filter(|entry| entry.kind == TranscriptEntryKind::AssistantRound)
         .filter(|entry| entry.data["work_item_id"].as_str() == Some(work_item.id.as_str()))
         .take(2)
@@ -633,6 +645,11 @@ fn assistant_round_text_preview(entry: &TranscriptEntry) -> Option<String> {
         .as_array()?
         .iter()
         .filter_map(|block| {
+            if let Some(kind) = block.get("type").and_then(serde_json::Value::as_str) {
+                if kind != "text" {
+                    return None;
+                }
+            }
             block
                 .get("Text")
                 .and_then(|value| value.get("text"))
@@ -649,42 +666,44 @@ fn assistant_round_text_preview(entry: &TranscriptEntry) -> Option<String> {
 fn render_work_item_candidates(
     projection: &crate::storage::WorkQueuePromptProjection,
     storage: &AppStorage,
+    agent_id: &str,
     agent_home: &std::path::Path,
 ) -> Result<Option<String>> {
+    let completion_reports = latest_delivery_summary_text_by_work_item(storage, agent_id)?;
     let mut lines = vec!["Work item candidates by scheduler ranking:".to_string()];
     append_candidate_group(
         &mut lines,
         "Triggered work items:",
         &projection.triggered_blocked,
-        storage,
+        &completion_reports,
         agent_home,
     )?;
     append_candidate_group(
         &mut lines,
         "Queued runnable work items:",
         &projection.queued_runnable,
-        storage,
+        &completion_reports,
         agent_home,
     )?;
     append_candidate_group(
         &mut lines,
         "Waiting for operator:",
         &projection.waiting_for_operator,
-        storage,
+        &completion_reports,
         agent_home,
     )?;
     append_candidate_group(
         &mut lines,
         "Blocked work items:",
         &projection.blocked,
-        storage,
+        &completion_reports,
         agent_home,
     )?;
     append_candidate_group(
         &mut lines,
         "Recently completed work items:",
         &projection.completed_recent,
-        storage,
+        &completion_reports,
         agent_home,
     )?;
     if lines.len() == 1 {
@@ -697,7 +716,7 @@ fn append_candidate_group(
     lines: &mut Vec<String>,
     title: &str,
     items: &[crate::storage::WorkItemReadinessProjection],
-    storage: &AppStorage,
+    completion_reports: &BTreeMap<String, String>,
     agent_home: &std::path::Path,
 ) -> Result<()> {
     if items.is_empty() {
@@ -714,7 +733,7 @@ fn append_candidate_group(
     for item in items {
         let record = item.record();
         let completion_report = if record.state == crate::types::WorkItemState::Completed {
-            let report = completion_report_for_work_item(storage, record)?;
+            let report = completion_report_for_work_item(completion_reports, record);
             if report.is_none() {
                 continue;
             }
@@ -759,20 +778,39 @@ fn append_candidate_group(
 }
 
 fn completion_report_for_work_item(
-    storage: &AppStorage,
+    completion_reports: &BTreeMap<String, String>,
     record: &WorkItemRecord,
-) -> Result<Option<String>> {
+) -> Option<String> {
     if let Some(summary) = record
         .result_summary
         .as_ref()
         .filter(|text| !text.is_empty())
     {
-        return Ok(Some(summary.clone()));
+        return Some(summary.clone());
     }
-    Ok(storage
-        .latest_delivery_summary(&record.id)?
-        .map(|summary| summary.text)
-        .filter(|text| !text.is_empty()))
+    completion_reports
+        .get(&record.id)
+        .filter(|text| !text.is_empty())
+        .cloned()
+}
+
+fn latest_delivery_summary_text_by_work_item(
+    storage: &AppStorage,
+    agent_id: &str,
+) -> Result<BTreeMap<String, String>> {
+    let mut summaries = BTreeMap::new();
+    for summary in storage
+        .read_recent_delivery_summaries(usize::MAX)?
+        .into_iter()
+        .rev()
+        .filter(|summary| summary.agent_id == agent_id)
+        .filter(|summary| !summary.text.is_empty())
+    {
+        summaries
+            .entry(summary.work_item_id)
+            .or_insert(summary.text);
+    }
+    Ok(summaries)
 }
 
 fn render_work_item_plan_artifact_lines(
@@ -2547,12 +2585,46 @@ mod tests {
             })
             .unwrap();
         storage
+            .append_waiting_intent(&WaitingIntentRecord {
+                id: "wait-other-agent".into(),
+                agent_id: "other-agent".into(),
+                scope: ExternalTriggerScope::WorkItem,
+                work_item_id: Some(active.id.clone()),
+                description: "other agent wait must not leak".into(),
+                source: "github".into(),
+                resource: Some("pull/other".into()),
+                condition: Some("ci completed".into()),
+                delivery_mode: CallbackDeliveryMode::EnqueueMessage,
+                status: WaitingIntentStatus::Active,
+                external_trigger_id: "cb-other".into(),
+                created_at: chrono::Utc::now(),
+                cancelled_at: None,
+                last_triggered_at: Some(chrono::Utc::now()),
+                trigger_count: 1,
+                correlation_id: None,
+                causation_id: None,
+            })
+            .unwrap();
+        storage
             .append_brief(&BriefRecord {
                 work_item_id: Some(active.id.clone()),
                 ..BriefRecord::new(
                     "default",
                     BriefKind::Result,
                     "Bound brief captured current WorkItem evidence.",
+                    None,
+                    None,
+                )
+            })
+            .unwrap();
+        storage
+            .append_brief(&BriefRecord {
+                agent_id: "other-agent".into(),
+                work_item_id: Some(active.id.clone()),
+                ..BriefRecord::new(
+                    "default",
+                    BriefKind::Result,
+                    "Other agent brief must not leak.",
                     None,
                     None,
                 )
@@ -2577,6 +2649,24 @@ mod tests {
             })
             .unwrap();
         storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-other-agent".into(),
+                agent_id: "other-agent".into(),
+                work_item_id: Some(active.id.clone()),
+                turn_index: 1,
+                tool_name: "ExecCommand".into(),
+                created_at: chrono::Utc::now(),
+                completed_at: Some(chrono::Utc::now()),
+                duration_ms: 10,
+                trust: TrustLevel::TrustedOperator,
+                status: ToolExecutionStatus::Success,
+                input: json!({"cmd": "echo other"}),
+                output: json!({}),
+                summary: "Other agent tool must not leak".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+        storage
             .append_transcript_entry(&TranscriptEntry::new(
                 "default",
                 TranscriptEntryKind::AssistantRound,
@@ -2584,7 +2674,22 @@ mod tests {
                 None,
                 json!({
                     "work_item_id": active.id.clone(),
-                    "blocks": [{"text": "Assistant summarized current WorkItem progress."}]
+                    "blocks": [
+                        {"type": "thinking", "text": "Provider thinking must not leak."},
+                        {"type": "text", "text": "Assistant summarized current WorkItem progress."}
+                    ]
+                }),
+            ))
+            .unwrap();
+        storage
+            .append_transcript_entry(&TranscriptEntry::new(
+                "other-agent",
+                TranscriptEntryKind::AssistantRound,
+                Some(1),
+                None,
+                json!({
+                    "work_item_id": active.id.clone(),
+                    "blocks": [{"type": "text", "text": "Other agent transcript must not leak."}]
                 }),
             ))
             .unwrap();
@@ -2630,6 +2735,9 @@ mod tests {
             .contains("Project active item into prompt"));
         assert!(active_section.content.contains("Active waits:"));
         assert!(active_section.content.contains("wait for CI webhook"));
+        assert!(!active_section
+            .content
+            .contains("other agent wait must not leak"));
 
         let trace_section = built
             .sections
@@ -2645,6 +2753,18 @@ mod tests {
         assert!(trace_section
             .content
             .contains("Assistant summarized current WorkItem progress"));
+        assert!(!trace_section
+            .content
+            .contains("Provider thinking must not leak"));
+        assert!(!trace_section
+            .content
+            .contains("Other agent brief must not leak"));
+        assert!(!trace_section
+            .content
+            .contains("Other agent tool must not leak"));
+        assert!(!trace_section
+            .content
+            .contains("Other agent transcript must not leak"));
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,8 @@ use crate::{
         AdmissionContext, AgentState, AuthorityClass, BriefRecord, ContextEpisodeRecord,
         ContinuationClass, ContinuationResolution, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TodoItemState,
-        ToolExecutionRecord, TrustLevel, WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot,
+        ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord,
+        WaitingIntentStatus, WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot,
     },
 };
 
@@ -60,16 +61,15 @@ pub fn build_context(
         storage.read_messages_from(agent.compacted_message_count, config.recent_messages)?;
     let briefs = storage.read_recent_briefs(config.recent_briefs)?;
     let tools = storage.read_recent_tool_executions(config.recent_messages)?;
+    let transcript = storage.read_recent_transcript(config.recent_messages)?;
+    let active_waiting_intents = storage
+        .latest_waiting_intents()?
+        .into_iter()
+        .filter(|intent| intent.status == WaitingIntentStatus::Active)
+        .collect::<Vec<_>>();
     let episodes = storage.read_recent_context_episodes(config.recent_episode_candidates)?;
     let work_queue_projection = storage.work_queue_prompt_projection()?;
     let current_work_item = work_queue_projection.current.as_ref();
-    let queued_blocked_items = work_queue_projection
-        .readiness
-        .iter()
-        .filter(|item| {
-            !item.is_current && item.work_item.state == crate::types::WorkItemState::Open
-        })
-        .collect::<Vec<_>>();
 
     let current_input_reserved_budget =
         reserve_current_input_budget(config.prompt_budget_estimated_tokens);
@@ -214,20 +214,33 @@ pub fn build_context(
             &mut remaining_budget,
             turn_section(
                 "current_work_item",
-                render_current_work_item(work_item, storage.data_dir()),
+                render_current_work_item(work_item, storage.data_dir(), &active_waiting_intents),
             ),
         );
     }
 
-    if !queued_blocked_items.is_empty() {
-        push_budgeted_section(
-            &mut sections,
-            &mut remaining_budget,
-            turn_section(
-                "queued_blocked_work_items",
-                render_queued_blocked_work_items(&queued_blocked_items, storage.data_dir()),
-            ),
-        );
+    if let Some(work_item) = current_work_item {
+        if let Some(content) =
+            render_current_work_item_process_trace(work_item, &briefs, &tools, &transcript)
+        {
+            push_budgeted_section(
+                &mut sections,
+                &mut remaining_budget,
+                turn_section("current_work_item_process_trace", content),
+            );
+        }
+    }
+
+    if work_queue_projection.has_non_current_candidates() {
+        let candidates =
+            render_work_item_candidates(&work_queue_projection, storage, storage.data_dir())?;
+        if let Some(content) = candidates {
+            push_budgeted_section(
+                &mut sections,
+                &mut remaining_budget,
+                turn_section("queued_blocked_work_items", content),
+            );
+        }
     }
 
     push_budgeted_section(
@@ -501,7 +514,11 @@ fn render_brief(brief: &BriefRecord) -> String {
     format!("- [{:?}] {}", brief.kind, brief.text)
 }
 
-fn render_current_work_item(work_item: &WorkItemRecord, agent_home: &std::path::Path) -> String {
+fn render_current_work_item(
+    work_item: &WorkItemRecord,
+    agent_home: &std::path::Path,
+    active_waiting_intents: &[WaitingIntentRecord],
+) -> String {
     let mut lines = vec![
         "Current work item:".to_string(),
         format!("- Id: {}", work_item.id),
@@ -530,6 +547,25 @@ fn render_current_work_item(work_item: &WorkItemRecord, agent_home: &std::path::
     if let Some(blocked_by) = work_item.blocked_by.as_deref() {
         lines.push(format!("- Blocked by: {blocked_by}"));
     }
+    let waits = active_waiting_intents
+        .iter()
+        .filter(|intent| intent.work_item_id.as_deref() == Some(work_item.id.as_str()))
+        .collect::<Vec<_>>();
+    if !waits.is_empty() {
+        lines.push("- Active waits:".to_string());
+        lines.extend(waits.into_iter().take(4).map(|intent| {
+            let triggered = intent
+                .last_triggered_at
+                .map(|at| format!(" :: last_triggered_at={at}"))
+                .unwrap_or_default();
+            let resource = intent
+                .resource
+                .as_deref()
+                .map(|resource| format!(" :: resource={resource}"))
+                .unwrap_or_default();
+            format!("  - {}{resource}{triggered}", intent.description)
+        }));
+    }
     lines.join("\n")
 }
 
@@ -541,13 +577,155 @@ fn work_item_plan_status_label(status: crate::types::WorkItemPlanStatus) -> &'st
     }
 }
 
-fn render_queued_blocked_work_items(
-    items: &[&crate::storage::WorkItemReadinessProjection],
+fn render_current_work_item_process_trace(
+    work_item: &WorkItemRecord,
+    briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
+    transcript: &[TranscriptEntry],
+) -> Option<String> {
+    let mut lines = vec!["Recent current WorkItem process trace:".to_string()];
+    let mut added = 0usize;
+    for brief in briefs
+        .iter()
+        .rev()
+        .filter(|brief| brief.work_item_id.as_deref() == Some(work_item.id.as_str()))
+        .take(3)
+    {
+        lines.push(format!(
+            "- brief:{:?} {}",
+            brief.kind,
+            truncate_text(&brief.text.replace('\n', " "), 180)
+        ));
+        added += 1;
+    }
+    for tool in tools
+        .iter()
+        .rev()
+        .filter(|tool| tool.work_item_id.as_deref() == Some(work_item.id.as_str()))
+        .take(4)
+    {
+        lines.push(format!(
+            "- tool:{} {}",
+            tool.tool_name,
+            truncate_text(&tool.summary.replace('\n', " "), 180)
+        ));
+        added += 1;
+    }
+    for entry in transcript
+        .iter()
+        .rev()
+        .filter(|entry| entry.kind == TranscriptEntryKind::AssistantRound)
+        .filter(|entry| entry.data["work_item_id"].as_str() == Some(work_item.id.as_str()))
+        .take(2)
+    {
+        if let Some(text) = assistant_round_text_preview(entry) {
+            lines.push(format!("- assistant_round: {}", truncate_text(&text, 180)));
+            added += 1;
+        }
+    }
+    (added > 0).then(|| lines.join("\n"))
+}
+
+fn assistant_round_text_preview(entry: &TranscriptEntry) -> Option<String> {
+    let text = entry
+        .data
+        .get("blocks")?
+        .as_array()?
+        .iter()
+        .filter_map(|block| {
+            block
+                .get("Text")
+                .and_then(|value| value.get("text"))
+                .or_else(|| block.get("text"))
+                .and_then(serde_json::Value::as_str)
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim()
+        .to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+fn render_work_item_candidates(
+    projection: &crate::storage::WorkQueuePromptProjection,
+    storage: &AppStorage,
     agent_home: &std::path::Path,
-) -> String {
-    let mut lines = vec!["Queued and blocked work items:".to_string()];
+) -> Result<Option<String>> {
+    let mut lines = vec!["Work item candidates by scheduler ranking:".to_string()];
+    append_candidate_group(
+        &mut lines,
+        "Triggered work items:",
+        &projection.triggered_blocked,
+        storage,
+        agent_home,
+    )?;
+    append_candidate_group(
+        &mut lines,
+        "Queued runnable work items:",
+        &projection.queued_runnable,
+        storage,
+        agent_home,
+    )?;
+    append_candidate_group(
+        &mut lines,
+        "Waiting for operator:",
+        &projection.waiting_for_operator,
+        storage,
+        agent_home,
+    )?;
+    append_candidate_group(
+        &mut lines,
+        "Blocked work items:",
+        &projection.blocked,
+        storage,
+        agent_home,
+    )?;
+    append_candidate_group(
+        &mut lines,
+        "Recently completed work items:",
+        &projection.completed_recent,
+        storage,
+        agent_home,
+    )?;
+    if lines.len() == 1 {
+        return Ok(None);
+    }
+    Ok(Some(lines.join("\n")))
+}
+
+fn append_candidate_group(
+    lines: &mut Vec<String>,
+    title: &str,
+    items: &[crate::storage::WorkItemReadinessProjection],
+    storage: &AppStorage,
+    agent_home: &std::path::Path,
+) -> Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+    let items = items
+        .iter()
+        .filter(|item| !item.is_current)
+        .collect::<Vec<_>>();
+    if items.is_empty() {
+        return Ok(());
+    }
+    let mut title_pushed = false;
     for item in items {
         let record = item.record();
+        let completion_report = if record.state == crate::types::WorkItemState::Completed {
+            let report = completion_report_for_work_item(storage, record)?;
+            if report.is_none() {
+                continue;
+            }
+            report
+        } else {
+            None
+        };
+        if !title_pushed {
+            lines.push(title.to_string());
+            title_pushed = true;
+        }
         let view = match item.candidate_class {
             crate::storage::WorkItemCandidateClass::TriggeredBlocked => "triggered_blocked",
             crate::storage::WorkItemCandidateClass::QueuedRunnable => "queued_runnable",
@@ -567,11 +745,34 @@ fn render_queued_blocked_work_items(
             summary.push_str(&format!(" :: blocked_by={blocked_by}"));
         }
         lines.push(summary);
+        if let Some(report) = completion_report {
+            lines.push(format!(
+                "  - Completion report: {}",
+                truncate_text(&report.replace('\n', " "), 240)
+            ));
+        }
         lines.extend(render_work_item_plan_artifact_lines(
             record, agent_home, "  - ",
         ));
     }
-    lines.join("\n")
+    Ok(())
+}
+
+fn completion_report_for_work_item(
+    storage: &AppStorage,
+    record: &WorkItemRecord,
+) -> Result<Option<String>> {
+    if let Some(summary) = record
+        .result_summary
+        .as_ref()
+        .filter(|text| !text.is_empty())
+    {
+        return Ok(Some(summary.clone()));
+    }
+    Ok(storage
+        .latest_delivery_summary(&record.id)?
+        .map(|summary| summary.text)
+        .filter(|text| !text.is_empty()))
 }
 
 fn render_work_item_plan_artifact_lines(
@@ -1400,9 +1601,11 @@ mod tests {
         storage::AppStorage,
         types::{
             AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
-            AgentVisibility, BriefKind, BriefRecord, ContextEpisodeRecord, ContinuationTriggerKind,
-            EpisodeBoundaryReason, LoadedAgentsMd, MessageKind, MessageOrigin, Priority,
-            ToolExecutionRecord, ToolExecutionStatus, TrustLevel, WorkItemState,
+            AgentVisibility, BriefKind, BriefRecord, CallbackDeliveryMode, ContextEpisodeRecord,
+            ContinuationTriggerKind, EpisodeBoundaryReason, ExternalTriggerScope, LoadedAgentsMd,
+            MessageKind, MessageOrigin, Priority, TodoItem, TodoItemState, ToolExecutionRecord,
+            ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+            WaitingIntentRecord, WaitingIntentStatus, WorkItemState,
         },
     };
 
@@ -2312,16 +2515,79 @@ mod tests {
         );
         active.plan = Some("Persist the work item store and project it into prompts.".into());
         active.todo_list = vec![
-            crate::types::TodoItem {
+            TodoItem {
                 text: "Persist work-item store".into(),
-                state: crate::types::TodoItemState::Completed,
+                state: TodoItemState::Completed,
             },
-            crate::types::TodoItem {
+            TodoItem {
                 text: "Project active item into prompt".into(),
-                state: crate::types::TodoItemState::InProgress,
+                state: TodoItemState::InProgress,
             },
         ];
         storage.append_work_item(&active).unwrap();
+        storage
+            .append_waiting_intent(&WaitingIntentRecord {
+                id: "wait-current".into(),
+                agent_id: "default".into(),
+                scope: ExternalTriggerScope::WorkItem,
+                work_item_id: Some(active.id.clone()),
+                description: "wait for CI webhook".into(),
+                source: "github".into(),
+                resource: Some("pull/1099".into()),
+                condition: Some("ci completed".into()),
+                delivery_mode: CallbackDeliveryMode::EnqueueMessage,
+                status: WaitingIntentStatus::Active,
+                external_trigger_id: "cb-current".into(),
+                created_at: chrono::Utc::now(),
+                cancelled_at: None,
+                last_triggered_at: Some(chrono::Utc::now()),
+                trigger_count: 1,
+                correlation_id: None,
+                causation_id: None,
+            })
+            .unwrap();
+        storage
+            .append_brief(&BriefRecord {
+                work_item_id: Some(active.id.clone()),
+                ..BriefRecord::new(
+                    "default",
+                    BriefKind::Result,
+                    "Bound brief captured current WorkItem evidence.",
+                    None,
+                    None,
+                )
+            })
+            .unwrap();
+        storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-current".into(),
+                agent_id: "default".into(),
+                work_item_id: Some(active.id.clone()),
+                turn_index: 1,
+                tool_name: "ExecCommand".into(),
+                created_at: chrono::Utc::now(),
+                completed_at: Some(chrono::Utc::now()),
+                duration_ms: 10,
+                trust: TrustLevel::TrustedOperator,
+                status: ToolExecutionStatus::Success,
+                input: json!({"cmd": "cargo test -p holon context"}),
+                output: json!({}),
+                summary: "Verified current WorkItem projection".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+        storage
+            .append_transcript_entry(&TranscriptEntry::new(
+                "default",
+                TranscriptEntryKind::AssistantRound,
+                Some(1),
+                None,
+                json!({
+                    "work_item_id": active.id.clone(),
+                    "blocks": [{"text": "Assistant summarized current WorkItem progress."}]
+                }),
+            ))
+            .unwrap();
 
         let mut agent = AgentState::new("default");
         agent.current_work_item_id = Some(active.id.clone());
@@ -2362,10 +2628,27 @@ mod tests {
         assert!(active_section
             .content
             .contains("Project active item into prompt"));
+        assert!(active_section.content.contains("Active waits:"));
+        assert!(active_section.content.contains("wait for CI webhook"));
+
+        let trace_section = built
+            .sections
+            .iter()
+            .find(|section| section.name == "current_work_item_process_trace")
+            .expect("current_work_item_process_trace section should be present");
+        assert!(trace_section
+            .content
+            .contains("Bound brief captured current WorkItem evidence"));
+        assert!(trace_section
+            .content
+            .contains("Verified current WorkItem projection"));
+        assert!(trace_section
+            .content
+            .contains("Assistant summarized current WorkItem progress"));
     }
 
     #[test]
-    fn build_context_includes_compact_queued_waiting_work_item_summary_and_omits_completed() {
+    fn build_context_includes_ranked_work_item_candidates_and_completion_reports() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
 
@@ -2380,6 +2663,13 @@ mod tests {
             },
         );
 
+        let mut triggered = crate::types::WorkItemRecord::new(
+            "default",
+            "Resume triggered CI follow-up",
+            crate::types::WorkItemState::Open,
+        );
+        triggered.blocked_by = Some("waiting for CI".into());
+        triggered.plan = Some("Handle the triggered CI result.".into());
         let mut queued = crate::types::WorkItemRecord::new(
             "default",
             "Queue follow-up verification",
@@ -2394,16 +2684,39 @@ mod tests {
             "Wait for operator confirmation",
             crate::types::WorkItemState::Open,
         );
-        waiting.blocked_by = Some("needs explicit approval before completion".into());
+        waiting.plan_status = crate::types::WorkItemPlanStatus::NeedsInput;
         waiting.plan = Some("Wait for the operator answer before retrying.".into());
-        let completed = crate::types::WorkItemRecord::new(
+        let mut completed = crate::types::WorkItemRecord::new(
             "default",
             "Already finished item",
             crate::types::WorkItemState::Completed,
         );
+        completed.result_summary = Some("Promoted completion report only.".into());
+        storage.append_work_item(&triggered).unwrap();
         storage.append_work_item(&queued).unwrap();
         storage.append_work_item(&waiting).unwrap();
         storage.append_work_item(&completed).unwrap();
+        storage
+            .append_waiting_intent(&WaitingIntentRecord {
+                id: "wait-triggered".into(),
+                agent_id: "default".into(),
+                scope: ExternalTriggerScope::WorkItem,
+                work_item_id: Some(triggered.id.clone()),
+                description: "CI completed".into(),
+                source: "github".into(),
+                resource: Some("pull/1099".into()),
+                condition: Some("ci completed".into()),
+                delivery_mode: CallbackDeliveryMode::EnqueueMessage,
+                status: WaitingIntentStatus::Active,
+                external_trigger_id: "cb-triggered".into(),
+                created_at: chrono::Utc::now(),
+                cancelled_at: None,
+                last_triggered_at: Some(chrono::Utc::now()),
+                trigger_count: 1,
+                correlation_id: None,
+                causation_id: None,
+            })
+            .unwrap();
 
         let built = build_context(
             &storage,
@@ -2427,17 +2740,28 @@ mod tests {
             .iter()
             .find(|section| section.name == "queued_blocked_work_items")
             .expect("queued_blocked_work_items section should be present");
-        assert!(summary.content.contains("Queue follow-up verification"));
-        assert!(summary.content.contains("Wait for operator confirmation"));
         assert!(summary
             .content
-            .contains("needs explicit approval before completion"));
+            .contains("Work item candidates by scheduler ranking:"));
+        assert!(summary.content.contains("Triggered work items:"));
+        assert!(summary.content.contains("Resume triggered CI follow-up"));
+        assert!(summary.content.contains("[triggered_blocked]"));
+        assert!(summary.content.contains("Queued runnable work items:"));
+        assert!(summary.content.contains("Queue follow-up verification"));
+        assert!(summary.content.contains("[queued_runnable]"));
+        assert!(summary.content.contains("Waiting for operator:"));
+        assert!(summary.content.contains("Wait for operator confirmation"));
+        assert!(summary.content.contains("[waiting_for_operator]"));
+        assert!(summary.content.contains("Recently completed work items:"));
+        assert!(summary.content.contains("Already finished item"));
+        assert!(summary
+            .content
+            .contains("Completion report: Promoted completion report only."));
         assert!(summary.content.contains("Plan artifact:"));
         assert!(summary.content.contains("Plan preview:"));
         assert!(summary.content.contains("Verify the queued path."));
         assert!(summary.content.contains("Plan preview complete: false"));
         assert!(summary.content.contains("Plan preview complete: true"));
-        assert!(!summary.content.contains("Already finished item"));
     }
 
     #[test]

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -158,13 +158,7 @@ pub fn derive_working_memory_snapshot(
     let todo_list = current_work_item
         .map(|item| item.todo_list.clone())
         .unwrap_or_default();
-    let queued_waiting_followups = projection
-        .queued_blocked
-        .iter()
-        .filter(|item| Some(item.id.as_str()) != current_work_item.map(|anchor| anchor.id.as_str()))
-        .cloned()
-        .collect::<Vec<_>>();
-    let pending_followups = collect_pending_followups(current_work_item, &queued_waiting_followups);
+    let pending_followups = collect_pending_followups(current_work_item, &projection);
     let waiting_on = collect_waiting_on(&active_waiting, current_work_item_id, current_closure);
     let working_set_files = collect_working_set_files(&memory_tools);
 
@@ -378,7 +372,7 @@ fn merge_pending_delta(
 
 fn collect_pending_followups(
     current_work_item: Option<&WorkItemRecord>,
-    queued_waiting: &[WorkItemRecord],
+    projection: &crate::storage::WorkQueuePromptProjection,
 ) -> Vec<String> {
     let mut items = Vec::new();
 
@@ -397,9 +391,56 @@ fn collect_pending_followups(
         );
     }
     items.extend(
-        queued_waiting
+        projection
+            .triggered_blocked
             .iter()
-            .map(|item| format!("queued: {}", truncate_line(&item.objective, 120))),
+            .filter(|item| !item.is_current)
+            .map(|item| {
+                format!(
+                    "triggered: {}",
+                    truncate_line(&item.record().objective, 120)
+                )
+            }),
+    );
+    items.extend(
+        projection
+            .queued_runnable
+            .iter()
+            .filter(|item| !item.is_current)
+            .map(|item| format!("queued: {}", truncate_line(&item.record().objective, 120))),
+    );
+    items.extend(
+        projection
+            .waiting_for_operator
+            .iter()
+            .filter(|item| !item.is_current)
+            .take(2)
+            .map(|item| {
+                format!(
+                    "waiting_for_operator: {}",
+                    truncate_line(&item.record().objective, 120)
+                )
+            }),
+    );
+    items.extend(
+        projection
+            .blocked
+            .iter()
+            .filter(|item| !item.is_current)
+            .take(2)
+            .map(|item| format!("blocked: {}", truncate_line(&item.record().objective, 120))),
+    );
+    items.extend(
+        projection
+            .completed_recent
+            .iter()
+            .take(2)
+            .filter_map(|item| {
+                item.record()
+                    .result_summary
+                    .as_ref()
+                    .map(|summary| format!("completed: {}", truncate_line(summary, 120)))
+            }),
     );
 
     dedup_owned(items, MEMORY_FOLLOWUP_LIMIT)
@@ -759,10 +800,11 @@ mod tests {
     use crate::{
         storage::AppStorage,
         types::{
-            AgentState, BriefKind, BriefRecord, CallbackDeliveryMode, ClosureDecision, MessageBody,
-            MessageEnvelope, MessageKind, MessageOrigin, Priority, RuntimePosture, TodoItem,
-            TodoItemState, ToolExecutionRecord, ToolExecutionStatus, TrustLevel,
-            WaitingIntentRecord, WaitingIntentStatus, WaitingReason, WorkItemRecord, WorkItemState,
+            AgentState, BriefKind, BriefRecord, CallbackDeliveryMode, ClosureDecision,
+            ExternalTriggerScope, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
+            Priority, RuntimePosture, TodoItem, TodoItemState, ToolExecutionRecord,
+            ToolExecutionStatus, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
+            WaitingReason, WorkItemRecord, WorkItemState,
         },
     };
 
@@ -811,6 +853,47 @@ mod tests {
         ];
         storage.append_work_item(&active).unwrap();
         set_current_work_item(&storage, &active.id);
+        let mut triggered = WorkItemRecord::new(
+            "default",
+            "inspect triggered CI result",
+            WorkItemState::Open,
+        );
+        triggered.blocked_by = Some("waiting for CI".into());
+        storage.append_work_item(&triggered).unwrap();
+        storage
+            .append_waiting_intent(&WaitingIntentRecord {
+                id: "wait-triggered".into(),
+                agent_id: "default".into(),
+                scope: ExternalTriggerScope::WorkItem,
+                work_item_id: Some(triggered.id.clone()),
+                description: "CI webhook fired".into(),
+                source: "github".into(),
+                resource: Some("pull/1099".into()),
+                condition: Some("ci completed".into()),
+                delivery_mode: CallbackDeliveryMode::EnqueueMessage,
+                status: WaitingIntentStatus::Active,
+                external_trigger_id: "cb-triggered".into(),
+                created_at: Utc::now(),
+                cancelled_at: None,
+                last_triggered_at: Some(Utc::now()),
+                trigger_count: 1,
+                correlation_id: None,
+                causation_id: None,
+            })
+            .unwrap();
+        let queued = WorkItemRecord::new(
+            "default",
+            "queue follow-up snapshot assertions",
+            WorkItemState::Open,
+        );
+        storage.append_work_item(&queued).unwrap();
+        let mut completed = WorkItemRecord::new(
+            "default",
+            "completed report selection",
+            WorkItemState::Completed,
+        );
+        completed.result_summary = Some("Selected promoted completion report.".into());
+        storage.append_work_item(&completed).unwrap();
         storage
             .append_brief(&BriefRecord::new(
                 "default",
@@ -902,6 +985,18 @@ mod tests {
             .waiting_on
             .iter()
             .any(|item| item.contains("wait for CI webhook")));
+        assert!(snapshot
+            .pending_followups
+            .iter()
+            .any(|item| item == "triggered: inspect triggered CI result"));
+        assert!(snapshot
+            .pending_followups
+            .iter()
+            .any(|item| item == "queued: queue follow-up snapshot assertions"));
+        assert!(snapshot
+            .pending_followups
+            .iter()
+            .any(|item| item == "completed: Selected promoted completion report."));
     }
 
     #[test]

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -434,13 +434,14 @@ fn collect_pending_followups(
         projection
             .completed_recent
             .iter()
-            .take(2)
+            .filter(|item| !item.is_current)
             .filter_map(|item| {
                 item.record()
                     .result_summary
                     .as_ref()
                     .map(|summary| format!("completed: {}", truncate_line(summary, 120)))
-            }),
+            })
+            .take(2),
     );
 
     dedup_owned(items, MEMORY_FOLLOWUP_LIMIT)
@@ -887,6 +888,20 @@ mod tests {
             WorkItemState::Open,
         );
         storage.append_work_item(&queued).unwrap();
+        storage
+            .append_work_item(&WorkItemRecord::new(
+                "default",
+                "completed without report one",
+                WorkItemState::Completed,
+            ))
+            .unwrap();
+        storage
+            .append_work_item(&WorkItemRecord::new(
+                "default",
+                "completed without report two",
+                WorkItemState::Completed,
+            ))
+            .unwrap();
         let mut completed = WorkItemRecord::new(
             "default",
             "completed report selection",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -40,6 +40,19 @@ pub struct WorkQueuePromptProjection {
     pub completed_recent: Vec<WorkItemReadinessProjection>,
 }
 
+impl WorkQueuePromptProjection {
+    pub fn has_non_current_candidates(&self) -> bool {
+        self.triggered_blocked.iter().any(|item| !item.is_current)
+            || self.queued_runnable.iter().any(|item| !item.is_current)
+            || self
+                .waiting_for_operator
+                .iter()
+                .any(|item| !item.is_current)
+            || self.blocked.iter().any(|item| !item.is_current)
+            || self.completed_recent.iter().any(|item| !item.is_current)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkItemReadinessProjection {
     pub work_item: WorkItemRecord,

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -577,7 +577,8 @@ Current work item:
 - Blocked by: currently adding queued work interaction tests
 
 ## queued_blocked_work_items
-Queued and blocked work items:
+Work item candidates by scheduler ranking:
+Blocked work items:
 - [blocked] work_queued :: Review and merge PR #485 :: current_todo=Review expanded snapshot coverage changes :: blocked_by=blocked on active work completion
   - Plan artifact: $AGENT_HOME/work-items/work_queued/plan.md
   - Plan preview complete: true

--- a/tests/support/runtime_compaction.rs
+++ b/tests/support/runtime_compaction.rs
@@ -118,7 +118,7 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
         Some("resume after workflow completes"),
     )
     .await?;
-    let _completed = test_work_item(
+    let mut completed = test_work_item(
         &runtime,
         "Already shipped shadow-state cleanup",
         WorkItemState::Completed,
@@ -126,6 +126,9 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
         None,
     )
     .await?;
+    completed.result_summary = Some("Promoted cleanup completion report.".into());
+    completed.updated_at = Utc::now();
+    runtime.storage().append_work_item(&completed)?;
 
     for idx in 0..4 {
         runtime.storage().append_message(&MessageEnvelope::new(
@@ -175,9 +178,12 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
     assert!(queued_blocked_section
         .content
         .contains(waiting.objective.as_str()));
-    assert!(!queued_blocked_section
+    assert!(queued_blocked_section
         .content
         .contains("Already shipped shadow-state cleanup"));
+    assert!(queued_blocked_section
+        .content
+        .contains("Completion report: Promoted cleanup completion report."));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- render current WorkItem memory with active waits and recent bound process trace from briefs, tools, and assistant transcript evidence
- render non-current WorkItem candidates by scheduler projection groups: triggered, queued runnable, waiting, blocked, and completed reports
- expose WorkItem-centered pending followups in working memory deltas, including triggered/queued candidates and promoted completion reports

Closes #1099

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo test -p holon context::tests --lib
- cargo test -p holon memory::working --lib
- cargo test -p holon --test prompt_context_snapshots
- cargo test -p holon --test runtime_compaction preview_prompt_after_compaction_keeps_work_item_plan_and_pending_work_visible
- RUSTFLAGS="-D warnings" cargo check --all-targets
