### PR TITLE
feat(provider): add opt-in OpenAI HTTP tracing

### DIFF
--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -942,6 +942,7 @@ async function runHolonRealTask({ runnerConfig, prompt, worktreePath, taskDir, r
   await copyAgentJsonlArtifact(agentDir, taskDir, "transcript.jsonl");
   await copyAgentStateArtifact(agentDir, taskDir, "agent.json");
   await copyAgentJsonlArtifact(agentDir, taskDir, "work_items.jsonl");
+  await copyHolonProviderHttpTraceArtifacts(homeDir, agentId, taskDir);
 
   const briefs = await readAgentJsonlArtifact(agentDir, "briefs.jsonl", taskDir);
   const toolExecutions = await readAgentJsonlArtifact(agentDir, "tools.jsonl", taskDir);
@@ -3913,6 +3914,23 @@ async function copyAgentStateArtifact(agentDir, taskDir, filename) {
       return;
     }
   }
+}
+
+export async function copyHolonProviderHttpTraceArtifacts(homeDir, agentId, taskDir) {
+  const destination = path.join(taskDir, "provider-http-trace");
+  const candidates = [
+    path.join(homeDir, ".holon", "http-trace", agentId),
+    path.join(homeDir, "agents", agentId, ".holon", "http-trace")
+  ];
+  let copied = false;
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      await mkdir(destination, { recursive: true });
+      await cp(candidate, destination, { recursive: true });
+      copied = true;
+    }
+  }
+  return copied;
 }
 
 function latestRecordsById(rows) {

--- a/benchmark/tests/manifest.test.mjs
+++ b/benchmark/tests/manifest.test.mjs
@@ -17,6 +17,7 @@ import {
   classifyBenchmarkFinalizationDecision,
   classifyHolonBenchmarkCompletion,
   collectChangedFilesFromGitOutputs,
+  copyHolonProviderHttpTraceArtifacts,
   captureHolonProviderRequests,
   codexBenchmarkConfigToml,
   detectScopeViolation,
@@ -373,6 +374,27 @@ test("captureHolonProviderRequests redacts sensitive fields", () => {
   );
   assert.equal(captured.rounds[0].token_usage.input_tokens, 123);
   assert.equal(captured.rounds[0].token_usage.output_tokens, 45);
+});
+
+test("copyHolonProviderHttpTraceArtifacts copies home-scoped traces", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "holon-trace-test-"));
+  try {
+    const homeDir = path.join(root, "home");
+    const taskDir = path.join(root, "task");
+    const traceDir = path.join(homeDir, ".holon", "http-trace", "agent-1");
+    await fs.mkdir(traceDir, { recursive: true });
+    await fs.writeFile(path.join(traceDir, "trace.jsonl"), "{\"type\":\"request\"}\n", "utf8");
+
+    const copied = await copyHolonProviderHttpTraceArtifacts(homeDir, "agent-1", taskDir);
+
+    assert.equal(copied, true);
+    assert.equal(
+      await fs.readFile(path.join(taskDir, "provider-http-trace", "trace.jsonl"), "utf8"),
+      "{\"type\":\"request\"}\n"
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 });
 
 test("buildOperatorPrompt preserves legacy push-only PR policy", () => {

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -75,12 +75,14 @@ pub(crate) fn build_candidate(
                 provider_config,
                 &model_ref.model,
                 config.runtime_max_output_tokens,
+                &config.home_dir,
             )?)
         }
         ProviderTransportKind::OpenAiResponses => Arc::new(OpenAiProvider::from_runtime_config(
             provider_config,
             &model_ref.model,
             config.runtime_max_output_tokens,
+            &config.home_dir,
         )?),
         ProviderTransportKind::AnthropicMessages => {
             Arc::new(AnthropicProvider::from_runtime_config(
@@ -94,6 +96,7 @@ pub(crate) fn build_candidate(
                 provider_config,
                 &model_ref.model,
                 config.runtime_max_output_tokens,
+                &config.home_dir,
             )?)
         }
     };

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -308,12 +308,7 @@ fn redact_json_secrets(value: &Value) -> Value {
             map.iter()
                 .map(|(key, value)| {
                     let lowered = key.to_ascii_lowercase();
-                    let value = if lowered.contains("api_key")
-                        || lowered.contains("apikey")
-                        || lowered.contains("token")
-                        || lowered.contains("secret")
-                        || lowered == "authorization"
-                    {
+                    let value = if is_secret_json_key(&lowered) {
                         Value::String("[REDACTED]".into())
                     } else {
                         redact_json_secrets(value)
@@ -325,6 +320,17 @@ fn redact_json_secrets(value: &Value) -> Value {
         Value::Array(items) => Value::Array(items.iter().map(redact_json_secrets).collect()),
         other => other.clone(),
     }
+}
+
+fn is_secret_json_key(lowered: &str) -> bool {
+    lowered.contains("api_key")
+        || lowered.contains("apikey")
+        || lowered.contains("secret")
+        || lowered == "authorization"
+        || lowered == "token"
+        || lowered.ends_with("_token")
+        || lowered.starts_with("token_")
+        || lowered.contains("_token_")
 }
 
 fn request_agent_id(request: &ProviderTurnRequest) -> Option<&str> {
@@ -4260,11 +4266,19 @@ mod tests {
 
         let body = redact_json_secrets(&json!({
             "model": "gpt-test",
+            "max_output_tokens": 4096,
             "access_token": "secret",
-            "nested": { "api_key": "secret" }
+            "nested": {
+                "api_key": "secret",
+                "prompt_tokens": 123,
+                "reasoning_tokens": 45
+            }
         }));
         assert_eq!(body["access_token"], "[REDACTED]");
         assert_eq!(body["nested"]["api_key"], "[REDACTED]");
+        assert_eq!(body["max_output_tokens"], 4096);
+        assert_eq!(body["nested"]["prompt_tokens"], 123);
+        assert_eq!(body["nested"]["reasoning_tokens"], 45);
         assert_eq!(body["model"], "gpt-test");
     }
 

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -5,8 +5,13 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
     sync::{Arc, Mutex, MutexGuard},
     time::Duration,
+    time::SystemTime,
 };
 
 use crate::{
@@ -36,6 +41,7 @@ pub struct OpenAiProvider {
     api_key: Option<String>,
     model: String,
     max_output_tokens: u32,
+    trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
 }
 
@@ -48,6 +54,7 @@ pub struct OpenAiCodexProvider {
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
+    trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
 }
 
@@ -58,6 +65,7 @@ pub struct OpenAiChatCompletionsProvider {
     api_key: Option<String>,
     model: String,
     max_output_tokens: u32,
+    trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
 }
 
@@ -69,6 +77,263 @@ pub(crate) enum OpenAiResponsesTransportContract {
 
 const OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS: usize = 8;
 const OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND: &str = "responses_compact";
+static OPENAI_HTTP_TRACE_SEQ: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug)]
+struct OpenAiHttpTrace {
+    home_dir: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct OpenAiHttpTraceRequest {
+    file_path: Arc<PathBuf>,
+}
+
+impl OpenAiHttpTrace {
+    fn from_env(home_dir: impl Into<PathBuf>) -> Option<Self> {
+        if std::env::var("HOLON_PROVIDER_HTTP_TRACE").ok().as_deref() != Some("1") {
+            return None;
+        }
+        Some(Self {
+            home_dir: home_dir.into(),
+        })
+    }
+
+    fn begin_request(
+        &self,
+        agent_id: Option<&str>,
+        provider: &str,
+        model_ref: Option<&str>,
+        url: &str,
+        endpoint_kind: &str,
+        headers: &[(&str, String)],
+        body: &Value,
+    ) -> Option<OpenAiHttpTraceRequest> {
+        let agent_id = agent_id
+            .filter(|value| !value.trim().is_empty())
+            .map(ToString::to_string)
+            .or_else(|| {
+                std::env::var("HOLON_AGENT_ID")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .unwrap_or_else(|| "unknown-agent".into());
+        let trace_dir = self
+            .home_dir
+            .join(".holon")
+            .join("http-trace")
+            .join(sanitize_trace_path_segment(&agent_id));
+        fs::create_dir_all(&trace_dir).ok()?;
+        let sequence = OPENAI_HTTP_TRACE_SEQ.fetch_add(1, Ordering::Relaxed);
+        let created_at_ms = current_time_millis();
+        let file_path = trace_dir.join(format!("trace-{created_at_ms}-{sequence}.jsonl"));
+        let trace = OpenAiHttpTraceRequest {
+            file_path: Arc::new(file_path),
+        };
+        trace.write_event(json!({
+            "type": "request",
+            "created_at_ms": created_at_ms,
+            "sequence": sequence,
+            "agent_id": agent_id,
+            "provider": provider,
+            "model_ref": model_ref,
+            "endpoint_kind": endpoint_kind,
+            "url": redact_url(url),
+            "headers": redact_headers(headers),
+            "body": redact_json_secrets(body),
+        }));
+        Some(trace)
+    }
+}
+
+impl OpenAiHttpTraceRequest {
+    fn write_event(&self, event: Value) {
+        let Ok(line) = serde_json::to_string(&event) else {
+            return;
+        };
+        let Ok(mut file) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.file_path.as_path())
+        else {
+            return;
+        };
+        let _ = writeln!(file, "{line}");
+    }
+}
+
+fn sanitize_trace_path_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn redact_headers(headers: &[(&str, String)]) -> Value {
+    Value::Array(
+        headers
+            .iter()
+            .map(|(name, value)| {
+                json!({
+                    "name": *name,
+                    "value": redact_header_value(name, value),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn redact_header_map(headers: &reqwest::header::HeaderMap) -> Value {
+    Value::Array(
+        headers
+            .iter()
+            .map(|(name, value)| {
+                let value = value.to_str().unwrap_or("<non-utf8>");
+                json!({
+                    "name": name.as_str(),
+                    "value": redact_header_value(name.as_str(), value),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn trace_response_headers(
+    trace: Option<&OpenAiHttpTraceRequest>,
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+) {
+    if let Some(trace) = trace {
+        trace.write_event(json!({
+            "type": "response_headers",
+            "created_at_ms": current_time_millis(),
+            "status": status.as_u16(),
+            "headers": redact_header_map(headers),
+        }));
+    }
+}
+
+fn trace_response_body(trace: Option<&OpenAiHttpTraceRequest>, body: &str) {
+    if let Some(trace) = trace {
+        trace.write_event(json!({
+            "type": "response_body",
+            "created_at_ms": current_time_millis(),
+            "bytes": body.len(),
+            "body": body,
+        }));
+    }
+}
+
+fn trace_stream_chunk(trace: Option<&OpenAiHttpTraceRequest>, chunk: &[u8]) {
+    if let Some(trace) = trace {
+        trace.write_event(json!({
+            "type": "stream_chunk",
+            "created_at_ms": current_time_millis(),
+            "bytes": chunk.len(),
+            "text": String::from_utf8_lossy(chunk),
+        }));
+    }
+}
+
+fn trace_stream_terminal(trace: Option<&OpenAiHttpTraceRequest>, body: &Value) {
+    if let Some(trace) = trace {
+        trace.write_event(json!({
+            "type": "stream_terminal_response",
+            "created_at_ms": current_time_millis(),
+            "body": body,
+        }));
+    }
+}
+
+fn current_time_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+fn redact_header_value(name: &str, value: &str) -> String {
+    let lowered = name.to_ascii_lowercase();
+    if matches!(
+        lowered.as_str(),
+        "authorization" | "proxy-authorization" | "cookie" | "set-cookie" | "x-api-key"
+    ) {
+        "[REDACTED]".into()
+    } else {
+        value.into()
+    }
+}
+
+fn redact_url(raw: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(raw) else {
+        return raw.into();
+    };
+    if url.password().is_some() {
+        let _ = url.set_password(Some("[REDACTED]"));
+    }
+    if !url.username().is_empty() {
+        let _ = url.set_username("[REDACTED]");
+    }
+    let redacted_pairs = url
+        .query_pairs()
+        .map(|(key, value)| {
+            let lowered = key.to_ascii_lowercase();
+            let value = if lowered.contains("key")
+                || lowered.contains("token")
+                || lowered.contains("secret")
+            {
+                "[REDACTED]".into()
+            } else {
+                value.into_owned()
+            };
+            (key.into_owned(), value)
+        })
+        .collect::<Vec<_>>();
+    if !redacted_pairs.is_empty() {
+        url.query_pairs_mut().clear().extend_pairs(redacted_pairs);
+    }
+    url.to_string()
+}
+
+fn redact_json_secrets(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| {
+                    let lowered = key.to_ascii_lowercase();
+                    let value = if lowered.contains("api_key")
+                        || lowered.contains("apikey")
+                        || lowered.contains("token")
+                        || lowered.contains("secret")
+                        || lowered == "authorization"
+                    {
+                        Value::String("[REDACTED]".into())
+                    } else {
+                        redact_json_secrets(value)
+                    };
+                    (key.clone(), value)
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.iter().map(redact_json_secrets).collect()),
+        other => other.clone(),
+    }
+}
+
+fn request_agent_id(request: &ProviderTurnRequest) -> Option<&str> {
+    request
+        .prompt_frame
+        .cache
+        .as_ref()
+        .map(|cache| cache.agent_id.as_str())
+}
 
 #[derive(Debug, Default)]
 struct OpenAiContinuationState {
@@ -169,13 +434,19 @@ impl OpenAiProvider {
             .providers
             .get(&ProviderId::openai())
             .ok_or_else(|| anyhow::anyhow!("missing openai provider config"))?;
-        Self::from_runtime_config(provider_config, model, config.runtime_max_output_tokens)
+        Self::from_runtime_config(
+            provider_config,
+            model,
+            config.runtime_max_output_tokens,
+            &config.home_dir,
+        )
     }
 
     pub fn from_runtime_config(
         provider_config: &ProviderRuntimeConfig,
         model: &str,
         max_output_tokens: u32,
+        trace_home_dir: &Path,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let api_key = match (provider_config.auth.source, provider_config.auth.kind) {
@@ -203,6 +474,7 @@ impl OpenAiProvider {
             api_key,
             model: model.to_string(),
             max_output_tokens,
+            trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
     }
@@ -214,13 +486,19 @@ impl OpenAiCodexProvider {
             .providers
             .get(&ProviderId::openai_codex())
             .ok_or_else(|| anyhow::anyhow!("missing openai-codex provider config"))?;
-        Self::from_runtime_config(provider_config, model, config.runtime_max_output_tokens)
+        Self::from_runtime_config(
+            provider_config,
+            model,
+            config.runtime_max_output_tokens,
+            &config.home_dir,
+        )
     }
 
     pub fn from_runtime_config(
         provider_config: &ProviderRuntimeConfig,
         model: &str,
         max_output_tokens: u32,
+        trace_home_dir: &Path,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let codex_home = provider_config
@@ -239,6 +517,7 @@ impl OpenAiCodexProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
+            trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
     }
@@ -250,13 +529,19 @@ impl OpenAiChatCompletionsProvider {
             .providers
             .get(&ProviderId::openai())
             .ok_or_else(|| anyhow::anyhow!("missing openai provider config"))?;
-        Self::from_runtime_config(provider_config, model, config.runtime_max_output_tokens)
+        Self::from_runtime_config(
+            provider_config,
+            model,
+            config.runtime_max_output_tokens,
+            &config.home_dir,
+        )
     }
 
     pub fn from_runtime_config(
         provider_config: &ProviderRuntimeConfig,
         model: &str,
         max_output_tokens: u32,
+        trace_home_dir: &Path,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let api_key = match (provider_config.auth.source, provider_config.auth.kind) {
@@ -284,6 +569,7 @@ impl OpenAiChatCompletionsProvider {
             api_key,
             model: model.to_string(),
             max_output_tokens,
+            trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
     }
@@ -309,12 +595,15 @@ impl AgentProvider for OpenAiProvider {
             .as_ref()
             .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
             .unwrap_or_default();
+        let trace = OpenAiHttpTrace::from_env(self.trace_home_dir.clone());
         if let Some(remote_compaction) = maybe_compact_openai_request_plan(
             &self.continuation,
             &mut plan,
             &self.client,
             openai_responses_compact_url(&self.base_url),
             headers.clone(),
+            trace.as_ref(),
+            request_agent_id(&request),
         )
         .await
         {
@@ -326,6 +615,8 @@ impl AgentProvider for OpenAiProvider {
             openai_responses_url(&self.base_url),
             plan.body,
             headers.clone(),
+            trace.as_ref(),
+            request_agent_id(&request),
         )
         .await
         {
@@ -351,6 +642,8 @@ impl AgentProvider for OpenAiProvider {
                 &self.client,
                 openai_responses_compact_url(&self.base_url),
                 headers,
+                trace.as_ref(),
+                request_agent_id(&request),
             )
             .await;
         }
@@ -404,12 +697,15 @@ impl AgentProvider for OpenAiCodexProvider {
             ("OpenAI-Beta", "responses=experimental".to_string()),
             ("originator", self.originator.clone()),
         ];
+        let trace = OpenAiHttpTrace::from_env(self.trace_home_dir.clone());
         if let Some(remote_compaction) = maybe_compact_openai_request_plan(
             &self.continuation,
             &mut plan,
             &self.client,
             openai_codex_responses_compact_url(&self.base_url),
             headers.clone(),
+            trace.as_ref(),
+            request_agent_id(&request),
         )
         .await
         {
@@ -421,6 +717,8 @@ impl AgentProvider for OpenAiCodexProvider {
             openai_codex_responses_url(&self.base_url),
             plan.body,
             headers.clone(),
+            trace.as_ref(),
+            request_agent_id(&request),
         )
         .await
         {
@@ -446,6 +744,8 @@ impl AgentProvider for OpenAiCodexProvider {
                 &self.client,
                 openai_codex_responses_compact_url(&self.base_url),
                 headers,
+                trace.as_ref(),
+                request_agent_id(&request),
             )
             .await;
         }
@@ -483,16 +783,21 @@ impl AgentProvider for OpenAiChatCompletionsProvider {
             &self.continuation,
         )?;
         let sent_diagnostics = plan.diagnostics.clone();
+        let headers = self
+            .api_key
+            .as_ref()
+            .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
+            .unwrap_or_default();
+        let trace = OpenAiHttpTrace::from_env(self.trace_home_dir.clone());
 
         // Send to /v1/chat/completions endpoint
         let parsed = match send_chat_completion_request(
             &self.client,
             chat_completions_url(&self.base_url),
             body,
-            self.api_key
-                .as_ref()
-                .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
-                .unwrap_or_default(),
+            headers,
+            trace.as_ref(),
+            request_agent_id(&request),
         )
         .await
         {
@@ -1483,6 +1788,8 @@ async fn maybe_compact_openai_provider_window(
     client: &Client,
     compact_url: String,
     headers: Vec<(&str, String)>,
+    trace: Option<&OpenAiHttpTrace>,
+    agent_id: Option<&str>,
 ) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
     let Some(scope) = scope else {
         return None;
@@ -1530,43 +1837,21 @@ async fn maybe_compact_openai_provider_window(
         ));
     }
     let compact_body = build_openai_compact_request_body(request_shape, &candidate.items);
-    let compacted =
-        match send_openai_compact_request(client, compact_url.clone(), compact_body, headers).await
-        {
-            Ok(compacted) => compacted,
-            Err(error) => {
-                if is_non_persisted_compact_item_id_error(&error) {
-                    return Some(ProviderOpenAiRemoteCompactionDiagnostics {
-                        status: "invalid_non_persisted_item_id".into(),
-                        trigger_reason: Some("provider_window_item_threshold".into()),
-                        endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
-                        http_status: error_status(&error),
-                        input_items: Some(input_items),
-                        output_items: None,
-                        compaction_items: None,
-                        latest_compaction_index: candidate.latest_compaction_index,
-                        encrypted_content_hashes: None,
-                        encrypted_content_bytes: None,
-                        request_shape_hash: Some(request_shape_hash),
-                        continuation_generation: Some(window.generation),
-                        error: Some(error.to_string()),
-                    });
-                }
-                if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
-                    mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
-                    return Some(openai_compact_unsupported_diagnostics(
-                        "unsupported_endpoint",
-                        "provider_window_item_threshold",
-                        input_items,
-                        candidate.latest_compaction_index,
-                        Some(request_shape_hash),
-                        Some(window.generation),
-                        http_status,
-                        Some(error.to_string()),
-                    ));
-                }
+    let compacted = match send_openai_compact_request(
+        client,
+        compact_url.clone(),
+        compact_body,
+        headers,
+        trace,
+        agent_id,
+    )
+    .await
+    {
+        Ok(compacted) => compacted,
+        Err(error) => {
+            if is_non_persisted_compact_item_id_error(&error) {
                 return Some(ProviderOpenAiRemoteCompactionDiagnostics {
-                    status: "failed".into(),
+                    status: "invalid_non_persisted_item_id".into(),
                     trigger_reason: Some("provider_window_item_threshold".into()),
                     endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                     http_status: error_status(&error),
@@ -1581,7 +1866,36 @@ async fn maybe_compact_openai_provider_window(
                     error: Some(error.to_string()),
                 });
             }
-        };
+            if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
+                mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
+                return Some(openai_compact_unsupported_diagnostics(
+                    "unsupported_endpoint",
+                    "provider_window_item_threshold",
+                    input_items,
+                    candidate.latest_compaction_index,
+                    Some(request_shape_hash),
+                    Some(window.generation),
+                    http_status,
+                    Some(error.to_string()),
+                ));
+            }
+            return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                status: "failed".into(),
+                trigger_reason: Some("provider_window_item_threshold".into()),
+                endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                http_status: error_status(&error),
+                input_items: Some(input_items),
+                output_items: None,
+                compaction_items: None,
+                latest_compaction_index: candidate.latest_compaction_index,
+                encrypted_content_hashes: None,
+                encrypted_content_bytes: None,
+                request_shape_hash: Some(request_shape_hash),
+                continuation_generation: Some(window.generation),
+                error: Some(error.to_string()),
+            });
+        }
+    };
     if compacted.is_empty() {
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_empty_output".into(),
@@ -1688,6 +2002,8 @@ async fn maybe_compact_openai_request_plan(
     client: &Client,
     compact_url: String,
     headers: Vec<(&str, String)>,
+    trace: Option<&OpenAiHttpTrace>,
+    agent_id: Option<&str>,
 ) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
     if plan.diagnostics.request_lowering_mode != "incremental_continuation" {
         return None;
@@ -1748,45 +2064,21 @@ async fn maybe_compact_openai_request_plan(
         ));
     }
     let compact_body = build_openai_compact_request_body(&plan.request_shape, &candidate.items);
-    let compacted =
-        match send_openai_compact_request(client, compact_url.clone(), compact_body, headers).await
-        {
-            Ok(compacted) => compacted,
-            Err(error) => {
-                if is_non_persisted_compact_item_id_error(&error) {
-                    return Some(ProviderOpenAiRemoteCompactionDiagnostics {
-                        status: "invalid_non_persisted_item_id".into(),
-                        trigger_reason: Some(
-                            "provider_window_item_threshold_before_request".into(),
-                        ),
-                        endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
-                        http_status: error_status(&error),
-                        input_items: Some(input_items),
-                        output_items: None,
-                        compaction_items: None,
-                        latest_compaction_index: candidate.latest_compaction_index,
-                        encrypted_content_hashes: None,
-                        encrypted_content_bytes: None,
-                        request_shape_hash: Some(request_shape_hash),
-                        continuation_generation: Some(previous.generation),
-                        error: Some(error.to_string()),
-                    });
-                }
-                if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
-                    mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
-                    return Some(openai_compact_unsupported_diagnostics(
-                        "unsupported_endpoint",
-                        "provider_window_item_threshold_before_request",
-                        input_items,
-                        candidate.latest_compaction_index,
-                        Some(request_shape_hash),
-                        Some(previous.generation),
-                        http_status,
-                        Some(error.to_string()),
-                    ));
-                }
+    let compacted = match send_openai_compact_request(
+        client,
+        compact_url.clone(),
+        compact_body,
+        headers,
+        trace,
+        agent_id,
+    )
+    .await
+    {
+        Ok(compacted) => compacted,
+        Err(error) => {
+            if is_non_persisted_compact_item_id_error(&error) {
                 return Some(ProviderOpenAiRemoteCompactionDiagnostics {
-                    status: "failed".into(),
+                    status: "invalid_non_persisted_item_id".into(),
                     trigger_reason: Some("provider_window_item_threshold_before_request".into()),
                     endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                     http_status: error_status(&error),
@@ -1801,7 +2093,36 @@ async fn maybe_compact_openai_request_plan(
                     error: Some(error.to_string()),
                 });
             }
-        };
+            if let Some(http_status) = unsupported_compact_endpoint_status(&error) {
+                mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
+                return Some(openai_compact_unsupported_diagnostics(
+                    "unsupported_endpoint",
+                    "provider_window_item_threshold_before_request",
+                    input_items,
+                    candidate.latest_compaction_index,
+                    Some(request_shape_hash),
+                    Some(previous.generation),
+                    http_status,
+                    Some(error.to_string()),
+                ));
+            }
+            return Some(ProviderOpenAiRemoteCompactionDiagnostics {
+                status: "failed".into(),
+                trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+                endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
+                http_status: error_status(&error),
+                input_items: Some(input_items),
+                output_items: None,
+                compaction_items: None,
+                latest_compaction_index: candidate.latest_compaction_index,
+                encrypted_content_hashes: None,
+                encrypted_content_bytes: None,
+                request_shape_hash: Some(request_shape_hash),
+                continuation_generation: Some(previous.generation),
+                error: Some(error.to_string()),
+            });
+        }
+    };
     if compacted.is_empty() {
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_empty_output".into(),
@@ -2461,7 +2782,20 @@ async fn send_chat_completion_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
+    trace: Option<&OpenAiHttpTrace>,
+    agent_id: Option<&str>,
 ) -> Result<ParsedOpenAiResponse> {
+    let request_trace = trace.and_then(|trace| {
+        trace.begin_request(
+            agent_id,
+            "openai",
+            Some(&provider_model_ref("openai", &body)),
+            url.as_str(),
+            "chat_completions",
+            &headers,
+            &body,
+        )
+    });
     let mut request = client.post(&url).header("content-type", "application/json");
     for (name, value) in headers {
         request = request.header(name, value);
@@ -2477,10 +2811,16 @@ async fn send_chat_completion_request(
         true,
     )
     .await?;
+    trace_response_headers(
+        request_trace.as_ref(),
+        response.status(),
+        response.headers(),
+    );
 
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_chat_completion_status_error(
             "OpenAI Chat Completions request failed",
             status,
@@ -2498,6 +2838,7 @@ async fn send_chat_completion_request(
             error,
         )
     })?;
+    trace_response_body(request_trace.as_ref(), &body);
 
     let parsed: Value = serde_json::from_str(&body)
         .map_err(|error| invalid_response_error("invalid OpenAI Chat Completions JSON", error))?;
@@ -3088,7 +3429,20 @@ async fn send_openai_responses_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
+    trace: Option<&OpenAiHttpTrace>,
+    agent_id: Option<&str>,
 ) -> Result<ParsedOpenAiResponse> {
+    let request_trace = trace.and_then(|trace| {
+        trace.begin_request(
+            agent_id,
+            "openai",
+            Some(&provider_model_ref("openai", &body)),
+            url.as_str(),
+            "responses",
+            &headers,
+            &body,
+        )
+    });
     let mut request = client.post(&url).header("content-type", "application/json");
     for (name, value) in headers {
         request = request.header(name, value);
@@ -3104,10 +3458,16 @@ async fn send_openai_responses_request(
         true,
     )
     .await?;
+    trace_response_headers(
+        request_trace.as_ref(),
+        response.status(),
+        response.headers(),
+    );
 
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error(
             "OpenAI-style request failed",
             status,
@@ -3125,6 +3485,7 @@ async fn send_openai_responses_request(
             error,
         )
     })?;
+    trace_response_body(request_trace.as_ref(), &body);
     let parsed: Value = serde_json::from_str(&body)
         .map_err(|error| invalid_response_error("invalid OpenAI-style JSON", error))?;
     parse_openai_response_with_transport_state(parsed)
@@ -3135,7 +3496,20 @@ async fn send_openai_compact_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
+    trace: Option<&OpenAiHttpTrace>,
+    agent_id: Option<&str>,
 ) -> Result<Vec<Value>> {
+    let request_trace = trace.and_then(|trace| {
+        trace.begin_request(
+            agent_id,
+            "openai",
+            Some(&provider_model_ref("openai", &body)),
+            url.as_str(),
+            OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND,
+            &headers,
+            &body,
+        )
+    });
     let mut request = client.post(&url).header("content-type", "application/json");
     for (name, value) in headers {
         request = request.header(name, value);
@@ -3151,10 +3525,16 @@ async fn send_openai_compact_request(
         true,
     )
     .await?;
+    trace_response_headers(
+        request_trace.as_ref(),
+        response.status(),
+        response.headers(),
+    );
 
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error(
             "OpenAI compact request failed",
             status,
@@ -3172,6 +3552,7 @@ async fn send_openai_compact_request(
             error,
         )
     })?;
+    trace_response_body(request_trace.as_ref(), &response_body);
     let parsed: Value = serde_json::from_str(&response_body)
         .map_err(|error| invalid_response_error("invalid OpenAI compact JSON", error))?;
     let output = parsed
@@ -3195,7 +3576,20 @@ async fn send_openai_responses_streaming_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
+    trace: Option<&OpenAiHttpTrace>,
+    agent_id: Option<&str>,
 ) -> Result<ParsedOpenAiResponse> {
+    let request_trace = trace.and_then(|trace| {
+        trace.begin_request(
+            agent_id,
+            "openai-codex",
+            Some(&provider_model_ref("openai-codex", &body)),
+            url.as_str(),
+            "responses_streaming",
+            &headers,
+            &body,
+        )
+    });
     let mut request = client.post(&url).header("content-type", "application/json");
     for (name, value) in headers {
         request = request.header(name, value);
@@ -3211,10 +3605,16 @@ async fn send_openai_responses_streaming_request(
         false,
     )
     .await?;
+    trace_response_headers(
+        request_trace.as_ref(),
+        response.status(),
+        response.headers(),
+    );
 
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error(
             "OpenAI-style streaming request failed",
             status,
@@ -3222,7 +3622,8 @@ async fn send_openai_responses_streaming_request(
         ));
     }
 
-    let terminal_response = read_openai_streaming_response(response).await?;
+    let terminal_response =
+        read_openai_streaming_response(response, request_trace.as_ref()).await?;
     parse_openai_response_with_transport_state(terminal_response)
 }
 
@@ -3259,14 +3660,18 @@ async fn send_openai_request(
         })
 }
 
-async fn read_openai_streaming_response(response: Response) -> Result<Value> {
+async fn read_openai_streaming_response(
+    response: Response,
+    trace: Option<&OpenAiHttpTraceRequest>,
+) -> Result<Value> {
     let idle_timeout = stream_idle_timeout();
-    read_openai_streaming_response_with_timeout(response, idle_timeout).await
+    read_openai_streaming_response_with_timeout(response, idle_timeout, trace).await
 }
 
 async fn read_openai_streaming_response_with_timeout(
     response: Response,
     idle_timeout: Duration,
+    trace: Option<&OpenAiHttpTraceRequest>,
 ) -> Result<Value> {
     const MAX_STREAMED_OUTPUT_ITEMS: usize = 128;
 
@@ -3301,6 +3706,7 @@ async fn read_openai_streaming_response_with_timeout(
             )
         })?
     {
+        trace_stream_chunk(trace, &chunk);
         pending.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(newline_idx) = pending.find('\n') {
             let mut line = pending[..newline_idx].to_string();
@@ -3321,10 +3727,10 @@ async fn read_openai_streaming_response_with_timeout(
                     }
                     StreamingSseEvent::Done => return Err(early_done_protocol_violation_error()),
                     StreamingSseEvent::Terminal(response) => {
-                        return Ok(finalize_openai_terminal_response(
-                            response,
-                            &streamed_output_items,
-                        ))
+                        let response =
+                            finalize_openai_terminal_response(response, &streamed_output_items);
+                        trace_stream_terminal(trace, &response);
+                        return Ok(response);
                     }
                 }
                 continue;
@@ -3351,10 +3757,9 @@ async fn read_openai_streaming_response_with_timeout(
         }
         StreamingSseEvent::Done => return Err(early_done_protocol_violation_error()),
         StreamingSseEvent::Terminal(response) => {
-            return Ok(finalize_openai_terminal_response(
-                response,
-                &streamed_output_items,
-            ))
+            let response = finalize_openai_terminal_response(response, &streamed_output_items);
+            trace_stream_terminal(trace, &response);
+            return Ok(response);
         }
     }
 
@@ -3759,6 +4164,7 @@ fn unsupported_streaming_transport_error(provider_name: &str) -> anyhow::Error {
 mod tests {
     use super::{
         build_openai_responses_request, chat_completions_url, latest_openai_compaction_index,
+        redact_headers, redact_json_secrets, redact_url, sanitize_trace_path_segment,
         OpenAiResponsesTransportContract, ToolSchemaContract,
     };
     use crate::provider::{
@@ -3766,6 +4172,7 @@ mod tests {
         ProviderTurnRequest,
     };
     use serde_json::json;
+    use std::fs;
 
     #[test]
     fn chat_completions_url_accepts_openai_compatible_base_urls() {
@@ -3835,5 +4242,75 @@ mod tests {
         ];
 
         assert_eq!(latest_openai_compaction_index(&items), Some(3));
+    }
+
+    #[test]
+    fn openai_http_trace_redacts_secrets() {
+        let headers = redact_headers(&[
+            ("authorization", "Bearer secret".into()),
+            ("openai-beta", "responses=experimental".into()),
+        ]);
+        assert_eq!(headers[0]["value"], "[REDACTED]");
+        assert_eq!(headers[1]["value"], "responses=experimental");
+
+        assert_eq!(
+            redact_url("https://user:pass@example.com/v1/responses?api_key=secret&debug=1"),
+            "https://%5BREDACTED%5D:%5BREDACTED%5D@example.com/v1/responses?api_key=%5BREDACTED%5D&debug=1"
+        );
+
+        let body = redact_json_secrets(&json!({
+            "model": "gpt-test",
+            "access_token": "secret",
+            "nested": { "api_key": "secret" }
+        }));
+        assert_eq!(body["access_token"], "[REDACTED]");
+        assert_eq!(body["nested"]["api_key"], "[REDACTED]");
+        assert_eq!(body["model"], "gpt-test");
+    }
+
+    #[test]
+    fn openai_http_trace_sanitizes_agent_path_segment() {
+        assert_eq!(
+            sanitize_trace_path_segment("agent/with spaces"),
+            "agent_with_spaces"
+        );
+    }
+
+    #[test]
+    fn openai_http_trace_writes_full_request_body_under_home() {
+        let home = tempfile::tempdir().unwrap();
+        let trace = super::OpenAiHttpTrace {
+            home_dir: home.path().to_path_buf(),
+        };
+        let body = json!({
+            "model": "gpt-test",
+            "input": [{ "type": "message", "content": "hello" }],
+            "tools": [{ "type": "function", "name": "ApplyPatch" }]
+        });
+
+        trace
+            .begin_request(
+                Some("agent/one"),
+                "openai",
+                Some("openai/gpt-test"),
+                "https://api.openai.com/v1/responses",
+                "responses",
+                &[("authorization", "Bearer secret".into())],
+                &body,
+            )
+            .expect("trace should be written");
+
+        let trace_dir = home.path().join(".holon/http-trace/agent_one");
+        let entries = fs::read_dir(trace_dir)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        let line = fs::read_to_string(entries[0].path()).unwrap();
+        let event: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(event["type"], "request");
+        assert_eq!(event["body"]["input"][0]["content"], "hello");
+        assert_eq!(event["body"]["tools"][0]["name"], "ApplyPatch");
+        assert_eq!(event["headers"][0]["value"], "[REDACTED]");
     }
 }


### PR DESCRIPTION
## Summary

- Add opt-in OpenAI provider HTTP tracing behind `HOLON_PROVIDER_HTTP_TRACE=1`.
- Write raw request events before send, plus response headers/body and streaming chunks when available.
- Store traces under the active Holon home and copy them into benchmark artifacts as `provider-http-trace/`.

## Details

This captures the exact OpenAI request body sent at the transport boundary, including lowered `input` items, tool schemas, request controls, and compact request bodies. Request headers and known secret-like JSON fields are redacted, while provider request/response bodies remain available for benchmark debugging.

The trace home comes from `AppConfig.home_dir`, so benchmark `--home` works without relying on `HOLON_HOME` being set separately.

Closes #1223

## Verification

- `cargo check --quiet`
- `cargo test openai_http_trace --quiet`
- `cargo test provider::tests::tool_schema::openai_responses_request_sets_store_false --quiet`
- `node --test benchmark/tests/manifest.test.mjs`
