### PR TITLE
feat: add command web search provider config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -406,6 +406,56 @@ pub struct WebProviderConfigFile {
     /// and must be of kind `api_key`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<WebCommandProviderConfigFile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<WebCommandOutputConfigFile>,
+    #[serde(
+        default,
+        skip_serializing_if = "WebProviderLimitsConfigFile::is_default"
+    )]
+    pub limits: WebProviderLimitsConfigFile,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebCommandProviderConfigFile {
+    pub argv: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebCommandOutputConfigFile {
+    #[serde(default)]
+    pub format: WebCommandOutputFormatFile,
+    pub mapping: WebCommandResultMappingFile,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum WebCommandOutputFormatFile {
+    #[default]
+    Json,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebCommandResultMappingFile {
+    pub title: String,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snippet: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct WebProviderLimitsConfigFile {
+    pub timeout_ms: Option<u64>,
+    pub max_output_bytes: Option<usize>,
+}
+
+impl WebProviderLimitsConfigFile {
+    pub fn is_default(value: &Self) -> bool {
+        value == &Self::default()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -578,7 +628,7 @@ impl AppConfig {
             .transpose()?
             .or(stored_config.tui.alternate_screen)
             .unwrap_or(AltScreenMode::Auto);
-        let web_config = crate::web::materialize_web_config(&stored_config.web, &credential_store);
+        let web_config = crate::web::materialize_web_config(&stored_config.web, &credential_store)?;
 
         Ok(Self {
             default_agent_id,
@@ -1847,6 +1897,9 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                     kind,
                     base_url: None,
                     credential_profile: None,
+                    command: None,
+                    output: None,
+                    limits: Default::default(),
                 })
                 .kind = kind;
         }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -26,21 +26,22 @@ impl Default for WebConfig {
     }
 }
 
-impl From<&crate::config::WebConfigFile> for WebConfig {
-    fn from(value: &crate::config::WebConfigFile) -> Self {
-        Self {
+impl TryFrom<&crate::config::WebConfigFile> for WebConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &crate::config::WebConfigFile) -> Result<Self> {
+        Ok(Self {
             fetch: WebFetchConfig::from(&value.fetch),
             search: WebSearchConfig::from(&value.search),
             providers: value
                 .providers
                 .iter()
-                .filter_map(|(id, provider)| {
+                .map(|(id, provider)| {
                     WebProviderConfig::from_file(id, provider)
-                        .ok()
                         .map(|provider| (id.clone(), provider))
                 })
-                .collect(),
-        }
+                .collect::<Result<BTreeMap<_, _>>>()?,
+        })
     }
 }
 
@@ -256,12 +257,6 @@ impl Default for WebProviderLimitsConfig {
     }
 }
 
-impl From<&crate::config::WebProviderConfigFile> for WebProviderConfig {
-    fn from(value: &crate::config::WebProviderConfigFile) -> Self {
-        Self::from_file("", value).expect("non-command web provider config")
-    }
-}
-
 impl WebProviderConfig {
     fn from_file(id: &str, value: &crate::config::WebProviderConfigFile) -> Result<Self> {
         validate_provider_config(id, value)?;
@@ -338,6 +333,24 @@ fn validate_provider_config(
     provider: &crate::config::WebProviderConfigFile,
 ) -> Result<()> {
     if provider.kind != WebProviderKind::Command {
+        if provider.command.is_some() {
+            return Err(anyhow!(
+                "web provider `{id}` kind={} must not configure command.argv; command is only supported for kind=command",
+                provider.kind.as_str()
+            ));
+        }
+        if provider.output.is_some() {
+            return Err(anyhow!(
+                "web provider `{id}` kind={} must not configure output.mapping; command output is only supported for kind=command",
+                provider.kind.as_str()
+            ));
+        }
+        if provider.limits.timeout_ms.is_some() || provider.limits.max_output_bytes.is_some() {
+            return Err(anyhow!(
+                "web provider `{id}` kind={} must not configure command limits; limits are only supported for kind=command",
+                provider.kind.as_str()
+            ));
+        }
         return Ok(());
     }
     let command = provider
@@ -514,7 +527,7 @@ impl WebProviderKind {
                 supports_full_content: false,
                 supports_native_citations: false,
                 default_priority: 40,
-                status: WebProviderSupportStatus::Supported,
+                status: WebProviderSupportStatus::Unsupported,
             },
         }
     }
@@ -523,7 +536,10 @@ impl WebProviderKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{CredentialProfileFile, CredentialStoreFile, WebProviderConfigFile};
+    use crate::config::{
+        CredentialProfileFile, CredentialStoreFile, WebCommandProviderConfigFile,
+        WebProviderConfigFile,
+    };
     use std::collections::BTreeMap;
 
     fn credential_store_with(profile: &str, material: &str) -> CredentialStoreFile {
@@ -536,6 +552,17 @@ mod tests {
             },
         );
         CredentialStoreFile { profiles }
+    }
+
+    fn provider_file(kind: WebProviderKind) -> WebProviderConfigFile {
+        WebProviderConfigFile {
+            kind,
+            base_url: None,
+            credential_profile: None,
+            command: None,
+            output: None,
+            limits: Default::default(),
+        }
     }
 
     #[test]
@@ -649,11 +676,59 @@ mod tests {
     }
 
     #[test]
+    fn try_from_web_config_file_propagates_provider_errors() {
+        let mut file = crate::config::WebConfigFile::default();
+        let mut provider = provider_file(WebProviderKind::Command);
+        provider.command = Some(WebCommandProviderConfigFile {
+            argv: vec!["search".to_string()],
+        });
+        file.providers.insert("cmd".to_string(), provider);
+
+        let error = WebConfig::try_from(&file).unwrap_err().to_string();
+
+        assert!(error.contains("requires output.mapping"));
+    }
+
+    #[test]
+    fn materialize_rejects_command_fields_on_non_command_provider() {
+        let mut file = crate::config::WebConfigFile::default();
+        let mut provider = provider_file(WebProviderKind::Brave);
+        provider.command = Some(WebCommandProviderConfigFile {
+            argv: vec!["search".to_string()],
+        });
+        file.providers.insert("brave".to_string(), provider);
+
+        let error = materialize_web_config(&file, &CredentialStoreFile::default())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("must not configure command.argv"));
+    }
+
+    #[test]
+    fn materialize_rejects_command_limits_on_non_command_provider() {
+        let mut file = crate::config::WebConfigFile::default();
+        let mut provider = provider_file(WebProviderKind::Brave);
+        provider.limits.timeout_ms = Some(1000);
+        file.providers.insert("brave".to_string(), provider);
+
+        let error = materialize_web_config(&file, &CredentialStoreFile::default())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("must not configure command limits"));
+    }
+
+    #[test]
     fn provider_capabilities_mark_reserved_kinds() {
         assert_eq!(
             WebProviderKind::OpenAiNative.capabilities().status,
             WebProviderSupportStatus::NativeOnly
         );
         assert_eq!(WebProviderKind::Brave.capabilities().default_priority, 80);
+        assert_eq!(
+            WebProviderKind::Command.capabilities().status,
+            WebProviderSupportStatus::Unsupported
+        );
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6,6 +6,7 @@ pub mod search;
 
 use std::collections::BTreeMap;
 
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -33,7 +34,11 @@ impl From<&crate::config::WebConfigFile> for WebConfig {
             providers: value
                 .providers
                 .iter()
-                .map(|(id, provider)| (id.clone(), WebProviderConfig::from(provider)))
+                .filter_map(|(id, provider)| {
+                    WebProviderConfig::from_file(id, provider)
+                        .ok()
+                        .map(|provider| (id.clone(), provider))
+                })
                 .collect(),
         }
     }
@@ -206,14 +211,91 @@ pub struct WebProviderConfig {
     /// Empty when no credential profile is configured.
     #[serde(skip)]
     pub api_key: String,
+    pub command: Option<WebCommandProviderConfig>,
+    pub output: Option<WebCommandOutputConfig>,
+    pub limits: WebProviderLimitsConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebCommandProviderConfig {
+    pub argv: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebCommandOutputConfig {
+    pub format: WebCommandOutputFormat,
+    pub mapping: WebCommandResultMapping,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebCommandOutputFormat {
+    Json,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebCommandResultMapping {
+    pub title: String,
+    pub url: String,
+    pub snippet: Option<String>,
+    pub published_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WebProviderLimitsConfig {
+    pub timeout_ms: u64,
+    pub max_output_bytes: usize,
+}
+
+impl Default for WebProviderLimitsConfig {
+    fn default() -> Self {
+        Self {
+            timeout_ms: 10_000,
+            max_output_bytes: 200_000,
+        }
+    }
 }
 
 impl From<&crate::config::WebProviderConfigFile> for WebProviderConfig {
     fn from(value: &crate::config::WebProviderConfigFile) -> Self {
-        Self {
+        Self::from_file("", value).expect("non-command web provider config")
+    }
+}
+
+impl WebProviderConfig {
+    fn from_file(id: &str, value: &crate::config::WebProviderConfigFile) -> Result<Self> {
+        validate_provider_config(id, value)?;
+        Ok(Self {
             kind: value.kind,
             base_url: value.base_url.clone(),
             api_key: String::new(),
+            command: value
+                .command
+                .as_ref()
+                .map(|command| WebCommandProviderConfig {
+                    argv: command.argv.clone(),
+                }),
+            output: value.output.as_ref().map(|output| WebCommandOutputConfig {
+                format: output.format.into(),
+                mapping: WebCommandResultMapping {
+                    title: output.mapping.title.clone(),
+                    url: output.mapping.url.clone(),
+                    snippet: output.mapping.snippet.clone(),
+                    published_at: output.mapping.published_at.clone(),
+                },
+            }),
+            limits: WebProviderLimitsConfig {
+                timeout_ms: value.limits.timeout_ms.unwrap_or(10_000).max(1),
+                max_output_bytes: value.limits.max_output_bytes.unwrap_or(200_000).max(1),
+            },
+        })
+    }
+}
+
+impl From<crate::config::WebCommandOutputFormatFile> for WebCommandOutputFormat {
+    fn from(value: crate::config::WebCommandOutputFormatFile) -> Self {
+        match value {
+            crate::config::WebCommandOutputFormatFile::Json => Self::Json,
         }
     }
 }
@@ -222,36 +304,71 @@ impl From<&crate::config::WebProviderConfigFile> for WebProviderConfig {
 pub fn materialize_web_config(
     file: &crate::config::WebConfigFile,
     credential_store: &CredentialStoreFile,
-) -> WebConfig {
-    WebConfig {
+) -> Result<WebConfig> {
+    let providers = file
+        .providers
+        .iter()
+        .map(|(id, provider)| -> Result<(String, WebProviderConfig)> {
+            let api_key = provider
+                .credential_profile
+                .as_deref()
+                .and_then(|profile| {
+                    credential_store
+                        .profiles
+                        .get(profile)
+                        .filter(|entry| entry.kind == crate::config::CredentialKind::ApiKey)
+                })
+                .map(|entry| entry.material.clone())
+                .unwrap_or_default();
+            let mut provider_config = WebProviderConfig::from_file(id, provider)?;
+            provider_config.api_key = api_key;
+            Ok((id.clone(), provider_config))
+        })
+        .collect::<Result<BTreeMap<_, _>>>()?;
+
+    Ok(WebConfig {
         fetch: WebFetchConfig::from(&file.fetch),
         search: WebSearchConfig::from(&file.search),
-        providers: file
-            .providers
-            .iter()
-            .map(|(id, provider)| {
-                let api_key = provider
-                    .credential_profile
-                    .as_deref()
-                    .and_then(|profile| {
-                        credential_store
-                            .profiles
-                            .get(profile)
-                            .filter(|entry| entry.kind == crate::config::CredentialKind::ApiKey)
-                    })
-                    .map(|entry| entry.material.clone())
-                    .unwrap_or_default();
-                (
-                    id.clone(),
-                    WebProviderConfig {
-                        kind: provider.kind,
-                        base_url: provider.base_url.clone(),
-                        api_key,
-                    },
-                )
-            })
-            .collect(),
+        providers,
+    })
+}
+
+fn validate_provider_config(
+    id: &str,
+    provider: &crate::config::WebProviderConfigFile,
+) -> Result<()> {
+    if provider.kind != WebProviderKind::Command {
+        return Ok(());
     }
+    let command = provider
+        .command
+        .as_ref()
+        .ok_or_else(|| anyhow!("web provider `{id}` kind=command requires command.argv"))?;
+    provider
+        .output
+        .as_ref()
+        .ok_or_else(|| anyhow!("web provider `{id}` kind=command requires output.mapping"))?;
+    let binary = command.argv.first().map(|arg| arg.trim()).unwrap_or("");
+    if binary.is_empty() {
+        return Err(anyhow!(
+            "web provider `{id}` command.argv must not be empty"
+        ));
+    }
+    let basename = binary.rsplit(['/', '\\']).next().unwrap_or(binary);
+    if matches!(
+        basename,
+        "sh" | "bash" | "zsh" | "fish" | "cmd" | "powershell" | "pwsh"
+    ) {
+        return Err(anyhow!(
+            "web provider `{id}` command binary `{binary}` is unsafe"
+        ));
+    }
+    if command.argv.iter().any(|arg| arg.contains('\0')) {
+        return Err(anyhow!(
+            "web provider `{id}` command argv contains a NUL byte"
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -267,6 +384,7 @@ pub enum WebProviderKind {
     OpenAiNative,
     AnthropicNative,
     GeminiNative,
+    Command,
 }
 
 impl WebProviderKind {
@@ -282,6 +400,7 @@ impl WebProviderKind {
             WebProviderKind::OpenAiNative => "open_ai_native",
             WebProviderKind::AnthropicNative => "anthropic_native",
             WebProviderKind::GeminiNative => "gemini_native",
+            WebProviderKind::Command => "command",
         }
     }
 
@@ -385,6 +504,18 @@ impl WebProviderKind {
                 default_priority: 65,
                 status: WebProviderSupportStatus::NativeOnly,
             },
+            WebProviderKind::Command => WebProviderCapabilityMetadata {
+                auth: WebProviderAuthClass::None,
+                cost_class: WebProviderCostClass::Free,
+                quality_hint: WebProviderQualityHint::Keyword,
+                supports_domain_filter: false,
+                supports_freshness: false,
+                supports_region_or_language: false,
+                supports_full_content: false,
+                supports_native_citations: false,
+                default_priority: 40,
+                status: WebProviderSupportStatus::Supported,
+            },
         }
     }
 }
@@ -416,6 +547,9 @@ mod tests {
                 kind: WebProviderKind::Brave,
                 base_url: None,
                 credential_profile: Some("brave_key".to_string()),
+                command: None,
+                output: None,
+                limits: Default::default(),
             },
         );
         let file = crate::config::WebConfigFile {
@@ -424,7 +558,7 @@ mod tests {
             providers,
         };
         let store = credential_store_with("brave_key", "test-api-key-123");
-        let config = materialize_web_config(&file, &store);
+        let config = materialize_web_config(&file, &store).unwrap();
         let provider = config.providers.get("my_brave").unwrap();
         assert_eq!(provider.api_key, "test-api-key-123");
         assert_eq!(provider.kind, WebProviderKind::Brave);
@@ -439,6 +573,9 @@ mod tests {
                 kind: WebProviderKind::Tavily,
                 base_url: None,
                 credential_profile: None,
+                command: None,
+                output: None,
+                limits: Default::default(),
             },
         );
         let file = crate::config::WebConfigFile {
@@ -447,7 +584,7 @@ mod tests {
             providers,
         };
         let store = CredentialStoreFile::default();
-        let config = materialize_web_config(&file, &store);
+        let config = materialize_web_config(&file, &store).unwrap();
         let provider = config.providers.get("my_tavily").unwrap();
         assert!(provider.api_key.is_empty());
     }
@@ -461,6 +598,9 @@ mod tests {
                 kind: WebProviderKind::Brave,
                 base_url: None,
                 credential_profile: Some("missing_profile".to_string()),
+                command: None,
+                output: None,
+                limits: Default::default(),
             },
         );
         let file = crate::config::WebConfigFile {
@@ -470,7 +610,7 @@ mod tests {
         };
         // Credential store does not contain "missing_profile"
         let store = credential_store_with("other", "irrelevant");
-        let config = materialize_web_config(&file, &store);
+        let config = materialize_web_config(&file, &store).unwrap();
         let provider = config.providers.get("my_brave").unwrap();
         assert!(provider.api_key.is_empty());
     }
@@ -484,6 +624,9 @@ mod tests {
                 kind: WebProviderKind::Brave,
                 base_url: None,
                 credential_profile: Some("session_token".to_string()),
+                command: None,
+                output: None,
+                limits: Default::default(),
             },
         );
         let file = crate::config::WebConfigFile {
@@ -500,7 +643,7 @@ mod tests {
                 material: "some-session-hash".to_string(),
             },
         );
-        let config = materialize_web_config(&file, &store);
+        let config = materialize_web_config(&file, &store).unwrap();
         let provider = config.providers.get("my_brave").unwrap();
         assert!(provider.api_key.is_empty());
     }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -460,6 +460,12 @@ async fn search_configured_provider(
         WebProviderKind::Firecrawl => {
             firecrawl_search(query, max_results, provider_id, provider_config, fetch_config).await
         }
+        WebProviderKind::Command => Err(search_error(
+            "provider_unavailable",
+            "WebSearch command providers can be configured but command execution is not implemented yet",
+            provider_id,
+            "configure a built-in web search provider until command provider execution lands",
+        )),
         kind => Err(search_error(
             "provider_unavailable",
             format!("WebSearch provider kind `{kind:?}` is reserved for future provider support"),

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -1379,6 +1379,9 @@ mod tests {
                         kind: WebProviderKind::Searxng,
                         base_url: None,
                         api_key: String::new(),
+                        command: None,
+                        output: None,
+                        limits: Default::default(),
                     },
                 ),
                 ("good", test_provider(WebProviderKind::Searxng, &good_url)),
@@ -1533,6 +1536,9 @@ mod tests {
                         kind: WebProviderKind::Searxng,
                         base_url: None,
                         api_key: String::new(),
+                        command: None,
+                        output: None,
+                        limits: Default::default(),
                     },
                 ),
                 ("good", test_provider(WebProviderKind::Searxng, &good_url)),
@@ -1635,6 +1641,9 @@ mod tests {
             kind,
             base_url: Some(base_url.to_string()),
             api_key: "test-key-123".to_string(),
+            command: None,
+            output: None,
+            limits: Default::default(),
         }
     }
 
@@ -2093,6 +2102,9 @@ mod tests {
             kind: WebProviderKind::Perplexity,
             base_url: Some("http://localhost:1".to_string()),
             api_key: String::new(),
+            command: None,
+            output: None,
+            limits: Default::default(),
         };
 
         let err = perplexity_search(
@@ -2194,6 +2206,9 @@ mod tests {
             kind: WebProviderKind::Firecrawl,
             base_url: Some("http://localhost:1".to_string()),
             api_key: String::new(),
+            command: None,
+            output: None,
+            limits: Default::default(),
         };
 
         let err = firecrawl_search("test", 5, "firecrawl_test", &provider, &test_fetch_config())
@@ -2277,6 +2292,9 @@ mod tests {
             kind: WebProviderKind::Brave,
             base_url: Some("http://localhost:1".to_string()),
             api_key: String::new(),
+            command: None,
+            output: None,
+            limits: Default::default(),
         };
         let err = brave_search("test", 5, "brave_test", &provider, &test_fetch_config())
             .await
@@ -2354,6 +2372,9 @@ mod tests {
             kind: WebProviderKind::Brave,
             base_url: None, // use default https://api.search.brave.com
             api_key,
+            command: None,
+            output: None,
+            limits: Default::default(),
         };
         let fetch_config = test_fetch_config();
 


### PR DESCRIPTION
Refs #1147

## Summary
- add command provider configuration, output mapping, and limits fields for WebSearch providers
- validate command provider definitions while materializing app web config
- update WebSearch provider fixtures/tests for the expanded provider shape

## Verification
- git diff --check
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets