### PR TITLE
fix: isolate agent list from work queue decode errors

### DIFF
--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -414,8 +414,14 @@ impl RuntimeHandle {
     pub async fn agent_list_entry(&self) -> Result<AgentListEntry> {
         let agent = self.agent_state().await?;
         let model = self.model_state_for(&agent);
-        let closure = self.current_closure_decision().await?;
         let identity = self.agent_identity_view().await?;
+        let waiting_reason = if agent.current_run_id.is_some() {
+            Some(WaitingReason::AwaitingExternalChange)
+        } else if agent.status == AgentStatus::Asleep {
+            Some(WaitingReason::AwaitingOperatorInput)
+        } else {
+            None
+        };
         Ok(AgentListEntry {
             identity,
             lifecycle: crate::types::AgentLifecycleHint::from_status(
@@ -425,7 +431,7 @@ impl RuntimeHandle {
             status: agent.status,
             pending: agent.pending,
             current_run_id: agent.current_run_id,
-            waiting_reason: closure.waiting_reason,
+            waiting_reason,
             model: (&model).into(),
             active_workspace_entry: agent
                 .active_workspace_entry

--- a/tests/http_client.rs
+++ b/tests/http_client.rs
@@ -13,6 +13,7 @@ macro_rules! http_async_tests {
 
 http_async_tests!(
     agent_list_entries_are_slim_for_tui_bootstrap,
+    agent_list_entries_do_not_require_decoding_work_queue,
     local_client_over_http_can_read_agent_state_snapshot,
     local_client_over_http_can_stream_events_with_cursor_query,
     local_client_over_http_stream_without_cursor_starts_at_tail,

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -3,6 +3,8 @@
 #![allow(dead_code, unused_imports)]
 
 use std::{
+    fs::OpenOptions,
+    io::Write,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     process::Command,
@@ -178,6 +180,50 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
         .active_workspace_entry
         .as_ref()
         .is_some_and(|entry| entry.projection_metadata.is_none()));
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn agent_list_entries_do_not_require_decoding_work_queue() -> Result<()> {
+    let data_dir = tempdir()?.keep();
+    let workspace_dir = tempdir()?.keep();
+    let mut config = test_config_with_paths(
+        data_dir.clone(),
+        workspace_dir,
+        "127.0.0.1:0".to_string(),
+        ControlAuthMode::Auto,
+    );
+    let (_host, base, server) = spawn_server_with_config(config.clone()).await?;
+
+    let work_items_path = data_dir
+        .join(".holon")
+        .join("ledger")
+        .join("work_items.jsonl");
+    if let Some(parent) = work_items_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&work_items_path)?;
+    writeln!(file, "{{not valid json")?;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base}/agents/list"))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let payload: serde_json::Value = response.json().await?;
+    let entry = payload
+        .as_array()
+        .and_then(|entries| entries.first())
+        .expect("agent list should contain default agent");
+    assert_eq!(entry["identity"]["agent_id"], "default");
+
+    config.http_addr = base.trim_start_matches("http://").to_string();
+    let entries = LocalClient::new(config)?.list_agent_entries().await?;
+    assert_eq!(entries.len(), 1);
 
     server.abort();
     Ok(())


### PR DESCRIPTION
Fixes #1209

## Summary
- keep `/agents/list` entry construction independent from work queue closure decision decoding
- derive list `waiting_reason` from agent lifecycle state only
- add HTTP/local client regression coverage for malformed `work_items.jsonl`

## Verification
- `cargo test --test http_client agent_list_entries_do_not_require_decoding_work_queue`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
