### PR TITLE
feat: expose WebSearch provider capabilities

### DIFF
--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -199,8 +199,15 @@ TUI debug instrumentation is controlled by environment variables:
 | `web.fetch.allowed_hosts` | string_list | `[]` | Hosts allowed (empty = all) |
 | `web.fetch.denied_hosts` | string_list | `[]` | Hosts blocked |
 | `web.search.enabled` | boolean | `true` | Enable WebSearch tool |
-| `web.search.provider` | string | `"auto"` | Default search provider |
+| `web.search.provider` | string | `"auto"` | Default search provider or `auto` |
+| `web.search.mode` | enum | `"fallback"` | Routing mode: `single`, `fallback`, or `aggregate` |
+| `web.search.providers` | string_list | `[]` | Explicit auto-mode provider attempt order |
 | `web.search.max_results` | integer | `5` | Max results returned |
+| `web.search.max_provider_attempts` | integer | `3` | Max providers attempted by fallback/aggregate routing |
+| `web.providers.<name>.kind` | string | required | Provider kind: `duck_duck_go`, `searxng`, `brave`, `tavily`, `exa`, `perplexity`, `firecrawl`, `open_ai_native`, `anthropic_native`, or `gemini_native` |
+| `web.providers.<name>.base_url` | string | unset | Custom provider endpoint |
+| `web.providers.<name>.credential_profile` | string | unset | Credential profile for API-backed providers |
+| `web.providers.<name>.capabilities` | json_object | derived | Read-only capability metadata surfaced by `holon config get` and routing diagnostics |
 
 ## See Also
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1485,6 +1485,13 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             allowed_values: vec![],
         },
         ConfigSchemaEntry {
+            key: "web.providers.<name>.capabilities",
+            kind: "json_object",
+            description: "Derived WebSearch provider capability metadata used for routing diagnostics.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
             key: "web.providers.<name>.credential_profile",
             kind: "string",
             description: "Named credential profile to load the API key from. The profile must be of kind api_key.",
@@ -1669,6 +1676,12 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
                     .and_then(|p| p.base_url.as_ref())
                     .map(|v| Value::String(v.clone()))
                     .unwrap_or(Value::Null));
