### PR TITLE
[bench][holon-openai][#858] docs(test): refresh stale coverage review after runtime test split

### DIFF
--- a/docs/test-coverage-review.md
+++ b/docs/test-coverage-review.md
@@ -21,7 +21,7 @@ Current automated test surface is broad:
 - 458 test functions total across unit, integration, worktree, HTTP, TUI, and
   live-provider suites
 - heaviest coverage files:
-  - `tests/runtime_flow.rs`: 58 tests
+  - `tests/support/runtime_flow.rs`: 58 tests
   - `tests/http_routes.rs`: 49 tests
   - `src/provider/tests.rs`: 57 tests
   - `src/runtime.rs`: 45 tests
@@ -50,7 +50,7 @@ place to spend more test effort unless regressions appear:
   - failure briefs
   - wake hints
   - token usage persistence
-  - `tests/runtime_flow.rs`
+  - `tests/support/runtime_flow.rs`
 - HTTP control and status API behavior
   - `tests/http_routes.rs`
 - `run_once` lifecycle and wait/no-wait semantics


### PR DESCRIPTION
Benchmark metadata:

- task_id: `holon-0858-refresh-stale-coverage-review`
- runner: `holon-openai`
- base_sha: `d929b046e5f237e831fd1d7efe6a10e44efe2b1d`
- issue: `#858`
- benchmark_mode: `live`

Canonical task brief:

Fix GitHub issue #858 in this repository.

Issue:
https://github.com/holon-run/holon/issues/858

Instructions:
- Use `gh` commands to inspect the issue and related GitHub context.
- Stay within the issue scope.
- Use local repository context when needed.
- Do not stop to ask for confirmation; continue until the issue is fully handled.
- Do not stop at analysis or partial plans when implementation is still possible.
- Complete the issue acceptance criteria in one pull request; do not submit a partial, preparatory, or shim-only PR when the issue asks for the full implementation.
- You may split the implementation into multiple commits inside that one PR when that makes review easier.
- If you introduce compatibility shims as an intermediate step, continue moving the real implementation until the issue is fully solved before stopping.
- Only stop without implementation if you conclude the task cannot be completed from the current repository state and available tools; in that case, provide a concise operator-facing report explaining the blocker and the remaining work.
- Run the task verifier before stopping.
- If you make a real implementation, follow the PR submission policy below.

PR policy:
- Submit a pull request if you make a real implementation.
- Submit it as a draft pull request.
