### PR TITLE
Fix #1257: avoid duplicate ExecCommand background runs with duplicate policy

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2423,6 +2423,13 @@ Phase-1 envelope rules:
     - `task_handle`
     - `initial_output_preview`
     - `initial_output_truncated`
+  - duplicate active command startup behavior:
+    - `duplicate_policy` defaults to `reuse_running`
+    - `duplicate_policy = start_new` always starts an additional task
+    - with default policy, equivalent active commands return
+      `disposition = already_running` with the existing `task_handle` and command
+      metadata so operators can continue with `TaskStatus` / `TaskOutput`
+      against the same task id
   - `disposition` is the stable discriminant; completion-only fields and
     promotion-only fields should not be mixed in the same outcome
   - `tty = true` remains an explicit startup choice made by the agent; the

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -22,10 +22,11 @@ use crate::{
     },
     tool::ToolError,
     types::{
-        CommandCostDiagnostics, CommandTaskSpec, ExecCommandOutcome, ExecCommandResult,
-        ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind,
-        MessageOrigin, Priority, TaskHandle, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus,
-        ToolArtifactRef, TrustLevel,
+        CommandCostDiagnostics, CommandTaskSpec, CommandTaskStatusSnapshot,
+        ExecCommandDuplicatePolicy, ExecCommandOutcome, ExecCommandResult, ExternalTriggerScope,
+        ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+        TaskHandle, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, ToolArtifactRef,
+        TrustLevel,
     },
 };
 
