### PR TITLE
fix: remove aggregate agents endpoint

### DIFF
--- a/docs/website/guides/integration.md
+++ b/docs/website/guides/integration.md
@@ -32,8 +32,7 @@ Access modes: `local`, `tunnel`, `lan`, `tailnet`.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/agents` | List active agent IDs |
-| `GET` | `/agents/list` | List agent entries with metadata |
+| `GET` | `/agents/list` | List active agent entries with metadata |
 | `POST` | `/control/agents/:agent_id/create` | Create a new agent |
 | `GET` | `/agents/:agent_id/status` | Get agent status and lifecycle |
 | `GET` | `/agents/:agent_id/state` | Get full agent state snapshot |
@@ -206,4 +205,3 @@ curl -X POST http://localhost:8787/control/agents/my-agent/operator-ingress \
 - [HTTP Control Plane Reference](/reference/http-control-plane.md) — Design philosophy and concepts
 - [CLI Reference](/reference/cli.md) — Command-line equivalent operations
 - [Configuration Reference](/reference/configuration.md) — Server and runtime configuration
-

--- a/docs/website/guides/remote-access.md
+++ b/docs/website/guides/remote-access.md
@@ -97,7 +97,7 @@ The same token authenticates HTTP control plane requests:
 
 ```bash
 curl -H "Authorization: Bearer your-token" \
