### PR TITLE
fix: select ApplyPatch surface by model lineage

### DIFF
--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -109,21 +109,34 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
     }
     if let Some(apply_patch_tool) = apply_patch_tool {
         let invocation_contract = if apply_patch_tool.freeform_grammar.is_some() {
-            "Current ApplyPatch surface is a freeform grammar tool: send the unified diff body directly. Do not wrap it in JSON, and do not use `patch` or `input` fields."
+            "Current ApplyPatch surface is Codex DSL freeform: send raw `*** Begin Patch` / `*** End Patch` text directly. Do not wrap it in JSON, and do not use `patch` or `input` fields."
         } else {
             "Current ApplyPatch surface is a JSON/function tool: call it with exactly `{\"patch\":\"--- a/path\\n+++ b/path\\n@@ -1,1 +1,1 @@\\n-old\\n+new\\n\"}`. Do not use `input`, and do not send a raw freeform diff body."
+        };
+        let patch_language = if apply_patch_tool.freeform_grammar.is_some() {
+            "express ordinary file mutation as Codex DSL with `*** Add File`, `*** Delete File`, or `*** Update File` hunks"
+        } else {
+            "express ordinary file mutation as unified diff text"
         };
         sections.push(section(
             "tool_apply_patch",
             PromptStability::Stable,
-            format!("Use ApplyPatch as the primary precise file-mutation tool. Use it for focused new files, small local edits, multi-hunk single-file changes, structural edits, and bounded refactors. For very large new files, generated files, whole-file rewrites, bulk deletes, or broad mechanical refactors, choose the lower-context path: split the change into smaller ApplyPatch calls, or use a carefully bounded ExecCommand/scripted rewrite when that avoids emitting a huge diff and is easier to verify. Do not expect separate Write or Edit tools; express ordinary file mutation as unified diff text. {invocation_contract} The model-visible ApplyPatch receipt is concise text with action markers like `A`, `M`, `D`, or `R`; if it says success with diagnostics, treat the target file as potentially different from your intended mental model. The canonical result still records structured changed-file metadata, `changed_paths`, `changed_file_count`, ignored metadata, diagnostics, and `summary_text`."),
+            format!("Use ApplyPatch as the primary precise file-mutation tool. Use it for focused new files, small local edits, multi-hunk single-file changes, structural edits, and bounded refactors. For very large new files, generated files, whole-file rewrites, bulk deletes, or broad mechanical refactors, choose the lower-context path: split the change into smaller ApplyPatch calls, or use a carefully bounded ExecCommand/scripted rewrite when that avoids emitting a huge diff and is easier to verify. Do not expect separate Write or Edit tools; {patch_language}. {invocation_contract} The model-visible ApplyPatch receipt is concise text with action markers like `A`, `M`, `D`, or `R`; if it says success with diagnostics, treat the target file as potentially different from your intended mental model. The canonical result still records structured changed-file metadata, `changed_paths`, `changed_file_count`, ignored metadata, diagnostics, and `summary_text`."),
         ));
     }
     if names.contains(&"ApplyPatch") {
+        let format_guidance = if apply_patch_tool
+            .and_then(|tool| tool.freeform_grammar.as_ref())
+            .is_some()
+        {
+            "Use Codex DSL file hunks: `*** Add File`, `*** Delete File`, `*** Update File`, optional `*** Move to`, and `@@` chunk separators when useful. Prefer focused chunks with enough surrounding context to stay unambiguous. Blank context lines within update chunks must have a space prefix."
+        } else {
+            "Use unified diff `---`/`+++` file headers and `@@` hunks for deletes, precise edits, and renames. Prefer focused hunks with enough surrounding context to stay unambiguous. Include at least 3 context lines before and after each changed line, and expand to 5-10 lines when the file contains repeated structures or similar patterns. Blank lines within hunks must have a space prefix to be valid context lines."
+        };
         sections.push(section(
             "tool_file_mutation",
             PromptStability::Stable,
-            "File mutation is workspace-scoped and centered on ApplyPatch. Use unified diff `---`/`+++` file headers and `@@` hunks for deletes, precise edits, and renames. Prefer focused hunks with enough surrounding context to stay unambiguous. Include at least 3 context lines before and after each changed line, and expand to 5–10 lines when the file contains repeated structures or similar patterns. Blank lines within hunks must have a space prefix to be valid context lines. Keep tool output bounded: do not paste enormous malformed patches, do not retry the same large failed patch unchanged, and split large refactors into smaller patch/application steps when that keeps failures recoverable. Avoid using ExecCommand with shell rewrite tricks like `sed -i` as the default editing path, but use a bounded script or heredoc when generating/replacing a large file is cheaper and safer than a huge diff. After a clean file mutation, rely on the ApplyPatch receipt first, then run focused verification with ExecCommand when correctness matters. If ApplyPatch reports diagnostics, warnings, partial application, context mismatch, or any non-clean receipt, inspect the exact affected region before continuing edits to that file and do not retry the same diagnostic-producing patch unchanged. Do not use file mutation tools for broad exploration; inspect with shell-first read commands through ExecCommand instead.".to_string(),
+            format!("File mutation is workspace-scoped and centered on ApplyPatch. {format_guidance} Keep tool output bounded: do not paste enormous malformed patches, do not retry the same large failed patch unchanged, and split large refactors into smaller patch/application steps when that keeps failures recoverable. Avoid using ExecCommand with shell rewrite tricks like `sed -i` as the default editing path, but use a bounded script or heredoc when generating/replacing a large file is cheaper and safer than a huge diff. After a clean file mutation, rely on the ApplyPatch receipt first, then run focused verification with ExecCommand when correctness matters. If ApplyPatch reports diagnostics, warnings, partial application, context mismatch, or any non-clean receipt, inspect the exact affected region before continuing edits to that file and do not retry the same diagnostic-producing patch unchanged. Do not use file mutation tools for broad exploration; inspect with shell-first read commands through ExecCommand instead."),
         ));
     }
     if names.contains(&"UseWorkspace") {
@@ -546,7 +559,7 @@ mod tests {
             .contains("do not send a raw freeform diff body"));
         assert!(!apply_patch
             .content
-            .contains("Current ApplyPatch surface is a freeform grammar tool"));
+            .contains("Current ApplyPatch surface is Codex DSL freeform"));
         let section = sections
             .iter()
             .find(|s| s.name == "tool_file_mutation")
