### PR TITLE
fix: serialize JSONL appends and slim agent listing

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -14,6 +14,7 @@ use tokio::{
     sync::RwLock,
     task::{spawn_blocking, JoinHandle},
 };
+use tracing::warn;
 
 use crate::{
     agent_template::{
@@ -31,11 +32,11 @@ use crate::{
     system::WorkspaceAccessMode,
     types::{
         AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry,
-        AgentListModelSummary, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
-        AgentStatus, AgentSummary, AgentVisibility, ChildAgentSummary, ClosureOutcome,
-        ExternalTriggerRecord, ExternalTriggerStatus, OperatorNotificationRecord,
-        RuntimeFailureSummary, TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind,
-        TrustLevel, WorkspaceEntry, WorkspaceOccupancyRecord,
+        AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus,
+        AgentSummary, AgentVisibility, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
+        ExternalTriggerStatus, OperatorNotificationRecord, RuntimeFailureSummary, TaskRecord,
+        TaskStatus, TranscriptEntry, TranscriptEntryKind, TrustLevel, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -95,6 +96,12 @@ struct HostInner {
 struct AgentEntry {
     runtime: RuntimeHandle,
     task: JoinHandle<()>,
+}
+
+fn stopped_unloaded_agent(agent_id: &str) -> AgentState {
+    let mut agent = AgentState::new(agent_id.to_string());
+    agent.status = AgentStatus::Stopped;
+    agent
 }
 
 #[derive(Clone)]
@@ -577,17 +584,24 @@ impl RuntimeHost {
         identity: &AgentIdentityRecord,
     ) -> Result<AgentListEntry> {
         let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
-        let agent = storage.read_agent().unwrap_or_else(|_| {
-            let mut agent = AgentState::new(identity.agent_id.clone());
-            agent.status = AgentStatus::Stopped;
-            Some(agent)
-        });
-        let agent = agent.unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
-        let model = self.agent_list_model_summary_for(&agent);
-        let waiting_reason = match agent.status {
-            AgentStatus::AwaitingTask => Some(crate::types::WaitingReason::AwaitingTaskResult),
-            _ => None,
+        let agent = match storage.read_agent() {
+            Ok(Some(agent)) => agent,
+            Ok(None) => stopped_unloaded_agent(&identity.agent_id),
+            Err(error) => {
+                warn!(
+                    agent_id = %identity.agent_id,
+                    error = %error,
+                    "failed to read agent state for /agents/list; using stopped placeholder"
+                );
+                stopped_unloaded_agent(&identity.agent_id)
+            }
         };
+        let model = crate::runtime::agent_model_state_for_catalog(
+            &RuntimeModelCatalog::from_config(self.config()),
+            &self.runtime_context_config(),
+            &agent,
+        );
+        let waiting_reason = crate::runtime::lightweight_agent_list_waiting_reason(&agent);
         Ok(AgentListEntry {
             identity: AgentIdentityView::from_record(identity, &self.config().default_agent_id),
             lifecycle: AgentLifecycleHint::from_status(&agent.id, agent.status.clone()),
@@ -595,39 +609,11 @@ impl RuntimeHost {
             pending: agent.pending,
             current_run_id: agent.current_run_id,
             waiting_reason,
-            model,
+            model: (&model).into(),
             active_workspace_entry: agent
                 .active_workspace_entry
                 .map(crate::types::ActiveWorkspaceEntry::without_projection_metadata),
         })
-    }
-
-    fn agent_list_model_summary_for(&self, state: &AgentState) -> AgentListModelSummary {
-        let catalog = RuntimeModelCatalog::from_config(self.config());
-        let effective_model = catalog.effective_model(state.model_override.as_ref());
-        let active_model = state
-            .last_requested_model
-            .as_ref()
-            .filter(|requested| *requested == &effective_model)
-            .and_then(|_| state.last_active_model.clone())
-            .unwrap_or_else(|| effective_model.clone());
-        let fallback_active = active_model != effective_model;
-        let effective_chain = catalog.provider_chain(state.model_override.as_ref());
-        AgentListModelSummary {
-            source: if state.model_override.is_some() {
-                crate::types::AgentModelSource::AgentOverride
-            } else {
-                crate::types::AgentModelSource::RuntimeDefault
-            },
-            runtime_default_model: catalog.default_model.clone(),
-            effective_model: effective_model.clone(),
-            requested_model: Some(effective_model),
-            active_model: Some(active_model),
-            fallback_active,
-            effective_fallback_models: effective_chain.into_iter().skip(1).collect(),
-            override_model: state.model_override.clone(),
-            override_reasoning_effort: state.model_override_reasoning_effort.clone(),
-        }
     }
 
     pub fn public_agent_activity_snapshots(&self) -> Result<Vec<PublicAgentActivitySnapshot>> {

--- a/src/host.rs
+++ b/src/host.rs
@@ -30,12 +30,12 @@ use crate::{
     storage::AppStorage,
     system::WorkspaceAccessMode,
     types::{
-        AgentIdentityRecord, AgentIdentityView, AgentKind, AgentListEntry, AgentOwnership,
-        AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus, AgentSummary,
-        AgentVisibility, ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord,
-        ExternalTriggerStatus, OperatorNotificationRecord, RuntimeFailureSummary, TaskRecord,
-        TaskStatus, TranscriptEntry, TranscriptEntryKind, TrustLevel, WorkspaceEntry,
-        WorkspaceOccupancyRecord,
+        AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry,
+        AgentListModelSummary, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
+        AgentStatus, AgentSummary, AgentVisibility, ChildAgentSummary, ClosureOutcome,
+        ExternalTriggerRecord, ExternalTriggerStatus, OperatorNotificationRecord,
+        RuntimeFailureSummary, TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind,
+        TrustLevel, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -554,11 +554,80 @@ impl RuntimeHost {
             record.status == AgentRegistryStatus::Active
                 && record.visibility == AgentVisibility::Public
         }) {
-            let runtime = self.get_or_create_agent(&identity.agent_id).await?;
-            entries.push(runtime.agent_list_entry().await?);
+            let runtime = {
+                let agents = self.inner.agents.read().await;
+                agents
+                    .get(&identity.agent_id)
+                    .filter(|entry| !entry.task.is_finished())
+                    .map(|entry| entry.runtime.clone())
+            };
+            let entry = if let Some(runtime) = runtime {
+                runtime.agent_list_entry().await?
+            } else {
+                self.agent_list_entry_from_storage(&identity)?
+            };
+            entries.push(entry);
         }
         entries.sort_by(|left, right| left.identity.agent_id.cmp(&right.identity.agent_id));
         Ok(entries)
+    }
+
+    fn agent_list_entry_from_storage(
+        &self,
+        identity: &AgentIdentityRecord,
+    ) -> Result<AgentListEntry> {
+        let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
+        let agent = storage.read_agent().unwrap_or_else(|_| {
+            let mut agent = AgentState::new(identity.agent_id.clone());
+            agent.status = AgentStatus::Stopped;
+            Some(agent)
+        });
+        let agent = agent.unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
+        let model = self.agent_list_model_summary_for(&agent);
+        let waiting_reason = match agent.status {
+            AgentStatus::AwaitingTask => Some(crate::types::WaitingReason::AwaitingTaskResult),
+            _ => None,
+        };
+        Ok(AgentListEntry {
+            identity: AgentIdentityView::from_record(identity, &self.config().default_agent_id),
+            lifecycle: AgentLifecycleHint::from_status(&agent.id, agent.status.clone()),
+            status: agent.status,
+            pending: agent.pending,
+            current_run_id: agent.current_run_id,
+            waiting_reason,
+            model,
+            active_workspace_entry: agent
+                .active_workspace_entry
+                .map(crate::types::ActiveWorkspaceEntry::without_projection_metadata),
+        })
+    }
+
+    fn agent_list_model_summary_for(&self, state: &AgentState) -> AgentListModelSummary {
+        let catalog = RuntimeModelCatalog::from_config(self.config());
+        let effective_model = catalog.effective_model(state.model_override.as_ref());
+        let active_model = state
+            .last_requested_model
+            .as_ref()
+            .filter(|requested| *requested == &effective_model)
+            .and_then(|_| state.last_active_model.clone())
+            .unwrap_or_else(|| effective_model.clone());
+        let fallback_active = active_model != effective_model;
+        let effective_chain = catalog.provider_chain(state.model_override.as_ref());
+        AgentListModelSummary {
+            source: if state.model_override.is_some() {
+                crate::types::AgentModelSource::AgentOverride
+            } else {
+                crate::types::AgentModelSource::RuntimeDefault
+            },
+            runtime_default_model: catalog.default_model.clone(),
+            effective_model: effective_model.clone(),
+            requested_model: Some(effective_model),
+            active_model: Some(active_model),
+            fallback_active,
+            effective_fallback_models: effective_chain.into_iter().skip(1).collect(),
+            override_model: state.model_override.clone(),
+            override_reasoning_effort: state.model_override_reasoning_effort.clone(),
+        }
     }
 
     pub fn public_agent_activity_snapshots(&self) -> Result<Vec<PublicAgentActivitySnapshot>> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -70,20 +70,21 @@ use crate::{
     },
     tool::{ToolRegistry, ToolResult},
     types::{
-        ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView, AgentKind, AgentState,
-        AgentStatus, AgentSummary, AuditEvent, BriefRecord, CallbackDeliveryMode,
-        CallbackDeliveryPayload, CallbackDeliveryResult, CallbackIngressDisposition,
-        CancelWaitingResult, ClosureDecision, ContinuationResolution, ControlAction,
-        ExecCommandBatchItemStatus, ExecCommandBatchResult, ExternalTriggerCapability,
-        ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus, ExternalTriggerSummary,
-        LoadedAgentsMd, MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
-        MessageOrigin, PendingWakeHint, Priority, QueueEntryRecord, QueueEntryStatus,
-        ResolvedModelAvailability, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
-        SkillActivationSource, SkillActivationState, SkillCatalogEntry, SkillLoadReason,
-        SkillsRuntimeView, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord,
-        TimerStatus, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
-        WaitingIntentRecord, WaitingIntentStatus, WaitingIntentSummary, WorkItemState,
-        WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
+        ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView, AgentKind, AgentModelSource,
+        AgentModelState, AgentState, AgentStatus, AgentSummary, AuditEvent, BriefRecord,
+        CallbackDeliveryMode, CallbackDeliveryPayload, CallbackDeliveryResult,
+        CallbackIngressDisposition, CancelWaitingResult, ClosureDecision, ContinuationResolution,
+        ControlAction, ExecCommandBatchItemStatus, ExecCommandBatchResult,
+        ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerScope,
+        ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
+        Priority, QueueEntryRecord, QueueEntryStatus, ResolvedModelAvailability,
+        RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
+        SkillActivationState, SkillCatalogEntry, SkillLoadReason, SkillsRuntimeView, TaskKind,
+        TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
+        TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord, WaitingIntentStatus,
+        WaitingIntentSummary, WaitingReason, WorkItemState, WorkspaceEntry,
+        AGENT_HOME_WORKSPACE_ID,
     },
     web::WebConfig,
 };
@@ -135,6 +136,47 @@ impl From<Option<WorkspaceEntry>> for InitialWorkspaceBinding {
             Some(value) => Self::Entry(value),
             None => Self::Detached,
         }
+    }
+}
+
+pub(crate) fn agent_model_state_for_catalog(
+    model_catalog: &RuntimeModelCatalog,
+    base_context_config: &ContextConfig,
+    state: &AgentState,
+) -> AgentModelState {
+    let effective_model = model_catalog.effective_model(state.model_override.as_ref());
+    let active_model = state
+        .last_requested_model
+        .as_ref()
+        .filter(|requested| *requested == &effective_model)
+        .and_then(|_| state.last_active_model.clone())
+        .unwrap_or_else(|| effective_model.clone());
+    let fallback_active = active_model != effective_model;
+    let effective_chain = model_catalog.provider_chain(state.model_override.as_ref());
+    let resolved_policy =
+        model_catalog.resolved_model_policy(base_context_config, state.model_override.as_ref());
+    AgentModelState {
+        source: if state.model_override.is_some() {
+            AgentModelSource::AgentOverride
+        } else {
+            AgentModelSource::RuntimeDefault
+        },
+        runtime_default_model: model_catalog.default_model.clone(),
+        effective_model: effective_model.clone(),
+        requested_model: Some(effective_model),
+        active_model: Some(active_model),
+        fallback_active,
+        effective_fallback_models: effective_chain.into_iter().skip(1).collect(),
+        override_model: state.model_override.clone(),
+        override_reasoning_effort: state.model_override_reasoning_effort.clone(),
+        resolved_policy,
+    }
+}
+
+pub(crate) fn lightweight_agent_list_waiting_reason(agent: &AgentState) -> Option<WaitingReason> {
+    match agent.status {
+        AgentStatus::AwaitingTask => Some(WaitingReason::AwaitingTaskResult),
+        _ => None,
     }
 }
 

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -335,41 +335,11 @@ impl RuntimeHandle {
     }
 
     pub(crate) fn model_state_for(&self, state: &AgentState) -> crate::types::AgentModelState {
-        let effective_model = self
-            .inner
-            .model_catalog
-            .effective_model(state.model_override.as_ref());
-        let active_model = state
-            .last_requested_model
-            .as_ref()
-            .filter(|requested| *requested == &effective_model)
-            .and_then(|_| state.last_active_model.clone())
-            .unwrap_or_else(|| effective_model.clone());
-        let fallback_active = active_model != effective_model;
-        let effective_chain = self
-            .inner
-            .model_catalog
-            .provider_chain(state.model_override.as_ref());
-        let resolved_policy = self.inner.model_catalog.resolved_model_policy(
+        super::agent_model_state_for_catalog(
+            &self.inner.model_catalog,
             &self.inner.base_context_config,
-            state.model_override.as_ref(),
-        );
-        crate::types::AgentModelState {
-            source: if state.model_override.is_some() {
-                crate::types::AgentModelSource::AgentOverride
-            } else {
-                crate::types::AgentModelSource::RuntimeDefault
-            },
-            runtime_default_model: self.inner.model_catalog.default_model.clone(),
-            effective_model: effective_model.clone(),
-            requested_model: Some(effective_model),
-            active_model: Some(active_model),
-            fallback_active,
-            effective_fallback_models: effective_chain.into_iter().skip(1).collect(),
-            override_model: state.model_override.clone(),
-            override_reasoning_effort: state.model_override_reasoning_effort.clone(),
-            resolved_policy,
-        }
+            state,
+        )
     }
 
     pub(crate) async fn reconfigure_provider_for_state(&self, state: &AgentState) -> Result<()> {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -414,8 +414,8 @@ impl RuntimeHandle {
     pub async fn agent_list_entry(&self) -> Result<AgentListEntry> {
         let agent = self.agent_state().await?;
         let model = self.model_state_for(&agent);
-        let closure = self.current_closure_decision().await?;
         let identity = self.agent_identity_view().await?;
+        let waiting_reason = lightweight_agent_list_waiting_reason(&agent);
         Ok(AgentListEntry {
             identity,
             lifecycle: crate::types::AgentLifecycleHint::from_status(
@@ -425,7 +425,7 @@ impl RuntimeHandle {
             status: agent.status,
             pending: agent.pending,
             current_run_id: agent.current_run_id,
-            waiting_reason: closure.waiting_reason,
+            waiting_reason,
             model: (&model).into(),
             active_workspace_entry: agent
                 .active_workspace_entry
@@ -1289,6 +1289,13 @@ impl RuntimeHandle {
 
     pub(super) async fn agent_id(&self) -> Result<String> {
         Ok(self.inner.agent.lock().await.state.id.clone())
+    }
+}
+
+fn lightweight_agent_list_waiting_reason(agent: &AgentState) -> Option<WaitingReason> {
+    match agent.status {
+        AgentStatus::AwaitingTask => Some(WaitingReason::AwaitingTaskResult),
+        _ => None,
     }
 }
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -415,7 +415,7 @@ impl RuntimeHandle {
         let agent = self.agent_state().await?;
         let model = self.model_state_for(&agent);
         let identity = self.agent_identity_view().await?;
-        let waiting_reason = lightweight_agent_list_waiting_reason(&agent);
+        let waiting_reason = super::lightweight_agent_list_waiting_reason(&agent);
         Ok(AgentListEntry {
             identity,
             lifecycle: crate::types::AgentLifecycleHint::from_status(
@@ -1289,13 +1289,6 @@ impl RuntimeHandle {
 
     pub(super) async fn agent_id(&self) -> Result<String> {
         Ok(self.inner.agent.lock().await.state.id.clone())
-    }
-}
-
-fn lightweight_agent_list_waiting_reason(agent: &AgentState) -> Option<WaitingReason> {
-    match agent.status {
-        AgentStatus::AwaitingTask => Some(WaitingReason::AwaitingTaskResult),
-        _ => None,
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,6 +3,7 @@ use std::{
     fs::{self, OpenOptions},
     io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
     time::UNIX_EPOCH,
 };
 
@@ -116,6 +117,7 @@ pub struct AppStorage {
     occupancies_path: PathBuf,
     agent_identities_path: PathBuf,
     agent_path: PathBuf,
+    append_mutex: Arc<Mutex<()>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -175,6 +177,7 @@ impl AppStorage {
             occupancies_path: ledger_dir.join("workspace_occupancies.jsonl"),
             agent_identities_path: ledger_dir.join("agent_identities.jsonl"),
             agent_path: state_dir.join("agent.json"),
+            append_mutex: Arc::new(Mutex::new(())),
             data_dir,
         })
     }
@@ -214,94 +217,107 @@ impl AppStorage {
     }
 
     pub fn append_event(&self, event: &AuditEvent) -> Result<()> {
-        append_jsonl(&self.events_path, event)
+        self.append_jsonl(&self.events_path, event)
     }
 
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
-        append_jsonl(&self.briefs_path, brief)?;
+        self.append_jsonl(&self.briefs_path, brief)?;
         self.mark_memory_index_dirty()
     }
 
     pub fn append_message(&self, message: &MessageEnvelope) -> Result<()> {
-        append_jsonl(&self.messages_path, message)
+        self.append_jsonl(&self.messages_path, message)
     }
 
     pub fn append_task(&self, task: &TaskRecord) -> Result<()> {
-        append_jsonl(&self.tasks_path, task)
+        self.append_jsonl(&self.tasks_path, task)
     }
 
     pub fn append_work_item(&self, record: &WorkItemRecord) -> Result<()> {
-        append_jsonl(&self.work_items_path, record)?;
+        self.append_jsonl(&self.work_items_path, record)?;
         self.mark_memory_index_dirty()
     }
 
     pub fn append_delivery_summary(&self, record: &DeliverySummaryRecord) -> Result<()> {
-        append_jsonl(&self.delivery_summaries_path, record)
+        self.append_jsonl(&self.delivery_summaries_path, record)
     }
 
     pub fn append_work_item_delegation(&self, record: &WorkItemDelegationRecord) -> Result<()> {
-        append_jsonl(&self.work_item_delegations_path, record)
+        self.append_jsonl(&self.work_item_delegations_path, record)
     }
 
     pub fn append_timer(&self, timer: &TimerRecord) -> Result<()> {
-        append_jsonl(&self.timers_path, timer)
+        self.append_jsonl(&self.timers_path, timer)
     }
 
     pub fn append_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
-        append_jsonl(&self.tools_path, record)
+        self.append_jsonl(&self.tools_path, record)
     }
 
     pub fn append_transcript_entry(&self, entry: &TranscriptEntry) -> Result<()> {
-        append_jsonl(&self.transcript_path, entry)
+        self.append_jsonl(&self.transcript_path, entry)
     }
 
     pub fn append_queue_entry(&self, record: &QueueEntryRecord) -> Result<()> {
-        append_jsonl(&self.queue_entries_path, record)
+        self.append_jsonl(&self.queue_entries_path, record)
     }
 
     pub fn append_waiting_intent(&self, record: &WaitingIntentRecord) -> Result<()> {
-        append_jsonl(&self.waiting_intents_path, record)
+        self.append_jsonl(&self.waiting_intents_path, record)
     }
 
     pub fn append_external_trigger(&self, record: &ExternalTriggerRecord) -> Result<()> {
-        append_jsonl(&self.external_triggers_path, record)
+        self.append_jsonl(&self.external_triggers_path, record)
     }
 
     pub fn append_operator_notification(&self, record: &OperatorNotificationRecord) -> Result<()> {
-        append_jsonl(&self.operator_notifications_path, record)
+        self.append_jsonl(&self.operator_notifications_path, record)
     }
 
     pub fn append_operator_transport_binding(
         &self,
         record: &OperatorTransportBinding,
     ) -> Result<()> {
-        append_jsonl(&self.operator_transport_bindings_path, record)
+        self.append_jsonl(&self.operator_transport_bindings_path, record)
     }
 
     pub fn append_operator_delivery_record(&self, record: &OperatorDeliveryRecord) -> Result<()> {
-        append_jsonl(&self.operator_delivery_records_path, record)
+        self.append_jsonl(&self.operator_delivery_records_path, record)
     }
 
     pub fn append_working_memory_delta(&self, record: &WorkingMemoryDelta) -> Result<()> {
-        append_jsonl(&self.working_memory_deltas_path, record)
+        self.append_jsonl(&self.working_memory_deltas_path, record)
     }
 
     pub fn append_context_episode(&self, record: &ContextEpisodeRecord) -> Result<()> {
-        append_jsonl(&self.context_episodes_path, record)?;
+        self.append_jsonl(&self.context_episodes_path, record)?;
         self.mark_memory_index_dirty()
     }
 
     pub fn append_workspace_entry(&self, entry: &WorkspaceEntry) -> Result<()> {
-        append_jsonl(&self.workspaces_path, entry)?;
+        self.append_jsonl(&self.workspaces_path, entry)?;
         self.mark_memory_index_dirty()
     }
 
     pub fn append_workspace_occupancy(&self, entry: &WorkspaceOccupancyRecord) -> Result<()> {
-        append_jsonl(&self.occupancies_path, entry)
+        self.append_jsonl(&self.occupancies_path, entry)
     }
 
     pub fn append_agent_identity(&self, entry: &AgentIdentityRecord) -> Result<()> {
-        append_jsonl(&self.agent_identities_path, entry)
+        self.append_jsonl(&self.agent_identities_path, entry)
+    }
+
+    fn append_jsonl<T: Serialize>(&self, path: &Path, value: &T) -> Result<()> {
+        let line = serde_json::to_string(value)?;
+        let mut bytes = Vec::with_capacity(line.len() + 1);
+        bytes.extend_from_slice(line.as_bytes());
+        bytes.push(b'\n');
+
+        let _guard = self
+            .append_mutex
+            .lock()
+            .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        append_jsonl_bytes(path, &bytes)
     }
 
     pub fn mark_memory_index_dirty(&self) -> Result<()> {
@@ -1029,7 +1045,7 @@ impl AppStorage {
     }
 }
 
-fn append_jsonl<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+fn append_jsonl_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
@@ -1039,8 +1055,7 @@ fn append_jsonl<T: Serialize>(path: &Path, value: &T) -> Result<()> {
         .append(true)
         .open(path)
         .with_context(|| format!("failed to open {}", path.display()))?;
-    let line = serde_json::to_string(value)?;
-    writeln!(file, "{line}")?;
+    file.write_all(bytes)?;
     Ok(())
 }
 
@@ -1524,6 +1539,58 @@ mod tests {
             active[0].recovery,
             Some(TaskRecoverySpec::ChildAgentTask { .. })
         ));
+    }
+
+    #[test]
+    fn cloned_storage_serializes_concurrent_large_task_appends() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+        let thread_count = 8;
+        let records_per_thread = 40;
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(thread_count));
+        let mut handles = Vec::new();
+
+        for thread_index in 0..thread_count {
+            let storage = storage.clone();
+            let barrier = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                for record_index in 0..records_per_thread {
+                    storage
+                        .append_task(&TaskRecord {
+                            id: format!("task-{thread_index}-{record_index}"),
+                            agent_id: "default".into(),
+                            kind: TaskKind::CommandTask,
+                            status: TaskStatus::Completed,
+                            created_at: now,
+                            updated_at: now,
+                            parent_message_id: None,
+                            work_item_id: None,
+                            summary: Some("large concurrent append".into()),
+                            detail: Some(serde_json::json!({
+                                "payload": "x".repeat(16 * 1024),
+                                "thread": thread_index,
+                                "record": record_index,
+                            })),
+                            recovery: None,
+                        })
+                        .unwrap();
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let content = fs::read_to_string(storage.ledger_dir().join("tasks.jsonl")).unwrap();
+        let mut parsed = 0usize;
+        for line in content.lines().filter(|line| !line.trim().is_empty()) {
+            serde_json::from_str::<TaskRecord>(line).unwrap();
+            parsed += 1;
+        }
+        assert_eq!(parsed, thread_count * records_per_thread);
     }
 
     #[test]

--- a/tests/http_client.rs
+++ b/tests/http_client.rs
@@ -13,6 +13,7 @@ macro_rules! http_async_tests {
 
 http_async_tests!(
     agent_list_entries_are_slim_for_tui_bootstrap,
+    agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue,
     local_client_over_http_can_read_agent_state_snapshot,
     local_client_over_http_can_stream_events_with_cursor_query,
     local_client_over_http_stream_without_cursor_starts_at_tail,

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -212,6 +212,15 @@ pub async fn agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue(
         .append(true)
         .open(&work_items_path)?;
     writeln!(file, "{{not valid json")?;
+    let agent_state_path = data_dir
+        .join("agents")
+        .join("corrupt-list")
+        .join(".holon")
+        .join("state")
+        .join("agent.json");
+    if agent_state_path.exists() {
+        std::fs::remove_file(&agent_state_path)?;
+    }
 
     config.workspace_dir = tempdir()?.keep();
     let (_host, base, server) = spawn_server_with_config(config.clone()).await?;
@@ -229,6 +238,14 @@ pub async fn agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue(
             .iter()
             .any(|entry| entry["identity"]["agent_id"] == "corrupt-list"),
         "agent list should include the unloaded public agent"
+    );
+    let corrupt_entry = entries
+        .iter()
+        .find(|entry| entry["identity"]["agent_id"] == "corrupt-list")
+        .expect("corrupt-list entry should be present");
+    assert_eq!(
+        corrupt_entry["status"], "stopped",
+        "unloaded agent without agent.json should not be shown as booting"
     );
 
     let mut client_config = config;

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -3,6 +3,8 @@
 #![allow(dead_code, unused_imports)]
 
 use std::{
+    fs::OpenOptions,
+    io::Write,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     process::Command,
@@ -178,6 +180,65 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
         .active_workspace_entry
         .as_ref()
         .is_some_and(|entry| entry.projection_metadata.is_none()));
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue() -> Result<()> {
+    let data_dir = tempdir()?.keep();
+    let workspace_dir = tempdir()?.keep();
+    let mut config = test_config_with_paths(
+        data_dir.clone(),
+        workspace_dir,
+        "127.0.0.1:0".to_string(),
+        ControlAuthMode::Auto,
+    );
+    let (host, _base, server) = spawn_server_with_config(config.clone()).await?;
+    host.create_named_agent("corrupt-list", None).await?;
+    server.abort();
+
+    let work_items_path = data_dir
+        .join("agents")
+        .join("corrupt-list")
+        .join(".holon")
+        .join("ledger")
+        .join("work_items.jsonl");
+    if let Some(parent) = work_items_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&work_items_path)?;
+    writeln!(file, "{{not valid json")?;
+
+    config.workspace_dir = tempdir()?.keep();
+    let (_host, base, server) = spawn_server_with_config(config.clone()).await?;
+    let response = reqwest::Client::new()
+        .get(format!("{base}/agents/list"))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let payload: serde_json::Value = response.json().await?;
+    let entries = payload
+        .as_array()
+        .expect("agent list response should be an array");
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["identity"]["agent_id"] == "corrupt-list"),
+        "agent list should include the unloaded public agent"
+    );
+
+    let mut client_config = config;
+    client_config.http_addr = base.trim_start_matches("http://").to_string();
+    let entries = LocalClient::new(client_config)?
+        .list_agent_entries()
+        .await?;
+    assert!(entries
+        .iter()
+        .any(|entry| entry.identity.agent_id == "corrupt-list"));
 
     server.abort();
     Ok(())


### PR DESCRIPTION
Fixes #1207
Fixes #1209
Replaces #1210

## Summary
- serialize all AppStorage JSONL append paths through a shared per-storage mutex and single-buffer write
- keep `/agents/list` slim without instantiating unloaded public agent runtimes or decoding work queue ledgers
- preserve only lightweight list waiting reasons, avoiding the asleep => awaiting-operator-input regression from #1210
- add regressions for concurrent large task appends and corrupt unloaded-agent work queue listing

## Verification
- cargo fmt --all -- --check
- cargo test cloned_storage_serializes_concurrent_large_task_appends
- cargo test --test http_client agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue
- cargo test --test http_client agent_list_entries_are_slim_for_tui_bootstrap
- RUSTFLAGS="-D warnings" cargo check --all-targets
