### PR TITLE
feat: lower native web search tools

### DIFF
--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -13,8 +13,8 @@ use super::{
         provider_retry_backoff, RetryDisposition,
     },
     AgentProvider, PromptContentBlock, ProviderAttemptOutcome, ProviderAttemptRecord,
-    ProviderAttemptTimeline, ProviderContextManagementPolicy, ProviderTurnRequest,
-    ProviderTurnResponse,
+    ProviderAttemptTimeline, ProviderContextManagementPolicy, ProviderNativeWebSearchKind,
+    ProviderTurnRequest, ProviderTurnResponse,
 };
 use crate::prompt::PromptStability;
 
@@ -270,6 +270,7 @@ mod tests {
             ),
             conversation: Vec::new(),
             tools: Vec::new(),
+            native_web_search: None,
         };
 
         provider
@@ -475,6 +476,19 @@ impl AgentProvider for FallbackProvider {
                 .candidates
                 .iter()
                 .all(|candidate| candidate.provider.supports_freeform_grammar_tools())
+    }
+
+    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
+        let mut kinds = self
+            .candidates
+            .iter()
+            .map(|candidate| candidate.provider.native_web_search_kind());
+        let first = kinds.next().flatten()?;
+        if kinds.all(|kind| kind == Some(first)) {
+            Some(first)
+        } else {
+            None
+        }
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -25,6 +25,7 @@ pub struct ProviderTurnRequest {
     pub prompt_frame: ProviderPromptFrame,
     pub conversation: Vec<ConversationMessage>,
     pub tools: Vec<ToolSpec>,
+    pub native_web_search: Option<ProviderNativeWebSearchRequest>,
 }
 
 impl ProviderTurnRequest {
@@ -37,6 +38,7 @@ impl ProviderTurnRequest {
             prompt_frame: ProviderPromptFrame::plain(system_prompt),
             conversation,
             tools,
+            native_web_search: None,
         }
     }
 }
@@ -126,6 +128,33 @@ pub struct ProviderRequestDiagnostics {
     pub incremental_continuation: Option<ProviderIncrementalContinuationDiagnostics>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openai_remote_compaction: Option<ProviderOpenAiRemoteCompactionDiagnostics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_web_search: Option<ProviderNativeWebSearchDiagnostics>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderNativeWebSearchKind {
+    OpenAi,
+    Anthropic,
+    Gemini,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderNativeWebSearchRequest {
+    pub kind: ProviderNativeWebSearchKind,
+    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_results: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderNativeWebSearchDiagnostics {
+    pub kind: ProviderNativeWebSearchKind,
+    pub provider_id: String,
+    pub lowered: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -323,6 +352,10 @@ pub trait AgentProvider: Send + Sync {
                 tool
             })
             .collect()
+    }
+
+    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
+        None
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -174,6 +174,7 @@ pub fn provider_turn_request_with_prompt_frame() -> ProviderTurnRequest {
             cache_breakpoint: true,
         }])],
         tools: Vec::new(),
+        native_web_search: None,
     }
 }
 

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -17,7 +17,8 @@ use crate::{
     provider::{
         AgentProvider, AnthropicPromptCacheDiagnostics, CacheBreakpointInfo, ConversationMessage,
         ModelBlock, PromptContentBlock, ProviderCacheUsage, ProviderContextManagementPolicy,
-        ProviderPromptCapability, ProviderTurnRequest, ProviderTurnResponse,
+        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind, ProviderPromptCapability,
+        ProviderTurnRequest, ProviderTurnResponse,
     },
 };
 
@@ -42,7 +43,7 @@ struct MessagesRequest<'a> {
     max_tokens: u32,
     system: Value,
     messages: Vec<ApiMessage>,
