### PR TITLE
docs: add scheduler and agent state RFCs

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -10,6 +10,7 @@ For a short architecture map and reading path, see
 
 - [Agent Control Plane Model](./agent-control-plane-model.md)
 - [Agent Lifecycle Control Posture](./agent-lifecycle-control-posture.md)
+- [Agent State Model And Runtime Projection](./agent-state-model.md)
 - [Agent Profile Model](./agent-profile-model.md)
 - [Runtime Scheduler Contract](./runtime-scheduler-contract.md)
 - [Result Closure](./result-closure.md)
@@ -24,6 +25,7 @@ For a short architecture map and reading path, see
 - [Turn Model Lineage And Recovery](./turn-model-lineage-and-recovery.md)
 - [Operator Notification and Intervention](./operator-wait-and-intervention.md)
 - [Waiting Plane And Reactivation](./waiting-plane-and-reactivation.md)
+- [Scheduler Wait State And Recoverable Agent Continuation](./scheduler-wait-state.md)
 - [External Trigger Capability And Providerless Ingress](./external-trigger-capability.md)
 
 ## Provenance, Policy, And Execution

--- a/docs/rfcs/agent-state-model.md
+++ b/docs/rfcs/agent-state-model.md
@@ -1,0 +1,447 @@
+---
+title: RFC: Agent State Model And Runtime Projection
+date: 2026-05-19
+status: draft
+---
+
+# RFC: Agent State Model And Runtime Projection
+
+## Summary
+
+Holon should define agent state as a layered runtime model rather than a single
+opaque status string or an ever-growing `AgentSummary` payload.
+
+An agent's observable state should be derived from authoritative records:
+agent identity and lifecycle records, the current turn, queue state, WorkItems,
+tasks, wait conditions, external trigger capability, and capability snapshots.
+`AgentSummary` should be a stable projection assembled from those sources, not
+the state source that the scheduler, UI, or API consumers treat as canonical.
+
+This RFC complements
+[Scheduler Wait State And Recoverable Agent Continuation](./scheduler-wait-state.md).
+That RFC defines how WorkItems become runnable, waiting, blocked, or completed.
+This RFC defines how the agent as a whole should express its runtime posture
+across queue, turn, work, task, wait, wake, and capability state.
+
+## Problem
+
+Holon agents are long-lived runtime actors. A single agent can have:
+
+- a durable identity and lifecycle;
+- a current or recently completed turn;
+- pending input in its queue;
+- open WorkItems with different scheduling states;
+- active command or child-agent tasks;
+- external triggers and waiting intents;
+- active model, tool, and execution capabilities;
+- user-facing state shown through `/agents`, `/state`, `AgentGet`, or TUI.
+
+Today these concepts are easy to collapse into vague labels such as
+`sleeping`, `idle`, `waiting`, or `running`. Those labels hide important
+distinctions:
+
+- sleeping with runnable work is not truly idle;
+- waiting for an internal task is different from waiting for external state;
+- waiting for the operator is different from being blocked;
+- queue input should take precedence over passive sleep posture;
+- model/provider availability is capability state, not lifecycle state;
+- `AgentSummary` is useful for display but should not become the source of
+  truth for scheduling.
+
+Without an explicit state model, different runtime surfaces can disagree:
+
+- UI may show an agent as idle while the scheduler sees runnable work;
+- scheduler code may depend on fields that were intended only for display;
+- API consumers may not know which fields are stable contract and which are
+  debug or convenience projection;
+- runtime changes may keep adding unrelated fields to `AgentSummary`;
+- `Sleep` may be mistaken for an authoritative agent state instead of a
+  turn-end posture.
+
+## Goals
+
+- Define the authoritative layers that make up agent state.
+- Distinguish durable state, runtime state, derived state, and user-facing
+  projection.
+- Define an agent-level scheduling posture that can be derived from queue,
+  turn, WorkItem, task, and wait state.
+- Make clear that `Sleep` is not the source of truth for whether an agent is
+  idle.
+- Keep `AgentSummary` stable and user-facing without making it a dumping ground
+  for internal records.
+- Give scheduler, API, and UI code a shared vocabulary for agent state.
+- Support incremental migration from the current runtime structures.
+
+## Non-goals
+
+- Do not design a UI layout.
+- Do not define provider-specific states such as GitHub checks, reviews,
+  deployments, or inbox policy.
+- Do not move every runtime record into `AgentSummary`.
+- Do not make agents manually maintain derived status strings.
+- Do not replace WorkItem scheduling state; this RFC consumes the WorkItem
+  state model defined by the scheduler wait-state RFC.
+- Do not require a large immediate schema rewrite before the projection is
+  useful.
+
+## Current structure
+
+The repository already has several relevant surfaces:
+
+- agent identity, profile, lifecycle, and execution snapshots;
+- WorkItem records with lifecycle, plan status, blockers, readiness, and todo
+  progress;
+- command and child task lifecycle records;
+- waiting intents and external trigger capability records;
+- runtime closure and scheduler logic;
+- `AgentSummary`, `AgentGet`, `/agents`, `/state`, and TUI-facing projections;
+- model/provider availability data exposed independently through the model
+  capability surface.
+
+This RFC does not propose replacing those records. It proposes clarifying which
+records are authoritative and how a stable agent projection should be derived.
+
+## State layers
+
+Agent state should be described in layers. Each layer has a different owner and
+stability expectation.
+
+### Agent identity and lifecycle
+
+Authoritative source: agent registry and lifecycle records.
+
+This layer answers:
+
+- which agent is this;
+- is the agent public or private;
+- who owns it;
+- which profile/template contract applies;
+- does the agent still exist;
+- is it active, archived, terminal, or otherwise unavailable.
+
+This state changes rarely and should be safe to expose through stable API
+projection.
+
+### Turn execution state
+
+Authoritative source: turn lifecycle and closure records.
+
+This layer answers:
+
+- is a model turn currently active;
+- what triggered the current or last turn;
+- did the last turn close normally, with an error, or by cancellation;
+- what posture did the agent submit at turn end.
+
+Turn state is transient. It is important for scheduling and operator
+observability, but it should not be confused with durable agent lifecycle.
+
+### Queue state
+
+Authoritative source: message queue and admission records.
+
+This layer answers:
+
+- are there pending operator, external, system, or self-enqueued messages;
+- what priority and provenance do they have;
+- is the agent eligible to start another turn.
+
+Queue state should take precedence over passive sleep posture. An agent with
+queued input is not merely asleep.
+
+### Work state
+
+Authoritative source: WorkItem records and the derived WorkItem scheduling
+model.
+
+This layer answers:
+
+- what is the current focused WorkItem;
+- which WorkItems are open, completed, queued, blocked, waiting for operator,
+  or runnable;
+- whether any WorkItem can be automatically continued.
+
+The scheduler wait-state RFC defines the WorkItem-level states:
+
+```text
+Runnable
+WaitingOperator
+WaitingTask
+WaitingExternal
+Blocked
+Completed
+```
+
+Agent state consumes those derived WorkItem states rather than reimplementing
+them as a separate hand-maintained status.
+
+### Task state
+
+Authoritative source: task lifecycle records.
+
+This layer answers:
+
+- are command tasks or child-agent tasks active;
+- are any tasks accepting input;
+- which WorkItems or waits depend on task results;
+- did task completion produce a continuation trigger.
+
+Task state is runtime-owned. Waiting for a task should be represented as a task
+dependency or wait condition, not as an unstructured `blocked_by` string.
+
+### Wait and wake state
+
+Authoritative source: wait condition, waiting intent, timer, task result,
+operator input, and external trigger records.
+
+This layer answers:
+
+- is the agent waiting for operator, task, external, or timer state;
+- which wake sources can reactivate it;
+- whether the wait is recoverable, weak, expired, resolved, or cancelled;
+- what continuation should run when a wake source fires.
+
+External trigger capability is part of the wake surface. It should be modeled
+as ingress capability or wake source, not as the whole agent state.
+
+### Capability state
+
+Authoritative source: runtime capability and provider snapshots.
+
+This layer answers:
+
+- which model is active;
+- which models/providers are currently available;
+- which tools and execution resources are exposed;
+- which workspace and execution environment are active.
+
+Capability state informs what the agent can do. It should not be overloaded as
+work state or lifecycle state.
+
+### User-facing projection
+
+Authoritative source: derived projection assembled from the above layers.
+
+This layer answers:
+
+- what should `/agents`, `/state`, `AgentGet`, and TUI show;
+- what status should be stable enough for clients to depend on;
+- what details are diagnostic and may remain runtime-internal.
+
+`AgentSummary` belongs to this layer. It should summarize stable facts and
+derived posture, but it should not become the primary store for queue, task,
+wait, or capability records.
+
+## Derived AgentSchedulingPosture
+
+The runtime should derive an agent-level scheduling posture from the layers
+above.
+
+Initial shape:
+
+```text
+AgentSchedulingPosture =
+  ActiveTurn
+  HasQueuedInput
+  HasRunnableWork
+  WaitingForTask
+  WaitingForExternal
+  WaitingForOperator
+  Blocked
+  Idle
+  Archived
+```
+
+This posture is not manually written by the agent. It is derived.
+
+Suggested precedence:
+
+1. `Archived` if the agent lifecycle is terminal or unavailable.
+2. `ActiveTurn` if a turn is currently executing.
+3. `HasQueuedInput` if admitted queue input is pending.
+4. `HasRunnableWork` if any open WorkItem is runnable.
+5. `WaitingForTask` if open work is waiting on runtime-owned task results.
+6. `WaitingForExternal` if open work is waiting on external wake sources.
+7. `WaitingForOperator` if open work requires operator input.
+8. `Blocked` if open work has only non-recoverable or unstructured blockers.
+9. `Idle` if no open work, queued input, active turn, or active wait remains.
+
+The exact precedence can evolve, but the important rule is that passive sleep
+posture must not hide higher-priority facts such as queued input or runnable
+work.
+
+## Sleep semantics
+
+`Sleep` should not be treated as the authoritative agent state.
+
+`Sleep` is a turn-end action that says the agent is yielding control after
+submitting whatever durable state it has chosen to submit. The runtime should
+then derive the actual agent posture from queue, WorkItem, task, wait, and
+lifecycle records.
+
+Examples:
+
+```text
+Sleep + runnable WorkItem
+  => AgentSchedulingPosture::HasRunnableWork
+  => runtime should enqueue or schedule continuation
+
+Sleep + active task wait
+  => AgentSchedulingPosture::WaitingForTask
+  => runtime can rest until task result continuation
+
+Sleep + needs_input WorkItem
+  => AgentSchedulingPosture::WaitingForOperator
+  => runtime should wait for operator input
+
+Sleep + no open work and no queue
+  => AgentSchedulingPosture::Idle
+```
+
+This keeps `sleeping` as a runtime posture, not a broad state bucket that
+swallows runnable, waiting, blocked, and idle cases.
+
+## AgentSummary contract
+
+`AgentSummary` should be a stable projection, not the canonical state store.
+
+It may include:
+
+- identity and lifecycle facts;
+- current workspace/profile/model summary;
+- current turn or execution snapshot;
+- current WorkItem focus and compact work-state summary;
+- derived `AgentSchedulingPosture`;
+- compact waiting/wake summary;
+- capability summary useful to clients.
+
+It should avoid:
+
+- embedding full WorkItem lists;
+- embedding full task output or task records;
+- embedding provider-specific business state;
+- duplicating large model/provider metadata when a separate capability endpoint
+  exists;
+- fields that scheduler logic must mutate directly to make state true.
+
+If a field is only useful for debugging, it should be clearly marked as a
+diagnostic projection or live under a separate debug endpoint.
+
+## API and UI expectations
+
+### `/agents`
+
+Should expose compact per-agent identity, lifecycle, and derived posture. It
+should be enough for a client to distinguish:
+
+- active;
+- queued;
+- runnable;
+- waiting for task;
+- waiting for external source;
+- waiting for operator;
+- blocked;
+- idle;
+- archived.
+
+### `/state`
+
+Should expose the bootstrap projection needed by the current client without
+becoming the canonical store for every runtime record. Large or independently
+scoped capability data should stay on dedicated endpoints where possible.
+
+### `AgentGet`
+
+Should provide a richer agent-plane projection, including derived posture and
+compact lineage/task/work summaries. It should not be treated as a transcript
+dump or raw ledger export.
+
+### TUI
+
+Should display derived posture and compact reasons rather than inferring state
+from vague labels. For example, "waiting for external wake" and "has runnable
+work" should be different display states even if the last turn ended with
+`Sleep`.
+
+## Scheduler contract
+
+The scheduler should rely on authoritative records and derived posture, not on
+display strings.
+
+Scheduler owns:
+
+- deriving agent posture from queue, turn, WorkItem, task, and wait state;
+- preventing silent indefinite rest when queued input or runnable work exists;
+- routing task, timer, operator, external, and system wake sources into
+  continuations;
+- exposing enough audit information to explain why an agent is or is not
+  runnable.
+
+Scheduler does not own:
+
+- interpreting provider-specific business state;
+- deciding that CI, review, deployment, or inbox state is semantically done;
+- maintaining user-facing display labels as source of truth;
+- stuffing every runtime detail into `AgentSummary`.
+
+## Migration plan
+
+### Phase 1: Document and name the layers
+
+- Adopt the state-layer vocabulary in RFCs and runtime comments.
+- Treat `AgentSummary` as projection in new code.
+- Avoid adding unrelated authoritative state directly to `AgentSummary`.
+
+### Phase 2: Introduce derived posture
+
+- Add an internal derived `AgentSchedulingPosture`.
+- Compute it from lifecycle, active turn, queue, WorkItem scheduling state,
+  task, and wait data.
+- Surface it in `AgentGet` and compact API projections.
+
+### Phase 3: Align closure and scheduler behavior
+
+- Make turn closure use derived posture when deciding whether sleep can become
+  true idle.
+- Ensure queued input and runnable WorkItems override indefinite sleep.
+- Ensure task and external waits are represented through structured wait
+  state where possible.
+
+### Phase 4: Normalize projection surfaces
+
+- Update `/agents`, `/state`, and TUI to display derived posture consistently.
+- Move large or independently scoped capability data behind dedicated
+  capability endpoints.
+- Keep debug-only fields out of stable client contracts.
+
+### Phase 5: Audit ambiguous states
+
+- Emit diagnostics for agents that appear idle while open work is runnable.
+- Emit diagnostics for unstructured blockers that look recoverable but have no
+  wait condition.
+- Emit diagnostics for external waits without a durable or recoverable wake
+  path, following the scheduler wait-state RFC.
+
+## Open questions
+
+- Should `AgentSchedulingPosture` be a single enum, or should the API expose a
+  primary posture plus secondary flags such as `has_active_tasks` and
+  `has_weak_external_wait`?
+- Should `HasQueuedInput` outrank `ActiveTurn` in any projection where queued
+  input indicates backpressure?
+- What is the minimal stable posture set needed by TUI and API clients?
+- Which existing `AgentSummary` fields should be classified as stable,
+  diagnostic, or deprecated?
+- How much wait detail should be exposed in compact `/agents` responses versus
+  richer `AgentGet` responses?
+- Should archived or terminal agents retain their last derived posture for
+  historical display, or always collapse to `Archived`?
+
+## Design principles
+
+- Source-of-truth records should remain explicit and narrow.
+- Derived state should be recomputable from authoritative records.
+- Projection should serve users and clients, not drive hidden state mutation.
+- `Sleep` should yield execution; it should not erase runnable work.
+- Capability, lifecycle, work, task, wait, and queue state should remain
+  distinguishable even when summarized.

