### PR TITLE
fix: close WorkItem completion report gaps

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1824,7 +1824,9 @@ Work item read surfaces return `plan_artifact` instead of full inline plan
 text. The descriptor includes the absolute `path`, `hash`, `bytes`,
 `updated_at`, a bounded `preview`, and `preview_complete`. Agents should read,
 grep, or edit `plan_artifact.path` directly when the preview is incomplete or
-the plan body needs changes.
+the plan body needs changes. For completed work items, read surfaces also
+return `completion_report` when an explicit promoted report exists; this is the
+same canonical report used for result briefs and completion delivery summaries.
 
 `PickWorkItem` sets `AgentState.current_work_item_id` to an existing open work
 item owned by the agent.
@@ -1840,7 +1842,9 @@ item owned by the agent.
 `CompleteWorkItem` marks an existing work item completed:
 
 - `work_item_id` is required
-- `result_summary` is optional completion metadata
+- it accepts no `result_summary` or completion-report argument
+- the operator-facing completion report must be assistant text emitted in the
+  same assistant round as the successful `CompleteWorkItem` call
 - completion is an explicit agent assertion; it is not blocked by generic
   active task `wait_policy`
 - completion clears `blocked_by` and cancels work-item-scoped waiting intents

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1824,9 +1824,9 @@ Work item read surfaces return `plan_artifact` instead of full inline plan
 text. The descriptor includes the absolute `path`, `hash`, `bytes`,
 `updated_at`, a bounded `preview`, and `preview_complete`. Agents should read,
 grep, or edit `plan_artifact.path` directly when the preview is incomplete or
-the plan body needs changes. For completed work items, read surfaces also
-return `completion_report` when an explicit promoted report exists; this is the
-same canonical report used for result briefs and completion delivery summaries.
+the plan body needs changes. For completed work items, read surfaces return
+`completion_report` populated from promoted same-round reports when available,
+with fallback to legacy delivery summaries for older records.
 
 `PickWorkItem` sets `AgentState.current_work_item_id` to an existing open work
 item owned by the agent.

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2128,7 +2128,6 @@ impl RuntimeHandle {
     pub async fn complete_work_item(
         &self,
         work_item_id: String,
-        result_summary: Option<String>,
         warnings: Vec<serde_json::Value>,
     ) -> Result<WorkItemRecord> {
         let agent_id = self.agent_id().await?;
@@ -2140,7 +2139,7 @@ impl RuntimeHandle {
             revision: existing.revision + 1,
             state: WorkItemState::Completed,
             blocked_by: None,
-            result_summary: result_summary.clone(),
+            result_summary: existing.result_summary.clone(),
             updated_at: Utc::now(),
             ..existing
         };
@@ -2158,17 +2157,6 @@ impl RuntimeHandle {
                     "plan_artifact": record.plan_artifact.clone(),
                 }),
             ))?;
-        }
-        if let Some(result_summary) = result_summary {
-            self.inner
-                .storage
-                .append_delivery_summary(&DeliverySummaryRecord::new(
-                    agent_id.clone(),
-                    record.id.clone(),
-                    result_summary,
-                    None,
-                    None,
-                ))?;
         }
         self.cancel_work_item_waiting_intents(&record.id, "work_item_completed")
             .await?;

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -25,12 +25,12 @@ pub(crate) use crate::{
         ActiveWorkspaceEntry, AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset,
         AgentRegistryStatus, AgentState, AgentStatus, AgentVisibility, AuthorityClass, BriefKind,
         BriefRecord, CallbackDeliveryMode, ClosureDecision, ClosureOutcome, ContinuationClass,
-        ContinuationTriggerKind, LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageKind,
-        MessageOrigin, PendingWakeHint, Priority, QueueEntryStatus, TaskKind,
-        TaskOutputRetrievalStatus, TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord,
-        TimerStatus, TodoItem, TodoItemState, TokenUsage, TrustLevel, TurnTerminalKind,
-        TurnTerminalRecord, WaitingIntentStatus, WaitingReason, WorkItemRecord, WorkItemState,
-        WorkReactivationMode, WorkspaceEntry,
+        ContinuationTriggerKind, DeliverySummaryRecord, LoadedAgentsMd, MessageBody,
+        MessageDeliverySurface, MessageKind, MessageOrigin, PendingWakeHint, Priority,
+        QueueEntryStatus, TaskKind, TaskOutputRetrievalStatus, TaskRecord, TaskRecoverySpec,
+        TaskStatus, TimerRecord, TimerStatus, TodoItem, TodoItemState, TokenUsage, TrustLevel,
+        TurnTerminalKind, TurnTerminalRecord, WaitingIntentStatus, WaitingReason, WorkItemRecord,
+        WorkItemState, WorkReactivationMode, WorkspaceEntry,
     },
 };
 