+            }
+            if let Some(provider_name) = name.strip_suffix(".capabilities") {
+                return match config.web.providers.get(provider_name) {
+                    Some(provider) => Ok(serde_json::to_value(provider.kind.capabilities())?),
+                    None => Ok(Value::Null),
+                };
             }
             if let Some(provider_name) = name.strip_suffix(".credential_profile") {
                 return Ok(config
@@ -3299,7 +3312,7 @@ fn unknown_config_key(key: &str) -> anyhow::Error {
         return startup_only_config_key_error(key);
     }
     if key.starts_with("web.providers.") {
-        return anyhow!("unknown web providers config key {key}; supported fields: .kind, .base_url, .credential_profile; use web.providers.<name>.kind to create a provider first");
+        return anyhow!("unknown web providers config key {key}; supported fields: .kind, .base_url, .capabilities, .credential_profile; use web.providers.<name>.kind to create a provider first");
     }
     let supported = config_schema()
         .into_iter()
@@ -3738,6 +3751,7 @@ mod tests {
         set_config_key(&mut config, "web.search.mode", "aggregate").unwrap();
         set_config_key(&mut config, "web.search.providers", "searx,brave").unwrap();
         set_config_key(&mut config, "web.search.max_provider_attempts", "2").unwrap();
+        set_config_key(&mut config, "web.providers.brave.kind", "brave").unwrap();
         set_config_key(&mut config, "web.fetch.max_response_bytes", "12345").unwrap();
         set_config_key(&mut config, "web.fetch.timeout_seconds", "7").unwrap();
         set_config_key(&mut config, "web.fetch.max_redirects", "2").unwrap();
@@ -3771,6 +3785,22 @@ mod tests {
             json!(2)
         );
         assert_eq!(
+            get_config_key(&config, "web.providers.searx.capabilities").unwrap(),
+            Value::Null
+        );
+        let capabilities = get_config_key(&config, "web.providers.brave.capabilities").unwrap();
+        assert_eq!(capabilities["auth"], json!("api_key"));
+        assert_eq!(capabilities["status"], json!("supported"));
+        assert_eq!(capabilities["default_priority"], json!(80));
+        assert_eq!(
+            get_config_key(&config, "web.providers.brave.kind").unwrap(),
+            json!("brave")
+        );
+        assert_eq!(
+            get_config_key(&config, "web.providers.brave.base_url").unwrap(),
+            Value::Null
+        );
+        assert_eq!(
             get_config_key(&config, "web.fetch.max_response_bytes").unwrap(),
             json!(12_345)
         );
@@ -3788,6 +3818,7 @@ mod tests {
         unset_config_key(&mut config, "web.search.mode").unwrap();
         unset_config_key(&mut config, "web.search.providers").unwrap();
         unset_config_key(&mut config, "web.search.max_provider_attempts").unwrap();
+        unset_config_key(&mut config, "web.providers.brave").unwrap();
         unset_config_key(&mut config, "web.fetch.max_response_bytes").unwrap();
         unset_config_key(&mut config, "web.fetch.timeout_seconds").unwrap();
         unset_config_key(&mut config, "web.fetch.max_redirects").unwrap();
@@ -4764,6 +4795,7 @@ mod tests {
         assert!(keys.contains(&"web.fetch.timeout_seconds"));
         assert!(keys.contains(&"web.fetch.max_redirects"));
         assert!(keys.contains(&"web.search.provider"));
+        assert!(keys.contains(&"web.providers.<name>.capabilities"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1845,6 +1845,9 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 })
                 .kind = kind;
         }
+        key if key.starts_with("web.providers.") && key.ends_with(".capabilities") => {
+            return Err(read_only_web_provider_capabilities_key_error(key));
+        }
         key if key.starts_with("web.providers.") && key.ends_with(".base_url") => {
             let rest = key.strip_prefix("web.providers.").unwrap();
             let name = rest.strip_suffix(".base_url").unwrap();
@@ -1946,6 +1949,9 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
             } else {
                 return Err(anyhow!("web provider {name} not found"));
             }
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".capabilities") => {
+            return Err(read_only_web_provider_capabilities_key_error(key));
         }
         key if key.starts_with("web.providers.") && key.ends_with(".base_url") => {
             let rest = key.strip_prefix("web.providers.").unwrap();
@@ -3312,7 +3318,7 @@ fn unknown_config_key(key: &str) -> anyhow::Error {
         return startup_only_config_key_error(key);
     }
     if key.starts_with("web.providers.") {
-        return anyhow!("unknown web providers config key {key}; supported fields: .kind, .base_url, .capabilities, .credential_profile; use web.providers.<name>.kind to create a provider first");
+        return anyhow!("unknown web providers config key {key}; mutable fields: .kind, .base_url, .credential_profile; .capabilities is derived read-only metadata; use web.providers.<name>.kind to create a provider first");
     }
     let supported = config_schema()
         .into_iter()
@@ -3334,6 +3340,12 @@ fn unknown_config_key(key: &str) -> anyhow::Error {
             suggestions.join(", ")
         )
     }
+}
+
+fn read_only_web_provider_capabilities_key_error(key: &str) -> anyhow::Error {
+    anyhow!(
+        "{key} is derived read-only capability metadata; configure web.providers.<name>.kind instead"
+    )
 }
 
 #[cfg(test)]
@@ -3792,6 +3804,24 @@ mod tests {
         assert_eq!(capabilities["auth"], json!("api_key"));
         assert_eq!(capabilities["status"], json!("supported"));
         assert_eq!(capabilities["default_priority"], json!(80));
+        let read_only_capabilities_error =
+            "web.providers.brave.capabilities is derived read-only capability metadata; configure web.providers.<name>.kind instead";
+        assert_eq!(
+            set_config_key(
+                &mut config,
+                "web.providers.brave.capabilities",
+                r#"{"status":"supported"}"#
+            )
+            .unwrap_err()
+            .to_string(),
+            read_only_capabilities_error
+        );
+        assert_eq!(
+            unset_config_key(&mut config, "web.providers.brave.capabilities")
+                .unwrap_err()
+                .to_string(),
+            read_only_capabilities_error
+        );
         assert_eq!(
             get_config_key(&config, "web.providers.brave.kind").unwrap(),
             json!("brave")

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -148,6 +148,56 @@ impl WebSearchMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebProviderAuthClass {
+    None,
+    ApiKey,
+    NativeProvider,
+    SelfHosted,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebProviderCostClass {
+    Free,
+    SelfHosted,
+    Paid,
+    ProviderMetered,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebProviderQualityHint {
+    HtmlFallback,
+    Keyword,
+    Semantic,
+    Research,
+    Native,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebProviderSupportStatus {
+    Supported,
+    Unsupported,
+    NativeOnly,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebProviderCapabilityMetadata {
+    pub auth: WebProviderAuthClass,
+    pub cost_class: WebProviderCostClass,
+    pub quality_hint: WebProviderQualityHint,
+    pub supports_domain_filter: bool,
+    pub supports_freshness: bool,
+    pub supports_region_or_language: bool,
+    pub supports_full_content: bool,
+    pub supports_native_citations: bool,
+    pub default_priority: u16,
+    pub status: WebProviderSupportStatus,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebProviderConfig {
     pub kind: WebProviderKind,
@@ -232,6 +282,109 @@ impl WebProviderKind {
             WebProviderKind::OpenAiNative => "open_ai_native",
             WebProviderKind::AnthropicNative => "anthropic_native",
             WebProviderKind::GeminiNative => "gemini_native",
+        }
+    }
+
+    pub fn capabilities(&self) -> WebProviderCapabilityMetadata {
+        match self {
+            WebProviderKind::DuckDuckGo => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::None,
+                cost_class: WebProviderCostClass::Free,
+                quality_hint: WebProviderQualityHint::HtmlFallback,
+                supports_domain_filter: false,
+                supports_freshness: false,
+                supports_region_or_language: false,
+                supports_full_content: false,
+                supports_native_citations: false,
+                default_priority: 10,
+                status: WebProviderSupportStatus::Supported,
+            },
+            WebProviderKind::Searxng => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::SelfHosted,
+                cost_class: WebProviderCostClass::SelfHosted,
+                quality_hint: WebProviderQualityHint::Keyword,
+                supports_domain_filter: false,
+                supports_freshness: false,
+                supports_region_or_language: true,
+                supports_full_content: false,
+                supports_native_citations: false,
+                default_priority: 50,
+                status: WebProviderSupportStatus::Supported,
+            },
+            WebProviderKind::Brave => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::ApiKey,
+                cost_class: WebProviderCostClass::Paid,
+                quality_hint: WebProviderQualityHint::Keyword,
+                supports_domain_filter: false,
+                supports_freshness: false,
+                supports_region_or_language: true,
+                supports_full_content: false,
+                supports_native_citations: false,
+                default_priority: 80,
+                status: WebProviderSupportStatus::Supported,
+            },
+            WebProviderKind::Tavily => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::ApiKey,
+                cost_class: WebProviderCostClass::Paid,
+                quality_hint: WebProviderQualityHint::Research,
+                supports_domain_filter: true,
+                supports_freshness: false,
+                supports_region_or_language: false,
+                supports_full_content: true,
+                supports_native_citations: false,
+                default_priority: 75,
+                status: WebProviderSupportStatus::Supported,
+            },
+            WebProviderKind::Exa => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::ApiKey,
+                cost_class: WebProviderCostClass::Paid,
+                quality_hint: WebProviderQualityHint::Semantic,
+                supports_domain_filter: true,
+                supports_freshness: false,
+                supports_region_or_language: false,
+                supports_full_content: true,
+                supports_native_citations: false,
+                default_priority: 70,
+                status: WebProviderSupportStatus::Supported,
+            },
+            WebProviderKind::Perplexity => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::ApiKey,
+                cost_class: WebProviderCostClass::Paid,
+                quality_hint: WebProviderQualityHint::Research,
+                supports_domain_filter: false,
+                supports_freshness: true,
+                supports_region_or_language: false,
+                supports_full_content: false,
+                supports_native_citations: true,
+                default_priority: 60,
+                status: WebProviderSupportStatus::Unsupported,
+            },
+            WebProviderKind::Firecrawl => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::ApiKey,
+                cost_class: WebProviderCostClass::Paid,
+                quality_hint: WebProviderQualityHint::Research,
+                supports_domain_filter: true,
+                supports_freshness: false,
+                supports_region_or_language: false,
+                supports_full_content: true,
+                supports_native_citations: false,
+                default_priority: 55,
+                status: WebProviderSupportStatus::Unsupported,
+            },
+            WebProviderKind::OpenAiNative
+            | WebProviderKind::AnthropicNative
+            | WebProviderKind::GeminiNative => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::NativeProvider,
+                cost_class: WebProviderCostClass::ProviderMetered,
+                quality_hint: WebProviderQualityHint::Native,
+                supports_domain_filter: false,
+                supports_freshness: true,
+                supports_region_or_language: false,
+                supports_full_content: false,
+                supports_native_citations: true,
+                default_priority: 65,
+                status: WebProviderSupportStatus::NativeOnly,
+            },
         }
     }
 }
