### PR TITLE
tool: harden built-in input contract tests

### DIFF
--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -342,68 +342,9 @@ pub(crate) fn truncate_output_with_flag(
     truncate_output_to_char_budget(text, output_char_budget(max_output_tokens))
 }
 
-/// Extract the sleep reason from input, handling structured payloads.
-pub(crate) fn extract_sleep_reason(input: &Value) -> String {
-    let reason = input
-        .get("reason")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-
-    let object = match input {
-        Value::Object(map) => map,
-        _ => return reason.unwrap_or("sleep requested").to_string(),
-    };
-
-    let has_extra_fields = object
-        .keys()
-        .any(|key| key != "reason" && key != "duration_ms");
-    if !has_extra_fields {
-        return reason.unwrap_or("sleep requested").to_string();
-    }
-
-    let pretty = serde_json::to_string_pretty(input).unwrap_or_else(|_| input.to_string());
-    match reason {
-        Some(reason) if reason.len() >= 160 => reason.to_string(),
-        Some(reason) => {
-            format!("{reason}\n\nAdditional structured summary from Sleep input:\n{pretty}")
-        }
-        None => format!("Sleep requested with structured summary:\n{pretty}"),
-    }
-}
-
-pub(crate) fn extract_sleep_duration_ms(input: &Value) -> Result<Option<u64>> {
-    let object = match input {
-        Value::Object(map) => map,
-        _ => return Ok(None),
-    };
-    let Some(duration) = object.get("duration_ms") else {
-        return Ok(None);
-    };
-    if duration.is_null() {
-        return Ok(None);
-    }
-    let Some(duration_ms) = duration.as_u64() else {
-        return Err(invalid_tool_input(
-            "Sleep",
-            "Sleep `duration_ms` must be an integer when provided",
-            json!({
-                "field": "duration_ms",
-                "validation_error": "expected integer",
-            }),
-            "omit `duration_ms` for ordinary terminal rest, or provide a positive integer millisecond delay",
-        ));
-    };
-    if duration_ms == 0 {
-        return Ok(None);
-    }
-    Ok(Some(duration_ms))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn output_budget_defaults_to_command_tool_default() {
@@ -452,63 +393,5 @@ mod tests {
         assert!(!preview.contains("abc123"));
         assert!(!preview.contains("hunter2"));
         assert!(!preview.contains("user:pass"));
-    }
-
-    #[test]
-    fn sleep_reason_uses_plain_reason_when_input_is_simple() {
-        let reason = extract_sleep_reason(&json!({ "reason": "done with verification" }));
-        assert_eq!(reason, "done with verification");
-    }
-
-    #[test]
-    fn sleep_reason_preserves_structured_payload_when_input_is_malformed() {
-        let reason = extract_sleep_reason(&json!({
-            "reason": "## Analysis Complete",
-            "Recommendation": "Add a stronger final delivery contract in src/runtime.rs.",
-            "Citations": "docs/benchmark-results.md and src/prompt.rs"
-        }));
-        assert!(reason.contains("## Analysis Complete"));
-        assert!(reason.contains("Additional structured summary from Sleep input"));
-        assert!(reason.contains("Recommendation"));
-        assert!(reason.contains("src/runtime.rs"));
-    }
-
-    #[test]
-    fn sleep_reason_ignores_supported_duration_field() {
-        let reason = extract_sleep_reason(&json!({
-            "reason": "wait briefly for a filesystem settle",
-            "duration_ms": 250,
-        }));
-        assert_eq!(reason, "wait briefly for a filesystem settle");
-    }
-
-    #[test]
-    fn sleep_duration_reads_positive_integer_delay() {
-        let duration_ms = extract_sleep_duration_ms(&json!({
-            "reason": "pause",
-            "duration_ms": 250,
-        }))
-        .unwrap();
-        assert_eq!(duration_ms, Some(250));
-    }
-
-    #[test]
-    fn sleep_duration_treats_null_as_omitted() {
-        let duration_ms = extract_sleep_duration_ms(&json!({
-            "reason": "pause",
-            "duration_ms": null,
-        }))
-        .unwrap();
-        assert_eq!(duration_ms, None);
-    }
-
-    #[test]
-    fn sleep_duration_treats_zero_as_omitted() {
-        let duration_ms = extract_sleep_duration_ms(&json!({
-            "reason": "pause",
-            "duration_ms": 0,
-        }))
-        .unwrap();
-        assert_eq!(duration_ms, None);
     }
 }

--- a/src/tool/tools/exec_command.rs
+++ b/src/tool/tools/exec_command.rs
@@ -15,11 +15,11 @@ use crate::{
 };
 
 use super::{serialize_success, BuiltinToolDefinition};
-use crate::tool::helpers::parse_tool_args;
+use crate::tool::helpers::{invalid_tool_input, parse_tool_args_with_recovery_hint};
 
 pub(crate) const NAME: &str = "ExecCommand";
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ExecCommandArgs {
     pub(crate) cmd: String,
@@ -49,7 +49,7 @@ pub(crate) async fn execute(
     trust: &TrustLevel,
     input: &Value,
 ) -> Result<ToolResult> {
-    let args: ExecCommandArgs = parse_tool_args(NAME, input)?;
+    let args: ExecCommandArgs = parse_exec_command_args(input)?;
     let tty = args.tty.unwrap_or(false);
     let spec = CommandTaskSpec {
         cmd: args.cmd,
@@ -67,6 +67,50 @@ pub(crate) async fn execute(
         .execute_exec_command(spec, trust)
         .await?;
     serialize_success(NAME, &result)
+}
+
+fn parse_exec_command_args(input: &Value) -> Result<ExecCommandArgs> {
+    if let Some(object) = input.as_object() {
+        if object.contains_key("command") {
+            return Err(invalid_tool_input(
+                NAME,
+                "ExecCommand uses `cmd`, not `command`",
+                serde_json::json!({
+                    "field": "command",
+                    "expected_field": "cmd",
+                }),
+                "use `cmd` to provide the startup command",
+            ));
+        }
+        if object.contains_key("status") {
+            return Err(invalid_tool_input(
+                NAME,
+                "ExecCommand does not accept command-task result fields",
+                serde_json::json!({
+                    "field": "status",
+                    "expected_tool": "TaskStatus",
+                    "expected_field": "task_id",
+                }),
+                "pass only startup arguments to ExecCommand, and use TaskStatus when you need task handle metadata",
+            ));
+        }
+        if object.contains_key("task_handle") {
+            return Err(invalid_tool_input(
+                NAME,
+                "ExecCommand does not accept command-task result fields",
+                serde_json::json!({
+                    "field": "task_handle",
+                    "expected_tool": "TaskStatus",
+                    "expected_field": "task_id",
+                }),
+                "pass only startup arguments to ExecCommand, and use TaskStatus when you need task handle metadata",
+            ));
+        }
+    }
+
+    parse_tool_args_with_recovery_hint(NAME, input, || {
+        "provide input for ExecCommand that matches the published tool schema".to_string()
+    })
 }
 
 pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
@@ -137,6 +181,8 @@ pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
 mod tests {
     use super::*;
     use crate::tool::tools::serialize_success;
+    use crate::tool::ToolError;
+    use serde_json::json;
 
     #[test]
     fn exec_command_completed_renders_text_receipt() {
@@ -215,5 +261,39 @@ mod tests {
         let rendered = render_for_model(&result).unwrap();
         assert!(rendered.contains("Initial output:"));
         assert!(rendered.contains("(none captured before promotion)"));
+    }
+
+    #[test]
+    fn rejects_command_alias_for_exec_command() {
+        let error = parse_exec_command_args(&json!({
+            "command": "git status"
+        }))
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert!(tool_error.message.contains("`cmd`"));
+        assert_eq!(tool_error.details.as_ref().unwrap()["field"], "command");
+        assert!(tool_error
+            .recovery_hint
+            .as_deref()
+            .unwrap_or_default()
+            .contains("cmd"));
+    }
+
+    #[test]
+    fn rejects_task_status_metadata_for_exec_command() {
+        let error = parse_exec_command_args(&json!({
+            "cmd": "git status",
+            "status": "running"
+        }))
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert_eq!(tool_error.details.as_ref().unwrap()["field"], "status");
+        assert!(tool_error
+            .recovery_hint
+            .as_deref()
+            .unwrap_or_default()
+            .contains("TaskStatus"));
     }
 }

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -363,6 +363,49 @@ mod tests {
         let error = rejected_item_error(&item).expect("tty should be rejected");
         assert_eq!(error.kind, "unsupported_batch_command_field");
         assert!(error.message.contains("tty"));
+        assert!(error
+            .recovery_hint
+            .as_deref()
+            .unwrap_or_default()
+            .contains("ExecCommand"));
+    }
+
+    #[test]
+    fn rejects_accepts_input_field_in_items() {
+        let item = ExecCommandBatchItemArgs {
+            cmd: "git status".into(),
+            workdir: None,
+            shell: None,
+            login: None,
+            yield_time_ms: None,
+            max_output_tokens: None,
+            tty: None,
+            accepts_input: Some(false),
+            continue_on_result: None,
+        };
+
+        let error = rejected_item_error(&item).expect("accepts_input should be rejected");
+        assert_eq!(error.kind, "unsupported_batch_command_field");
+        assert!(error.message.contains("accepts_input"));
+    }
+
+    #[test]
+    fn rejects_continue_on_result_field_in_items() {
+        let item = ExecCommandBatchItemArgs {
+            cmd: "git status".into(),
+            workdir: None,
+            shell: None,
+            login: None,
+            yield_time_ms: None,
+            max_output_tokens: None,
+            tty: None,
+            accepts_input: None,
+            continue_on_result: Some(true),
+        };
+
+        let error = rejected_item_error(&item).expect("continue_on_result should be rejected");
+        assert_eq!(error.kind, "unsupported_batch_command_field");
+        assert!(error.message.contains("continue_on_result"));
     }
 
     #[test]

--- a/src/tool/tools/sleep.rs
+++ b/src/tool/tools/sleep.rs
@@ -1,3 +1,4 @@
+use crate::tool::helpers::{invalid_tool_input, parse_tool_args_with_recovery_hint};
 use anyhow::Result;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -11,11 +12,10 @@ use crate::{
 };
 
 use super::BuiltinToolDefinition;
-use crate::tool::helpers::{extract_sleep_duration_ms, extract_sleep_reason};
-
 pub(crate) const NAME: &str = "Sleep";
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SleepArgs {
     pub(crate) reason: Option<String>,
     #[schemars(range(min = 1))]
@@ -38,8 +38,14 @@ pub(crate) async fn execute(
     _trust: &TrustLevel,
     input: &Value,
 ) -> Result<ToolResult> {
-    let reason = extract_sleep_reason(input);
-    let sleep_duration_ms = extract_sleep_duration_ms(input)?;
+    let args = parse_sleep_args(input)?;
+    let reason = args
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("sleep requested");
+    let sleep_duration_ms = args.duration_ms.filter(|duration| *duration > 0);
     Ok(ToolResult::sleep(
         NAME,
         json!({
@@ -53,4 +59,74 @@ pub(crate) async fn execute(
         ),
         sleep_duration_ms,
     ))
+}
+
+fn parse_sleep_args(input: &Value) -> Result<SleepArgs> {
+    let args: SleepArgs = parse_tool_args_with_recovery_hint(NAME, input, || {
+        "provide only `reason` and optional `duration_ms` that match the Sleep tool schema"
+            .to_string()
+    })?;
+    if let Some(0) = args.duration_ms {
+        return Err(invalid_tool_input(
+            NAME,
+            "Sleep `duration_ms` must be a positive integer",
+            json!({
+                "field": "duration_ms",
+                "validation_error": "must be greater than 0",
+            }),
+            "omit `duration_ms` for ordinary sleep, or provide a positive integer millisecond delay",
+        ));
+    }
+    Ok(SleepArgs {
+        reason: args.reason,
+        duration_ms: args.duration_ms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::ToolError;
+
+    #[test]
+    fn parse_sleep_args_rejects_unknown_fields() {
+        let error = parse_sleep_args(&serde_json::json!({
+            "reason": "done",
+            "summary": "should be rejected",
+        }))
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert!(tool_error.details.as_ref().unwrap()["parse_error"]
+            .as_str()
+            .unwrap()
+            .contains("unknown field"));
+    }
+
+    #[test]
+    fn parse_sleep_args_rejects_zero_duration() {
+        let error = parse_sleep_args(&serde_json::json!({
+            "reason": "pause",
+            "duration_ms": 0,
+        }))
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert_eq!(tool_error.details.as_ref().unwrap()["field"], "duration_ms");
+        assert!(tool_error
+            .recovery_hint
+            .as_deref()
+            .unwrap_or_default()
+            .contains("positive integer"));
+    }
+
+    #[test]
+    fn parse_sleep_args_accepts_defaulted_duration() {
+        let args = parse_sleep_args(&serde_json::json!({
+            "reason": "pause",
+        }))
+        .unwrap();
+        assert_eq!(args.reason.as_deref(), Some("pause"));
+        assert_eq!(args.duration_ms, None);
+    }
 }


### PR DESCRIPTION
## Summary

- Tighten Sleep validation to parse using the published schema and reject unknown fields.
- Enforce positive `duration_ms` for Sleep (zero is now rejected as invalid).
- Add focused contract tests for invalid `ExecCommand` inputs (`command`, `status`).
- Extend `ExecCommandBatch` item rejection tests for `accepts_input` and `continue_on_result`.

Closes #1244
