### PR TITLE
fix: UseWorkspace rejects nonexistent paths with structured error

### DIFF
--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -90,6 +90,89 @@ async fn use_workspace_agent_home_returns_to_fallback_without_deleting_project()
     assert!(retained_file.is_file());
 }
 
+#[tokio::test]
+async fn use_workspace_rejects_nonexistent_path() {
+    let (_home, _host, runtime) = host_backed_test_runtime().await;
+    let nonexistent = runtime.agent_home().join("__holon_test_nonexistent_dir__");
+    // Ensure the path truly does not exist.
+    if nonexistent.try_exists().unwrap_or(false) {
+        std::fs::remove_dir_all(&nonexistent).unwrap();
+    }
+
+    let result = crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &TrustLevel::TrustedOperator,
+        &crate::tool::ToolCall {
+            id: "use-workspace".into(),
+            name: "UseWorkspace".into(),
+            input: serde_json::json!({
+                "path": nonexistent.display().to_string(),
+            }),
+        },
+    )
+    .await;
+
+    // Must fail with an appropriate error.
+    let err = result.unwrap_err();
+    let err_msg = format!("{err:#}");
+    assert!(
+        err_msg.contains("path does not exist"),
+        "expected 'path does not exist' error, got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains(&nonexistent.display().to_string()),
+        "error should mention the missing path, got: {err_msg}"
+    );
+}
+
+#[tokio::test]
+async fn use_workspace_nonexistent_path_preserves_existing_workspace() {
+    let (_home, _host, runtime) = host_backed_test_runtime().await;
+
+    // Establish an initial valid workspace.
+    let workspace = tempdir().unwrap();
+    crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &TrustLevel::TrustedOperator,
+        &crate::tool::ToolCall {
+            id: "use-valid".into(),
+            name: "UseWorkspace".into(),
+            input: serde_json::json!({
+                "path": workspace.path().display().to_string(),
+            }),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Now attempt to switch to a nonexistent path.
+    let nonexistent = runtime.agent_home().join("__holon_test_nonexistent_dir2__");
+    if nonexistent.try_exists().unwrap_or(false) {
+        std::fs::remove_dir_all(&nonexistent).unwrap();
+    }
+
+    let result = crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &TrustLevel::TrustedOperator,
+        &crate::tool::ToolCall {
+            id: "use-bad".into(),
+            name: "UseWorkspace".into(),
+            input: serde_json::json!({
+                "path": nonexistent.display().to_string(),
+            }),
+        },
+    )
+    .await;
+    assert!(result.is_err(), "expected failure for nonexistent path");
+
+    // The existing valid workspace must still be active.
+    let snapshot = runtime.execution_snapshot().await.unwrap();
+    assert_eq!(snapshot.workspace_anchor, workspace.path());
+    assert_eq!(snapshot.execution_root, workspace.path());
+}
 #[test]
 fn execution_snapshot_includes_attached_workspaces() {
     let dir = tempdir().unwrap();

--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -172,6 +172,16 @@ async fn use_workspace_nonexistent_path_preserves_existing_workspace() {
     let snapshot = runtime.execution_snapshot().await.unwrap();
     assert_eq!(snapshot.workspace_anchor, workspace.path());
     assert_eq!(snapshot.execution_root, workspace.path());
+
+    // Verify the nonexistent path was never registered as an attached workspace.
+    let nonexistent_display = nonexistent.display().to_string();
+    assert!(
+        !snapshot
+            .attached_workspaces
+            .iter()
+            .any(|(_, p)| p.display().to_string() == nonexistent_display),
+        "nonexistent path must not appear in attached_workspaces"
+    );
 }
 #[test]
 fn execution_snapshot_includes_attached_workspaces() {

--- a/src/tool/tools/use_workspace.rs
+++ b/src/tool/tools/use_workspace.rs
@@ -144,6 +144,18 @@ pub(crate) async fn execute(
                 "call UseWorkspace with an existing directory path",
             ));
         }
+        if !normalized.is_dir() {
+            return Err(invalid_tool_input(
+                NAME,
+                format!("path is not a directory: {}", normalized.display()),
+                json!({
+                    "field": "path",
+                    "path": normalized.display().to_string(),
+                    "validation_error": "path is not a directory",
+                }),
+                "call UseWorkspace with an existing directory path",
+            ));
+        }
         if projection_kind == WorkspaceProjectionKind::CanonicalRoot {
             if let Some(existing_worktree) = runtime
                 .attached_workspace_for_existing_git_worktree(&path)

--- a/src/tool/tools/use_workspace.rs
+++ b/src/tool/tools/use_workspace.rs
@@ -130,6 +130,20 @@ pub(crate) async fn execute(
     } else if let Some(path) = path {
         let path = validate_non_empty(path, NAME, "path")?;
         let path = PathBuf::from(&path);
+        // Normalize and reject nonexistent paths before any state mutation.
+        let normalized = crate::tool::helpers::normalize_path(&path)?;
+        if !normalized.try_exists()? {
+            return Err(invalid_tool_input(
+                NAME,
+                format!("path does not exist: {}", normalized.display()),
+                json!({
+                    "field": "path",
+                    "path": normalized.display().to_string(),
+                    "validation_error": "path does not exist",
+                }),
+                "call UseWorkspace with an existing directory path",
+            ));
+        }
         if projection_kind == WorkspaceProjectionKind::CanonicalRoot {
             if let Some(existing_worktree) = runtime
                 .attached_workspace_for_existing_git_worktree(&path)


### PR DESCRIPTION
## Problem

`UseWorkspace` accepted any non-empty path string and registered it as a valid workspace without checking filesystem existence. This caused agents to treat nonexistent directories as usable workspaces, leading to misleading execution snapshots and later command failures.

Closes #1174.

## Fix

In `src/tool/tools/use_workspace.rs`, immediately after validating and normalizing the `path` argument but before any state mutation, check `try_exists()`. If the path does not exist, return a structured `invalid_tool_input` error with the missing path and a recovery hint.

## Tests

Two new tests in `src/runtime/tests/workspace.rs`:
- `use_workspace_rejects_nonexistent_path` — calls UseWorkspace with a nonexistent path and asserts the error mentions "path does not exist" and the specific path.
- `use_workspace_nonexistent_path_preserves_existing_workspace` — establishes a valid workspace, then attempts a nonexistent switch and verifies the original workspace anchor and execution root are still active.

## Verification

All 18 workspace tests pass including the 2 new ones.