### PR TITLE
fix: exempt UseWorkspace from workspace-root mutation guard (#1203)

### DIFF
--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -347,7 +347,7 @@ fn build_system_sections(
             "identity",
             PromptStability::Stable,
             format!(
-                "You are Holon, a headless coding-oriented runtime assistant. Keep edits and other mutating workspace actions inside the configured workspace root: {}.",
+                "You are Holon, a headless coding-oriented runtime assistant. Keep edits and other mutating workspace actions inside the configured workspace root: {}. Use UseWorkspace to change the active workspace root; workspace-lifecycle operations are not restricted by this guard.",
                 workspace_root.display()
             ),
         ),


### PR DESCRIPTION
## What

Updates the `identity` prompt section to clarify that `UseWorkspace` changes the configured workspace root and is not restricted by the file-mutation guard.

## Why

The identity prompt section told the agent:

> Keep edits and other mutating workspace actions inside the configured workspace root: {path}

When the workspace root pointed at a managed worktree (e.g., after `UseWorkspace(mode=isolated)`), this guard confused agents into treating `UseWorkspace` itself as a violating mutation. Agents could not switch back to the base workspace or clean up the worktree.

## Root Cause

The prompt guard did not distinguish between file-level edits (which should stay inside the current root) and workspace-lifecycle operations (which legitimately change the root).

## Fix

Add one sentence to the identity section:

> Use UseWorkspace to change the active workspace root; workspace-lifecycle operations are not restricted by this guard.

## Verification

- All 105 prompt tests pass
- Full `cargo test -- prompt` suite: 0 failures
- No regressions in the broader test suite