### PR TITLE
fix: preserve provider transport diagnostics

### DIFF
--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -101,6 +101,7 @@ pub(crate) fn build_candidate(
                 provider_config,
                 &model_ref.model,
                 config.runtime_max_output_tokens,
+                &config.home_dir,
             )?)
         }
         ProviderTransportKind::OpenAiChatCompletions => {

--- a/src/provider/http_trace.rs
+++ b/src/provider/http_trace.rs
@@ -1,0 +1,466 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+static PROVIDER_HTTP_TRACE_SEQ: AtomicU64 = AtomicU64::new(1);
+
+const PROVIDER_HTTP_TRACE_ENV: &str = "HOLON_PROVIDER_HTTP_TRACE";
+const PROVIDER_HTTP_FAILURE_TRACE_ENV: &str = "HOLON_PROVIDER_HTTP_FAILURE_TRACE";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderHttpTraceDiagnostics {
+    pub mode: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderHttpTraceMode {
+    All,
+    FailureOnly,
+}
+
+impl ProviderHttpTraceMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::FailureOnly => "failure_only",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProviderHttpTrace {
+    home_dir: PathBuf,
+    mode: ProviderHttpTraceMode,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProviderHttpTraceRequest {
+    inner: Arc<Mutex<ProviderHttpTraceRequestState>>,
+}
+
+#[derive(Debug)]
+struct ProviderHttpTraceRequestState {
+    home_dir: PathBuf,
+    mode: ProviderHttpTraceMode,
+    agent_id: String,
+    sequence: u64,
+    file_path: Option<PathBuf>,
+    events: Vec<Value>,
+}
+
+impl ProviderHttpTrace {
+    pub(crate) fn from_env(home_dir: impl Into<PathBuf>) -> Option<Self> {
+        let mode = if std::env::var(PROVIDER_HTTP_TRACE_ENV).ok().as_deref() == Some("1") {
+            ProviderHttpTraceMode::All
+        } else if std::env::var(PROVIDER_HTTP_FAILURE_TRACE_ENV)
+            .ok()
+            .as_deref()
+            == Some("1")
+        {
+            ProviderHttpTraceMode::FailureOnly
+        } else {
+            return None;
+        };
+        Some(Self {
+            home_dir: home_dir.into(),
+            mode,
+        })
+    }
+
+    pub(crate) fn begin_request(
+        &self,
+        agent_id: Option<&str>,
+        provider: &str,
+        model_ref: Option<&str>,
+        url: &str,
+        endpoint_kind: &str,
+        headers: &[(&str, String)],
+        body: &Value,
+    ) -> Option<ProviderHttpTraceRequest> {
+        let agent_id = agent_id
+            .filter(|value| !value.trim().is_empty())
+            .map(ToString::to_string)
+            .or_else(|| {
+                std::env::var("HOLON_AGENT_ID")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .unwrap_or_else(|| "unknown-agent".into());
+        let sequence = PROVIDER_HTTP_TRACE_SEQ.fetch_add(1, Ordering::Relaxed);
+        let request = ProviderHttpTraceRequest {
+            inner: Arc::new(Mutex::new(ProviderHttpTraceRequestState {
+                home_dir: self.home_dir.clone(),
+                mode: self.mode,
+                agent_id,
+                sequence,
+                file_path: None,
+                events: Vec::new(),
+            })),
+        };
+        request.write_event(json!({
+            "type": "request",
+            "created_at_ms": current_time_millis(),
+            "sequence": sequence,
+            "provider": provider,
+            "model_ref": model_ref,
+            "endpoint_kind": endpoint_kind,
+            "url": redact_url(url),
+            "headers": redact_headers(headers),
+            "body": redact_json_secrets(body),
+        }));
+        Some(request)
+    }
+}
+
+impl ProviderHttpTraceRequest {
+    pub(crate) fn write_response_headers(
+        &self,
+        status: reqwest::StatusCode,
+        headers: &reqwest::header::HeaderMap,
+    ) {
+        self.write_event(json!({
+            "type": "response_headers",
+            "created_at_ms": current_time_millis(),
+            "status": status.as_u16(),
+            "headers": redact_header_map(headers),
+        }));
+    }
+
+    pub(crate) fn write_response_body(&self, body: &str) {
+        self.write_event(json!({
+            "type": "response_body",
+            "created_at_ms": current_time_millis(),
+            "bytes": body.len(),
+            "body": body,
+        }));
+    }
+
+    pub(crate) fn write_stream_chunk(&self, chunk: &[u8]) {
+        self.write_event(json!({
+            "type": "stream_chunk",
+            "created_at_ms": current_time_millis(),
+            "bytes": chunk.len(),
+            "text": String::from_utf8_lossy(chunk),
+        }));
+    }
+
+    pub(crate) fn write_stream_terminal(&self, body: &Value) {
+        self.write_event(json!({
+            "type": "stream_terminal_response",
+            "created_at_ms": current_time_millis(),
+            "body": body,
+        }));
+    }
+
+    pub(crate) fn diagnostics(&self, status: Option<u16>) -> Option<ProviderHttpTraceDiagnostics> {
+        let mut guard = self.inner.lock().ok()?;
+        let path = ensure_trace_file(&mut guard)?;
+        Some(ProviderHttpTraceDiagnostics {
+            mode: guard.mode.as_str().to_string(),
+            path: path.to_string_lossy().to_string(),
+            status,
+        })
+    }
+
+    fn write_event(&self, event: Value) {
+        let Ok(mut guard) = self.inner.lock() else {
+            return;
+        };
+        guard.events.push(event.clone());
+        if guard.mode == ProviderHttpTraceMode::All {
+            let already_open = guard.file_path.is_some();
+            let Some(path) = ensure_trace_file(&mut guard) else {
+                return;
+            };
+            if already_open {
+                append_trace_event(&path, &event);
+            }
+        }
+    }
+}
+
+fn ensure_trace_file(state: &mut ProviderHttpTraceRequestState) -> Option<PathBuf> {
+    if let Some(path) = &state.file_path {
+        return Some(path.clone());
+    }
+    let trace_dir = state
+        .home_dir
+        .join(".holon")
+        .join("http-trace")
+        .join(sanitize_trace_path_segment(&state.agent_id));
+    fs::create_dir_all(&trace_dir).ok()?;
+    let created_at_ms = current_time_millis();
+    let path = trace_dir.join(format!(
+        "trace-{created_at_ms}-{sequence}.jsonl",
+        sequence = state.sequence
+    ));
+    for event in &state.events {
+        append_trace_event(&path, event);
+    }
+    state.file_path = Some(path.clone());
+    Some(path)
+}
+
+fn append_trace_event(path: &Path, event: &Value) {
+    let Ok(line) = serde_json::to_string(event) else {
+        return;
+    };
+    let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
+        return;
+    };
+    let _ = writeln!(file, "{line}");
+}
+
+pub(crate) fn sanitize_trace_path_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn redact_headers(headers: &[(&str, String)]) -> Value {
+    Value::Array(
+        headers
+            .iter()
+            .map(|(name, value)| {
+                json!({
+                    "name": *name,
+                    "value": redact_header_value(name, value),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn redact_header_map(headers: &reqwest::header::HeaderMap) -> Value {
+    Value::Array(
+        headers
+            .iter()
+            .map(|(name, value)| {
+                let value = value.to_str().unwrap_or("<non-utf8>");
+                json!({
+                    "name": name.as_str(),
+                    "value": redact_header_value(name.as_str(), value),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn redact_header_value(name: &str, value: &str) -> String {
+    let lowered = name.to_ascii_lowercase();
+    if matches!(
+        lowered.as_str(),
+        "authorization" | "proxy-authorization" | "cookie" | "set-cookie" | "x-api-key"
+    ) {
+        "[REDACTED]".into()
+    } else {
+        value.into()
+    }
+}
+
+pub(crate) fn redact_url(raw: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(raw) else {
+        return raw.into();
+    };
+    if url.password().is_some() {
+        let _ = url.set_password(Some("[REDACTED]"));
+    }
+    if !url.username().is_empty() {
+        let _ = url.set_username("[REDACTED]");
+    }
+    let redacted_pairs = url
+        .query_pairs()
+        .map(|(key, value)| {
+            let lowered = key.to_ascii_lowercase();
+            let value = if lowered.contains("key")
+                || lowered.contains("token")
+                || lowered.contains("secret")
+            {
+                "[REDACTED]".into()
+            } else {
+                value.into_owned()
+            };
+            (key.into_owned(), value)
+        })
+        .collect::<Vec<_>>();
+    if !redacted_pairs.is_empty() {
+        url.query_pairs_mut().clear().extend_pairs(redacted_pairs);
+    }
+    url.to_string()
+}
+
+pub(crate) fn redact_json_secrets(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| {
+                    let lowered = key.to_ascii_lowercase();
+                    let value = if is_secret_json_key(&lowered) {
+                        Value::String("[REDACTED]".into())
+                    } else {
+                        redact_json_secrets(value)
+                    };
+                    (key.clone(), value)
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.iter().map(redact_json_secrets).collect()),
+        other => other.clone(),
+    }
+}
+
+fn is_secret_json_key(lowered: &str) -> bool {
+    lowered.contains("api_key")
+        || lowered.contains("apikey")
+        || lowered.contains("secret")
+        || lowered == "authorization"
+        || lowered == "token"
+        || lowered.ends_with("_token")
+        || lowered.starts_with("token_")
+        || lowered.contains("_token_")
+}
+
+fn current_time_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        redact_headers, redact_json_secrets, redact_url, sanitize_trace_path_segment,
+        ProviderHttpTrace,
+    };
+    use serde_json::{json, Value};
+    use std::fs;
+
+    #[test]
+    fn provider_http_trace_redacts_secrets() {
+        let headers = redact_headers(&[
+            ("authorization", "Bearer secret".into()),
+            ("openai-beta", "responses=experimental".into()),
+        ]);
+        assert_eq!(headers[0]["value"], "[REDACTED]");
+        assert_eq!(headers[1]["value"], "responses=experimental");
+
+        assert_eq!(
+            redact_url("https://user:pass@example.com/v1/responses?api_key=secret&debug=1"),
+            "https://%5BREDACTED%5D:%5BREDACTED%5D@example.com/v1/responses?api_key=%5BREDACTED%5D&debug=1"
+        );
+
+        let body = redact_json_secrets(&json!({
+            "model": "gpt-test",
+            "max_output_tokens": 4096,
+            "access_token": "secret",
+            "nested": {
+                "api_key": "secret",
+                "prompt_tokens": 123,
+                "reasoning_tokens": 45
+            }
+        }));
+        assert_eq!(body["access_token"], "[REDACTED]");
+        assert_eq!(body["nested"]["api_key"], "[REDACTED]");
+        assert_eq!(body["max_output_tokens"], 4096);
+        assert_eq!(body["nested"]["prompt_tokens"], 123);
+        assert_eq!(body["nested"]["reasoning_tokens"], 45);
+        assert_eq!(body["model"], "gpt-test");
+    }
+
+    #[test]
+    fn provider_http_trace_sanitizes_agent_path_segment() {
+        assert_eq!(
+            sanitize_trace_path_segment("agent/with spaces"),
+            "agent_with_spaces"
+        );
+    }
+
+    #[test]
+    fn provider_http_trace_writes_full_request_body_under_home() {
+        let home = tempfile::tempdir().unwrap();
+        let trace = ProviderHttpTrace {
+            home_dir: home.path().to_path_buf(),
+            mode: super::ProviderHttpTraceMode::All,
+        };
+        let body = json!({
+            "model": "gpt-test",
+            "input": [{ "type": "message", "content": "hello" }],
+            "tools": [{ "type": "function", "name": "ApplyPatch" }]
+        });
+
+        trace
+            .begin_request(
+                Some("agent/one"),
+                "openai",
+                Some("openai/gpt-test"),
+                "https://api.openai.com/v1/responses",
+                "responses",
+                &[("authorization", "Bearer secret".into())],
+                &body,
+            )
+            .expect("trace should be written");
+
+        let trace_dir = home.path().join(".holon/http-trace/agent_one");
+        let entries = fs::read_dir(trace_dir)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        let line = fs::read_to_string(entries[0].path()).unwrap();
+        let event: Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(event["type"], "request");
+        assert_eq!(
+            event["body"]["tools"][0]["name"],
+            Value::String("ApplyPatch".into())
+        );
+        assert_eq!(event["headers"][0]["value"], "[REDACTED]");
+    }
+
+    #[test]
+    fn provider_http_failure_trace_writes_only_when_diagnostics_are_requested() {
+        let home = tempfile::tempdir().unwrap();
+        let trace = ProviderHttpTrace {
+            home_dir: home.path().to_path_buf(),
+            mode: super::ProviderHttpTraceMode::FailureOnly,
+        };
+        let request = trace
+            .begin_request(
+                Some("agent/one"),
+                "anthropic",
+                Some("anthropic/claude"),
+                "https://api.anthropic.com/v1/messages",
+                "messages",
+                &[("authorization", "Bearer secret".into())],
+                &json!({ "model": "claude", "messages": [] }),
+            )
+            .expect("trace should be created");
+        let trace_dir = home.path().join(".holon/http-trace/agent_one");
+        assert!(!trace_dir.exists());
+
+        let diagnostics = request
+            .diagnostics(Some(400))
+            .expect("failure diagnostics should write trace");
+        assert_eq!(diagnostics.mode, "failure_only");
+        assert!(std::path::Path::new(&diagnostics.path).exists());
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -9,6 +9,7 @@ use crate::{prompt::PromptStability, tool::ToolError, tool::ToolSpec, types::Tok
 mod catalog;
 mod diagnostics;
 mod fallback;
+mod http_trace;
 mod retry;
 pub mod test_support;
 mod tool_schema;
@@ -16,6 +17,7 @@ mod transports;
 
 pub use catalog::{build_provider_from_config, build_provider_from_model_chain};
 pub use diagnostics::{provider_doctor, resolved_model_availability};
+pub use http_trace::ProviderHttpTraceDiagnostics;
 pub use transports::{
     AnthropicProvider, OpenAiChatCompletionsProvider, OpenAiCodexProvider, OpenAiProvider,
 };
@@ -478,6 +480,8 @@ pub struct ProviderTransportDiagnostics {
     pub status: Option<u16>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reqwest: Option<ReqwestTransportDiagnostics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_trace: Option<ProviderHttpTraceDiagnostics>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_chain: Vec<String>,
 }

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -6,7 +6,9 @@ use serde_json::{json, Value};
 use thiserror::Error;
 use tokio::time::Duration;
 
-use super::{ProviderTransportDiagnostics, ReqwestTransportDiagnostics};
+use super::{
+    http_trace::ProviderHttpTraceRequest, ProviderTransportDiagnostics, ReqwestTransportDiagnostics,
+};
 
 pub(crate) const PROVIDER_MAX_RETRIES: usize = 2;
 const PROVIDER_RETRY_BASE_BACKOFF_MS: u64 = 200;
@@ -126,13 +128,14 @@ pub(crate) fn provider_transport_error(
     .into()
 }
 
-pub(crate) fn classify_reqwest_transport_error(
+pub(crate) fn classify_reqwest_transport_error_with_trace(
     context: &str,
     stage: &str,
     provider: &str,
     model_ref: Option<&str>,
     url: Option<&str>,
     error: reqwest::Error,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> anyhow::Error {
     let status = error.status().map(|status| status.as_u16());
     let source_chain = error_chain_messages(&error);
@@ -167,6 +170,7 @@ pub(crate) fn classify_reqwest_transport_error(
             url,
             &error,
             source_chain,
+            trace,
         )),
         format!("{context}: {error}"),
     )
@@ -199,10 +203,15 @@ fn is_retryable_response_body_read_interruption(
     })
 }
 
-pub(crate) fn classify_status_error(
+pub(crate) fn classify_status_error_with_trace(
     context: &str,
+    stage: &str,
+    provider: Option<&str>,
+    model_ref: Option<&str>,
+    url: Option<&str>,
     status: StatusCode,
     body: String,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> anyhow::Error {
     let classification = match status {
         StatusCode::TOO_MANY_REQUESTS => ProviderFailureClassification {
@@ -229,7 +238,16 @@ pub(crate) fn classify_status_error(
     provider_transport_error(
         classification,
         Some(status.as_u16()),
-        None,
+        Some(ProviderTransportDiagnostics {
+            stage: stage.to_string(),
+            provider: provider.map(ToString::to_string),
+            model_ref: model_ref.map(ToString::to_string),
+            url: url.map(sanitize_transport_url),
+            status: Some(status.as_u16()),
+            reqwest: None,
+            http_trace: trace.and_then(|trace| trace.diagnostics(Some(status.as_u16()))),
+            source_chain: Vec::new(),
+        }),
         format!("{context} with status {status}: {body}"),
     )
 }
@@ -249,13 +267,14 @@ pub(crate) fn invalid_response_error(
     )
 }
 
-pub(crate) fn timeout_transport_error(
+pub(crate) fn timeout_transport_error_with_trace(
     context: &str,
     stage: &str,
     provider: &str,
     model_ref: Option<&str>,
     url: Option<&str>,
     reason: impl Into<String>,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> anyhow::Error {
     provider_transport_error(
         ProviderFailureClassification {
@@ -270,13 +289,14 @@ pub(crate) fn timeout_transport_error(
             url: url.map(sanitize_transport_url),
             status: None,
             reqwest: None,
+            http_trace: trace.and_then(|trace| trace.diagnostics(None)),
             source_chain: vec![reason.into()],
         }),
         context.to_string(),
     )
 }
 
-fn sanitize_transport_url(raw: &str) -> String {
+pub(crate) fn sanitize_transport_url(raw: &str) -> String {
     let Ok(mut url) = reqwest::Url::parse(raw) else {
         return raw.to_string();
     };
@@ -296,7 +316,9 @@ fn reqwest_transport_diagnostics(
     url: Option<&str>,
     error: &reqwest::Error,
     source_chain: Vec<String>,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> ProviderTransportDiagnostics {
+    let status = error.status().map(|status| status.as_u16());
     ProviderTransportDiagnostics {
         stage: stage.to_string(),
         provider: Some(provider.to_string()),
@@ -304,7 +326,7 @@ fn reqwest_transport_diagnostics(
         url: url
             .or_else(|| error.url().map(reqwest::Url::as_str))
             .map(sanitize_transport_url),
-        status: error.status().map(|status| status.as_u16()),
+        status,
         reqwest: Some(ReqwestTransportDiagnostics {
             is_timeout: error.is_timeout(),
             is_connect: error.is_connect(),
@@ -312,8 +334,9 @@ fn reqwest_transport_diagnostics(
             is_body: error.is_body(),
             is_decode: error.is_decode(),
             is_redirect: error.is_redirect(),
-            status: error.status().map(|status| status.as_u16()),
+            status,
         }),
+        http_trace: trace.and_then(|trace| trace.diagnostics(status)),
         source_chain,
     }
 }

--- a/src/provider/tests/openai_chat_completions.rs
+++ b/src/provider/tests/openai_chat_completions.rs
@@ -3,6 +3,7 @@
 use super::support::*;
 use super::*;
 use crate::config::{ModelRef, ProviderId, ProviderTransportKind};
+use crate::provider::provider_transport_diagnostics;
 use crate::provider::retry::{classify_provider_error, ProviderFailureKind, RetryDisposition};
 use crate::provider::transports::build_chat_completion_messages;
 use crate::tool::ToolSpec;
@@ -664,11 +665,28 @@ fn chat_completion_provider_classifies_rate_limit_errors() {
         }
     });
 
-    let error = classify_openai_chat_completion_error("test context", &error_json["error"]);
+    let error = classify_openai_chat_completion_error(
+        "test context",
+        &error_json["error"],
+        reqwest::StatusCode::TOO_MANY_REQUESTS,
+        Some("openai/gpt-test"),
+        Some("https://example.com/v1/chat/completions"),
+        None,
+    );
     let classification = classify_provider_error(&error);
 
     assert_eq!(classification.kind, ProviderFailureKind::RateLimited);
     assert_eq!(classification.disposition, RetryDisposition::Retryable);
+    assert_eq!(
+        provider_transport_diagnostics(&error).and_then(|diag| diag.status),
+        Some(429)
+    );
+    let diagnostics = provider_transport_diagnostics(&error).unwrap();
+    assert_eq!(diagnostics.model_ref.as_deref(), Some("openai/gpt-test"));
+    assert_eq!(
+        diagnostics.url.as_deref(),
+        Some("https://example.com/v1/chat/completions")
+    );
 }
 
 #[test]
@@ -684,7 +702,14 @@ fn chat_completion_provider_classifies_auth_errors() {
         }
     });
 
-    let error = classify_openai_chat_completion_error("test context", &error_json["error"]);
+    let error = classify_openai_chat_completion_error(
+        "test context",
+        &error_json["error"],
+        reqwest::StatusCode::UNAUTHORIZED,
+        None,
+        None,
+        None,
+    );
     let classification = classify_provider_error(&error);
 
     assert_eq!(classification.kind, ProviderFailureKind::AuthError);
@@ -704,7 +729,14 @@ fn chat_completion_provider_classifies_context_length_errors() {
         }
     });
 
-    let error = classify_openai_chat_completion_error("test context", &error_json["error"]);
+    let error = classify_openai_chat_completion_error(
+        "test context",
+        &error_json["error"],
+        reqwest::StatusCode::BAD_REQUEST,
+        None,
+        None,
+        None,
+    );
     let classification = classify_provider_error(&error);
 
     assert_eq!(classification.kind, ProviderFailureKind::ContractError);
@@ -724,7 +756,14 @@ fn chat_completion_provider_classifies_server_errors() {
         }
     });
 
-    let error = classify_openai_chat_completion_error("test context", &error_json["error"]);
+    let error = classify_openai_chat_completion_error(
+        "test context",
+        &error_json["error"],
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        None,
+        None,
+        None,
+    );
     let classification = classify_provider_error(&error);
 
     assert_eq!(classification.kind, ProviderFailureKind::ServerError);
@@ -744,7 +783,14 @@ fn chat_completion_provider_classifies_unknown_errors_as_contract_errors() {
         }
     });
 
-    let error = classify_openai_chat_completion_error("test context", &error_json["error"]);
+    let error = classify_openai_chat_completion_error(
+        "test context",
+        &error_json["error"],
+        reqwest::StatusCode::BAD_REQUEST,
+        None,
+        None,
+        None,
+    );
     let classification = classify_provider_error(&error);
 
     // Unknown errors should default to contract errors

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -859,6 +859,16 @@ async fn openai_provider_fails_fast_on_contract_errors() {
         timeline.attempts[0].outcome,
         ProviderAttemptOutcome::FailFastAborted
     );
+    let transport = timeline.attempts[0]
+        .transport_diagnostics
+        .as_ref()
+        .expect("status failures should carry transport diagnostics");
+    assert_eq!(transport.stage, "response_status");
+    assert_eq!(transport.provider.as_deref(), Some("openai"));
+    assert_eq!(transport.model_ref.as_deref(), Some("openai/gpt-5.4"));
+    assert_eq!(transport.status, Some(400));
+    assert_eq!(transport.reqwest, None);
+    assert_eq!(transport.http_trace, None);
     assert!(!timeline.attempts[0].advanced_to_fallback);
 }
 
@@ -1097,6 +1107,73 @@ async fn provider_fallback_defers_after_fail_fast_error() {
     );
     assert!(timeline.attempts[0].advanced_to_fallback);
     assert_eq!(timeline.attempts[0].attempt, 1);
+    let transport = timeline.attempts[0]
+        .transport_diagnostics
+        .as_ref()
+        .expect("fallback status failure should preserve diagnostics");
+    assert_eq!(transport.stage, "response_status");
+    assert_eq!(transport.provider.as_deref(), Some("openai"));
+    assert_eq!(transport.status, Some(400));
+}
+
+#[tokio::test]
+async fn anthropic_status_errors_preserve_transport_diagnostics() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let server_attempts = attempts.clone();
+    let base_url = spawn_test_server(Router::new().route(
+        "/v1/messages",
+        post(move || {
+            let attempts = server_attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                (axum::http::StatusCode::UNAUTHORIZED, "bad token").into_response()
+            }
+        }),
+    ))
+    .await;
+
+    let mut fixture = test_config(
+        "anthropic/claude-sonnet-4-6",
+        &[],
+        None,
+        Some("anthropic-token"),
+        false,
+    );
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::anthropic())
+        .unwrap()
+        .base_url = base_url;
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+    let error = provider
+        .complete_turn(provider_turn_request())
+        .await
+        .err()
+        .expect("401 should fail fast without retry");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
+    assert_eq!(timeline.attempts.len(), 1);
+    assert_eq!(
+        timeline.attempts[0].failure_kind.as_deref(),
+        Some("auth_error")
+    );
+    let transport = timeline.attempts[0]
+        .transport_diagnostics
+        .as_ref()
+        .expect("anthropic status failure should preserve diagnostics");
+    assert_eq!(transport.stage, "response_status");
+    assert_eq!(transport.provider.as_deref(), Some("anthropic"));
+    assert_eq!(
+        transport.model_ref.as_deref(),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert_eq!(transport.status, Some(401));
+    assert!(transport
+        .url
+        .as_deref()
+        .is_some_and(|url| url.ends_with("/v1/messages")));
 }
 
 #[tokio::test]

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
 use twox_hash::XxHash64;
 
 use crate::{
@@ -15,16 +16,18 @@ use crate::{
     },
     prompt::PromptStability,
     provider::{
-        AgentProvider, AnthropicPromptCacheDiagnostics, CacheBreakpointInfo, ConversationMessage,
-        ModelBlock, PromptContentBlock, ProviderCacheUsage, ProviderContextManagementPolicy,
-        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind, ProviderPromptCapability,
-        ProviderTurnRequest, ProviderTurnResponse,
+        http_trace::ProviderHttpTrace, AgentProvider, AnthropicPromptCacheDiagnostics,
+        CacheBreakpointInfo, ConversationMessage, ModelBlock, PromptContentBlock,
+        ProviderCacheUsage, ProviderContextManagementPolicy, ProviderNativeWebSearchDiagnostics,
+        ProviderNativeWebSearchKind, ProviderPromptCapability, ProviderTurnRequest,
+        ProviderTurnResponse,
     },
 };
 
 use super::{build_http_client, request_send_timeout};
 use crate::provider::retry::{
-    classify_reqwest_transport_error, classify_status_error, invalid_response_error,
+    classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
+    invalid_response_error,
 };
 
 #[derive(Clone)]
@@ -35,6 +38,7 @@ pub struct AnthropicProvider {
     model: String,
     max_output_tokens: u32,
     context_management: AnthropicContextManagementConfig,
+    trace_home_dir: PathBuf,
 }
 
 #[derive(Debug, Serialize)]
@@ -122,13 +126,19 @@ impl AnthropicProvider {
             .providers
             .get(&ProviderId::anthropic())
             .ok_or_else(|| anyhow!("missing anthropic provider config"))?;
-        Self::from_runtime_config(provider_config, model, config.runtime_max_output_tokens)
+        Self::from_runtime_config(
+            provider_config,
+            model,
+            config.runtime_max_output_tokens,
+            &config.home_dir,
+        )
     }
 
     pub fn from_runtime_config(
         provider_config: &ProviderRuntimeConfig,
         model: &str,
         max_output_tokens: u32,
+        trace_home_dir: &Path,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let auth_token = provider_config
@@ -152,6 +162,7 @@ impl AnthropicProvider {
             model: model.to_string(),
             max_output_tokens,
             context_management: provider_config.context_management.clone(),
+            trace_home_dir: trace_home_dir.to_path_buf(),
         })
     }
 }
@@ -179,15 +190,36 @@ impl AgentProvider for AnthropicProvider {
         let request_payload = serde_json::to_value(&request_body)?;
 
         let url = format!("{}/v1/messages", self.base_url);
-        let mut request_builder = self
-            .client
-            .post(url)
-            .header("content-type", "application/json")
-            .header("authorization", format!("Bearer {}", self.auth_token))
-            .header("anthropic-version", "2023-06-01");
+        let mut headers = vec![
+            ("content-type", "application/json".to_string()),
+            ("authorization", format!("Bearer {}", self.auth_token)),
+            ("anthropic-version", "2023-06-01".to_string()),
+        ];
         if self.context_management.enabled {
-            request_builder =
-                request_builder.header("anthropic-beta", "context-management-2025-06-27");
+            headers.push((
+                "anthropic-beta",
+                "context-management-2025-06-27".to_string(),
+            ));
+        }
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        let request_trace = trace.and_then(|trace| {
+            trace.begin_request(
+                request
+                    .prompt_frame
+                    .cache
+                    .as_ref()
+                    .map(|cache| cache.agent_id.as_str()),
+                "anthropic",
+                Some(&format!("anthropic/{}", self.model)),
+                url.as_str(),
+                "messages",
+                &headers,
+                &request_payload,
+            )
+        });
+        let mut request_builder = self.client.post(&url);
+        for (name, value) in &headers {
+            request_builder = request_builder.header(*name, value);
         }
         let response = request_builder
             .timeout(request_send_timeout())
@@ -195,36 +227,52 @@ impl AgentProvider for AnthropicProvider {
             .send()
             .await
             .map_err(|error| {
-                classify_reqwest_transport_error(
+                classify_reqwest_transport_error_with_trace(
                     "Anthropic request failed",
                     "request_send",
                     "anthropic",
                     Some(&format!("anthropic/{}", self.model)),
                     Some(&format!("{}/v1/messages", self.base_url)),
                     error,
+                    request_trace.as_ref(),
                 )
             })?;
+        request_trace
+            .as_ref()
+            .map(|trace| trace.write_response_headers(response.status(), response.headers()));
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(classify_status_error(
+            request_trace
+                .as_ref()
+                .map(|trace| trace.write_response_body(&body));
+            return Err(classify_status_error_with_trace(
                 "Anthropic request failed",
+                "response_status",
+                Some("anthropic"),
+                Some(&format!("anthropic/{}", self.model)),
+                Some(url.as_str()),
                 status,
                 body,
+                request_trace.as_ref(),
             ));
         }
 
         let response_body = response.text().await.map_err(|error| {
-            classify_reqwest_transport_error(
+            classify_reqwest_transport_error_with_trace(
                 "Anthropic response body failed",
                 "response_body",
                 "anthropic",
                 Some(&format!("anthropic/{}", self.model)),
                 Some(&format!("{}/v1/messages", self.base_url)),
                 error,
+                request_trace.as_ref(),
             )
         })?;
+        request_trace
+            .as_ref()
+            .map(|trace| trace.write_response_body(&response_body));
         let parsed: MessagesResponse = serde_json::from_str(&response_body)
             .map_err(|error| invalid_response_error("invalid Anthropic JSON", error))?;
         let input_tokens = parsed

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -5,13 +5,9 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    fs::{self, OpenOptions},
-    io::Write,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
     sync::{Arc, Mutex, MutexGuard},
     time::Duration,
-    time::SystemTime,
 };
 
 use crate::{
@@ -22,21 +18,22 @@ use crate::{
     context::ContextConfig,
     model_catalog::BuiltInModelCatalog,
     provider::{
-        emitted_tool_json_schema, AgentProvider, ConversationMessage, ModelBlock,
-        ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
-        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
-        ProviderOpenAiRemoteCompactionDiagnostics, ProviderOpenAiRequestControlsDiagnostics,
-        ProviderPromptFrame, ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
-        ToolSchemaContract,
+        emitted_tool_json_schema,
+        http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
+        AgentProvider, ConversationMessage, ModelBlock, ProviderCacheUsage,
+        ProviderIncrementalContinuationDiagnostics, ProviderNativeWebSearchDiagnostics,
+        ProviderNativeWebSearchKind, ProviderOpenAiRemoteCompactionDiagnostics,
+        ProviderOpenAiRequestControlsDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
+        ProviderTurnRequest, ProviderTurnResponse, ToolSchemaContract,
     },
     token_estimate::estimate_json_tokens,
 };
 
 use super::{build_http_client, request_send_timeout, stream_idle_timeout};
 use crate::provider::retry::{
-    classify_reqwest_transport_error, classify_status_error, invalid_response_error,
-    provider_transport_error, timeout_transport_error, ProviderFailureClassification,
-    ProviderFailureKind, ProviderTransportError, RetryDisposition,
+    classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
+    invalid_response_error, provider_transport_error, timeout_transport_error_with_trace,
+    ProviderFailureClassification, ProviderFailureKind, ProviderTransportError, RetryDisposition,
 };
 
 #[derive(Clone)]
@@ -83,265 +80,38 @@ pub(crate) enum OpenAiResponsesTransportContract {
 }
 
 const OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND: &str = "responses_compact";
-static OPENAI_HTTP_TRACE_SEQ: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct OpenAiCompactionPolicy {
     pub(crate) trigger_input_tokens: u64,
 }
 
-#[derive(Clone, Debug)]
-struct OpenAiHttpTrace {
-    home_dir: PathBuf,
-}
-
-#[derive(Clone, Debug)]
-struct OpenAiHttpTraceRequest {
-    file_path: Arc<PathBuf>,
-}
-
-impl OpenAiHttpTrace {
-    fn from_env(home_dir: impl Into<PathBuf>) -> Option<Self> {
-        if std::env::var("HOLON_PROVIDER_HTTP_TRACE").ok().as_deref() != Some("1") {
-            return None;
-        }
-        Some(Self {
-            home_dir: home_dir.into(),
-        })
-    }
-
-    fn begin_request(
-        &self,
-        agent_id: Option<&str>,
-        provider: &str,
-        model_ref: Option<&str>,
-        url: &str,
-        endpoint_kind: &str,
-        headers: &[(&str, String)],
-        body: &Value,
-    ) -> Option<OpenAiHttpTraceRequest> {
-        let agent_id = agent_id
-            .filter(|value| !value.trim().is_empty())
-            .map(ToString::to_string)
-            .or_else(|| {
-                std::env::var("HOLON_AGENT_ID")
-                    .ok()
-                    .filter(|value| !value.trim().is_empty())
-            })
-            .unwrap_or_else(|| "unknown-agent".into());
-        let trace_dir = self
-            .home_dir
-            .join(".holon")
-            .join("http-trace")
-            .join(sanitize_trace_path_segment(&agent_id));
-        fs::create_dir_all(&trace_dir).ok()?;
-        let sequence = OPENAI_HTTP_TRACE_SEQ.fetch_add(1, Ordering::Relaxed);
-        let created_at_ms = current_time_millis();
-        let file_path = trace_dir.join(format!("trace-{created_at_ms}-{sequence}.jsonl"));
-        let trace = OpenAiHttpTraceRequest {
-            file_path: Arc::new(file_path),
-        };
-        trace.write_event(json!({
-            "type": "request",
-            "created_at_ms": created_at_ms,
-            "sequence": sequence,
-            "agent_id": agent_id,
-            "provider": provider,
-            "model_ref": model_ref,
-            "endpoint_kind": endpoint_kind,
-            "url": redact_url(url),
-            "headers": redact_headers(headers),
-            "body": redact_json_secrets(body),
-        }));
-        Some(trace)
-    }
-}
-
-impl OpenAiHttpTraceRequest {
-    fn write_event(&self, event: Value) {
-        let Ok(line) = serde_json::to_string(&event) else {
-            return;
-        };
-        let Ok(mut file) = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(self.file_path.as_path())
-        else {
-            return;
-        };
-        let _ = writeln!(file, "{line}");
-    }
-}
-
-fn sanitize_trace_path_segment(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
-fn redact_headers(headers: &[(&str, String)]) -> Value {
-    Value::Array(
-        headers
-            .iter()
-            .map(|(name, value)| {
-                json!({
-                    "name": *name,
-                    "value": redact_header_value(name, value),
-                })
-            })
-            .collect(),
-    )
-}
-
-fn redact_header_map(headers: &reqwest::header::HeaderMap) -> Value {
-    Value::Array(
-        headers
-            .iter()
-            .map(|(name, value)| {
-                let value = value.to_str().unwrap_or("<non-utf8>");
-                json!({
-                    "name": name.as_str(),
-                    "value": redact_header_value(name.as_str(), value),
-                })
-            })
-            .collect(),
-    )
-}
-
 fn trace_response_headers(
-    trace: Option<&OpenAiHttpTraceRequest>,
+    trace: Option<&ProviderHttpTraceRequest>,
     status: reqwest::StatusCode,
     headers: &reqwest::header::HeaderMap,
 ) {
     if let Some(trace) = trace {
-        trace.write_event(json!({
-            "type": "response_headers",
-            "created_at_ms": current_time_millis(),
-            "status": status.as_u16(),
-            "headers": redact_header_map(headers),
-        }));
+        trace.write_response_headers(status, headers);
     }
 }
 
-fn trace_response_body(trace: Option<&OpenAiHttpTraceRequest>, body: &str) {
+fn trace_response_body(trace: Option<&ProviderHttpTraceRequest>, body: &str) {
     if let Some(trace) = trace {
-        trace.write_event(json!({
-            "type": "response_body",
-            "created_at_ms": current_time_millis(),
-            "bytes": body.len(),
-            "body": body,
-        }));
+        trace.write_response_body(body);
     }
 }
 
-fn trace_stream_chunk(trace: Option<&OpenAiHttpTraceRequest>, chunk: &[u8]) {
+fn trace_stream_chunk(trace: Option<&ProviderHttpTraceRequest>, chunk: &[u8]) {
     if let Some(trace) = trace {
-        trace.write_event(json!({
-            "type": "stream_chunk",
-            "created_at_ms": current_time_millis(),
-            "bytes": chunk.len(),
-            "text": String::from_utf8_lossy(chunk),
-        }));
+        trace.write_stream_chunk(chunk);
     }
 }
 
-fn trace_stream_terminal(trace: Option<&OpenAiHttpTraceRequest>, body: &Value) {
+fn trace_stream_terminal(trace: Option<&ProviderHttpTraceRequest>, body: &Value) {
     if let Some(trace) = trace {
-        trace.write_event(json!({
-            "type": "stream_terminal_response",
-            "created_at_ms": current_time_millis(),
-            "body": body,
-        }));
+        trace.write_stream_terminal(body);
     }
-}
-
-fn current_time_millis() -> u128 {
-    SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()
-        .map(|duration| duration.as_millis())
-        .unwrap_or_default()
-}
-
-fn redact_header_value(name: &str, value: &str) -> String {
-    let lowered = name.to_ascii_lowercase();
-    if matches!(
-        lowered.as_str(),
-        "authorization" | "proxy-authorization" | "cookie" | "set-cookie" | "x-api-key"
-    ) {
-        "[REDACTED]".into()
-    } else {
-        value.into()
-    }
-}
-
-fn redact_url(raw: &str) -> String {
-    let Ok(mut url) = reqwest::Url::parse(raw) else {
-        return raw.into();
-    };
-    if url.password().is_some() {
-        let _ = url.set_password(Some("[REDACTED]"));
-    }
-    if !url.username().is_empty() {
-        let _ = url.set_username("[REDACTED]");
-    }
-    let redacted_pairs = url
-        .query_pairs()
-        .map(|(key, value)| {
-            let lowered = key.to_ascii_lowercase();
-            let value = if lowered.contains("key")
-                || lowered.contains("token")
-                || lowered.contains("secret")
-            {
-                "[REDACTED]".into()
-            } else {
-                value.into_owned()
-            };
-            (key.into_owned(), value)
-        })
-        .collect::<Vec<_>>();
-    if !redacted_pairs.is_empty() {
-        url.query_pairs_mut().clear().extend_pairs(redacted_pairs);
-    }
-    url.to_string()
-}
-
-fn redact_json_secrets(value: &Value) -> Value {
-    match value {
-        Value::Object(map) => Value::Object(
-            map.iter()
-                .map(|(key, value)| {
-                    let lowered = key.to_ascii_lowercase();
-                    let value = if is_secret_json_key(&lowered) {
-                        Value::String("[REDACTED]".into())
-                    } else {
-                        redact_json_secrets(value)
-                    };
-                    (key.clone(), value)
-                })
-                .collect(),
-        ),
-        Value::Array(items) => Value::Array(items.iter().map(redact_json_secrets).collect()),
-        other => other.clone(),
-    }
-}
-
-fn is_secret_json_key(lowered: &str) -> bool {
-    lowered.contains("api_key")
-        || lowered.contains("apikey")
-        || lowered.contains("secret")
-        || lowered == "authorization"
-        || lowered == "token"
-        || lowered.ends_with("_token")
-        || lowered.starts_with("token_")
-        || lowered.contains("_token_")
 }
 
 fn request_agent_id(request: &ProviderTurnRequest) -> Option<&str> {
@@ -698,7 +468,7 @@ impl AgentProvider for OpenAiProvider {
             .as_ref()
             .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
             .unwrap_or_default();
-        let trace = OpenAiHttpTrace::from_env(self.trace_home_dir.clone());
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
         if let Some(remote_compaction) = maybe_compact_openai_request_plan(
             &self.continuation,
             &mut plan,
@@ -802,7 +572,7 @@ impl AgentProvider for OpenAiCodexProvider {
             ("OpenAI-Beta", "responses=experimental".to_string()),
             ("originator", self.originator.clone()),
         ];
-        let trace = OpenAiHttpTrace::from_env(self.trace_home_dir.clone());
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
         if let Some(remote_compaction) = maybe_compact_openai_request_plan(
             &self.continuation,
             &mut plan,
@@ -895,7 +665,7 @@ impl AgentProvider for OpenAiChatCompletionsProvider {
             .as_ref()
             .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
             .unwrap_or_default();
-        let trace = OpenAiHttpTrace::from_env(self.trace_home_dir.clone());
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
 
         // Send to /v1/chat/completions endpoint
         let parsed = match send_chat_completion_request(
@@ -1898,7 +1668,7 @@ async fn maybe_compact_openai_provider_window(
     client: &Client,
     compact_url: String,
     headers: Vec<(&str, String)>,
-    trace: Option<&OpenAiHttpTrace>,
+    trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
 ) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
     let Some(scope) = scope else {
@@ -2134,7 +1904,7 @@ async fn maybe_compact_openai_request_plan(
     client: &Client,
     compact_url: String,
     headers: Vec<(&str, String)>,
-    trace: Option<&OpenAiHttpTrace>,
+    trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
 ) -> Option<ProviderOpenAiRemoteCompactionDiagnostics> {
     if plan.diagnostics.request_lowering_mode != "incremental_continuation" {
@@ -2998,14 +2768,15 @@ async fn send_chat_completion_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
-    trace: Option<&OpenAiHttpTrace>,
+    trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
 ) -> Result<ParsedOpenAiResponse> {
+    let model_ref = provider_model_ref("openai", &body);
     let request_trace = trace.and_then(|trace| {
         trace.begin_request(
             agent_id,
             "openai",
-            Some(&provider_model_ref("openai", &body)),
+            Some(&model_ref),
             url.as_str(),
             "chat_completions",
             &headers,
@@ -3022,9 +2793,10 @@ async fn send_chat_completion_request(
         "OpenAI Chat Completions request failed",
         "request_send",
         "openai",
-        Some(&provider_model_ref("openai", &body)),
+        Some(&model_ref),
         Some(url.as_str()),
         true,
+        request_trace.as_ref(),
     )
     .await?;
     trace_response_headers(
@@ -3041,17 +2813,21 @@ async fn send_chat_completion_request(
             "OpenAI Chat Completions request failed",
             status,
             body,
+            Some(&model_ref),
+            Some(url.as_str()),
+            request_trace.as_ref(),
         ));
     }
 
     let body = response.text().await.map_err(|error| {
-        classify_reqwest_transport_error(
+        classify_reqwest_transport_error_with_trace(
             "OpenAI Chat Completions response body failed",
             "response_body",
             "openai",
-            Some(&provider_model_ref("openai", &body)),
+            Some(&model_ref),
             Some(url.as_str()),
             error,
+            request_trace.as_ref(),
         )
     })?;
     trace_response_body(request_trace.as_ref(), &body);
@@ -3066,19 +2842,40 @@ fn classify_chat_completion_status_error(
     context: &str,
     status: reqwest::StatusCode,
     body: String,
+    model_ref: Option<&str>,
+    url: Option<&str>,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> anyhow::Error {
     // Try to parse as OpenAI error response
     if let Ok(error_json) = serde_json::from_str::<Value>(&body) {
         if let Some(error_obj) = error_json.get("error") {
-            return classify_openai_chat_completion_error(context, error_obj);
+            return classify_openai_chat_completion_error(
+                context, error_obj, status, model_ref, url, trace,
+            );
         }
     }
 
     // Fallback to generic status error classification
-    classify_status_error(context, status, body)
+    classify_status_error_with_trace(
+        context,
+        "response_status",
+        Some("openai"),
+        model_ref,
+        url,
+        status,
+        body,
+        trace,
+    )
 }
 
-pub(crate) fn classify_openai_chat_completion_error(context: &str, error: &Value) -> anyhow::Error {
+pub(crate) fn classify_openai_chat_completion_error(
+    context: &str,
+    error: &Value,
+    status: reqwest::StatusCode,
+    model_ref: Option<&str>,
+    url: Option<&str>,
+    trace: Option<&ProviderHttpTraceRequest>,
+) -> anyhow::Error {
     let error_type = error
         .get("type")
         .and_then(Value::as_str)
@@ -3148,8 +2945,17 @@ pub(crate) fn classify_openai_chat_completion_error(context: &str, error: &Value
 
     provider_transport_error(
         classification,
-        None,
-        None,
+        Some(status.as_u16()),
+        Some(crate::provider::ProviderTransportDiagnostics {
+            stage: "response_status".into(),
+            provider: Some("openai".into()),
+            model_ref: model_ref.map(ToString::to_string),
+            url: url.map(crate::provider::retry::sanitize_transport_url),
+            status: Some(status.as_u16()),
+            reqwest: None,
+            http_trace: trace.and_then(|trace| trace.diagnostics(Some(status.as_u16()))),
+            source_chain: Vec::new(),
+        }),
         format!("{}: {}", context, detail),
     )
 }
@@ -3330,6 +3136,7 @@ pub(crate) async fn send_chat_completion_stream_request(
         Some(&provider_model_ref("openai", &body)),
         Some(url.as_str()),
         true,
+        None,
     )
     .await?;
 
@@ -3340,6 +3147,9 @@ pub(crate) async fn send_chat_completion_stream_request(
             "OpenAI Chat Completions streaming request failed",
             status,
             body,
+            None,
+            None,
+            None,
         ));
     }
 
@@ -3358,13 +3168,14 @@ async fn read_chat_completion_stream(response: Response) -> Result<Value> {
     let mut data_lines = Vec::new();
 
     while let Some(chunk) = response.chunk().await.map_err(|error| {
-        classify_reqwest_transport_error(
+        crate::provider::retry::classify_reqwest_transport_error_with_trace(
             "OpenAI Chat Completions streaming response failed",
             "streaming_response_body",
             "openai",
             None,
             None,
             error,
+            None,
         )
     })? {
         pending.push_str(&String::from_utf8_lossy(&chunk));
@@ -3645,14 +3456,15 @@ async fn send_openai_responses_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
-    trace: Option<&OpenAiHttpTrace>,
+    trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
 ) -> Result<ParsedOpenAiResponse> {
+    let model_ref = provider_model_ref("openai", &body);
     let request_trace = trace.and_then(|trace| {
         trace.begin_request(
             agent_id,
             "openai",
-            Some(&provider_model_ref("openai", &body)),
+            Some(&model_ref),
             url.as_str(),
             "responses",
             &headers,
@@ -3669,9 +3481,10 @@ async fn send_openai_responses_request(
         "OpenAI-style request failed",
         "request_send",
         "openai",
-        Some(&provider_model_ref("openai", &body)),
+        Some(&model_ref),
         Some(url.as_str()),
         true,
+        request_trace.as_ref(),
     )
     .await?;
     trace_response_headers(
@@ -3684,21 +3497,27 @@ async fn send_openai_responses_request(
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         trace_response_body(request_trace.as_ref(), &body);
-        return Err(classify_status_error(
+        return Err(classify_status_error_with_trace(
             "OpenAI-style request failed",
+            "response_status",
+            Some("openai"),
+            Some(&model_ref),
+            Some(url.as_str()),
             status,
             body,
+            request_trace.as_ref(),
         ));
     }
 
     let body = response.text().await.map_err(|error| {
-        classify_reqwest_transport_error(
+        classify_reqwest_transport_error_with_trace(
             "OpenAI-style response body failed",
             "response_body",
             "openai",
-            Some(&provider_model_ref("openai", &body)),
+            Some(&model_ref),
             Some(url.as_str()),
             error,
+            request_trace.as_ref(),
         )
     })?;
     trace_response_body(request_trace.as_ref(), &body);
@@ -3712,14 +3531,15 @@ async fn send_openai_compact_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
-    trace: Option<&OpenAiHttpTrace>,
+    trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
 ) -> Result<Vec<Value>> {
+    let model_ref = provider_model_ref("openai", &body);
     let request_trace = trace.and_then(|trace| {
         trace.begin_request(
             agent_id,
             "openai",
-            Some(&provider_model_ref("openai", &body)),
+            Some(&model_ref),
             url.as_str(),
             OPENAI_RESPONSES_COMPACT_ENDPOINT_KIND,
             &headers,
@@ -3736,9 +3556,10 @@ async fn send_openai_compact_request(
         "OpenAI compact request failed",
         "request_send",
         "openai",
-        Some(&provider_model_ref("openai", &body)),
+        Some(&model_ref),
         Some(url.as_str()),
         true,
+        request_trace.as_ref(),
     )
     .await?;
     trace_response_headers(
@@ -3751,21 +3572,27 @@ async fn send_openai_compact_request(
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         trace_response_body(request_trace.as_ref(), &body);
-        return Err(classify_status_error(
+        return Err(classify_status_error_with_trace(
             "OpenAI compact request failed",
+            "response_status",
+            Some("openai"),
+            Some(&model_ref),
+            Some(url.as_str()),
             status,
             body,
+            request_trace.as_ref(),
         ));
     }
 
     let response_body = response.text().await.map_err(|error| {
-        classify_reqwest_transport_error(
+        classify_reqwest_transport_error_with_trace(
             "OpenAI compact response body failed",
             "response_body",
             "openai",
-            Some(&provider_model_ref("openai", &body)),
+            Some(&model_ref),
             Some(url.as_str()),
             error,
+            request_trace.as_ref(),
         )
     })?;
     trace_response_body(request_trace.as_ref(), &response_body);
@@ -3792,14 +3619,15 @@ async fn send_openai_responses_streaming_request(
     url: String,
     body: Value,
     headers: Vec<(&str, String)>,
-    trace: Option<&OpenAiHttpTrace>,
+    trace: Option<&ProviderHttpTrace>,
     agent_id: Option<&str>,
 ) -> Result<ParsedOpenAiResponse> {
+    let model_ref = provider_model_ref("openai-codex", &body);
     let request_trace = trace.and_then(|trace| {
         trace.begin_request(
             agent_id,
             "openai-codex",
-            Some(&provider_model_ref("openai-codex", &body)),
+            Some(&model_ref),
             url.as_str(),
             "responses_streaming",
             &headers,
@@ -3816,9 +3644,10 @@ async fn send_openai_responses_streaming_request(
         "OpenAI-style streaming request failed",
         "streaming_request_send",
         "openai-codex",
-        Some(&provider_model_ref("openai-codex", &body)),
+        Some(&model_ref),
         Some(url.as_str()),
         false,
+        request_trace.as_ref(),
     )
     .await?;
     trace_response_headers(
@@ -3831,10 +3660,15 @@ async fn send_openai_responses_streaming_request(
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         trace_response_body(request_trace.as_ref(), &body);
-        return Err(classify_status_error(
+        return Err(classify_status_error_with_trace(
             "OpenAI-style streaming request failed",
+            "response_status",
+            Some("openai-codex"),
+            Some(&model_ref),
+            Some(url.as_str()),
             status,
             body,
+            request_trace.as_ref(),
         ));
     }
 
@@ -3851,34 +3685,40 @@ async fn send_openai_request(
     model_ref: Option<&str>,
     url: Option<&str>,
     enforce_full_request_deadline: bool,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> Result<Response> {
     let timeout = request_send_timeout();
     if enforce_full_request_deadline {
         request = request.timeout(timeout);
         return request.send().await.map_err(|error| {
-            classify_reqwest_transport_error(context, stage, provider, model_ref, url, error)
+            classify_reqwest_transport_error_with_trace(
+                context, stage, provider, model_ref, url, error, trace,
+            )
         });
     }
     tokio::time::timeout(timeout, request.send())
         .await
         .map_err(|_| {
-            timeout_transport_error(
+            timeout_transport_error_with_trace(
                 context,
                 stage,
                 provider,
                 model_ref,
                 url,
                 format!("request_send_timeout_ms={}", timeout.as_millis()),
+                trace,
             )
         })?
         .map_err(|error| {
-            classify_reqwest_transport_error(context, stage, provider, model_ref, url, error)
+            classify_reqwest_transport_error_with_trace(
+                context, stage, provider, model_ref, url, error, trace,
+            )
         })
 }
 
 async fn read_openai_streaming_response(
     response: Response,
-    trace: Option<&OpenAiHttpTraceRequest>,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> Result<Value> {
     let idle_timeout = stream_idle_timeout();
     read_openai_streaming_response_with_timeout(response, idle_timeout, trace).await
@@ -3887,7 +3727,7 @@ async fn read_openai_streaming_response(
 async fn read_openai_streaming_response_with_timeout(
     response: Response,
     idle_timeout: Duration,
-    trace: Option<&OpenAiHttpTraceRequest>,
+    trace: Option<&ProviderHttpTraceRequest>,
 ) -> Result<Value> {
     const MAX_STREAMED_OUTPUT_ITEMS: usize = 128;
 
@@ -3899,7 +3739,7 @@ async fn read_openai_streaming_response_with_timeout(
     while let Some(chunk) = tokio::time::timeout(idle_timeout, response.chunk())
         .await
         .map_err(|_| {
-            timeout_transport_error(
+            timeout_transport_error_with_trace(
                 "OpenAI-style streaming response body timed out",
                 "streaming_response_body",
                 "openai-codex",
@@ -3909,16 +3749,18 @@ async fn read_openai_streaming_response_with_timeout(
                     "timed out waiting for SSE chunk after {} ms",
                     idle_timeout.as_millis()
                 ),
+                trace,
             )
         })?
         .map_err(|error| {
-            classify_reqwest_transport_error(
+            classify_reqwest_transport_error_with_trace(
                 "OpenAI-style streaming response body failed",
                 "streaming_response_body",
                 "openai-codex",
                 None,
                 None,
                 error,
+                trace,
             )
         })?
     {
@@ -4382,7 +4224,6 @@ mod tests {
         build_openai_responses_request, chat_completions_url, incremental_diagnostics,
         latest_openai_compaction_index, openai_compaction_trigger_for_request_plan,
         openai_compaction_trigger_for_window, openai_provider_window_compaction_candidate,
-        redact_headers, redact_json_secrets, redact_url, sanitize_trace_path_segment,
         OpenAiCompactionPolicy, OpenAiProviderWindow, OpenAiRequestPlan, OpenAiRequestShape,
         OpenAiResponsesTransportContract, ToolSchemaContract,
     };
@@ -4391,7 +4232,6 @@ mod tests {
         ProviderTurnRequest,
     };
     use serde_json::json;
-    use std::fs;
 
     #[test]
     fn chat_completions_url_accepts_openai_compatible_base_urls() {
@@ -4590,83 +4430,5 @@ mod tests {
             wire_shape: json!({ "model": "gpt-test" }),
             prompt_frame: crate::provider::ProviderPromptFrame::plain("system"),
         }
-    }
-
-    #[test]
-    fn openai_http_trace_redacts_secrets() {
-        let headers = redact_headers(&[
-            ("authorization", "Bearer secret".into()),
-            ("openai-beta", "responses=experimental".into()),
-        ]);
-        assert_eq!(headers[0]["value"], "[REDACTED]");
-        assert_eq!(headers[1]["value"], "responses=experimental");
-
-        assert_eq!(
-            redact_url("https://user:pass@example.com/v1/responses?api_key=secret&debug=1"),
-            "https://%5BREDACTED%5D:%5BREDACTED%5D@example.com/v1/responses?api_key=%5BREDACTED%5D&debug=1"
-        );
-
-        let body = redact_json_secrets(&json!({
-            "model": "gpt-test",
-            "max_output_tokens": 4096,
-            "access_token": "secret",
-            "nested": {
-                "api_key": "secret",
-                "prompt_tokens": 123,
-                "reasoning_tokens": 45
-            }
-        }));
-        assert_eq!(body["access_token"], "[REDACTED]");
-        assert_eq!(body["nested"]["api_key"], "[REDACTED]");
-        assert_eq!(body["max_output_tokens"], 4096);
-        assert_eq!(body["nested"]["prompt_tokens"], 123);
-        assert_eq!(body["nested"]["reasoning_tokens"], 45);
-        assert_eq!(body["model"], "gpt-test");
-    }
-
-    #[test]
-    fn openai_http_trace_sanitizes_agent_path_segment() {
-        assert_eq!(
-            sanitize_trace_path_segment("agent/with spaces"),
-            "agent_with_spaces"
-        );
-    }
-
-    #[test]
-    fn openai_http_trace_writes_full_request_body_under_home() {
-        let home = tempfile::tempdir().unwrap();
-        let trace = super::OpenAiHttpTrace {
-            home_dir: home.path().to_path_buf(),
-        };
-        let body = json!({
-            "model": "gpt-test",
-            "input": [{ "type": "message", "content": "hello" }],
-            "tools": [{ "type": "function", "name": "ApplyPatch" }]
-        });
-
-        trace
-            .begin_request(
-                Some("agent/one"),
-                "openai",
-                Some("openai/gpt-test"),
-                "https://api.openai.com/v1/responses",
-                "responses",
-                &[("authorization", "Bearer secret".into())],
-                &body,
-            )
-            .expect("trace should be written");
-
-        let trace_dir = home.path().join(".holon/http-trace/agent_one");
-        let entries = fs::read_dir(trace_dir)
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        assert_eq!(entries.len(), 1);
-        let line = fs::read_to_string(entries[0].path()).unwrap();
-        let event: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
-        assert_eq!(event["type"], "request");
-        assert_eq!(event["body"]["input"][0]["content"], "hello");
-        assert_eq!(event["body"]["tools"][0]["name"], "ApplyPatch");
-        assert_eq!(event["headers"][0]["value"], "[REDACTED]");
     }
 }

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -66,6 +66,10 @@ impl RuntimeHandle {
             if let Some(url) = diag.url.clone() {
                 metadata.insert("url".into(), Self::sanitize_failure_artifact_url(&url));
             }
+            if let Some(http_trace) = diag.http_trace.as_ref() {
+                metadata.insert("http_trace_mode".into(), http_trace.mode.clone());
+                metadata.insert("http_trace_path".into(), http_trace.path.clone());
+            }
             metadata.insert(
                 "reqwest_is_timeout".into(),
                 diag.reqwest

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -754,6 +754,7 @@ impl AgentProvider for FailingTimelineProvider {
                             is_redirect: false,
                             status: None,
                         }),
+                        http_trace: None,
                         source_chain: vec!["connection reset by peer".into()],
                     }),
                 }],

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -39,8 +39,13 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
     provider_config.context_management.trigger_input_tokens = 1;
     provider_config.context_management.keep_recent_tool_uses = 1;
 
-    let provider =
-        AnthropicProvider::from_runtime_config(provider_config, model, runtime_max_output_tokens)?;
+    let trace_home_dir = tempfile::tempdir()?.keep();
+    let provider = AnthropicProvider::from_runtime_config(
+        provider_config,
+        model,
+        runtime_max_output_tokens,
+        &trace_home_dir,
+    )?;
 
     let tool = ToolSpec {
         name: "ProbeTool".into(),


### PR DESCRIPTION
## Summary

Fixes #1264.

- Adds a provider-wide HTTP trace helper and attaches trace metadata to `ProviderTransportDiagnostics`.
- Ensures HTTP status failures populate `ProviderTransportDiagnostics.status` instead of only `ProviderTransportError.status`.
- Routes OpenAI and Anthropic status/transport errors through the shared diagnostics path.
- Preserves trace path/mode in runtime failure artifact metadata when available.

## Notes

- Existing `HOLON_PROVIDER_HTTP_TRACE=1` remains the all-request trace mode.
- New `HOLON_PROVIDER_HTTP_FAILURE_TRACE=1` enables failure-only trace files: request/response events are buffered and only written when diagnostics are produced for a failed provider request.
- Full request/response content stays in trace files rather than inline event JSON.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -q routing_auth_doctor:: -- --nocapture`
- `cargo test -q provider_http_trace -- --nocapture`
- `cargo test -q chat_completion_provider_classifies_rate_limit_errors -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
