### PR TITLE
docs: add config unset example in configuration reference

### DIFF
--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -37,6 +37,9 @@ holon config get model.default
 
 # See all current config
 holon config list
+
+# Remove a config key (reverts to default)
+holon config unset model.fallbacks
 ```
 
 ### Per-Model Policy


### PR DESCRIPTION
Fixes #1167

Adds a `holon config unset` usage example to the configuration reference, showing how to remove a config key to revert to its default.