@@ -582,10 +595,10 @@ mod tests {
 
         assert!(apply_patch
             .content
-            .contains("Current ApplyPatch surface is a freeform grammar tool"));
+            .contains("Current ApplyPatch surface is Codex DSL freeform"));
         assert!(apply_patch
             .content
-            .contains("send the unified diff body directly"));
+            .contains("send raw `*** Begin Patch` / `*** End Patch` text directly"));
         assert!(apply_patch
             .content
             .contains("do not use `patch` or `input` fields"));

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -4,7 +4,7 @@ use super::support::*;
 use super::*;
 use crate::provider::retry::{ProviderFailureKind, RetryDisposition};
 use crate::provider::transports::OpenAiResponsesTransportContract;
-use crate::tool::ToolSpec;
+use crate::tool::{apply_patch::ApplyPatchSurface, tools::apply_patch_tool, ToolSpec};
 use serde_json::{json, Value};
 
 #[test]
@@ -319,7 +319,7 @@ fn build_openai_codex_streaming_request_sends_supported_reasoning_effort() {
 }
 
 #[test]
-fn openai_request_uses_custom_tool_shape_for_apply_patch() {
+fn openai_request_uses_function_tool_shape_for_generic_apply_patch() {
     let apply_patch = tool_spec_named("ApplyPatch");
     let request = provider_turn_request_with_tools(vec![apply_patch]);
     let body = build_openai_responses_request(
@@ -332,6 +332,31 @@ fn openai_request_uses_custom_tool_shape_for_apply_patch() {
     )
     .unwrap();
 
+    assert_eq!(body["tools"][0]["type"], "function");
+    assert_eq!(body["tools"][0]["name"], "ApplyPatch");
+    assert_eq!(
+        body["tools"][0]["parameters"]["properties"]["patch"]["type"],
+        "string"
+    );
+    assert!(body["tools"][0].get("format").is_none());
+}
+
+#[test]
+fn openai_codex_request_uses_custom_codex_dsl_tool_shape_for_apply_patch() {
+    let apply_patch = apply_patch_tool::definition_for_surface(ApplyPatchSurface::CodexDslFreeform)
+        .unwrap()
+        .spec;
+    let request = provider_turn_request_with_tools(vec![apply_patch]);
+    let body = build_openai_responses_request(
+        "gpt-5.4",
+        256,
+        &request,
+        OpenAiResponsesTransportContract::CodexStreaming,
+        ToolSchemaContract::Relaxed,
+        None,
+    )
+    .unwrap();
+
     assert_eq!(body["tools"][0]["type"], "custom");
     assert_eq!(body["tools"][0]["name"], "ApplyPatch");
     assert_eq!(body["tools"][0]["format"]["type"], "grammar");
@@ -339,9 +364,8 @@ fn openai_request_uses_custom_tool_shape_for_apply_patch() {
     let grammar = body["tools"][0]["format"]["definition"]
         .as_str()
         .expect("grammar definition should be a string");
-    assert!(grammar.contains("old_file: \"--- \" file_path LF"));
-    assert!(grammar.contains("new_file: \"+++ \" file_path LF"));
-    assert!(!grammar.contains("*** Begin Patch"));
+    assert!(grammar.contains("*** Begin Patch"));
+    assert!(!grammar.contains("old_file: \"--- \" file_path LF"));
 }
 
 #[test]

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Result};
 use tokio::sync::{Mutex, Notify, RwLock};
 
 use crate::{
-    config::{AppConfig, RuntimeModelCatalog},
+    config::{AppConfig, ModelRef, RuntimeModelCatalog},
     context::ContextConfig,
     host::RuntimeHostBridge,
     model_catalog::BuiltInModelMetadata,
@@ -16,7 +16,7 @@ use crate::{
     queue::RuntimeQueue,
     storage::AppStorage,
     system::{LocalSystem, WorkspaceAccessMode, WorkspaceProjectionKind},
-    tool::ToolRegistry,
+    tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
     types::{
         ActiveWorkspaceEntry, AgentState, AuditEvent, ResolvedModelAvailability,
         SkillActivationSource, SkillActivationState,
@@ -343,6 +343,32 @@ impl RuntimeHandle {
             &self.inner.base_context_config,
             state,
         )
+    }
+
+    pub(crate) async fn current_apply_patch_surface(&self) -> ApplyPatchSurface {
+        let state = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.clone()
+        };
+        self.apply_patch_surface_for_state(&state)
+    }
+
+    pub(crate) fn apply_patch_surface_for_state(&self, state: &AgentState) -> ApplyPatchSurface {
+        let model_ref = self
+            .selected_model_ref_for_state(state)
+            .unwrap_or_else(|| self.model_state_for(state).effective_model);
+        ApplyPatchSurface::for_model_ref(&model_ref.as_string())
+    }
+
+    fn selected_model_ref_for_state(&self, state: &AgentState) -> Option<ModelRef> {
+        self.inner
+            .model_catalog
+            .provider_chain_for_turn(
+                state.model_override.as_ref(),
+                state.pending_fallback_model.as_ref(),
+            )
+            .into_iter()
+            .next()
     }
 
     pub(crate) async fn reconfigure_provider_for_state(&self, state: &AgentState) -> Result<()> {

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::tool::ToolSpec;
+use crate::tool::{apply_patch::ApplyPatchSurface, ToolSpec};
 
 impl RuntimeHandle {
     pub(super) async fn process_interactive_message(
@@ -112,14 +112,26 @@ impl RuntimeHandle {
         Ok(())
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn filtered_tool_specs(
         &self,
         identity: &AgentIdentityView,
     ) -> Result<Vec<crate::tool::ToolSpec>> {
+        self.filtered_tool_specs_for_apply_patch_surface(
+            identity,
+            ApplyPatchSurface::UnifiedDiffJson,
+        )
+    }
+
+    fn filtered_tool_specs_for_apply_patch_surface(
+        &self,
+        identity: &AgentIdentityView,
+        apply_patch_surface: ApplyPatchSurface,
+    ) -> Result<Vec<crate::tool::ToolSpec>> {
         Ok(self
             .inner
             .tools
-            .tool_specs_with_families()?
+            .tool_specs_with_families_for_apply_patch_surface(apply_patch_surface)?
             .into_iter()
             .filter(|(family, _)| {
                 identity
@@ -264,8 +276,12 @@ impl RuntimeHandle {
             provider.as_ref(),
             native_search_provider.as_ref(),
         );
+        let apply_patch_surface = {
+            let guard = self.inner.agent.lock().await;
+            self.apply_patch_surface_for_state(&guard.state)
+        };
         let available_tools = self.filter_native_web_search_tools(
-            self.filtered_tool_specs(identity)?,
+            self.filtered_tool_specs_for_apply_patch_surface(identity, apply_patch_surface)?,
             native_search_provider.is_some(),
         );
         Ok((provider, available_tools, native_web_search))

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -236,11 +236,12 @@ async fn preview_prompt_lowers_apply_patch_contract_for_json_tool_providers() {
         .contains("Current ApplyPatch surface is a JSON/function tool"));
     assert!(!preview
         .rendered_system_prompt
-        .contains("Current ApplyPatch surface is a freeform grammar tool"));
+        .contains("Current ApplyPatch surface is Codex DSL freeform"));
 }
 
 #[tokio::test]
-async fn preview_prompt_keeps_apply_patch_contract_for_freeform_tool_providers() {
+async fn preview_prompt_keeps_json_apply_patch_for_generic_lineage_even_when_provider_supports_freeform(
+) {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -261,10 +262,10 @@ async fn preview_prompt_keeps_apply_patch_contract_for_freeform_tool_providers()
 
     assert!(preview
         .rendered_system_prompt
-        .contains("Current ApplyPatch surface is a freeform grammar tool"));
+        .contains("Current ApplyPatch surface is a JSON/function tool"));
     assert!(!preview
         .rendered_system_prompt
-        .contains("Current ApplyPatch surface is a JSON/function tool"));
+        .contains("Current ApplyPatch surface is Codex DSL freeform"));
 }
 
 #[tokio::test]

--- a/src/tool/apply_patch.rs
+++ b/src/tool/apply_patch.rs
@@ -18,6 +18,53 @@ pub(crate) struct ApplyPatchOutcome {
     pub(crate) diagnostics: Vec<ApplyPatchDiagnostic>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApplyPatchSurface {
+    CodexDslFreeform,
+    UnifiedDiffJson,
+}
+
+impl ApplyPatchSurface {
+    pub(crate) fn for_model_ref(model_ref: &str) -> Self {
+        if model_ref.starts_with("openai-codex/") {
+            Self::CodexDslFreeform
+        } else {
+            Self::UnifiedDiffJson
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::CodexDslFreeform => "codex_dsl_freeform",
+            Self::UnifiedDiffJson => "unified_diff_json",
+        }
+    }
+
+    fn expected_format(self) -> PatchFormat {
+        match self {
+            Self::CodexDslFreeform => PatchFormat::CodexDsl,
+            Self::UnifiedDiffJson => PatchFormat::UnifiedDiff,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PatchFormat {
+    CodexDsl,
+    UnifiedDiff,
+    Unknown,
+}
+
+impl PatchFormat {
+    fn label(self) -> &'static str {
+        match self {
+            Self::CodexDsl => "codex_dsl",
+            Self::UnifiedDiff => "unified_diff",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct FilePatch {
     old_path: PatchPath,
@@ -105,10 +152,57 @@ impl FileState {
     }
 }
 
-pub(crate) async fn apply_patch(workspace_root: &Path, input: &str) -> Result<ApplyPatchOutcome> {
-    let patches = parse_patch(input)?;
+pub(crate) async fn apply_patch(
+    workspace_root: &Path,
+    input: &str,
+    surface: ApplyPatchSurface,
+) -> Result<ApplyPatchOutcome> {
+    let expected_format = surface.expected_format();
+    let patch_bytes = input.len();
+    let parse = parse_patch_for_format(input, expected_format);
+    let (patches, parser_mode, detected_format, strict_failure_kind) = match parse {
+        Ok(patches) => (patches, "strict", expected_format, None),
+        Err(strict_error) => {
+            let detected = detect_patch_format(input);
+            if detected != PatchFormat::Unknown && detected != expected_format {
+                match parse_patch_for_format(input, detected) {
+                    Ok(patches) => (
+                        patches,
+                        "compatibility",
+                        detected,
+                        Some(ToolError::from_anyhow(&strict_error).kind),
+                    ),
+                    Err(_) => return Err(strict_error),
+                }
+            } else {
+                return Err(strict_error);
+            }
+        }
+    };
+    let file_count = patches.len();
+    let hunk_count = patches.iter().map(|patch| patch.hunks.len()).sum::<usize>();
     let (changed_files, touched, ignored_metadata, diagnostics) =
         apply_file_patches(workspace_root, &patches).await?;
+    let mut diagnostics = diagnostics;
+    if let Some(kind) = strict_failure_kind {
+        diagnostics.push(ApplyPatchDiagnostic {
+            path: String::new(),
+            kind: "apply_patch_compatibility_fallback".to_string(),
+            message: format!(
+                "ApplyPatch succeeded using {}, but this turn expects {}. Continue using {} for future ApplyPatch calls. surface={}, expected_format={}, detected_format={}, parser_mode={}, compatibility_fallback_used=true, patch_bytes={}, file_count={}, hunk_count={}, strict_parse_failure_kind={kind}",
+                detected_format.label(),
+                expected_format.label(),
+                expected_format.label(),
+                surface.label(),
+                expected_format.label(),
+                detected_format.label(),
+                parser_mode,
+                patch_bytes,
+                file_count,
+                hunk_count,
+            ),
+        });
+    }
     Ok(ApplyPatchOutcome {
         changed_files,
         changed_paths: touched,
@@ -117,11 +211,46 @@ pub(crate) async fn apply_patch(workspace_root: &Path, input: &str) -> Result<Ap
     })
 }
 
-fn parse_patch(input: &str) -> Result<Vec<FilePatch>> {
-    if input.lines().next().map(str::trim) == Some("*** Begin Patch") {
+fn parse_patch_for_format(input: &str, format: PatchFormat) -> Result<Vec<FilePatch>> {
+    match format {
+        PatchFormat::CodexDsl => parse_codex_dsl_patch(input),
+        PatchFormat::UnifiedDiff => parse_unified_diff_patch(input),
+        PatchFormat::Unknown => Err(syntax_error(
+            "unknown_patch_format",
+            "unknown ApplyPatch format",
+            None,
+            "submit the patch format advertised for this turn",
+        )),
+    }
+}
+
+fn detect_patch_format(input: &str) -> PatchFormat {
+    let trimmed = input.trim_start();
+    if trimmed.starts_with("*** Begin Patch")
+        || trimmed.lines().any(|line| line == "*** Begin Patch")
+    {
+        return PatchFormat::CodexDsl;
+    }
+    let mut has_old = false;
+    let mut has_new = false;
+    let mut has_hunk = false;
+    for line in trimmed.lines().take(40) {
+        has_old |= line.starts_with("--- ");
+        has_new |= line.starts_with("+++ ");
+        has_hunk |= line.starts_with("@@ ");
+    }
+    if has_old && has_new && has_hunk {
+        PatchFormat::UnifiedDiff
+    } else {
+        PatchFormat::Unknown
+    }
+}
+
+fn parse_unified_diff_patch(input: &str) -> Result<Vec<FilePatch>> {
+    if detect_patch_format(input) == PatchFormat::CodexDsl {
         return Err(syntax_error(
-            "legacy_patch_format",
-            "ApplyPatch now expects unified diff text, not *** Begin Patch DSL",
+            "wrong_patch_format",
+            "this turn expects unified diff JSON, not Codex *** Begin Patch DSL",
             None,
             "submit unified diff with --- old_path, +++ new_path, and @@ hunks",
         ));
@@ -305,6 +434,240 @@ fn parse_patch(input: &str) -> Result<Vec<FilePatch>> {
     }
 
     Ok(patches)
+}
+
+fn parse_codex_dsl_patch(input: &str) -> Result<Vec<FilePatch>> {
+    let lines = codex_dsl_lines(input);
+    if lines.first().map(String::as_str) != Some("*** Begin Patch") {
+        return Err(syntax_error(
+            "wrong_patch_format",
+            "this turn expects Codex *** Begin Patch DSL",
+            None,
+            "submit raw *** Begin Patch / *** End Patch text without JSON wrapping",
+        ));
+    }
+    if lines.last().map(String::as_str) != Some("*** End Patch") {
+        return Err(syntax_error(
+            "missing_end_patch",
+            "Codex DSL patch must end with *** End Patch",
+            None,
+            "end the patch with *** End Patch",
+        ));
+    }
+
+    let mut patches = Vec::new();
+    let mut index = 1usize;
+    while index + 1 < lines.len() {
+        let line = &lines[index];
+        if let Some(path) = line.strip_prefix("*** Add File: ") {
+            index += 1;
+            let mut hunk_lines = Vec::new();
+            while index + 1 < lines.len() && !lines[index].starts_with("*** ") {
+                let Some(text) = lines[index].strip_prefix('+') else {
+                    return Err(syntax_error(
+                        "invalid_codex_add_line",
+                        "Codex Add File lines must start with +",
+                        Some(path),
+                        "prefix every added line with +",
+                    ));
+                };
+                hunk_lines.push(HunkLine {
+                    kind: HunkLineKind::Add,
+                    text: text.to_string(),
+                });
+                index += 1;
+            }
+            if hunk_lines.is_empty() {
+                return Err(syntax_error(
+                    "missing_hunk",
+                    "Codex Add File must include at least one added line",
+                    Some(path),
+                    "add one or more + lines",
+                ));
+            }
+            patches.push(FilePatch {
+                old_path: PatchPath::DevNull,
+                new_path: PatchPath::Workspace(path.to_string()),
+                rename_from: None,
+                rename_to: None,
+                hunks: vec![PatchHunk {
+                    old_start: 0,
+                    old_count: 0,
+                    new_start: 1,
+                    new_count: hunk_lines.len(),
+                    lines: hunk_lines,
+                    no_newline_at_end: false,
+                }],
+                ignored_metadata: Vec::new(),
+                diagnostics: Vec::new(),
+            });
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Delete File: ") {
+            patches.push(FilePatch {
+                old_path: PatchPath::Workspace(path.to_string()),
+                new_path: PatchPath::DevNull,
+                rename_from: None,
+                rename_to: None,
+                hunks: Vec::new(),
+                ignored_metadata: Vec::new(),
+                diagnostics: Vec::new(),
+            });
+            index += 1;
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Update File: ") {
+            index += 1;
+            let mut rename_to = None;
+            if index + 1 < lines.len() {
+                if let Some(move_to) = lines[index].strip_prefix("*** Move to: ") {
+                    rename_to = Some(move_to.to_string());
+                    index += 1;
+                }
+            }
+            let mut hunks = Vec::new();
+            let mut current = Vec::new();
+            let mut no_newline_at_end = false;
+            while index + 1 < lines.len() {
+                let line = &lines[index];
+                if line == "*** End of File" {
+                    no_newline_at_end = true;
+                    index += 1;
+                    continue;
+                }
+                if line.starts_with("*** ") {
+                    break;
+                }
+                if line == "@@" || line.starts_with("@@ ") {
+                    if !current.is_empty() {
+                        hunks.push(codex_dsl_hunk(
+                            std::mem::take(&mut current),
+                            no_newline_at_end,
+                        ));
+                        no_newline_at_end = false;
+                    }
+                    index += 1;
+                    continue;
+                }
+                let Some(first) = line.chars().next() else {
+                    return Err(syntax_error(
+                        "invalid_codex_change_line",
+                        "Codex change lines must start with space, +, or -",
+                        Some(path),
+                        "prefix blank context lines with a space",
+                    ));
+                };
+                let kind = match first {
+                    ' ' => HunkLineKind::Context,
+                    '+' => HunkLineKind::Add,
+                    '-' => HunkLineKind::Remove,
+                    _ => {
+                        return Err(syntax_error(
+                            "invalid_codex_change_line",
+                            format!(
+                                "Codex change line must start with space, +, or -, got: {line}"
+                            ),
+                            Some(path),
+                            "use only context, added, and removed lines inside update chunks",
+                        ))
+                    }
+                };
+                current.push(HunkLine {
+                    kind,
+                    text: line[1..].to_string(),
+                });
+                index += 1;
+            }
+            if !current.is_empty() {
+                hunks.push(codex_dsl_hunk(current, no_newline_at_end));
+            }
+            if hunks.is_empty() && rename_to.is_none() {
+                return Err(syntax_error(
+                    "missing_hunk",
+                    "Codex Update File must include a change or Move to",
+                    Some(path),
+                    "add change lines or a *** Move to header",
+                ));
+            }
+            let target = rename_to.clone().unwrap_or_else(|| path.to_string());
+            patches.push(FilePatch {
+                old_path: PatchPath::Workspace(path.to_string()),
+                new_path: PatchPath::Workspace(target),
+                rename_from: rename_to.as_ref().map(|_| path.to_string()),
+                rename_to,
+                hunks,
+                ignored_metadata: Vec::new(),
+                diagnostics: Vec::new(),
+            });
+            continue;
+        }
+
+        return Err(syntax_error(
+            "invalid_codex_hunk",
+            format!("unexpected Codex DSL line: {line}"),
+            None,
+            "use *** Add File, *** Delete File, or *** Update File hunks",
+        ));
+    }
+
+    if patches.is_empty() {
+        return Err(syntax_error(
+            "missing_hunk",
+            "Codex DSL patch must include at least one file hunk",
+            None,
+            "add a file hunk between Begin Patch and End Patch",
+        ));
+    }
+    Ok(patches)
+}
+
+fn codex_dsl_lines(input: &str) -> Vec<String> {
+    let mut lines = input.lines().map(ToString::to_string).collect::<Vec<_>>();
+    while lines
+        .first()
+        .map(|line| line.trim().is_empty())
+        .unwrap_or(false)
+    {
+        lines.remove(0);
+    }
+    while lines
+        .last()
+        .map(|line| line.trim().is_empty())
+        .unwrap_or(false)
+    {
+        lines.pop();
+    }
+    if lines
+        .first()
+        .map(|line| line.trim_start())
+        .is_some_and(|line| line == "<<EOF" || line == "<<'EOF'" || line == "<<\"EOF\"")
+        && lines.last().map(String::as_str) == Some("EOF")
+    {
+        lines.remove(0);
+        lines.pop();
+    }
+    lines
+}
+
+fn codex_dsl_hunk(lines: Vec<HunkLine>, no_newline_at_end: bool) -> PatchHunk {
+    let old_count = lines
+        .iter()
+        .filter(|line| line.kind != HunkLineKind::Add)
+        .count();
+    let new_count = lines
+        .iter()
+        .filter(|line| line.kind != HunkLineKind::Remove)
+        .count();
+    PatchHunk {
+        old_start: 1,
+        old_count,
+        new_start: 1,
+        new_count,
+        lines,
+        no_newline_at_end,
+    }
 }
 
 fn parse_git_header(line: &str) -> Result<(String, String)> {
@@ -1236,6 +1599,14 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    async fn apply_patch(workspace_root: &Path, input: &str) -> Result<ApplyPatchOutcome> {
+        super::apply_patch(workspace_root, input, ApplyPatchSurface::UnifiedDiffJson).await
+    }
+
+    fn parse_patch(input: &str) -> Result<Vec<FilePatch>> {
+        parse_unified_diff_patch(input)
+    }
+
     #[tokio::test]
     async fn apply_patch_updates_multiple_files_with_unified_diff() {
         let dir = tempdir().unwrap();
@@ -1268,6 +1639,121 @@ mod tests {
             "keep\nnew\n"
         );
         assert_eq!(outcome.changed_files.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn apply_patch_updates_file_with_codex_dsl() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("sample.txt");
+        tokio::fs::write(&file, "one\ntwo\nthree\n").await.unwrap();
+
+        let patch = r#"*** Begin Patch
+*** Update File: sample.txt
+ one
+-two
++TWO
+ three
+*** End Patch
+"#;
+
+        let outcome = super::apply_patch(dir.path(), patch, ApplyPatchSurface::CodexDslFreeform)
+            .await
+            .unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(&file).await.unwrap(),
+            "one\nTWO\nthree\n"
+        );
+        assert_eq!(outcome.changed_files[0].action, ApplyPatchAction::Modify);
+        assert!(outcome.diagnostics.is_empty());
+    }
+
+    #[tokio::test]
+    async fn apply_patch_codex_dsl_add_delete_and_move_share_changed_shape() {
+        let dir = tempdir().unwrap();
+        let old = dir.path().join("old.txt");
+        let doomed = dir.path().join("doomed.txt");
+        tokio::fs::write(&old, "hello\n").await.unwrap();
+        tokio::fs::write(&doomed, "bye\n").await.unwrap();
+
+        let patch = r#"*** Begin Patch
+*** Add File: created.txt
++hi
+*** Delete File: doomed.txt
+*** Update File: old.txt
+*** Move to: new.txt
+ hello
+*** End Patch
+"#;
+
+        let outcome = super::apply_patch(dir.path(), patch, ApplyPatchSurface::CodexDslFreeform)
+            .await
+            .unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(dir.path().join("created.txt"))
+                .await
+                .unwrap(),
+            "hi\n"
+        );
+        assert!(!tokio::fs::try_exists(&doomed).await.unwrap());
+        assert!(!tokio::fs::try_exists(&old).await.unwrap());
+        assert_eq!(
+            tokio::fs::read_to_string(dir.path().join("new.txt"))
+                .await
+                .unwrap(),
+            "hello\n"
+        );
+        assert_eq!(outcome.changed_files.len(), 3);
+        assert_eq!(outcome.changed_files[0].action, ApplyPatchAction::Add);
+        assert_eq!(outcome.changed_files[1].action, ApplyPatchAction::Delete);
+        assert_eq!(outcome.changed_files[2].action, ApplyPatchAction::Move);
+    }
+
+    #[tokio::test]
+    async fn apply_patch_compatibility_parses_non_active_known_format() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("sample.txt");
+        tokio::fs::write(&file, "old\n").await.unwrap();
+
+        let patch = r#"--- a/sample.txt
++++ b/sample.txt
+@@ -1,1 +1,1 @@
+-old
++new
+"#;
+
+        let outcome = super::apply_patch(dir.path(), patch, ApplyPatchSurface::CodexDslFreeform)
+            .await
+            .unwrap();
+        assert_eq!(tokio::fs::read_to_string(&file).await.unwrap(), "new\n");
+        let diagnostic = outcome
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.kind == "apply_patch_compatibility_fallback")
+            .expect("compatibility diagnostic");
+        assert!(diagnostic.message.contains("expected_format=codex_dsl"));
+        assert!(diagnostic
+            .message
+            .contains("compatibility_fallback_used=true"));
+    }
+
+    #[tokio::test]
+    async fn apply_patch_codex_dsl_accepts_end_of_file_marker() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("sample.txt");
+        tokio::fs::write(&file, "old\n").await.unwrap();
+
+        let patch = r#"*** Begin Patch
+*** Update File: sample.txt
+-old
++new
+*** End of File
+*** End Patch
+"#;
+
+        super::apply_patch(dir.path(), patch, ApplyPatchSurface::CodexDslFreeform)
+            .await
+            .unwrap();
+        assert_eq!(tokio::fs::read_to_string(&file).await.unwrap(), "new");
     }
 
     #[tokio::test]
@@ -1648,7 +2134,7 @@ rename to new.txt
         assert_eq!(tool_error.kind, "invalid_patch_syntax");
         assert_eq!(
             tool_error.details.as_ref().unwrap()["rule"],
-            "legacy_patch_format"
+            "wrong_patch_format"
         );
     }
 

--- a/src/tool/apply_patch.rs
+++ b/src/tool/apply_patch.rs
@@ -227,7 +227,9 @@ fn parse_patch_for_format(input: &str, format: PatchFormat) -> Result<Vec<FilePa
 fn detect_patch_format(input: &str) -> PatchFormat {
     let trimmed = input.trim_start();
     if trimmed.starts_with("*** Begin Patch")
-        || trimmed.lines().any(|line| line == "*** Begin Patch")
+        || codex_dsl_lines(input)
+            .first()
+            .is_some_and(|line| line == "*** Begin Patch")
     {
         return PatchFormat::CodexDsl;
     }
@@ -1639,6 +1641,31 @@ mod tests {
             "keep\nnew\n"
         );
         assert_eq!(outcome.changed_files.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn apply_patch_unified_diff_allows_codex_marker_as_file_content() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("sample.txt");
+        tokio::fs::write(&file, "before\n*** Begin Patch\nafter\n")
+            .await
+            .unwrap();
+
+        let patch = r#"--- a/sample.txt
++++ b/sample.txt
+@@ -1,3 +1,3 @@
+ before
+ *** Begin Patch
+-after
++AFTER
+"#;
+
+        let outcome = apply_patch(dir.path(), patch).await.unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(&file).await.unwrap(),
+            "before\n*** Begin Patch\nAFTER\n"
+        );
+        assert_eq!(outcome.changed_files[0].action, ApplyPatchAction::Modify);
     }
 
     #[tokio::test]

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{
     runtime::RuntimeHandle,
-    tool::ToolError,
+    tool::{apply_patch::ApplyPatchSurface, ToolError},
     types::{ToolCapabilityFamily, ToolExecutionRecord, ToolExecutionStatus, TrustLevel},
 };
 
@@ -55,6 +55,7 @@ impl ToolRegistry {
             .collect())
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn tool_specs_with_families(&self) -> Result<Vec<(ToolCapabilityFamily, ToolSpec)>> {
         let catalog = TOOL_SPEC_CATALOG
             .as_ref()
@@ -64,6 +65,18 @@ impl ToolRegistry {
             .iter()
             .map(|entry| (entry.family, entry.spec.clone()))
             .collect())
+    }
+
+    pub(crate) fn tool_specs_with_families_for_apply_patch_surface(
+        &self,
+        surface: ApplyPatchSurface,
+    ) -> Result<Vec<(ToolCapabilityFamily, ToolSpec)>> {
+        Ok(
+            tools::builtin_tool_definitions_for_apply_patch_surface(surface)?
+                .into_iter()
+                .map(|definition| (definition.family, definition.spec))
+                .collect(),
+        )
     }
 
     pub(crate) fn family_for_tool(&self, tool_name: &str) -> Result<Option<ToolCapabilityFamily>> {

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -6,7 +6,7 @@
 //! - `helpers`: Shared utility functions
 //! - `tools`: Builtin tool modules, one per tool
 
-mod apply_patch;
+pub(crate) mod apply_patch;
 pub mod dispatch;
 pub mod error;
 pub(crate) mod helpers;

--- a/src/tool/tools/apply_patch_tool.rs
+++ b/src/tool/tools/apply_patch_tool.rs
@@ -7,7 +7,7 @@ use crate::{
     runtime::RuntimeHandle,
     system::ExecutionScopeKind,
     tool::{
-        apply_patch,
+        apply_patch::{self, ApplyPatchSurface},
         helpers::{invalid_tool_input, truncate_text, validate_non_empty},
         spec::{ToolFreeformGrammar, ToolResultStatus},
         ToolError, ToolResult,
@@ -21,7 +21,9 @@ use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::{helpers::parse_tool_args, schema::tool_input_schema};
 
 pub(crate) const NAME: &str = "ApplyPatch";
-const APPLY_PATCH_LARK_GRAMMAR: &str = include_str!("apply_patch_tool.lark");
+// Grammar matches OpenAI Codex's ApplyPatch DSL surface; Holon still applies
+// parsed edits through its own workspace guards and atomic apply path.
+const CODEX_DSL_LARK_GRAMMAR: &str = include_str!("apply_patch_tool_codex.lark");
 const MODEL_ERROR_TEXT_LIMIT: usize = 700;
 const MODEL_ERROR_TOKEN_LIMIT: usize = 96;
 const MODEL_DIAGNOSTIC_LIMIT: usize = 8;
@@ -34,16 +36,35 @@ pub(crate) struct ApplyPatchArgs {
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    definition_for_surface(ApplyPatchSurface::UnifiedDiffJson)
+}
+
+pub(crate) fn definition_for_surface(surface: ApplyPatchSurface) -> Result<BuiltinToolDefinition> {
+    let (description, input_schema, freeform_grammar) = match surface {
+        ApplyPatchSurface::CodexDslFreeform => (
+            "Apply a Codex-style patch DSL across one or more files. Submit raw *** Begin Patch / *** End Patch text directly as the freeform tool body; do not wrap it in JSON.".to_string(),
+            serde_json::json!({
+                "type": "string",
+                "description": "Raw Codex ApplyPatch DSL beginning with *** Begin Patch and ending with *** End Patch"
+            }),
+            Some(ToolFreeformGrammar {
+                syntax: "lark".to_string(),
+                definition: CODEX_DSL_LARK_GRAMMAR.to_string(),
+            }),
+        ),
+        ApplyPatchSurface::UnifiedDiffJson => (
+            "Apply a unified diff patch across one or more files. Call the JSON/function tool with exactly {\"patch\":\"--- a/path\\n+++ b/path\\n@@ ...\"}; do not use the Codex *** Begin Patch DSL as the advertised format.".to_string(),
+            tool_input_schema::<ApplyPatchArgs>()?,
+            None,
+        ),
+    };
     Ok(BuiltinToolDefinition {
         family: ToolCapabilityFamily::LocalEnvironment,
         spec: crate::tool::ToolSpec {
             name: NAME.to_string(),
-            description: "Apply a unified diff patch across one or more files. Follow the invocation shape exposed by the current tool surface, and do not use the old *** Begin Patch format.".to_string(),
-            input_schema: tool_input_schema::<ApplyPatchArgs>()?,
-            freeform_grammar: Some(ToolFreeformGrammar {
-                syntax: "lark".to_string(),
-                definition: APPLY_PATCH_LARK_GRAMMAR.to_string(),
-            }),
+            description,
+            input_schema,
+            freeform_grammar,
         },
     })
 }
@@ -54,12 +75,14 @@ pub(crate) async fn execute(
     _trust: &TrustLevel,
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
-    let patch_input = extract_patch_input(input)?;
+    let surface = runtime.current_apply_patch_surface().await;
+    let patch_input = extract_patch_input(input, surface)?;
     let execution = runtime
         .effective_execution(ExecutionScopeKind::AgentTurn)
         .await?;
     let outcome =
-        apply_patch::apply_patch(execution.workspace.execution_root(), &patch_input).await?;
+        apply_patch::apply_patch(execution.workspace.execution_root(), &patch_input, surface)
+            .await?;
     let mut summary_text = if outcome.changed_files.is_empty() {
         "patched no files".to_string()
     } else {
@@ -162,9 +185,7 @@ fn render_apply_patch_error_for_model(error: &ToolError) -> String {
     if error.retryable {
         lines.push("- retryable: true".to_string());
     }
-    lines.push(
-        "Use a smaller, valid unified diff or inspect the target file before retrying.".to_string(),
-    );
+    lines.push("Use the ApplyPatch format advertised for this turn, keep the patch smaller when possible, and inspect the target file before retrying.".to_string());
     format!("{}\n", lines.join("\n"))
 }
 
@@ -191,11 +212,26 @@ fn sanitize_model_visible_error_text(text: &str) -> String {
     truncate_text(&sanitized, MODEL_ERROR_TEXT_LIMIT)
 }
 
-fn extract_patch_input(input: &Value) -> Result<String> {
+fn extract_patch_input(input: &Value, surface: ApplyPatchSurface) -> Result<String> {
     match input {
         Value::String(patch) => validate_non_empty(patch.clone(), NAME, "patch"),
-        Value::Object(map) if map.contains_key("input") && !map.contains_key("patch") => Err(
-            invalid_tool_input(
+        Value::Object(map) if map.contains_key("input") && !map.contains_key("patch") => {
+            if matches!(surface, ApplyPatchSurface::CodexDslFreeform) {
+                return map
+                    .get("input")
+                    .and_then(Value::as_str)
+                    .map(|value| validate_non_empty(value.to_string(), NAME, "input"))
+                    .transpose()?
+                    .ok_or_else(|| {
+                        invalid_tool_input(
+                            NAME,
+                            "ApplyPatch input must be a string",
+                            serde_json::json!({"field": "input"}),
+                            "Submit raw *** Begin Patch / *** End Patch text directly.",
+                        )
+                    });
+            }
+            Err(invalid_tool_input(
                 NAME,
                 "ApplyPatch expects `patch`, not `input`",
                 serde_json::json!({
@@ -203,8 +239,8 @@ fn extract_patch_input(input: &Value) -> Result<String> {
                     "expected_field": "patch",
                 }),
                 "ApplyPatch expects exactly {\"patch\": \"--- a/path\\n+++ b/path\\n@@ -1,1 +1,1 @@\\n-old\\n+new\\n\"}. Do not use \"input\".",
-            ),
-        ),
+            ))
+        }
         _ => {
             let args: ApplyPatchArgs = parse_tool_args(NAME, input)?;
             validate_non_empty(args.patch, NAME, "patch")
@@ -427,9 +463,12 @@ mod tests {
 
     #[test]
     fn apply_patch_json_input_rejects_legacy_input_field() {
-        let error = extract_patch_input(&serde_json::json!({
-            "input": "--- a/old.txt\n+++ b/old.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n"
-        }))
+        let error = extract_patch_input(
+            &serde_json::json!({
+                "input": "--- a/old.txt\n+++ b/old.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n"
+            }),
+            ApplyPatchSurface::UnifiedDiffJson,
+        )
         .unwrap_err();
         let tool_error = crate::tool::ToolError::from_anyhow(&error);
         assert_eq!(tool_error.kind, "invalid_tool_input");
@@ -445,7 +484,18 @@ mod tests {
         let spec = definition().unwrap().spec;
         assert!(spec.input_schema["properties"]["patch"].is_object());
         assert!(spec.input_schema["properties"]["input"].is_null());
-        assert!(spec.freeform_grammar.is_some());
+        assert!(spec.freeform_grammar.is_none());
+    }
+
+    #[test]
+    fn apply_patch_codex_surface_uses_freeform_dsl_grammar() {
+        let spec = definition_for_surface(ApplyPatchSurface::CodexDslFreeform)
+            .unwrap()
+            .spec;
+        assert!(spec.input_schema["type"] == "string");
+        let grammar = spec.freeform_grammar.expect("codex grammar");
+        assert!(grammar.definition.contains("*** Begin Patch"));
+        assert!(!spec.description.contains("unified diff"));
     }
 
     #[test]
@@ -460,16 +510,16 @@ mod tests {
     }
 
     #[test]
-    fn apply_patch_freeform_grammar_requires_update_hunks() {
-        let grammar = definition()
+    fn apply_patch_codex_freeform_grammar_requires_codex_hunks() {
+        let grammar = definition_for_surface(ApplyPatchSurface::CodexDslFreeform)
             .unwrap()
             .spec
             .freeform_grammar
             .expect("apply patch should expose freeform grammar")
             .definition;
-        assert!(grammar.contains("old_file: \"--- \" file_path LF"));
-        assert!(grammar.contains("new_file: \"+++ \" file_path LF"));
-        assert!(grammar.contains("hunk_header: \"@@ -\" range \" +\" range \" @@\""));
-        assert!(!grammar.contains("*** Begin Patch"));
+        assert!(grammar.contains("begin_patch: \"*** Begin Patch\" LF"));
+        assert!(grammar.contains("update_hunk: \"*** Update File: \""));
+        assert!(grammar.contains("change_move: \"*** Move to: \""));
+        assert!(!grammar.contains("old_file: \"--- \" file_path LF"));
     }
 }

--- a/src/tool/tools/apply_patch_tool.rs
+++ b/src/tool/tools/apply_patch_tool.rs
@@ -214,7 +214,14 @@ fn sanitize_model_visible_error_text(text: &str) -> String {
 
 fn extract_patch_input(input: &Value, surface: ApplyPatchSurface) -> Result<String> {
     match input {
-        Value::String(patch) => validate_non_empty(patch.clone(), NAME, "patch"),
+        Value::String(patch) => validate_non_empty(
+            patch.clone(),
+            NAME,
+            match surface {
+                ApplyPatchSurface::CodexDslFreeform => "input",
+                ApplyPatchSurface::UnifiedDiffJson => "patch",
+            },
+        ),
         Value::Object(map) if map.contains_key("input") && !map.contains_key("patch") => {
             if matches!(surface, ApplyPatchSurface::CodexDslFreeform) {
                 return map
@@ -477,6 +484,19 @@ mod tests {
             .as_deref()
             .unwrap_or_default()
             .contains("Do not use \"input\""));
+    }
+
+    #[test]
+    fn apply_patch_codex_freeform_empty_string_uses_input_label() {
+        let error = extract_patch_input(
+            &serde_json::json!("   "),
+            ApplyPatchSurface::CodexDslFreeform,
+        )
+        .unwrap_err();
+        let tool_error = crate::tool::ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert_eq!(tool_error.details.as_ref().unwrap()["field"], "input");
+        assert!(!tool_error.message.contains("`patch`"));
     }
 
     #[test]

--- a/src/tool/tools/apply_patch_tool_codex.lark
+++ b/src/tool/tools/apply_patch_tool_codex.lark
@@ -1,0 +1,19 @@
+start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::{
     runtime::RuntimeHandle,
-    tool::{ToolCall, ToolResult, ToolSpec},
+    tool::{apply_patch::ApplyPatchSurface, ToolCall, ToolResult, ToolSpec},
     types::{ToolCapabilityFamily, TrustLevel},
 };
 
@@ -71,6 +71,21 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         web_fetch::definition()?,
         web_search::definition()?,
     ])
+}
+
+pub(crate) fn builtin_tool_definitions_for_apply_patch_surface(
+    surface: ApplyPatchSurface,
+) -> Result<Vec<BuiltinToolDefinition>> {
+    builtin_tool_definitions()?
+        .into_iter()
+        .map(|definition| {
+            if definition.spec.name == apply_patch_tool::NAME {
+                apply_patch_tool::definition_for_surface(surface)
+            } else {
+                Ok(definition)
+            }
+        })
+        .collect()
 }
 
 pub(crate) async fn execute_builtin_tool(


### PR DESCRIPTION
## Summary

Fixes #1230.

This selects the model-visible ApplyPatch surface from the active model lineage for the turn:

- `openai-codex/*` gets a Codex DSL freeform grammar surface.
- generic model lineages get a JSON/function tool carrying unified diff in `patch`.
- prompt guidance describes only the active surface.
- tool execution keeps one runtime ApplyPatch implementation and applies both parsed formats through the same workspace guards and staged apply path.

## Details

- Added `ApplyPatchSurface` with lineage mapping and runtime selection from the current turn provider chain.
- Added a Codex DSL parser and Lark grammar for `*** Begin Patch` / file hunks / `*** End Patch`.
- Kept generic OpenAI/other providers on unified diff JSON rather than custom grammar.
- Added compatibility parsing: if the current strict parser fails but the submitted body is a known alternate format, Holon applies it and records a corrective diagnostic.
- Updated ApplyPatch prompt sections, provider schema tests, and focused parser/tool tests.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test apply_patch --lib`
- `cargo test --all-targets -- --test-threads=1`

Note: default parallel `cargo test --all-targets` repeatedly failed on `agent_template::tests::ensure_agent_home_agents_md_from_template_fills_missing_agents_md`, while that test passed standalone and the full suite passed with `--test-threads=1`. This looks like an existing parallel test environment interaction around HOME/template seeding, not an ApplyPatch regression.
