### PR TITLE
docs: align WorkItem memory projection spec

### DIFF
--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -460,7 +460,9 @@ anchor.
 
 Other open WorkItems should be summarized compactly by id, objective, state,
 plan artifact preview, readiness, current todo, and blocker. Completed
-WorkItems should not be injected by default.
+WorkItems should not replay raw transcript by default. They may appear as
+bounded recent completed summaries only when they have an explicit promoted
+completion report (`result_summary` or matching `DeliverySummaryRecord`).
 
 If the agent changes focus during a turn, the tool result must return the new
 current WorkItem snapshot and state that subsequent tool calls in the turn are

--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -462,7 +462,9 @@ Other open WorkItems should be summarized compactly by id, objective, state,
 plan artifact preview, readiness, current todo, and blocker. Completed
 WorkItems should not replay raw transcript by default. They may appear as
 bounded recent completed summaries only when they have an explicit promoted
-completion report (`result_summary` or matching `DeliverySummaryRecord`).
+completion report: prefer a non-empty `WorkItemRecord.result_summary`; otherwise
+use the newest non-empty `DeliverySummaryRecord.text` for the same work item
+(see "Work-Queue Prompt Projection" in `docs/runtime-spec.md`).
 
 If the agent changes focus during a turn, the tool result must return the new
 current WorkItem snapshot and state that subsequent tool calls in the turn are

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1793,8 +1793,8 @@ Early rollout projection rules are:
   executions, and assistant transcript text blocks, without promoting provider
   thinking or other-agent records
 - project non-current candidates using the shared readiness projection:
-  triggered blocked, queued runnable, waiting-for-operator, blocked, and
-  recently completed
+  `triggered_blocked`, `queued_runnable`, `waiting_for_operator`, `blocked`,
+  and `completed_recent`
 - project completed items only through explicit promoted completion reports;
   do not infer reports from arbitrary transcript text
 - if no work items exist yet, preserve the current message-driven prompt path

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1787,9 +1787,16 @@ When work items exist, prompt context should project them explicitly.
 
 Early rollout projection rules are:
 
-- project the full current `WorkItemRecord`, including plan and todo_list
-- project only compact entries for queued and blocked open items
-- exclude completed items from the normal prompt projection
+- project the full current `WorkItemRecord`, including plan artifact preview,
+  todo_list, blocker, and active WorkItem-scoped waits
+- project recent current-WorkItem process trace from bound briefs, tool
+  executions, and assistant transcript text blocks, without promoting provider
+  thinking or other-agent records
+- project non-current candidates using the shared readiness projection:
+  triggered blocked, queued runnable, waiting-for-operator, blocked, and
+  recently completed
+- project completed items only through explicit promoted completion reports;
+  do not infer reports from arbitrary transcript text
 - if no work items exist yet, preserve the current message-driven prompt path
   without synthesizing a bootstrap work item
 


### PR DESCRIPTION
## Summary

- align the WorkItem runtime RFC with the implemented completed-report projection behavior
- update runtime-spec prompt projection rules for active waits, current WorkItem process trace, scheduler-ranked candidates, and promoted completion reports

Closes #1101

## Verification

- rg -n "completed WorkItems should not be injected|exclude completed items from the normal prompt|raw transcript by default|triggered blocked, queued runnable" docs/rfcs/work-item-runtime-model.md docs/runtime-spec.md docs/rfcs/work-item-centered-agent-runtime.md
