### PR TITLE
feat: add WebSearch routing policy

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use crate::{
     model_catalog::{
         BuiltInModelCatalog, BuiltInModelMetadata, ModelRuntimeOverride, ResolvedRuntimeModelPolicy,
     },
-    web::WebProviderKind,
+    web::{WebProviderKind, WebSearchMode},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -376,12 +376,23 @@ pub struct WebSearchConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<WebSearchMode>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_results: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_provider_attempts: Option<usize>,
 }
 
 impl WebSearchConfigFile {
     pub fn is_empty(&self) -> bool {
-        self.enabled.is_none() && self.provider.is_none() && self.max_results.is_none()
+        self.enabled.is_none()
+            && self.provider.is_none()
+            && self.mode.is_none()
+            && self.providers.is_empty()
+            && self.max_results.is_none()
+            && self.max_provider_attempts.is_none()
     }
 }
 
@@ -1427,8 +1438,22 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
         ConfigSchemaEntry {
             key: "web.search.provider",
             kind: "string",
-            description: "Default WebSearch provider id, or auto for SearXNG then DuckDuckGo fallback.",
+            description: "Default WebSearch provider id, or auto for configured routing policy.",
             default: json!("auto"),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.search.mode",
+            kind: "enum",
+            description: "WebSearch routing mode: single, fallback, or aggregate.",
+            default: json!("fallback"),
+            allowed_values: vec!["single", "fallback", "aggregate"],
+        },
+        ConfigSchemaEntry {
+            key: "web.search.providers",
+            kind: "string_list",
+            description: "Explicit WebSearch provider attempt order for auto fallback or aggregate mode.",
+            default: json!([]),
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
@@ -1436,6 +1461,13 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             kind: "positive_integer",
             description: "Maximum number of WebSearch results returned to the model.",
             default: json!(crate::web::WebSearchConfig::default().max_results),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.search.max_provider_attempts",
+            kind: "positive_integer",
+            description: "Maximum WebSearch providers attempted for fallback or aggregate routing.",
+            default: json!(crate::web::WebSearchConfig::default().max_provider_attempts),
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
@@ -1599,10 +1631,23 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .as_ref()
             .map(|value| Value::String(value.clone()))
             .unwrap_or(Value::Null)),
+        "web.search.mode" => Ok(config
+            .web
+            .search
+            .mode
+            .map(|value| Value::String(value.as_str().to_string()))
+            .unwrap_or(Value::Null)),
+        "web.search.providers" => Ok(json!(config.web.search.providers)),
         "web.search.max_results" => Ok(config
             .web
             .search
             .max_results
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
+        "web.search.max_provider_attempts" => Ok(config
+            .web
+            .search
+            .max_provider_attempts
             .map(|value| json!(value))
             .unwrap_or(Value::Null)),
         "web.providers" => Ok(serde_json::to_value(&config.web.providers)?),
@@ -1749,8 +1794,21 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
             }
             config.web.search.provider = Some(provider.to_string());
         }
