### PR TITLE
feat: add ExecCommand duplicate startup policy

### DIFF
--- a/docs/rfcs/tool-result-envelope.md
+++ b/docs/rfcs/tool-result-envelope.md
@@ -707,6 +707,33 @@ An execution-root violation should look like:
 }
 ```
 
+When `duplicate_policy = "reuse_running"` finds a matching active command task, the
+result should look like:
+
+```json
+{
+  "tool_name": "ExecCommand",
+  "status": "success",
+  "summary_text": "command is already running",
+  "result": {
+    "disposition": "already_running",
+    "task": {
+      "task_id": "task_123",
+      "kind": "command_task",
+      "status": "running",
+      "command": {
+        "cmd": "cargo test",
+        "workdir": "/workspace",
+        "shell": "bash",
+        "login": true,
+        "tty": false
+      }
+    }
+  },
+  "error": null
+}
+```
+
 ## Command Tool Rendered Example
 
 The command-family model-visible rendering should usually be a textual receipt
@@ -729,6 +756,17 @@ Task: task_123
 
 Initial output:
 short output preview
+```
+
+An already-running coordination receipt may render as:
+
+```text
+Command is already running
+Existing task: task_123
+Status: running
+
+Inspect with TaskStatus and TaskOutput using this task id.
+To start a second instance, set duplicate_policy to "start_new".
 ```
 
 The exact wording may evolve, but the family contract should stay stable:

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2418,6 +2418,25 @@ Phase-1 envelope rules:
     - `artifacts`
     - `stdout_artifact`
     - `stderr_artifact`
+  - startup accepts `duplicate_policy` with:
+    - `reuse_running` (default): if an equivalent active `command_task` exists, return
+      `disposition = already_running` with the live task handle instead of spawning a
+      second process
+    - `start_new`: always spawn a second process even if an equivalent active command
+      already exists
+  - `disposition = already_running` returns:
+    - `task`
+    - `task.status`
+    - command identity fields from task-level command snapshot for explicit inspection
+    - this path is a successful coordination receipt, not a spawn failure
+  - equivalence is command identity comparison, not preview-based comparison:
+    - full `cmd`
+    - resolved `workdir`
+    - `shell`
+    - `login`
+    - `tty`
+  - reuse is limited to active non-terminal command tasks (`queued`, `running`,
+    `cancelling`) and ignores terminal tasks
   - promotion to managed execution uses fields such as:
     - `disposition = promoted_to_task`
     - `task_handle`

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -22,9 +22,10 @@ use crate::{
     },
     tool::ToolError,
     types::{
-        CommandCostDiagnostics, CommandTaskSpec, ExecCommandOutcome, ExecCommandResult,
-        ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind,
-        MessageOrigin, Priority, TaskHandle, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus,
+        CommandCostDiagnostics, CommandTaskSpec, CommandTaskStatusSnapshot,
+        ExecCommandDuplicatePolicy, ExecCommandOutcome, ExecCommandResult, ExternalTriggerScope,
+        ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+        TaskHandle, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TaskStatusSnapshot,
         ToolArtifactRef, TrustLevel,
     },
 };
