### PR TITLE
fix: preserve TUI chat history across refreshes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -558,11 +558,12 @@ impl AppConfig {
             resolve_provider_registry(&stored_config, &settings_env, &credential_store)?;
         let explicit_default = resolve_default_model(&stored_config)?;
         let explicit_fallbacks = resolve_fallback_models(&stored_config)?;
-        let (default_model, fallback_models) = match resolve_model_selection_from_explicit(
+        let (default_model, fallback_models) = match resolve_model_selection_for_load_mode(
             explicit_default,
             explicit_fallbacks,
             &providers,
             &validated_model_overrides,
+            mode,
         ) {
             Ok(selection) => selection,
             Err(error) if mode.allow_unresolved_model() => {
@@ -669,6 +670,10 @@ enum ConfigLoadMode {
 
 impl ConfigLoadMode {
     fn allow_unresolved_model(self) -> bool {
+        matches!(self, Self::ConfigInspection)
+    }
+
+    fn skip_authenticated_model_resolution(self) -> bool {
         matches!(self, Self::ConfigInspection)
     }
 }
@@ -2774,6 +2779,31 @@ pub fn provider_registry_for_tests(
     registry
 }
 
+fn resolve_model_selection_for_load_mode(
+    explicit_default: Option<ModelRef>,
+    explicit_fallbacks: Option<Vec<ModelRef>>,
+    providers: &ProviderRegistry,
+    model_overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+    mode: ConfigLoadMode,
+) -> Result<(ModelRef, Vec<ModelRef>)> {
+    if mode.skip_authenticated_model_resolution() {
+        let default_model =
+            explicit_default.unwrap_or_else(|| ModelRef::new(ProviderId::openai(), "unknown"));
+        let fallback_models = explicit_fallbacks.unwrap_or_default();
+        return Ok((
+            default_model.clone(),
+            dedupe_fallback_models(fallback_models, &default_model),
+        ));
+    }
+
+    resolve_model_selection_from_explicit(
+        explicit_default,
+        explicit_fallbacks,
+        providers,
+        model_overrides,
+    )
+}
+
 fn resolve_model_selection_from_explicit(
     explicit_default: Option<ModelRef>,
     explicit_fallbacks: Option<Vec<ModelRef>>,
@@ -4553,13 +4583,53 @@ mod tests {
     #[test]
     fn config_inspection_loads_provider_state_without_resolved_model() {
         let home = tempdir().unwrap();
+        let codex_home = home.path().join("codex-home");
         let _env_guard = EnvVarGuard::set_and_unset(
-            &[("HOME", home.path().as_os_str())],
+            &[
+                ("HOME", home.path().as_os_str()),
+                ("CODEX_HOME", codex_home.as_os_str()),
+            ],
             &[
                 "HOLON_MODEL",
                 "HOLON_MODEL_FALLBACKS",
                 "OPENAI_API_KEY",
                 "ANTHROPIC_AUTH_TOKEN",
+                "ARCEE_API_KEY",
+                "BYTEPLUS_API_KEY",
+                "BYTEPLUS_CODING_API_KEY",
+                "CHUTES_API_KEY",
+                "DEEPSEEK_API_KEY",
+                "FIREWORKS_API_KEY",
+                "HUGGINGFACE_API_KEY",
+                "HF_TOKEN",
+                "KILOCODE_API_KEY",
+                "LITELLM_API_KEY",
+                "MISTRAL_API_KEY",
+                "MOONSHOT_API_KEY",
+                "NVIDIA_API_KEY",
+                "OPENCODE_GO_API_KEY",
+                "OPENROUTER_API_KEY",
+                "QIANFAN_API_KEY",
+                "QWEN_API_KEY",
+                "DASHSCOPE_API_KEY",
+                "STEPFUN_API_KEY",
+                "STEPFUN_PLAN_API_KEY",
+                "SYNTHETIC_API_KEY",
+                "TOKENHUB_API_KEY",
+                "TOGETHER_API_KEY",
+                "VENICE_API_KEY",
+                "VOLCENGINE_API_KEY",
+                "VOLCENGINE_CODING_API_KEY",
+                "ARK_API_KEY",
+                "XIAOMI_API_KEY",
+                "XIAOMI_TOKEN_PLAN_API_KEY",
+                "XAI_API_KEY",
+                "ZAI_API_KEY",
+                "BIGMODEL_API_KEY",
+                "MINIMAX_API_KEY",
+                "AI_GATEWAY_API_KEY",
+                "VERCEL_AI_GATEWAY_API_KEY",
+                "HOLON_TEST_MISSING_CUSTOM_OPENAI_API_KEY",
             ],
         );
         let provider_id = ProviderId::parse("custom-openai").unwrap();

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -78,6 +78,14 @@ impl ChatScrollState {
         self.offset_from_bottom = max_scroll.saturating_sub(preserved_scroll.min(max_scroll));
     }
 
+    pub(super) fn preserve_across_refresh(&mut self, max_scroll: u16) {
+        if self.follow_tail {
+            return;
+        }
+        self.offset_from_bottom = self.offset_from_bottom.min(max_scroll);
+        self.pending_prepend_anchor = None;
+    }
+
     #[cfg(test)]
     pub(super) fn is_following_tail(self) -> bool {
         self.follow_tail
@@ -833,6 +841,18 @@ mod tests {
         scroll.apply_history_prepend_adjustment(35);
 
         assert_eq!(scroll.effective_scroll(35), 15);
+    }
+
+    #[test]
+    fn chat_scroll_clamps_non_tail_refresh_without_following_tail() {
+        let mut scroll = super::ChatScrollState::new();
+        scroll.scroll_with_key(crossterm::event::KeyCode::PageUp, 20);
+        assert!(!scroll.is_following_tail());
+
+        scroll.preserve_across_refresh(5);
+
+        assert!(!scroll.is_following_tail());
+        assert_eq!(scroll.effective_scroll(5), 0);
     }
 
     #[test]

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -32,7 +32,7 @@ use crate::{
 
 const TASK_TAIL_LIMIT: usize = 50;
 const TIMER_TAIL_LIMIT: usize = 50;
-const EVENT_LOG_LIMIT: usize = 256;
+pub(crate) const EVENT_LOG_LIMIT: usize = 1024;
 const EVENT_HISTORY_LOG_LIMIT: usize = 16_384;
 const DURABLE_CONVERSATION_LOG_LIMIT: usize = 256;
 static TUI_EVENT_LOG_WRITE_WARNED: AtomicBool = AtomicBool::new(false);
@@ -124,6 +124,20 @@ impl TuiProjection {
         *self = Self::from_snapshot(snapshot);
     }
 
+    pub(crate) fn reset_from_snapshot_preserving_event_history(
+        &mut self,
+        snapshot: AgentStateSnapshot,
+    ) {
+        let mut refreshed = Self::from_snapshot(snapshot);
+        refreshed.cursor = self.cursor.take();
+        refreshed.history_oldest_cursor = self.history_oldest_cursor.take();
+        refreshed.history_has_older = self.history_has_older;
+        refreshed.history_paging_active = self.history_paging_active;
+        refreshed.event_log = mem::take(&mut self.event_log);
+        refreshed.durable_conversation_log = mem::take(&mut self.durable_conversation_log);
+        *self = refreshed;
+    }
+
     pub(crate) fn replace_event_window(
         &mut self,
         events_tail: Vec<StreamEventEnvelope>,
@@ -135,6 +149,45 @@ impl TuiProjection {
         self.seed_event_log(events_tail);
     }
 
+    pub(crate) fn merge_event_tail(
+        &mut self,
+        events_tail: Vec<StreamEventEnvelope>,
+        cursor: Option<String>,
+    ) {
+        self.cursor = cursor.or_else(|| self.cursor.clone());
+        let event_log_limit = if self.history_paging_active {
+            EVENT_HISTORY_LOG_LIMIT
+        } else {
+            EVENT_LOG_LIMIT
+        };
+        let mut existing_ids = self
+            .event_log
+            .iter()
+            .map(|event| event.id.clone())
+            .collect::<BTreeSet<_>>();
+        for envelope in events_tail {
+            if !existing_ids.insert(envelope.id.clone()) {
+                continue;
+            }
+            let record = self.projection_event_record_from_envelope(envelope);
+            push_limited(&mut self.event_log, record, event_log_limit);
+        }
+        self.event_log.sort_by(|left, right| {
+            left.seq
+                .cmp(&right.seq)
+                .then_with(|| left.ts.cmp(&right.ts))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        if self.event_log.len() > event_log_limit {
+            self.event_log
+                .drain(0..(self.event_log.len() - event_log_limit));
+        }
+        self.rebuild_durable_conversation_log();
+        if self.cursor.is_none() {
+            self.cursor = self.event_log.last().map(|event| event.id.clone());
+        }
+    }
+
     pub(crate) fn set_event_history_state(
         &mut self,
         oldest_cursor: Option<String>,
@@ -142,6 +195,18 @@ impl TuiProjection {
     ) {
         self.history_oldest_cursor = oldest_cursor;
         self.history_has_older = has_older;
+    }
+
+    pub(crate) fn set_event_history_state_from_tail(
+        &mut self,
+        oldest_cursor: Option<String>,
+        has_older: bool,
+    ) {
+        if self.history_paging_active && self.history_oldest_cursor.is_some() {
+            self.history_has_older = self.history_has_older || has_older;
+            return;
+        }
+        self.set_event_history_state(oldest_cursor, has_older);
     }
 
     pub(crate) fn prepend_event_history_page(
@@ -1554,6 +1619,44 @@ mod tests {
             Some("evt-older-1")
         );
         assert!(projection.history_has_older);
+    }
+
+    #[test]
+    fn projection_merges_tail_refresh_without_dropping_paged_history() {
+        let snapshot = sample_snapshot();
+        let events_tail = vec![sample_event_envelope("evt-newer", 3)];
+        let mut projection = TuiProjection::from_snapshot(snapshot);
+        projection.replace_event_window(events_tail, Some("evt-newer".into()));
+        projection.set_event_history_state(Some("evt-newer".into()), true);
+
+        let added = projection.prepend_event_history_page(
+            vec![
+                sample_event_envelope("evt-older-2", 2),
+                sample_event_envelope("evt-older-1", 1),
+            ],
+            Some("evt-older-1".into()),
+            true,
+        );
+        assert_eq!(added, 2);
+
+        projection.merge_event_tail(
+            vec![
+                sample_event_envelope("evt-newer", 3),
+                sample_event_envelope("evt-live", 4),
+            ],
+            Some("evt-live".into()),
+        );
+
+        let ids = projection
+            .event_log()
+            .iter()
+            .map(|event| event.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ids,
+            vec!["evt-older-1", "evt-older-2", "evt-newer", "evt-live"]
+        );
+        assert_eq!(projection.cursor.as_deref(), Some("evt-live"));
     }
 
     #[test]

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -170,7 +170,7 @@ impl TuiProjection {
                 continue;
             }
             let record = self.projection_event_record_from_envelope(envelope);
-            push_limited(&mut self.event_log, record, event_log_limit);
+            self.event_log.push(record);
         }
         self.event_log.sort_by(|left, right| {
             left.seq
@@ -1420,7 +1420,7 @@ fn trim_summary(value: &str) -> String {
 mod tests {
     use super::{
         OperatorDisplayMode, OperatorVisibility, ProjectionEventLane, ProjectionSlice,
-        TuiProjection, TASK_TAIL_LIMIT,
+        TuiProjection, EVENT_LOG_LIMIT, TASK_TAIL_LIMIT,
     };
     use crate::{
         client::{
@@ -1657,6 +1657,33 @@ mod tests {
             vec!["evt-older-1", "evt-older-2", "evt-newer", "evt-live"]
         );
         assert_eq!(projection.cursor.as_deref(), Some("evt-live"));
+    }
+
+    #[test]
+    fn projection_merges_tail_refresh_truncates_after_chronological_sort() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let events_tail = (0..EVENT_LOG_LIMIT)
+            .map(|index| {
+                sample_event_envelope(&format!("evt-existing-{index}"), (index + 100) as u64)
+            })
+            .collect::<Vec<_>>();
+        projection.replace_event_window(
+            events_tail,
+            Some(format!("evt-existing-{}", EVENT_LOG_LIMIT - 1)),
+        );
+
+        projection.merge_event_tail(vec![sample_event_envelope("evt-old-refresh", 1)], None);
+
+        let ids = projection
+            .event_log()
+            .iter()
+            .map(|event| event.id.as_str())
+            .collect::<Vec<_>>();
+        let newest_id = format!("evt-existing-{}", EVENT_LOG_LIMIT - 1);
+        assert_eq!(projection.event_log().len(), EVENT_LOG_LIMIT);
+        assert!(!ids.contains(&"evt-old-refresh"));
+        assert!(ids.contains(&"evt-existing-0"));
+        assert!(ids.iter().any(|id| *id == newest_id.as_str()));
     }
 
     #[test]
@@ -2123,14 +2150,14 @@ mod tests {
             &test_log_writer(),
         );
 
-        for index in 0..300 {
+        for index in 0..=EVENT_LOG_LIMIT {
             projection.apply_event(
                 AgentStreamEvent {
                     id: format!("evt-debug-{index}"),
                     event: "provider_round_completed".into(),
                     data: StreamEventEnvelope {
                         id: format!("evt-debug-{index}"),
-                        seq: index + 2,
+                        seq: (index + 2) as u64,
                         ts: Utc::now(),
                         agent_id: "default".into(),
                         event_type: "provider_round_completed".into(),
@@ -2143,6 +2170,7 @@ mod tests {
             );
         }
 
+        assert_eq!(projection.event_log().len(), EVENT_LOG_LIMIT);
         assert_eq!(
             projection
                 .durable_conversation_events()
@@ -2153,7 +2181,7 @@ mod tests {
         assert!(projection
             .event_log()
             .iter()
-            .all(|event| event.id != "evt-work_item_written"));
+            .any(|event| event.id == format!("evt-debug-{EVENT_LOG_LIMIT}")));
     }
 
     #[test]

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -1,4 +1,4 @@
-use super::projection::ProjectionSlice;
+use super::projection::{ProjectionSlice, EVENT_LOG_LIMIT};
 use super::state::TuiClientState;
 use super::*;
 use crate::client::{
@@ -385,7 +385,7 @@ impl TuiApp {
                         .agent_events_page(
                             &agent_id,
                             EventPageRequest {
-                                limit: Some(256),
+                                limit: Some(EVENT_LOG_LIMIT),
                                 order: Some("desc".into()),
                                 ..Default::default()
                             },
@@ -442,9 +442,24 @@ impl TuiApp {
                 return;
             }
         };
-        let mut projection = TuiProjection::from_snapshot(snapshot);
-        projection.replace_event_window(events_tail, newest_cursor);
-        projection.set_event_history_state(oldest_cursor, has_older);
+        let same_agent = self
+            .projection
+            .as_ref()
+            .is_some_and(|current| current.agent.identity.agent_id == agent_id);
+        let mut projection = if same_agent {
+            self.chat_scroll
+                .preserve_across_refresh(self.chat_max_scroll);
+            if let Some(mut projection) = self.projection.take() {
+                projection.reset_from_snapshot_preserving_event_history(snapshot);
+                projection
+            } else {
+                TuiProjection::from_snapshot(snapshot)
+            }
+        } else {
+            TuiProjection::from_snapshot(snapshot)
+        };
+        projection.merge_event_tail(events_tail, newest_cursor);
+        projection.set_event_history_state_from_tail(oldest_cursor, has_older);
         let cursor = projection.cursor.clone();
 
         self.stop_stream_task();


### PR DESCRIPTION
Closes #1180

## Summary
- preserve previously paged TUI chat history when runtime projections refresh
- merge tail refreshes without dropping older loaded events
- keep non-tail scroll positions from snapping back to the newest tail on refresh

## Verification
- cargo test projection_merges_tail_refresh_without_dropping_paged_history
- cargo test chat_scroll_clamps_non_tail_refresh_without_following_tail
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
