### PR TITLE
fix: gate OpenAI remote compaction on token pressure

### DIFF
--- a/docs/rfcs/openai-remote-compaction.md
+++ b/docs/rfcs/openai-remote-compaction.md
@@ -253,8 +253,9 @@ Remote compaction should be budget-driven.
 
 Suggested initial triggers:
 
-- provider input estimate exceeds a soft limit
-- provider rounds exceed a benchmarked loop threshold
+- provider-reported input usage reaches the configured compaction trigger
+- provider input estimate reaches the configured compaction trigger when usage
+  data is unavailable
 - OpenAI returns a context-window error and the provider window is compactable
 
 Suggested non-triggers:
@@ -264,6 +265,12 @@ Suggested non-triggers:
 - after every local semantic compaction
 - while a tool call and its output are not paired yet
 - when request shape changed for unrelated reasons
+
+Holon should not use a minimum provider-item count as an additional compaction
+gate. Item boundaries are safety boundaries for choosing the compactable prefix;
+they are not pressure signals. A single large provider item may need compaction,
+while many tiny items should not compact until the token budget is under
+pressure.
 
 The "tool call and its output are not paired yet" rule applies to the compacted
 span, not necessarily to the whole provider window. If the latest provider

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod skills;
 pub mod solve;
 pub mod storage;
 pub mod system;
+mod token_estimate;
 pub mod tool;
 pub mod tui;
 mod tui_markdown;

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -4,11 +4,15 @@ use anyhow::{anyhow, Result};
 
 use crate::{
     config::{AppConfig, ModelRef, ProviderTransportKind},
+    context::ContextConfig,
+    model_catalog::BuiltInModelCatalog,
     provider::fallback::FallbackProvider,
 };
 
 use super::{
-    transports::{OpenAiChatCompletionsProvider, OpenAiCodexProvider, OpenAiProvider},
+    transports::{
+        OpenAiChatCompletionsProvider, OpenAiCodexProvider, OpenAiCompactionPolicy, OpenAiProvider,
+    },
     AgentProvider, AnthropicProvider,
 };
 
@@ -69,21 +73,29 @@ pub(crate) fn build_candidate(
             model_ref.provider.as_str()
         )
     })?;
+    let resolved_policy = resolved_model_policy_for_candidate(config, model_ref);
+    let openai_compaction_policy = OpenAiCompactionPolicy {
+        trigger_input_tokens: resolved_policy.compaction_trigger_estimated_tokens as u64,
+    };
     let provider: Arc<dyn AgentProvider> = match provider_config.transport {
-        ProviderTransportKind::OpenAiCodexResponses => {
-            Arc::new(OpenAiCodexProvider::from_runtime_config(
+        ProviderTransportKind::OpenAiCodexResponses => Arc::new(
+            OpenAiCodexProvider::from_runtime_config_with_compaction_policy(
                 provider_config,
                 &model_ref.model,
                 config.runtime_max_output_tokens,
                 &config.home_dir,
+                openai_compaction_policy,
+            )?,
+        ),
+        ProviderTransportKind::OpenAiResponses => {
+            Arc::new(OpenAiProvider::from_runtime_config_with_compaction_policy(
+                provider_config,
+                &model_ref.model,
+                config.runtime_max_output_tokens,
+                &config.home_dir,
+                openai_compaction_policy,
             )?)
         }
-        ProviderTransportKind::OpenAiResponses => Arc::new(OpenAiProvider::from_runtime_config(
-            provider_config,
-            &model_ref.model,
-            config.runtime_max_output_tokens,
-            &config.home_dir,
-        )?),
         ProviderTransportKind::AnthropicMessages => {
             Arc::new(AnthropicProvider::from_runtime_config(
                 provider_config,
@@ -105,4 +117,28 @@ pub(crate) fn build_candidate(
         provider_name: model_ref.provider.as_str().to_string(),
         provider,
     })
+}
+
+fn resolved_model_policy_for_candidate(
+    config: &AppConfig,
+    model_ref: &ModelRef,
+) -> crate::model_catalog::ResolvedRuntimeModelPolicy {
+    let base_context_config = ContextConfig {
+        recent_messages: config.context_window_messages,
+        recent_briefs: config.context_window_briefs,
+        compaction_trigger_messages: config.compaction_trigger_messages,
+        compaction_keep_recent_messages: config.compaction_keep_recent_messages,
+        prompt_budget_estimated_tokens: config.prompt_budget_estimated_tokens,
+        compaction_trigger_estimated_tokens: config.compaction_trigger_estimated_tokens,
+        compaction_keep_recent_estimated_tokens: config.compaction_keep_recent_estimated_tokens,
+        recent_episode_candidates: config.recent_episode_candidates,
+        max_relevant_episodes: config.max_relevant_episodes,
+    };
+    BuiltInModelCatalog::default().resolve_policy(
+        model_ref,
+        &config.validated_model_overrides,
+        config.validated_unknown_model_fallback.as_ref(),
+        &base_context_config,
+        config.runtime_max_output_tokens,
+    )
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -255,6 +255,10 @@ pub struct ProviderOpenAiRemoteCompactionDiagnostics {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub latest_compaction_index: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_input_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_input_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encrypted_content_hashes: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encrypted_content_bytes: Option<Vec<usize>>,

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -17,7 +17,7 @@ fn openai_tool_call_response(response_id: &str) -> Value {
     json!({
         "id": response_id,
         "status": "completed",
-        "usage": { "input_tokens": 3, "output_tokens": 2 },
+        "usage": { "input_tokens": 256, "output_tokens": 2 },
         "output": [{
             "type": "function_call",
             "id": "fc_non_persisted",
@@ -30,10 +30,18 @@ fn openai_tool_call_response(response_id: &str) -> Value {
 }
 
 fn openai_text_response(response_id: &str, text: &str) -> Value {
+    openai_text_response_with_input_tokens(response_id, text, 2)
+}
+
+fn openai_text_response_with_input_tokens(
+    response_id: &str,
+    text: &str,
+    input_tokens: u64,
+) -> Value {
     json!({
         "id": response_id,
         "status": "completed",
-        "usage": { "input_tokens": 2, "output_tokens": 1 },
+        "usage": { "input_tokens": input_tokens, "output_tokens": 1 },
         "output": [{
             "type": "message",
             "id": "msg_non_persisted",
@@ -48,7 +56,7 @@ fn openai_text_response_with_provider_metadata(response_id: &str, text: &str) ->
     json!({
         "id": response_id,
         "status": "completed",
-        "usage": { "input_tokens": 2, "output_tokens": 1 },
+        "usage": { "input_tokens": 256, "output_tokens": 1 },
         "output": [{
             "type": "message",
             "id": "msg_non_persisted",
@@ -78,12 +86,20 @@ fn set_remote_compaction_trigger(config: &mut crate::config::AppConfig, model_re
 }
 
 fn openai_text_sse_response(response_id: &str, text: &str) -> String {
+    openai_text_sse_response_with_input_tokens(response_id, text, 2)
+}
+
+fn openai_text_sse_response_with_input_tokens(
+    response_id: &str,
+    text: &str,
+    input_tokens: u64,
+) -> String {
     format!(
         concat!(
             "event: response.completed\n",
-            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":2,\"output_tokens\":1}},\"output\":[{{\"type\":\"message\",\"id\":\"msg_non_persisted\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{{\"type\":\"output_text\",\"text\":\"{}\"}}]}}]}}}}\n\n"
+            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":{},\"output_tokens\":1}},\"output\":[{{\"type\":\"message\",\"id\":\"msg_non_persisted\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{{\"type\":\"output_text\",\"text\":\"{}\"}}]}}]}}}}\n\n"
         ),
-        response_id, text
+        response_id, input_tokens, text
     )
 }
 
@@ -91,7 +107,7 @@ fn openai_reasoning_and_tool_call_sse_response(response_id: &str) -> String {
     format!(
         concat!(
             "event: response.completed\n",
-            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":10,\"output_tokens\":4}},\"output\":[",
+            "data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"status\":\"completed\",\"usage\":{{\"input_tokens\":256,\"output_tokens\":4}},\"output\":[",
             "{{\"type\":\"reasoning\",\"id\":\"rs_non_persisted\",\"encrypted_content\":\"opaque-reasoning\"}},",
             "{{\"type\":\"function_call\",\"id\":\"fc_non_persisted\",\"call_id\":\"exec-1\",\"name\":\"ExecCommand\",\"arguments\":\"{{\\\"cmd\\\":\\\"printf ok\\\"}}\"}}",
             "]}}}}\n\n"
@@ -479,7 +495,7 @@ async fn openai_codex_remote_compact_uses_codex_backend_route_for_legacy_base_ur
                         captured.lock().unwrap().push(body);
                         (
                             [("content-type", "text/event-stream")],
-                            openai_text_sse_response("resp_1", "ready"),
+                            openai_text_sse_response_with_input_tokens("resp_1", "ready", 256),
                         )
                     }
                 }),
@@ -540,7 +556,7 @@ async fn openai_codex_remote_compact_does_not_double_codex_path_for_new_base_url
                 post(|Json(_body): Json<Value>| async {
                     (
                         [("content-type", "text/event-stream")],
-                        openai_text_sse_response("resp_1", "ready"),
+                        openai_text_sse_response_with_input_tokens("resp_1", "ready", 256),
                     )
                 }),
             )
@@ -682,7 +698,9 @@ async fn openai_responses_caches_unsupported_remote_compact_endpoint() {
                     async move {
                         let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                         if attempt == 0 {
-                            Json(openai_text_response("resp_1", "ready"))
+                            Json(openai_text_response_with_input_tokens(
+                                "resp_1", "ready", 256,
+                            ))
                         } else {
                             Json(openai_text_response("resp_2", "done"))
                         }
@@ -756,7 +774,9 @@ async fn openai_responses_reports_non_persisted_compact_item_ids_without_endpoin
                     async move {
                         let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                         if attempt == 0 {
-                            Json(openai_text_response("resp_1", "ready"))
+                            Json(openai_text_response_with_input_tokens(
+                                "resp_1", "ready", 256,
+                            ))
                         } else {
                             Json(openai_text_response("resp_2", "done"))
                         }
@@ -1106,7 +1126,7 @@ async fn openai_responses_compacts_safe_prefix_without_item_count_gate() {
     );
     assert_eq!(
         remote_compaction.trigger_reason.as_deref(),
-        Some("estimated_window_pressure")
+        Some("token_budget_pressure")
     );
     assert_eq!(remote_compaction.trigger_input_tokens, Some(128));
 
@@ -1194,7 +1214,7 @@ async fn openai_responses_replays_compacted_prefix_with_retained_tool_tail() {
     assert_eq!(first_compaction.status, "compacted");
     assert_eq!(
         first_compaction.trigger_reason.as_deref(),
-        Some("estimated_window_pressure")
+        Some("token_budget_pressure")
     );
     assert_eq!(first_compaction.input_items, Some(8));
 

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -7,7 +7,8 @@ use std::sync::{
 
 use super::support::*;
 use super::*;
-use crate::config::ProviderId;
+use crate::config::{ModelRef, ProviderId};
+use crate::model_catalog::ModelRuntimeOverride;
 use crate::provider::transports::set_stream_idle_timeout_override_for_tests;
 use axum::{http::StatusCode, response::IntoResponse, routing::post, Json, Router};
 use serde_json::{json, Value};
@@ -62,6 +63,18 @@ fn openai_text_response_with_provider_metadata(response_id: &str, text: &str) ->
             }]
         }]
     })
+}
+
+fn set_remote_compaction_trigger(config: &mut crate::config::AppConfig, model_ref: &str) {
+    config.validated_model_overrides.insert(
+        ModelRef::parse(model_ref).unwrap(),
+        ModelRuntimeOverride {
+            prompt_budget_estimated_tokens: Some(256),
+            compaction_trigger_estimated_tokens: Some(128),
+            compaction_keep_recent_estimated_tokens: Some(32),
+            ..ModelRuntimeOverride::default()
+        },
+    );
 }
 
 fn openai_text_sse_response(response_id: &str, text: &str) -> String {
@@ -401,6 +414,7 @@ async fn openai_responses_remote_compacts_provider_window_and_replays_compaction
         .get_mut(&ProviderId::openai())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai/gpt-5.4");
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let first = provider
@@ -493,6 +507,7 @@ async fn openai_codex_remote_compact_uses_codex_backend_route_for_legacy_base_ur
         .get_mut(&ProviderId::openai_codex())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai-codex/gpt-5.4");
     let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let response = provider
@@ -552,6 +567,7 @@ async fn openai_codex_remote_compact_does_not_double_codex_path_for_new_base_url
         .get_mut(&ProviderId::openai_codex())
         .unwrap()
         .base_url = format!("{base_url}/codex");
+    set_remote_compaction_trigger(&mut fixture.config, "openai-codex/gpt-5.4");
     let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     provider
@@ -612,6 +628,7 @@ async fn openai_codex_remote_compact_sanitizes_ids_and_retains_unpaired_tail() {
         .get_mut(&ProviderId::openai_codex())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai-codex/gpt-5.4");
     let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let first = provider
@@ -694,6 +711,7 @@ async fn openai_responses_caches_unsupported_remote_compact_endpoint() {
         .get_mut(&ProviderId::openai())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai/gpt-5.4");
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let first = provider
@@ -774,6 +792,7 @@ async fn openai_responses_reports_non_persisted_compact_item_ids_without_endpoin
         .get_mut(&ProviderId::openai())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai/gpt-5.4");
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let first = provider
@@ -986,6 +1005,7 @@ async fn openai_responses_compacts_safe_prefix_before_unpaired_tool_call() {
         .get_mut(&ProviderId::openai())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai/gpt-5.4");
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let response = provider
@@ -1008,7 +1028,7 @@ async fn openai_responses_compacts_safe_prefix_before_unpaired_tool_call() {
 }
 
 #[tokio::test]
-async fn openai_responses_skips_remote_compaction_when_safe_prefix_is_below_threshold() {
+async fn openai_responses_compacts_safe_prefix_without_item_count_gate() {
     let response_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
     let response_bodies_for_server = response_bodies.clone();
     let compact_bodies = Arc::new(Mutex::new(Vec::<Value>::new()));
@@ -1056,6 +1076,7 @@ async fn openai_responses_skips_remote_compaction_when_safe_prefix_is_below_thre
         .get_mut(&ProviderId::openai())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai/gpt-5.4");
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let response = provider
@@ -1071,37 +1092,36 @@ async fn openai_responses_skips_remote_compaction_when_safe_prefix_is_below_thre
         .request_diagnostics
         .as_ref()
         .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
-        .expect("remote compaction skip diagnostics");
-    assert_eq!(remote_compaction.status, "skipped_unpaired_tool_call");
-    assert_eq!(remote_compaction.input_items, Some(8));
+        .expect("remote compaction diagnostics");
+    assert_eq!(remote_compaction.status, "compacted");
+    assert_eq!(remote_compaction.input_items, Some(7));
 
-    let second_compaction = second
-        .request_diagnostics
-        .as_ref()
-        .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
-        .expect("pre-request remote compaction diagnostics");
-    assert_eq!(second_compaction.status, "compacted");
-    assert_eq!(
-        second_compaction.trigger_reason.as_deref(),
-        Some("provider_window_item_threshold_before_request")
+    assert!(
+        second
+            .request_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.openai_remote_compaction.as_ref())
+            .is_none(),
+        "the second request should replay the compacted prefix and retained tool tail without another compact pass"
     );
-    assert_eq!(second_compaction.input_items, Some(9));
+    assert_eq!(
+        remote_compaction.trigger_reason.as_deref(),
+        Some("estimated_window_pressure")
+    );
+    assert_eq!(remote_compaction.trigger_input_tokens, Some(128));
 
     let response_bodies = response_bodies.lock().unwrap();
     assert_eq!(response_bodies.len(), 2);
     assert!(response_bodies[1].get("previous_response_id").is_none());
     let second_input = response_bodies[1]["input"].as_array().unwrap();
-    assert_eq!(second_input.len(), 1);
+    assert_eq!(second_input.len(), 3);
     assert_eq!(second_input[0]["type"], json!("compaction"));
 
     let compact_bodies = compact_bodies.lock().unwrap();
     assert_eq!(compact_bodies.len(), 1);
     let compact_input = compact_bodies[0]["input"].as_array().unwrap();
-    assert_eq!(compact_input.len(), 9);
-    assert_eq!(
-        compact_input.last().unwrap()["type"],
-        json!("function_call_output")
-    );
+    assert_eq!(compact_input.len(), 7);
+    assert_eq!(compact_input.last().unwrap()["type"], json!("message"));
 }
 
 #[tokio::test]
@@ -1154,6 +1174,7 @@ async fn openai_responses_replays_compacted_prefix_with_retained_tool_tail() {
         .get_mut(&ProviderId::openai())
         .unwrap()
         .base_url = base_url;
+    set_remote_compaction_trigger(&mut fixture.config, "openai/gpt-5.4");
     let provider = OpenAiProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
 
     let first = provider
@@ -1173,7 +1194,7 @@ async fn openai_responses_replays_compacted_prefix_with_retained_tool_tail() {
     assert_eq!(first_compaction.status, "compacted");
     assert_eq!(
         first_compaction.trigger_reason.as_deref(),
-        Some("provider_window_item_threshold")
+        Some("estimated_window_pressure")
     );
     assert_eq!(first_compaction.input_items, Some(8));
 

--- a/src/provider/transports/mod.rs
+++ b/src/provider/transports/mod.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::{env, time::Duration};
 
 pub use anthropic::AnthropicProvider;
+pub(crate) use openai::OpenAiCompactionPolicy;
 #[cfg(test)]
 pub(crate) use openai::OpenAiResponsesTransportContract;
 #[cfg(test)]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -16,7 +16,11 @@ use std::{
 
 use crate::{
     auth::load_codex_cli_credential,
-    config::{AppConfig, CredentialKind, CredentialSource, ProviderId, ProviderRuntimeConfig},
+    config::{
+        AppConfig, CredentialKind, CredentialSource, ModelRef, ProviderId, ProviderRuntimeConfig,
+    },
+    context::ContextConfig,
+    model_catalog::BuiltInModelCatalog,
     provider::{
         emitted_tool_json_schema, AgentProvider, ConversationMessage, ModelBlock,
         ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
@@ -25,6 +29,7 @@ use crate::{
         ProviderPromptFrame, ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
         ToolSchemaContract,
     },
+    token_estimate::estimate_json_tokens,
 };
 
 use super::{build_http_client, request_send_timeout, stream_idle_timeout};
@@ -41,6 +46,7 @@ pub struct OpenAiProvider {
     api_key: Option<String>,
     model: String,
     max_output_tokens: u32,
+    compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
 }
@@ -54,6 +60,7 @@ pub struct OpenAiCodexProvider {
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
+    compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
 }
@@ -75,9 +82,21 @@ pub(crate) enum OpenAiResponsesTransportContract {
     CodexStreaming,
 }
 
-const OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS: usize = 8;
 const OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND: &str = "responses_compact";
 static OPENAI_HTTP_TRACE_SEQ: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct OpenAiCompactionPolicy {
+    pub(crate) trigger_input_tokens: u64,
+}
+
+impl Default for OpenAiCompactionPolicy {
+    fn default() -> Self {
+        Self {
+            trigger_input_tokens: u64::MAX,
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 struct OpenAiHttpTrace {
@@ -386,6 +405,7 @@ struct OpenAiProviderWindow {
     items: Vec<Value>,
     append_match_items: Vec<Value>,
     latest_compaction_index: Option<usize>,
+    total_usage_tokens: u64,
     generation: u64,
 }
 
@@ -440,11 +460,12 @@ impl OpenAiProvider {
             .providers
             .get(&ProviderId::openai())
             .ok_or_else(|| anyhow::anyhow!("missing openai provider config"))?;
-        Self::from_runtime_config(
+        Self::from_runtime_config_with_compaction_policy(
             provider_config,
             model,
             config.runtime_max_output_tokens,
             &config.home_dir,
+            openai_compaction_policy_from_config(config, ProviderId::openai(), model),
         )
     }
 
@@ -453,6 +474,22 @@ impl OpenAiProvider {
         model: &str,
         max_output_tokens: u32,
         trace_home_dir: &Path,
+    ) -> Result<Self> {
+        Self::from_runtime_config_with_compaction_policy(
+            provider_config,
+            model,
+            max_output_tokens,
+            trace_home_dir,
+            OpenAiCompactionPolicy::default(),
+        )
+    }
+
+    pub(crate) fn from_runtime_config_with_compaction_policy(
+        provider_config: &ProviderRuntimeConfig,
+        model: &str,
+        max_output_tokens: u32,
+        trace_home_dir: &Path,
+        compaction_policy: OpenAiCompactionPolicy,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let api_key = match (provider_config.auth.source, provider_config.auth.kind) {
@@ -480,6 +517,7 @@ impl OpenAiProvider {
             api_key,
             model: model.to_string(),
             max_output_tokens,
+            compaction_policy,
             trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
@@ -492,11 +530,12 @@ impl OpenAiCodexProvider {
             .providers
             .get(&ProviderId::openai_codex())
             .ok_or_else(|| anyhow::anyhow!("missing openai-codex provider config"))?;
-        Self::from_runtime_config(
+        Self::from_runtime_config_with_compaction_policy(
             provider_config,
             model,
             config.runtime_max_output_tokens,
             &config.home_dir,
+            openai_compaction_policy_from_config(config, ProviderId::openai_codex(), model),
         )
     }
 
@@ -505,6 +544,22 @@ impl OpenAiCodexProvider {
         model: &str,
         max_output_tokens: u32,
         trace_home_dir: &Path,
+    ) -> Result<Self> {
+        Self::from_runtime_config_with_compaction_policy(
+            provider_config,
+            model,
+            max_output_tokens,
+            trace_home_dir,
+            OpenAiCompactionPolicy::default(),
+        )
+    }
+
+    pub(crate) fn from_runtime_config_with_compaction_policy(
+        provider_config: &ProviderRuntimeConfig,
+        model: &str,
+        max_output_tokens: u32,
+        trace_home_dir: &Path,
+        compaction_policy: OpenAiCompactionPolicy,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let codex_home = provider_config
@@ -523,9 +578,38 @@ impl OpenAiCodexProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
+            compaction_policy,
             trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
+    }
+}
+
+fn openai_compaction_policy_from_config(
+    config: &AppConfig,
+    provider: ProviderId,
+    model: &str,
+) -> OpenAiCompactionPolicy {
+    let base_context_config = ContextConfig {
+        recent_messages: config.context_window_messages,
+        recent_briefs: config.context_window_briefs,
+        compaction_trigger_messages: config.compaction_trigger_messages,
+        compaction_keep_recent_messages: config.compaction_keep_recent_messages,
+        prompt_budget_estimated_tokens: config.prompt_budget_estimated_tokens,
+        compaction_trigger_estimated_tokens: config.compaction_trigger_estimated_tokens,
+        compaction_keep_recent_estimated_tokens: config.compaction_keep_recent_estimated_tokens,
+        recent_episode_candidates: config.recent_episode_candidates,
+        max_relevant_episodes: config.max_relevant_episodes,
+    };
+    let policy = BuiltInModelCatalog::default().resolve_policy(
+        &ModelRef::new(provider, model),
+        &config.validated_model_overrides,
+        config.validated_unknown_model_fallback.as_ref(),
+        &base_context_config,
+        config.runtime_max_output_tokens,
+    );
+    OpenAiCompactionPolicy {
+        trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
     }
 }
 
@@ -605,6 +689,7 @@ impl AgentProvider for OpenAiProvider {
         if let Some(remote_compaction) = maybe_compact_openai_request_plan(
             &self.continuation,
             &mut plan,
+            self.compaction_policy,
             &self.client,
             openai_responses_compact_url(&self.base_url),
             headers.clone(),
@@ -645,6 +730,7 @@ impl AgentProvider for OpenAiProvider {
                 &self.continuation,
                 plan_scope.as_ref(),
                 &plan_request_shape,
+                self.compaction_policy,
                 &self.client,
                 openai_responses_compact_url(&self.base_url),
                 headers,
@@ -707,6 +793,7 @@ impl AgentProvider for OpenAiCodexProvider {
         if let Some(remote_compaction) = maybe_compact_openai_request_plan(
             &self.continuation,
             &mut plan,
+            self.compaction_policy,
             &self.client,
             openai_codex_responses_compact_url(&self.base_url),
             headers.clone(),
@@ -747,6 +834,7 @@ impl AgentProvider for OpenAiCodexProvider {
                 &self.continuation,
                 plan_scope.as_ref(),
                 &plan_request_shape,
+                self.compaction_policy,
                 &self.client,
                 openai_codex_responses_compact_url(&self.base_url),
                 headers,
@@ -1739,6 +1827,20 @@ fn update_openai_continuation(
         return;
     };
     let mut state = lock_openai_continuation(continuation);
+    let previous_total_usage_tokens = state
+        .windows
+        .get(&scope)
+        .map(|window| window.total_usage_tokens)
+        .unwrap_or_default();
+    let previous_total_usage_tokens = if latest_openai_compaction_index(&provider_input).is_some() {
+        0
+    } else {
+        previous_total_usage_tokens
+    };
+    let latest_usage_tokens = parsed
+        .response
+        .input_tokens
+        .saturating_add(parsed.response.output_tokens);
     let next = match (parsed.response_id.as_ref(), parsed.output_items.is_empty()) {
         (Some(response_id), false) => {
             state.next_generation = state.next_generation.saturating_add(1);
@@ -1761,6 +1863,7 @@ fn update_openai_continuation(
                 items,
                 append_match_items,
                 generation: state.next_generation,
+                total_usage_tokens: previous_total_usage_tokens.saturating_add(latest_usage_tokens),
             })
         }
         _ => None,
@@ -1791,6 +1894,7 @@ async fn maybe_compact_openai_provider_window(
     continuation: &Arc<Mutex<OpenAiContinuationState>>,
     scope: Option<&OpenAiContinuationScope>,
     request_shape: &OpenAiRequestShape,
+    compaction_policy: OpenAiCompactionPolicy,
     client: &Client,
     compact_url: String,
     headers: Vec<(&str, String)>,
@@ -1804,21 +1908,25 @@ async fn maybe_compact_openai_provider_window(
         let state = lock_openai_continuation(continuation);
         state.windows.get(scope).cloned()
     }?;
+    let Some(trigger) =
+        openai_compaction_trigger_for_window(&window, request_shape, compaction_policy)
+    else {
+        return None;
+    };
     let candidate = match openai_provider_window_compaction_candidate(&window) {
         Ok(candidate) => candidate,
         Err(skip_reason) => {
-            if skip_reason == "below_item_threshold" {
-                return None;
-            }
             return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                 status: format!("skipped_{skip_reason}"),
-                trigger_reason: Some("provider_window_item_threshold".into()),
+                trigger_reason: Some(trigger.reason.into()),
                 endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                 http_status: None,
                 input_items: Some(window.items.len()),
                 output_items: None,
                 compaction_items: None,
                 latest_compaction_index: window.latest_compaction_index,
+                estimated_input_tokens: trigger.estimated_input_tokens,
+                trigger_input_tokens: Some(trigger.trigger_input_tokens),
                 encrypted_content_hashes: None,
                 encrypted_content_bytes: None,
                 request_shape_hash: Some(request_shape_hash(request_shape)),
@@ -1833,9 +1941,11 @@ async fn maybe_compact_openai_provider_window(
     if let Some(http_status) = compact_endpoint_unsupported_status(continuation, &compact_url) {
         return Some(openai_compact_unsupported_diagnostics(
             "skipped_unsupported_endpoint",
-            "provider_window_item_threshold",
+            trigger.reason,
             input_items,
             candidate.latest_compaction_index,
+            trigger.estimated_input_tokens,
+            Some(trigger.trigger_input_tokens),
             Some(request_shape_hash),
             Some(window.generation),
             http_status,
@@ -1858,13 +1968,15 @@ async fn maybe_compact_openai_provider_window(
             if is_non_persisted_compact_item_id_error(&error) {
                 return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                     status: "invalid_non_persisted_item_id".into(),
-                    trigger_reason: Some("provider_window_item_threshold".into()),
+                    trigger_reason: Some(trigger.reason.into()),
                     endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                     http_status: error_status(&error),
                     input_items: Some(input_items),
                     output_items: None,
                     compaction_items: None,
                     latest_compaction_index: candidate.latest_compaction_index,
+                    estimated_input_tokens: trigger.estimated_input_tokens,
+                    trigger_input_tokens: Some(trigger.trigger_input_tokens),
                     encrypted_content_hashes: None,
                     encrypted_content_bytes: None,
                     request_shape_hash: Some(request_shape_hash),
@@ -1876,9 +1988,11 @@ async fn maybe_compact_openai_provider_window(
                 mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
                 return Some(openai_compact_unsupported_diagnostics(
                     "unsupported_endpoint",
-                    "provider_window_item_threshold",
+                    trigger.reason,
                     input_items,
                     candidate.latest_compaction_index,
+                    trigger.estimated_input_tokens,
+                    Some(trigger.trigger_input_tokens),
                     Some(request_shape_hash),
                     Some(window.generation),
                     http_status,
@@ -1887,13 +2001,15 @@ async fn maybe_compact_openai_provider_window(
             }
             return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                 status: "failed".into(),
-                trigger_reason: Some("provider_window_item_threshold".into()),
+                trigger_reason: Some(trigger.reason.into()),
                 endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                 http_status: error_status(&error),
                 input_items: Some(input_items),
                 output_items: None,
                 compaction_items: None,
                 latest_compaction_index: candidate.latest_compaction_index,
+                estimated_input_tokens: trigger.estimated_input_tokens,
+                trigger_input_tokens: Some(trigger.trigger_input_tokens),
                 encrypted_content_hashes: None,
                 encrypted_content_bytes: None,
                 request_shape_hash: Some(request_shape_hash),
@@ -1905,13 +2021,15 @@ async fn maybe_compact_openai_provider_window(
     if compacted.is_empty() {
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_empty_output".into(),
-            trigger_reason: Some("provider_window_item_threshold".into()),
+            trigger_reason: Some(trigger.reason.into()),
             endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
             http_status: None,
             input_items: Some(input_items),
             output_items: Some(0),
             compaction_items: Some(0),
             latest_compaction_index: candidate.latest_compaction_index,
+            estimated_input_tokens: trigger.estimated_input_tokens,
+            trigger_input_tokens: Some(trigger.trigger_input_tokens),
             encrypted_content_hashes: Some(Vec::new()),
             encrypted_content_bytes: Some(Vec::new()),
             request_shape_hash: Some(request_shape_hash),
@@ -1927,13 +2045,15 @@ async fn maybe_compact_openai_provider_window(
     if compaction_items == 0 {
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_missing_compaction_item".into(),
-            trigger_reason: Some("provider_window_item_threshold".into()),
+            trigger_reason: Some(trigger.reason.into()),
             endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
             http_status: None,
             input_items: Some(input_items),
             output_items: Some(compacted.len()),
             compaction_items: Some(0),
             latest_compaction_index: None,
+            estimated_input_tokens: trigger.estimated_input_tokens,
+            trigger_input_tokens: Some(trigger.trigger_input_tokens),
             encrypted_content_hashes: Some(Vec::new()),
             encrypted_content_bytes: Some(Vec::new()),
             request_shape_hash: Some(request_shape_hash),
@@ -1949,13 +2069,15 @@ async fn maybe_compact_openai_provider_window(
         if current_generation != Some(window.generation) {
             return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                 status: "stale_generation".into(),
-                trigger_reason: Some("provider_window_item_threshold".into()),
+                trigger_reason: Some(trigger.reason.into()),
                 endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                 http_status: None,
                 input_items: Some(input_items),
                 output_items: Some(output_items),
                 compaction_items: Some(compaction_items),
                 latest_compaction_index,
+                estimated_input_tokens: trigger.estimated_input_tokens,
+                trigger_input_tokens: Some(trigger.trigger_input_tokens),
                 encrypted_content_hashes: Some(encrypted_content_hashes),
                 encrypted_content_bytes: Some(encrypted_content_bytes),
                 request_shape_hash: Some(request_shape_hash),
@@ -1979,6 +2101,7 @@ async fn maybe_compact_openai_provider_window(
                 items,
                 append_match_items: window.append_match_items,
                 latest_compaction_index,
+                total_usage_tokens: 0,
                 generation,
             },
         );
@@ -1987,13 +2110,15 @@ async fn maybe_compact_openai_provider_window(
 
     Some(ProviderOpenAiRemoteCompactionDiagnostics {
         status: "compacted".into(),
-        trigger_reason: Some("provider_window_item_threshold".into()),
+        trigger_reason: Some(trigger.reason.into()),
         endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
         http_status: None,
         input_items: Some(input_items),
         output_items: Some(output_items),
         compaction_items: Some(compaction_items),
         latest_compaction_index,
+        estimated_input_tokens: trigger.estimated_input_tokens,
+        trigger_input_tokens: Some(trigger.trigger_input_tokens),
         encrypted_content_hashes: Some(encrypted_content_hashes),
         encrypted_content_bytes: Some(encrypted_content_bytes),
         request_shape_hash: Some(request_shape_hash),
@@ -2005,6 +2130,7 @@ async fn maybe_compact_openai_provider_window(
 async fn maybe_compact_openai_request_plan(
     continuation: &Arc<Mutex<OpenAiContinuationState>>,
     plan: &mut OpenAiRequestPlan,
+    compaction_policy: OpenAiCompactionPolicy,
     client: &Client,
     compact_url: String,
     headers: Vec<(&str, String)>,
@@ -2029,23 +2155,28 @@ async fn maybe_compact_openai_request_plan(
         latest_compaction_index: latest_openai_compaction_index(&compactable_items),
         items: compactable_items,
         append_match_items: plan.append_match_input.clone(),
+        total_usage_tokens: previous.total_usage_tokens,
         generation: previous.generation,
+    };
+    let Some(trigger) =
+        openai_compaction_trigger_for_request_plan(&previous, plan, compaction_policy)
+    else {
+        return None;
     };
     let candidate = match openai_provider_window_compaction_candidate(&compactable_window) {
         Ok(candidate) => candidate,
         Err(skip_reason) => {
-            if skip_reason == "below_item_threshold" {
-                return None;
-            }
             return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                 status: format!("skipped_{skip_reason}"),
-                trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+                trigger_reason: Some(trigger.reason.into()),
                 endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                 http_status: None,
                 input_items: Some(compactable_window.items.len()),
                 output_items: None,
                 compaction_items: None,
                 latest_compaction_index: compactable_window.latest_compaction_index,
+                estimated_input_tokens: trigger.estimated_input_tokens,
+                trigger_input_tokens: Some(trigger.trigger_input_tokens),
                 encrypted_content_hashes: None,
                 encrypted_content_bytes: None,
                 request_shape_hash: Some(request_shape_hash(&plan.request_shape)),
@@ -2060,9 +2191,11 @@ async fn maybe_compact_openai_request_plan(
     if let Some(http_status) = compact_endpoint_unsupported_status(continuation, &compact_url) {
         return Some(openai_compact_unsupported_diagnostics(
             "skipped_unsupported_endpoint",
-            "provider_window_item_threshold_before_request",
+            trigger.reason,
             input_items,
             candidate.latest_compaction_index,
+            trigger.estimated_input_tokens,
+            Some(trigger.trigger_input_tokens),
             Some(request_shape_hash),
             Some(previous.generation),
             http_status,
@@ -2085,13 +2218,15 @@ async fn maybe_compact_openai_request_plan(
             if is_non_persisted_compact_item_id_error(&error) {
                 return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                     status: "invalid_non_persisted_item_id".into(),
-                    trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+                    trigger_reason: Some(trigger.reason.into()),
                     endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                     http_status: error_status(&error),
                     input_items: Some(input_items),
                     output_items: None,
                     compaction_items: None,
                     latest_compaction_index: candidate.latest_compaction_index,
+                    estimated_input_tokens: trigger.estimated_input_tokens,
+                    trigger_input_tokens: Some(trigger.trigger_input_tokens),
                     encrypted_content_hashes: None,
                     encrypted_content_bytes: None,
                     request_shape_hash: Some(request_shape_hash),
@@ -2103,9 +2238,11 @@ async fn maybe_compact_openai_request_plan(
                 mark_compact_endpoint_unsupported(continuation, &compact_url, http_status);
                 return Some(openai_compact_unsupported_diagnostics(
                     "unsupported_endpoint",
-                    "provider_window_item_threshold_before_request",
+                    trigger.reason,
                     input_items,
                     candidate.latest_compaction_index,
+                    trigger.estimated_input_tokens,
+                    Some(trigger.trigger_input_tokens),
                     Some(request_shape_hash),
                     Some(previous.generation),
                     http_status,
@@ -2114,13 +2251,15 @@ async fn maybe_compact_openai_request_plan(
             }
             return Some(ProviderOpenAiRemoteCompactionDiagnostics {
                 status: "failed".into(),
-                trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+                trigger_reason: Some(trigger.reason.into()),
                 endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
                 http_status: error_status(&error),
                 input_items: Some(input_items),
                 output_items: None,
                 compaction_items: None,
                 latest_compaction_index: candidate.latest_compaction_index,
+                estimated_input_tokens: trigger.estimated_input_tokens,
+                trigger_input_tokens: Some(trigger.trigger_input_tokens),
                 encrypted_content_hashes: None,
                 encrypted_content_bytes: None,
                 request_shape_hash: Some(request_shape_hash),
@@ -2132,13 +2271,15 @@ async fn maybe_compact_openai_request_plan(
     if compacted.is_empty() {
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_empty_output".into(),
-            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            trigger_reason: Some(trigger.reason.into()),
             endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
             http_status: None,
             input_items: Some(input_items),
             output_items: Some(0),
             compaction_items: Some(0),
             latest_compaction_index: candidate.latest_compaction_index,
+            estimated_input_tokens: trigger.estimated_input_tokens,
+            trigger_input_tokens: Some(trigger.trigger_input_tokens),
             encrypted_content_hashes: Some(Vec::new()),
             encrypted_content_bytes: Some(Vec::new()),
             request_shape_hash: Some(request_shape_hash),
@@ -2154,13 +2295,15 @@ async fn maybe_compact_openai_request_plan(
     if compaction_items == 0 {
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "rejected_missing_compaction_item".into(),
-            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            trigger_reason: Some(trigger.reason.into()),
             endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
             http_status: None,
             input_items: Some(input_items),
             output_items: Some(compacted.len()),
             compaction_items: Some(0),
             latest_compaction_index: None,
+            estimated_input_tokens: trigger.estimated_input_tokens,
+            trigger_input_tokens: Some(trigger.trigger_input_tokens),
             encrypted_content_hashes: Some(Vec::new()),
             encrypted_content_bytes: Some(Vec::new()),
             request_shape_hash: Some(request_shape_hash),
@@ -2176,13 +2319,15 @@ async fn maybe_compact_openai_request_plan(
     if current_generation != Some(previous.generation) {
         return Some(ProviderOpenAiRemoteCompactionDiagnostics {
             status: "stale_generation".into(),
-            trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+            trigger_reason: Some(trigger.reason.into()),
             endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
             http_status: None,
             input_items: Some(input_items),
             output_items: Some(compacted.len()),
             compaction_items: Some(compaction_items),
             latest_compaction_index,
+            estimated_input_tokens: trigger.estimated_input_tokens,
+            trigger_input_tokens: Some(trigger.trigger_input_tokens),
             encrypted_content_hashes: Some(encrypted_content_hashes),
             encrypted_content_bytes: Some(encrypted_content_bytes),
             request_shape_hash: Some(request_shape_hash),
@@ -2206,13 +2351,15 @@ async fn maybe_compact_openai_request_plan(
 
     Some(ProviderOpenAiRemoteCompactionDiagnostics {
         status: "compacted".into(),
-        trigger_reason: Some("provider_window_item_threshold_before_request".into()),
+        trigger_reason: Some(trigger.reason.into()),
         endpoint_kind: Some(OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND.into()),
         http_status: None,
         input_items: Some(input_items),
         output_items: Some(output_items),
         compaction_items: Some(compaction_items),
         latest_compaction_index,
+        estimated_input_tokens: trigger.estimated_input_tokens,
+        trigger_input_tokens: Some(trigger.trigger_input_tokens),
         encrypted_content_hashes: Some(encrypted_content_hashes),
         encrypted_content_bytes: Some(encrypted_content_bytes),
         request_shape_hash: Some(request_shape_hash),
@@ -2272,6 +2419,8 @@ fn openai_compact_unsupported_diagnostics(
     trigger_reason: &str,
     input_items: usize,
     latest_compaction_index: Option<usize>,
+    estimated_input_tokens: Option<u64>,
+    trigger_input_tokens: Option<u64>,
     request_shape_hash: Option<String>,
     continuation_generation: Option<u64>,
     http_status: u16,
@@ -2286,6 +2435,8 @@ fn openai_compact_unsupported_diagnostics(
         output_items: None,
         compaction_items: None,
         latest_compaction_index,
+        estimated_input_tokens,
+        trigger_input_tokens,
         encrypted_content_hashes: None,
         encrypted_content_bytes: None,
         request_shape_hash,
@@ -2294,23 +2445,91 @@ fn openai_compact_unsupported_diagnostics(
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct OpenAiCompactionTrigger {
+    reason: &'static str,
+    estimated_input_tokens: Option<u64>,
+    trigger_input_tokens: u64,
+}
+
+fn openai_compaction_trigger_for_window(
+    window: &OpenAiProviderWindow,
+    request_shape: &OpenAiRequestShape,
+    policy: OpenAiCompactionPolicy,
+) -> Option<OpenAiCompactionTrigger> {
+    if window.total_usage_tokens > 0 && window.total_usage_tokens >= policy.trigger_input_tokens {
+        return Some(OpenAiCompactionTrigger {
+            reason: "token_budget_pressure",
+            estimated_input_tokens: None,
+            trigger_input_tokens: policy.trigger_input_tokens,
+        });
+    }
+
+    let estimated = estimate_openai_provider_payload_tokens(
+        request_shape,
+        openai_items_after_latest_compaction(&window.items),
+    );
+    (estimated >= policy.trigger_input_tokens).then_some(OpenAiCompactionTrigger {
+        reason: "estimated_window_pressure",
+        estimated_input_tokens: Some(estimated),
+        trigger_input_tokens: policy.trigger_input_tokens,
+    })
+}
+
+fn openai_compaction_trigger_for_request_plan(
+    previous: &OpenAiProviderWindow,
+    plan: &OpenAiRequestPlan,
+    policy: OpenAiCompactionPolicy,
+) -> Option<OpenAiCompactionTrigger> {
+    let estimated_incremental_input =
+        estimate_openai_provider_payload_tokens(&plan.request_shape, &plan.provider_input);
+    if previous.total_usage_tokens > 0
+        && previous
+            .total_usage_tokens
+            .saturating_add(estimated_incremental_input)
+            >= policy.trigger_input_tokens
+    {
+        return Some(OpenAiCompactionTrigger {
+            reason: "token_budget_pressure",
+            estimated_input_tokens: Some(estimated_incremental_input),
+            trigger_input_tokens: policy.trigger_input_tokens,
+        });
+    }
+
+    let mut compactable_items = previous.items.clone();
+    compactable_items.extend(plan.provider_input.clone());
+    let estimated = estimate_openai_provider_payload_tokens(
+        &plan.request_shape,
+        openai_items_after_latest_compaction(&compactable_items),
+    );
+    (estimated >= policy.trigger_input_tokens).then_some(OpenAiCompactionTrigger {
+        reason: "estimated_window_pressure",
+        estimated_input_tokens: Some(estimated),
+        trigger_input_tokens: policy.trigger_input_tokens,
+    })
+}
+
+fn estimate_openai_provider_payload_tokens(
+    _request_shape: &OpenAiRequestShape,
+    input_items: &[Value],
+) -> u64 {
+    estimate_json_tokens(&Value::Array(input_items.to_vec())) as u64
+}
+
+fn openai_items_after_latest_compaction(items: &[Value]) -> &[Value] {
+    latest_openai_compaction_index(items)
+        .map(|index| &items[index.saturating_add(1)..])
+        .unwrap_or(items)
+}
+
 fn openai_provider_window_compaction_candidate(
     window: &OpenAiProviderWindow,
 ) -> std::result::Result<OpenAiCompactionCandidate, &'static str> {
-    if items_since_latest_openai_compaction(&window.items) < OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS
-    {
-        return Err("below_item_threshold");
-    }
-
     let boundary =
-        latest_complete_openai_tool_call_boundary(&window.items).ok_or("unpaired_tool_call")?;
+        latest_complete_openai_tool_call_boundary(&window.items).ok_or("no_safe_boundary")?;
     debug_assert!(boundary > 0);
 
     let compact_items = window.items[..boundary].to_vec();
-    if items_since_latest_openai_compaction(&compact_items) < OPENAI_REMOTE_COMPACTION_TRIGGER_ITEMS
-    {
-        return Err("unpaired_tool_call");
-    }
     if has_unpaired_openai_tool_call(&compact_items) {
         return Err("unpaired_tool_call");
     }
@@ -2326,12 +2545,6 @@ fn openai_compacted_replay_items(compacted: &[Value]) -> Vec<Value> {
     latest_openai_compaction_index(compacted)
         .map(|index| compacted[index..].to_vec())
         .unwrap_or_else(|| compacted.to_vec())
-}
-
-fn items_since_latest_openai_compaction(items: &[Value]) -> usize {
-    latest_openai_compaction_index(items)
-        .map(|index| items.len().saturating_sub(index + 1))
-        .unwrap_or(items.len())
 }
 
 fn latest_complete_openai_tool_call_boundary(items: &[Value]) -> Option<usize> {
@@ -4170,7 +4383,9 @@ fn unsupported_streaming_transport_error(provider_name: &str) -> anyhow::Error {
 mod tests {
     use super::{
         build_openai_responses_request, chat_completions_url, latest_openai_compaction_index,
+        openai_compaction_trigger_for_window, openai_provider_window_compaction_candidate,
         redact_headers, redact_json_secrets, redact_url, sanitize_trace_path_segment,
+        OpenAiCompactionPolicy, OpenAiProviderWindow, OpenAiRequestShape,
         OpenAiResponsesTransportContract, ToolSchemaContract,
     };
     use crate::provider::{
@@ -4248,6 +4463,94 @@ mod tests {
         ];
 
         assert_eq!(latest_openai_compaction_index(&items), Some(3));
+    }
+
+    #[test]
+    fn openai_compaction_trigger_skips_many_small_items_below_budget() {
+        let request_shape = test_request_shape();
+        let window = OpenAiProviderWindow {
+            response_id: Some("resp_1".into()),
+            request_shape: request_shape.clone(),
+            items: (0..24)
+                .map(|index| json!({ "type": "message", "content": format!("m{index}") }))
+                .collect(),
+            append_match_items: Vec::new(),
+            latest_compaction_index: None,
+            total_usage_tokens: 0,
+            generation: 1,
+        };
+
+        assert!(openai_compaction_trigger_for_window(
+            &window,
+            &request_shape,
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: 10_000,
+            },
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn openai_compaction_candidate_allows_single_large_item() {
+        let request_shape = test_request_shape();
+        let window = OpenAiProviderWindow {
+            response_id: Some("resp_1".into()),
+            request_shape: request_shape.clone(),
+            items: vec![json!({
+                "type": "message",
+                "content": "x".repeat(4096),
+            })],
+            append_match_items: Vec::new(),
+            latest_compaction_index: None,
+            total_usage_tokens: 0,
+            generation: 1,
+        };
+
+        let trigger = openai_compaction_trigger_for_window(
+            &window,
+            &request_shape,
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: 128,
+            },
+        )
+        .expect("large item should reach token pressure");
+        assert_eq!(trigger.reason, "estimated_window_pressure");
+
+        let candidate = openai_provider_window_compaction_candidate(&window)
+            .expect("single complete message should be compactable");
+        assert_eq!(candidate.items.len(), 1);
+    }
+
+    #[test]
+    fn openai_compaction_trigger_prefers_provider_usage_tokens() {
+        let request_shape = test_request_shape();
+        let window = OpenAiProviderWindow {
+            response_id: Some("resp_1".into()),
+            request_shape: request_shape.clone(),
+            items: vec![json!({ "type": "message", "content": "small" })],
+            append_match_items: Vec::new(),
+            latest_compaction_index: None,
+            total_usage_tokens: 512,
+            generation: 1,
+        };
+
+        let trigger = openai_compaction_trigger_for_window(
+            &window,
+            &request_shape,
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: 128,
+            },
+        )
+        .expect("usage should reach token pressure");
+        assert_eq!(trigger.reason, "token_budget_pressure");
+        assert_eq!(trigger.estimated_input_tokens, None);
+    }
+
+    fn test_request_shape() -> OpenAiRequestShape {
+        OpenAiRequestShape {
+            wire_shape: json!({ "model": "gpt-test" }),
+            prompt_frame: crate::provider::ProviderPromptFrame::plain("system"),
+        }
     }
 
     #[test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -90,14 +90,6 @@ pub(crate) struct OpenAiCompactionPolicy {
     pub(crate) trigger_input_tokens: u64,
 }
 
-impl Default for OpenAiCompactionPolicy {
-    fn default() -> Self {
-        Self {
-            trigger_input_tokens: u64::MAX,
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 struct OpenAiHttpTrace {
     home_dir: PathBuf,
@@ -405,7 +397,7 @@ struct OpenAiProviderWindow {
     items: Vec<Value>,
     append_match_items: Vec<Value>,
     latest_compaction_index: Option<usize>,
-    total_usage_tokens: u64,
+    latest_input_tokens: u64,
     generation: u64,
 }
 
@@ -480,7 +472,7 @@ impl OpenAiProvider {
             model,
             max_output_tokens,
             trace_home_dir,
-            OpenAiCompactionPolicy::default(),
+            openai_compaction_policy_for_model(ProviderId::openai(), model, max_output_tokens),
         )
     }
 
@@ -550,7 +542,11 @@ impl OpenAiCodexProvider {
             model,
             max_output_tokens,
             trace_home_dir,
-            OpenAiCompactionPolicy::default(),
+            openai_compaction_policy_for_model(
+                ProviderId::openai_codex(),
+                model,
+                max_output_tokens,
+            ),
         )
     }
 
@@ -607,6 +603,23 @@ fn openai_compaction_policy_from_config(
         config.validated_unknown_model_fallback.as_ref(),
         &base_context_config,
         config.runtime_max_output_tokens,
+    );
+    OpenAiCompactionPolicy {
+        trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
+    }
+}
+
+fn openai_compaction_policy_for_model(
+    provider: ProviderId,
+    model: &str,
+    max_output_tokens: u32,
+) -> OpenAiCompactionPolicy {
+    let policy = BuiltInModelCatalog::default().resolve_policy(
+        &ModelRef::new(provider, model),
+        &Default::default(),
+        None,
+        &ContextConfig::default(),
+        max_output_tokens,
     );
     OpenAiCompactionPolicy {
         trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
@@ -1827,20 +1840,7 @@ fn update_openai_continuation(
         return;
     };
     let mut state = lock_openai_continuation(continuation);
-    let previous_total_usage_tokens = state
-        .windows
-        .get(&scope)
-        .map(|window| window.total_usage_tokens)
-        .unwrap_or_default();
-    let previous_total_usage_tokens = if latest_openai_compaction_index(&provider_input).is_some() {
-        0
-    } else {
-        previous_total_usage_tokens
-    };
-    let latest_usage_tokens = parsed
-        .response
-        .input_tokens
-        .saturating_add(parsed.response.output_tokens);
+    let latest_input_tokens = parsed.response.input_tokens;
     let next = match (parsed.response_id.as_ref(), parsed.output_items.is_empty()) {
         (Some(response_id), false) => {
             state.next_generation = state.next_generation.saturating_add(1);
@@ -1863,7 +1863,7 @@ fn update_openai_continuation(
                 items,
                 append_match_items,
                 generation: state.next_generation,
-                total_usage_tokens: previous_total_usage_tokens.saturating_add(latest_usage_tokens),
+                latest_input_tokens,
             })
         }
         _ => None,
@@ -2101,7 +2101,7 @@ async fn maybe_compact_openai_provider_window(
                 items,
                 append_match_items: window.append_match_items,
                 latest_compaction_index,
-                total_usage_tokens: 0,
+                latest_input_tokens: 0,
                 generation,
             },
         );
@@ -2155,7 +2155,7 @@ async fn maybe_compact_openai_request_plan(
         latest_compaction_index: latest_openai_compaction_index(&compactable_items),
         items: compactable_items,
         append_match_items: plan.append_match_input.clone(),
-        total_usage_tokens: previous.total_usage_tokens,
+        latest_input_tokens: previous.latest_input_tokens,
         generation: previous.generation,
     };
     let Some(trigger) =
@@ -2457,12 +2457,14 @@ fn openai_compaction_trigger_for_window(
     request_shape: &OpenAiRequestShape,
     policy: OpenAiCompactionPolicy,
 ) -> Option<OpenAiCompactionTrigger> {
-    if window.total_usage_tokens > 0 && window.total_usage_tokens >= policy.trigger_input_tokens {
-        return Some(OpenAiCompactionTrigger {
-            reason: "token_budget_pressure",
-            estimated_input_tokens: None,
-            trigger_input_tokens: policy.trigger_input_tokens,
-        });
+    if window.latest_input_tokens > 0 {
+        return (window.latest_input_tokens >= policy.trigger_input_tokens).then_some(
+            OpenAiCompactionTrigger {
+                reason: "token_budget_pressure",
+                estimated_input_tokens: None,
+                trigger_input_tokens: policy.trigger_input_tokens,
+            },
+        );
     }
 
     let estimated = estimate_openai_provider_payload_tokens(
@@ -2481,23 +2483,13 @@ fn openai_compaction_trigger_for_request_plan(
     plan: &OpenAiRequestPlan,
     policy: OpenAiCompactionPolicy,
 ) -> Option<OpenAiCompactionTrigger> {
-    let estimated_incremental_input =
-        estimate_openai_provider_payload_tokens(&plan.request_shape, &plan.provider_input);
-    if previous.total_usage_tokens > 0
-        && previous
-            .total_usage_tokens
-            .saturating_add(estimated_incremental_input)
-            >= policy.trigger_input_tokens
-    {
-        return Some(OpenAiCompactionTrigger {
-            reason: "token_budget_pressure",
-            estimated_input_tokens: Some(estimated_incremental_input),
-            trigger_input_tokens: policy.trigger_input_tokens,
-        });
-    }
-
     let mut compactable_items = previous.items.clone();
     compactable_items.extend(plan.provider_input.clone());
+    if previous.latest_input_tokens == 0
+        && latest_openai_compaction_index(&compactable_items).is_some()
+    {
+        return None;
+    }
     let estimated = estimate_openai_provider_payload_tokens(
         &plan.request_shape,
         openai_items_after_latest_compaction(&compactable_items),
@@ -2510,10 +2502,15 @@ fn openai_compaction_trigger_for_request_plan(
 }
 
 fn estimate_openai_provider_payload_tokens(
-    _request_shape: &OpenAiRequestShape,
+    request_shape: &OpenAiRequestShape,
     input_items: &[Value],
 ) -> u64 {
-    estimate_json_tokens(&Value::Array(input_items.to_vec())) as u64
+    let shape_tokens = estimate_json_tokens(&request_shape.wire_shape);
+    let input_tokens = input_items
+        .iter()
+        .map(estimate_json_tokens)
+        .fold(0usize, usize::saturating_add);
+    shape_tokens.saturating_add(input_tokens).saturating_add(1) as u64
 }
 
 fn openai_items_after_latest_compaction(items: &[Value]) -> &[Value] {
@@ -4382,10 +4379,11 @@ fn unsupported_streaming_transport_error(provider_name: &str) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_openai_responses_request, chat_completions_url, latest_openai_compaction_index,
+        build_openai_responses_request, chat_completions_url, incremental_diagnostics,
+        latest_openai_compaction_index, openai_compaction_trigger_for_request_plan,
         openai_compaction_trigger_for_window, openai_provider_window_compaction_candidate,
         redact_headers, redact_json_secrets, redact_url, sanitize_trace_path_segment,
-        OpenAiCompactionPolicy, OpenAiProviderWindow, OpenAiRequestShape,
+        OpenAiCompactionPolicy, OpenAiProviderWindow, OpenAiRequestPlan, OpenAiRequestShape,
         OpenAiResponsesTransportContract, ToolSchemaContract,
     };
     use crate::provider::{
@@ -4476,7 +4474,7 @@ mod tests {
                 .collect(),
             append_match_items: Vec::new(),
             latest_compaction_index: None,
-            total_usage_tokens: 0,
+            latest_input_tokens: 0,
             generation: 1,
         };
 
@@ -4502,7 +4500,7 @@ mod tests {
             })],
             append_match_items: Vec::new(),
             latest_compaction_index: None,
-            total_usage_tokens: 0,
+            latest_input_tokens: 0,
             generation: 1,
         };
 
@@ -4530,7 +4528,7 @@ mod tests {
             items: vec![json!({ "type": "message", "content": "small" })],
             append_match_items: Vec::new(),
             latest_compaction_index: None,
-            total_usage_tokens: 512,
+            latest_input_tokens: 512,
             generation: 1,
         };
 
@@ -4544,6 +4542,47 @@ mod tests {
         .expect("usage should reach token pressure");
         assert_eq!(trigger.reason, "token_budget_pressure");
         assert_eq!(trigger.estimated_input_tokens, None);
+    }
+
+    #[test]
+    fn openai_compaction_trigger_skips_immediate_compacted_replay_before_usage() {
+        let request_shape = test_request_shape();
+        let previous = OpenAiProviderWindow {
+            response_id: Some("resp_1".into()),
+            request_shape: request_shape.clone(),
+            items: vec![
+                json!({ "type": "compaction", "encrypted_content": "opaque" }),
+                json!({ "type": "message", "content": "recent" }),
+            ],
+            append_match_items: Vec::new(),
+            latest_compaction_index: Some(0),
+            latest_input_tokens: 0,
+            generation: 1,
+        };
+        let plan = OpenAiRequestPlan {
+            body: json!({ "model": "gpt-test", "input": [] }),
+            scope: None,
+            append_match_input: Vec::new(),
+            provider_input: vec![json!({ "type": "message", "content": "continue" })],
+            request_shape,
+            diagnostics: incremental_diagnostics(
+                "provider_window_compacted",
+                "test",
+                None,
+                0,
+                None,
+                None,
+            ),
+        };
+
+        assert!(openai_compaction_trigger_for_request_plan(
+            &previous,
+            &plan,
+            OpenAiCompactionPolicy {
+                trigger_input_tokens: 1,
+            },
+        )
+        .is_none());
     }
 
     fn test_request_shape() -> OpenAiRequestShape {

--- a/src/token_estimate.rs
+++ b/src/token_estimate.rs
@@ -1,0 +1,10 @@
+use serde_json::Value;
+
+pub(crate) fn estimate_text_tokens(text: &str) -> usize {
+    let bytes = text.len();
+    bytes.saturating_add(3) / 4
+}
+
+pub(crate) fn estimate_json_tokens(value: &Value) -> usize {
+    estimate_text_tokens(&serde_json::to_string(value).unwrap_or_default())
+}

--- a/src/token_estimate.rs
+++ b/src/token_estimate.rs
@@ -6,5 +6,8 @@ pub(crate) fn estimate_text_tokens(text: &str) -> usize {
 }
 
 pub(crate) fn estimate_json_tokens(value: &Value) -> usize {
-    estimate_text_tokens(&serde_json::to_string(value).unwrap_or_default())
+    match serde_json::to_string(value) {
+        Ok(json) => estimate_text_tokens(&json),
+        Err(_) => 1,
+    }
 }


### PR DESCRIPTION
Closes #1243.

## Summary

- gate OpenAI remote compaction on token pressure instead of provider item count
- prefer provider usage tokens when available, with a lightweight JSON estimator fallback
- keep tool-call pairing as a safe compaction boundary, not as a trigger signal
- thread resolved model compaction policy into OpenAI Responses and OpenAI Codex providers
- update remote compaction diagnostics and RFC trigger policy

## Validation

- `cargo fmt --all -- --check`
- `cargo test openai_responses --lib`
- `cargo test openai_compaction --lib`
- `cargo test tool_schema --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