-    tools: Vec<ApiTool>,
+    tools: Vec<Value>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     betas: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -80,13 +81,6 @@ struct ContextManagementThreshold {
 struct ApiMessage {
     role: &'static str,
     content: Value,
-}
-
-#[derive(Debug, Serialize)]
-struct ApiTool {
-    name: String,
-    description: String,
-    input_schema: Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -175,15 +169,7 @@ impl AgentProvider for AnthropicProvider {
             max_tokens: self.max_output_tokens,
             system: build_anthropic_system(&request, cache_strategy),
             messages,
-            tools: request
-                .tools
-                .iter()
-                .map(|tool| ApiTool {
-                    name: tool.name.clone(),
-                    description: tool.description.clone(),
-                    input_schema: tool.input_schema.clone(),
-                })
-                .collect(),
+            tools: build_anthropic_tools(&request),
             betas: self.context_management.betas.clone(),
             metadata: build_anthropic_metadata(&request, cache_strategy),
             temperature: (cache_strategy == AnthropicCacheStrategy::ClaudeCodePromptCache)
@@ -292,6 +278,7 @@ impl AgentProvider for AnthropicProvider {
                 openai_request_controls: None,
                 incremental_continuation: None,
                 openai_remote_compaction: None,
+                native_web_search: native_web_search_diagnostics(&request),
             }),
         })
     }
@@ -310,6 +297,10 @@ impl AgentProvider for AnthropicProvider {
             capabilities.push(ProviderPromptCapability::ContextManagement);
         }
         capabilities
+    }
+
+    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
+        Some(ProviderNativeWebSearchKind::Anthropic)
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {
@@ -519,6 +510,44 @@ fn anthropic_request_lowering_mode(
         }
         AnthropicCacheStrategy::MessagesNative => "plain_system",
     }
+}
+
+fn build_anthropic_tools(request: &ProviderTurnRequest) -> Vec<Value> {
+    let mut tools = request
+        .tools
+        .iter()
+        .map(|tool| {
+            json!({
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": tool.input_schema,
+            })
+        })
+        .collect::<Vec<_>>();
+    if matches!(
+        request.native_web_search.as_ref().map(|native| native.kind),
+        Some(ProviderNativeWebSearchKind::Anthropic)
+    ) {
+        tools.push(json!({
+            "type": "web_search_20250305",
+            "name": "web_search"
+        }));
+    }
+    tools
+}
+
+fn native_web_search_diagnostics(
+    request: &ProviderTurnRequest,
+) -> Option<ProviderNativeWebSearchDiagnostics> {
+    let native = request.native_web_search.as_ref()?;
+    let lowered = native.kind == ProviderNativeWebSearchKind::Anthropic;
+    Some(ProviderNativeWebSearchDiagnostics {
+        kind: native.kind,
+        provider_id: native.provider_id.clone(),
+        lowered,
+        fallback_reason: (!lowered)
+            .then(|| "anthropic transport only supports Anthropic-native web search".into()),
+    })
 }
 
 fn build_context_management_request(
@@ -1297,7 +1326,10 @@ fn count_payload_cache_controls(request_payload: &Value) -> (usize, usize) {
 mod tests {
     use super::*;
     use crate::prompt::PromptStability;
-    use crate::provider::{PromptContentBlock, ProviderPromptFrame, ToolResultBlock};
+    use crate::provider::{
+        PromptContentBlock, ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
+        ProviderPromptFrame, ToolResultBlock,
+    };
     use serde_json::json;
 
     #[test]
@@ -1397,6 +1429,7 @@ mod tests {
             },
             conversation: vec![ConversationMessage::UserText("Hello".to_string())],
             tools: vec![],
+            native_web_search: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -1444,6 +1477,7 @@ mod tests {
                 "Hello, how are you?".to_string(),
             )],
             tools: vec![],
+            native_web_search: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -1526,6 +1560,7 @@ mod tests {
                 }]),
             ],
             tools: vec![],
+            native_web_search: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -1580,13 +1615,35 @@ mod tests {
                 Value::String(request.prompt_frame.system_prompt.clone())
             },
             messages: build_anthropic_messages(&request.conversation, rolling_cache_marker),