@@ -91,6 +92,14 @@ struct CapturedOutput {
     stdout: String,
     stderr: String,
     combined: String,
+}
+
+struct CommandTaskMatch {
+    id: String,
+    kind: String,
+    status: crate::types::TaskStatus,
+    summary: Option<String>,
+    command: Option<CommandTaskStatusSnapshot>,
 }
 
 impl CapturedOutput {
@@ -193,12 +202,40 @@ impl RuntimeHandle {
     pub(crate) async fn execute_exec_command(
         &self,
         mut spec: CommandTaskSpec,
+        duplicate_policy: ExecCommandDuplicatePolicy,
         trust: &TrustLevel,
     ) -> Result<ExecCommandResult> {
         self.ensure_process_execution_exposed("ExecCommand").await?;
         self.apply_command_output_policy(&mut spec);
         let diagnostics = self.command_cost_diagnostics_for(&spec);
         let resolved = self.resolve_command_task(&spec).await?;
+        if matches!(duplicate_policy, ExecCommandDuplicatePolicy::ReuseRunning) {
+            if let Some(existing) = self
+                .find_reusable_active_command_task(&resolved.spec, &resolved.workdir)
+                .await?
+            {
+                return Ok(ExecCommandResult {
+                    outcome: ExecCommandOutcome::AlreadyRunning {
+                        task_handle: TaskHandle::new(
+                            existing.id.clone(),
+                            existing.kind.clone(),
+                            existing.status.clone(),
+                            None,
+                        ),
+                        command: existing.command,
+                        summary: existing.summary,
+                        instructions: Some(
+                            "Set duplicate_policy=\"start_new\" to start another instance.".into(),
+                        ),
+                    },
+                    summary_text: Some(format!(
+                        "command already running as {} (status {:?})",
+                        existing.id, existing.status
+                    )),
+                    command_diagnostics: Some(diagnostics),
+                });
+            }
+        }
         self.append_audit_event(
             "process_execution_requested",
             serde_json::json!({
@@ -380,6 +417,43 @@ impl RuntimeHandle {
                 }
             }
         }
+    }
+
+    fn command_entry_matches_identity(
+        &self,
+        command: &CommandTaskStatusSnapshot,
+        spec: &CommandTaskSpec,
+        workdir: &PathBuf,
+    ) -> bool {
+        command.cmd.as_deref() == Some(spec.cmd.as_str())
+            && command.workdir.as_deref() == Some(workdir.to_string_lossy().as_ref())
+            && command.shell.as_deref() == spec.shell.as_deref()
+            && command.login == Some(spec.login)
+            && command.tty == Some(spec.tty)
+    }
+
+    async fn find_reusable_active_command_task(
+        &self,
+        spec: &CommandTaskSpec,
+        workdir: &PathBuf,
+    ) -> Result<Option<CommandTaskMatch>> {
+        let mut entries = self.managed_tasks().latest_task_list_entries().await?;
+        let found = entries
+            .drain(..)
+            .find(|entry| {
+                entry.kind == TaskKind::CommandTask.as_str()
+                    && entry.command.as_ref().is_some_and(|command| {
+                        self.command_entry_matches_identity(command, spec, workdir)
+                    })
+            })
+            .map(|entry| CommandTaskMatch {
+                id: entry.id,
+                kind: entry.kind,
+                status: entry.status,
+                summary: entry.summary,
+                command: entry.command,
+            });
+        Ok(found)
     }
 
     fn apply_command_output_policy(&self, spec: &mut CommandTaskSpec) {

--- a/src/runtime/task_supervisor.rs
+++ b/src/runtime/task_supervisor.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 
 use super::RuntimeHandle;
 use crate::types::{
-    AgentProfilePreset, CommandTaskSpec, ExecCommandResult, SpawnAgentResult, TaskInputResult,
-    TaskListEntry, TaskOutputResult, TaskRecord, TaskStatusSnapshot, TrustLevel,
+    AgentProfilePreset, CommandTaskSpec, ExecCommandDuplicatePolicy, ExecCommandResult,
+    SpawnAgentResult, TaskInputResult, TaskListEntry, TaskOutputResult, TaskRecord,
+    TaskStatusSnapshot, TrustLevel,
 };
 
 pub(crate) struct ManagedTaskSupervisor<'a> {
@@ -20,9 +21,12 @@ impl ManagedTaskSupervisor<'_> {
     pub(crate) async fn execute_exec_command(
         &self,
         spec: CommandTaskSpec,
+        duplicate_policy: ExecCommandDuplicatePolicy,
         trust: &TrustLevel,
     ) -> Result<ExecCommandResult> {
-        self.runtime.execute_exec_command(spec, trust).await
+        self.runtime
+            .execute_exec_command(spec, duplicate_policy, trust)
+            .await
     }
 
     pub(crate) async fn execute_exec_command_once(

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -551,6 +551,19 @@ fn summarize_exec_command_result(result: &Value) -> String {
                 .unwrap_or(false);
             format!("promoted_to_task task_id={task_id} initial_output_truncated={truncated}")
         }
+        "already_running" => {
+            let task_id = result
+                .get("task_handle")
+                .and_then(|handle| handle.get("task_id"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let status = result
+                .get("task_handle")
+                .and_then(|handle| handle.get("status"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            format!("already_running task_id={task_id} status={status}")
+        }
         _ => format!("disposition={disposition}"),
     }
 }

--- a/src/tool/tools/exec_command.rs
+++ b/src/tool/tools/exec_command.rs
@@ -10,7 +10,8 @@ use crate::{
         ToolResult,
     },
     types::{
-        CommandTaskSpec, ExecCommandOutcome, ExecCommandResult, ToolCapabilityFamily, TrustLevel,
+        CommandTaskSpec, ExecCommandDuplicatePolicy, ExecCommandOutcome, ExecCommandResult,
+        ToolCapabilityFamily, TrustLevel,
     },
 };
 
@@ -27,6 +28,8 @@ pub(crate) struct ExecCommandArgs {
     pub(crate) shell: Option<String>,
     pub(crate) login: Option<bool>,
     pub(crate) tty: Option<bool>,
+    #[serde(default)]
+    pub(crate) duplicate_policy: ExecCommandDuplicatePolicy,
     pub(crate) accepts_input: Option<bool>,
     pub(crate) yield_time_ms: Option<u64>,
     pub(crate) max_output_tokens: Option<u64>,
@@ -37,7 +40,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::LocalEnvironment,
         spec: typed_spec::<ExecCommandArgs>(
             NAME,
-            "Start a shell command inside the workspace. Valid startup input uses `cmd` plus optional `workdir`, `shell`, `login`, `tty`, `accepts_input`, `yield_time_ms`, and `max_output_tokens`; do not pass result or task metadata such as `status` or `task_handle`. `yield_time_ms` defaults to 10_000 ms when omitted; set it only when intentionally changing the foreground wait window. Short commands return immediately; long non-interactive commands become command_task automatically.",
+            "Start a shell command inside the workspace. Valid startup input uses `cmd` plus optional `workdir`, `shell`, `login`, `tty`, `duplicate_policy`, `accepts_input`, `yield_time_ms`, and `max_output_tokens`; do not pass result or task metadata such as `status` or `task_handle`. `duplicate_policy` defaults to `reuse_running` and `yield_time_ms` defaults to 10_000 ms when omitted; set it only when intentionally changing the foreground wait window. Short commands return immediately; long non-interactive commands become command_task automatically.",
         )?,
     })
 }
@@ -50,6 +53,7 @@ pub(crate) async fn execute(
 ) -> Result<ToolResult> {
     let args: ExecCommandArgs = parse_tool_args(NAME, input)?;
     let tty = args.tty.unwrap_or(false);
+    let duplicate_policy = args.duplicate_policy;
     let spec = CommandTaskSpec {
         cmd: args.cmd,
         workdir: args.workdir,
@@ -63,7 +67,7 @@ pub(crate) async fn execute(
     };
     let result: ExecCommandResult = runtime
         .managed_tasks()
-        .execute_exec_command(spec, trust)
+        .execute_exec_command(spec, duplicate_policy, trust)
         .await?;
     serialize_success(NAME, &result)
 }
@@ -127,6 +131,42 @@ pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
                     .filter(|value| !value.trim().is_empty())
                     .unwrap_or_else(|| "(none captured before promotion)".to_string()),
             );
+            Ok(lines.join("\n"))
+        }
+        ExecCommandOutcome::AlreadyRunning {
+            task_handle,
+            command,
+            summary,
+            instructions,
+            ..
+        } => {
+            let mut lines = vec![
+                "Command is already running".to_string(),
+                format!("Task: {}", task_handle.task_id),
+                format!("Status: {:?}", task_handle.status),
+            ];
+            if let Some(summary) = summary.filter(|value| !value.trim().is_empty()) {
+                lines.push(format!("Task summary: {summary}"));
+            }
+            if let Some(command) = command {
+                if let Some(cmd) = command
+                    .cmd
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
+                {
+                    lines.push(format!("Command: {cmd}"));
+                }
+                if let Some(workdir) = command.workdir.as_deref() {
+                    lines.push(format!("workdir={workdir}"));
+                }
+                if let Some(shell) = command.shell.as_deref() {
+                    lines.push(format!("shell={shell}"));
+                }
+            }
+            if let Some(instructions) = instructions.filter(|value| !value.trim().is_empty()) {
+                lines.push(String::new());
+                lines.push(instructions);
+            }
             Ok(lines.join("\n"))
         }
     }
@@ -278,5 +318,27 @@ mod tests {
         let rendered = render_for_model(&result).unwrap();
         assert!(rendered.contains("Initial output:"));
         assert!(rendered.contains("(none captured before promotion)"));
+    }
+
+    #[test]
+    fn exec_command_default_duplicate_policy_is_reuse_running() {
+        let args = serde_json::from_value::<ExecCommandArgs>(serde_json::json!({
+            "cmd": "printf ok",
+        }))
+        .expect("default duplicate policy should parse");
+        assert_eq!(
+            args.duplicate_policy,
+            ExecCommandDuplicatePolicy::ReuseRunning
+        );
+    }
+
+    #[test]
+    fn exec_command_duplicate_policy_start_new_parses() {
+        let args = serde_json::from_value::<ExecCommandArgs>(serde_json::json!({
+            "cmd": "printf ok",
+            "duplicate_policy": "start_new",
+        }))
+        .expect("start_new duplicate policy should parse");
+        assert_eq!(args.duplicate_policy, ExecCommandDuplicatePolicy::StartNew);
     }
 }

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -200,6 +200,7 @@ async fn execute_batch_item(
                 }
                 ExecCommandOutcome::Completed { .. } => ExecCommandBatchItemStatus::Failed,
                 ExecCommandOutcome::PromotedToTask { .. } => ExecCommandBatchItemStatus::Failed,
+                ExecCommandOutcome::AlreadyRunning { .. } => ExecCommandBatchItemStatus::Failed,
             };
             ExecCommandBatchItemResult {
                 index,
@@ -334,6 +335,10 @@ fn render_exec_item(lines: &mut Vec<String>, result: Option<&ExecCommandResult>)
         }
         ExecCommandOutcome::PromotedToTask { task_handle, .. } => {
             lines.push("failed=promoted_to_task".to_string());
+            lines.push(format!("task={}", task_handle.task_id));
+        }
+        ExecCommandOutcome::AlreadyRunning { task_handle, .. } => {
+            lines.push("failed=already_running".to_string());
             lines.push(format!("task={}", task_handle.task_id));
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use clap::ValueEnum;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -2433,6 +2434,28 @@ pub enum ExecCommandOutcome {
         initial_output_preview: Option<String>,
         initial_output_truncated: bool,
     },
+    AlreadyRunning {
+        task_handle: TaskHandle,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        command: Option<CommandTaskStatusSnapshot>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        instructions: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecCommandDuplicatePolicy {
+    ReuseRunning,
+    StartNew,
+}
+
+impl Default for ExecCommandDuplicatePolicy {
+    fn default() -> Self {
+        Self::ReuseRunning
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -52,4 +52,9 @@ runtime_async_tests!(
     command_task_runner_failure_marks_task_failed_and_cleans_up,
     command_task_nonzero_exit_produces_failed_output_and_runtime_state,
     exec_command_auto_promotes_long_running_command_task,
+    exec_command_reuses_equivalent_active_command_task_by_default,
+    exec_command_can_start_new_with_duplicate_policy,
+    exec_command_non_equivalent_same_preview_does_not_reuse,
+    exec_command_reuses_equivalent_scheduled_background_task,
+    exec_command_terminal_tasks_do_not_block_new_run,
 );

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -2314,3 +2314,267 @@ pub async fn exec_command_auto_promotes_long_running_command_task() -> Result<()
     }));
     Ok(())
 }