@@ -193,12 +194,24 @@ impl RuntimeHandle {
     pub(crate) async fn execute_exec_command(
         &self,
         mut spec: CommandTaskSpec,
+        duplicate_policy: &ExecCommandDuplicatePolicy,
         trust: &TrustLevel,
     ) -> Result<ExecCommandResult> {
         self.ensure_process_execution_exposed("ExecCommand").await?;
         self.apply_command_output_policy(&mut spec);
         let diagnostics = self.command_cost_diagnostics_for(&spec);
         let resolved = self.resolve_command_task(&spec).await?;
+        if matches!(duplicate_policy, ExecCommandDuplicatePolicy::ReuseRunning) {
+            if let Some(task) = self.find_active_equivalent_command_task(&resolved).await? {
+                return Ok(ExecCommandResult {
+                    outcome: ExecCommandOutcome::AlreadyRunning {
+                        task: TaskStatusSnapshot::from_task_record(&task),
+                    },
+                    summary_text: Some("command is already running".to_string()),
+                    command_diagnostics: Some(diagnostics),
+                });
+            }
+        }
         self.append_audit_event(
             "process_execution_requested",
             serde_json::json!({
@@ -302,6 +315,43 @@ impl RuntimeHandle {
                 }
             }
         }
+    }
+
+    async fn find_active_equivalent_command_task(
+        &self,
+        resolved: &ResolvedCommandTask,
+    ) -> Result<Option<TaskRecord>> {
+        let agent_id = self.agent_id().await?;
+        let tasks = self
+            .inner
+            .storage
+            .latest_active_task_records_for_agent(&agent_id, usize::MAX)?;
+        let resolved_workdir = resolved.workdir.to_string_lossy().into_owned();
+        Ok(tasks
+            .into_iter()
+            .filter(|task| task.kind == TaskKind::CommandTask)
+            .find_map(|task| {
+                CommandTaskStatusSnapshot::identity_from_task_record(&task).and_then(|identity| {
+                    if self.command_task_matches_identity(resolved, &identity, &resolved_workdir) {
+                        Some(task)
+                    } else {
+                        None
+                    }
+                })
+            }))
+    }
+
+    fn command_task_matches_identity(
+        &self,
+        resolved: &ResolvedCommandTask,
+        identity: &CommandTaskStatusSnapshot,
+        resolved_workdir: &str,
+    ) -> bool {
+        identity.cmd == Some(resolved.spec.cmd.clone())
+            && identity.workdir == Some(resolved_workdir.to_string())
+            && identity.shell == resolved.spec.shell
+            && identity.login == Some(resolved.spec.login)
+            && identity.tty == Some(resolved.spec.tty)
     }
 
     pub(crate) async fn execute_exec_command_once(

--- a/src/runtime/task_supervisor.rs
+++ b/src/runtime/task_supervisor.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 
 use super::RuntimeHandle;
 use crate::types::{
-    AgentProfilePreset, CommandTaskSpec, ExecCommandResult, SpawnAgentResult, TaskInputResult,
-    TaskListEntry, TaskOutputResult, TaskRecord, TaskStatusSnapshot, TrustLevel,
+    AgentProfilePreset, CommandTaskSpec, ExecCommandDuplicatePolicy, ExecCommandResult,
+    SpawnAgentResult, TaskInputResult, TaskListEntry, TaskOutputResult, TaskRecord,
+    TaskStatusSnapshot, TrustLevel,
 };
 
 pub(crate) struct ManagedTaskSupervisor<'a> {
@@ -20,9 +21,12 @@ impl ManagedTaskSupervisor<'_> {
     pub(crate) async fn execute_exec_command(
         &self,
         spec: CommandTaskSpec,
+        duplicate_policy: &ExecCommandDuplicatePolicy,
         trust: &TrustLevel,
     ) -> Result<ExecCommandResult> {
-        self.runtime.execute_exec_command(spec, trust).await
+        self.runtime
+            .execute_exec_command(spec, duplicate_policy, trust)
+            .await
     }
 
     pub(crate) async fn execute_exec_command_once(

--- a/src/tool/tools/exec_command.rs
+++ b/src/tool/tools/exec_command.rs
@@ -10,7 +10,8 @@ use crate::{
         ToolResult,
     },
     types::{
-        CommandTaskSpec, ExecCommandOutcome, ExecCommandResult, ToolCapabilityFamily, TrustLevel,
+        CommandTaskSpec, ExecCommandDuplicatePolicy, ExecCommandOutcome, ExecCommandResult,
+        TaskStatus, ToolCapabilityFamily, TrustLevel,
     },
 };
 
@@ -27,6 +28,7 @@ pub(crate) struct ExecCommandArgs {
     pub(crate) shell: Option<String>,
     pub(crate) login: Option<bool>,
     pub(crate) tty: Option<bool>,
+    pub(crate) duplicate_policy: Option<ExecCommandDuplicatePolicy>,
     pub(crate) accepts_input: Option<bool>,
     pub(crate) yield_time_ms: Option<u64>,
     pub(crate) max_output_tokens: Option<u64>,
@@ -37,7 +39,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::LocalEnvironment,
         spec: typed_spec::<ExecCommandArgs>(
             NAME,
-            "Start a shell command inside the workspace. Valid startup input uses `cmd` plus optional `workdir`, `shell`, `login`, `tty`, `accepts_input`, `yield_time_ms`, and `max_output_tokens`; do not pass result or task metadata such as `status` or `task_handle`. `yield_time_ms` defaults to 10_000 ms when omitted; set it only when intentionally changing the foreground wait window. Short commands return immediately; long non-interactive commands become command_task automatically.",
+            "Start a shell command inside the workspace. Valid startup input uses `cmd` plus optional `workdir`, `shell`, `login`, `tty`, `accepts_input`, `yield_time_ms`, `max_output_tokens`, and `duplicate_policy`; do not pass result or task metadata such as `status` or `task_handle`. `yield_time_ms` defaults to 10_000 ms when omitted; set it only when intentionally changing the foreground wait window. `duplicate_policy` controls active task reuse (`reuse_running` default, `start_new` to force a second process). Short commands return immediately; long non-interactive commands become command_task automatically.",
         )?,
     })
 }
@@ -50,6 +52,7 @@ pub(crate) async fn execute(
 ) -> Result<ToolResult> {
     let args: ExecCommandArgs = parse_tool_args(NAME, input)?;
     let tty = args.tty.unwrap_or(false);
+    let duplicate_policy = args.duplicate_policy.unwrap_or_default();
     let spec = CommandTaskSpec {
         cmd: args.cmd,
         workdir: args.workdir,
@@ -63,7 +66,7 @@ pub(crate) async fn execute(
     };
     let result: ExecCommandResult = runtime
         .managed_tasks()
-        .execute_exec_command(spec, trust)
+        .execute_exec_command(spec, &duplicate_policy, trust)
         .await?;
     serialize_success(NAME, &result)
 }
@@ -129,6 +132,35 @@ pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
             );
             Ok(lines.join("\n"))
         }