+        "web.search.mode" => {
+            config.web.search.mode = Some(
+                serde_json::from_value(serde_json::Value::String(raw_value.trim().to_string()))
+                    .with_context(|| format!("invalid web search mode: {}", raw_value))?,
+            );
+        }
+        "web.search.providers" => {
+            config.web.search.providers = parse_string_list(raw_value)?;
+        }
         "web.search.max_results" => {
             config.web.search.max_results = Some(parse_positive_usize_key(key, raw_value)?);
+        }
+        "web.search.max_provider_attempts" => {
+            config.web.search.max_provider_attempts =
+                Some(parse_positive_usize_key(key, raw_value)?);
         }
         key if key.starts_with("web.providers.") && key.ends_with(".kind") => {
             let rest = key.strip_prefix("web.providers.").unwrap();
@@ -1863,7 +1921,10 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "web.fetch.denied_hosts" => config.web.fetch.denied_hosts.clear(),
         "web.search.enabled" => config.web.search.enabled = None,
         "web.search.provider" => config.web.search.provider = None,
+        "web.search.mode" => config.web.search.mode = None,
+        "web.search.providers" => config.web.search.providers.clear(),
         "web.search.max_results" => config.web.search.max_results = None,
+        "web.search.max_provider_attempts" => config.web.search.max_provider_attempts = None,
         key if key.starts_with("web.providers.") && key.ends_with(".kind") => {
             let rest = key.strip_prefix("web.providers.").unwrap();
             let name = rest.strip_suffix(".kind").unwrap();
@@ -3674,6 +3735,9 @@ mod tests {
         .unwrap();
         set_config_key(&mut config, "web.search.provider", "duckduckgo").unwrap();
         set_config_key(&mut config, "web.search.max_results", "3").unwrap();
+        set_config_key(&mut config, "web.search.mode", "aggregate").unwrap();
+        set_config_key(&mut config, "web.search.providers", "searx,brave").unwrap();
+        set_config_key(&mut config, "web.search.max_provider_attempts", "2").unwrap();
         set_config_key(&mut config, "web.fetch.max_response_bytes", "12345").unwrap();
         set_config_key(&mut config, "web.fetch.timeout_seconds", "7").unwrap();
         set_config_key(&mut config, "web.fetch.max_redirects", "2").unwrap();
@@ -3695,6 +3759,18 @@ mod tests {
             json!(3)
         );
         assert_eq!(
+            get_config_key(&config, "web.search.mode").unwrap(),
+            json!("aggregate")
+        );
+        assert_eq!(
+            get_config_key(&config, "web.search.providers").unwrap(),
+            json!(["searx", "brave"])
+        );
+        assert_eq!(
+            get_config_key(&config, "web.search.max_provider_attempts").unwrap(),
+            json!(2)
+        );
+        assert_eq!(
             get_config_key(&config, "web.fetch.max_response_bytes").unwrap(),
             json!(12_345)
         );
@@ -3709,6 +3785,9 @@ mod tests {
 
         unset_config_key(&mut config, "web.fetch.allowed_hosts").unwrap();
         unset_config_key(&mut config, "web.search.provider").unwrap();
+        unset_config_key(&mut config, "web.search.mode").unwrap();
+        unset_config_key(&mut config, "web.search.providers").unwrap();
+        unset_config_key(&mut config, "web.search.max_provider_attempts").unwrap();
         unset_config_key(&mut config, "web.fetch.max_response_bytes").unwrap();
         unset_config_key(&mut config, "web.fetch.timeout_seconds").unwrap();
         unset_config_key(&mut config, "web.fetch.max_redirects").unwrap();
@@ -3718,6 +3797,18 @@ mod tests {
         );
         assert_eq!(
             get_config_key(&config, "web.search.provider").unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            get_config_key(&config, "web.search.mode").unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            get_config_key(&config, "web.search.providers").unwrap(),
+            json!([])
+        );
+        assert_eq!(
+            get_config_key(&config, "web.search.max_provider_attempts").unwrap(),
             Value::Null
         );
         assert_eq!(

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -85,7 +85,10 @@ impl From<&crate::config::WebFetchConfigFile> for WebFetchConfig {
 pub struct WebSearchConfig {
     pub enabled: bool,
     pub provider: String,
+    pub mode: WebSearchMode,
+    pub providers: Vec<String>,
     pub max_results: usize,
+    pub max_provider_attempts: usize,
 }
 
 impl Default for WebSearchConfig {
@@ -93,7 +96,10 @@ impl Default for WebSearchConfig {
         Self {
             enabled: true,
             provider: "auto".into(),
+            mode: WebSearchMode::Fallback,
+            providers: Vec::new(),
             max_results: 5,
+            max_provider_attempts: 3,
         }
     }
 }
@@ -108,7 +114,36 @@ impl From<&crate::config::WebSearchConfigFile> for WebSearchConfig {
                 .clone()
                 .filter(|provider| !provider.trim().is_empty())
                 .unwrap_or(fallback.provider),
+            mode: value.mode.unwrap_or(fallback.mode),
+            providers: value
+                .providers
+                .iter()
+                .map(|provider| provider.trim().to_string())
+                .filter(|provider| !provider.is_empty())
+                .collect(),
             max_results: value.max_results.unwrap_or(fallback.max_results),
+            max_provider_attempts: value
+                .max_provider_attempts
+                .unwrap_or(fallback.max_provider_attempts)
+                .max(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSearchMode {
+    Single,
+    Fallback,
+    Aggregate,
+}
+
+impl WebSearchMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::Fallback => "fallback",
+            Self::Aggregate => "aggregate",
         }
     }
 }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use chrono::Utc;
 use reqwest::{Client, Response, StatusCode};
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use url::{form_urlencoded, Url};
 
 use crate::{
@@ -139,20 +139,40 @@ struct RoutedSearchOutcome {
 
 fn provider_order(provider: &str, config: &WebConfig) -> Vec<String> {
     if provider != "auto" {
-        return vec![provider.to_string()];
+        return vec![provider.trim().to_string()];
     }
-    let mut providers = config
-        .search
-        .providers
-        .iter()
-        .map(|provider| provider.trim().to_string())
-        .filter(|provider| !provider.is_empty())
-        .collect::<Vec<_>>();
+    let configured = dedupe_provider_order(&config.search.providers);
+    let mut providers = if configured.is_empty() {
+        dedupe_provider_order(
+            config
+                .providers
+                .keys()
+                .cloned()
+                .chain(std::iter::once("duckduckgo".to_string())),
+        )
+    } else {
+        configured
+    };
     if providers.is_empty() {
         providers.push("duckduckgo".to_string());
     }
     providers.truncate(config.search.max_provider_attempts.max(1));
     providers
+}
+
+fn dedupe_provider_order<I, S>(providers: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut seen = BTreeSet::new();
+    providers
+        .into_iter()
+        .filter_map(|provider| {
+            let provider = provider.as_ref().trim().to_string();
+            (!provider.is_empty() && seen.insert(provider.clone())).then_some(provider)
+        })
+        .collect()
 }
 
 fn routed_single(
@@ -165,10 +185,7 @@ fn routed_single(
             winning_provider: Some(provider_id),
             results,
         }),
-        Err(error) => {
-            let attempt = failed_attempt(&provider_id, &error);
-            Err(routing_error(vec![attempt], None))
-        }
+        Err(error) => Err(single_provider_error(&provider_id, error)),
     }
 }
 
@@ -254,6 +271,48 @@ fn failed_attempt(provider: &str, error: &anyhow::Error) -> WebSearchProviderAtt
         result_count: 0,
         error_kind: Some(tool_error.kind),
         error_message: Some(tool_error.message),
+    }
+}
+
+fn single_provider_error(provider: &str, error: anyhow::Error) -> anyhow::Error {
+    let attempt = failed_attempt(provider, &error);
+    let original = ToolError::from_anyhow(&error);
+    let mut tool_error = ToolError::new(original.kind, original.message)
+        .with_details(single_provider_error_details(original.details, attempt))
+        .with_retryable(original.retryable);
+    if let Some(recovery_hint) = original.recovery_hint {
+        tool_error = tool_error.with_recovery_hint(recovery_hint);
+    }
+    anyhow::Error::from(tool_error)
+}
+
+fn single_provider_error_details(
+    details: Option<Value>,
+    attempt: WebSearchProviderAttempt,
+) -> Value {
+    let attempted_providers = vec![attempt.provider.clone()];
+    let provider_attempts = vec![attempt];
+    match details {
+        Some(Value::Object(mut object)) => {
+            object.insert(
+                "attempted_providers".to_string(),
+                json!(attempted_providers),
+            );
+            object.insert("winning_provider".to_string(), Value::Null);
+            object.insert("provider_attempts".to_string(), json!(provider_attempts));
+            Value::Object(object)
+        }
+        Some(details) => json!({
+            "provider_error_details": details,
+            "attempted_providers": attempted_providers,
+            "winning_provider": null,
+            "provider_attempts": provider_attempts,
+        }),
+        None => json!({
+            "attempted_providers": attempted_providers,
+            "winning_provider": null,
+            "provider_attempts": provider_attempts,
+        }),
     }
 }
 
@@ -1060,6 +1119,43 @@ mod tests {
         assert_eq!(response.results[0].source, "good");
     }
 
+    #[test]
+    fn provider_order_deduplicates_explicit_auto_order() {
+        let config = test_search_config(
+            vec![(
+                "good",
+                test_provider(WebProviderKind::Searxng, "https://good.example"),
+            )],
+            vec![" good ", "bad", "good", "", " bad "],
+            WebSearchMode::Fallback,
+        );
+
+        assert_eq!(provider_order("auto", &config), vec!["good", "bad"]);
+    }
+
+    #[test]
+    fn provider_order_defaults_to_configured_providers() {
+        let config = test_search_config(
+            vec![
+                (
+                    "zeta",
+                    test_provider(WebProviderKind::Searxng, "https://zeta.example"),
+                ),
+                (
+                    "alpha",
+                    test_provider(WebProviderKind::Searxng, "https://alpha.example"),
+                ),
+            ],
+            vec![],
+            WebSearchMode::Fallback,
+        );
+
+        assert_eq!(
+            provider_order("auto", &config),
+            vec!["alpha", "zeta", "duckduckgo"]
+        );
+    }
+
     #[tokio::test]
     async fn single_provider_request_does_not_fallback() {
         let good_url = searxng_mock_base_url(searxng_results_json(&[(
@@ -1095,7 +1191,10 @@ mod tests {
         .await
         .unwrap_err();
         let tool_error = ToolError::from_anyhow(&err);
+        assert_eq!(tool_error.kind, "provider_unavailable");
+        assert_eq!(tool_error.message, "SearXNG provider requires base_url");
         let details = tool_error.details.as_ref().unwrap();
+        assert_eq!(details["provider"], json!("bad"));
         assert_eq!(details["attempted_providers"], json!(["bad"]));
         assert_eq!(details["winning_provider"], serde_json::Value::Null);
         assert_eq!(details["provider_attempts"].as_array().unwrap().len(), 1);

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use anyhow::{anyhow, Result};
 use chrono::Utc;
 use reqwest::{Client, Response, StatusCode};
@@ -7,7 +9,10 @@ use url::{form_urlencoded, Url};
 
 use crate::{
     tool::ToolError,
-    web::{policy::timeout, WebConfig, WebFetchConfig, WebProviderConfig, WebProviderKind},
+    web::{
+        policy::timeout, WebConfig, WebFetchConfig, WebProviderConfig, WebProviderKind,
+        WebSearchMode,
+    },
 };
 
 const SEARCH_RESPONSE_BYTES: usize = 1_000_000;
@@ -23,10 +28,29 @@ pub struct WebSearchRequest {
 pub struct WebSearchResponse {
     pub query: String,
     pub provider: String,
+    pub mode: WebSearchMode,
+    pub provider_attempts: Vec<WebSearchProviderAttempt>,
+    pub winning_provider: Option<String>,
     pub results: Vec<WebSearchResult>,
     pub citations: Vec<WebCitation>,
     pub fetched_at: String,
     pub summary_text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WebSearchProviderAttempt {
+    pub provider: String,
+    pub status: WebSearchProviderAttemptStatus,
+    pub result_count: usize,
+    pub error_kind: Option<String>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSearchProviderAttemptStatus {
+    Success,
+    Error,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -59,10 +83,219 @@ pub async fn search(request: WebSearchRequest, config: &WebConfig) -> Result<Web
         .provider
         .as_deref()
         .unwrap_or(config.search.provider.as_str());
+    let mode = if request.provider.is_some() && provider != "auto" {
+        WebSearchMode::Single
+    } else {
+        config.search.mode
+    };
+    let provider_order = provider_order(provider, config);
+    let routed = match mode {
+        WebSearchMode::Single => {
+            let provider_id = provider_order
+                .first()
+                .cloned()
+                .unwrap_or_else(|| provider.to_string());
+            let outcome =
+                search_one_provider(&request.query, max_results, &provider_id, config).await;
+            routed_single(provider_id, outcome)?
+        }
+        WebSearchMode::Fallback => {
+            search_fallback(&request.query, max_results, provider_order, config).await?
+        }
+        WebSearchMode::Aggregate => {
+            search_aggregate(&request.query, max_results, provider_order, config).await?
+        }
+    };
 
-    let results = match provider {
-        "auto" => search_auto(&request.query, max_results, config).await?,
-        "duckduckgo" => duckduckgo_search(&request.query, max_results, &config.fetch).await?,
+    let citations = routed
+        .results
+        .iter()
+        .map(|result| WebCitation {
+            title: result.title.clone(),
+            url: result.url.clone(),
+        })
+        .collect::<Vec<_>>();
+    Ok(WebSearchResponse {
+        query: request.query,
+        provider: routed
+            .winning_provider
+            .clone()
+            .unwrap_or_else(|| provider.to_string()),
+        mode,
+        provider_attempts: routed.provider_attempts,
+        winning_provider: routed.winning_provider,
+        summary_text: format!("{} web results", routed.results.len()),
+        results: routed.results,
+        citations,
+        fetched_at: Utc::now().to_rfc3339(),
+    })
+}
+
+struct RoutedSearchOutcome {
+    results: Vec<WebSearchResult>,
+    provider_attempts: Vec<WebSearchProviderAttempt>,
+    winning_provider: Option<String>,
+}
+
+fn provider_order(provider: &str, config: &WebConfig) -> Vec<String> {
+    if provider != "auto" {
+        return vec![provider.to_string()];
+    }
+    let mut providers = config
+        .search
+        .providers
+        .iter()
+        .map(|provider| provider.trim().to_string())
+        .filter(|provider| !provider.is_empty())
+        .collect::<Vec<_>>();
+    if providers.is_empty() {
+        providers.push("duckduckgo".to_string());
+    }
+    providers.truncate(config.search.max_provider_attempts.max(1));
+    providers
+}
+
+fn routed_single(
+    provider_id: String,
+    outcome: Result<Vec<WebSearchResult>>,
+) -> Result<RoutedSearchOutcome> {
+    match outcome {
+        Ok(results) => Ok(RoutedSearchOutcome {
+            provider_attempts: vec![successful_attempt(&provider_id, results.len())],
+            winning_provider: Some(provider_id),
+            results,
+        }),
+        Err(error) => {
+            let attempt = failed_attempt(&provider_id, &error);
+            Err(routing_error(vec![attempt], None))
+        }
+    }
+}
+
+async fn search_fallback(
+    query: &str,
+    max_results: usize,
+    provider_order: Vec<String>,
+    config: &WebConfig,
+) -> Result<RoutedSearchOutcome> {
+    let mut attempts = Vec::new();
+    for provider_id in provider_order {
+        match search_one_provider(query, max_results, &provider_id, config).await {
+            Ok(results) => {
+                attempts.push(successful_attempt(&provider_id, results.len()));
+                return Ok(RoutedSearchOutcome {
+                    results,
+                    provider_attempts: attempts,
+                    winning_provider: Some(provider_id),
+                });
+            }
+            Err(error) => attempts.push(failed_attempt(&provider_id, &error)),
+        }
+    }
+    Err(routing_error(attempts, None))
+}
+
+async fn search_aggregate(
+    query: &str,
+    max_results: usize,
+    provider_order: Vec<String>,
+    config: &WebConfig,
+) -> Result<RoutedSearchOutcome> {
+    let mut attempts = Vec::new();
+    let mut seen_urls = BTreeSet::new();
+    let mut results = Vec::new();
+
+    for provider_id in provider_order {
+        match search_one_provider(query, max_results, &provider_id, config).await {
+            Ok(provider_results) => {
+                attempts.push(successful_attempt(&provider_id, provider_results.len()));
+                for result in provider_results {
+                    if seen_urls.insert(result.url.clone()) {
+                        results.push(result);
+                    }
+                    if results.len() >= max_results {
+                        break;
+                    }
+                }
+            }
+            Err(error) => attempts.push(failed_attempt(&provider_id, &error)),
+        }
+        if results.len() >= max_results {
+            break;
+        }
+    }
+
+    if results.is_empty() {
+        return Err(routing_error(attempts, None));
+    }
+
+    Ok(RoutedSearchOutcome {
+        results,
+        provider_attempts: attempts,
+        winning_provider: None,
+    })
+}
+
+fn successful_attempt(provider: &str, result_count: usize) -> WebSearchProviderAttempt {
+    WebSearchProviderAttempt {
+        provider: provider.to_string(),
+        status: WebSearchProviderAttemptStatus::Success,
+        result_count,
+        error_kind: None,
+        error_message: None,
+    }
+}
+
+fn failed_attempt(provider: &str, error: &anyhow::Error) -> WebSearchProviderAttempt {
+    let tool_error = ToolError::from_anyhow(error);
+    WebSearchProviderAttempt {
+        provider: provider.to_string(),
+        status: WebSearchProviderAttemptStatus::Error,
+        result_count: 0,
+        error_kind: Some(tool_error.kind),
+        error_message: Some(tool_error.message),
+    }
+}
+
+fn routing_error(
+    provider_attempts: Vec<WebSearchProviderAttempt>,
+    winning_provider: Option<String>,
+) -> anyhow::Error {
+    let attempted_providers = provider_attempts
+        .iter()
+        .map(|attempt| attempt.provider.clone())
+        .collect::<Vec<_>>();
+    let retryable = provider_attempts.iter().any(|attempt| {
+        attempt
+            .error_kind
+            .as_deref()
+            .is_some_and(|kind| matches!(kind, "rate_limited" | "network_failed"))
+    });
+    anyhow::Error::from(
+        ToolError::new(
+            "provider_unavailable",
+            "WebSearch routing exhausted all configured providers",
+        )
+        .with_details(json!({
+            "attempted_providers": attempted_providers,
+            "winning_provider": winning_provider,
+            "provider_attempts": provider_attempts,
+        }))
+        .with_recovery_hint(
+            "configure web.search.providers or use provider=<id> for single-provider debugging",
+        )
+        .with_retryable(retryable),
+    )
+}
+
+async fn search_one_provider(
+    query: &str,
+    max_results: usize,
+    provider_id: &str,
+    config: &WebConfig,
+) -> Result<Vec<WebSearchResult>> {
+    match provider_id {
+        "duckduckgo" => duckduckgo_search(query, max_results, &config.fetch).await,
         provider_id => {
             let provider_config = config.providers.get(provider_id).ok_or_else(|| {
                 search_error(
@@ -72,104 +305,46 @@ pub async fn search(request: WebSearchRequest, config: &WebConfig) -> Result<Web
                     "configure web.providers or use provider=duckduckgo",
                 )
             })?;
-            match provider_config.kind {
-                WebProviderKind::Searxng => {
-                    searxng_search(
-                        &request.query,
-                        max_results,
-                        provider_id,
-                        provider_config,
-                        &config.fetch,
-                    )
-                    .await?
-                }
-                WebProviderKind::DuckDuckGo => {
-                    duckduckgo_search(&request.query, max_results, &config.fetch).await?
-                }
-                kind => match kind {
-                    WebProviderKind::Brave => {
-                        brave_search(
-                            &request.query,
-                            max_results,
-                            provider_id,
-                            provider_config,
-                            &config.fetch,
-                        )
-                        .await?
-                    }
-                    WebProviderKind::Tavily => {
-                        tavily_search(
-                            &request.query,
-                            max_results,
-                            provider_id,
-                            provider_config,
-                            &config.fetch,
-                        )
-                        .await?
-                    }
-                    WebProviderKind::Exa => {
-                        exa_search(
-                            &request.query,
-                            max_results,
-                            provider_id,
-                            provider_config,
-                            &config.fetch,
-                        )
-                        .await?
-                    }
-                    kind => {
-                        return Err(search_error(
-                                "provider_unavailable",
-                                format!("WebSearch provider kind `{kind:?}` is reserved for future provider support"),
-                                provider_id,
-                                "configure a duckduckgo, searxng, brave, tavily, or exa provider for this Holon version",
-                            ));
-                    }
-                },
-            }
+            search_configured_provider(
+                query,
+                max_results,
+                provider_id,
+                provider_config,
+                &config.fetch,
+            )
+            .await
         }
-    };
-
-    let citations = results
-        .iter()
-        .map(|result| WebCitation {
-            title: result.title.clone(),
-            url: result.url.clone(),
-        })
-        .collect::<Vec<_>>();
-    Ok(WebSearchResponse {
-        query: request.query,
-        provider: results
-            .first()
-            .map(|result| result.source.clone())
-            .unwrap_or_else(|| provider.to_string()),
-        summary_text: format!("{} web results", results.len()),
-        results,
-        citations,
-        fetched_at: Utc::now().to_rfc3339(),
-    })
+    }
 }
 
-async fn search_auto(
+async fn search_configured_provider(
     query: &str,
     max_results: usize,
-    config: &WebConfig,
+    provider_id: &str,
+    provider_config: &WebProviderConfig,
+    fetch_config: &WebFetchConfig,
 ) -> Result<Vec<WebSearchResult>> {
-    if let Some((provider_id, provider_config)) = config
-        .providers
-        .iter()
-        .find(|(_, provider)| provider.kind == WebProviderKind::Searxng)
-    {
-        return searxng_search(
-            query,
-            max_results,
+    match provider_config.kind {
+        WebProviderKind::Searxng => {
+            searxng_search(query, max_results, provider_id, provider_config, fetch_config).await
+        }
+        WebProviderKind::DuckDuckGo => duckduckgo_search(query, max_results, fetch_config).await,
+        WebProviderKind::Brave => {
+            brave_search(query, max_results, provider_id, provider_config, fetch_config).await
+        }
+        WebProviderKind::Tavily => {
+            tavily_search(query, max_results, provider_id, provider_config, fetch_config).await
+        }
+        WebProviderKind::Exa => {
+            exa_search(query, max_results, provider_id, provider_config, fetch_config).await
+        }
+        kind => Err(search_error(
+            "provider_unavailable",
+            format!("WebSearch provider kind `{kind:?}` is reserved for future provider support"),
             provider_id,
-            provider_config,
-            &config.fetch,
-        )
-        .await;
+            "configure a duckduckgo, searxng, brave, tavily, or exa provider for this Holon version",
+        )),
     }
-    duckduckgo_search(query, max_results, &config.fetch).await
 }
 
 async fn duckduckgo_search(
@@ -788,6 +963,7 @@ fn search_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::web::WebSearchConfig;
     use axum::{
         body::Body,
         http::{
@@ -797,7 +973,7 @@ mod tests {
         response::Response,
     };
     use flate2::{write::GzEncoder, Compression};
-    use std::io::Write;
+    use std::{collections::BTreeMap, io::Write};
 
     #[test]
     fn parses_duckduckgo_lite_links() {
@@ -833,6 +1009,155 @@ mod tests {
         assert_eq!(tool_error.kind, "invalid_tool_input");
     }
 
+    #[tokio::test]
+    async fn fallback_mode_tries_explicit_order_until_success() {
+        let good_url = searxng_mock_base_url(searxng_results_json(&[(
+            "Good result",
+            "https://example.com/good",
+            "ok",
+        )]))
+        .await;
+        let config = test_search_config(
+            vec![
+                (
+                    "bad",
+                    WebProviderConfig {
+                        kind: WebProviderKind::Searxng,
+                        base_url: None,
+                        api_key: String::new(),
+                    },
+                ),
+                ("good", test_provider(WebProviderKind::Searxng, &good_url)),
+            ],
+            vec!["bad", "good"],
+            WebSearchMode::Fallback,
+        );
+
+        let response = search(
+            WebSearchRequest {
+                query: "test".to_string(),
+                max_results: Some(5),
+                provider: None,
+            },
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.mode, WebSearchMode::Fallback);
+        assert_eq!(response.winning_provider.as_deref(), Some("good"));
+        assert_eq!(response.provider_attempts.len(), 2);
+        assert_eq!(response.provider_attempts[0].provider, "bad");
+        assert_eq!(
+            response.provider_attempts[0].status,
+            WebSearchProviderAttemptStatus::Error
+        );
+        assert_eq!(response.provider_attempts[1].provider, "good");
+        assert_eq!(
+            response.provider_attempts[1].status,
+            WebSearchProviderAttemptStatus::Success
+        );
+        assert_eq!(response.results[0].source, "good");
+    }
+
+    #[tokio::test]
+    async fn single_provider_request_does_not_fallback() {
+        let good_url = searxng_mock_base_url(searxng_results_json(&[(
+            "Good result",
+            "https://example.com/good",
+            "ok",
+        )]))
+        .await;
+        let config = test_search_config(
+            vec![
+                (
+                    "bad",
+                    WebProviderConfig {
+                        kind: WebProviderKind::Searxng,
+                        base_url: None,
+                        api_key: String::new(),
+                    },
+                ),
+                ("good", test_provider(WebProviderKind::Searxng, &good_url)),
+            ],
+            vec!["bad", "good"],
+            WebSearchMode::Fallback,
+        );
+
+        let err = search(
+            WebSearchRequest {
+                query: "test".to_string(),
+                max_results: Some(5),
+                provider: Some("bad".to_string()),
+            },
+            &config,
+        )
+        .await
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&err);
+        let details = tool_error.details.as_ref().unwrap();
+        assert_eq!(details["attempted_providers"], json!(["bad"]));
+        assert_eq!(details["winning_provider"], serde_json::Value::Null);
+        assert_eq!(details["provider_attempts"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn aggregate_mode_deduplicates_urls_and_keeps_provenance() {
+        let first_url = searxng_mock_base_url(searxng_results_json(&[
+            ("Shared", "https://example.com/shared", "from one"),
+            ("One", "https://example.com/one", "only one"),
+        ]))
+        .await;
+        let second_url = searxng_mock_base_url(searxng_results_json(&[
+            ("Shared", "https://example.com/shared", "from two"),
+            ("Two", "https://example.com/two", "only two"),
+        ]))
+        .await;
+        let config = test_search_config(
+            vec![
+                ("one", test_provider(WebProviderKind::Searxng, &first_url)),
+                ("two", test_provider(WebProviderKind::Searxng, &second_url)),
+            ],
+            vec!["one", "two"],
+            WebSearchMode::Aggregate,
+        );
+
+        let response = search(
+            WebSearchRequest {
+                query: "test".to_string(),
+                max_results: Some(5),
+                provider: None,
+            },
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.mode, WebSearchMode::Aggregate);
+        assert_eq!(response.winning_provider, None);
+        assert_eq!(response.provider_attempts.len(), 2);
+        assert!(response
+            .provider_attempts
+            .iter()
+            .all(|attempt| attempt.status == WebSearchProviderAttemptStatus::Success));
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .filter(|result| result.url == "https://example.com/shared")
+                .count(),
+            1
+        );
+        assert!(response
+            .results
+            .iter()
+            .any(|result| result.url == "https://example.com/shared" && result.source == "one"));
+        assert!(response
+            .results
+            .iter()
+            .any(|result| result.url == "https://example.com/two" && result.source == "two"));
+    }
+
     // ---------------------------------------------------------------------------
     // Integration tests against mock HTTP servers for API-backed providers
     // ---------------------------------------------------------------------------
@@ -847,6 +1172,56 @@ mod tests {
 
     fn test_fetch_config() -> WebFetchConfig {
         WebFetchConfig::default()
+    }
+
+    fn test_search_config(
+        providers: Vec<(&str, WebProviderConfig)>,
+        order: Vec<&str>,
+        mode: WebSearchMode,
+    ) -> WebConfig {
+        WebConfig {
+            fetch: test_fetch_config(),
+            search: WebSearchConfig {
+                mode,
+                providers: order.into_iter().map(str::to_string).collect(),
+                ..WebSearchConfig::default()
+            },
+            providers: providers
+                .into_iter()
+                .map(|(id, provider)| (id.to_string(), provider))
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+
+    fn searxng_results_json(entries: &[(&str, &str, &str)]) -> serde_json::Value {
+        json!({
+            "results": entries
+                .iter()
+                .map(|(title, url, content)| {
+                    json!({
+                        "title": title,
+                        "url": url,
+                        "content": content,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+    }
+
+    async fn searxng_mock_base_url(results: serde_json::Value) -> String {
+        let router = axum::Router::new().route(
+            "/search",
+            axum::routing::get(move || {
+                let results = results.clone();
+                async move { axum::Json(results) }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        format!("http://{}", addr)
     }
 
     fn brave_results_json() -> serde_json::Value {


### PR DESCRIPTION
Closes #1146.

## Summary
- Add configurable WebSearch routing modes for fallback, single-provider, and aggregate search.
- Preserve explicit provider attempt order, winning-provider diagnostics, and per-result provider provenance.
- Record provider attempts in WebSearch tool output/ledger details, including aggregate URL deduplication.

## Tests
- cargo fmt --all -- --check
- cargo test web::search::tests -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets
