### PR TITLE
fix: preserve command receipts for recovery

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
+use serde_json::Value;
 
 use crate::{
     prompt::{PromptSection, PromptStability},
@@ -1367,19 +1368,63 @@ fn render_recent_briefs_with_budget(briefs: &[BriefRecord], budget: usize) -> Op
 fn render_recent_tools_with_budget(tools: &[ToolExecutionRecord], budget: usize) -> Option<String> {
     render_budgeted_lines(
         "Recent tool executions:",
-        tools
-            .iter()
-            .map(|record| {
-                format!(
-                    "- [{}][{:?}] {}",
-                    trust_label(&record.trust),
-                    record.status,
-                    record.summary
-                )
-            })
-            .collect(),
+        tools.iter().map(render_recent_tool_execution).collect(),
         budget,
     )
+}
+
+fn render_recent_tool_execution(record: &ToolExecutionRecord) -> String {
+    let prefix = format!(
+        "- [{}][{:?}] {}",
+        trust_label(&record.trust),
+        record.status,
+        record.summary
+    );
+    match record.tool_name.as_str() {
+        "ExecCommand" => record
+            .input
+            .get("cmd")
+            .and_then(Value::as_str)
+            .map(|cmd| {
+                format!(
+                    "{prefix} tool_execution_id={} cmd_digest={} cmd_ref={} cmd_preview={}",
+                    record.id,
+                    crate::tool::helpers::command_digest(cmd),
+                    crate::tool::helpers::command_receipt_source_ref(&record.id, None),
+                    crate::tool::helpers::command_preview(cmd)
+                )
+            })
+            .unwrap_or(prefix),
+        "ExecCommandBatch" => {
+            let Some(items) = record.input.get("items").and_then(Value::as_array) else {
+                return prefix;
+            };
+            let refs = items
+                .iter()
+                .enumerate()
+                .filter_map(|(offset, item)| {
+                    let cmd = item.get("cmd").and_then(Value::as_str)?;
+                    let index = offset + 1;
+                    Some(format!(
+                        "{{index={index}, cmd_digest={}, cmd_ref={}, cmd_preview={}}}",
+                        crate::tool::helpers::command_digest(cmd),
+                        crate::tool::helpers::command_receipt_source_ref(&record.id, Some(index)),
+                        crate::tool::helpers::command_preview(cmd)
+                    ))
+                })
+                .collect::<Vec<_>>();
+            if refs.is_empty() {
+                prefix
+            } else {
+                format!(
+                    "{prefix} tool_execution_id={} batch_cmds=[{}]",
+                    record.id,
+                    refs.join(", ")
+                )
+            }
+        }
+        _ => prefix,
+    }
 }
 
 fn render_budgeted_lines(heading: &str, lines: Vec<String>, budget: usize) -> Option<String> {
@@ -1996,6 +2041,72 @@ mod tests {
         assert!(context_contract
             .content
             .contains("current work item objective first"));
+    }
+
+    #[test]
+    fn recent_tool_context_includes_recoverable_command_receipt_ref() {
+        let command = "python - <<'PY'\nprint('context_receipt_middle_1246')\nPY";
+        let record = ToolExecutionRecord {
+            id: "tool-context-1246".to_string(),
+            agent_id: "default".to_string(),
+            work_item_id: Some("work_123".to_string()),
+            turn_index: 1,
+            tool_name: "ExecCommand".to_string(),
+            created_at: chrono::Utc::now(),
+            completed_at: Some(chrono::Utc::now()),
+            duration_ms: 123,
+            trust: TrustLevel::TrustedOperator,
+            status: ToolExecutionStatus::Success,
+            input: json!({"cmd": command}),
+            output: json!({"exit_code": 0}),
+            summary: "command exited with status 0".to_string(),
+            invocation_surface: None,
+        };
+
+        let rendered = render_recent_tool_execution(&record);
+
+        assert!(rendered.contains("tool_execution_id=tool-context-1246"));
+        assert!(rendered.contains("cmd_ref=tool_execution:tool-context-1246:cmd"));
+        assert!(rendered.contains("cmd_digest="));
+        assert!(rendered.contains("[omitted: command contains heredoc or inline script]"));
+        assert!(!rendered.contains("context_receipt_middle_1246"));
+    }
+
+    #[test]
+    fn recent_tool_context_includes_batch_item_receipt_refs() {
+        let record = ToolExecutionRecord {
+            id: "tool-context-batch-1246".to_string(),
+            agent_id: "default".to_string(),
+            work_item_id: None,
+            turn_index: 1,
+            tool_name: "ExecCommandBatch".to_string(),
+            created_at: chrono::Utc::now(),
+            completed_at: Some(chrono::Utc::now()),
+            duration_ms: 123,
+            trust: TrustLevel::TrustedOperator,
+            status: ToolExecutionStatus::Success,
+            input: json!({
+                "items": [
+                    {"cmd": "rg -n \"foo\" src"},
+                    {"cmd": "node - <<'NODE'\nconsole.log('hidden_batch_1246')\nNODE"}
+                ]
+            }),
+            output: json!({"completed_count": 2}),
+            summary: "ExecCommandBatch completed 2/2 items".to_string(),
+            invocation_surface: None,
+        };
+
+        let rendered = render_recent_tool_execution(&record);
+
+        assert!(rendered.contains("tool_execution_id=tool-context-batch-1246"));
+        assert!(
+            rendered.contains("cmd_ref=tool_execution:tool-context-batch-1246:batch_item:1:cmd")
+        );
+        assert!(
+            rendered.contains("cmd_ref=tool_execution:tool-context-batch-1246:batch_item:2:cmd")
+        );
+        assert!(rendered.contains("cmd_digest="));
+        assert!(!rendered.contains("hidden_batch_1246"));
     }
 
     #[test]

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -725,7 +725,7 @@ fn command_execution_documents(storage: &AppStorage) -> Result<Vec<MemoryDocumen
         match record.tool_name.as_str() {
             "ExecCommand" => {
                 if let Some(cmd) = record.input.get("cmd").and_then(Value::as_str) {
-                    documents.push(command_receipt_document(&record, None, cmd));
+                    documents.push(command_receipt_document(&record, None, None, cmd));
                 }
             }
             "ExecCommandBatch" => {
@@ -735,6 +735,7 @@ fn command_execution_documents(storage: &AppStorage) -> Result<Vec<MemoryDocumen
                             documents.push(command_receipt_document(
                                 &record,
                                 Some(offset + 1),
+                                Some(item),
                                 cmd,
                             ));
                         }
@@ -750,6 +751,7 @@ fn command_execution_documents(storage: &AppStorage) -> Result<Vec<MemoryDocumen
 fn command_receipt_document(
     record: &ToolExecutionRecord,
     batch_item_index: Option<usize>,
+    batch_item_input: Option<&Value>,
     cmd: &str,
 ) -> MemoryDocument {
     let cmd_digest = command_digest(cmd);
@@ -759,9 +761,21 @@ fn command_receipt_document(
         None => format!("{} command receipt", record.tool_name),
     };
     let preview = command_preview(cmd);
+    let input_json =
+        serde_json::to_string_pretty(&record.input).unwrap_or_else(|_| record.input.to_string());
+    let batch_item_input = batch_item_input
+        .map(|value| serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()));
     let body = format!(
-        "tool_execution_id: {}\ntool_name: {}\ncmd_digest: {}\ncmd:\n{}",
-        record.id, record.tool_name, cmd_digest, cmd
+        "tool_execution_id: {}\ntool_name: {}\ncmd_digest: {}\ninput_json:\n{}\n{}cmd:\n{}",
+        record.id,
+        record.tool_name,
+        cmd_digest,
+        input_json,
+        batch_item_input
+            .as_deref()
+            .map(|value| format!("batch_item_input_json:\n{value}\n"))
+            .unwrap_or_default(),
+        cmd
     );
     MemoryDocument {
         source_ref,

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -14,7 +14,10 @@ use sha2::{Digest, Sha256};
 use crate::{
     agent_template::{agent_memory_operator_path, agent_memory_self_path},
     storage::AppStorage,
-    types::{BriefRecord, ContextEpisodeRecord, WorkItemRecord, WorkspaceEntry},
+    tool::helpers::{command_digest, command_preview, command_receipt_source_ref},
+    types::{
+        BriefRecord, ContextEpisodeRecord, ToolExecutionRecord, WorkItemRecord, WorkspaceEntry,
+    },
 };
 
 const INDEX_FILENAME: &str = "memory.sqlite3";
@@ -25,6 +28,7 @@ const GET_CHARS_MAX: usize = 50_000;
 const REBUILD_BRIEF_LIMIT: usize = 500;
 const REBUILD_EPISODE_LIMIT: usize = 500;
 const REBUILD_WORK_ITEM_LIMIT: usize = 500;
+const REBUILD_COMMAND_RECEIPT_LIMIT: usize = 500;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -490,6 +494,7 @@ fn collect_documents(
     documents.extend(brief_documents(storage)?);
     documents.extend(context_episode_documents(storage)?);
     documents.extend(work_item_documents(storage)?);
+    documents.extend(command_execution_documents(storage)?);
     Ok(documents)
 }
 
@@ -712,6 +717,79 @@ fn work_item_document_body(item: &WorkItemRecord) -> String {
         }
     }
     lines.join("\n")
+}
+
+fn command_execution_documents(storage: &AppStorage) -> Result<Vec<MemoryDocument>> {
+    let mut documents = Vec::new();
+    for record in storage.read_recent_tool_executions(REBUILD_COMMAND_RECEIPT_LIMIT)? {
+        match record.tool_name.as_str() {
+            "ExecCommand" => {
+                if let Some(cmd) = record.input.get("cmd").and_then(Value::as_str) {
+                    documents.push(command_receipt_document(&record, None, cmd));
+                }
+            }
+            "ExecCommandBatch" => {
+                if let Some(items) = record.input.get("items").and_then(Value::as_array) {
+                    for (offset, item) in items.iter().enumerate() {
+                        if let Some(cmd) = item.get("cmd").and_then(Value::as_str) {
+                            documents.push(command_receipt_document(
+                                &record,
+                                Some(offset + 1),
+                                cmd,
+                            ));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(documents)
+}
+
+fn command_receipt_document(
+    record: &ToolExecutionRecord,
+    batch_item_index: Option<usize>,
+    cmd: &str,
+) -> MemoryDocument {
+    let cmd_digest = command_digest(cmd);
+    let source_ref = command_receipt_source_ref(&record.id, batch_item_index);
+    let title = match batch_item_index {
+        Some(index) => format!("{} command receipt item {}", record.tool_name, index),
+        None => format!("{} command receipt", record.tool_name),
+    };
+    let preview = command_preview(cmd);
+    let body = format!(
+        "tool_execution_id: {}\ntool_name: {}\ncmd_digest: {}\ncmd:\n{}",
+        record.id, record.tool_name, cmd_digest, cmd
+    );
+    MemoryDocument {
+        source_ref,
+        source_kind: "tool_command_receipt".into(),
+        scope_kind: "agent".into(),
+        workspace_id: None,
+        agent_id: record.agent_id.clone(),
+        source_path: None,
+        title,
+        sanitized_excerpt: format!(
+            "tool_execution_id={} tool_name={} cmd_digest={} cmd_preview={}",
+            record.id, record.tool_name, cmd_digest, preview
+        ),
+        body,
+        metadata: json!({
+            "tool_execution_id": record.id,
+            "tool_name": record.tool_name,
+            "turn_index": record.turn_index,
+            "work_item_id": record.work_item_id,
+            "batch_item_index": batch_item_index,
+            "cmd_digest": cmd_digest,
+            "cmd_preview": preview,
+            "governance_surface": "runtime_evidence",
+            "provenance_class": "tool_execution_record",
+            "trust_class": "runtime_evidence",
+        }),
+        updated_at: record.completed_at.unwrap_or(record.created_at),
+    }
 }
 
 fn work_item_plan_status_label(status: crate::types::WorkItemPlanStatus) -> &'static str {
@@ -1233,5 +1311,115 @@ mod tests {
             results.is_empty(),
             "workspace README marker must not be searchable as Holon memory: {results:?}"
         );
+    }
+
+    #[test]
+    fn command_receipts_preserve_long_exec_command_input_for_memory_get() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let command = "python - <<'PY'\nprint('receipt_start')\nprint('sentinel_middle_line_1246')\nprint('receipt_end')\nPY";
+        storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-exec-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: Some("work-1246".into()),
+                turn_index: 7,
+                tool_name: "ExecCommand".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 10,
+                trust: crate::types::TrustLevel::TrustedOperator,
+                status: crate::types::ToolExecutionStatus::Success,
+                input: json!({"cmd": command}),
+                output: json!({"exit_code": 0}),
+                summary: "command exited with status 0".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let results = search_memory(
+            &storage,
+            "sentinel_middle_line_1246",
+            10,
+            Some("ws-holon"),
+            false,
+        )
+        .unwrap();
+        let result = results
+            .iter()
+            .find(|result| result.kind == "tool_command_receipt")
+            .expect("command receipt should be indexed");
+        assert_eq!(result.source_ref, "tool_execution:tool-exec-1246:cmd");
+        assert_eq!(
+            result.metadata["tool_execution_id"].as_str(),
+            Some("tool-exec-1246")
+        );
+        assert_eq!(
+            result.metadata["cmd_preview"].as_str(),
+            Some("[omitted: command contains heredoc or inline script]")
+        );
+
+        let memory = get_memory(&storage, &result.source_ref, None, Some("ws-holon"))
+            .unwrap()
+            .expect("command receipt should be retrievable");
+        assert!(memory.content.contains(command));
+        assert!(memory.content.contains("sentinel_middle_line_1246"));
+        assert!(!memory.truncated);
+    }
+
+    #[test]
+    fn command_receipts_preserve_exec_command_batch_item_inputs() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let first_command = "rg -n \"MemorySearch\" src/memory/index.rs";
+        let second_command = "node - <<'NODE'\nconsole.log('batch_receipt_middle_1246')\nNODE";
+        storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-batch-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: None,
+                turn_index: 8,
+                tool_name: "ExecCommandBatch".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 20,
+                trust: crate::types::TrustLevel::TrustedOperator,
+                status: crate::types::ToolExecutionStatus::Success,
+                input: json!({
+                    "items": [
+                        {"cmd": first_command},
+                        {"cmd": second_command}
+                    ]
+                }),
+                output: json!({"completed_count": 2}),
+                summary: "ExecCommandBatch completed 2/2 items".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let results = search_memory(
+            &storage,
+            "batch_receipt_middle_1246",
+            10,
+            Some("ws-holon"),
+            false,
+        )
+        .unwrap();
+        let result = results
+            .iter()
+            .find(|result| result.source_ref == "tool_execution:tool-batch-1246:batch_item:2:cmd")
+            .expect("second batch item receipt should be indexed");
+        assert_eq!(result.metadata["batch_item_index"].as_u64(), Some(2));
+        assert_eq!(
+            result.metadata["cmd_preview"].as_str(),
+            Some("[omitted: command contains heredoc or inline script]")
+        );
+        let memory = get_memory(&storage, &result.source_ref, None, Some("ws-holon"))
+            .unwrap()
+            .expect("batch command receipt should be retrievable");
+        assert!(memory.content.contains(second_command));
+        assert!(!memory.content.contains(first_command));
     }
 }

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -690,9 +690,9 @@ fn command_recap_receipt(call: &ToolCall) -> Option<String> {
         "ExecCommand" => {
             let cmd = call.input.get("cmd").and_then(Value::as_str)?;
             Some(format!(
-                "ExecCommand cmd_digest={} cmd_preview={}",
-                command_digest(cmd),
-                command_preview(cmd)
+                "ExecCommand tool_call_id={} cmd_digest={}",
+                call.id,
+                command_digest(cmd)
             ))
         }
         "ExecCommandBatch" => {
@@ -703,14 +703,19 @@ fn command_recap_receipt(call: &ToolCall) -> Option<String> {
                 .filter_map(|(offset, item)| {
                     let cmd = item.get("cmd").and_then(Value::as_str)?;
                     Some(format!(
-                        "item={} cmd_digest={} cmd_preview={}",
+                        "item={} cmd_digest={}",
                         offset + 1,
-                        command_digest(cmd),
-                        command_preview(cmd)
+                        command_digest(cmd)
                     ))
                 })
                 .collect::<Vec<_>>();
-            (!refs.is_empty()).then(|| format!("ExecCommandBatch {}", refs.join(" | ")))
+            (!refs.is_empty()).then(|| {
+                format!(
+                    "ExecCommandBatch tool_call_id={} {}",
+                    call.id,
+                    refs.join(" | ")
+                )
+            })
         }
         _ => None,
     }
@@ -3157,8 +3162,9 @@ mod tests {
         let recap = build_round_recap_line(&round);
 
         assert!(recap.contains("recoverable_command_inputs=[ExecCommand"));
+        assert!(recap.contains("tool_call_id=call_3"));
         assert!(recap.contains("cmd_digest="));
-        assert!(recap.contains("[omitted: command contains heredoc or inline script]"));
+        assert!(!recap.contains("cmd_preview="));
         assert!(!recap.contains("turn_recap_hidden_1246"));
     }
 
@@ -3179,9 +3185,10 @@ mod tests {
         let recap = build_round_recap_line(&round);
 
         assert!(recap.contains("recoverable_command_inputs=[ExecCommandBatch"));
+        assert!(recap.contains("tool_call_id=call_4"));
         assert!(recap.contains("item=1 cmd_digest="));
         assert!(recap.contains("item=2 cmd_digest="));
-        assert!(recap.contains("[omitted: command contains heredoc or inline script]"));
+        assert!(!recap.contains("cmd_preview="));
         assert!(!recap.contains("turn_batch_hidden_1246"));
     }
 

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -17,7 +17,9 @@ use crate::{
         build_continuation_request, build_provider_prompt_frame, build_provider_turn_request,
     },
     tool::{
-        helpers::{command_cost_diagnostics, command_preview, effective_tool_output_tokens},
+        helpers::{
+            command_cost_diagnostics, command_digest, command_preview, effective_tool_output_tokens,
+        },
         spec::{ToolResultEnvelope, ToolResultStatus},
         ToolCall, ToolError, ToolSpec,
     },
@@ -654,6 +656,17 @@ fn build_round_recap_line(round: &TurnRoundRecord) -> String {
     if !tool_calls.is_empty() {
         parts.push(format!("tool_calls=[{}]", tool_calls.join(", ")));
     }
+    let command_receipts = round
+        .tool_calls
+        .iter()
+        .filter_map(command_recap_receipt)
+        .collect::<Vec<_>>();
+    if !command_receipts.is_empty() {
+        parts.push(format!(
+            "recoverable_command_inputs=[{}]",
+            command_receipts.join(", ")
+        ));
+    }
     if !tool_results.is_empty() {
         parts.push(format!("results=[{}]", tool_results.join(" | ")));
     }
@@ -670,6 +683,37 @@ fn build_round_recap_line(round: &TurnRoundRecord) -> String {
         parts.join("; ")
     };
     format!("- Round {}: {}", round.round, detail)
+}
+
+fn command_recap_receipt(call: &ToolCall) -> Option<String> {
+    match call.name.as_str() {
+        "ExecCommand" => {
+            let cmd = call.input.get("cmd").and_then(Value::as_str)?;
+            Some(format!(
+                "ExecCommand cmd_digest={} cmd_preview={}",
+                command_digest(cmd),
+                command_preview(cmd)
+            ))
+        }
+        "ExecCommandBatch" => {
+            let items = call.input.get("items").and_then(Value::as_array)?;
+            let refs = items
+                .iter()
+                .enumerate()
+                .filter_map(|(offset, item)| {
+                    let cmd = item.get("cmd").and_then(Value::as_str)?;
+                    Some(format!(
+                        "item={} cmd_digest={} cmd_preview={}",
+                        offset + 1,
+                        command_digest(cmd),
+                        command_preview(cmd)
+                    ))
+                })
+                .collect::<Vec<_>>();
+            (!refs.is_empty()).then(|| format!("ExecCommandBatch {}", refs.join(" | ")))
+        }
+        _ => None,
+    }
 }
 
 fn build_compacted_round_recap(rounds: &[TurnRoundRecord], recap_budget: usize) -> String {
@@ -3098,6 +3142,47 @@ mod tests {
         assert!(work_item.contains("complete smaller tool call"));
         assert!(!work_item.contains("huge patch"));
         assert!(!work_item.contains("ExecCommand/scripted rewrite"));
+    }
+
+    #[test]
+    fn turn_local_round_recap_preserves_command_recovery_identity() {
+        let command = "python - <<'PY'\nprint('turn_recap_hidden_1246')\nPY";
+        let round = fixture_round_with_tool(
+            3,
+            "running a diagnostic command",
+            "ExecCommand",
+            serde_json::json!({"cmd": command}),
+        );
+
+        let recap = build_round_recap_line(&round);
+
+        assert!(recap.contains("recoverable_command_inputs=[ExecCommand"));
+        assert!(recap.contains("cmd_digest="));
+        assert!(recap.contains("[omitted: command contains heredoc or inline script]"));
+        assert!(!recap.contains("turn_recap_hidden_1246"));
+    }
+
+    #[test]
+    fn turn_local_round_recap_preserves_batch_command_recovery_identity() {
+        let round = fixture_round_with_tool(
+            4,
+            "running command batch",
+            "ExecCommandBatch",
+            serde_json::json!({
+                "items": [
+                    {"cmd": "rg -n \"foo\" src"},
+                    {"cmd": "node - <<'NODE'\nconsole.log('turn_batch_hidden_1246')\nNODE"}
+                ]
+            }),
+        );
+
+        let recap = build_round_recap_line(&round);
+
+        assert!(recap.contains("recoverable_command_inputs=[ExecCommandBatch"));
+        assert!(recap.contains("item=1 cmd_digest="));
+        assert!(recap.contains("item=2 cmd_digest="));
+        assert!(recap.contains("[omitted: command contains heredoc or inline script]"));
+        assert!(!recap.contains("turn_batch_hidden_1246"));
     }
 
     fn fixture_round(round: usize, text: &str) -> TurnRoundRecord {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -251,7 +251,14 @@ impl AppStorage {
     }
 
     pub fn append_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
-        self.append_jsonl(&self.tools_path, record)
+        self.append_jsonl(&self.tools_path, record)?;
+        if matches!(
+            record.tool_name.as_str(),
+            "ExecCommand" | "ExecCommandBatch"
+        ) {
+            self.mark_memory_index_dirty()?;
+        }
+        Ok(())
     }
 
     pub fn append_transcript_entry(&self, entry: &TranscriptEntry) -> Result<()> {

--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
 use crate::tool::ToolError;
@@ -153,6 +154,21 @@ pub(crate) fn command_preview(cmd: &str) -> String {
         return "[omitted: command contains heredoc or inline script]".to_string();
     }
     truncate_text(&redact_command_secrets(cmd), COMMAND_PREVIEW_CHARS)
+}
+
+pub(crate) fn command_digest(cmd: &str) -> String {
+    let digest = Sha256::digest(cmd.as_bytes());
+    format!("{digest:x}")
+}
+
+pub(crate) fn command_receipt_source_ref(
+    tool_execution_id: &str,
+    batch_item_index: Option<usize>,
+) -> String {
+    match batch_item_index {
+        Some(index) => format!("tool_execution:{tool_execution_id}:batch_item:{index}:cmd"),
+        None => format!("tool_execution:{tool_execution_id}:cmd"),
+    }
 }
 
 pub(crate) fn command_cost_diagnostics(

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -20,6 +20,7 @@ const ALLOWED_SOURCE_REF_PREFIXES: &[&str] = &[
     "brief:",
     "episode:",
     "work_item:",
+    "tool_execution:",
 ];
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -93,6 +94,11 @@ fn validate_source_ref(source_ref: String) -> Result<String> {
             "missing source_ref prefix",
         ));
     };
+    let prefix = format!("{prefix}:");
+    if prefix == "tool_execution:" {
+        return validate_tool_execution_source_ref(&source_ref, suffix);
+    }
+
     if suffix.is_empty() {
         return Err(invalid_source_ref_error(
             &source_ref,
@@ -109,7 +115,6 @@ fn validate_source_ref(source_ref: String) -> Result<String> {
         ));
     }
 
-    let prefix = format!("{prefix}:");
     if !ALLOWED_SOURCE_REF_PREFIXES.contains(&prefix.as_str()) {
         return Err(invalid_source_ref_error(
             &source_ref,
@@ -118,6 +123,33 @@ fn validate_source_ref(source_ref: String) -> Result<String> {
     }
 
     Ok(source_ref)
+}
+
+fn validate_tool_execution_source_ref(source_ref: &str, suffix: &str) -> Result<String> {
+    let parts = suffix.split(':').collect::<Vec<_>>();
+    let valid = match parts.as_slice() {
+        [tool_execution_id, "cmd"] => valid_source_ref_segment(tool_execution_id),
+        [tool_execution_id, "batch_item", index, "cmd"] => {
+            valid_source_ref_segment(tool_execution_id)
+                && !index.is_empty()
+                && index.chars().all(|ch| ch.is_ascii_digit())
+        }
+        _ => false,
+    };
+    if !valid {
+        return Err(invalid_source_ref_error(
+            source_ref,
+            "tool_execution source_ref must match tool_execution:<id>:cmd or tool_execution:<id>:batch_item:<index>:cmd",
+        ));
+    }
+    Ok(source_ref.to_string())
+}
+
+fn valid_source_ref_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
 }
 
 fn validate_max_chars(max_chars: Option<usize>) -> Result<Option<usize>> {
@@ -157,7 +189,19 @@ fn invalid_source_ref_error(source_ref: &str, validation_error: &'static str) ->
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+    use serde_json::json;
+    use tempfile::tempdir;
+
     use super::*;
+    use crate::{
+        context::ContextConfig,
+        provider::StubProvider,
+        runtime::RuntimeHandle,
+        types::{ToolExecutionRecord, ToolExecutionStatus, TrustLevel},
+    };
 
     fn tool_error(error: anyhow::Error) -> crate::tool::ToolError {
         error
@@ -174,6 +218,8 @@ mod tests {
             "brief:abc",
             "episode:ep_123",
             "work_item:work_123",
+            "tool_execution:tool-123:cmd",
+            "tool_execution:tool-123:batch_item:2:cmd",
         ] {
             assert_eq!(
                 validate_source_ref(source_ref.to_string()).unwrap(),
@@ -194,6 +240,9 @@ mod tests {
             "brief:https://example.com/memory",
             "episode:../ledger/episode-1",
             "work_item:work_123?raw=true",
+            "tool_execution:tool-123",
+            "tool_execution:tool-123:batch_item:abc:cmd",
+            "tool_execution:tool-123:batch_item:2",
         ] {
             let error = tool_error(validate_source_ref(source_ref.to_string()).unwrap_err());
             assert_eq!(error.kind, "invalid_tool_input");
@@ -246,5 +295,66 @@ mod tests {
                 .and_then(|details| details.get("maximum"))
                 .is_some());
         }
+    }
+
+    #[tokio::test]
+    async fn memory_get_tool_accepts_command_receipt_source_refs() {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(StubProvider::new("done")),
+            "default".into(),
+            ContextConfig::default(),
+        )
+        .unwrap();
+        let command = "python - <<'PY'\nprint('memory_get_tool_receipt_1246')\nPY";
+        runtime
+            .storage()
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-get-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: None,
+                turn_index: 1,
+                tool_name: "ExecCommand".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 10,
+                trust: TrustLevel::TrustedOperator,
+                status: ToolExecutionStatus::Success,
+                input: json!({
+                    "cmd": command,
+                    "workdir": "src",
+                    "yield_time_ms": 1000,
+                    "max_output_tokens": 1200
+                }),
+                output: json!({"exit_code": 0}),
+                summary: "command exited with status 0".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let result = execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &json!({
+                "source_ref": "tool_execution:tool-get-1246:cmd"
+            }),
+        )
+        .await
+        .unwrap();
+        let content = result.envelope.result.unwrap()["memory"]["content"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert!(content.contains("memory_get_tool_receipt_1246"));
+        assert!(content.contains("\"workdir\": \"src\""));
+        assert!(content.contains("\"yield_time_ms\": 1000"));
+        assert!(content.contains("\"max_output_tokens\": 1200"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1246.

This preserves command startup inputs as recoverable runtime evidence without stuffing full code-shaped commands back into every prompt.

## Changes

- Add stable command receipt refs and SHA-256 command digests for `ExecCommand` and `ExecCommandBatch` items.
- Index command receipts in `MemorySearch` / `MemoryGet` as `tool_command_receipt` documents backed by canonical `ToolExecutionRecord.input`.
- Keep UI/model previews bounded and redacted while exposing `tool_execution_id`, `cmd_digest`, and `cmd_ref` in recent tool context.
- Include command recovery identity in turn-local compaction recaps for command calls compacted inside a provider turn.
- Mark the memory index dirty when command tool executions are appended so receipts become searchable after new commands.

## Verification

- `cargo test memory::index::tests::command_receipts --lib`
- `cargo test context::tests::recent_tool_context_includes --lib`
- `cargo test runtime::turn::tests::turn_local_round_recap_preserves --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