+
+pub async fn exec_command_reuses_equivalent_active_command_task_by_default() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+    let cmd = "printf start && sleep 2 && printf done";
+    let first_task = runtime
+        .schedule_command_task(
+            format!("Run command: {cmd}"),
+            CommandTaskSpec {
+                cmd: cmd.into(),
+                workdir: None,
+                shell: None,
+                login: false,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: Some(8_000),
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    let second = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-dup-second".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": cmd,
+                    "login": false,
+                    "yield_time_ms": 50
+                }),
+            },
+        )
+        .await?;
+
+    let second_value = parse_tool_result_payload(&second.0)?;
+    assert_eq!(second_value["disposition"], "already_running");
+    assert_eq!(second_value["task_handle"]["task_id"], first_task.id);
+
+    let active = runtime.storage().latest_task_records()?;
+    let command_task_ids = active
+        .into_iter()
+        .filter(|record| {
+            record.kind.as_str() == "command_task"
+                && record.summary
+                    == Some("Run command: printf start && sleep 2 && printf done".into())
+        })
+        .map(|record| record.id)
+        .collect::<Vec<_>>();
+    assert_eq!(command_task_ids.len(), 1);
+    assert_eq!(command_task_ids[0], first_task.id);
+    Ok(())
+}
+
+pub async fn exec_command_reuses_equivalent_scheduled_background_task() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+
+    runtime
+        .schedule_command_task(
+            "scheduled background".into(),
+            CommandTaskSpec {
+                cmd: "sleep 2 && printf scheduled".into(),
+                workdir: None,
+                shell: None,
+                login: false,
+                tty: false,
+                yield_time_ms: 10_000,
+                max_output_tokens: Some(8_000),
+                accepts_input: false,
+                terminal_reentry: false,
+            },
+            TrustLevel::TrustedOperator,
+        )
+        .await?;
+
+    let result = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-scheduled-background".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": "sleep 2 && printf scheduled",
+                    "login": false,
+                    "yield_time_ms": 50
+                }),
+            },
+        )
+        .await?;
+
+    let value = parse_tool_result_payload(&result.0)?;
+    assert_eq!(value["disposition"], "already_running");
+    Ok(())
+}
+
+pub async fn exec_command_terminal_tasks_do_not_block_new_run() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+    let cmd = "printf done";
+
+    let first = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-terminal-first".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": cmd,
+                    "login": false,
+                }),
+            },
+        )
+        .await?;
+
+    let first_value = parse_tool_result_payload(&first.0)?;
+    assert_eq!(first_value["disposition"], "completed");
+    assert_eq!(first_value["exit_status"], 0);
+
+    let second = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-terminal-second".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": cmd,
+                    "login": false,
+                }),
+            },
+        )
+        .await?;
+
+    let second_value = parse_tool_result_payload(&second.0)?;
+    assert_eq!(second_value["disposition"], "completed");
+    assert_eq!(second_value["exit_status"], 0);
+    Ok(())
+}
+
+pub async fn exec_command_can_start_new_with_duplicate_policy() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+    let cmd = "printf start && sleep 2 && printf done";
+
+    let first = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-start-new-first".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": cmd,
+                    "login": false,
+                    "yield_time_ms": 50
+                }),
+            },
+        )
+        .await?;
+    let first_value = parse_tool_result_payload(&first.0)?;
+    let first_task_id = first_value["task_handle"]["task_id"]
+        .as_str()
+        .expect("expected promoted task handle");
+
+    let second = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-start-new-second".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": cmd,
+                    "login": false,
+                    "yield_time_ms": 50,
+                    "duplicate_policy": "start_new"
+                }),
+            },
+        )
+        .await?;
+    let second_value = parse_tool_result_payload(&second.0)?;
+    assert_eq!(second_value["disposition"], "promoted_to_task");
+    assert_ne!(second_value["task_handle"]["task_id"], first_task_id);
+    Ok(())
+}
+
+pub async fn exec_command_non_equivalent_same_preview_does_not_reuse() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+    let shared = "x".repeat(300);
+    let first_cmd = format!("printf '{}'; sleep 2", shared);
+    let second_cmd = format!("printf '{}B'; sleep 2", shared);
+
+    let first = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-preview-first".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": first_cmd,
+                    "login": false,
+                    "yield_time_ms": 50
+                }),
+            },
+        )
+        .await?;
+    let first_value = parse_tool_result_payload(&first.0)?;
+    assert_eq!(first_value["disposition"], "promoted_to_task");
+    let first_task_id = first_value["task_handle"]["task_id"]
+        .as_str()
+        .expect("expected promoted task handle");
+
+    let second = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &ToolCall {
+                id: "tool-exec-preview-second".into(),
+                name: "ExecCommand".into(),
+                input: json!({
+                    "cmd": second_cmd,
+                    "login": false,
+                    "yield_time_ms": 50
+                }),
+            },
+        )
+        .await?;
+    let second_value = parse_tool_result_payload(&second.0)?;
+    assert_eq!(second_value["disposition"], "promoted_to_task");
+    assert_ne!(second_value["task_handle"]["task_id"], first_task_id);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add optional `duplicate_policy` to `ExecCommand` input with values `reuse_running` (default) and `start_new`.
- By default, `ExecCommand` now reuses an equivalent non-terminal active command task and returns an `already_running` result containing the existing task handle and command metadata.
- With `start_new`, the command is always scheduled, bypassing duplicate reuse checks.
- Wire the behavior through `ExecCommand` tool handling, batch result matching, runtime turn rendering, and duplicate lookup in the command-task execution path.
- Add docs in `docs/runtime-spec.md` for duplicate policy semantics and payload behavior.
- Add focused tests for duplicate reuse, `start_new`, non-equivalent command distinction, and terminal tasks not blocking new commands.

## Verification

- `cargo test --test runtime_tasks exec_command_`
- `cargo test --test runtime_tasks`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #1257