-            tools: Vec::new(),
+            tools: build_anthropic_tools(request),
             betas: Vec::new(),
             metadata: None,
             temperature: None,
             context_management: None,
         };
         serde_json::to_value(body).expect("test request payload should serialize")
+    }
+
+    #[test]
+    fn anthropic_request_payload_lowers_native_web_search_tool() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("search the web".into())],
+            vec![],
+        );
+        request.native_web_search = Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::Anthropic,
+            provider_id: "anthropic_native".into(),
+            max_results: None,
+        });
+
+        let payload = anthropic_request_payload_for_test(&request);
+
+        assert!(payload["tools"]
+            .as_array()
+            .expect("tools should be an array")
+            .iter()
+            .any(|tool| tool == &json!({ "type": "web_search_20250305", "name": "web_search" })));
     }
 
     #[test]
@@ -1771,6 +1828,7 @@ mod tests {
             },
             conversation: vec![ConversationMessage::UserText("User message".to_string())],
             tools: vec![],
+            native_web_search: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -1815,6 +1873,7 @@ mod tests {
             },
             conversation: vec![],
             tools: vec![],
+            native_web_search: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -15,6 +15,7 @@ use crate::{
     provider::{
         emitted_tool_json_schema, AgentProvider, ConversationMessage, ModelBlock,
         ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
+        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
         ProviderOpenAiRemoteCompactionDiagnostics, ProviderOpenAiRequestControlsDiagnostics,
         ProviderPromptFrame, ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
         ToolSchemaContract,
@@ -371,6 +372,10 @@ impl AgentProvider for OpenAiProvider {
 
     fn supports_freeform_grammar_tools(&self) -> bool {
         true
+    }
+
+    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
+        Some(ProviderNativeWebSearchKind::OpenAi)
     }
 }
 
@@ -860,7 +865,7 @@ pub(crate) fn build_openai_responses_request(
     tool_schema_contract: ToolSchemaContract,
     reasoning_effort: Option<&str>,
 ) -> Result<Value> {
-    let tools = request
+    let mut tools = request
         .tools
         .iter()
         .map(|tool| {
@@ -886,6 +891,9 @@ pub(crate) fn build_openai_responses_request(
             }
         })
         .collect::<Result<Vec<_>>>()?;
+    if let Some(tool) = openai_native_web_search_tool(request) {
+        tools.push(tool);
+    }
 
     let mut body = json!({
         "model": model,
@@ -915,6 +923,14 @@ pub(crate) fn build_openai_responses_request(
         }
     }
     Ok(body)
+}
+
+fn openai_native_web_search_tool(request: &ProviderTurnRequest) -> Option<Value> {
+    let native = request.native_web_search.as_ref()?;
+    if native.kind != ProviderNativeWebSearchKind::OpenAi {
+        return None;
+    }
+    Some(json!({ "type": "web_search_preview" }))
 }
 
 fn openai_request_controls_diagnostics(body: &Value) -> ProviderOpenAiRequestControlsDiagnostics {
@@ -1100,6 +1116,7 @@ fn plan_openai_responses_request(
                 first_mismatch_path: None,
                 mismatch_kind: None,
             }),
+            native_web_search: native_web_search_diagnostics(request),
         },
     })
 }
@@ -1381,7 +1398,22 @@ fn incremental_diagnostics(
             first_mismatch_path: mismatch.first_mismatch_path,
             mismatch_kind: mismatch.mismatch_kind,
         }),
+        native_web_search: None,
     }
