### PR TITLE
fix: defer model fallback across turn lineage

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -757,6 +757,23 @@ impl RuntimeModelCatalog {
         }
         chain
     }
+
+    pub fn provider_chain_for_turn(
+        &self,
+        model_override: Option<&ModelRef>,
+        pending_fallback_model: Option<&ModelRef>,
+    ) -> Vec<ModelRef> {
+        let chain = self.provider_chain(model_override);
+        let Some(pending_fallback_model) = pending_fallback_model else {
+            return chain;
+        };
+        chain
+            .iter()
+            .position(|model| model == pending_fallback_model)
+            .map(|index| chain[index..].to_vec())
+            .unwrap_or_else(|| vec![pending_fallback_model.clone()])
+    }
+
     pub fn effective_model(&self, model_override: Option<&ModelRef>) -> ModelRef {
         model_override
             .cloned()
@@ -4874,6 +4891,33 @@ mod tests {
                 "openai/gpt-5.4-mini",
                 "anthropic/claude-sonnet-4-6",
                 "openai/gpt-5.4",
+            ]
+        );
+    }
+
+    #[test]
+    fn provider_chain_for_turn_starts_at_pending_fallback_model() {
+        let fixture = test_app_config(
+            "openai/gpt-5.4",
+            &[
+                "anthropic/claude-sonnet-4-6",
+                "openai-codex/gpt-5.3-codex-spark",
+            ],
+        );
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+        let pending = ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap();
+
+        let chain = catalog
+            .provider_chain_for_turn(None, Some(&pending))
+            .into_iter()
+            .map(|model| model.as_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            chain,
+            vec![
+                "anthropic/claude-sonnet-4-6",
+                "openai-codex/gpt-5.3-codex-spark",
             ]
         );
     }

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -183,7 +183,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn model_visible_hint_marks_fallback_attempt_with_requested_model() {
+    async fn fallback_candidate_is_recorded_but_not_invoked_in_the_same_turn() {
         let prompts = Arc::new(Mutex::new(Vec::new()));
         let system_blocks = Arc::new(Mutex::new(Vec::new()));
         let provider = FallbackProvider {
@@ -211,33 +211,30 @@ mod tests {
             ],
         };
 
-        let (_response, timeline) = provider
+        let error = provider
             .complete_turn_with_diagnostics(ProviderTurnRequest::plain(
                 "base",
                 Vec::new(),
                 Vec::new(),
             ))
             .await
-            .expect("fallback provider should succeed");
+            .expect_err("fallback should be deferred to the next turn");
 
         let recorded = prompts.lock().await;
-        assert_eq!(recorded.len(), 2);
+        assert_eq!(recorded.len(), 1);
         assert!(recorded[0].contains("Runtime: active_model=openai/gpt-5.4"));
         assert!(!recorded[0].contains("requested_model="));
-        assert!(recorded[1].contains(
-            "Runtime: active_model=anthropic/claude-sonnet-4-6 requested_model=openai/gpt-5.4"
-        ));
         assert!(system_blocks.lock().await[0].is_empty());
-        let timeline = timeline.expect("timeline");
+        let timeline = super::super::provider_attempt_timeline(&error).expect("timeline");
         assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
+        assert_eq!(timeline.active_model_ref.as_deref(), None);
+        assert_eq!(timeline.winning_model_ref.as_deref(), None);
         assert_eq!(
-            timeline.active_model_ref.as_deref(),
+            timeline.pending_fallback_model_ref.as_deref(),
             Some("anthropic/claude-sonnet-4-6")
         );
-        assert_eq!(
-            timeline.winning_model_ref.as_deref(),
-            Some("anthropic/claude-sonnet-4-6")
-        );
+        assert_eq!(timeline.attempts.len(), 1);
+        assert!(timeline.attempts[0].advanced_to_fallback);
     }
 
     #[tokio::test]
@@ -303,87 +300,74 @@ impl AgentProvider for FallbackProvider {
             .first()
             .map(|candidate| candidate.model_ref.clone())
             .unwrap_or_default();
-        let mut errors = Vec::new();
+        let pending_fallback_model_ref = self
+            .candidates
+            .get(1)
+            .map(|candidate| candidate.model_ref.clone());
         let mut timeline = Vec::new();
-        for (candidate_index, candidate) in self.candidates.iter().enumerate() {
-            let max_attempts = provider_max_attempts();
-            let mut last_error = None;
-            for attempt in 1..=max_attempts {
-                let attempt_request =
-                    request_for_model_attempt(&request, &requested_model_ref, &candidate.model_ref);
-                let attempt_started_at = Utc::now();
-                let attempt_started = std::time::Instant::now();
-                match candidate.provider.complete_turn(attempt_request).await {
-                    Ok(response) => {
-                        let attempt_completed_at = Utc::now();
-                        let attempt_duration_ms = attempt_started.elapsed().as_millis() as u64;
-                        timeline.push(ProviderAttemptRecord {
-                            provider: candidate.provider_name.clone(),
-                            model_ref: candidate.model_ref.clone(),
-                            attempt,
-                            max_attempts,
-                            started_at: Some(attempt_started_at),
-                            completed_at: Some(attempt_completed_at),
-                            duration_ms: Some(attempt_duration_ms),
-                            failure_kind: None,
-                            disposition: None,
-                            outcome: ProviderAttemptOutcome::Succeeded,
-                            advanced_to_fallback: false,
-                            backoff_ms: None,
-                            token_usage: Some(crate::types::TokenUsage::new(
-                                response.input_tokens,
-                                response.output_tokens,
-                            )),
-                            transport_diagnostics: None,
-                        });
-                        let diagnostics = ProviderAttemptTimeline {
-                            aggregated_token_usage: aggregate_attempt_token_usage(&timeline),
-                            attempts: timeline,
-                            requested_model_ref: requested_model_ref.clone(),
-                            active_model_ref: Some(candidate.model_ref.clone()),
-                            winning_model_ref: Some(candidate.model_ref.clone()),
-                        };
-                        return Ok((response, Some(diagnostics)));
-                    }
-                    Err(error) => {
-                        let attempt_completed_at = Utc::now();
-                        let attempt_duration_ms = attempt_started.elapsed().as_millis() as u64;
-                        let classification = classify_provider_error(&error);
-                        let should_retry = classification.disposition
-                            == RetryDisposition::Retryable
-                            && attempt < max_attempts;
-                        if should_retry {
-                            let backoff = provider_retry_backoff(attempt);
-                            timeline.push(ProviderAttemptRecord {
-                                provider: candidate.provider_name.clone(),
-                                model_ref: candidate.model_ref.clone(),
-                                attempt,
-                                max_attempts,
-                                started_at: Some(attempt_started_at),
-                                completed_at: Some(attempt_completed_at),
-                                duration_ms: Some(attempt_duration_ms),
-                                failure_kind: Some(classification.kind.as_str().to_string()),
-                                disposition: Some(classification.disposition.as_str().to_string()),
-                                outcome: ProviderAttemptOutcome::Retrying,
-                                advanced_to_fallback: false,
-                                backoff_ms: Some(backoff.as_millis() as u64),
-                                token_usage: None,
-                                transport_diagnostics: provider_transport_diagnostics(&error)
-                                    .cloned(),
-                            });
-                            warn!(
-                                model_ref = %candidate.model_ref,
-                                attempt,
-                                max_attempts,
-                                failure_kind = classification.kind.as_str(),
-                                disposition = classification.disposition.as_str(),
-                                backoff_ms = backoff.as_millis(),
-                                "provider turn failed; retrying"
-                            );
-                            sleep(backoff).await;
-                            last_error = Some(error);
-                            continue;
-                        }
+        let Some(candidate) = self.candidates.first() else {
+            let source = anyhow!("all configured providers failed for this turn: no candidates");
+            return Err(provider_turn_error(
+                source.to_string(),
+                ProviderAttemptTimeline {
+                    aggregated_token_usage: None,
+                    attempts: timeline,
+                    requested_model_ref,
+                    active_model_ref: None,
+                    winning_model_ref: None,
+                    pending_fallback_model_ref: None,
+                },
+                source,
+            ));
+        };
+        let max_attempts = provider_max_attempts();
+        let mut last_error = None;
+        for attempt in 1..=max_attempts {
+            let attempt_request =
+                request_for_model_attempt(&request, &requested_model_ref, &candidate.model_ref);
+            let attempt_started_at = Utc::now();
+            let attempt_started = std::time::Instant::now();
+            match candidate.provider.complete_turn(attempt_request).await {
+                Ok(response) => {
+                    let attempt_completed_at = Utc::now();
+                    let attempt_duration_ms = attempt_started.elapsed().as_millis() as u64;
+                    timeline.push(ProviderAttemptRecord {
+                        provider: candidate.provider_name.clone(),
+                        model_ref: candidate.model_ref.clone(),
+                        attempt,
+                        max_attempts,
+                        started_at: Some(attempt_started_at),
+                        completed_at: Some(attempt_completed_at),
+                        duration_ms: Some(attempt_duration_ms),
+                        failure_kind: None,
+                        disposition: None,
+                        outcome: ProviderAttemptOutcome::Succeeded,
+                        advanced_to_fallback: false,
+                        backoff_ms: None,
+                        token_usage: Some(crate::types::TokenUsage::new(
+                            response.input_tokens,
+                            response.output_tokens,
+                        )),
+                        transport_diagnostics: None,
+                    });
+                    let diagnostics = ProviderAttemptTimeline {
+                        aggregated_token_usage: aggregate_attempt_token_usage(&timeline),
+                        attempts: timeline,
+                        requested_model_ref: requested_model_ref.clone(),
+                        active_model_ref: Some(candidate.model_ref.clone()),
+                        winning_model_ref: Some(candidate.model_ref.clone()),
+                        pending_fallback_model_ref: None,
+                    };
+                    return Ok((response, Some(diagnostics)));
+                }
+                Err(error) => {
+                    let attempt_completed_at = Utc::now();
+                    let attempt_duration_ms = attempt_started.elapsed().as_millis() as u64;
+                    let classification = classify_provider_error(&error);
+                    let should_retry = classification.disposition == RetryDisposition::Retryable
+                        && attempt < max_attempts;
+                    if should_retry {
+                        let backoff = provider_retry_backoff(attempt);
                         timeline.push(ProviderAttemptRecord {
                             provider: candidate.provider_name.clone(),
                             model_ref: candidate.model_ref.clone(),
@@ -394,45 +378,66 @@ impl AgentProvider for FallbackProvider {
                             duration_ms: Some(attempt_duration_ms),
                             failure_kind: Some(classification.kind.as_str().to_string()),
                             disposition: Some(classification.disposition.as_str().to_string()),
-                            outcome: match classification.disposition {
-                                RetryDisposition::Retryable => {
-                                    ProviderAttemptOutcome::RetriesExhausted
-                                }
-                                RetryDisposition::FailFast => {
-                                    ProviderAttemptOutcome::FailFastAborted
-                                }
-                            },
-                            advanced_to_fallback: candidate_index + 1 < self.candidates.len(),
-                            backoff_ms: None,
+                            outcome: ProviderAttemptOutcome::Retrying,
+                            advanced_to_fallback: false,
+                            backoff_ms: Some(backoff.as_millis() as u64),
                             token_usage: None,
                             transport_diagnostics: provider_transport_diagnostics(&error).cloned(),
                         });
-                        last_error = Some(error);
-                        let has_fallback = candidate_index + 1 < self.candidates.len();
                         warn!(
                             model_ref = %candidate.model_ref,
                             attempt,
                             max_attempts,
                             failure_kind = classification.kind.as_str(),
                             disposition = classification.disposition.as_str(),
-                            has_fallback,
-                            "provider turn failed; {}", if has_fallback { "advancing to fallback" } else { "no fallback remaining" }
+                            backoff_ms = backoff.as_millis(),
+                            "provider turn failed; retrying"
                         );
-                        break;
+                        sleep(backoff).await;
+                        last_error = Some(error);
+                        continue;
                     }
+                    let has_fallback = pending_fallback_model_ref.is_some();
+                    timeline.push(ProviderAttemptRecord {
+                        provider: candidate.provider_name.clone(),
+                        model_ref: candidate.model_ref.clone(),
+                        attempt,
+                        max_attempts,
+                        started_at: Some(attempt_started_at),
+                        completed_at: Some(attempt_completed_at),
+                        duration_ms: Some(attempt_duration_ms),
+                        failure_kind: Some(classification.kind.as_str().to_string()),
+                        disposition: Some(classification.disposition.as_str().to_string()),
+                        outcome: match classification.disposition {
+                            RetryDisposition::Retryable => ProviderAttemptOutcome::RetriesExhausted,
+                            RetryDisposition::FailFast => ProviderAttemptOutcome::FailFastAborted,
+                        },
+                        advanced_to_fallback: has_fallback,
+                        backoff_ms: None,
+                        token_usage: None,
+                        transport_diagnostics: provider_transport_diagnostics(&error).cloned(),
+                    });
+                    last_error = Some(error);
+                    warn!(
+                        model_ref = %candidate.model_ref,
+                        attempt,
+                        max_attempts,
+                        failure_kind = classification.kind.as_str(),
+                        disposition = classification.disposition.as_str(),
+                        has_fallback,
+                        "provider turn failed; {}", if has_fallback { "deferring fallback to next turn" } else { "no fallback remaining" }
+                    );
+                    break;
                 }
             }
-            if let Some(error) = last_error {
-                errors.push(format_provider_failure(
-                    &candidate.model_ref,
-                    max_attempts,
-                    &error,
-                ));
-            }
         }
+        let error_summary = last_error
+            .as_ref()
+            .map(|error| format_provider_failure(&candidate.model_ref, max_attempts, error))
+            .unwrap_or_else(|| format!("{}: provider failed", candidate.model_ref));
         let source = anyhow!(
             "all configured providers failed for this turn: {}",
-            errors.join("; ")
+            error_summary
         );
         Err(provider_turn_error(
             source.to_string(),
@@ -442,6 +447,7 @@ impl AgentProvider for FallbackProvider {
                 requested_model_ref,
                 active_model_ref: None,
                 winning_model_ref: None,
+                pending_fallback_model_ref,
             },
             source,
         ))

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -456,6 +456,8 @@ pub struct ProviderAttemptTimeline {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub winning_model_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_fallback_model_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aggregated_token_usage: Option<TokenUsage>,
 }
 

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -913,7 +913,7 @@ async fn openai_provider_retries_response_body_read_interruptions() {
 }
 
 #[tokio::test]
-async fn provider_fallback_continues_after_retry_exhaustion() {
+async fn provider_fallback_defers_after_retry_exhaustion() {
     let openai_attempts = Arc::new(AtomicUsize::new(0));
     let openai_server_attempts = openai_attempts.clone();
     let openai_base_url = spawn_test_server(Router::new().route(
@@ -972,19 +972,20 @@ async fn provider_fallback_continues_after_retry_exhaustion() {
         .base_url = anthropic_base_url;
 
     let provider = build_provider_from_config(&fixture.config).unwrap();
-    let (response, diagnostics) = provider
+    let error = provider
         .complete_turn_with_diagnostics(provider_turn_request())
         .await
-        .unwrap();
+        .expect_err("cross-lineage fallback should defer to the next turn");
 
     assert_eq!(
         openai_attempts.load(Ordering::SeqCst),
         provider_max_attempts()
     );
-    assert_eq!(anthropic_attempts.load(Ordering::SeqCst), 1);
-    let timeline = diagnostics.expect("missing attempt timeline");
+    assert_eq!(anthropic_attempts.load(Ordering::SeqCst), 0);
+    let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
+    assert_eq!(timeline.winning_model_ref.as_deref(), None);
     assert_eq!(
-        timeline.winning_model_ref.as_deref(),
+        timeline.pending_fallback_model_ref.as_deref(),
         Some("anthropic/claude-sonnet-4-6")
     );
     assert_eq!(
@@ -992,9 +993,9 @@ async fn provider_fallback_continues_after_retry_exhaustion() {
             .aggregated_token_usage
             .as_ref()
             .map(|usage| usage.total_tokens),
-        Some(6)
+        None
     );
-    assert_eq!(timeline.attempts.len(), provider_max_attempts() + 1);
+    assert_eq!(timeline.attempts.len(), provider_max_attempts());
     assert_eq!(
         timeline.attempts[0].outcome,
         ProviderAttemptOutcome::Retrying
@@ -1008,18 +1009,10 @@ async fn provider_fallback_continues_after_retry_exhaustion() {
         ProviderAttemptOutcome::RetriesExhausted
     );
     assert!(timeline.attempts[provider_max_attempts() - 1].advanced_to_fallback);
-    assert_eq!(
-        timeline.attempts.last().unwrap().outcome,
-        ProviderAttemptOutcome::Succeeded
-    );
-    match &response.blocks[0] {
-        ModelBlock::Text { text } => assert_eq!(text, "anthropic fallback"),
-        _ => panic!("expected text block"),
-    }
 }
 
 #[tokio::test]
-async fn provider_fallback_continues_immediately_after_fail_fast_error() {
+async fn provider_fallback_defers_after_fail_fast_error() {
     let openai_attempts = Arc::new(AtomicUsize::new(0));
     let openai_server_attempts = openai_attempts.clone();
     let openai_base_url = spawn_test_server(Router::new().route(
@@ -1074,22 +1067,20 @@ async fn provider_fallback_continues_immediately_after_fail_fast_error() {
         .base_url = anthropic_base_url;
 
     let provider = build_provider_from_config(&fixture.config).unwrap();
-    let (response, diagnostics) = provider
+    let error = provider
         .complete_turn_with_diagnostics(provider_turn_request())
         .await
-        .unwrap();
+        .expect_err("cross-lineage fallback should defer to the next turn");
 
     assert_eq!(openai_attempts.load(Ordering::SeqCst), 1);
-    assert_eq!(anthropic_attempts.load(Ordering::SeqCst), 1);
-    let timeline = diagnostics.expect("missing attempt timeline");
-    assert_eq!(timeline.attempts.len(), 2);
+    assert_eq!(anthropic_attempts.load(Ordering::SeqCst), 0);
+    let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
+    assert_eq!(timeline.attempts.len(), 1);
     assert_eq!(timeline.requested_model_ref, "openai/gpt-5.4");
+    assert_eq!(timeline.active_model_ref.as_deref(), None);
+    assert_eq!(timeline.winning_model_ref.as_deref(), None);
     assert_eq!(
-        timeline.active_model_ref.as_deref(),
-        Some("anthropic/claude-sonnet-4-6")
-    );
-    assert_eq!(
-        timeline.winning_model_ref.as_deref(),
+        timeline.pending_fallback_model_ref.as_deref(),
         Some("anthropic/claude-sonnet-4-6")
     );
     assert_eq!(
@@ -1106,13 +1097,6 @@ async fn provider_fallback_continues_immediately_after_fail_fast_error() {
     );
     assert!(timeline.attempts[0].advanced_to_fallback);
     assert_eq!(timeline.attempts[0].attempt, 1);
-    assert_eq!(
-        timeline.attempts[1].outcome,
-        ProviderAttemptOutcome::Succeeded
-    );
-    assert!(
-        matches!(&response.blocks[0], ModelBlock::Text { text } if text == "anthropic fallback")
-    );
 }
 
 #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -155,7 +155,10 @@ pub(crate) fn agent_model_state_for_catalog(
         .and_then(|_| state.last_active_model.clone())
         .unwrap_or_else(|| effective_model.clone());
     let fallback_active = active_model != effective_model;
-    let effective_chain = model_catalog.provider_chain(state.model_override.as_ref());
+    let effective_chain = model_catalog.provider_chain_for_turn(
+        state.model_override.as_ref(),
+        state.pending_fallback_model.as_ref(),
+    );
     let resolved_policy =
         model_catalog.resolved_model_policy(base_context_config, state.model_override.as_ref());
     AgentModelState {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -282,7 +282,10 @@ impl RuntimeHandle {
         );
 
         if let Some(reconfig) = provider_reconfig.as_ref() {
-            let chain = model_catalog.provider_chain(state.model_override.as_ref());
+            let chain = model_catalog.provider_chain_for_turn(
+                state.model_override.as_ref(),
+                state.pending_fallback_model.as_ref(),
+            );
             let mut provider_config = reconfig.config.clone();
             provider_config.runtime_max_output_tokens = model_catalog
                 .resolved_model_policy(&base_context_config, state.model_override.as_ref())
@@ -348,10 +351,10 @@ impl RuntimeHandle {
                 "agent model override is unavailable for runtimes without host-managed provider configuration"
             ));
         };
-        let chain = self
-            .inner
-            .model_catalog
-            .provider_chain(state.model_override.as_ref());
+        let chain = self.inner.model_catalog.provider_chain_for_turn(
+            state.model_override.as_ref(),
+            state.pending_fallback_model.as_ref(),
+        );
         let resolved_context_config = self.inner.model_catalog.resolved_context_config(
             &self.inner.base_context_config,
             state.model_override.as_ref(),
@@ -377,6 +380,17 @@ impl RuntimeHandle {
         *self.inner.provider.write().await = provider;
         *self.inner.context_config.write().await = resolved_context_config;
         Ok(())
+    }
+
+    pub(crate) async fn reconfigure_provider_for_current_state(&self) -> Result<()> {
+        if self.inner.provider_reconfig.is_none() {
+            return Ok(());
+        }
+        let state = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.clone()
+        };
+        self.reconfigure_provider_for_state(&state).await
     }
 
     pub(crate) async fn current_context_config(&self) -> ContextConfig {

--- a/src/runtime/closure.rs
+++ b/src/runtime/closure.rs
@@ -109,6 +109,10 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
             let marker = match kind {
                 TurnTerminalKind::Aborted => "turn_terminal_aborted",
                 TurnTerminalKind::BaselineOverBudget => "turn_terminal_baseline_over_budget",
+                TurnTerminalKind::DeferredToFallback => "turn_terminal_deferred_to_fallback",
+                TurnTerminalKind::ProviderFailedNeedsRecovery => {
+                    "turn_terminal_provider_failed_needs_recovery"
+                }
                 TurnTerminalKind::Completed => unreachable!("completed is not a failure"),
             };
             evidence.push(marker.to_string());

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -608,20 +608,30 @@ impl RuntimeHandle {
         let mut next_state = self.agent_state().await?;
         next_state.model_override = Some(model_override.clone());
         next_state.model_override_reasoning_effort = reasoning_effort.clone();
-        self.reconfigure_provider_for_state(&next_state).await?;
+        next_state.pending_fallback_model = None;
+        let turn_in_progress = next_state.current_run_id.is_some();
+        if !turn_in_progress {
+            self.reconfigure_provider_for_state(&next_state).await?;
+        }
 
         let model_state = self.model_state_for(&next_state);
         {
             let mut guard = self.inner.agent.lock().await;
             guard.state.model_override = Some(model_override);
             guard.state.model_override_reasoning_effort = reasoning_effort;
+            guard.state.pending_fallback_model = None;
             self.inner.storage.write_agent(&guard.state)?;
         }
         self.append_audit_event(
-            "agent_model_override_set",
+            if turn_in_progress {
+                "agent_model_override_requested"
+            } else {
+                "agent_model_override_set"
+            },
             serde_json::json!({
                 "agent_id": next_state.id,
                 "model": model_state,
+                "pending_next_turn": turn_in_progress,
             }),
         )?;
         Ok(model_state)
@@ -631,20 +641,30 @@ impl RuntimeHandle {
         let mut next_state = self.agent_state().await?;
         next_state.model_override = None;
         next_state.model_override_reasoning_effort = None;
-        self.reconfigure_provider_for_state(&next_state).await?;
+        next_state.pending_fallback_model = None;
+        let turn_in_progress = next_state.current_run_id.is_some();
+        if !turn_in_progress {
+            self.reconfigure_provider_for_state(&next_state).await?;
+        }
 
         let model_state = self.model_state_for(&next_state);
         {
             let mut guard = self.inner.agent.lock().await;
             guard.state.model_override = None;
             guard.state.model_override_reasoning_effort = None;
+            guard.state.pending_fallback_model = None;
             self.inner.storage.write_agent(&guard.state)?;
         }
         self.append_audit_event(
-            "agent_model_override_cleared",
+            if turn_in_progress {
+                "agent_model_override_clear_requested"
+            } else {
+                "agent_model_override_cleared"
+            },
             serde_json::json!({
                 "agent_id": next_state.id,
                 "model": model_state,
+                "pending_next_turn": turn_in_progress,
             }),
         )?;
         Ok(model_state)

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -310,6 +310,12 @@ impl BaselineOverBudgetProbeProvider {
 
 pub(crate) struct ContextLengthExceededProvider;
 
+pub(crate) struct DeferredFallbackProvider;
+
+pub(crate) struct TextThenFailingFallbackProvider {
+    pub(crate) calls: Mutex<usize>,
+}
+
 pub(crate) struct SleepOnlyToolProvider {
     pub(crate) calls: Mutex<usize>,
 }
@@ -440,6 +446,7 @@ impl AgentProvider for TimelineProvider {
                 requested_model_ref: "openai/gpt-5.4".into(),
                 active_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
                 winning_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
+                pending_fallback_model_ref: None,
             }),
         ))
     }
@@ -752,6 +759,7 @@ impl AgentProvider for FailingTimelineProvider {
                 requested_model_ref: "openai/gpt-5.4".into(),
                 active_model_ref: None,
                 winning_model_ref: None,
+                pending_fallback_model_ref: None,
             },
             anyhow!("bad request"),
         ))
@@ -784,8 +792,90 @@ impl AgentProvider for ContextLengthExceededProvider {
                 requested_model_ref: "openai-codex/gpt-5.3-codex-spark".into(),
                 active_model_ref: None,
                 winning_model_ref: None,
+                pending_fallback_model_ref: None,
             },
             anyhow!("context_length_exceeded: input too long"),
+        ))
+    }
+}
+
+#[async_trait]
+impl AgentProvider for DeferredFallbackProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        Err(provider_turn_error(
+            "all configured providers failed for this turn: openai/gpt-5.4: retryable exhausted",
+            ProviderAttemptTimeline {
+                attempts: vec![ProviderAttemptRecord {
+                    provider: "openai".into(),
+                    model_ref: "openai/gpt-5.4".into(),
+                    attempt: 3,
+                    max_attempts: 3,
+                    started_at: None,
+                    completed_at: None,
+                    duration_ms: Some(125),
+                    failure_kind: Some("server_error".into()),
+                    disposition: Some("retryable".into()),
+                    outcome: ProviderAttemptOutcome::RetriesExhausted,
+                    advanced_to_fallback: true,
+                    backoff_ms: None,
+                    token_usage: None,
+                    transport_diagnostics: None,
+                }],
+                aggregated_token_usage: None,
+                requested_model_ref: "openai/gpt-5.4".into(),
+                active_model_ref: None,
+                winning_model_ref: None,
+                pending_fallback_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
+            },
+            anyhow!("server unavailable"),
+        ))
+    }
+}
+
+#[async_trait]
+impl AgentProvider for TextThenFailingFallbackProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        if *calls == 1 {
+            return Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text {
+                    text: "Partial report heading".into(),
+                }],
+                stop_reason: Some("max_output_tokens".into()),
+                input_tokens: 20,
+                output_tokens: 10,
+                cache_usage: None,
+                request_diagnostics: None,
+            });
+        }
+
+        Err(provider_turn_error(
+            "all configured providers failed for this turn: openai/gpt-5.4: retryable exhausted",
+            ProviderAttemptTimeline {
+                attempts: vec![ProviderAttemptRecord {
+                    provider: "openai".into(),
+                    model_ref: "openai/gpt-5.4".into(),
+                    attempt: 3,
+                    max_attempts: 3,
+                    started_at: None,
+                    completed_at: None,
+                    duration_ms: Some(125),
+                    failure_kind: Some("server_error".into()),
+                    disposition: Some("retryable".into()),
+                    outcome: ProviderAttemptOutcome::RetriesExhausted,
+                    advanced_to_fallback: true,
+                    backoff_ms: None,
+                    token_usage: None,
+                    transport_diagnostics: None,
+                }],
+                aggregated_token_usage: None,
+                requested_model_ref: "openai/gpt-5.4".into(),
+                active_model_ref: None,
+                winning_model_ref: None,
+                pending_fallback_model_ref: Some("anthropic/claude-sonnet-4-6".into()),
+            },
+            anyhow!("server unavailable"),
         ))
     }
 }

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -914,6 +914,127 @@ async fn runtime_persists_provider_attempt_timeline_on_successful_round() {
 }
 
 #[tokio::test]
+async fn provider_failure_before_output_defers_fallback_to_next_turn() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(DeferredFallbackProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let outcome = runtime
+        .run_agent_loop(
+            "default",
+            TrustLevel::TrustedOperator,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.terminal_kind, TurnTerminalKind::DeferredToFallback);
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state
+            .pending_fallback_model
+            .as_ref()
+            .map(|model| model.as_string())
+            .as_deref(),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert_eq!(
+        state.last_turn_terminal.as_ref().map(|record| record.kind),
+        Some(TurnTerminalKind::DeferredToFallback)
+    );
+    let queued = {
+        let guard = runtime.inner.agent.lock().await;
+        guard.queue.peek().cloned().expect("fallback followup")
+    };
+    assert_eq!(queued.kind, MessageKind::InternalFollowup);
+    assert_eq!(queued.priority, Priority::Next);
+    assert!(matches!(queued.trust, TrustLevel::TrustedSystem));
+
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "lineage_retry_exhausted"));
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "deferred_to_fallback"));
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "recovery_turn_started"));
+}
+
+#[tokio::test]
+async fn provider_failure_after_accepted_output_queues_recovery_turn() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(TextThenFailingFallbackProvider {
+            calls: Mutex::new(0),
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let outcome = runtime
+        .run_agent_loop(
+            "default",
+            TrustLevel::TrustedOperator,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        outcome.terminal_kind,
+        TurnTerminalKind::ProviderFailedNeedsRecovery
+    );
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.last_turn_terminal.as_ref().map(|record| record.kind),
+        Some(TurnTerminalKind::ProviderFailedNeedsRecovery)
+    );
+    assert_eq!(
+        state
+            .last_turn_terminal
+            .as_ref()
+            .and_then(|record| record.last_assistant_message.as_deref()),
+        Some("Partial report heading")
+    );
+
+    let events = runtime.storage().read_recent_events(30).unwrap();
+    assert!(events
+        .iter()
+        .any(|event| event.kind == "provider_failed_needs_recovery"));
+    let exhausted = events
+        .iter()
+        .find(|event| event.kind == "lineage_retry_exhausted")
+        .expect("lineage retry exhausted event");
+    assert_eq!(
+        exhausted.data["side_effect_boundary_crossed"].as_bool(),
+        Some(true)
+    );
+}
+
+#[tokio::test]
 async fn runtime_records_turn_latency_phase_events_for_provider_and_tool() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -22,8 +22,9 @@ use crate::{
         ToolCall, ToolError, ToolSpec,
     },
     types::{
-        AuditEvent, MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TodoItemState, TokenUsage,
-        TranscriptEntry, TranscriptEntryKind, TrustLevel, TurnTerminalCheckpointRecord,
+        AdmissionContext, AuditEvent, MessageBody, MessageDeliverySurface, MessageEnvelope,
+        MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus, TodoItemState,
+        TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, TurnTerminalCheckpointRecord,
         TurnTerminalKind, TurnTerminalRecord, WorkItemPlanStatus, WorkItemRecord,
     },
 };
