### PR TITLE
fix: clean TUI diagnostics and chat presentation

### DIFF
--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -181,7 +181,7 @@ TUI debug instrumentation is controlled by environment variables:
 
 | Environment variable | Values | Default | Description |
 |----------------------|--------|---------|-------------|
-| `HOLON_TUI_PRESENTATION_LOG` | `1`, `true`, `yes`, `on`, `debug` | unset | Enable `logs/tui/presentation.jsonl` debug logging for stream-driven presentation decisions |
+| `HOLON_TUI_PRESENTATION_LOG` | `1`, `true`, `yes`, `on`, `debug` | unset | Enable `<HOLON_HOME>/logs/tui/presentation.jsonl` debug logging for stream-driven presentation decisions |
 | `HOLON_TUI_PRESENTATION_LOG_MAX_BYTES` | positive integer bytes | `5242880` | Rotate the presentation debug log when it reaches this size |
 
 ## Web Fetch/Search Settings

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -1,11 +1,13 @@
 use crate::types::{BriefKind, BriefRecord, MessageEnvelope};
 
+pub const QUEUED_WORK_ACK_PREFIX: &str = "Queued work: ";
+
 pub fn make_ack(agent_id: &str, message: &MessageEnvelope) -> BriefRecord {
     let preview = preview_message(message);
     BriefRecord::new(
         agent_id,
         BriefKind::Ack,
-        format!("Queued work: {preview}"),
+        format!("{QUEUED_WORK_ACK_PREFIX}{preview}"),
         Some(message.id.clone()),
         None,
     )

--- a/src/config.rs
+++ b/src/config.rs
@@ -611,6 +611,10 @@ impl AppConfig {
         self.data_dir.join("agents")
     }
 
+    pub fn log_root_dir(&self) -> PathBuf {
+        self.data_dir.join("logs")
+    }
+
     pub fn control_token_required(&self, transport: ControlTransportKind) -> bool {
         match self.control_auth_mode {
             ControlAuthMode::Disabled => false,

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -5,6 +5,8 @@
 //!
 //! See `docs/rfcs/presentation-item-model-and-renderer.md`.
 
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
@@ -345,14 +347,9 @@ impl Renderable for PresentationItem {
             }
 
             PresentationItem::AssistantResult { body, outcome, .. } => {
-                let display_body = if level >= 5 {
-                    body.clone()
-                } else {
-                    truncate_text(body, 500)
-                };
                 vec![RenderedCell::new(
                     "Holon",
-                    format!("{} {}", outcome.symbol(), display_body),
+                    format!("{} {}", outcome.symbol(), body),
                 )]
             }
 
@@ -578,6 +575,8 @@ impl PresentationReducer {
 
     pub(crate) fn reduce(&mut self, events: &[ProjectionEventRecord]) -> Vec<TimedItem> {
         let mut items: Vec<TimedItem> = Vec::new();
+        let final_brief_texts = final_brief_texts(events);
+        let mut observed_assistant_text_keys = HashSet::new();
 
         let mut i = 0;
         while i < events.len() {
@@ -622,13 +621,24 @@ impl PresentationReducer {
                 }
 
                 "brief_created" => {
-                    items.push(TimedItem {
-                        item: brief_result_item(event),
-                        ts: event.ts,
-                    });
+                    if let Some(item) = brief_result_item(event) {
+                        items.push(TimedItem { item, ts: event.ts });
+                    }
                 }
 
                 "tool_executed" | "tool_execution_failed" => {
+                    if is_sleep_tool_event(event) {
+                        items.push(TimedItem {
+                            item: PresentationItem::InternalTransition {
+                                what: "Sleep".into(),
+                                from: "tool".into(),
+                                to: event.summary.clone(),
+                            },
+                            ts: event.ts,
+                        });
+                        i += 1;
+                        continue;
+                    }
                     let cmd_preview =
                         exec_command_preview(event).unwrap_or_else(|| event.summary.clone());
                     let exit_code = tool_exit_code(event).or_else(|| match event.kind.as_str() {
@@ -654,7 +664,11 @@ impl PresentationReducer {
 
                 "assistant_round_recorded" | "text_only_round_observed" => {
                     if let Some(text) = round_text_preview(event) {
-                        if !text.trim().is_empty() {
+                        let text_key = normalized_event_text_key(event, &text);
+                        if !text.trim().is_empty()
+                            && !matches_final_brief_text(event, &text, &final_brief_texts)
+                            && observed_assistant_text_keys.insert(text_key)
+                        {
                             items.push(TimedItem {
                                 item: PresentationItem::AssistantProgress {
                                     text,
@@ -866,9 +880,10 @@ impl PresentationReducer {
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-fn brief_result_item(event: &ProjectionEventRecord) -> PresentationItem {
+fn brief_result_item(event: &ProjectionEventRecord) -> Option<PresentationItem> {
     match serde_json::from_value::<BriefRecord>(event.payload.clone()) {
-        Ok(brief) => PresentationItem::AssistantResult {
+        Ok(brief) if is_operator_queue_ack(&brief) => None,
+        Ok(brief) => Some(PresentationItem::AssistantResult {
             brief_id: Some(brief.id),
             body: brief.text,
             outcome: match brief.kind {
@@ -876,13 +891,77 @@ fn brief_result_item(event: &ProjectionEventRecord) -> PresentationItem {
                 BriefKind::Result => Outcome::Success,
                 BriefKind::Ack => Outcome::Neutral,
             },
-        },
-        Err(_) => PresentationItem::AssistantResult {
+        }),
+        Err(_) => Some(PresentationItem::AssistantResult {
             brief_id: None,
             body: event.summary.clone(),
             outcome: Outcome::Neutral,
-        },
+        }),
     }
+}
+
+fn is_operator_queue_ack(brief: &BriefRecord) -> bool {
+    brief.kind == BriefKind::Ack
+        && brief.related_message_id.is_some()
+        && brief.text.trim_start().starts_with("Queued work:")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FinalBriefText {
+    agent_id: String,
+    text: String,
+}
+
+fn final_brief_texts(events: &[ProjectionEventRecord]) -> Vec<FinalBriefText> {
+    events
+        .iter()
+        .filter(|event| event.kind == "brief_created")
+        .filter_map(|event| serde_json::from_value::<BriefRecord>(event.payload.clone()).ok())
+        .filter(|brief| !is_operator_queue_ack(brief))
+        .filter(|brief| !brief.text.trim().is_empty())
+        .map(|brief| FinalBriefText {
+            agent_id: brief.agent_id,
+            text: normalized_text(brief.text.as_str()),
+        })
+        .collect()
+}
+
+fn matches_final_brief_text(
+    event: &ProjectionEventRecord,
+    text: &str,
+    final_brief_texts: &[FinalBriefText],
+) -> bool {
+    let Some(agent_id) = event.payload.get("agent_id").and_then(Value::as_str) else {
+        return false;
+    };
+    let observed = normalized_text(text)
+        .trim_end_matches('\u{2026}')
+        .trim()
+        .to_string();
+    if observed.is_empty() {
+        return false;
+    }
+    final_brief_texts
+        .iter()
+        .filter(|brief| brief.agent_id == agent_id)
+        .any(|brief| brief.text == observed || brief.text.starts_with(&observed))
+}
+
+fn normalized_event_text_key(event: &ProjectionEventRecord, text: &str) -> String {
+    let agent_id = event.payload.get("agent_id").and_then(Value::as_str);
+    normalized_text_key(agent_id, text)
+}
+
+fn normalized_text_key(agent_id: Option<&str>, text: &str) -> String {
+    format!("{}::{}", agent_id.unwrap_or(""), normalized_text(text))
+}
+
+fn normalized_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn is_sleep_tool_event(event: &ProjectionEventRecord) -> bool {
+    event.payload.get("tool_name").and_then(Value::as_str) == Some("Sleep")
 }
 
 fn is_suppressed_known_runtime_event(kind: &str) -> bool {
@@ -1271,6 +1350,122 @@ mod tests {
                 assert!(!body.contains("Brief:"));
             }
             other => panic!("expected AssistantResult, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reducer_filters_operator_queue_ack_briefs() {
+        let brief = BriefRecord::new(
+            "default",
+            BriefKind::Ack,
+            "Queued work: duplicate operator input",
+            Some("msg-1".into()),
+            None,
+        );
+        let event = make_event("brief_created", "Queued work: duplicate", json!(brief));
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[event]);
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn reducer_deduplicates_assistant_observations_against_final_brief() {
+        let assistant = make_event(
+            "assistant_round_recorded",
+            "assistant round",
+            json!({
+                "agent_id": "default",
+                "text_preview": "Issue recorded: #1128\u{2026}"
+            }),
+        );
+        let text_only = make_event(
+            "text_only_round_observed",
+            "text only round",
+            json!({
+                "agent_id": "default",
+                "text_preview": "Issue recorded: #1128\u{2026}"
+            }),
+        );
+        let brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "Issue recorded: #1128 with complete details",
+            None,
+            None,
+        );
+        let brief_event = make_event(
+            "brief_created",
+            "Issue recorded: #1128 with complete details",
+            json!(brief),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[assistant, text_only, brief_event]);
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::AssistantResult { body, .. } => {
+                assert_eq!(body, "Issue recorded: #1128 with complete details");
+            }
+            other => panic!("expected AssistantResult, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reducer_deduplicates_repeated_assistant_text_observations() {
+        let assistant = make_event(
+            "assistant_round_recorded",
+            "assistant round",
+            json!({
+                "agent_id": "default",
+                "text_preview": "Analyzing the issue"
+            }),
+        );
+        let text_only = make_event(
+            "text_only_round_observed",
+            "text only round",
+            json!({
+                "agent_id": "default",
+                "text_preview": "Analyzing   the issue"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[assistant, text_only]);
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::AssistantProgress { text, .. } => {
+                assert_eq!(text, "Analyzing the issue");
+            }
+            other => panic!("expected AssistantProgress, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reducer_downgrades_sleep_tool_to_debug_internal_transition() {
+        let event = make_event(
+            "tool_executed",
+            "Slept: sleep requested",
+            json!({
+                "tool_name": "Sleep"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[event]);
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::InternalTransition { what, .. } => {
+                assert_eq!(what, "Sleep");
+                assert_eq!(items[0].item.min_display_level(), 5);
+                assert!(items[0].item.render(4).is_empty());
+                assert!(!items[0].item.render(5).is_empty());
+            }
+            other => panic!("expected InternalTransition, got {:?}", other),
         }
     }
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -901,9 +901,14 @@ fn brief_result_item(event: &ProjectionEventRecord) -> Option<PresentationItem> 
 }
 
 fn is_operator_queue_ack(brief: &BriefRecord) -> bool {
+    // This matches the canonical operator-input acknowledgement from
+    // `brief::make_ack`; arbitrary Ack briefs should still render normally.
     brief.kind == BriefKind::Ack
         && brief.related_message_id.is_some()
-        && brief.text.trim_start().starts_with("Queued work:")
+        && brief
+            .text
+            .trim_start()
+            .starts_with(crate::brief::QUEUED_WORK_ACK_PREFIX)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -934,10 +939,7 @@ fn matches_final_brief_text(
     let Some(agent_id) = event.payload.get("agent_id").and_then(Value::as_str) else {
         return false;
     };
-    let observed = normalized_text(text)
-        .trim_end_matches('\u{2026}')
-        .trim()
-        .to_string();
+    let observed = strip_preview_ellipsis(normalized_text(text).as_str());
     if observed.is_empty() {
         return false;
     }
@@ -958,6 +960,22 @@ fn normalized_text_key(agent_id: Option<&str>, text: &str) -> String {
 
 fn normalized_text(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_preview_ellipsis(text: &str) -> String {
+    let mut observed = text.trim().to_string();
+    loop {
+        let trimmed = observed.trim_end();
+        if let Some(stripped) = trimmed.strip_suffix("...") {
+            observed = stripped.trim_end().to_string();
+            continue;
+        }
+        if let Some(stripped) = trimmed.strip_suffix('\u{2026}') {
+            observed = stripped.trim_end().to_string();
+            continue;
+        }
+        return trimmed.to_string();
+    }
 }
 
 fn is_sleep_tool_event(event: &ProjectionEventRecord) -> bool {
@@ -1354,14 +1372,19 @@ mod tests {
     }
 
     #[test]
-    fn reducer_filters_operator_queue_ack_briefs() {
-        let brief = BriefRecord::new(
+    fn reducer_filters_canonical_operator_queue_ack_briefs() {
+        let message = crate::types::MessageEnvelope::new(
             "default",
-            BriefKind::Ack,
-            "Queued work: duplicate operator input",
-            Some("msg-1".into()),
-            None,
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator { actor_id: None },
+            crate::types::TrustLevel::TrustedOperator,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text {
+                text: "duplicate operator input".into(),
+            },
         );
+        let brief = crate::brief::make_ack("default", &message);
+        assert!(brief.text.starts_with(crate::brief::QUEUED_WORK_ACK_PREFIX));
         let event = make_event("brief_created", "Queued work: duplicate", json!(brief));
 
         let mut reducer = PresentationReducer::new();
@@ -1377,7 +1400,7 @@ mod tests {
             "assistant round",
             json!({
                 "agent_id": "default",
-                "text_preview": "Issue recorded: #1128\u{2026}"
+                "text_preview": "Issue recorded: #1128..."
             }),
         );
         let text_only = make_event(
@@ -1385,7 +1408,7 @@ mod tests {
             "text only round",
             json!({
                 "agent_id": "default",
-                "text_preview": "Issue recorded: #1128\u{2026}"
+                "text_preview": "Issue recorded: #1128..."
             }),
         );
         let brief = BriefRecord::new(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -67,7 +67,7 @@ pub async fn run_tui(
         Some(client) => client,
         None => LocalClient::new(config.clone())?,
     };
-    let log_writer = TuiLogWriter::new(config.agent_root_dir())?;
+    let log_writer = TuiLogWriter::new(config.log_root_dir())?;
     let mut app = TuiApp::new(client, log_writer);
     app.initialize().await;
 

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -681,6 +681,9 @@ fn presentation_activity_text(event: &ProjectionEventRecord) -> Option<String> {
 
 fn action_event_body(event: &crate::tui::projection::ProjectionEventRecord) -> String {
     if event.kind == "tool_executed" || event.kind == "tool_execution_failed" {
+        if is_sleep_tool_event(event) {
+            return String::new();
+        }
         progress_event_body(event)
     } else if is_progress_event(event) {
         assistant_message_from_event(event).unwrap_or_default()
@@ -796,6 +799,10 @@ pub(super) fn conversation_event_body(
     format!("{prefix}{}", event.summary)
 }
 
+fn is_sleep_tool_event(event: &crate::tui::projection::ProjectionEventRecord) -> bool {
+    event.payload.get("tool_name").and_then(Value::as_str) == Some("Sleep")
+}
+
 fn progress_event_body(event: &crate::tui::projection::ProjectionEventRecord) -> String {
     if matches!(
         event.presentation.category,
@@ -824,7 +831,9 @@ fn trim_preview(input: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{assistant_message_from_event, latest_action_event, progress_event_body};
+    use super::{
+        action_event_body, assistant_message_from_event, latest_action_event, progress_event_body,
+    };
     use crate::operator_event::{present_operator_event, OperatorPresentationContext};
     use crate::tui::projection::{ProjectionEventLane, ProjectionEventRecord};
     use chrono::Utc;
@@ -892,7 +901,7 @@ mod tests {
     }
 
     #[test]
-    fn progress_event_body_uses_summary_for_non_command_tools() {
+    fn sleep_tool_is_not_activity_content() {
         let event = event(
             "tool_executed",
             "tool executed: Sleep",
@@ -900,8 +909,7 @@ mod tests {
                 "tool_name": "Sleep"
             }),
         );
-        let rendered = progress_event_body(&event);
-        assert_eq!(rendered, "Slept");
+        assert!(action_event_body(&event).is_empty());
     }
 
     #[test]

--- a/src/tui/logging.rs
+++ b/src/tui/logging.rs
@@ -29,8 +29,8 @@ pub(crate) struct TuiLogWriter {
 }
 
 impl TuiLogWriter {
-    pub(crate) fn new(agent_home: impl Into<PathBuf>) -> Result<Self> {
-        let root = agent_home.into().join("logs").join("tui");
+    pub(crate) fn new(log_root: impl Into<PathBuf>) -> Result<Self> {
+        let root = log_root.into().join("tui");
         fs::create_dir_all(&root)
             .with_context(|| format!("failed to create {}", root.display()))?;
         Ok(Self {
@@ -349,6 +349,26 @@ mod tests {
     use crate::presentation::Outcome;
     use crate::tui::projection::{ProjectionEventLane, ProjectionEventRecord};
     use serde_json::json;
+
+    #[test]
+    fn new_uses_log_root_not_agent_root() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let log_root = tempdir.path().join("logs");
+
+        let writer = TuiLogWriter::new(&log_root).unwrap();
+
+        assert_eq!(writer.root, log_root.join("tui"));
+        assert!(writer.root.exists());
+        assert!(
+            !tempdir
+                .path()
+                .join("agents")
+                .join("logs")
+                .join("tui")
+                .exists(),
+            "TUI diagnostics must not create a pseudo agent under agents/logs"
+        );
+    }
 
     #[test]
     fn presentation_log_is_disabled_by_default() {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1445,21 +1445,19 @@ fn chat_text_filters_operator_queue_ack_but_keeps_result_brief_events() {
         client,
         crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
     );
-    apply_brief_event(
-        &mut app,
-        BriefRecord {
-            id: "brief-ack".into(),
-            agent_id: "default".into(),
-            workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
-            work_item_id: None,
-            kind: BriefKind::Ack,
-            created_at: Utc::now(),
-            text: "Queued work: duplicate".into(),
-            attachments: None,
-            related_message_id: Some("msg-1".into()),
-            related_task_id: None,
+    let message = crate::types::MessageEnvelope::new(
+        "default",
+        crate::types::MessageKind::OperatorPrompt,
+        crate::types::MessageOrigin::Operator { actor_id: None },
+        crate::types::TrustLevel::TrustedOperator,
+        crate::types::Priority::Normal,
+        crate::types::MessageBody::Text {
+            text: "duplicate".into(),
         },
     );
+    let ack = crate::brief::make_ack("default", &message);
+    assert!(ack.text.starts_with(crate::brief::QUEUED_WORK_ACK_PREFIX));
+    apply_brief_event(&mut app, ack);
     apply_brief_event(
         &mut app,
         BriefRecord {
@@ -2465,7 +2463,7 @@ fn snapshot_refresh_failure_updates_status_line() {
 }
 
 #[test]
-fn chat_text_uses_presentation_summary_for_long_brief_events() {
+fn chat_text_renders_full_long_brief_events() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(
         client,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1439,7 +1439,7 @@ fn chat_text_renders_brief_events_from_projection() {
 }
 
 #[test]
-fn chat_text_renders_ack_and_result_brief_events() {
+fn chat_text_filters_operator_queue_ack_but_keeps_result_brief_events() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(
         client,
@@ -1481,7 +1481,7 @@ fn chat_text_renders_ack_and_result_brief_events() {
         .into_iter()
         .flat_map(|line| line.spans.into_iter().map(|span| span.content))
         .collect();
-    assert!(rendered.contains("Queued work: duplicate"));
+    assert!(!rendered.contains("Queued work: duplicate"));
     assert!(rendered.contains("Real response"));
 }
 
@@ -2498,7 +2498,7 @@ fn chat_text_uses_presentation_summary_for_long_brief_events() {
         .flat_map(|line| line.spans.into_iter().map(|span| span.content))
         .collect();
     assert!(rendered.contains("intro"));
-    assert!(!rendered.contains("tail marker that used to be trimmed away"));
+    assert!(rendered.contains("tail marker that used to be trimmed away"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Move TUI diagnostics from the agent-home namespace to `<HOLON_HOME>/logs/tui`, keeping `agents/` reserved for agent homes.
- Clean TUI chat presentation semantics:
  - render final assistant results fully at normal display levels
  - filter operator-origin `Queued work` ack briefs from the main chat stream
  - deduplicate assistant text observations against final briefs and repeated text-only observations
  - downgrade `Sleep` tool output to debug/internal presentation and remove it from active activity text

Closes #1128
Closes #1130

## Tests

- `cargo test tui::logging --lib`
- `cargo test chat_text --lib`
- `cargo test presentation --lib`
- `cargo test tui --lib`
- `git diff --check`
