### PR TITLE
Expose command identity in TaskList and TaskStatus

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2450,6 +2450,13 @@ Phase-1 envelope rules:
   - `TaskStatus.task.command.output_path` may identify where command output is
     stored, but the status snapshot must not include raw output preview bytes or
     artifact arrays
+  - `TaskStatus.task.command.cmd` is the model-facing command identity
+  - `TaskStatus.task.command.cmd_digest` is the machine-comparable identity key
+  - `TaskStatus.task.command.workdir`, `TaskStatus.task.command.shell`,
+    `TaskStatus.task.command.login`, and `TaskStatus.task.command.tty` are
+    identity-carrying execution metadata
+  - `cmd_preview` remains a model/operator-facing summary only; it is not the
+    source of truth for command identity
   - `TaskStatus.task.command.terminal_reentry` is the explicit command-task
     terminal result re-entry projection; it is not a scheduler wait policy
 - for `child_agent_task`, the `task` detail carries

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -16,7 +16,7 @@ use crate::{
         RunningProcessExitStatus, StdioSpec, StopSignal,
     },
     tool::helpers::{
-        command_cost_diagnostics, command_preview, effective_tool_output_tokens,
+        command_cost_diagnostics, command_digest, command_preview, effective_tool_output_tokens,
         output_char_budget, truncate_output_to_char_budget, truncate_output_with_flag,
         truncate_text,
     },
