### PR TITLE
docs: add memory system concepts page

### DIFF
--- a/docs/website/concepts/README.md
+++ b/docs/website/concepts/README.md
@@ -49,6 +49,9 @@ out, and the state disappears. Holon is different because:
 
 ## Deeper reading
 
+The **memory system** page explains how Holon preserves continuity across
+turns through working memory, episode archives, and indexed search.
+
 The **runtime model** page expands the four-object mental model into precise
 lifecycle vocabulary: agent profiles, work-item states, task kinds, queue
 semantics, triggers, and workspace isolation.
@@ -67,6 +70,10 @@ decisions](https://github.com/holon-run/holon/tree/main/docs/implementation-deci
 These are maintainer-facing documents; you do not need them to use Holon.
 
 <!-- INDEX:START -->
+
+- [Memory system](./memory.md)
+  How Holon's memory layers preserve continuity — working memory, episodes, durable ledger, and indexed search.
+  <!-- mdorigin:index kind=article -->
 
 - [Runtime model](./runtime-model.md)
   Agents, tasks, work items, workspaces, and the execution loop that make up Holon's runtime.

--- a/docs/website/concepts/memory.md
+++ b/docs/website/concepts/memory.md
@@ -1,0 +1,156 @@
+---
+title: Memory system
+summary: How Holon's memory layers preserve continuity across turns — working memory, episodes, durable ledger, and indexed search.
+order: 15
+---
+
+# Memory System
+
+Holon is designed for long-lived agents. Memory preserves what matters across
+turns without replaying the entire conversation history. The runtime derives
+memory from durable evidence rather than relying on free-form model summaries.
+
+## Memory Layers
+
+Holon's context memory has four layers, each with a distinct role:
+
+```
+Durable Ledger  ──── append-only audit trail (messages, briefs, tool calls, tasks)
+     │
+     ▼
+Working Memory  ──── compact current-state snapshot rebuilt after each turn
+     │
+     ▼
+Episode Memory  ──── archived records of completed work chunks
+     │
+     ▼
+Context Assembly ──── budgeted prompt sections selected from all layers
+```
+
+### Durable Ledger
+
+The append-only source of truth. Every runtime event is recorded:
+
+- Messages and briefs
+- Tool executions and command results
+- Task lifecycle transitions
+- Work item state changes
+- Working memory deltas
+- Episode records
+
+The ledger is **not prompt-bounded**. It grows indefinitely as the audit
+trail. The model-visible projection is a compressed selection, not a full
+replay.
+
+### Working Memory
+
+Working memory is the compact current-state snapshot that answers:
+
+- What work is active right now?
+- What is the delivery target?
+- Which constraints and scope limits apply?
+- What follow-ups remain?
+- What is the agent waiting on?
+
+It is derived deterministically from runtime state and rebuilt after each turn
+reaches closure. When the snapshot changes, the runtime appends a
+**working memory delta** to the ledger.
+
+Working memory is **not free-form summary**. It is a structured projection of
+the runtime's own records — current work item, active todo list, pending
+follow-ups, and waiting conditions.
+
+### Episode Memory
+
+Episode memory archives completed work. While work is in progress, an active
+episode builder accumulates:
+
+- Active work item ID and delivery target
+- Work summary and scope
+- Touched files
+- Verification evidence
+- Decisions made
+- Carry-forward follow-ups
+
+When a meaningful boundary is reached (work item completed, task finished),
+the runtime finalizes the builder into an immutable **episode record** and
+stores it.
+
+Archived episodes are selected into prompt context by relevance and budget,
+not rendered in full by default.
+
+### Context Assembly
+
+Each turn assembles a prompt from budgeted memory sections:
+
+- Hot turn context (current input, continuation, recent events)
+- Current work item and plan
+- Relevant episode memory
+- Working memory snapshot
+- Execution environment projection
+
+This assembly keeps prompt size bounded while preserving continuity.
+Slow-changing memory sections keep provider cache identity stable.
+
+## Memory vs Agent Home Files
+
+Memory and agent home files serve different purposes:
+
+| Aspect | Runtime Memory | Agent Home Files |
+|--------|---------------|-----------------|
+| **What it stores** | Current state, episodes, evidence | Role contract, notes, references |
+| **Who writes it** | Runtime (automatic) | Agent or operator (manual) |
+| **Durability** | Append-only ledger + snapshots | Persistent files |
+| **Search** | Indexed via `MemorySearch` | Ordinary file read |
+| **Loaded** | Budgeted prompt assembly | `AGENTS.md` always loaded |
+
+`agent_home/AGENTS.md` is loaded guidance — the agent's long-lived role
+contract. Runtime memory is automatically derived evidence. They coexist
+without overlapping.
+
+## MemorySearch and MemoryGet
+
+Holon exposes two memory tools for indexed retrieval:
+
+- **`MemorySearch`** — Search across memory sources (agent memory markdown, runtime evidence) by query. Returns ranked results with opaque `source_ref` values.
+- **`MemoryGet`** — Fetch exact memory content by `source_ref`. Used to retrieve a specific record identified by search.
+
+These tools let the agent pull relevant past context on demand without
+rendering every archived episode into every prompt.
+
+## Memory and Work Items
+
+Memory is tightly coupled to work items:
+
+- **Current work item** anchors the working memory snapshot — objective,
+  plan, todo list, and blocked status.
+- **Episode records** are scoped to work items. When a work item completes,
+  its accumulated evidence becomes an archived episode.
+- **MemorySearch** indexes across completed episodes, making past work
+  findable by content rather than by timestamp alone.
+
+This means Holon can remember what it did for a previous issue without
+re-reading the entire transcript of that work.
+
+## Memory Boundaries
+
+Holon separates memory by identity scope:
+
+- **Agent-scoped memory** — Working memory, episodes, and search index belong
+  to a specific agent.
+- **Workspace-scoped memory** — Episode records are tagged with the
+  `workspace_id` where the work happened.
+- **Curated durable memory** — `agent_home/memory/self.md` and
+  `agent_home/memory/operator.md` are manually curated Markdown files for
+  agent-specific facts and operator preferences.
+
+These boundaries prevent session transcripts from becoming the only memory
+surface and let shared workspaces accumulate knowledge across multiple agents.
+
+## See Also
+
+- [Runtime Model](/concepts/runtime-model.md) — Agents, work items, and the execution loop
+- [Documentation Layers](/concepts/documentation-layers.md) — How memory fits into Holon's documentation architecture
+- [Agent Templates](/guides/agent-templates.md) — How templates initialize agent role contracts
+- RFC: [Long-Lived Context Memory](https://github.com/holon-run/holon/blob/main/docs/rfcs/long-lived-context-memory.md)
+- RFC: [Agent and Workspace Memory](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-and-workspace-memory.md)

--- a/docs/website/concepts/runtime-model.md
+++ b/docs/website/concepts/runtime-model.md
@@ -117,6 +117,7 @@ Each agent turn follows this pattern:
 
 ## See Also
 
+- [Memory System](/concepts/memory.md) — How Holon preserves continuity across turns
 - [Trust Boundaries](/concepts/trust-boundaries.md) — How Holon classifies and
   enforces trust
 - [CLI Reference](/reference/cli.md) — All CLI commands


### PR DESCRIPTION
Fixes #1158

Adds a dedicated memory system page under concepts covering:

- Four memory layers: durable ledger, working memory, episode memory, context assembly
- Memory vs agent home files comparison
- MemorySearch and MemoryGet tools
- Memory and WorkItem lifecycle coupling
- Memory boundaries (agent-scoped, workspace-scoped, curated)

Also updates concepts README and runtime-model See Also to link the new page.