### PR TITLE
[bench][holon-openai][#1256] Expose command identity in TaskList and TaskStatus

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2447,11 +2447,24 @@ Phase-1 envelope rules:
 - `TaskStatus` returns a stable lifecycle envelope with a compact `task`
   snapshot rather than exposing a bare internal record or raw detail blob
   - `TaskStatus` is lifecycle and coordination state, not an output channel
-  - `TaskStatus.task.command.output_path` may identify where command output is
-    stored, but the status snapshot must not include raw output preview bytes or
-    artifact arrays
+  - `TaskStatus.task.command` exposes full command-task identity for agent-facing
+    coordination:
+    - `cmd`: full command string
+    - `cmd_digest`: stable machine-comparable command identity hash
+    - `workdir`, `shell`, `login`, `tty`
+    - `output_path`, `result_summary`, `exit_status`,
+      `terminal_reentry`, `promoted_from_exec_command`, `accepts_input`,
+      and `input_target`
+  - For command-task projections, `cmd_preview` is intentionally not a
+    coordination source of truth and may remain summary-only in logs and audit
+    surfaces
+  - The status snapshot must not include raw output bytes or artifact arrays
   - `TaskStatus.task.command.terminal_reentry` is the explicit command-task
     terminal result re-entry projection; it is not a scheduler wait policy
+- `TaskList` keeps its compact shape and includes a compact `command` projection
+  for `command_task` entries with the same `cmd`, `cmd_digest`, `workdir`,
+  `shell`, `login`, and `tty` fields so model-facing task dedup and handoff can
+  compare command identity safely
 - for `child_agent_task`, the `task` detail carries
   `workspace_mode = inherit | worktree`; in worktree mode, worktree artifact
   metadata is reported under task detail/result metadata when available

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -16,7 +16,7 @@ use crate::{
         RunningProcessExitStatus, StdioSpec, StopSignal,
     },
     tool::helpers::{
-        command_cost_diagnostics, command_preview, effective_tool_output_tokens,
+        command_cost_diagnostics, command_digest, command_preview, effective_tool_output_tokens,
         output_char_budget, truncate_output_to_char_budget, truncate_output_with_flag,
         truncate_text,
     },
@@ -1176,6 +1176,7 @@ fn command_task_detail(
 ) -> serde_json::Value {
     serde_json::json!({
         "cmd": resolved.spec.cmd,
+        "cmd_digest": command_digest(&resolved.spec.cmd),
         "wait_policy": "background",
         "workdir": resolved.workdir,
         "execution": resolved.execution,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1148,6 +1148,7 @@ impl RuntimeHandle {
             .into_iter()
             .map(|task| {
                 let wait_policy = task.wait_policy();
+                let command = TaskStatusSnapshot::from_task_record(&task).command;
                 TaskListEntry {
                     id: task.id,
                     kind: task.kind.as_str().to_string(),
@@ -1155,6 +1156,7 @@ impl RuntimeHandle {
                     summary: task.summary,
                     updated_at: task.updated_at,
                     wait_policy,
+                    command,
                 }
             })
             .collect())

--- a/src/types.rs
+++ b/src/types.rs
@@ -2152,10 +2152,22 @@ pub struct TaskListEntry {
     pub summary: Option<String>,
     pub updated_at: DateTime<Utc>,
     pub wait_policy: TaskWaitPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<CommandTaskStatusSnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CommandTaskStatusSnapshot {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workdir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub login: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tty: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2257,6 +2269,11 @@ impl TaskStatusSnapshot {
     pub fn from_task_record(task: &TaskRecord) -> Self {
         let command = if task.kind == TaskKind::CommandTask {
             Some(CommandTaskStatusSnapshot {
+                cmd: task_detail_string(&task.detail, "cmd"),
+                cmd_digest: task_detail_string(&task.detail, "cmd_digest"),
+                workdir: task_detail_string(&task.detail, "workdir"),
+                shell: task_detail_string(&task.detail, "shell"),
+                login: task_detail_bool(&task.detail, "login"),
                 tty: task_detail_bool(&task.detail, "tty"),
                 output_path: task_detail_string(&task.detail, "output_path"),
                 result_summary: task_detail_string(&task.detail, "output_summary"),

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -42,6 +42,7 @@ runtime_async_tests!(
     task_output_accepts_terminal_command_without_snapshot_fields,
     task_output_rejects_message_only_terminal_status_for_running_command,
     task_status_and_task_output_keep_lifecycle_and_output_boundaries,
+    task_list_includes_command_identity,
     command_task_output_truncation_preserves_path_artifact_reference,
     command_task_stop_cancels_running_command,
     background_command_task_persists_terminal_state_while_runtime_stopped,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
+use sha2::{Digest, Sha256};
 use holon::{
     config::{AppConfig, ControlAuthMode},
     host::RuntimeHost,
@@ -1652,15 +1653,16 @@ pub async fn task_status_and_task_output_keep_lifecycle_and_output_boundaries() 
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
     let runtime = host.default_runtime().await?;
+    let cmd = "printf boundary_ok";
     let registry = ToolRegistry::new(runtime.workspace_root());
 
     let task = runtime
         .schedule_command_task(
             "separate status from output".into(),
             holon::types::CommandTaskSpec {
-                cmd: "printf boundary_ok".into(),
+                cmd: cmd.into(),
                 workdir: None,
-                shell: None,
+                shell: Some("sh".into()),
                 login: true,
                 tty: false,
                 yield_time_ms: 10_000,
@@ -1696,6 +1698,18 @@ pub async fn task_status_and_task_output_keep_lifecycle_and_output_boundaries() 
     assert_eq!(status_value["task"]["kind"], "command_task");
     assert_eq!(status_value["task"]["status"], "completed");
     assert!(status_value["task"]["command"]["output_path"].is_string());
+    assert_eq!(status_value["task"]["command"]["cmd"], cmd);
+    assert_eq!(
+        status_value["task"]["command"]["cmd_digest"],
+        serde_json::Value::String(format!("{:x}", Sha256::digest(cmd.as_bytes())))
+    );
+    assert_eq!(
+        status_value["task"]["command"]["workdir"],
+        serde_json::Value::String(runtime.workspace_root().to_string_lossy().to_string())
+    );
+    assert_eq!(status_value["task"]["command"]["shell"], "sh");
+    assert_eq!(status_value["task"]["command"]["login"], true);
+    assert_eq!(status_value["task"]["command"]["tty"], false);
     assert!(status_value["task"].get("output_preview").is_none());
     assert!(status_value["task"].get("artifacts").is_none());
 
@@ -1720,6 +1734,76 @@ pub async fn task_status_and_task_output_keep_lifecycle_and_output_boundaries() 
     assert_eq!(output_value["task"]["output_artifact"], 0);
     assert!(output_value["task"]["artifacts"][0]["path"].is_string());
     assert_eq!(output_value["task"]["exit_status"], 0);
+    Ok(())
+}
+
+pub async fn task_list_includes_command_identity() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+    let cmd = "printf list_identity";
+
+    let task = runtime
+        .schedule_command_task(
+            "identity task".into(),
+            holon::types::CommandTaskSpec {
+                cmd: cmd.into(),
+                workdir: None,
+                shell: Some("sh".into()),
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: Some(512),
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    wait_until(|| {
+        let tasks = runtime.storage().latest_task_records()?;
+        Ok(tasks
+            .iter()
+            .any(|record| record.id == task.id && record.status == TaskStatus::Completed))
+    })
+    .await?;
+
+    let (list_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-task-list-identity".into(),
+                name: "TaskList".into(),
+                input: json!({}),
+            },
+        )
+        .await?;
+    let list_value: serde_json::Value = parse_tool_result_payload(&list_result)?;
+    let entries = list_value
+        .as_array()
+        .expect("TaskList should return an array");
+    let entry = entries
+        .iter()
+        .find(|entry| entry["id"] == task.id)
+        .expect("task list should include created command task");
+    let command = &entry["command"];
+
+    assert_eq!(command["cmd"], cmd);
+    assert_eq!(
+        command["cmd_digest"],
+        serde_json::Value::String(format!("{:x}", Sha256::digest(cmd.as_bytes())))
+    );
+    assert_eq!(
+        command["workdir"],
+        serde_json::Value::String(runtime.workspace_root().to_string_lossy().to_string())
+    );
+    assert_eq!(command["shell"], "sh");
+    assert_eq!(command["login"], true);
+    assert_eq!(command["tty"], false);
     Ok(())
 }
 


### PR DESCRIPTION
Benchmark metadata:

- task_id: `holon-1256-command-task-identity`
- runner: `holon-openai`
- base_sha: `8800a336b9ba0eff76650b6fb2e02063d314a117`
- issue: `#1256`
- benchmark_mode: `live`

Canonical task brief:

Fix GitHub issue #1256 in this repository.

Issue:
https://github.com/holon-run/holon/issues/1256

Instructions:
- Use `gh` commands to inspect the issue and related GitHub context.
- Stay within the issue scope.
- Use local repository context when needed.
- Do not stop to ask for confirmation; continue until the issue is fully handled.
- Do not stop at analysis or partial plans when implementation is still possible.
- Complete the issue acceptance criteria in one pull request; do not submit a partial, preparatory, or shim-only PR when the issue asks for the full implementation.
- You may split the implementation into multiple commits inside that one PR when that makes review easier.
- If you introduce compatibility shims as an intermediate step, continue moving the real implementation until the issue is fully solved before stopping.
- Only stop without implementation if you conclude the task cannot be completed from the current repository state and available tools; in that case, provide a concise operator-facing report explaining the blocker and the remaining work.
- Run the task verifier before stopping.
- If you make a real implementation, follow the PR submission policy below.

PR policy:
- Submit a pull request if you make a real implementation.
- Submit it as a draft pull request.
