### PR TITLE
docs: add missing debug scheduler-fixture to CLI reference

### DIFF
--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -69,7 +69,8 @@ holon (v0.13.0)
 ├── workspace    Workspace management (attach, exit, detach)
 ├── debug        Debug utilities
 │   ├── prompt   Debug-mode prompt
-│   └── latency  Show latency metrics
+│   ├── latency  Show latency metrics
+│   └── scheduler-fixture Generate scheduler fixture data (--agent, --output)
 └── help         Print help
 ```
 


### PR DESCRIPTION
Fixes #1155

Adds the missing `scheduler-fixture` subcommand under `debug` in the CLI reference command tree, with its `--agent` and `--output` flags.