@@ -1352,6 +1353,122 @@ impl RuntimeHandle {
         Ok(record)
     }
 
+    async fn maybe_defer_provider_lineage_failure(
+        &self,
+        agent_id: &str,
+        round: usize,
+        error: &anyhow::Error,
+        last_assistant_message: Option<String>,
+        duration_ms: u64,
+        side_effect_boundary_crossed: bool,
+    ) -> Result<Option<AgentLoopOutcome>> {
+        let Some(timeline) = provider_attempt_timeline(error).cloned() else {
+            return Ok(None);
+        };
+        let Some(fallback_ref) = timeline.pending_fallback_model_ref.as_deref() else {
+            return Ok(None);
+        };
+        let Ok(fallback_model) = ModelRef::parse(fallback_ref) else {
+            return Ok(None);
+        };
+        let terminal_kind = if side_effect_boundary_crossed {
+            TurnTerminalKind::ProviderFailedNeedsRecovery
+        } else {
+            TurnTerminalKind::DeferredToFallback
+        };
+        {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state.pending_fallback_model = Some(fallback_model.clone());
+            self.inner.storage.write_agent(&guard.state)?;
+        }
+        self.inner.storage.append_event(&AuditEvent::new(
+            "lineage_retry_exhausted",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "round": round,
+                "requested_model_ref": timeline.requested_model_ref,
+                "active_model_ref": timeline.active_model_ref,
+                "pending_fallback_model_ref": fallback_ref,
+                "side_effect_boundary_crossed": side_effect_boundary_crossed,
+                "provider_attempt_timeline": timeline,
+            }),
+        ))?;
+        let final_text = if side_effect_boundary_crossed {
+            format!(
+                "Turn stopped after the active provider lineage failed; queued a recovery turn on {fallback_ref}."
+            )
+        } else {
+            format!(
+                "Turn stopped before provider output was accepted; queued fallback turn on {fallback_ref}."
+            )
+        };
+        self.persist_turn_terminal_record(
+            terminal_kind,
+            last_assistant_message
+                .clone()
+                .or_else(|| Some(final_text.clone())),
+            duration_ms,
+            None,
+        )
+        .await?;
+        let event_kind = if side_effect_boundary_crossed {
+            "provider_failed_needs_recovery"
+        } else {
+            "deferred_to_fallback"
+        };
+        self.inner.storage.append_event(&AuditEvent::new(
+            event_kind,
+            serde_json::json!({
+                "agent_id": agent_id,
+                "round": round,
+                "fallback_model_ref": fallback_ref,
+                "side_effect_boundary_crossed": side_effect_boundary_crossed,
+                "last_assistant_preview": last_assistant_message
+                    .as_deref()
+                    .map(|text| truncate_preview(text, ROUND_TEXT_PREVIEW_LIMIT)),
+            }),
+        ))?;
+
+        let mut message = MessageEnvelope::new(
+            agent_id.to_string(),
+            MessageKind::InternalFollowup,
+            MessageOrigin::System {
+                subsystem: "model_lineage_recovery".into(),
+            },
+            TrustLevel::TrustedSystem,
+            Priority::Next,
+            MessageBody::Text {
+                text: "Runtime recovery: the previous turn stopped after the active provider failed. Continue from the persisted transcript, current work item, and workspace state. Do not assume hidden provider continuation state is still available. Do not repeat completed tool work unless current evidence shows it is necessary.".into(),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            AdmissionContext::RuntimeOwned,
+        );
+        message.metadata = Some(serde_json::json!({
+            "fallback_model_ref": fallback_ref,
+            "source_terminal_kind": terminal_kind,
+            "source_round": round,
+            "side_effect_boundary_crossed": side_effect_boundary_crossed,
+        }));
+        let queued = self.enqueue(message).await?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "recovery_turn_started",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "message_id": queued.id,
+                "fallback_model_ref": fallback_ref,
+                "source_terminal_kind": terminal_kind,
+            }),
+        ))?;
+        Ok(Some(AgentLoopOutcome {
+            final_text,
+            should_sleep: false,
+            sleep_duration_ms: None,
+            terminal_kind,
+        }))
+    }
+
     async fn persist_turn_aborted_record(
         &self,
         run_id: &str,
@@ -1595,6 +1712,40 @@ impl TurnExecution<'_> {
             let guard = runtime.inner.agent.lock().await;
             checkpoint_state_from_last_terminal(guard.state.last_turn_terminal.as_ref())
         };