-  https://your-server:8787/v1/agents
+  https://your-server:8787/v1/agents/list
 ```
 
 See the [HTTP Control Plane reference](/reference/http-control-plane.md) for

--- a/docs/website/legacy-static/index.html
+++ b/docs/website/legacy-static/index.html
@@ -139,7 +139,7 @@ cargo run -- serve
 curl http://127.0.0.1:8787/runtime/status
 
 # List public agents
-curl http://127.0.0.1:8787/agents</code></pre>
+curl http://127.0.0.1:8787/agents/list</code></pre>
                     </div>
                     <div class="quickstart-note">
                         <strong>Model:</strong> Holon keeps runtime state, events, tasks, transcripts, and agent

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -70,15 +70,10 @@ Returns model catalog and runtime availability.
 
 ### Agents
 
-**`GET /agents`** — List agent summaries
+**`GET /agents/list`** — List agent entries
 
-Returns a compact summary for each registered agent: id, visibility, profile, current
-work item, waiting state, and latest execution snapshot.
-
-**`GET /agents/list`** — List agent entries (detailed)
-
-Returns full `AgentRegistryStatus` entries including registered-at timestamps and
-workspace occupancies.
+Returns lightweight public agent entries for selection and navigation without
+loading full per-agent runtime summaries.
 
 **`GET /agents/:id/status`** — Single agent status
 
@@ -452,7 +447,7 @@ These will be added as the surface stabilizes.
 curl http://127.0.0.1:9101/handshake
 
 # List agents
-curl http://127.0.0.1:9101/agents
+curl http://127.0.0.1:9101/agents/list
 
 # Get agent state
 curl http://127.0.0.1:9101/agents/main/state

--- a/src/client.rs
+++ b/src/client.rs
@@ -341,10 +341,6 @@ impl LocalClient {
         self.remote.as_ref().map(|remote| remote.base_url.as_str())
     }
 
-    pub async fn list_agents(&self) -> Result<Vec<AgentSummary>> {
-        self.get_json("/agents").await
-    }
-
     pub async fn list_agent_entries(&self) -> Result<Vec<AgentListEntry>> {
         self.get_json("/agents/list").await
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,10 +11,9 @@ pub use lifecycle::{
 };
 pub(crate) use service::runtime_activity_message;
 pub use service::{
-    runtime_activity_summary, RuntimeActivityState, RuntimeActivitySummary,
-    RuntimeAgentOverrideSummary, RuntimeConfigSurface, RuntimeControlAuthMode,
-    RuntimeServiceHandle, RuntimeServiceMetadata, RuntimeShutdownResponse, RuntimeStartupSurface,
-    RuntimeStatusResponse,
+    runtime_activity_summary, RuntimeActivityState, RuntimeActivitySummary, RuntimeConfigSurface,
+    RuntimeControlAuthMode, RuntimeServiceHandle, RuntimeServiceMetadata, RuntimeShutdownResponse,
+    RuntimeStartupSurface, RuntimeStatusResponse,
 };
 pub use state::{
     cleanup_daemon_state, config_fingerprint, daemon_logs, daemon_paths, load_daemon_metadata,

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -39,8 +39,6 @@ pub struct RuntimeStatusResponse {
     pub startup_surface: Option<RuntimeStartupSurface>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_surface: Option<RuntimeConfigSurface>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub agent_model_overrides: Vec<RuntimeAgentOverrideSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_failure: Option<RuntimeFailureSummary>,
 }
@@ -135,13 +133,6 @@ impl RuntimeConfigSurface {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RuntimeAgentOverrideSummary {
-    pub agent_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub override_model: Option<String>,
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeActivityState {
@@ -202,7 +193,6 @@ impl RuntimeServiceHandle {
         last_failure: Option<RuntimeFailureSummary>,
         startup_surface: RuntimeStartupSurface,
         runtime_surface: RuntimeConfigSurface,
-        agent_model_overrides: Vec<RuntimeAgentOverrideSummary>,
     ) -> RuntimeStatusResponse {
         RuntimeStatusResponse {
             ok: true,
@@ -215,7 +205,6 @@ impl RuntimeServiceHandle {
             config_fingerprint: self.inner.metadata.config_fingerprint.clone(),
             startup_surface: Some(startup_surface),
             runtime_surface: Some(runtime_surface),
-            agent_model_overrides,
             activity: Some(activity),
             last_failure,
         }

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -299,7 +299,6 @@ fn effective_config_mismatch_summary_lists_actionable_differences() {
             control_auth_mode: RuntimeControlAuthMode::Auto,
         }),
         runtime_surface: Some(actual_surface),
-        agent_model_overrides: Vec::new(),
         last_failure: None,
     };
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -133,7 +133,6 @@ pub fn router(state: AppState) -> Router {
         .route("/", get(root))
         .route("/handshake", get(handshake))
         .route("/models", get(models_handler))
-        .route("/agents", get(list_agents))
         .route("/agents/list", get(list_agent_entries))
         .route("/agents/:agent_id/enqueue", post(enqueue))
         .route("/agents/:agent_id/status", get(status))
@@ -603,15 +602,6 @@ pub async fn handshake(
     })))
 }
 
-pub async fn list_agents(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
-    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
-    let agents = state.host.list_agents().await.map_err(error_response)?;
-    Ok(Json(agents))
-}
-
 pub async fn list_agent_entries(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -644,7 +634,6 @@ pub async fn runtime_status(
         .into_iter()
         .filter_map(|agent| agent.last_runtime_failure)
         .max_by(|left, right| left.occurred_at.cmp(&right.occurred_at));
-    let agent_summaries = state.host.list_agents().await.map_err(error_response)?;
     let config = state.host.config();
     let startup_surface = crate::daemon::RuntimeStartupSurface {
         home_dir: config.home_dir.clone(),
@@ -656,19 +645,11 @@ pub async fn runtime_status(
         control_auth_mode: config.control_auth_mode.into(),
     };
     let runtime_surface = RuntimeConfigSurface::new(config);
-    let agent_model_overrides = agent_summaries
-        .into_iter()
-        .map(|summary| crate::daemon::RuntimeAgentOverrideSummary {
-            agent_id: summary.identity.agent_id,
-            override_model: summary.model.override_model.map(|model| model.as_string()),
-        })
-        .collect::<Vec<_>>();
     Ok(Json(runtime_service.status_response(
         activity,
         last_failure,
         startup_surface,
         runtime_surface,
-        agent_model_overrides,
     )))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2258,7 +2258,7 @@ async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>
     match command {
         None | Some(AgentCommands::List) => {
             let client = LocalClient::new(config.clone())?;
-            print_json(&serde_json::to_value(client.list_agents().await?)?)
+            print_json(&serde_json::to_value(client.list_agent_entries().await?)?)
         }
         Some(AgentCommands::Status { agent_id }) => {
             let agent = agent_id.unwrap_or_else(|| config.default_agent_id.clone());

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -65,7 +65,7 @@ pub async fn local_client_over_unix_socket_can_poll_without_http_fallback() -> R
     let (_host, _socket_path, server) = spawn_unix_server(config.clone()).await?;
     let client = LocalClient::new(config)?;
 
-    let agents = client.list_agents().await?;
+    let agents = client.list_agent_entries().await?;
     assert_eq!(agents.len(), 1);
     assert_eq!(agents[0].identity.agent_id, "default");
 
@@ -141,19 +141,11 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
         );
     }
 
-    let agents_payload: serde_json::Value = client
-        .get(format!("{base}/agents"))
-        .send()
-        .await?
-        .json()
-        .await?;
-    let agent = agents_payload
-        .as_array()
-        .and_then(|entries| entries.first())
-        .expect("agent list should contain default agent");
-    assert!(
-        agent.get("model_availability").is_none(),
-        "/agents must not embed runtime-global model availability"
+    let removed_agents = client.get(format!("{base}/agents")).send().await?;
+    assert_eq!(
+        removed_agents.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "/agents aggregate summary endpoint should not be exposed"
     );
 
     let models_payload: serde_json::Value = client

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -454,7 +454,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         "/handshake",
         "/",
         "/control/runtime/status",
-        "/agents",
+        "/agents/list",
         "/agents/default/status",
         "/agents/default/state",
         "/agents/default/briefs",
@@ -486,11 +486,18 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
     assert_eq!(handshake["runtime"]["default_agent"], "default");
 
     let agents = client
-        .get(format!("{base}/agents"))
+        .get(format!("{base}/agents/list"))
         .bearer_auth("secret")
         .send()
         .await?;
     assert!(agents.status().is_success());
+
+    let removed_agents = client
+        .get(format!("{base}/agents"))
+        .bearer_auth("secret")
+        .send()
+        .await?;
+    assert_eq!(removed_agents.status(), reqwest::StatusCode::NOT_FOUND);
 
     let invalid_runtime_status = client
         .get(format!("{base}/control/runtime/status"))
@@ -992,7 +999,7 @@ pub async fn runtime_status_route_reports_runtime_metadata() -> Result<()> {
         payload["runtime_surface"]["disable_provider_fallback"],
         false
     );
-    assert!(payload["agent_model_overrides"].as_array().is_some());
+    assert!(payload.get("agent_model_overrides").is_none());
     assert!(payload["pid"].as_u64().unwrap_or_default() > 0);
     assert_eq!(payload["activity"]["state"], "idle");
     assert_eq!(payload["activity"]["active_agent_count"], 1);

--- a/tests/support/http_ingress.rs
+++ b/tests/support/http_ingress.rs
@@ -169,18 +169,18 @@ pub async fn generic_webhook_and_multi_agent_listing_work() -> Result<()> {
     assert!(response.status().is_success());
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
-    let agents = client.get(format!("{base}/agents")).send().await?;
+    let agents = client.get(format!("{base}/agents/list")).send().await?;
     let agents_json: serde_json::Value = agents.json().await?;
     assert!(agents_json
         .as_array()
         .unwrap()
         .iter()
-        .any(|item| item["agent"]["id"] == "default"));
+        .any(|item| item["identity"]["agent_id"] == "default"));
     assert!(agents_json
         .as_array()
         .unwrap()
         .iter()
-        .any(|item| item["agent"]["id"] == "alpha"));
+        .any(|item| item["identity"]["agent_id"] == "alpha"));
 
     let alpha = host.get_or_create_agent("alpha").await?;
     let briefs = alpha.recent_briefs(10).await?;


### PR DESCRIPTION
## Summary

- remove the aggregate `GET /agents` HTTP endpoint and its `LocalClient::list_agents` wrapper
- switch `holon agent list` to the lightweight `/agents/list` surface
- remove `agent_model_overrides` from `/control/runtime/status` so runtime readiness no longer loads all agent summaries
- update HTTP docs and tests for the lightweight listing contract

Fixes part of #1251.

## Verification

- `cargo fmt --all -- --check`
- `cargo test runtime_status_response_decodes --lib`
- `cargo test -p holon --test http_client`
- `cargo test -p holon --test http_control runtime_status_route_reports_runtime_metadata`
- `cargo test -p holon --test http_control remote_tcp_surfaces_require_bearer_token_when_required`
- `cargo test -p holon --test http_ingress generic_webhook_and_multi_agent_listing_work`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