@@ -1176,6 +1176,7 @@ fn command_task_detail(
 ) -> serde_json::Value {
     serde_json::json!({
         "cmd": resolved.spec.cmd,
+        "cmd_digest": command_digest(&resolved.spec.cmd),
         "wait_policy": "background",
         "workdir": resolved.workdir,
         "execution": resolved.execution,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1148,6 +1148,7 @@ impl RuntimeHandle {
             .into_iter()
             .map(|task| {
                 let wait_policy = task.wait_policy();
+                let command = CommandTaskStatusSnapshot::from_task_record(&task);
                 TaskListEntry {
                     id: task.id,
                     kind: task.kind.as_str().to_string(),
@@ -1155,6 +1156,7 @@ impl RuntimeHandle {
                     summary: task.summary,
                     updated_at: task.updated_at,
                     wait_policy,
+                    command,
                 }
             })
             .collect())

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1148,7 +1148,7 @@ impl RuntimeHandle {
             .into_iter()
             .map(|task| {
                 let wait_policy = task.wait_policy();
-                let command = CommandTaskStatusSnapshot::from_task_record(&task);
+                let command = CommandTaskStatusSnapshot::identity_from_task_record(&task);
                 TaskListEntry {
                     id: task.id,
                     kind: task.kind.as_str().to_string(),

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -848,6 +848,7 @@ async fn latest_task_list_entries_return_compact_projection() {
                 "shell": "/bin/bash",
                 "login": false,
                 "output_path": "/tmp/output.log",
+                "output_summary": "large output summary should not appear in TaskList",
                 "tty": false,
                 "promoted_from_exec_command": false,
             })),
@@ -892,7 +893,8 @@ async fn latest_task_list_entries_return_compact_projection() {
     assert_eq!(command.shell.as_deref(), Some("/bin/bash"));
     assert_eq!(command.login, Some(false));
     assert_eq!(command.tty, Some(false));
-    assert_eq!(command.output_path.as_deref(), Some("/tmp/output.log"));
+    assert_eq!(command.output_path, None);
+    assert_eq!(command.result_summary, None);
 }
 
 #[tokio::test]

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -843,7 +843,13 @@ async fn latest_task_list_entries_return_compact_projection() {
             detail: Some(serde_json::json!({
                 "wait_policy": "blocking",
                 "cmd": "tail -f app.log",
+                "cmd_digest": crate::tool::helpers::command_digest("tail -f app.log"),
+                "workdir": "/tmp/workspace",
+                "shell": "/bin/bash",
+                "login": false,
                 "output_path": "/tmp/output.log",
+                "tty": false,
+                "promoted_from_exec_command": false,
             })),
             recovery: Some(TaskRecoverySpec::CommandTask {
                 summary: "watch logs".into(),
@@ -873,6 +879,20 @@ async fn latest_task_list_entries_return_compact_projection() {
         entries[0].wait_policy,
         crate::types::TaskWaitPolicy::Blocking
     );
+    let command = entries[0]
+        .command
+        .as_ref()
+        .expect("command projection should be present for command_task");
+    assert_eq!(command.cmd.as_deref(), Some("tail -f app.log"));
+    assert_eq!(
+        command.cmd_digest,
+        Some(crate::tool::helpers::command_digest("tail -f app.log"))
+    );
+    assert_eq!(command.workdir.as_deref(), Some("/tmp/workspace"));
+    assert_eq!(command.shell.as_deref(), Some("/bin/bash"));
+    assert_eq!(command.login, Some(false));
+    assert_eq!(command.tty, Some(false));
+    assert_eq!(command.output_path.as_deref(), Some("/tmp/output.log"));
 }
 
 #[tokio::test]

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -365,11 +365,10 @@ mod tests {
             workdir: None,
             shell: None,
             login: None,
-            yield_time_ms: None,
             max_output_tokens: None,
             tty: None,
             accepts_input: Some(true),
-            continue_on_result: None,
+            yield_time_ms: None,
         };
         let error = rejected_item_error(&item).expect("accepts_input should be rejected");
         assert_eq!(error.kind, "unsupported_batch_command_field");
@@ -378,24 +377,6 @@ mod tests {
             .recovery_hint
             .as_deref()
             .is_some_and(|hint| hint == "call ExecCommand directly when you need `accepts_input`"));
-
-        let item = ExecCommandBatchItemArgs {
-            cmd: "python -i".into(),
-            workdir: None,
-            shell: None,
-            login: None,
-            yield_time_ms: None,
-            max_output_tokens: None,
-            tty: None,
-            accepts_input: None,
-            continue_on_result: Some(true),
-        };
-        let error = rejected_item_error(&item).expect("continue_on_result should be rejected");
-        assert_eq!(error.kind, "unsupported_batch_command_field");
-        assert!(error.message.contains("continue_on_result"));
-        assert!(error.recovery_hint.as_deref().is_some_and(
-            |hint| hint == "call ExecCommand directly when you need `continue_on_result`"
-        ));
     }
 
     #[test]

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -365,10 +365,10 @@ mod tests {
             workdir: None,
             shell: None,
             login: None,
+            yield_time_ms: None,
             max_output_tokens: None,
             tty: None,
             accepts_input: Some(true),
-            yield_time_ms: None,
         };
         let error = rejected_item_error(&item).expect("accepts_input should be rejected");
         assert_eq!(error.kind, "unsupported_batch_command_field");

--- a/src/types.rs
+++ b/src/types.rs
@@ -3767,7 +3767,10 @@ mod tests {
         assert_eq!(command.shell.as_deref(), Some("/bin/bash"));
         assert_eq!(command.login, Some(true));
         assert_eq!(command.tty, Some(false));
-        assert_eq!(command.output_path.as_deref(), Some("/tmp/command-output.txt"));
+        assert_eq!(
+            command.output_path.as_deref(),
+            Some("/tmp/command-output.txt")
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2188,27 +2188,76 @@ pub struct CommandTaskStatusSnapshot {
 
 impl CommandTaskStatusSnapshot {
     pub(crate) fn from_task_record(task: &TaskRecord) -> Option<Self> {
+        Self::from_task_record_with_runtime_fields(task, true)
+    }
+
+    pub(crate) fn identity_from_task_record(task: &TaskRecord) -> Option<Self> {
+        Self::from_task_record_with_runtime_fields(task, false)
+    }
+
+    fn from_task_record_with_runtime_fields(
+        task: &TaskRecord,
+        include_runtime_fields: bool,
+    ) -> Option<Self> {
         if task.kind != TaskKind::CommandTask {
             return None;
         }
 
+        let recovery_command = match task.recovery.as_ref() {
+            Some(TaskRecoverySpec::CommandTask {
+                spec,
+                promoted_from_exec_command,
+                ..
+            }) => Some((spec, *promoted_from_exec_command)),
+            _ => None,
+        };
+
+        let cmd = task_detail_string(&task.detail, "cmd")
+            .or_else(|| recovery_command.map(|(spec, _)| spec.cmd.clone()));
+        let cmd_digest = task_detail_string(&task.detail, "cmd_digest").or_else(|| {
+            cmd.as_ref()
+                .map(|cmd| crate::tool::helpers::command_digest(cmd))
+        });
+        let workdir = task_detail_string(&task.detail, "workdir").or_else(|| {
+            recovery_command.and_then(|(spec, _)| spec.workdir.as_ref().map(ToString::to_string))
+        });
+        let shell = task_detail_string(&task.detail, "shell").or_else(|| {
+            recovery_command.and_then(|(spec, _)| spec.shell.as_ref().map(ToString::to_string))
+        });
+        let login = task_detail_bool(&task.detail, "login")
+            .or_else(|| recovery_command.map(|(spec, _)| spec.login));
+        let tty = task_detail_bool(&task.detail, "tty")
+            .or_else(|| recovery_command.map(|(spec, _)| spec.tty));
+        let promoted_from_exec_command =
+            task_detail_bool(&task.detail, "promoted_from_exec_command")
+                .or_else(|| recovery_command.map(|(_, promoted)| promoted));
+
         Some(Self {
-            cmd: task_detail_string(&task.detail, "cmd"),
-            cmd_digest: task_detail_string(&task.detail, "cmd_digest"),
-            workdir: task_detail_string(&task.detail, "workdir"),
-            shell: task_detail_string(&task.detail, "shell"),
-            login: task_detail_bool(&task.detail, "login"),
-            tty: task_detail_bool(&task.detail, "tty"),
-            output_path: task_detail_string(&task.detail, "output_path"),
-            result_summary: task_detail_string(&task.detail, "output_summary"),
-            exit_status: task_detail_i32(&task.detail, "exit_status"),
-            terminal_reentry: task.terminal_reentry().then_some(true),
-            promoted_from_exec_command: task_detail_bool(
-                &task.detail,
-                "promoted_from_exec_command",
-            ),
-            accepts_input: task_detail_bool(&task.detail, "accepts_input"),
-            input_target: task_detail_string(&task.detail, "input_target"),
+            cmd,
+            cmd_digest,
+            workdir,
+            shell,
+            login,
+            tty,
+            output_path: include_runtime_fields
+                .then(|| task_detail_string(&task.detail, "output_path"))
+                .flatten(),
+            result_summary: include_runtime_fields
+                .then(|| task_detail_string(&task.detail, "output_summary"))
+                .flatten(),
+            exit_status: include_runtime_fields
+                .then(|| task_detail_i32(&task.detail, "exit_status"))
+                .flatten(),
+            terminal_reentry: include_runtime_fields
+                .then(|| task.terminal_reentry().then_some(true))
+                .flatten(),
+            promoted_from_exec_command,
+            accepts_input: include_runtime_fields
+                .then(|| task_detail_bool(&task.detail, "accepts_input"))
+                .flatten(),
+            input_target: include_runtime_fields
+                .then(|| task_detail_string(&task.detail, "input_target"))
+                .flatten(),
         })
     }
 }
@@ -3733,7 +3782,7 @@ mod tests {
             summary: Some("check git".into()),
             detail: Some(serde_json::json!({
                 "cmd": cmd,
-                "cmd_digest": digest,
+                "cmd_digest": digest.clone(),
                 "workdir": "/tmp/repo",
                 "shell": "/bin/bash",
                 "login": true,
@@ -3771,6 +3820,68 @@ mod tests {
             command.output_path.as_deref(),
             Some("/tmp/command-output.txt")
         );
+    }
+
+    #[test]
+    fn command_snapshot_falls_back_to_recovery_identity() {
+        let cmd = "cargo test --quiet";
+        let task = TaskRecord {
+            id: "task-command".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("run tests".into()),
+            detail: Some(serde_json::json!({
+                "output_summary": "still running"
+            })),
+            recovery: Some(TaskRecoverySpec::CommandTask {
+                summary: "run tests".into(),
+                spec: CommandTaskSpec {
+                    cmd: cmd.into(),
+                    workdir: Some("/tmp/repo".into()),
+                    shell: Some("/bin/zsh".into()),
+                    login: false,
+                    tty: true,
+                    yield_time_ms: 1_000,
+                    max_output_tokens: None,
+                    accepts_input: false,
+                    terminal_reentry: false,
+                },
+                trust: TrustLevel::TrustedOperator,
+                promoted_from_exec_command: true,
+            }),
+        };
+
+        let snapshot = TaskStatusSnapshot::from_task_record(&task);
+        let command = snapshot.command.expect("command task snapshot");
+
+        assert_eq!(command.cmd.as_deref(), Some(cmd));
+        assert_eq!(
+            command.cmd_digest,
+            Some(crate::tool::helpers::command_digest(cmd))
+        );
+        assert_eq!(command.workdir.as_deref(), Some("/tmp/repo"));
+        assert_eq!(command.shell.as_deref(), Some("/bin/zsh"));
+        assert_eq!(command.login, Some(false));
+        assert_eq!(command.tty, Some(true));
+        assert_eq!(command.promoted_from_exec_command, Some(true));
+        assert_eq!(command.result_summary.as_deref(), Some("still running"));
+
+        let list_command =
+            CommandTaskStatusSnapshot::identity_from_task_record(&task).expect("list projection");
+        assert_eq!(list_command.cmd.as_deref(), Some(cmd));
+        assert_eq!(
+            list_command.cmd_digest,
+            Some(crate::tool::helpers::command_digest(cmd))
+        );
+        assert_eq!(list_command.promoted_from_exec_command, Some(true));
+        assert_eq!(list_command.result_summary, None);
+        assert_eq!(list_command.output_path, None);
+        assert_eq!(list_command.exit_status, None);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2152,10 +2152,22 @@ pub struct TaskListEntry {
     pub summary: Option<String>,
     pub updated_at: DateTime<Utc>,
     pub wait_policy: TaskWaitPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<CommandTaskStatusSnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CommandTaskStatusSnapshot {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workdir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub login: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tty: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2172,6 +2184,33 @@ pub struct CommandTaskStatusSnapshot {
     pub accepts_input: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_target: Option<String>,
+}
+
+impl CommandTaskStatusSnapshot {
+    pub(crate) fn from_task_record(task: &TaskRecord) -> Option<Self> {
+        if task.kind != TaskKind::CommandTask {
+            return None;
+        }
+
+        Some(Self {
+            cmd: task_detail_string(&task.detail, "cmd"),
+            cmd_digest: task_detail_string(&task.detail, "cmd_digest"),
+            workdir: task_detail_string(&task.detail, "workdir"),
+            shell: task_detail_string(&task.detail, "shell"),
+            login: task_detail_bool(&task.detail, "login"),
+            tty: task_detail_bool(&task.detail, "tty"),
+            output_path: task_detail_string(&task.detail, "output_path"),
+            result_summary: task_detail_string(&task.detail, "output_summary"),
+            exit_status: task_detail_i32(&task.detail, "exit_status"),
+            terminal_reentry: task.terminal_reentry().then_some(true),
+            promoted_from_exec_command: task_detail_bool(
+                &task.detail,
+                "promoted_from_exec_command",
+            ),
+            accepts_input: task_detail_bool(&task.detail, "accepts_input"),
+            input_target: task_detail_string(&task.detail, "input_target"),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -2255,23 +2294,7 @@ pub struct TaskStatusSnapshot {
 
 impl TaskStatusSnapshot {
     pub fn from_task_record(task: &TaskRecord) -> Self {
-        let command = if task.kind == TaskKind::CommandTask {
-            Some(CommandTaskStatusSnapshot {
-                tty: task_detail_bool(&task.detail, "tty"),
-                output_path: task_detail_string(&task.detail, "output_path"),
-                result_summary: task_detail_string(&task.detail, "output_summary"),
-                exit_status: task_detail_i32(&task.detail, "exit_status"),
-                terminal_reentry: task.terminal_reentry().then_some(true),
-                promoted_from_exec_command: task_detail_bool(
-                    &task.detail,
-                    "promoted_from_exec_command",
-                ),
-                accepts_input: task_detail_bool(&task.detail, "accepts_input"),
-                input_target: task_detail_string(&task.detail, "input_target"),
-            })
-        } else {
-            None
-        };
+        let command = CommandTaskStatusSnapshot::from_task_record(task);
         let child_agent_id = task_detail_string(&task.detail, "child_agent_id");
         let child_observability = task_detail_value(&task.detail, "child_observability")
             .and_then(|value| serde_json::from_value(value.clone()).ok());
@@ -3692,6 +3715,59 @@ mod tests {
                 .terminal_reentry,
             Some(true)
         );
+    }
+
+    #[test]
+    fn task_status_snapshot_includes_command_identity_fields() {
+        let cmd = "git status --short";
+        let digest = crate::tool::helpers::command_digest(cmd);
+        let task = TaskRecord {
+            id: "task-command".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Completed,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("check git".into()),
+            detail: Some(serde_json::json!({
+                "cmd": cmd,
+                "cmd_digest": digest,
+                "workdir": "/tmp/repo",
+                "shell": "/bin/bash",
+                "login": true,
+                "tty": false,
+                "output_path": "/tmp/command-output.txt",
+            })),
+            recovery: Some(TaskRecoverySpec::CommandTask {
+                summary: "check git".into(),
+                spec: CommandTaskSpec {
+                    cmd: cmd.into(),
+                    workdir: Some("/tmp/repo".into()),
+                    shell: Some("/bin/bash".into()),
+                    login: true,
+                    tty: false,
+                    yield_time_ms: 10_000,
+                    max_output_tokens: None,
+                    accepts_input: false,
+                    terminal_reentry: false,
+                },
+                trust: TrustLevel::TrustedOperator,
+                promoted_from_exec_command: false,
+            }),
+        };
+
+        let snapshot = TaskStatusSnapshot::from_task_record(&task);
+        let command = snapshot.command.expect("command task snapshot");
+
+        assert_eq!(command.cmd.as_deref(), Some(cmd));
+        assert_eq!(command.cmd_digest.as_deref(), Some(digest.as_str()));
+        assert_eq!(command.workdir.as_deref(), Some("/tmp/repo"));
+        assert_eq!(command.shell.as_deref(), Some("/bin/bash"));
+        assert_eq!(command.login, Some(true));
+        assert_eq!(command.tty, Some(false));
+        assert_eq!(command.output_path.as_deref(), Some("/tmp/command-output.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add command identity projection to `TaskList` for command tasks via a new optional `command` field on each list entry.
- Reuse a shared `CommandTaskStatusSnapshot::from_task_record` in both `TaskList` and `TaskStatus` to keep command projection canonical.
- Include full command identity in command task detail snapshots (`cmd`, `cmd_digest`, `workdir`, `shell`, `login`, `tty`) in persisted task detail.
- Keep `cmd_preview` as summary-only; docs now state command identity should rely on `command.cmd` and `command.cmd_digest`.
- Extend tests to assert command identity fields are present in `TaskList` and `TaskStatus` projections.

## Verification
- `cargo test --lib types::tests::task_status_snapshot_includes_command_identity_fields -- --nocapture`
- `cargo test latest_task_list_entries_return_compact_projection -- --nocapture`

## Related issue
Closes #1256
