### PR TITLE
docs: add explicit deprecation notice for holon control

### DIFF
--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -99,6 +99,11 @@ holon agent stop reviewer
 holon agent abort reviewer
 ```
 
+> **Deprecated:** The `holon control` command has been replaced by
+> `holon agent start`, `holon agent stop`, and `holon agent abort`.
+> The old `control` command is kept for backward compatibility only and
+> may be removed in a future release.
+
 ### Model selection
 
 ```bash


### PR DESCRIPTION
Fixes #1163

Adds an explicit deprecation callout under the agent lifecycle section, directing users to `holon agent start`, `holon agent stop`, and `holon agent abort`.

The control command was already collapsed to a single line in the command tree; this adds a visible notice in the workflows section.