+        ExecCommandOutcome::AlreadyRunning { task } => {
+            let status = match task.status {
+                TaskStatus::Queued => "queued",
+                TaskStatus::Running => "running",
+                TaskStatus::Cancelling => "cancelling",
+                TaskStatus::Completed => "completed",
+                TaskStatus::Failed => "failed",
+                TaskStatus::Cancelled => "cancelled",
+                TaskStatus::Interrupted => "interrupted",
+            };
+            let mut lines = vec![
+                "Command is already running".to_string(),
+                format!("Existing task: {}", task.task_id),
+                format!("Status: {status}"),
+            ];
+            if let Some(command) = &task.command {
+                if let Some(cmd) = &command.cmd {
+                    lines.push(format!("Command: {cmd}"));
+                }
+                if let Some(workdir) = &command.workdir {
+                    lines.push(format!("Workdir: {workdir}"));
+                }
+            }
+            lines.push("Inspect with TaskStatus and TaskOutput using this task id.".to_string());
+            lines.push(
+                "To start a second instance, set duplicate_policy to \"start_new\".".to_string(),
+            );
+            Ok(lines.join("\n"))
+        }
     }
 }
 
@@ -137,6 +169,7 @@ mod tests {
     use super::*;
     use crate::tool::tools::serialize_success;
     use crate::tool::ToolError;
+    use crate::types::TaskStatusSnapshot;
     use serde_json::json;
 
     #[test]
@@ -176,6 +209,53 @@ mod tests {
         assert!(rendered.contains("Process exited with code 0"));
         assert!(rendered.contains("stdout:"));
         assert!(rendered.contains("line one"));
+    }
+
+    #[test]
+    fn exec_command_renders_already_running_receipt() {
+        let result = serialize_success(
+            NAME,
+            &ExecCommandResult {
+                outcome: ExecCommandOutcome::AlreadyRunning {
+                    task: TaskStatusSnapshot {
+                        task_id: "task_123".into(),
+                        kind: "command_task".into(),
+                        status: TaskStatus::Running,
+                        summary: Some("long command".into()),
+                        created_at: chrono::Utc::now(),
+                        updated_at: chrono::Utc::now(),
+                        wait_policy: crate::types::TaskWaitPolicy::Background,
+                        parent_message_id: None,
+                        command: Some(crate::types::CommandTaskStatusSnapshot {
+                            cmd: Some("printf hi".into()),
+                            cmd_digest: Some("digest".into()),
+                            workdir: Some("/workspace".into()),
+                            shell: Some("bash".into()),
+                            login: Some(true),
+                            tty: Some(false),
+                            output_path: None,
+                            result_summary: None,
+                            exit_status: None,
+                            terminal_reentry: None,
+                            promoted_from_exec_command: None,
+                            accepts_input: None,
+                            input_target: None,
+                        }),
+                        child_agent_id: None,
+                        child_observability: None,
+                        child_supervision: None,
+                    },
+                },
+                command_diagnostics: None,
+                summary_text: Some("command already running".into()),
+            },
+        )
+        .unwrap();
+
+        let rendered = render_for_model(&result).unwrap();
+        assert!(rendered.contains("Command is already running"));
+        assert!(rendered.contains("Existing task: task_123"));
+        assert!(rendered.contains("To start a second instance"));
     }
 
     #[test]

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -200,6 +200,7 @@ async fn execute_batch_item(
                 }
                 ExecCommandOutcome::Completed { .. } => ExecCommandBatchItemStatus::Failed,
                 ExecCommandOutcome::PromotedToTask { .. } => ExecCommandBatchItemStatus::Failed,
+                ExecCommandOutcome::AlreadyRunning { .. } => ExecCommandBatchItemStatus::Failed,
             };
             ExecCommandBatchItemResult {
                 index,
@@ -335,6 +336,10 @@ fn render_exec_item(lines: &mut Vec<String>, result: Option<&ExecCommandResult>)
         ExecCommandOutcome::PromotedToTask { task_handle, .. } => {
             lines.push("failed=promoted_to_task".to_string());
             lines.push(format!("task={}", task_handle.task_id));
+        }
+        ExecCommandOutcome::AlreadyRunning { task } => {
+            lines.push("failed=already_running".to_string());
+            lines.push(format!("task={}", task.task_id));
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use clap::ValueEnum;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -2415,6 +2416,9 @@ pub struct CommandCostDiagnostics {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "disposition", rename_all = "snake_case")]
 pub enum ExecCommandOutcome {
+    AlreadyRunning {
+        task: TaskStatusSnapshot,
+    },
     Completed {
         exit_status: Option<i32>,
         stdout_preview: Option<String>,
@@ -2433,6 +2437,19 @@ pub enum ExecCommandOutcome {
         initial_output_preview: Option<String>,
         initial_output_truncated: bool,
     },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecCommandDuplicatePolicy {
+    ReuseRunning,
+    StartNew,
+}
+
+impl Default for ExecCommandDuplicatePolicy {
+    fn default() -> Self {
+        Self::ReuseRunning
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -52,4 +52,8 @@ runtime_async_tests!(
     command_task_runner_failure_marks_task_failed_and_cleans_up,
     command_task_nonzero_exit_produces_failed_output_and_runtime_state,
     exec_command_auto_promotes_long_running_command_task,
+    exec_command_reuses_active_background_command_task,
+    exec_command_start_new_forces_second_task,
+    exec_command_rejects_non_equivalent_background_commands,
+    exec_command_allows_restart_after_terminal_background_command,
 );

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -2264,53 +2264,319 @@ pub async fn command_task_nonzero_exit_produces_failed_output_and_runtime_state(
 }
 
 pub async fn exec_command_auto_promotes_long_running_command_task() -> Result<()> {
-    let host = RuntimeHost::new_with_provider(test_config(), Arc::new(LongShellProvider::new()))?;
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
 
-    runtime
-        .enqueue(MessageEnvelope::new(
+    let input = json!({
+        "cmd": "printf start && sleep 5 && printf done",
+        "yield_time_ms": 50,
+        "login": false,
+    });
+    let (first_result, _) = registry
+        .execute(
+            &runtime,
             "default",
-            MessageKind::OperatorPrompt,
-            MessageOrigin::Operator { actor_id: None },
-            TrustLevel::TrustedOperator,
-            Priority::Normal,
-            MessageBody::Text {
-                text: "run a long command".into(),
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-duplicate-first".into(),
+                name: "ExecCommand".into(),
+                input: input.clone(),
             },
-        ))
+        )
         .await?;
-
-    wait_until(|| {
-        let briefs = runtime.storage().read_recent_briefs(10)?;
-        Ok(briefs
-            .iter()
-            .any(|brief| brief.text.contains("auto promotion observed")))
-    })
-    .await?;
+    let first_payload = parse_tool_result_payload(&first_result)?;
+    assert_eq!(first_payload["disposition"], "promoted_to_task");
+    let first_task_id = first_payload["task_handle"]["task_id"]
+        .as_str()
+        .expect("promoted result should include task id");
 
     wait_until(|| {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
-            record.kind.as_str() == "command_task"
-                && record.status == holon::types::TaskStatus::Completed
+            record.id == first_task_id
+                && matches!(
+                    record.status,
+                    holon::types::TaskStatus::Queued | holon::types::TaskStatus::Running
+                )
         }))
     })
     .await?;
+
+    let (second_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-duplicate-second".into(),
+                name: "ExecCommand".into(),
+                input,
+            },
+        )
+        .await?;
+    let second_payload = parse_tool_result_payload(&second_result)?;
+    assert_eq!(second_payload["disposition"], "already_running");
+    assert_eq!(second_payload["task"]["task_id"], first_task_id);
 
     let command_task = runtime
         .storage()
         .latest_task_records()?
         .into_iter()
-        .find(|task| task.kind.as_str() == "command_task")
+        .find(|task| task.id == first_task_id)
         .expect("auto-promoted command task should exist");
     let detail = command_task.detail.unwrap_or_default();
     assert_eq!(detail["promoted_from_exec_command"], true);
-    assert_eq!(detail["cmd"], "printf start && sleep 1 && printf done");
-    let messages = runtime.storage().read_recent_messages(20)?;
-    assert!(messages.iter().any(|message| {
-        message.kind == MessageKind::TaskResult
-            && matches!(&message.body, MessageBody::Text { text } if text.contains("exit_status: 0"))
-    }));
+    assert_eq!(detail["cmd"], "printf start && sleep 5 && printf done");
+    Ok(())
+}
+
+pub async fn exec_command_reuses_active_background_command_task() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+
+    let active_task = runtime
+        .schedule_command_task(
+            "long running command".into(),
+            CommandTaskSpec {
+                cmd: "sleep 20".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: None,
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    wait_until(|| {
+        let active = runtime
+            .storage()
+            .latest_active_task_records_for_agent("default", usize::MAX)?;
+        Ok(active.iter().any(|task| task.id == active_task.id))
+    })
+    .await?;
+
+    let (second_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-duplicate-background".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": "sleep 20",
+                    "login": true,
+                }),
+            },
+        )
+        .await?;
+    let payload = parse_tool_result_payload(&second_result)?;
+    assert_eq!(payload["disposition"], "already_running");
+    assert_eq!(payload["task"]["task_id"], active_task.id);
+    Ok(())
+}
+
+pub async fn exec_command_start_new_forces_second_task() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+
+    let active_task = runtime
+        .schedule_command_task(
+            "long running command".into(),
+            CommandTaskSpec {
+                cmd: "sleep 20".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: None,
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    wait_until(|| {
+        let active = runtime
+            .storage()
+            .latest_active_task_records_for_agent("default", usize::MAX)?;
+        Ok(active.iter().any(|task| {
+            task.id == active_task.id
+                && matches!(
+                    task.status,
+                    holon::types::TaskStatus::Queued
+                        | holon::types::TaskStatus::Running
+                        | holon::types::TaskStatus::Cancelling
+                )
+        }))
+    })
+    .await?;
+
+    let (second_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-start-new".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": "sleep 20",
+                    "login": true,
+                    "duplicate_policy": "start_new",
+                }),
+            },
+        )
+        .await?;
+    let payload = parse_tool_result_payload(&second_result)?;
+    assert_eq!(payload["disposition"], "promoted_to_task");
+    assert_ne!(
+        payload["task_handle"]["task_id"].as_str(),
+        Some(active_task.id.as_str())
+    );
+    assert!(
+        runtime
+            .storage()
+            .latest_task_records()?
+            .iter()
+            .filter(|task| task.kind.as_str() == "command_task")
+            .count()
+            >= 2
+    );
+    Ok(())
+}
+
+pub async fn exec_command_rejects_non_equivalent_background_commands() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+
+    let active_task = runtime
+        .schedule_command_task(
+            "long running command".into(),
+            CommandTaskSpec {
+                cmd: "sleep 20".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: None,
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    wait_until(|| {
+        let active = runtime
+            .storage()
+            .latest_active_task_records_for_agent("default", usize::MAX)?;
+        Ok(active.iter().any(|task| {
+            task.id == active_task.id
+                && matches!(
+                    task.status,
+                    holon::types::TaskStatus::Queued | holon::types::TaskStatus::Running
+                )
+        }))
+    })
+    .await?;
+
+    let (second_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-duplicate-background-non-equivalent".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": "sleep 20 && echo different",
+                    "login": true,
+                }),
+            },
+        )
+        .await?;
+    let payload = parse_tool_result_payload(&second_result)?;
+    assert_eq!(payload["disposition"], "promoted_to_task");
+    assert_ne!(payload["task_handle"]["task_id"], active_task.id);
+    Ok(())
+}
+
+pub async fn exec_command_allows_restart_after_terminal_background_command() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+
+    let active_task = runtime
+        .schedule_command_task(
+            "quick command".into(),
+            CommandTaskSpec {
+                cmd: "printf done".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: None,
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    wait_until(|| {
+        let tasks = runtime.storage().latest_task_records()?;
+        Ok(tasks
+            .iter()
+            .find(|task| task.id == active_task.id)
+            .is_some_and(|task| {
+                matches!(
+                    task.status,
+                    TaskStatus::Completed | TaskStatus::Failed | TaskStatus::Cancelled
+                )
+            }))
+    })
+    .await?;
+
+    let (second_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-terminal-reuse".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": "printf done",
+                    "login": true,
+                }),
+            },
+        )
+        .await?;
+    let payload = parse_tool_result_payload(&second_result)?;
+    assert_eq!(payload["disposition"], "completed");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add `duplicate_policy` to `ExecCommand` startup input with enum `reuse_running` (default) and `start_new`.
- When `reuse_running` is used, runtime now checks active non-terminal command tasks and returns `already_running` with existing task snapshot (task id/status) instead of spawning a duplicate process.
- Add `already_running` task outcome and tool receipt rendering in command tool output.
- Keep terminal command tasks out of duplicate matching.
- Update docs in `docs/runtime-spec.md` and `docs/rfcs/tool-result-envelope.md`.
- Add regression tests for reuse of active commands, explicit `start_new`, non-equivalent command differentiation, and terminal-task exception.

## Issue
- Closes #1257

## Verification
- cargo check --all-targets
- cargo test --test runtime_tasks exec_command_