+}
+
+fn native_web_search_diagnostics(
+    request: &ProviderTurnRequest,
+) -> Option<ProviderNativeWebSearchDiagnostics> {
+    let native = request.native_web_search.as_ref()?;
+    let lowered = native.kind == ProviderNativeWebSearchKind::OpenAi;
+    Some(ProviderNativeWebSearchDiagnostics {
+        kind: native.kind,
+        provider_id: native.provider_id.clone(),
+        lowered,
+        fallback_reason: (!lowered)
+            .then(|| "openai responses transport only supports OpenAI-native web search".into()),
+    })
 }
 
 fn update_openai_continuation(
@@ -3725,7 +3757,14 @@ fn unsupported_streaming_transport_error(provider_name: &str) -> anyhow::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{chat_completions_url, latest_openai_compaction_index};
+    use super::{
+        build_openai_responses_request, chat_completions_url, latest_openai_compaction_index,
+        OpenAiResponsesTransportContract, ToolSchemaContract,
+    };
+    use crate::provider::{
+        ConversationMessage, ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
+        ProviderTurnRequest,
+    };
     use serde_json::json;
 
     #[test]
@@ -3754,6 +3793,36 @@ mod tests {
             chat_completions_url("https://proxy.example/chat/completions"),
             "https://proxy.example/chat/completions"
         );
+    }
+
+    #[test]
+    fn openai_responses_request_lowers_native_web_search_tool() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("search the web".into())],
+            vec![],
+        );
+        request.native_web_search = Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::OpenAi,
+            provider_id: "openai_native".into(),
+            max_results: Some(5),
+        });
+
+        let body = build_openai_responses_request(
+            "gpt-test",
+            1024,
+            &request,
+            OpenAiResponsesTransportContract::StandardJson,
+            ToolSchemaContract::Strict,
+            None,
+        )
+        .expect("openai responses request should build");
+
+        assert!(body["tools"]
+            .as_array()
+            .expect("tools should be an array")
+            .iter()
+            .any(|tool| tool == &json!({ "type": "web_search_preview" })));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -57,7 +57,10 @@ use crate::{
     ingress::WakeDisposition,
     memory::{mark_working_memory_prompted, refresh_episode_memory, refresh_working_memory},
     prompt::{build_effective_prompt, EffectivePrompt},
-    provider::{provider_attempt_timeline, AgentProvider, ModelBlock},
+    provider::{
+        provider_attempt_timeline, AgentProvider, ModelBlock, ProviderNativeWebSearchKind,
+        ProviderNativeWebSearchRequest,
+    },
     queue::RuntimeQueue,
     skills::{
         find_skill_by_entrypoint, find_skill_by_script_path, load_skills_runtime_view,
@@ -86,7 +89,7 @@ use crate::{
         WaitingIntentSummary, WaitingReason, WorkItemState, WorkspaceEntry,
         AGENT_HOME_WORKSPACE_ID,
     },
-    web::WebConfig,
+    web::{WebConfig, WebProviderKind},
 };
 use command_task::ManagedTaskHandle;
 use continuation::{resolve_continuation, ContinuationTrigger};

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -259,10 +259,14 @@ impl RuntimeHandle {
         Option<ProviderNativeWebSearchRequest>,
     )> {
         let provider = self.current_provider().await;
-        let native_web_search = self.native_web_search_request_for_provider(provider.as_ref());
+        let native_search_provider = self.web_config().native_search_provider();
+        let native_web_search = self.native_web_search_request_for_provider(
+            provider.as_ref(),
+            native_search_provider.as_ref(),
+        );
         let available_tools = self.filter_native_web_search_tools(
             self.filtered_tool_specs(identity)?,
-            native_web_search.is_some(),
+            native_search_provider.is_some(),
         );
         Ok((provider, available_tools, native_web_search))
     }
@@ -270,32 +274,74 @@ impl RuntimeHandle {
     fn native_web_search_request_for_provider(
         &self,
         provider: &dyn AgentProvider,
+        native_search_provider: Option<&(String, WebProviderKind)>,
     ) -> Option<ProviderNativeWebSearchRequest> {
-        let (provider_id, provider_kind) = self.web_config().native_search_provider()?;
-        let kind = match provider_kind {
-            WebProviderKind::OpenAiNative => ProviderNativeWebSearchKind::OpenAi,
-            WebProviderKind::AnthropicNative => ProviderNativeWebSearchKind::Anthropic,
-            WebProviderKind::GeminiNative => ProviderNativeWebSearchKind::Gemini,
-            _ => return None,
-        };
-
-        (provider.native_web_search_kind() == Some(kind)).then_some(
-            ProviderNativeWebSearchRequest {
-                kind,
-                provider_id,
-                max_results: Some(self.web_config().search.max_results),
-            },
+        native_web_search_request_for_config(
+            provider.native_web_search_kind(),
+            native_search_provider,
+            self.web_config().search.max_results,
         )
     }
 
     fn filter_native_web_search_tools(
         &self,
         mut tools: Vec<ToolSpec>,
-        native_web_search: bool,
+        native_search_configured: bool,
     ) -> Vec<ToolSpec> {
-        if native_web_search {
+        if native_search_configured {
             tools.retain(|tool| tool.name != crate::tool::tools::web_search::NAME);
         }
         tools
+    }
+}
+
+fn native_web_search_request_for_config(
+    provider_native_kind: Option<ProviderNativeWebSearchKind>,
+    native_search_provider: Option<&(String, WebProviderKind)>,
+    max_results: usize,
+) -> Option<ProviderNativeWebSearchRequest> {
+    let (provider_id, provider_kind) = native_search_provider?;
+    let kind = match *provider_kind {
+        WebProviderKind::OpenAiNative => ProviderNativeWebSearchKind::OpenAi,
+        WebProviderKind::AnthropicNative => ProviderNativeWebSearchKind::Anthropic,
+        WebProviderKind::GeminiNative => ProviderNativeWebSearchKind::Gemini,
+        _ => return None,
+    };
+
+    (provider_native_kind == Some(kind)).then_some(ProviderNativeWebSearchRequest {
+        kind,
+        provider_id: provider_id.clone(),
+        max_results: Some(max_results.max(1)),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_web_search_request_requires_matching_model_provider() {
+        let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
+
+        assert!(native_web_search_request_for_config(
+            Some(ProviderNativeWebSearchKind::Anthropic),
+            Some(&native_provider),
+            5,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn native_web_search_request_clamps_max_results() {
+        let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
+
+        let request = native_web_search_request_for_config(
+            Some(ProviderNativeWebSearchKind::OpenAi),
+            Some(&native_provider),
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(request.max_results, Some(1));
     }
 }

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tool::ToolSpec;
 
 impl RuntimeHandle {
     pub(super) async fn process_interactive_message(
@@ -31,8 +32,7 @@ impl RuntimeHandle {
             }
             let state = guard.state.clone();
             drop(guard);
-            let available_tools = self.filtered_tool_specs(&identity)?;
-            let provider = self.current_provider().await;
+            let (provider, available_tools, _) = self.provider_tool_selection(&identity).await?;
             let prompt_tools = provider.prompt_tool_specs(&available_tools);
             let workspace = self.workspace_view_from_state(&state)?;
             let execution = self.execution_snapshot_for_view(
@@ -152,8 +152,7 @@ impl RuntimeHandle {
         let continuation = ContinuationTrigger::from_message(&message, None)
             .map(|trigger| resolve_continuation(&prior_closure, &trigger));
         let identity = self.agent_identity_view().await?;
-        let available_tools = self.filtered_tool_specs(&identity)?;
-        let provider = self.current_provider().await;
+        let (provider, available_tools, _) = self.provider_tool_selection(&identity).await?;
         let prompt_tools = provider.prompt_tool_specs(&available_tools);
         let execution = self.execution_snapshot().await?;
         let loaded_agents_md = self.loaded_agents_md_for_state(&agent)?;
@@ -249,5 +248,54 @@ impl RuntimeHandle {
             &[],
             continuation.as_ref(),
         )
+    }
+
+    pub(super) async fn provider_tool_selection(
+        &self,
+        identity: &AgentIdentityView,
+    ) -> Result<(
+        Arc<dyn AgentProvider>,
+        Vec<ToolSpec>,
+        Option<ProviderNativeWebSearchRequest>,
+    )> {
+        let provider = self.current_provider().await;
+        let native_web_search = self.native_web_search_request_for_provider(provider.as_ref());
+        let available_tools = self.filter_native_web_search_tools(
+            self.filtered_tool_specs(identity)?,
+            native_web_search.is_some(),
+        );
+        Ok((provider, available_tools, native_web_search))
+    }
+
+    fn native_web_search_request_for_provider(
+        &self,
+        provider: &dyn AgentProvider,
+    ) -> Option<ProviderNativeWebSearchRequest> {
+        let (provider_id, provider_kind) = self.web_config().native_search_provider()?;
+        let kind = match provider_kind {
+            WebProviderKind::OpenAiNative => ProviderNativeWebSearchKind::OpenAi,
+            WebProviderKind::AnthropicNative => ProviderNativeWebSearchKind::Anthropic,
+            WebProviderKind::GeminiNative => ProviderNativeWebSearchKind::Gemini,
+            _ => return None,
+        };
+
+        (provider.native_web_search_kind() == Some(kind)).then_some(
+            ProviderNativeWebSearchRequest {
+                kind,
+                provider_id,
+                max_results: Some(self.web_config().search.max_results),
+            },
+        )
+    }
+
+    fn filter_native_web_search_tools(
+        &self,
+        mut tools: Vec<ToolSpec>,
+        native_web_search: bool,
+    ) -> Vec<ToolSpec> {
+        if native_web_search {
+            tools.retain(|tool| tool.name != crate::tool::tools::web_search::NAME);
+        }
+        tools
     }
 }

--- a/src/runtime/provider_turn.rs
+++ b/src/runtime/provider_turn.rs
@@ -27,8 +27,8 @@
 use crate::{
     prompt::{render_section, EffectivePrompt, PromptSection, PromptStability},
     provider::{
-        ConversationMessage, PromptContentBlock, ProviderPromptCache, ProviderPromptFrame,
-        ProviderTurnRequest,
+        ConversationMessage, PromptContentBlock, ProviderNativeWebSearchRequest,
+        ProviderPromptCache, ProviderPromptFrame, ProviderTurnRequest,
     },
     tool::ToolSpec,
 };
@@ -50,6 +50,7 @@ pub fn build_provider_prompt_frame(effective_prompt: &EffectivePrompt) -> Provid
 pub fn build_provider_turn_request(
     effective_prompt: &EffectivePrompt,
     available_tools: Vec<ToolSpec>,
+    native_web_search: Option<ProviderNativeWebSearchRequest>,
 ) -> ProviderTurnRequest {
     let (system_blocks, context_blocks) = build_prompt_content_blocks(
         &effective_prompt.system_sections,
@@ -64,6 +65,7 @@ pub fn build_provider_turn_request(
         ),
         conversation: vec![ConversationMessage::UserBlocks(context_blocks)],
         tools: available_tools,
+        native_web_search,
     }
 }
 
@@ -75,11 +77,13 @@ pub fn build_continuation_request(
     prompt_frame: ProviderPromptFrame,
     conversation: Vec<ConversationMessage>,
     available_tools: Vec<ToolSpec>,
+    native_web_search: Option<ProviderNativeWebSearchRequest>,
 ) -> ProviderTurnRequest {
     ProviderTurnRequest {
         prompt_frame,
         conversation,
         tools: available_tools,
+        native_web_search,
     }
 }
 
@@ -198,7 +202,7 @@ mod tests {
             },
         ];
 
-        let request = build_provider_turn_request(&fixture_prompt(), tools.clone());
+        let request = build_provider_turn_request(&fixture_prompt(), tools.clone(), None);
         assert_eq!(
             request
                 .tools
@@ -222,7 +226,7 @@ mod tests {
             freeform_grammar: None,
         }];
 
-        let request = build_provider_turn_request(&effective_prompt, tools);
+        let request = build_provider_turn_request(&effective_prompt, tools, None);
 
         assert_eq!(request.prompt_frame.system_prompt, "system prompt");
         assert_eq!(request.prompt_frame.system_blocks.len(), 0);
@@ -385,7 +389,7 @@ mod tests {
             rendered_context_attachment: "context attachment".to_string(),
         };
 
-        let request = build_provider_turn_request(&effective_prompt, Vec::new());
+        let request = build_provider_turn_request(&effective_prompt, Vec::new(), None);
 
         let system_blocks = request.prompt_frame.system_blocks;
         assert_eq!(system_blocks[0].text, "## identity\nstable system\n\n");
@@ -453,7 +457,7 @@ mod tests {
             }),
         );
 
-        let request = build_continuation_request(prompt_frame, conversation, tools);
+        let request = build_continuation_request(prompt_frame, conversation, tools, None);
 
         assert_eq!(request.prompt_frame.system_prompt, "system");
         assert_eq!(request.prompt_frame.system_blocks.len(), 1);

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1645,7 +1645,8 @@ impl TurnExecution<'_> {
 
             let context_build_started = Instant::now();
             let identity = runtime.agent_identity_view().await?;
-            let available_tools = runtime.filtered_tool_specs(&identity)?;
+            let (provider, available_tools, native_web_search) =
+                runtime.provider_tool_selection(&identity).await?;
             let allowed_tool_names = available_tools
                 .iter()
                 .map(|tool| tool.name.clone())
@@ -1660,8 +1661,11 @@ impl TurnExecution<'_> {
                 provider_completed_at,
                 provider_round_ms,
             ) = if round == 1 {
-                let request = build_provider_turn_request(&effective_prompt, available_tools);
-                let provider = runtime.current_provider().await;
+                let request = build_provider_turn_request(
+                    &effective_prompt,
+                    available_tools,
+                    native_web_search,
+                );
                 let context_management = context_management_diagnostic(provider.as_ref(), &request);
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =
@@ -1891,8 +1895,8 @@ impl TurnExecution<'_> {
                     prompt_frame,
                     projection.conversation,
                     available_tools,
+                    native_web_search,
                 );
-                let provider = runtime.current_provider().await;
                 let context_management = context_management_diagnostic(provider.as_ref(), &request);
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -18,17 +18,16 @@ pub struct WebConfig {
 
 impl WebConfig {
     pub fn native_search_provider(&self) -> Option<(String, WebProviderKind)> {
-        if !self.search.enabled || self.search.provider == "auto" {
+        let provider_id = self.search.provider.trim();
+        if !self.search.enabled || provider_id.is_empty() || provider_id == "auto" {
             return None;
         }
-        self.providers
-            .get(&self.search.provider)
-            .and_then(|provider| {
-                provider
-                    .kind
-                    .is_native_search()
-                    .then(|| (self.search.provider.clone(), provider.kind))
-            })
+        self.providers.get(provider_id).and_then(|provider| {
+            provider
+                .kind
+                .is_native_search()
+                .then(|| (provider_id.to_string(), provider.kind))
+        })
     }
 }
 
@@ -133,8 +132,10 @@ impl From<&crate::config::WebSearchConfigFile> for WebSearchConfig {
             enabled: value.enabled.unwrap_or(fallback.enabled),
             provider: value
                 .provider
-                .clone()
-                .filter(|provider| !provider.trim().is_empty())
+                .as_deref()
+                .map(str::trim)
+                .filter(|provider| !provider.is_empty())
+                .map(ToOwned::to_owned)
                 .unwrap_or(fallback.provider),
             mode: value.mode.unwrap_or(fallback.mode),
             providers: value
@@ -698,6 +699,40 @@ mod tests {
         let config = materialize_web_config(&file, &store).unwrap();
         let provider = config.providers.get("my_brave").unwrap();
         assert!(provider.api_key.is_empty());
+    }
+
+    #[test]
+    fn web_search_config_trims_primary_provider() {
+        let file = crate::config::WebSearchConfigFile {
+            provider: Some("  openai-native  ".to_string()),
+            ..Default::default()
+        };
+
+        let config = WebSearchConfig::from(&file);
+
+        assert_eq!(config.provider, "openai-native");
+    }
+
+    #[test]
+    fn native_search_provider_uses_normalized_provider_id() {
+        let mut config = WebConfig::default();
+        config.search.provider = " openai-native ".to_string();
+        config.providers.insert(
+            "openai-native".to_string(),
+            WebProviderConfig {
+                kind: WebProviderKind::OpenAiNative,
+                base_url: None,
+                api_key: String::new(),
+                command: None,
+                output: None,
+                limits: WebProviderLimitsConfig::default(),
+            },
+        );
+
+        assert_eq!(
+            config.native_search_provider(),
+            Some(("openai-native".to_string(), WebProviderKind::OpenAiNative))
+        );
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -16,6 +16,22 @@ pub struct WebConfig {
     pub providers: BTreeMap<String, WebProviderConfig>,
 }
 
+impl WebConfig {
+    pub fn native_search_provider(&self) -> Option<(String, WebProviderKind)> {
+        if !self.search.enabled || self.search.provider == "auto" {
+            return None;
+        }
+        self.providers
+            .get(&self.search.provider)
+            .and_then(|provider| {
+                provider
+                    .kind
+                    .is_native_search()
+                    .then(|| (self.search.provider.clone(), provider.kind))
+            })
+    }
+}
+
 impl Default for WebConfig {
     fn default() -> Self {
         Self {
@@ -401,6 +417,15 @@ pub enum WebProviderKind {
 }
 
 impl WebProviderKind {
+    pub fn is_native_search(self) -> bool {
+        matches!(
+            self,
+            WebProviderKind::OpenAiNative
+                | WebProviderKind::AnthropicNative
+                | WebProviderKind::GeminiNative
+        )
+    }
+
     pub fn as_str(&self) -> &'static str {
         match self {
             WebProviderKind::DuckDuckGo => "duck_duck_go",

--- a/tests/live_anthropic.rs
+++ b/tests/live_anthropic.rs
@@ -95,6 +95,7 @@ async fn live_provider_accepts_tool_result_continuation_with_runtime_tools() -> 
                 }]),
             ],
             tools,
+            native_web_search: None,
         })
         .await?;
     assert!(!output.blocks.is_empty());

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -89,6 +89,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
                 ConversationMessage::UserText(initial_user_text.clone()),
             ],
             tools: vec![tool.clone()],
+            native_web_search: None,
         })
         .await?;
     let tool_use_id = first_output
@@ -120,6 +121,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
                 }]),
             ],
             tools: vec![tool],
+            native_web_search: None,
         })
         .await?;
 

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -110,6 +110,7 @@ async fn live_openai_codex_replays_provider_window_after_append_match() -> Resul
                 "Reply with exactly READY.".into(),
             )],
             tools: vec![],
+            native_web_search: None,
         })
         .await?;
     let first_text = response_text(&first.blocks);
@@ -127,6 +128,7 @@ async fn live_openai_codex_replays_provider_window_after_append_match() -> Resul
                 ConversationMessage::UserText("Reply with exactly DONE.".into()),
             ],
             tools: vec![],
+            native_web_search: None,
         })
         .await?;
 

--- a/tests/live_openai_codex_compact.rs
+++ b/tests/live_openai_codex_compact.rs
@@ -70,6 +70,7 @@ async fn live_openai_codex_remote_compact_route_probe() -> Result<()> {
                 .map(|index| ConversationMessage::UserText(format!("compact probe item {index}")))
                 .collect(),
             tools: vec![],
+            native_web_search: None,
         })
         .await?;
 


### PR DESCRIPTION
## Summary
- add provider-turn support for native web search requests and diagnostics
- route explicit native web provider config to matching model providers while suppressing the managed `WebSearch` function tool to avoid collisions
- lower OpenAI Responses requests to `web_search_preview` and Anthropic Messages requests to `web_search_20250305`
- keep Gemini native search represented but capability-gated until a Gemini provider transport exists

Closes #1149

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test native_web_search`