+        let turn_lineage_state = {
+            let guard = runtime.inner.agent.lock().await;
+            (
+                guard.state.model_override.clone(),
+                guard.state.pending_fallback_model.clone(),
+                runtime.model_state_for(&guard.state),
+            )
+        };
+        runtime.reconfigure_provider_for_current_state().await?;
+        let identity = runtime.agent_identity_view().await?;
+        let (provider, available_tools, native_web_search) =
+            runtime.provider_tool_selection(&identity).await?;
+        let allowed_tool_names = available_tools
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect::<HashSet<_>>();
+        runtime.inner.storage.append_event(&AuditEvent::new(
+            "lineage_selected",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "model_override": turn_lineage_state.0,
+                "pending_fallback_model": turn_lineage_state.1,
+                "model": turn_lineage_state.2,
+            }),
+        ))?;
+        if let Some(pending) = turn_lineage_state.1.as_ref() {
+            runtime.inner.storage.append_event(&AuditEvent::new(
+                "pending_model_promoted",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "fallback_model": pending,
+                }),
+            ))?;
+        }
 
         loop {
             if let Err(err) = runtime.ensure_not_aborted().await {
@@ -1644,13 +1795,6 @@ impl TurnExecution<'_> {
             }
 
             let context_build_started = Instant::now();
-            let identity = runtime.agent_identity_view().await?;
-            let (provider, available_tools, native_web_search) =
-                runtime.provider_tool_selection(&identity).await?;
-            let allowed_tool_names = available_tools
-                .iter()
-                .map(|tool| tool.name.clone())
-                .collect::<HashSet<_>>();
 
             let (
                 response,
@@ -1663,13 +1807,15 @@ impl TurnExecution<'_> {
             ) = if round == 1 {
                 let request = build_provider_turn_request(
                     &effective_prompt,
-                    available_tools,
-                    native_web_search,
+                    available_tools.clone(),
+                    native_web_search.clone(),
                 );
                 let context_management = context_management_diagnostic(provider.as_ref(), &request);
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =
-                    runtime.complete_turn_with_timing(provider, request).await;
+                    runtime
+                        .complete_turn_with_timing(provider.clone(), request)
+                        .await;
                 match result {
                     Ok((response, attempt_timeline)) => (
                         response,
@@ -1698,6 +1844,19 @@ impl TurnExecution<'_> {
                                 round,
                                 &err,
                                 turn_started_at.elapsed().as_millis() as u64,
+                            )
+                            .await?
+                        {
+                            return Ok(outcome);
+                        }
+                        if let Some(outcome) = runtime
+                            .maybe_defer_provider_lineage_failure(
+                                agent_id,
+                                round,
+                                &err,
+                                last_assistant_message.clone(),
+                                turn_started_at.elapsed().as_millis() as u64,
+                                !completed_rounds.is_empty() || last_assistant_message.is_some(),
                             )
                             .await?
                         {
@@ -1894,13 +2053,15 @@ impl TurnExecution<'_> {
                 let request = build_continuation_request(
                     prompt_frame,
                     projection.conversation,
-                    available_tools,
-                    native_web_search,
+                    available_tools.clone(),
+                    native_web_search.clone(),
                 );
                 let context_management = context_management_diagnostic(provider.as_ref(), &request);
                 let context_build_ms = context_build_started.elapsed().as_millis() as u64;
                 let (result, provider_started_at, provider_completed_at, provider_round_ms) =
-                    runtime.complete_turn_with_timing(provider, request).await;
+                    runtime
+                        .complete_turn_with_timing(provider.clone(), request)
+                        .await;
                 match result {
                     Ok((response, attempt_timeline)) => (
                         response,
@@ -1934,6 +2095,19 @@ impl TurnExecution<'_> {
                         {
                             return Ok(outcome);
                         }
+                        if let Some(outcome) = runtime
+                            .maybe_defer_provider_lineage_failure(
+                                agent_id,
+                                round,
+                                &err,
+                                last_assistant_message.clone(),
+                                turn_started_at.elapsed().as_millis() as u64,
+                                !completed_rounds.is_empty() || last_assistant_message.is_some(),
+                            )
+                            .await?
+                        {
+                            return Ok(outcome);
+                        }
                         runtime
                             .persist_turn_terminal_record(
                                 TurnTerminalKind::Aborted,
@@ -1962,6 +2136,7 @@ impl TurnExecution<'_> {
                 ));
                 guard.state.last_requested_model = model_attempt_state.requested_model.clone();
                 guard.state.last_active_model = model_attempt_state.active_model.clone();
+                guard.state.pending_fallback_model = None;
                 runtime.inner.storage.write_agent(&guard.state)?;
                 (
                     guard.state.turn_index,
@@ -3299,6 +3474,7 @@ mod tests {
             requested_model_ref: "test/model".into(),
             active_model_ref: None,
             winning_model_ref: None,
+            pending_fallback_model_ref: None,
             aggregated_token_usage: None,
         };
         let single = normalize_provider_attempt_timing(single.into(), started_at, completed_at, 42)
@@ -3313,6 +3489,7 @@ mod tests {
             requested_model_ref: "test/model".into(),
             active_model_ref: None,
             winning_model_ref: None,
+            pending_fallback_model_ref: None,
             aggregated_token_usage: None,
         };
         let multiple =

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1712,7 +1712,7 @@ impl TurnExecution<'_> {
             let guard = runtime.inner.agent.lock().await;
             checkpoint_state_from_last_terminal(guard.state.last_turn_terminal.as_ref())
         };
-        let turn_lineage_state = {
+        let (turn_model_override, turn_pending_fallback_model, turn_model_state) = {
             let guard = runtime.inner.agent.lock().await;
             (
                 guard.state.model_override.clone(),
@@ -1732,12 +1732,12 @@ impl TurnExecution<'_> {
             "lineage_selected",
             serde_json::json!({
                 "agent_id": agent_id,
-                "model_override": turn_lineage_state.0,
-                "pending_fallback_model": turn_lineage_state.1,
-                "model": turn_lineage_state.2,
+                "model_override": turn_model_override,
+                "pending_fallback_model": turn_pending_fallback_model,
+                "model": turn_model_state,
             }),
         ))?;
-        if let Some(pending) = turn_lineage_state.1.as_ref() {
+        if let Some(pending) = turn_pending_fallback_model.as_ref() {
             runtime.inner.storage.append_event(&AuditEvent::new(
                 "pending_model_promoted",
                 serde_json::json!({

--- a/src/types.rs
+++ b/src/types.rs
@@ -1237,6 +1237,8 @@ pub enum TurnTerminalKind {
     Completed,
     Aborted,
     BaselineOverBudget,
+    DeferredToFallback,
+    ProviderFailedNeedsRecovery,
 }
 
 impl TurnTerminalKind {
@@ -1531,6 +1533,8 @@ pub struct AgentState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_override_reasoning_effort: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_fallback_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_requested_model: Option<ModelRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_active_model: Option<ModelRef>,
@@ -1602,6 +1606,7 @@ impl AgentState {
             last_continuation: None,
             model_override: None,
             model_override_reasoning_effort: None,
+            pending_fallback_model: None,
             last_requested_model: None,
             last_active_model: None,
             last_turn_terminal: None,


### PR DESCRIPTION
## Summary

- lock each runtime turn to the provider chain selected at turn start
- defer cross-lineage fallback to a queued runtime recovery turn instead of switching providers mid-turn
- persist pending fallback model state, terminal lineage outcomes, and diagnostics for deferred/recovery turns
- keep model override changes pending for the next turn while a run is active

Fixes #1229

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets -- --test-threads=1`
