### PR TITLE
Harden tool args validation for common invalid payloads

### DIFF
--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -342,68 +342,9 @@ pub(crate) fn truncate_output_with_flag(
     truncate_output_to_char_budget(text, output_char_budget(max_output_tokens))
 }
 
-/// Extract the sleep reason from input, handling structured payloads.
-pub(crate) fn extract_sleep_reason(input: &Value) -> String {
-    let reason = input
-        .get("reason")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-
-    let object = match input {
-        Value::Object(map) => map,
-        _ => return reason.unwrap_or("sleep requested").to_string(),
-    };
-
-    let has_extra_fields = object
-        .keys()
-        .any(|key| key != "reason" && key != "duration_ms");
-    if !has_extra_fields {
-        return reason.unwrap_or("sleep requested").to_string();
-    }
-
-    let pretty = serde_json::to_string_pretty(input).unwrap_or_else(|_| input.to_string());
-    match reason {
-        Some(reason) if reason.len() >= 160 => reason.to_string(),
-        Some(reason) => {
-            format!("{reason}\n\nAdditional structured summary from Sleep input:\n{pretty}")
-        }
-        None => format!("Sleep requested with structured summary:\n{pretty}"),
-    }
-}
-
-pub(crate) fn extract_sleep_duration_ms(input: &Value) -> Result<Option<u64>> {
-    let object = match input {
-        Value::Object(map) => map,
-        _ => return Ok(None),
-    };
-    let Some(duration) = object.get("duration_ms") else {
-        return Ok(None);
-    };
-    if duration.is_null() {
-        return Ok(None);
-    }
-    let Some(duration_ms) = duration.as_u64() else {
-        return Err(invalid_tool_input(
-            "Sleep",
-            "Sleep `duration_ms` must be an integer when provided",
-            json!({
-                "field": "duration_ms",
-                "validation_error": "expected integer",
-            }),
-            "omit `duration_ms` for ordinary terminal rest, or provide a positive integer millisecond delay",
-        ));
-    };
-    if duration_ms == 0 {
-        return Ok(None);
-    }
-    Ok(Some(duration_ms))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn output_budget_defaults_to_command_tool_default() {
@@ -452,63 +393,5 @@ mod tests {
         assert!(!preview.contains("abc123"));
         assert!(!preview.contains("hunter2"));
         assert!(!preview.contains("user:pass"));
-    }
-
-    #[test]
-    fn sleep_reason_uses_plain_reason_when_input_is_simple() {
-        let reason = extract_sleep_reason(&json!({ "reason": "done with verification" }));
-        assert_eq!(reason, "done with verification");
-    }
-
-    #[test]
-    fn sleep_reason_preserves_structured_payload_when_input_is_malformed() {
-        let reason = extract_sleep_reason(&json!({
-            "reason": "## Analysis Complete",
-            "Recommendation": "Add a stronger final delivery contract in src/runtime.rs.",
-            "Citations": "docs/benchmark-results.md and src/prompt.rs"
-        }));
-        assert!(reason.contains("## Analysis Complete"));
-        assert!(reason.contains("Additional structured summary from Sleep input"));
-        assert!(reason.contains("Recommendation"));
-        assert!(reason.contains("src/runtime.rs"));
-    }
-
-    #[test]
-    fn sleep_reason_ignores_supported_duration_field() {
-        let reason = extract_sleep_reason(&json!({
-            "reason": "wait briefly for a filesystem settle",
-            "duration_ms": 250,
-        }));
-        assert_eq!(reason, "wait briefly for a filesystem settle");
-    }
-
-    #[test]
-    fn sleep_duration_reads_positive_integer_delay() {
-        let duration_ms = extract_sleep_duration_ms(&json!({
-            "reason": "pause",
-            "duration_ms": 250,
-        }))
-        .unwrap();
-        assert_eq!(duration_ms, Some(250));
-    }
-
-    #[test]
-    fn sleep_duration_treats_null_as_omitted() {
-        let duration_ms = extract_sleep_duration_ms(&json!({
-            "reason": "pause",
-            "duration_ms": null,
-        }))
-        .unwrap();
-        assert_eq!(duration_ms, None);
-    }
-
-    #[test]
-    fn sleep_duration_treats_zero_as_omitted() {
-        let duration_ms = extract_sleep_duration_ms(&json!({
-            "reason": "pause",
-            "duration_ms": 0,
-        }))
-        .unwrap();
-        assert_eq!(duration_ms, None);
     }
 }

--- a/src/tool/tools/exec_command.rs
+++ b/src/tool/tools/exec_command.rs
@@ -19,7 +19,7 @@ use crate::tool::helpers::parse_tool_args;
 
 pub(crate) const NAME: &str = "ExecCommand";
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ExecCommandArgs {
     pub(crate) cmd: String,
@@ -137,6 +137,8 @@ pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
 mod tests {
     use super::*;
     use crate::tool::tools::serialize_success;
+    use crate::tool::ToolError;
+    use serde_json::json;
 
     #[test]
     fn exec_command_completed_renders_text_receipt() {
@@ -162,6 +164,55 @@ mod tests {
         assert!(rendered.contains("Process exited with code 0"));
         assert!(rendered.contains("stdout:"));
         assert!(rendered.contains("line one"));
+    }
+
+    #[test]
+    fn exec_command_rejects_command_field_instead_of_cmd() {
+        let error = parse_tool_args::<ExecCommandArgs>(
+            NAME,
+            &json!({
+                "command": "git status",
+            }),
+        )
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert!(tool_error.recovery_hint.as_deref().is_some_and(|hint| hint
+            .contains("provide input for ExecCommand that matches the published tool schema")));
+        assert!(tool_error
+            .details
+            .as_ref()
+            .and_then(|value| value.get("parse_error"))
+            .and_then(|value| value.as_str())
+            .is_some_and(|message| {
+                message.contains("command")
+                    || message.contains("cmd")
+                    || message.contains("missing field")
+            }));
+    }
+
+    #[test]
+    fn exec_command_rejects_task_metadata_fields() {
+        let error = parse_tool_args::<ExecCommandArgs>(
+            NAME,
+            &json!({
+                "cmd": "git status",
+                "status": "running",
+            }),
+        )
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert!(tool_error
+            .details
+            .as_ref()
+            .and_then(|value| value.get("parse_error"))
+            .and_then(|value| value.as_str())
+            .is_some_and(|message| message.contains("status")));
+        assert!(tool_error.recovery_hint.as_deref().is_some_and(|hint| hint
+            .contains("provide input for ExecCommand that matches the published tool schema")));
     }
 
     #[test]

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -363,6 +363,43 @@ mod tests {
         let error = rejected_item_error(&item).expect("tty should be rejected");
         assert_eq!(error.kind, "unsupported_batch_command_field");
         assert!(error.message.contains("tty"));
+
+        let item = ExecCommandBatchItemArgs {
+            cmd: "python -i".into(),
+            workdir: None,
+            shell: None,
+            login: None,
+            yield_time_ms: None,
+            max_output_tokens: None,
+            tty: None,
+            accepts_input: Some(true),
+            continue_on_result: None,
+        };
+        let error = rejected_item_error(&item).expect("accepts_input should be rejected");
+        assert_eq!(error.kind, "unsupported_batch_command_field");
+        assert!(error.message.contains("accepts_input"));
+        assert!(error
+            .recovery_hint
+            .as_deref()
+            .is_some_and(|hint| hint == "call ExecCommand directly when you need `accepts_input`"));
+
+        let item = ExecCommandBatchItemArgs {
+            cmd: "python -i".into(),
+            workdir: None,
+            shell: None,
+            login: None,
+            yield_time_ms: None,
+            max_output_tokens: None,
+            tty: None,
+            accepts_input: None,
+            continue_on_result: Some(true),
+        };
+        let error = rejected_item_error(&item).expect("continue_on_result should be rejected");
+        assert_eq!(error.kind, "unsupported_batch_command_field");
+        assert!(error.message.contains("continue_on_result"));
+        assert!(error.recovery_hint.as_deref().is_some_and(
+            |hint| hint == "call ExecCommand directly when you need `continue_on_result`"
+        ));
     }
 
     #[test]

--- a/src/tool/tools/sleep.rs
+++ b/src/tool/tools/sleep.rs
@@ -11,11 +11,12 @@ use crate::{
 };
 
 use super::BuiltinToolDefinition;
-use crate::tool::helpers::{extract_sleep_duration_ms, extract_sleep_reason};
+use crate::tool::helpers::{invalid_tool_input, parse_tool_args};
 
 pub(crate) const NAME: &str = "Sleep";
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SleepArgs {
     pub(crate) reason: Option<String>,
     #[schemars(range(min = 1))]
@@ -38,8 +39,14 @@ pub(crate) async fn execute(
     _trust: &TrustLevel,
     input: &Value,
 ) -> Result<ToolResult> {
-    let reason = extract_sleep_reason(input);
-    let sleep_duration_ms = extract_sleep_duration_ms(input)?;
+    let args = parse_sleep_args(input)?;
+    let reason = args
+        .reason
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "sleep requested".to_string());
+    let sleep_duration_ms = args.duration_ms;
+
     Ok(ToolResult::sleep(
         NAME,
         json!({
@@ -53,4 +60,73 @@ pub(crate) async fn execute(
         ),
         sleep_duration_ms,
     ))
+}
+
+fn parse_sleep_args(input: &Value) -> Result<SleepArgs> {
+    let args: SleepArgs = parse_tool_args(NAME, input)?;
+    if args.duration_ms == Some(0) {
+        return Err(invalid_tool_input(
+            NAME,
+            "Sleep `duration_ms` must be a positive integer when provided",
+            json!({
+                "field": "duration_ms",
+                "validation_error": "must be greater than 0",
+            }),
+            "omit `duration_ms` for ordinary terminal rest, or provide a positive integer millisecond delay",
+        )
+        .into());
+    }
+    Ok(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::ToolError;
+    use serde_json::json;
+
+    #[test]
+    fn sleep_rejects_unknown_top_level_fields() {
+        let error = parse_sleep_args(&json!({
+            "reason": "test",
+            "duration_ms": 100,
+            "summary": "should be rejected",
+        }))
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert!(tool_error
+            .details
+            .as_ref()
+            .and_then(|value| value.get("parse_error"))
+            .and_then(|value| value.as_str())
+            .is_some_and(|error| error.contains("unknown field `summary`")));
+    }
+
+    #[test]
+    fn sleep_rejects_zero_duration_ms() {
+        let error = parse_sleep_args(&json!({
+            "reason": "pause briefly",
+            "duration_ms": 0
+        }))
+        .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert_eq!(
+            tool_error.message,
+            "Sleep `duration_ms` must be a positive integer when provided"
+        );
+        assert!(tool_error
+            .details
+            .as_ref()
+            .and_then(|value| value.get("validation_error"))
+            .and_then(|value| value.as_str())
+            .is_some_and(|error| error == "must be greater than 0"));
+        assert!(tool_error
+            .recovery_hint
+            .as_deref()
+            .is_some_and(|hint| hint.contains("positive integer")));
+    }
 }


### PR DESCRIPTION
## Summary
- Reject unknown top-level fields for Sleep tool args using strict schema parsing.
- Enforce Sleep `duration_ms` > 0 when provided (0 now returns invalid_tool_input).
- Add regression tests for malformed ExecCommand inputs (`command` field, task metadata fields like `status`).
- Expand ExecCommandBatch item validation tests to cover unsupported interactive/task fields (`tty`, `accepts_input`, `continue_on_result`).
- Move parsing behavior into typed argument parsing paths so errors carry consistent parse errors and recovery hints.

## Validation
- `cargo test sleep_rejects_unknown_top_level_fields -- --nocapture`
- `cargo test sleep_rejects_zero_duration_ms -- --nocapture`
- `cargo test exec_command_rejects_command_field_instead_of_cmd -- --nocapture`
- `cargo test exec_command_rejects_task_metadata_fields -- --nocapture`
- `cargo test rejects_command_task_fields_in_items -- --nocapture`

Closes #1244
