### PR TITLE
fix: address provider diagnostics review follow-up

### DIFF
--- a/src/provider/http_trace.rs
+++ b/src/provider/http_trace.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{self, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
@@ -14,6 +14,7 @@ static PROVIDER_HTTP_TRACE_SEQ: AtomicU64 = AtomicU64::new(1);
 
 const PROVIDER_HTTP_TRACE_ENV: &str = "HOLON_PROVIDER_HTTP_TRACE";
 const PROVIDER_HTTP_FAILURE_TRACE_ENV: &str = "HOLON_PROVIDER_HTTP_FAILURE_TRACE";
+const PROVIDER_HTTP_FAILURE_TRACE_MAX_EVENTS: usize = 128;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderHttpTraceDiagnostics {
@@ -177,14 +178,18 @@ impl ProviderHttpTraceRequest {
         let Ok(mut guard) = self.inner.lock() else {
             return;
         };
-        guard.events.push(event.clone());
-        if guard.mode == ProviderHttpTraceMode::All {
-            let already_open = guard.file_path.is_some();
-            let Some(path) = ensure_trace_file(&mut guard) else {
-                return;
-            };
-            if already_open {
+        match guard.mode {
+            ProviderHttpTraceMode::All => {
+                let Some(path) = ensure_trace_file(&mut guard) else {
+                    return;
+                };
                 append_trace_event(&path, &event);
+            }
+            ProviderHttpTraceMode::FailureOnly => {
+                guard.events.push(event);
+                if guard.events.len() > PROVIDER_HTTP_FAILURE_TRACE_MAX_EVENTS {
+                    guard.events.remove(0);
+                }
             }
         }
     }
@@ -205,11 +210,24 @@ fn ensure_trace_file(state: &mut ProviderHttpTraceRequestState) -> Option<PathBu
         "trace-{created_at_ms}-{sequence}.jsonl",
         sequence = state.sequence
     ));
-    for event in &state.events {
-        append_trace_event(&path, event);
+    if !state.events.is_empty() {
+        write_trace_events(&path, &state.events);
+        state.events.clear();
     }
     state.file_path = Some(path.clone());
     Some(path)
+}
+
+fn write_trace_events(path: &Path, events: &[Value]) {
+    let Ok(mut file) = File::create(path) else {
+        return;
+    };
+    for event in events {
+        let Ok(line) = serde_json::to_string(event) else {
+            continue;
+        };
+        let _ = writeln!(file, "{line}");
+    }
 }
 
 fn append_trace_event(path: &Path, event: &Value) {

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -190,6 +190,7 @@ impl AgentProvider for AnthropicProvider {
         let request_payload = serde_json::to_value(&request_body)?;
 
         let url = format!("{}/v1/messages", self.base_url);
+        let model_ref = format!("anthropic/{}", self.model);
         let mut headers = vec![
             ("content-type", "application/json".to_string()),
             ("authorization", format!("Bearer {}", self.auth_token)),
@@ -210,7 +211,7 @@ impl AgentProvider for AnthropicProvider {
                     .as_ref()
                     .map(|cache| cache.agent_id.as_str()),
                 "anthropic",
-                Some(&format!("anthropic/{}", self.model)),
+                Some(&model_ref),
                 url.as_str(),
                 "messages",
                 &headers,
@@ -231,27 +232,27 @@ impl AgentProvider for AnthropicProvider {
                     "Anthropic request failed",
                     "request_send",
                     "anthropic",
-                    Some(&format!("anthropic/{}", self.model)),
-                    Some(&format!("{}/v1/messages", self.base_url)),
+                    Some(&model_ref),
+                    Some(url.as_str()),
                     error,
                     request_trace.as_ref(),
                 )
             })?;
-        request_trace
-            .as_ref()
-            .map(|trace| trace.write_response_headers(response.status(), response.headers()));
+        if let Some(trace) = request_trace.as_ref() {
+            trace.write_response_headers(response.status(), response.headers());
+        }
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            request_trace
-                .as_ref()
-                .map(|trace| trace.write_response_body(&body));
+            if let Some(trace) = request_trace.as_ref() {
+                trace.write_response_body(&body);
+            }
             return Err(classify_status_error_with_trace(
                 "Anthropic request failed",
                 "response_status",
                 Some("anthropic"),
-                Some(&format!("anthropic/{}", self.model)),
+                Some(&model_ref),
                 Some(url.as_str()),
                 status,
                 body,
@@ -264,15 +265,15 @@ impl AgentProvider for AnthropicProvider {
                 "Anthropic response body failed",
                 "response_body",
                 "anthropic",
-                Some(&format!("anthropic/{}", self.model)),
-                Some(&format!("{}/v1/messages", self.base_url)),
+                Some(&model_ref),
+                Some(url.as_str()),
                 error,
                 request_trace.as_ref(),
             )
         })?;
-        request_trace
-            .as_ref()
-            .map(|trace| trace.write_response_body(&response_body));
+        if let Some(trace) = request_trace.as_ref() {
+            trace.write_response_body(&response_body);
+        }
         let parsed: MessagesResponse = serde_json::from_str(&response_body)
             .map_err(|error| invalid_response_error("invalid Anthropic JSON", error))?;
         let input_tokens = parsed

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -14,6 +14,19 @@ impl RuntimeHandle {
         url.to_string()
     }
 
+    fn sanitize_failure_artifact_path(raw: &str) -> String {
+        const TRACE_MARKER: &str = ".holon/http-trace/";
+        raw.find(TRACE_MARKER)
+            .map(|index| raw[index..].to_string())
+            .unwrap_or_else(|| {
+                std::path::Path::new(raw)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("<redacted-path>")
+                    .to_string()
+            })
+    }
+
     fn metadata_enum_value<T: serde::Serialize>(value: &T) -> String {
         let json = to_json_value(value);
         json.as_str()
@@ -68,7 +81,10 @@ impl RuntimeHandle {
             }
             if let Some(http_trace) = diag.http_trace.as_ref() {
                 metadata.insert("http_trace_mode".into(), http_trace.mode.clone());
-                metadata.insert("http_trace_path".into(), http_trace.path.clone());
+                metadata.insert(
+                    "http_trace_path".into(),
+                    Self::sanitize_failure_artifact_path(&http_trace.path),
+                );
             }
             metadata.insert(
                 "reqwest_is_timeout".into(),

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -16,8 +16,8 @@ pub(crate) use crate::{
     provider::{
         provider_turn_error, AgentProvider, ConversationMessage, ModelBlock,
         ProviderAttemptOutcome, ProviderAttemptRecord, ProviderAttemptTimeline,
-        ProviderTransportDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
-        ReqwestTransportDiagnostics, StubProvider,
+        ProviderHttpTraceDiagnostics, ProviderTransportDiagnostics, ProviderTurnRequest,
+        ProviderTurnResponse, ReqwestTransportDiagnostics, StubProvider,
     },
     storage::AppStorage,
     system::{ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind},
@@ -754,7 +754,12 @@ impl AgentProvider for FailingTimelineProvider {
                             is_redirect: false,
                             status: None,
                         }),
-                        http_trace: None,
+                        http_trace: Some(ProviderHttpTraceDiagnostics {
+                            mode: "failure_only".into(),
+                            path: "/Users/example/.holon/http-trace/default/trace-1-1.jsonl"
+                                .into(),
+                            status: None,
+                        }),
                         source_chain: vec!["connection reset by peer".into()],
                     }),
                 }],

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -1166,6 +1166,10 @@ async fn runtime_failure_artifacts_preserve_provider_attempt_timeline() {
         failure.data["failure_artifact"]["metadata"]["url"],
         "https://example.com/v1/responses"
     );
+    assert_eq!(
+        failure.data["failure_artifact"]["metadata"]["http_trace_path"],
+        ".holon/http-trace/default/trace-1-1.jsonl"
+    );
     assert!(failure.data["token_usage"].is_null());
     assert!(failure.data["provider_attempt_timeline"]["winning_model_ref"].is_null());
     assert!(!failure.data["error_chain"].as_array().unwrap().is_empty());

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -39,12 +39,12 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
     provider_config.context_management.trigger_input_tokens = 1;
     provider_config.context_management.keep_recent_tool_uses = 1;
 
-    let trace_home_dir = tempfile::tempdir()?.keep();
+    let trace_home_dir = tempfile::tempdir()?;
     let provider = AnthropicProvider::from_runtime_config(
         provider_config,
         model,
         runtime_max_output_tokens,
-        &trace_home_dir,
+        trace_home_dir.path(),
     )?;
 
     let tool = ToolSpec {


### PR DESCRIPTION
## Summary

Follow-up to #1269 review comments.

- Avoid leaking absolute HTTP trace paths in failure artifact metadata by storing only the `.holon/http-trace/...` suffix.
- Replace side-effect-only `Option::map` calls in Anthropic transport with explicit `if let` blocks and reuse the precomputed URL/model ref for diagnostics.
- Keep live Anthropic trace temp dirs scoped to the test instead of persisting them with `TempDir::keep()`.
- Bound failure-only trace buffering and clear buffered events after writing the trace file.
- Batch-write buffered trace events instead of opening the trace file once per event.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -q provider_http_trace -- --nocapture`
- `cargo test -q runtime_failure_artifacts_preserve_provider_attempt_timeline -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