@@ -176,9 +176,21 @@ pub(crate) async fn seed_bound_work_item(
     }
     if state == WorkItemState::Completed {
         record = runtime
-            .complete_work_item(record.id.clone(), summary.map(str::to_string), Vec::new())
+            .complete_work_item(record.id.clone(), Vec::new())
             .await
             .unwrap();
+        if let Some(summary) = summary {
+            record = runtime
+                .promote_work_item_completion_report(
+                    record.id.clone(),
+                    summary.to_string(),
+                    None,
+                    None,
+                    Vec::new(),
+                )
+                .await
+                .unwrap();
+        }
     }
     bind_turn_to_work_item(runtime, &record.id).await;
     record.id

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -128,7 +128,17 @@ async fn work_item_query_tools_return_current_open_done_views() {
         .await
         .unwrap();
     let completed = runtime
-        .complete_work_item(completed.id.clone(), None, Vec::new())
+        .complete_work_item(completed.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let completed = runtime
+        .promote_work_item_completion_report(
+            completed.id.clone(),
+            "Completed delivery report.".into(),
+            Some(7),
+            Some(0),
+            Vec::new(),
+        )
         .await
         .unwrap();
     bind_turn_to_work_item(&runtime, &active.id).await;
@@ -224,6 +234,18 @@ async fn work_item_query_tools_return_current_open_done_views() {
         completed_payload["work_item"]["readiness"].as_str(),
         Some("completed")
     );
+    assert_eq!(
+        completed_payload["work_item"]["completion_report"]["text"].as_str(),
+        Some("Completed delivery report.")
+    );
+    assert_eq!(
+        completed_payload["work_item"]["completion_report"]["source"].as_str(),
+        Some("work_item_result_summary")
+    );
+    assert_eq!(
+        completed_payload["work_item"]["completion_report"]["source_turn_index"].as_u64(),
+        Some(7)
+    );
 
     bind_turn_to_work_item(&runtime, completed.id.as_str()).await;
     let (fallback_result, _) = registry
@@ -248,6 +270,72 @@ async fn work_item_query_tools_return_current_open_done_views() {
         fallback_payload["work_items"][0]["id"].as_str(),
         Some(active.id.as_str())
     );
+}
+
+#[tokio::test]
+async fn work_item_query_tools_fall_back_to_delivery_summary_report() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item(
+            "legacy delivery summary fallback".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+    let completed = runtime
+        .complete_work_item(work.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let summary = DeliverySummaryRecord::new(
+        "default",
+        completed.id.clone(),
+        "Legacy delivery summary report.",
+        Some(11),
+        None,
+    );
+    let summary_id = summary.id.clone();
+    runtime.storage().append_delivery_summary(&summary).unwrap();
+
+    let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+    let (result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "completed".into(),
+                name: "GetWorkItem".into(),
+                input: serde_json::json!({"work_item_id": completed.id}),
+            },
+        )
+        .await
+        .unwrap();
+    let payload = result.envelope.result.unwrap();
+    let report = &payload["work_item"]["completion_report"];
+    assert_eq!(
+        report["text"].as_str(),
+        Some("Legacy delivery summary report.")
+    );
+    assert_eq!(report["source"].as_str(), Some("delivery_summary"));
+    assert_eq!(
+        report["delivery_summary_id"].as_str(),
+        Some(summary_id.as_str())
+    );
+    assert_eq!(report["source_turn_index"].as_u64(), Some(11));
 }
 
 #[tokio::test]
@@ -285,7 +373,7 @@ async fn work_item_revision_increments_on_updates_and_completion() {
     assert_eq!(updated.revision, 2);
 
     let completed = runtime
-        .complete_work_item(updated.id.clone(), Some("done".into()), Vec::new())
+        .complete_work_item(updated.id.clone(), Vec::new())
         .await
         .unwrap();
     assert_eq!(completed.revision, 3);
@@ -322,11 +410,11 @@ async fn work_item_completion_ignores_running_tasks_and_clears_explicit_waits() 
     runtime.storage().append_task(&unscoped_task).unwrap();
 
     let completed = runtime
-        .complete_work_item(target.id.clone(), Some("target done".into()), Vec::new())
+        .complete_work_item(target.id.clone(), Vec::new())
         .await
         .unwrap();
     assert_eq!(completed.id, target.id);
-    assert_eq!(completed.result_summary.as_deref(), Some("target done"));
+    assert_eq!(completed.result_summary, None);
 
     let explicit_wait = runtime
         .create_work_item("explicit wait".into(), None, None, Vec::new())
@@ -345,11 +433,7 @@ async fn work_item_completion_ignores_running_tasks_and_clears_explicit_waits() 
         .unwrap();
 
     let completed_wait = runtime
-        .complete_work_item(
-            explicit_wait.id.clone(),
-            Some("confirmed done".into()),
-            Vec::new(),
-        )
+        .complete_work_item(explicit_wait.id.clone(), Vec::new())
         .await
         .unwrap();
     assert_eq!(completed_wait.state, WorkItemState::Completed);
@@ -830,7 +914,7 @@ async fn complete_work_item_refreshes_latest_plan_artifact_snapshot() {
     let expected = crate::work_item_plan::describe_plan_artifact(&plan_path).unwrap();
 
     let completed = runtime
-        .complete_work_item(work.id.clone(), Some("done".into()), Vec::new())
+        .complete_work_item(work.id.clone(), Vec::new())
         .await
         .unwrap();
 
@@ -1565,10 +1649,16 @@ async fn repeated_complete_work_item_does_not_overwrite_existing_report() {
         .create_work_item("already completed".into(), None, None, Vec::new())
         .await
         .unwrap();
+    let completed = seed_runtime
+        .complete_work_item(work_item.id.clone(), Vec::new())
+        .await
+        .unwrap();
     seed_runtime
-        .complete_work_item(
-            work_item.id.clone(),
-            Some("Original completion report".into()),
+        .promote_work_item_completion_report(
+            completed.id.clone(),
+            "Original completion report".into(),
+            None,
+            None,
             Vec::new(),
         )
         .await
@@ -2371,11 +2461,7 @@ async fn triggered_work_item_waiting_intent_preserves_explicit_work_item_state_u
     }));
 
     let completed = runtime
-        .complete_work_item(
-            work.id.clone(),
-            Some("CI confirmed success".into()),
-            Vec::new(),
-        )
+        .complete_work_item(work.id.clone(), Vec::new())
         .await
         .unwrap();
     assert_eq!(completed.state, WorkItemState::Completed);
@@ -2421,11 +2507,7 @@ async fn completing_work_item_cancels_work_item_scoped_external_trigger() {
         .unwrap();
 
     runtime
-        .complete_work_item(
-            work.id.clone(),
-            Some("review no longer needed".into()),
-            Vec::new(),
-        )
+        .complete_work_item(work.id.clone(), Vec::new())
         .await
         .unwrap();
 
@@ -2654,11 +2736,7 @@ async fn reconcile_waiting_contract_cancels_old_waits_after_active_work_switch()
         .created_at;
 
     runtime
-        .complete_work_item(
-            old_work.id.clone(),
-            Some("old work done".into()),
-            Vec::new(),
-        )
+        .complete_work_item(old_work.id.clone(), Vec::new())
         .await
         .unwrap();
     let new_work = runtime
@@ -2747,11 +2825,7 @@ async fn reconcile_waiting_contract_keeps_agent_scoped_waits_after_active_work_s
         .created_at;
 
     runtime
-        .complete_work_item(
-            old_work.id.clone(),
-            Some("old work done".into()),
-            Vec::new(),
-        )
+        .complete_work_item(old_work.id.clone(), Vec::new())
         .await
         .unwrap();
     let new_work = runtime

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -64,7 +64,7 @@ pub(crate) async fn execute(
         .unwrap_or(false);
     let warnings = before.as_ref().map(completion_warnings).unwrap_or_default();
     let work_item = runtime
-        .complete_work_item(work_item_id, None, warnings_json(&warnings))
+        .complete_work_item(work_item_id, warnings_json(&warnings))
         .await?;
     let context = query_context(runtime).await?;
     let work_item = view_for_record(runtime, &context, work_item, true).await?;

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -67,7 +67,7 @@ pub(crate) async fn execute(
         .complete_work_item(work_item_id, warnings_json(&warnings))
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None).await?;
     serialize_success(
         NAME,
         &WorkItemMutationResult::with_completion_transition(

--- a/src/tool/tools/create_work_item.rs
+++ b/src/tool/tools/create_work_item.rs
@@ -88,6 +88,6 @@ pub(crate) async fn execute(
         )
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None).await?;
     serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/get_work_item.rs
+++ b/src/tool/tools/get_work_item.rs
@@ -60,6 +60,7 @@ pub(crate) async fn execute(
             )
         })?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, record, args.include_todo_list).await?;
+    let work_item =
+        view_for_record(runtime, &context, record, args.include_todo_list, None).await?;
     serialize_success(NAME, &GetWorkItemResult { context, work_item })
 }

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -12,8 +12,8 @@ use crate::{
 use super::{
     serialize_success,
     work_item_query::{
-        lifecycle_view, query_context, view_for_record, WorkItemFocusView, WorkItemLifecycleView,
-        WorkItemQueryContext, WorkItemView,
+        latest_delivery_summaries_by_work_item, lifecycle_view, query_context, view_for_record,
+        WorkItemFocusView, WorkItemLifecycleView, WorkItemQueryContext, WorkItemView,
     },
     BuiltinToolDefinition,
 };
@@ -86,9 +86,26 @@ pub(crate) async fn execute(
         .collect::<Vec<_>>();
     let total_matching = matching.len();
     let selected = matching.into_iter().take(limit).collect::<Vec<_>>();
+    let delivery_summaries = if selected
+        .iter()
+        .any(|record| record.state == WorkItemState::Completed)
+    {
+        Some(latest_delivery_summaries_by_work_item(runtime)?)
+    } else {
+        None
+    };
     let mut work_items = Vec::with_capacity(selected.len());
     for record in selected {
-        work_items.push(view_for_record(runtime, &context, record, args.include_todo_list).await?);
+        work_items.push(
+            view_for_record(
+                runtime,
+                &context,
+                record,
+                args.include_todo_list,
+                delivery_summaries.as_ref(),
+            )
+            .await?,
+        );
     }
     serialize_success(
         NAME,

--- a/src/tool/tools/update_work_item.rs
+++ b/src/tool/tools/update_work_item.rs
@@ -76,6 +76,6 @@ pub(crate) async fn execute(
         )
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None).await?;
     serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -74,6 +76,8 @@ pub(crate) struct WorkItemQueryContext {
     pub(crate) current_work_item_id: Option<String>,
 }
 
+pub(crate) type WorkItemDeliverySummaryMap = BTreeMap<String, DeliverySummaryRecord>;
+
 pub(crate) async fn query_context(runtime: &RuntimeHandle) -> Result<WorkItemQueryContext> {
     let state = runtime.agent_state().await?;
     if let Some(bound_id) = state.current_turn_work_item_id.as_deref() {
@@ -103,6 +107,7 @@ pub(crate) async fn view_for_record(
     context: &WorkItemQueryContext,
     record: WorkItemRecord,
     include_todo_list: bool,
+    delivery_summaries: Option<&WorkItemDeliverySummaryMap>,
 ) -> Result<WorkItemView> {
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
@@ -123,7 +128,7 @@ pub(crate) async fn view_for_record(
     let state = lifecycle_view(&record.state);
     let focus = focus_view(&record, is_current);
     let readiness = record.readiness();
-    let completion_report = completion_report_for_record(runtime, &record)?;
+    let completion_report = completion_report_for_record(runtime, &record, delivery_summaries)?;
     Ok(WorkItemView {
         id: record.id,
         agent_id: record.agent_id,
@@ -144,14 +149,40 @@ pub(crate) async fn view_for_record(
     })
 }
 
+pub(crate) fn latest_delivery_summaries_by_work_item(
+    runtime: &RuntimeHandle,
+) -> Result<WorkItemDeliverySummaryMap> {
+    let mut summaries = BTreeMap::new();
+    for summary in runtime
+        .storage()
+        .read_recent_delivery_summaries(usize::MAX)?
+        .into_iter()
+        .rev()
+        .filter(|summary| !summary.text.is_empty())
+    {
+        summaries
+            .entry(summary.work_item_id.clone())
+            .or_insert(summary);
+    }
+    Ok(summaries)
+}
+
 fn completion_report_for_record(
     runtime: &RuntimeHandle,
     record: &WorkItemRecord,
+    delivery_summaries: Option<&WorkItemDeliverySummaryMap>,
 ) -> Result<Option<WorkItemCompletionReportView>> {
     if record.state != WorkItemState::Completed {
         return Ok(None);
     }
-    let latest_delivery_summary = runtime.storage().latest_delivery_summary(&record.id)?;
+    let cached_delivery_summary = delivery_summaries
+        .and_then(|summaries| summaries.get(&record.id))
+        .cloned();
+    let latest_delivery_summary = match (delivery_summaries.is_some(), cached_delivery_summary) {
+        (_, Some(summary)) => Some(summary),
+        (true, None) => None,
+        (false, None) => runtime.storage().latest_delivery_summary(&record.id)?,
+    };
     if let Some(text) = record
         .result_summary
         .as_ref()

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     runtime::RuntimeHandle,
     types::{
-        TodoItem, WorkItemPlanArtifact, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord,
-        WorkItemState,
+        DeliverySummaryRecord, TodoItem, WorkItemPlanArtifact, WorkItemPlanStatus,
+        WorkItemReadiness, WorkItemRecord, WorkItemState,
     },
 };
 
@@ -27,6 +27,25 @@ pub(crate) enum WorkItemFocusView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WorkItemCompletionReportSource {
+    WorkItemResultSummary,
+    DeliverySummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct WorkItemCompletionReportView {
+    pub(crate) text: String,
+    pub(crate) source: WorkItemCompletionReportSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) delivery_summary_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source_turn_index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct WorkItemView {
     pub(crate) id: String,
     pub(crate) agent_id: String,
@@ -43,6 +62,8 @@ pub(crate) struct WorkItemView {
     pub(crate) todo_list: Vec<TodoItem>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) blocked_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) completion_report: Option<WorkItemCompletionReportView>,
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) updated_at: DateTime<Utc>,
 }
@@ -102,6 +123,7 @@ pub(crate) async fn view_for_record(
     let state = lifecycle_view(&record.state);
     let focus = focus_view(&record, is_current);
     let readiness = record.readiness();
+    let completion_report = completion_report_for_record(runtime, &record)?;
     Ok(WorkItemView {
         id: record.id,
         agent_id: record.agent_id,
@@ -116,9 +138,56 @@ pub(crate) async fn view_for_record(
         plan_artifact,
         todo_list,
         blocked_by: record.blocked_by,
+        completion_report,
         created_at: record.created_at,
         updated_at: record.updated_at,
     })
+}
+
+fn completion_report_for_record(
+    runtime: &RuntimeHandle,
+    record: &WorkItemRecord,
+) -> Result<Option<WorkItemCompletionReportView>> {
+    if record.state != WorkItemState::Completed {
+        return Ok(None);
+    }
+    let latest_delivery_summary = runtime.storage().latest_delivery_summary(&record.id)?;
+    if let Some(text) = record
+        .result_summary
+        .as_ref()
+        .filter(|text| !text.is_empty())
+    {
+        return Ok(Some(completion_report_view(
+            text.clone(),
+            WorkItemCompletionReportSource::WorkItemResultSummary,
+            latest_delivery_summary
+                .filter(|summary| summary.text == *text)
+                .as_ref(),
+        )));
+    }
+    Ok(latest_delivery_summary
+        .filter(|summary| !summary.text.is_empty())
+        .map(|summary| {
+            completion_report_view(
+                summary.text.clone(),
+                WorkItemCompletionReportSource::DeliverySummary,
+                Some(&summary),
+            )
+        }))
+}
+
+fn completion_report_view(
+    text: String,
+    source: WorkItemCompletionReportSource,
+    delivery_summary: Option<&DeliverySummaryRecord>,
+) -> WorkItemCompletionReportView {
+    WorkItemCompletionReportView {
+        text,
+        source,
+        delivery_summary_id: delivery_summary.map(|summary| summary.id.clone()),
+        source_turn_index: delivery_summary.and_then(|summary| summary.source_turn_index),
+        created_at: delivery_summary.map(|summary| summary.created_at),
+    }
 }
 
 pub(crate) fn lifecycle_view(state: &WorkItemState) -> WorkItemLifecycleView {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -74,7 +74,7 @@ pub async fn test_work_item(
     }
     if state == WorkItemState::Completed {
         record = runtime
-            .complete_work_item(record.id.clone(), None, Vec::new())
+            .complete_work_item(record.id.clone(), Vec::new())
             .await?;
     }
     Ok(record)


### PR DESCRIPTION
## Summary

- expose promoted WorkItem completion reports on `GetWorkItem` / `ListWorkItems` views
- remove the internal `complete_work_item(..., result_summary, ...)` shortcut so completion only transitions state and same-round promotion remains the report path
- align `runtime-spec.md` with the no-`result_summary` `CompleteWorkItem` contract

## Tests

- `cargo fmt --check`
- `cargo test work_items --lib`
- `cargo test --test run_once run_once_prefers_completed_work_item_delivery_summary_over_latest_turn_text -- --exact`
- `cargo test complete_work_item_schema_keeps_completion_report_out_of_tool_input --lib`
- `git diff --check`
