### PR TITLE
fix: preserve sleeping status in TUI activity

### DIFF
--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -463,6 +463,14 @@ fn active_activity_status_label(speaker: &str) -> Option<&'static str> {
         Some("Waiting")
     } else if speaker.starts_with("Holon (delegating)") {
         Some("Delegating")
+    } else if speaker.starts_with("Holon (sleeping)") {
+        Some("Sleeping")
+    } else if speaker.starts_with("Holon (idle)") {
+        Some("Idle")
+    } else if speaker.starts_with("Holon (paused)") {
+        Some("Paused")
+    } else if speaker.starts_with("Holon (stopped)") {
+        Some("Stopped")
     } else {
         None
     }
@@ -586,7 +594,10 @@ fn active_activity_speaker(agent: &AgentSummary) -> String {
         crate::types::AgentStatus::AwakeRunning => "Holon (working)".into(),
         crate::types::AgentStatus::AwakeIdle if agent.agent.pending > 0 => "Holon (queued)".into(),
         _ if !agent.active_children.is_empty() => "Holon (delegating)".into(),
-        _ => "Holon (working)".into(),
+        crate::types::AgentStatus::AwakeIdle => "Holon (idle)".into(),
+        crate::types::AgentStatus::Asleep => "Holon (sleeping)".into(),
+        crate::types::AgentStatus::Paused => "Holon (paused)".into(),
+        crate::types::AgentStatus::Stopped => "Holon (stopped)".into(),
     }
 }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2110,6 +2110,39 @@ fn active_activity_cells_stay_stable_without_new_events() {
 }
 
 #[test]
+fn sleeping_agent_activity_cell_does_not_display_working() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let mut snapshot = sample_snapshot("default", "evt-0");
+    snapshot.agent.agent.status = AgentStatus::Asleep;
+    snapshot.agent.agent.pending = 0;
+    snapshot.agent.active_task_count = 1;
+    app.projection = Some(TuiProjection::from_snapshot(snapshot));
+
+    let items = collect_chat_items(&app);
+    let active_item = items.last().expect("active activity item");
+    match active_item {
+        ConversationCell::ActiveActivity { speaker, .. } => {
+            assert!(speaker.starts_with("Holon (sleeping)"));
+            assert!(!speaker.starts_with("Holon (working)"));
+        }
+        other => panic!("expected active activity item, got {other:?}"),
+    }
+
+    let rendered: String = build_chat_text(&items)
+        .lines
+        .into_iter()
+        .flat_map(|line| line.spans.into_iter().map(|span| span.content))
+        .collect();
+
+    assert!(rendered.contains("Sleeping"));
+    assert!(!rendered.contains("Working"));
+}
+
+#[test]
 fn collect_chat_items_orders_equal_timestamps_deterministically() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(


### PR DESCRIPTION
## Summary
- keep sleeping/idle/paused/stopped agent lifecycle labels in the TUI active activity row instead of falling back to working
- map those labels to display status text
- add a regression test for sleeping agents with active background tasks

## Verification
- cargo test sleeping_agent_activity_cell_does_not_display_working
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo fmt --all -- --check