@@ -350,5 +503,14 @@ mod tests {
         let config = materialize_web_config(&file, &store);
         let provider = config.providers.get("my_brave").unwrap();
         assert!(provider.api_key.is_empty());
+    }
+
+    #[test]
+    fn provider_capabilities_mark_reserved_kinds() {
+        assert_eq!(
+            WebProviderKind::OpenAiNative.capabilities().status,
+            WebProviderSupportStatus::NativeOnly
+        );
+        assert_eq!(WebProviderKind::Brave.capabilities().default_priority, 80);
     }
 }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -10,8 +10,8 @@ use url::{form_urlencoded, Url};
 use crate::{
     tool::ToolError,
     web::{
-        policy::timeout, WebConfig, WebFetchConfig, WebProviderConfig, WebProviderKind,
-        WebSearchMode,
+        policy::timeout, WebConfig, WebFetchConfig, WebProviderCapabilityMetadata,
+        WebProviderConfig, WebProviderKind, WebSearchMode,
     },
 };
 
@@ -44,6 +44,8 @@ pub struct WebSearchProviderAttempt {
     pub result_count: usize,
     pub error_kind: Option<String>,
     pub error_message: Option<String>,
+    pub provider_kind: Option<WebProviderKind>,
+    pub capabilities: Option<WebProviderCapabilityMetadata>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -97,7 +99,8 @@ pub async fn search(request: WebSearchRequest, config: &WebConfig) -> Result<Web
                 .unwrap_or_else(|| provider.to_string());
             let outcome =
                 search_one_provider(&request.query, max_results, &provider_id, config).await;
-            routed_single(provider_id, outcome)?
+            let kind = provider_kind(&provider_id, config);
+            routed_single(provider_id, kind, outcome)?
         }
         WebSearchMode::Fallback => {
             search_fallback(&request.query, max_results, provider_order, config).await?
@@ -143,13 +146,7 @@ fn provider_order(provider: &str, config: &WebConfig) -> Vec<String> {
     }
     let configured = dedupe_provider_order(&config.search.providers);
     let mut providers = if configured.is_empty() {
-        dedupe_provider_order(
-            config
-                .providers
-                .keys()
-                .cloned()
-                .chain(std::iter::once("duckduckgo".to_string())),
-        )
+        default_provider_order(config)
     } else {
         configured
     };
@@ -158,6 +155,39 @@ fn provider_order(provider: &str, config: &WebConfig) -> Vec<String> {
     }
     providers.truncate(config.search.max_provider_attempts.max(1));
     providers
+}
+
+fn default_provider_order(config: &WebConfig) -> Vec<String> {
+    let mut providers = config
+        .providers
+        .iter()
+        .map(|(id, provider)| {
+            (
+                id.clone(),
+                provider.kind.capabilities().default_priority,
+                provider.kind.as_str().to_string(),
+            )
+        })
+        .chain(std::iter::once((
+            "duckduckgo".to_string(),
+            WebProviderKind::DuckDuckGo.capabilities().default_priority,
+            WebProviderKind::DuckDuckGo.as_str().to_string(),
+        )))
+        .collect::<Vec<_>>();
+    providers.sort_by(|left, right| {
+        right
+            .1
+            .cmp(&left.1)
+            .then_with(|| left.2.cmp(&right.2))
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    dedupe_provider_order(providers.into_iter().map(|(id, _, _)| id))
+}
+
+fn provider_kind(provider: &str, config: &WebConfig) -> Option<WebProviderKind> {
+    (provider == "duckduckgo")
+        .then_some(WebProviderKind::DuckDuckGo)
+        .or_else(|| config.providers.get(provider).map(|provider| provider.kind))
 }
 
 fn dedupe_provider_order<I, S>(providers: I) -> Vec<String>
@@ -177,15 +207,16 @@ where
 
 fn routed_single(
     provider_id: String,
+    kind: Option<WebProviderKind>,
     outcome: Result<Vec<WebSearchResult>>,
 ) -> Result<RoutedSearchOutcome> {
     match outcome {
         Ok(results) => Ok(RoutedSearchOutcome {
-            provider_attempts: vec![successful_attempt(&provider_id, results.len())],
+            provider_attempts: vec![successful_attempt(&provider_id, kind, results.len())],
             winning_provider: Some(provider_id),
             results,
         }),
-        Err(error) => Err(single_provider_error(&provider_id, error)),
+        Err(error) => Err(single_provider_error(&provider_id, kind, error)),
     }
 }
 
@@ -197,16 +228,17 @@ async fn search_fallback(
 ) -> Result<RoutedSearchOutcome> {
     let mut attempts = Vec::new();
     for provider_id in provider_order {
+        let kind = provider_kind(&provider_id, config);
         match search_one_provider(query, max_results, &provider_id, config).await {
             Ok(results) => {
-                attempts.push(successful_attempt(&provider_id, results.len()));
+                attempts.push(successful_attempt(&provider_id, kind, results.len()));
                 return Ok(RoutedSearchOutcome {
                     results,
                     provider_attempts: attempts,
                     winning_provider: Some(provider_id),
                 });
             }
-            Err(error) => attempts.push(failed_attempt(&provider_id, &error)),
+            Err(error) => attempts.push(failed_attempt(&provider_id, kind, &error)),
         }
     }
     Err(routing_error(attempts, None))
@@ -223,9 +255,14 @@ async fn search_aggregate(
     let mut results = Vec::new();
 
     for provider_id in provider_order {
+        let kind = provider_kind(&provider_id, config);
         match search_one_provider(query, max_results, &provider_id, config).await {
             Ok(provider_results) => {
-                attempts.push(successful_attempt(&provider_id, provider_results.len()));
+                attempts.push(successful_attempt(
+                    &provider_id,
+                    kind,
+                    provider_results.len(),
+                ));
                 for result in provider_results {
                     if seen_urls.insert(result.url.clone()) {
                         results.push(result);
@@ -235,7 +272,7 @@ async fn search_aggregate(
                     }
                 }
             }
-            Err(error) => attempts.push(failed_attempt(&provider_id, &error)),
+            Err(error) => attempts.push(failed_attempt(&provider_id, kind, &error)),
         }
         if results.len() >= max_results {
             break;
@@ -253,17 +290,27 @@ async fn search_aggregate(
     })
 }
 
-fn successful_attempt(provider: &str, result_count: usize) -> WebSearchProviderAttempt {
+fn successful_attempt(
+    provider: &str,
+    kind: Option<WebProviderKind>,
+    result_count: usize,
+) -> WebSearchProviderAttempt {
     WebSearchProviderAttempt {
         provider: provider.to_string(),
         status: WebSearchProviderAttemptStatus::Success,
         result_count,
         error_kind: None,
         error_message: None,
+        provider_kind: kind,
+        capabilities: kind.map(|kind| kind.capabilities()),
     }
 }
 
-fn failed_attempt(provider: &str, error: &anyhow::Error) -> WebSearchProviderAttempt {
+fn failed_attempt(
+    provider: &str,
+    kind: Option<WebProviderKind>,
+    error: &anyhow::Error,
+) -> WebSearchProviderAttempt {
     let tool_error = ToolError::from_anyhow(error);
     WebSearchProviderAttempt {
         provider: provider.to_string(),
@@ -271,11 +318,17 @@ fn failed_attempt(provider: &str, error: &anyhow::Error) -> WebSearchProviderAtt
         result_count: 0,
         error_kind: Some(tool_error.kind),
         error_message: Some(tool_error.message),
+        provider_kind: kind,
+        capabilities: kind.map(|kind| kind.capabilities()),
     }
 }
 
-fn single_provider_error(provider: &str, error: anyhow::Error) -> anyhow::Error {
-    let attempt = failed_attempt(provider, &error);
+fn single_provider_error(
+    provider: &str,
+    kind: Option<WebProviderKind>,
+    error: anyhow::Error,
+) -> anyhow::Error {
+    let attempt = failed_attempt(provider, kind, &error);
     let original = ToolError::from_anyhow(&error);
     let mut tool_error = ToolError::new(original.kind, original.message)
         .with_details(single_provider_error_details(original.details, attempt))
@@ -1116,6 +1169,14 @@ mod tests {
             response.provider_attempts[1].status,
             WebSearchProviderAttemptStatus::Success
         );
+        assert_eq!(
+            response.provider_attempts[1].provider_kind,
+            Some(WebProviderKind::Searxng)
+        );
+        assert_eq!(
+            response.provider_attempts[1].capabilities.unwrap().status,
+            crate::web::WebProviderSupportStatus::Supported
+        );
         assert_eq!(response.results[0].source, "good");
     }
 
@@ -1153,6 +1214,37 @@ mod tests {
         assert_eq!(
             provider_order("auto", &config),
             vec!["alpha", "zeta", "duckduckgo"]
+        );
+    }
+
+    #[test]
+    fn provider_order_defaults_to_capability_priority() {
+        let config = test_search_config(
+            vec![
+                (
+                    "searx",
+                    test_provider(WebProviderKind::Searxng, "https://searx.example"),
+                ),
+                (
+                    "exa",
+                    test_provider(WebProviderKind::Exa, "https://exa.example"),
+                ),
+                (
+                    "brave",
+                    test_provider(WebProviderKind::Brave, "https://brave.example"),
+                ),
+                (
+                    "tavily",
+                    test_provider(WebProviderKind::Tavily, "https://tavily.example"),
+                ),
+            ],
+            vec![],
+            WebSearchMode::Fallback,
+        );
+
+        assert_eq!(
+            provider_order("auto", &config),
+            vec!["brave", "tavily", "exa"]
         );
     }
 
@@ -1198,6 +1290,14 @@ mod tests {
         assert_eq!(details["attempted_providers"], json!(["bad"]));
         assert_eq!(details["winning_provider"], serde_json::Value::Null);
         assert_eq!(details["provider_attempts"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            details["provider_attempts"][0]["provider_kind"],
+            json!("searxng")
+        );
+        assert_eq!(
+            details["provider_attempts"][0]["capabilities"]["status"],
+            json!("supported")
+        );
     }
 
     #[tokio::test]

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -11,10 +11,11 @@ use crate::{
     tool::ToolError,
     web::{
         policy::timeout, WebConfig, WebFetchConfig, WebProviderCapabilityMetadata,
-        WebProviderConfig, WebProviderKind, WebSearchMode,
+        WebProviderConfig, WebProviderKind, WebProviderSupportStatus, WebSearchMode,
     },
 };
 
+const DUCKDUCKGO_PROVIDER_ID: &str = "duckduckgo";
 const SEARCH_RESPONSE_BYTES: usize = 1_000_000;
 
 #[derive(Debug, Clone)]
@@ -151,7 +152,7 @@ fn provider_order(provider: &str, config: &WebConfig) -> Vec<String> {
         configured
     };
     if providers.is_empty() {
-        providers.push("duckduckgo".to_string());
+        providers.push(DUCKDUCKGO_PROVIDER_ID.to_string());
     }
     providers.truncate(config.search.max_provider_attempts.max(1));
     providers
@@ -161,15 +162,18 @@ fn default_provider_order(config: &WebConfig) -> Vec<String> {
     let mut providers = config
         .providers
         .iter()
-        .map(|(id, provider)| {
-            (
-                id.clone(),
-                provider.kind.capabilities().default_priority,
-                provider.kind.as_str().to_string(),
-            )
+        .filter_map(|(id, provider)| {
+            let capabilities = provider.kind.capabilities();
+            (capabilities.status == WebProviderSupportStatus::Supported).then(|| {
+                (
+                    id.clone(),
+                    capabilities.default_priority,
+                    provider.kind.as_str().to_string(),
+                )
+            })
         })
         .chain(std::iter::once((
-            "duckduckgo".to_string(),
+            DUCKDUCKGO_PROVIDER_ID.to_string(),
             WebProviderKind::DuckDuckGo.capabilities().default_priority,
             WebProviderKind::DuckDuckGo.as_str().to_string(),
         )))
@@ -185,7 +189,7 @@ fn default_provider_order(config: &WebConfig) -> Vec<String> {
 }
 
 fn provider_kind(provider: &str, config: &WebConfig) -> Option<WebProviderKind> {
-    (provider == "duckduckgo")
+    (provider == DUCKDUCKGO_PROVIDER_ID)
         .then_some(WebProviderKind::DuckDuckGo)
         .or_else(|| config.providers.get(provider).map(|provider| provider.kind))
 }
@@ -407,7 +411,7 @@ async fn search_one_provider(
     config: &WebConfig,
 ) -> Result<Vec<WebSearchResult>> {
     match provider_id {
-        "duckduckgo" => duckduckgo_search(query, max_results, &config.fetch).await,
+        DUCKDUCKGO_PROVIDER_ID => duckduckgo_search(query, max_results, &config.fetch).await,
         provider_id => {
             let provider_config = config.providers.get(provider_id).ok_or_else(|| {
                 search_error(
@@ -467,13 +471,13 @@ async fn duckduckgo_search(
     let encoded = form_urlencoded::byte_serialize(query.as_bytes()).collect::<String>();
     let url = format!("https://lite.duckduckgo.com/lite/?q={encoded}");
     let client = Client::builder().timeout(timeout(fetch_config)).build()?;
-    let html = send_search_text(client.get(&url), "duckduckgo").await?;
+    let html = send_search_text(client.get(&url), DUCKDUCKGO_PROVIDER_ID).await?;
     let results = parse_duckduckgo_lite_results(&html, max_results);
     if results.is_empty() {
         return Err(search_error(
             "parse_failed",
             "DuckDuckGo returned no parseable search results",
-            "duckduckgo",
+            DUCKDUCKGO_PROVIDER_ID,
             "configure SearXNG or an API-backed provider if DuckDuckGo HTML is unavailable",
         ));
     }
@@ -1006,7 +1010,7 @@ fn parse_duckduckgo_lite_results(html: &str, max_results: usize) -> Vec<WebSearc
                     title: title.trim().to_string(),
                     url,
                     snippet: None,
-                    source: "duckduckgo".into(),
+                    source: DUCKDUCKGO_PROVIDER_ID.into(),
                     published_at: None,
                 });
             }
@@ -1213,7 +1217,34 @@ mod tests {
 
         assert_eq!(
             provider_order("auto", &config),
-            vec!["alpha", "zeta", "duckduckgo"]
+            vec!["alpha", "zeta", DUCKDUCKGO_PROVIDER_ID]
+        );
+    }
+
+    #[test]
+    fn provider_order_defaults_skip_unsupported_configured_providers() {
+        let config = test_search_config(
+            vec![
+                (
+                    "future",
+                    test_provider(WebProviderKind::Perplexity, "https://future.example"),
+                ),
+                (
+                    "native",
+                    test_provider(WebProviderKind::OpenAiNative, "https://native.example"),
+                ),
+                (
+                    "searx",
+                    test_provider(WebProviderKind::Searxng, "https://searx.example"),
+                ),
+            ],
+            vec![],
+            WebSearchMode::Fallback,
+        );
+
+        assert_eq!(
+            provider_order("auto", &config),
+            vec!["searx", DUCKDUCKGO_PROVIDER_ID]
         );
     }
 


### PR DESCRIPTION
Closes #1148

## Summary
- add structured WebSearch provider capability metadata and unsupported/native-only status labels
- surface provider capabilities through config schema output and configuration docs
- include routing provenance/diagnostics for skipped or selected providers in WebSearch results

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test web::search::tests -- --nocapture