--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -1,0 +1,459 @@
+---
+title: RFC: Scheduler Wait State And Recoverable Agent Continuation
+date: 2026-05-19
+status: draft
+---
+
+# RFC: Scheduler Wait State And Recoverable Agent Continuation
+
+## Summary
+
+Holon's scheduler should derive an explicit scheduling state for each open
+WorkItem and use that state to decide whether an agent should continue now,
+wait for a trusted wake source, ask the operator, remain blocked, or become
+idle.
+
+`Sleep` should not by itself mean "there is no runnable work". It should become
+the agent's posture after the agent has committed enough durable state for the
+runtime to classify the work. If any WorkItem is still runnable, an indefinite
+sleep must not silently strand the agent; the runtime should enqueue or
+schedule a continuation instead.
+
+The scheduler should also gain a generic `WaitCondition` / `WakeSource` model.
+This model records that a WorkItem is waiting, what opaque subject it is waiting
+on, and which runtime-observable sources can reactivate the agent. The scheduler
+does not interpret provider-specific meanings such as CI, review, merge,
+inbox, or deployment state.
+
+## Problem
+
+Holon is intended to drive long-lived goals. In practice, an agent pursuing a
+long objective often reaches a turn boundary where it is:
+
+- ready to continue immediately;
+- waiting for an internal task result;
+- waiting for external state;
+- waiting for operator input;
+- blocked by an unrecoverable or unstructured dependency;
+- actually complete; or
+- idle because no open work exists.
+
+Today those states are not expressed as a single scheduler-facing contract.
+They are partially encoded through:
+
+- WorkItem lifecycle and readiness;
+- `plan_status`;
+- natural-language `blocked_by`;
+- task lifecycle;
+- waiting intents;
+- external trigger callbacks;
+- `Sleep` calls.
+
+That makes closure-time behavior hard to reason about. A long-lived agent can
+appear to be asleep even though it has runnable work, or it can record an
+external wait that depends only on a callback path with no visible recovery or
+audit path if the callback never arrives.
+
+The runtime needs a generic scheduling model that keeps agent continuation
+reliable without teaching the core scheduler provider-specific business rules.
+
+## Goals
+
+- Define a scheduler-facing state model for WorkItems.
+- Make runnable work non-silent: indefinite sleep must not strand runnable
+  WorkItems.
+- Represent waiting as structured runtime state instead of relying only on
+  natural-language blockers.
+- Keep task result, external ingress, timer, operator input, and system tick
+  wakeups in one generic wake-source model.
+- Preserve the boundary between generic runtime scheduling and provider or
+  skill-specific business policy.
+- Support incremental migration from existing WorkItem, waiting intent, task,
+  and external trigger records.
+
+## Non-goals
+
+- Do not define GitHub, CI, review, merge, deployment, inbox, or other
+  provider-specific fallback durations.
+- Do not make the scheduler decide whether an external condition is
+  semantically resolved.
+- Do not require every external wait to have a timer in the first
+  implementation phase.
+- Do not replace WorkItem planning or todo tracking with a new project
+  management system.
+- Do not make `Sleep` a complex business workflow tool.
+
+## Current structure
+
+The current repository already has the major runtime pieces:
+
+- `WorkItem` records goal, readiness, plan state, blockers, todo progress, and
+  completion.
+- `Task` records command tasks, child-agent tasks, and other runtime-owned
+  execution units.
+- external trigger capability records provide providerless ingress for waking
+  or enqueueing agent input.
+- waiting intents provide a lower-level way to describe external waiting.
+- closure and lifecycle code decide whether to enqueue additional work or let
+  the agent rest.
+
+This RFC does not propose replacing those pieces. It proposes adding a clearer
+derived scheduling layer over them and evolving waiting intents into a more
+general `WaitCondition` model.
+
+## Core model
+
+### WorkItemSchedulingState
+
+The scheduler should derive a state for each WorkItem:
+
+```text
+WorkItemSchedulingState =
+  Runnable
+  WaitingOperator
+  WaitingTask
+  WaitingExternal
+  Blocked
+  Completed
+```
+
+`Idle` is an agent-level state, not a WorkItem state. An agent is idle when it
+has no open WorkItems and no other runnable runtime work.
+
+### Runnable
+
+A WorkItem is runnable when it is open, ready for execution, not blocked, and
+not covered by an active wait condition.
+
+Example derivation:
+
+```text
+open
+plan_status == ready
+blocked_by == None
+no active WaitCondition
+```
+
+Runnable WorkItems should cause the runtime to continue agent execution. If an
+agent calls indefinite `Sleep` while runnable WorkItems exist, the runtime must
+not treat the agent as truly idle. It should enqueue or schedule continuation.
+
+### WaitingOperator
+
+A WorkItem is waiting for the operator when it explicitly requires operator
+input.
+
+Example derivation:
+
+```text
+open
+plan_status == needs_input
+```
+
+The scheduler should not auto-continue this work without operator input unless
+a future explicit policy says otherwise.
+
+### WaitingTask
+
+A WorkItem is waiting on a runtime task when it has an active wait condition
+whose wake source is a task result.
+
+Task result wakeups are internal runtime signals. They usually do not need a
+provider fallback because the runtime owns the task lifecycle and terminal
+result delivery.
+
+### WaitingExternal
+
+A WorkItem is waiting externally when it has an active external wait condition.
+
+The scheduler does not understand what the external source means. It only knows:
+
+- there is an opaque waiting subject;
+- one or more wake sources may reactivate the agent;
+- a continuation should run when a wake source fires;
+- the wait may be auditable as weak if it lacks a durable recovery path.
+
+### Blocked
+
+A WorkItem is blocked when it has an explicit blocker that is not represented
+as a structured active wait.
+
+Natural-language blockers remain useful for operator visibility, but they are
+not enough for reliable automatic continuation. Over time, recoverable blockers
+should become structured wait conditions.
+
+### Completed
+
+Completed WorkItems do not participate in scheduling.
+
+## WaitCondition
+
+`WaitCondition` records that a WorkItem is waiting for a recoverable or
+operator-visible condition.
+
+Initial shape:
+
+```text
+WaitCondition {
+  id
+  work_item_id
+  status: active | resolved | cancelled | expired
+
+  kind: task | external | operator | timer
+  source: Option<String>
+  subject_ref: Option<String>
+  waiting_for: String
+
+  wake_sources: Vec<WakeSource>
+  continuation: ContinuationSpec
+
+  created_at
+  updated_at
+  expires_at: Option<Timestamp>
+}
+```
+
+The fields `source`, `subject_ref`, and `waiting_for` are intentionally opaque
+to the core scheduler. They are for display, correlation, and handoff to the
+agent, skill, provider, or operator.
+
+The scheduler should not mark an external wait as resolved simply because a
+wake source fired. A wake source means "reconcile this wait now". The agent,
+skill, provider, or operator-facing workflow decides whether the external
+condition is actually resolved.
+
+## WakeSource
+
+`WakeSource` is the scheduler-executable part of a wait condition.
+
+```text
+WakeSource =
+  TaskResult { task_id }
+  ExternalIngress { external_trigger_id?: String }
+  Timer { wake_at }
+  OperatorInput
+  SystemTick
+```
+
+### Task result
+
+Used when the runtime owns the executing task.
+
+```text
+WaitCondition {
+  kind: task
+  waiting_for: "task_completed"
+  wake_sources: [
+    TaskResult { task_id: "task_..." }
+  ]
+}
+```
+
+### External ingress
+
+Used when a providerless external trigger or other ingress path may wake the
+agent.
+
+```text
+WaitCondition {
+  kind: external
+  source: "github"
+  subject_ref: "repo=holon-run/holon,pr=123"
+  waiting_for: "checks_success"
+  wake_sources: [
+    ExternalIngress { external_trigger_id: "default" },
+    Timer { wake_at: "..." }
+  ]
+}
+```
+
+The example uses GitHub-like labels only as opaque metadata. The scheduler does
+not know what `checks_success` means.
+
+### Timer
+
+Used to make a wait recoverable even if another wake source fails or never
+arrives. The timer wake should enqueue a reconciliation continuation, not assume
+success or failure.
+
+### Operator input
+
+Used for waits that are explicitly waiting on the operator.
+
+### System tick
+
+Used for generic maintenance, audit, or soft recovery. A system tick is not a
+provider-specific fallback policy.
+
+## Turn-end and Sleep contract
+
+`Sleep` should be treated as a rest posture after state has been committed, not
+as the primary source of scheduling truth.
+
+At a turn boundary, the runtime should be able to classify the agent posture as:
+
+```text
+ContinueNow
+Wait
+NeedOperator
+Blocked
+Complete
+Idle
+```
+
+The preferred durable forms are:
+
+- runnable WorkItem exists -> `ContinueNow`;
+- active wait condition exists -> `Wait`;
+- WorkItem needs input -> `NeedOperator`;
+- WorkItem has unstructured blocker -> `Blocked`;
+- WorkItem completed -> `Complete`;
+- no open work -> `Idle`.
+
+If an agent calls indefinite `Sleep` while any WorkItem is `Runnable`, closure
+should enqueue or schedule a continuation instead of leaving the agent asleep.
+
+If all open WorkItems are `WaitingTask`, indefinite sleep is safe because task
+results are runtime-owned wake sources.
+
+If all open WorkItems are `WaitingOperator`, indefinite sleep is safe because
+operator input is the expected wake source.
+
+If any open WorkItem is `WaitingExternal`, sleep is safe only to the degree that
+the wait has recoverable wake sources. An external wait with only external
+ingress may be allowed during migration but should be auditable.
+
+If any open WorkItem is `Blocked` with only unstructured natural-language
+blockers, the runtime should not auto-continue it, but it should make the state
+visible as non-recoverable or weakly recoverable.
+
+## External wait recovery policy
+
+The core scheduler should not choose provider-specific fallback durations.
+
+It may classify external waits by recoverability:
+
+```text
+RecoverableExternalWait:
+  has ExternalIngress and Timer
+  or has Timer
+  or has provider-declared durable queue / recheck source
+
+WeakExternalWait:
+  has ExternalIngress only
+
+ExplicitNoFallbackExternalWait:
+  has no recovery path, with a recorded reason
+```
+
+The runtime can then evolve in phases:
+
+### Phase 1: warning
+
+Allow external waits without timer recovery, but surface an audit warning such
+as `external_wait_without_recovery`.
+
+### Phase 2: soft recovery
+
+Allow a generic system tick to re-enter the agent for audit or reconciliation.
+This is runtime safety, not business policy.
+
+### Phase 3: strict mode
+
+Require external waits to declare one of:
+
+- a recoverable wake source;
+- a provider-declared durable queue or recheck source;
+- an explicit `no_fallback` reason.
+
+## Scheduler responsibility boundary
+
+The scheduler owns:
+
+- deriving `WorkItemSchedulingState`;
+- preventing silent indefinite sleep while runnable work exists;
+- persisting and displaying structured wait lifecycle;
+- routing task, external ingress, timer, operator, and system tick wake sources;
+- enqueueing continuation for wake reconciliation;
+- surfacing weak or non-recoverable waits in audit/status views.
+
+The scheduler does not own:
+
+- interpreting CI, review, merge, deployment, inbox, or provider-specific state;
+- choosing provider-specific fallback durations;
+- deciding whether an external condition has semantically passed;
+- resolving an external wait without agent, skill, provider, or operator
+  reconciliation.
+
+## Incremental implementation plan
+
+### 1. Derive scheduling state
+
+Add an internal `WorkItemSchedulingState` derivation from existing WorkItem,
+task, waiting, and blocker state.
+
+Use the derived state in work listing, closure, and scheduler diagnostics before
+changing tool surfaces.
+
+### 2. Use scheduling state in closure
+
+Replace ad hoc runnable-work checks with state-derived closure behavior:
+
+- `Runnable` -> enqueue or schedule continuation;
+- `WaitingTask` -> sleep until task result;
+- `WaitingOperator` -> wait for operator input;
+- `WaitingExternal` -> wait for wake source and surface recoverability;
+- `Blocked` -> expose blocker and do not auto-continue;
+- `Completed` -> ignore for scheduling.
+
+### 3. Introduce WaitCondition ledger records
+
+Generalize or migrate waiting intents into `WaitCondition` records.
+
+The first version can keep the shape small:
+
+```text
+kind
+work_item_id
+waiting_for
+wake_sources
+continuation
+status
+```
+
+### 4. Normalize wake-source continuation
+
+Task result, external ingress, timer, operator input, and system tick should all
+enqueue continuation that asks the agent to reconcile the wait, rather than
+implicitly resolving the wait.
+
+### 5. Add external wait audit
+
+Surface weak external waits that have no timer, durable queue, or explicit
+`no_fallback` reason.
+
+## Open questions
+
+- Should `WaitingOperator` be represented only through `plan_status =
+  needs_input`, or should it also be a `WaitCondition(kind = operator)`?
+- Should `blocked_by` remain a separate WorkItem field forever, or eventually
+  become display text attached to a `Blocked` scheduling record?
+- What is the minimum continuation payload needed for reliable wake
+  reconciliation?
+- Should system tick be a first-class `WakeSource` or a scheduler-only audit
+  mechanism?
+- How should weak external waits be shown in `ListWorkItems`, `AgentGet`, and
+  TUI surfaces?
+
+## Relationship to existing RFCs
+
+- `work-item-runtime-model.md` defines WorkItem as the durable goal anchor.
+  This RFC defines the scheduling state derived from that anchor.
+- `waiting-plane-and-reactivation.md` describes waiting and reactivation
+  concepts. This RFC narrows the scheduler-facing contract around
+  `WaitCondition` and `WakeSource`.
+- `external-trigger-capability.md` defines providerless ingress as an
+  agent-level capability. This RFC treats external trigger capability as one
+  possible wake source, not as the waiting state itself.
+- `runtime-scheduler-contract.md` defines broader scheduler behavior. This RFC
+  should either extend it or be folded into it after discussion.

--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -229,7 +229,7 @@ condition is actually resolved.
 ```text
 WakeSource =
   TaskResult { task_id }
-  ExternalIngress { external_trigger_id?: String }
+  ExternalIngress { external_trigger_id: Option<String> }
   Timer { wake_at }
   OperatorInput
   SystemTick


### PR DESCRIPTION
## Summary
- add RFC for scheduler wait state and recoverable agent continuation
- add RFC for agent state model and runtime projection
- update RFC index

## Verification
- git diff --check -- docs/rfcs/README.md docs/rfcs/scheduler-wait-state.md docs/rfcs/agent-state-model.md