### PR TITLE
fix: surface agent template catalog

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -3,7 +3,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::types::{SkillInstallKind, SkillInstallMode};
+use crate::types::{
+    AgentTemplateCatalogEntry, AgentTemplateSourceKind, SkillInstallKind, SkillInstallMode,
+};
+
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
@@ -374,6 +377,155 @@ fn templates_root() -> Result<PathBuf> {
 
 fn templates_root_for_home(home_dir: &Path) -> PathBuf {
     home_dir.join(".agents").join("templates")
+}
+
+pub(crate) fn discover_agent_templates_catalog(
+    user_home: Option<&Path>,
+    agent_home: &Path,
+) -> Vec<AgentTemplateCatalogEntry> {
+    let user_templates_root = user_home.map(templates_root_for_home);
+    let mut entries = Vec::new();
+
+    if let Some(root) = user_templates_root.as_deref() {
+        entries.extend(discover_local_templates(
+            root,
+            AgentTemplateSourceKind::UserGlobal,
+            false,
+        ));
+    }
+
+    let user_template_ids = entries
+        .iter()
+        .map(|entry| entry.template_id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    for builtin in BUILTIN_TEMPLATES {
+        if user_template_ids.contains(builtin.template_id) {
+            continue;
+        }
+        entries.push(builtin_template_catalog_entry(builtin));
+    }
+
+    entries.extend(discover_local_templates(
+        &agent_home.join("templates"),
+        AgentTemplateSourceKind::AgentHome,
+        true,
+    ));
+    entries.sort_by(|left, right| {
+        (
+            left.source,
+            left.template_id.as_str(),
+            left.path.as_ref().map(|path| path.display().to_string()),
+        )
+            .cmp(&(
+                right.source,
+                right.template_id.as_str(),
+                right.path.as_ref().map(|path| path.display().to_string()),
+            ))
+    });
+    entries
+}
+
+fn builtin_template_catalog_entry(builtin: &BuiltinTemplate) -> AgentTemplateCatalogEntry {
+    AgentTemplateCatalogEntry {
+        catalog_id: format!("builtin:{}", builtin.template_id),
+        template: builtin.template_id.to_string(),
+        template_id: builtin.template_id.to_string(),
+        source: AgentTemplateSourceKind::Builtin,
+        path: None,
+        description: template_description(builtin.agents_md),
+        included_skills: builtin_template_skills(builtin),
+    }
+}
+
+fn discover_local_templates(
+    root: &Path,
+    source: AgentTemplateSourceKind,
+    use_absolute_selector: bool,
+) -> Vec<AgentTemplateCatalogEntry> {
+    let Ok(read_dir) = fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(template_id) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if validate_template_id(template_id).is_err() {
+            continue;
+        }
+        let agents_md_path = path.join(TEMPLATE_AGENTS_FILENAME);
+        let Ok(agents_md) = fs::read_to_string(&agents_md_path) else {
+            continue;
+        };
+        if agents_md.trim().is_empty() {
+            continue;
+        }
+        let template = if use_absolute_selector {
+            path.to_string_lossy().into_owned()
+        } else {
+            template_id.to_string()
+        };
+        entries.push(AgentTemplateCatalogEntry {
+            catalog_id: format!("{}:{}", source.label(), template_id),
+            template,
+            template_id: template_id.to_string(),
+            source,
+            path: Some(path.clone()),
+            description: template_description(&agents_md),
+            included_skills: local_template_skills(&path),
+        });
+    }
+    entries
+}
+
+fn template_description(agents_md: &str) -> String {
+    for line in agents_md.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("<!--") || trimmed.starts_with('#') {
+            continue;
+        }
+        return trimmed.to_string();
+    }
+    agents_md
+        .lines()
+        .find_map(|line| {
+            let heading = line.trim().trim_start_matches('#').trim();
+            (!heading.is_empty()).then(|| heading.to_string())
+        })
+        .unwrap_or_default()
+}
+
+fn local_template_skills(path: &Path) -> Vec<String> {
+    parse_skill_refs(path.join(TEMPLATE_SKILLS_FILENAME))
+        .map(skill_ref_names)
+        .unwrap_or_default()
+}
+
+fn builtin_template_skills(builtin: &BuiltinTemplate) -> Vec<String> {
+    let Some(skills_json) = builtin.skills_json else {
+        return Vec::new();
+    };
+    serde_json::from_str::<TemplateSkillsManifest>(skills_json)
+        .map(|manifest| skill_ref_names(manifest.skill_refs))
+        .unwrap_or_default()
+}
+
+fn skill_ref_names(skill_refs: Vec<TemplateSkillRef>) -> Vec<String> {
+    let mut names = skill_refs
+        .into_iter()
+        .map(|skill_ref| match skill_ref {
+            TemplateSkillRef::Local { path } => path.display().to_string(),
+            TemplateSkillRef::Github { package } => package,
+            TemplateSkillRef::Builtin { name } => name,
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
 }
 
 pub(crate) fn user_home_dir() -> Result<PathBuf> {
@@ -1070,6 +1222,70 @@ mod tests {
         seed_builtin_templates_for_home(home.path()).unwrap();
 
         assert!(template_dir.join("AGENTS.md").is_file());
+    }
+
+    #[test]
+    fn discover_agent_templates_catalog_lists_stable_selectors_and_shadowing() {
+        let user_home = tempdir().unwrap();
+        let agent_home = tempdir().unwrap();
+        let user_templates = templates_root_for_home(user_home.path());
+        let worker = user_templates.join("worker");
+        fs::create_dir_all(&worker).unwrap();
+        fs::write(
+            worker.join(TEMPLATE_AGENTS_FILENAME),
+            "# Worker\n\nDoes worker things\n",
+        )
+        .unwrap();
+        fs::write(
+            worker.join(TEMPLATE_SKILLS_FILENAME),
+            r#"{"skill_refs":[{"kind":"builtin","name":"ghx"}]}"#,
+        )
+        .unwrap();
+
+        let shadowed_default = user_templates.join("holon-default");
+        fs::create_dir_all(&shadowed_default).unwrap();
+        fs::write(
+            shadowed_default.join(TEMPLATE_AGENTS_FILENAME),
+            "# Custom default\n",
+        )
+        .unwrap();
+
+        let local = agent_home.path().join("templates").join("local-agent");
+        fs::create_dir_all(&local).unwrap();
+        fs::write(
+            local.join(TEMPLATE_AGENTS_FILENAME),
+            "# Local agent\n\nLocal template\n",
+        )
+        .unwrap();
+
+        let catalog = discover_agent_templates_catalog(Some(user_home.path()), agent_home.path());
+
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "user_global:holon-default"));
+        assert!(!catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "builtin:holon-default"));
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "builtin:holon-developer"));
+
+        let worker_entry = catalog
+            .iter()
+            .find(|entry| entry.catalog_id == "user_global:worker")
+            .unwrap();
+        assert_eq!(worker_entry.template, "worker");
+        assert_eq!(worker_entry.source, AgentTemplateSourceKind::UserGlobal);
+        assert_eq!(worker_entry.path.as_deref(), Some(worker.as_path()));
+        assert_eq!(worker_entry.description, "Does worker things");
+        assert_eq!(worker_entry.included_skills, vec!["ghx"]);
+
+        let local_entry = catalog
+            .iter()
+            .find(|entry| entry.catalog_id == "agent_home:local-agent")
+            .unwrap();
+        assert_eq!(local_entry.template, local.display().to_string());
+        assert_eq!(local_entry.path.as_deref(), Some(local.as_path()));
     }
 
     #[test]

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -384,32 +384,40 @@ pub(crate) fn discover_agent_templates_catalog(
     agent_home: &Path,
 ) -> Vec<AgentTemplateCatalogEntry> {
     let user_templates_root = user_home.map(templates_root_for_home);
-    let mut entries = Vec::new();
+    let user_entries = if let Some(root) = user_templates_root.as_deref() {
+        discover_local_templates(root, AgentTemplateSourceKind::UserGlobal, false)
+    } else {
+        Vec::new()
+    };
+    let agent_home_entries = discover_local_templates(
+        &agent_home.join("templates"),
+        AgentTemplateSourceKind::AgentHome,
+        true,
+    );
+    let agent_home_template_ids = agent_home_entries
+        .iter()
+        .map(|entry| entry.template_id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
 
-    if let Some(root) = user_templates_root.as_deref() {
-        entries.extend(discover_local_templates(
-            root,
-            AgentTemplateSourceKind::UserGlobal,
-            false,
-        ));
-    }
-
+    let mut entries = user_entries
+        .into_iter()
+        .filter(|entry| !agent_home_template_ids.contains(&entry.template_id))
+        .collect::<Vec<_>>();
     let user_template_ids = entries
         .iter()
         .map(|entry| entry.template_id.clone())
         .collect::<std::collections::BTreeSet<_>>();
+
     for builtin in BUILTIN_TEMPLATES {
-        if user_template_ids.contains(builtin.template_id) {
+        if user_template_ids.contains(builtin.template_id)
+            || agent_home_template_ids.contains(builtin.template_id)
+        {
             continue;
         }
         entries.push(builtin_template_catalog_entry(builtin));
     }
 
-    entries.extend(discover_local_templates(
-        &agent_home.join("templates"),
-        AgentTemplateSourceKind::AgentHome,
-        true,
-    ));
+    entries.extend(agent_home_entries);
     entries.sort_by(|left, right| {
         (
             left.source,
@@ -457,6 +465,11 @@ fn discover_local_templates(
         if validate_template_id(template_id).is_err() {
             continue;
         }
+        if source == AgentTemplateSourceKind::UserGlobal
+            && is_managed_seeded_builtin_template(&path, template_id)
+        {
+            continue;
+        }
         let agents_md_path = path.join(TEMPLATE_AGENTS_FILENAME);
         let Ok(agents_md) = fs::read_to_string(&agents_md_path) else {
             continue;
@@ -482,10 +495,42 @@ fn discover_local_templates(
     entries
 }
 
+fn is_managed_seeded_builtin_template(path: &Path, template_id: &str) -> bool {
+    let Some(builtin) = BUILTIN_TEMPLATES
+        .iter()
+        .find(|builtin| builtin.template_id == template_id)
+    else {
+        return false;
+    };
+    let state = match read_builtin_template_state(path) {
+        Ok(Some(state)) => state,
+        Ok(None) => return false,
+        Err(error) => {
+            tracing::debug!(
+                template_path = %path.display(),
+                %error,
+                "failed to read seeded builtin template state while building catalog"
+            );
+            return false;
+        }
+    };
+    if state.template_id != builtin.template_id
+        || state.version != builtin.version
+        || state.content_hash != builtin_template_content_hash(builtin)
+    {
+        return false;
+    }
+    builtin_template_is_managed(path, &state).unwrap_or(false)
+}
+
 fn template_description(agents_md: &str) -> String {
+    let mut in_html_comment = false;
     for line in agents_md.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with("<!--") || trimmed.starts_with('#') {
+        let Some(trimmed) = trim_leading_html_comments(trimmed, &mut in_html_comment) else {
+            continue;
+        };
+        if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
         return trimmed.to_string();
@@ -499,10 +544,37 @@ fn template_description(agents_md: &str) -> String {
         .unwrap_or_default()
 }
 
+fn trim_leading_html_comments<'a>(mut trimmed: &'a str, in_comment: &mut bool) -> Option<&'a str> {
+    loop {
+        if *in_comment {
+            let end = trimmed.find("-->")?;
+            *in_comment = false;
+            trimmed = trimmed[end + 3..].trim_start();
+            continue;
+        }
+        let Some(after_start) = trimmed.strip_prefix("<!--") else {
+            return Some(trimmed);
+        };
+        let Some(end) = after_start.find("-->") else {
+            *in_comment = true;
+            return None;
+        };
+        trimmed = after_start[end + 3..].trim_start();
+    }
+}
+
 fn local_template_skills(path: &Path) -> Vec<String> {
-    parse_skill_refs(path.join(TEMPLATE_SKILLS_FILENAME))
-        .map(skill_ref_names)
-        .unwrap_or_default()
+    match parse_skill_refs(path.join(TEMPLATE_SKILLS_FILENAME)) {
+        Ok(skill_refs) => skill_ref_names(skill_refs),
+        Err(error) => {
+            tracing::warn!(
+                template_path = %path.display(),
+                %error,
+                "failed to load local agent template skills"
+            );
+            Vec::new()
+        }
+    }
 }
 
 fn builtin_template_skills(builtin: &BuiltinTemplate) -> Vec<String> {
@@ -1229,6 +1301,7 @@ mod tests {
         let user_home = tempdir().unwrap();
         let agent_home = tempdir().unwrap();
         let user_templates = templates_root_for_home(user_home.path());
+        seed_builtin_templates_for_home(user_home.path()).unwrap();
         let worker = user_templates.join("worker");
         fs::create_dir_all(&worker).unwrap();
         fs::write(
@@ -1269,6 +1342,9 @@ mod tests {
         assert!(catalog
             .iter()
             .any(|entry| entry.catalog_id == "builtin:holon-developer"));
+        assert!(!catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "user_global:holon-developer"));
 
         let worker_entry = catalog
             .iter()
@@ -1286,6 +1362,65 @@ mod tests {
             .unwrap();
         assert_eq!(local_entry.template, local.display().to_string());
         assert_eq!(local_entry.path.as_deref(), Some(local.as_path()));
+    }
+
+    #[test]
+    fn discover_agent_templates_catalog_prefers_agent_home_over_other_sources() {
+        let user_home = tempdir().unwrap();
+        let agent_home = tempdir().unwrap();
+        let user_templates = templates_root_for_home(user_home.path());
+        seed_builtin_templates_for_home(user_home.path()).unwrap();
+
+        let user_worker = user_templates.join("worker");
+        fs::create_dir_all(&user_worker).unwrap();
+        fs::write(
+            user_worker.join(TEMPLATE_AGENTS_FILENAME),
+            "# User worker\n\nUser-global worker\n",
+        )
+        .unwrap();
+
+        let agent_templates = agent_home.path().join("templates");
+        let agent_worker = agent_templates.join("worker");
+        fs::create_dir_all(&agent_worker).unwrap();
+        fs::write(
+            agent_worker.join(TEMPLATE_AGENTS_FILENAME),
+            "# Agent worker\n\nAgent-home worker\n",
+        )
+        .unwrap();
+        let agent_default = agent_templates.join("holon-default");
+        fs::create_dir_all(&agent_default).unwrap();
+        fs::write(
+            agent_default.join(TEMPLATE_AGENTS_FILENAME),
+            "# Agent default\n\nAgent-home default\n",
+        )
+        .unwrap();
+
+        let catalog = discover_agent_templates_catalog(Some(user_home.path()), agent_home.path());
+
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "agent_home:worker"));
+        assert!(!catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "user_global:worker"));
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "agent_home:holon-default"));
+        assert!(!catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "builtin:holon-default"));
+        assert!(!catalog
+            .iter()
+            .any(|entry| entry.catalog_id == "user_global:holon-default"));
+    }
+
+    #[test]
+    fn template_description_skips_multiline_html_comments() {
+        assert_eq!(
+            template_description("<!--\nmetadata\n-->\n# Heading\n\nVisible description\n"),
+            "Visible description"
+        );
+        assert_eq!(template_description("<!-- hidden --> Visible\n"), "Visible");
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -155,6 +155,42 @@ pub fn build_context(
         );
     }
 
+    if !skills.agent_templates_catalog.is_empty() {
+        let rendered = skills
+            .agent_templates_catalog
+            .iter()
+            .map(|entry| {
+                let skills = if entry.included_skills.is_empty() {
+                    "skills=none".to_string()
+                } else {
+                    format!("skills={}", entry.included_skills.join(","))
+                };
+                let path = entry
+                    .path
+                    .as_ref()
+                    .map(|path| format!(" path={}", path.display()))
+                    .unwrap_or_default();
+                format!(
+                    "- [{}] {} template={} :: {}{} ({skills})",
+                    entry.source.label(),
+                    entry.catalog_id,
+                    entry.template,
+                    entry.description,
+                    path
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        push_budgeted_section(
+            &mut sections,
+            &mut remaining_budget,
+            section(
+                "agent_templates_catalog",
+                format!("Discovered agent templates catalog:\n{rendered}"),
+            ),
+        );
+    }
+
     if !skills.discoverable_skills.is_empty() {
         let rendered = skills
             .discoverable_skills
@@ -2416,6 +2452,7 @@ mod tests {
 
         let session = AgentState::new("default");
         let skills = SkillsRuntimeView {
+            agent_templates_catalog: Vec::new(),
             discovered_roots: Vec::new(),
             discoverable_skills: vec![crate::types::SkillCatalogEntry {
                 skill_id: "workspace:demo".into(),
@@ -2472,6 +2509,64 @@ mod tests {
             .expect("active_skills section should be present");
         assert!(active.content.contains("workspace:demo"));
         assert!(active.content.contains("session_active"));
+    }
+
+    #[test]
+    fn build_context_lists_agent_template_catalog_without_template_body() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Use a helper template".to_string(),
+            },
+        );
+
+        let session = AgentState::new("default");
+        let skills = SkillsRuntimeView {
+            agent_templates_catalog: vec![crate::types::AgentTemplateCatalogEntry {
+                catalog_id: "builtin:demo".into(),
+                template: "demo".into(),
+                template_id: "demo".into(),
+                source: crate::types::AgentTemplateSourceKind::Builtin,
+                path: None,
+                description: "demo template summary".into(),
+                included_skills: vec!["ghx".into()],
+            }],
+            ..SkillsRuntimeView::default()
+        };
+
+        let built = build_context(
+            &storage,
+            &session,
+            &execution_snapshot_for(&session),
+            &skills,
+            &current_message,
+            None,
+            &ContextConfig {
+                recent_messages: 4,
+                recent_briefs: 4,
+                compaction_trigger_messages: 10,
+                compaction_keep_recent_messages: 4,
+                ..ContextConfig::default()
+            },
+        )
+        .unwrap();
+
+        let catalog = built
+            .sections
+            .iter()
+            .find(|section| section.name == "agent_templates_catalog")
+            .expect("agent_templates_catalog section should be present");
+        assert!(catalog.content.contains("builtin:demo"));
+        assert!(catalog.content.contains("template=demo"));
+        assert!(catalog.content.contains("demo template summary"));
+        assert!(catalog.content.contains("skills=ghx"));
     }
 
     #[test]
@@ -3663,6 +3758,7 @@ mod tests {
             .current_work_item_id = Some(current_work_item.id.clone());
 
         let skills = crate::types::SkillsRuntimeView {
+            agent_templates_catalog: Vec::new(),
             discoverable_skills: vec![crate::types::SkillCatalogEntry {
                 skill_id: "skill/large-catalog-entry".into(),
                 name: "Large Catalog Entry".into(),

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -1553,7 +1553,6 @@ mod tests {
             Path::new("."),
             &LoadedAgentsMd::default(),
             &SkillsRuntimeView {
-                discovered_roots: Vec::new(),
                 discoverable_skills: vec![crate::types::SkillCatalogEntry {
                     skill_id: "user:demo".into(),
                     name: "demo".into(),
@@ -1561,8 +1560,7 @@ mod tests {
                     path: PathBuf::from("/tmp/user/.agents/skills/demo/SKILL.md"),
                     scope: crate::types::SkillScope::User,
                 }],
-                attached_skills: Vec::new(),
-                active_skills: Vec::new(),
+                ..SkillsRuntimeView::default()
             },
             &[],
         );

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -49,6 +49,7 @@ use uuid::Uuid;
 #[cfg(test)]
 use crate::provider::{ConversationMessage, ProviderTurnRequest};
 use crate::{
+    agent_template::discover_agent_templates_catalog,
     agents_md::load_agents_md,
     brief,
     config::RuntimeModelCatalog,
@@ -599,7 +600,7 @@ impl RuntimeHandle {
         state: &AgentState,
         identity: &AgentIdentityView,
     ) -> Result<SkillsRuntimeView> {
-        load_skills_runtime_view(
+        let mut view = load_skills_runtime_view(
             self.skill_visibility(identity),
             self.user_home().as_deref(),
             self.agent_home().as_path(),
@@ -608,7 +609,12 @@ impl RuntimeHandle {
                 .as_ref()
                 .map(|entry| entry.workspace_anchor.as_path()),
             &state.active_skills,
-        )
+        )?;
+        view.agent_templates_catalog = discover_agent_templates_catalog(
+            self.user_home().as_deref(),
+            self.agent_home().as_path(),
+        );
+        Ok(view)
     }
 
     async fn begin_interactive_turn(

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -79,6 +79,7 @@ pub fn load_skills_runtime_view(
         .collect::<Vec<_>>();
 
     Ok(SkillsRuntimeView {
+        agent_templates_catalog: Vec::new(),
         discovered_roots,
         discoverable_skills,
         attached_skills,

--- a/src/types.rs
+++ b/src/types.rs
@@ -506,14 +506,23 @@ impl AgentTemplateSourceKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTemplateCatalogEntry {
+    /// Stable source-scoped catalog identifier, such as `builtin:holon-default`.
     pub catalog_id: String,
+    /// Selector accepted by SpawnAgent.template.
+    ///
+    /// Builtin and user-global templates use the bare template id; agent-home
+    /// templates use an absolute local path.
     pub template: String,
+    /// Human-readable local id after precedence is applied.
     pub template_id: String,
     pub source: AgentTemplateSourceKind,
+    /// Filesystem location for local templates; builtins have no path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
+    /// Short display summary derived from the template AGENTS.md.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
+    /// Skill names declared by the template manifest, if any.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub included_skills: Vec<String>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -486,6 +486,38 @@ pub struct SkillRootView {
     pub path: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTemplateSourceKind {
+    Builtin,
+    UserGlobal,
+    AgentHome,
+}
+
+impl AgentTemplateSourceKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+            Self::UserGlobal => "user_global",
+            Self::AgentHome => "agent_home",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTemplateCatalogEntry {
+    pub catalog_id: String,
+    pub template: String,
+    pub template_id: String,
+    pub source: AgentTemplateSourceKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub included_skills: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillActivationSource {
@@ -688,6 +720,8 @@ pub struct ActiveSkillRecord {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SkillsRuntimeView {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agent_templates_catalog: Vec<AgentTemplateCatalogEntry>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub discovered_roots: Vec<SkillRootView>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## Summary
- discover builtin, user-global, and agent-home templates into a compact agent_templates_catalog
- inject the catalog into runtime context without loading template bodies
- add stable namespaced catalog ids plus included skill summaries and deterministic builtin shadowing

Closes #1137

## Verification
- cargo test agent_template -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-D warnings" cargo check --all-targets