### PR TITLE
fix: replace duplicate agent waiting intents

### DIFF
--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -50,7 +50,18 @@ impl RuntimeHandle {
         if let Some(work_item_id) = work_item_id.as_deref() {
             self.cancel_work_item_waiting_intents(work_item_id, "waiting_condition_replaced")
                 .await?;
+        } else if scope == ExternalTriggerScope::Agent {
+            self.cancel_agent_waiting_intents_for_dependency(
+                &description,
+                &source,
+                resource.as_deref(),
+                condition.as_deref(),
+                &delivery_mode,
+                "waiting_condition_replaced",
+            )
+            .await?;
         }
+
         let waiting = WaitingIntentRecord {
             id: waiting_intent_id.clone(),
             agent_id: agent_id.clone(),

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2623,6 +2623,91 @@ async fn replacing_work_item_trigger_revokes_previous_waiting_condition() {
 }
 
 #[tokio::test]
+async fn replacing_agent_scoped_duplicate_trigger_revokes_previous_waiting_condition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let old_capability = runtime
+        .create_external_trigger(
+            "watch durable inbox".into(),
+            "agentinbox".into(),
+            ExternalTriggerScope::Agent,
+            CallbackDeliveryMode::WakeHint,
+            Some("unread_entries".into()),
+            Some("inbox:default".into()),
+        )
+        .await
+        .unwrap();
+    let new_capability = runtime
+        .create_external_trigger(
+            "watch durable inbox".into(),
+            "agentinbox".into(),
+            ExternalTriggerScope::Agent,
+            CallbackDeliveryMode::WakeHint,
+            Some("unread_entries".into()),
+            Some("inbox:default".into()),
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(
+        old_capability.waiting_intent_id,
+        new_capability.waiting_intent_id
+    );
+    assert_ne!(
+        old_capability.external_trigger_id,
+        new_capability.external_trigger_id
+    );
+
+    let waiting = runtime.latest_waiting_intents().await.unwrap();
+    let descriptors = runtime.latest_external_triggers().await.unwrap();
+    assert_eq!(
+        waiting
+            .iter()
+            .filter(|record| record.status == WaitingIntentStatus::Active)
+            .count(),
+        1
+    );
+    assert!(waiting.iter().any(|record| {
+        record.id == old_capability.waiting_intent_id
+            && record.scope == ExternalTriggerScope::Agent
+            && record.status == WaitingIntentStatus::Cancelled
+    }));
+    assert!(waiting.iter().any(|record| {
+        record.id == new_capability.waiting_intent_id
+            && record.scope == ExternalTriggerScope::Agent
+            && record.status == WaitingIntentStatus::Active
+    }));
+    assert!(descriptors.iter().any(|record| {
+        record.external_trigger_id == old_capability.external_trigger_id
+            && record.status == ExternalTriggerStatus::Revoked
+    }));
+    assert!(descriptors.iter().any(|record| {
+        record.external_trigger_id == new_capability.external_trigger_id
+            && record.status == ExternalTriggerStatus::Active
+    }));
+
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "agent_waiting_intents_cancelled"
+            && event.data["reason"] == "waiting_condition_replaced"
+            && event.data["source"].as_str() == Some("agentinbox")
+            && event.data["resource"].as_str() == Some("inbox:default")
+            && event.data["condition"].as_str() == Some("unread_entries")
+    }));
+}
+
+#[tokio::test]
 async fn picking_new_work_item_cancels_previous_work_item_scoped_trigger_only() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -550,6 +550,49 @@ impl RuntimeHandle {
         Ok(cancelled_ids)
     }
 
+    pub(super) async fn cancel_agent_waiting_intents_for_dependency(
+        &self,
+        description: &str,
+        source: &str,
+        resource: Option<&str>,
+        condition: Option<&str>,
+        delivery_mode: &CallbackDeliveryMode,
+        reason: &'static str,
+    ) -> Result<Vec<String>> {
+        let waiting_intent_ids = self
+            .latest_waiting_intents()
+            .await?
+            .into_iter()
+            .filter(|record| record.status == WaitingIntentStatus::Active)
+            .filter(|record| record.scope == ExternalTriggerScope::Agent)
+            .filter(|record| record.description == description)
+            .filter(|record| record.source == source)
+            .filter(|record| record.resource.as_deref() == resource)
+            .filter(|record| record.condition.as_deref() == condition)
+            .filter(|record| record.delivery_mode == *delivery_mode)
+            .map(|record| record.id)
+            .collect::<Vec<_>>();
+        if waiting_intent_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let cancelled_ids = self.cancel_waiting_intents(waiting_intent_ids).await?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "agent_waiting_intents_cancelled",
+            serde_json::json!({
+                "agent_id": self.agent_id().await?,
+                "description": description,
+                "source": source,
+                "resource": resource,
+                "condition": condition,
+                "delivery_mode": delivery_mode,
+                "reason": reason,
+                "waiting_intent_ids": cancelled_ids,
+            }),
+        ))?;
+        Ok(cancelled_ids)
+    }
+
     async fn cancel_waiting_intents(&self, waiting_intent_ids: Vec<String>) -> Result<Vec<String>> {
         let mut cancelled = Vec::new();
         for waiting_intent_id in waiting_intent_ids {


### PR DESCRIPTION
Closes #1178

## Summary
- add agent-scoped replacement semantics for duplicate waiting intents from the same source/delivery/description
- revoke the previous external trigger capability when a duplicate agent wait is superseded
- add regression coverage for duplicate trigger replacement and active waiting projection

## Verification
- cargo test replacing_agent_scoped_duplicate_trigger_revokes_previous_waiting_contract
- cargo fmt --all -- --check && RUSTFLAGS="-D warnings" cargo check --all-targets
- RUSTFLAGS="-D warnings" cargo test --all-targets -- --test-threads=1
