### PR TITLE
fix: harden remote tui transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "twox-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.43", features = ["full"] }
 tokio-stream = "0.1"
 tokio-util = "0.7"
 tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.6.8", features = ["compression-gzip"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 unicode-width = "0.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,65 +24,32 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TuiTimeoutKind {
-    Connect,
-    Request,
-    Bootstrap,
-    StreamOpen,
-    StreamIdle,
-    Reconnect,
+pub struct TuiNetworkPolicy {
+    pub connect_timeout: Duration,
+    /// Maximum quiet interval while waiting for response headers or body chunks.
+    pub read_idle_timeout: Duration,
+    /// Maximum quiet interval between parsed SSE events after the stream is open.
+    pub stream_idle_timeout: Duration,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TuiTimeouts {
-    pub connect: Duration,
-    pub request: Duration,
-    pub bootstrap: Duration,
-    pub stream_open: Duration,
-    pub stream_idle: Duration,
-    pub reconnect: Duration,
-}
-
-pub const TUI_TIMEOUTS: TuiTimeouts = TuiTimeouts {
-    connect: Duration::from_secs(2),
-    request: Duration::from_secs(10),
-    bootstrap: Duration::from_secs(30),
-    stream_open: Duration::from_secs(10),
-    stream_idle: Duration::from_secs(45),
-    reconnect: Duration::from_secs(1),
+pub const TUI_LOCAL_NETWORK_POLICY: TuiNetworkPolicy = TuiNetworkPolicy {
+    connect_timeout: Duration::from_secs(2),
+    read_idle_timeout: Duration::from_secs(10),
+    stream_idle_timeout: Duration::from_secs(45),
 };
 
-impl TuiTimeouts {
-    pub fn get(self, kind: TuiTimeoutKind) -> Duration {
-        match kind {
-            TuiTimeoutKind::Connect => self.connect,
-            TuiTimeoutKind::Request => self.request,
-            TuiTimeoutKind::Bootstrap => self.bootstrap,
-            TuiTimeoutKind::StreamOpen => self.stream_open,
-            TuiTimeoutKind::StreamIdle => self.stream_idle,
-            TuiTimeoutKind::Reconnect => self.reconnect,
-        }
-    }
-
-    fn request_timeout(self, kind: TuiTimeoutKind) -> Duration {
-        debug_assert!(matches!(
-            kind,
-            TuiTimeoutKind::Request | TuiTimeoutKind::Bootstrap
-        ));
-        self.get(kind)
-    }
-}
-
-#[cfg(unix)]
-fn unix_response_timeout(kind: TuiTimeoutKind) -> Duration {
-    TUI_TIMEOUTS.request_timeout(kind)
-}
+pub const TUI_REMOTE_NETWORK_POLICY: TuiNetworkPolicy = TuiNetworkPolicy {
+    connect_timeout: Duration::from_secs(5),
+    read_idle_timeout: Duration::from_secs(10),
+    stream_idle_timeout: Duration::from_secs(45),
+};
 
 #[derive(Clone)]
 pub struct LocalClient {
     config: AppConfig,
     http: reqwest::Client,
     remote: Option<RemoteConnection>,
+    network: TuiNetworkPolicy,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -288,16 +255,69 @@ struct UnixEventStream {
     eof: bool,
 }
 
+async fn read_http_response_body(
+    mut response: reqwest::Response,
+    path: &str,
+    network: TuiNetworkPolicy,
+) -> Result<Vec<u8>> {
+    let mut body = Vec::new();
+    loop {
+        let chunk = tokio::time::timeout(network.read_idle_timeout, response.chunk())
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "read idle timeout after {} for {}",
+                    format_duration(network.read_idle_timeout),
+                    path
+                )
+            })?
+            .with_context(|| format!("failed to read response body for {path}"))?;
+        let Some(chunk) = chunk else {
+            return Ok(body);
+        };
+        body.extend_from_slice(&chunk);
+    }
+}
+
+#[cfg(unix)]
+async fn read_unix_response_body(
+    stream: &mut tokio::net::UnixStream,
+    path: &str,
+    network: TuiNetworkPolicy,
+) -> Result<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+
+    let mut body = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = tokio::time::timeout(network.read_idle_timeout, stream.read(&mut buffer))
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "read idle timeout after {} for unix-socket response {}",
+                    format_duration(network.read_idle_timeout),
+                    path
+                )
+            })?
+            .with_context(|| format!("failed to read unix-socket response for {path}"))?;
+        if read == 0 {
+            return Ok(body);
+        }
+        body.extend_from_slice(&buffer[..read]);
+    }
+}
+
 impl LocalClient {
     pub fn new(config: AppConfig) -> Result<Self> {
         let http = reqwest::Client::builder()
-            .connect_timeout(TUI_TIMEOUTS.get(TuiTimeoutKind::Connect))
+            .connect_timeout(TUI_LOCAL_NETWORK_POLICY.connect_timeout)
             .build()
             .context("failed to build local control client")?;
         Ok(Self {
             config,
             http,
             remote: None,
+            network: TUI_LOCAL_NETWORK_POLICY,
         })
     }
 
@@ -312,13 +332,14 @@ impl LocalClient {
             return Err(anyhow!("remote TUI token must not be empty"));
         }
         let http = reqwest::Client::builder()
-            .connect_timeout(TUI_TIMEOUTS.get(TuiTimeoutKind::Connect))
+            .connect_timeout(TUI_REMOTE_NETWORK_POLICY.connect_timeout)
             .build()
             .context("failed to build remote control client")?;
         Ok(Self {
             config,
             http,
             remote: Some(RemoteConnection { base_url, token }),
+            network: TUI_REMOTE_NETWORK_POLICY,
         })
     }
 
@@ -360,11 +381,7 @@ impl LocalClient {
     #[cfg(unix)]
     pub async fn runtime_status_unix_only(&self) -> Result<RuntimeStatusResponse> {
         let body = self
-            .send_unix(
-                RequestSpec::get("/control/runtime/status"),
-                true,
-                TuiTimeoutKind::Request,
-            )
+            .send_unix(RequestSpec::get("/control/runtime/status"), true)
             .await?;
         serde_json::from_slice(&body).with_context(|| {
             "failed to decode response body for GET /control/runtime/status over unix socket"
@@ -381,11 +398,7 @@ impl LocalClient {
     }
 
     pub async fn agent_state_snapshot(&self, agent_id: &str) -> Result<AgentStateSnapshot> {
-        self.get_json_with_timeout(
-            &format!("/agents/{agent_id}/state"),
-            TuiTimeoutKind::Bootstrap,
-        )
-        .await
+        self.get_json(&format!("/agents/{agent_id}/state")).await
     }
 
     pub async fn agent_briefs(&self, agent_id: &str, limit: usize) -> Result<Vec<BriefRecord>> {
@@ -547,7 +560,6 @@ impl LocalClient {
             .send(
                 RequestSpec::get(&format!("/agents/{}/skills", agent_id)),
                 false,
-                TuiTimeoutKind::Request,
             )
             .await?;
         serde_json::from_slice(&body).with_context(|| {
@@ -590,7 +602,7 @@ impl LocalClient {
         #[cfg(unix)]
         if self.remote.is_none() && self.config.socket_path.exists() {
             let socket_error = match tokio::time::timeout(
-                TUI_TIMEOUTS.get(TuiTimeoutKind::StreamOpen),
+                self.network.connect_timeout,
                 self.stream_unix_events(&path, false),
             )
             .await
@@ -599,7 +611,7 @@ impl LocalClient {
                     return Ok(LocalEventStream {
                         transport: EventStreamTransport::Unix(stream),
                         frame_buffer: Vec::new(),
-                        idle_timeout: TUI_TIMEOUTS.get(TuiTimeoutKind::StreamIdle),
+                        idle_timeout: self.network.stream_idle_timeout,
                     });
                 }
                 Ok(Err(err)) => err,
@@ -626,26 +638,13 @@ impl LocalClient {
     }
 
     async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-        self.get_json_with_timeout(path, TuiTimeoutKind::Request)
-            .await
-    }
-
-    async fn get_json_with_timeout<T: DeserializeOwned>(
-        &self,
-        path: &str,
-        timeout_kind: TuiTimeoutKind,
-    ) -> Result<T> {
-        let body = self
-            .send(RequestSpec::get(path), false, timeout_kind)
-            .await?;
+        let body = self.send(RequestSpec::get(path), false).await?;
         serde_json::from_slice(&body)
             .with_context(|| format!("failed to decode response body for GET {}", path))
     }
 
     async fn get_control_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-        let body = self
-            .send(RequestSpec::get(path), true, TuiTimeoutKind::Request)
-            .await?;
+        let body = self.send(RequestSpec::get(path), true).await?;
         serde_json::from_slice(&body)
             .with_context(|| format!("failed to decode response body for GET {}", path))
     }
@@ -656,61 +655,46 @@ impl LocalClient {
         payload: &B,
     ) -> Result<T> {
         let body = self
-            .send(
-                RequestSpec::post_json(path, payload)?,
-                true,
-                TuiTimeoutKind::Request,
-            )
+            .send(RequestSpec::post_json(path, payload)?, true)
             .await?;
         serde_json::from_slice(&body)
             .with_context(|| format!("failed to decode response body for POST {}", path))
     }
 
-    async fn send(
-        &self,
-        request: RequestSpec,
-        include_control_auth: bool,
-        timeout_kind: TuiTimeoutKind,
-    ) -> Result<Vec<u8>> {
+    async fn send(&self, request: RequestSpec, include_control_auth: bool) -> Result<Vec<u8>> {
         #[cfg(unix)]
         if self.remote.is_none() && self.config.socket_path.exists() {
-            let socket_error = match self
-                .send_unix(request.clone(), include_control_auth, timeout_kind)
-                .await
-            {
+            let socket_error = match self.send_unix(request.clone(), include_control_auth).await {
                 Ok(body) => return Ok(body),
                 Err(err) => err,
             };
             return self
-                .send_http(request, include_control_auth, timeout_kind)
+                .send_http(request, include_control_auth)
                 .await
                 .with_context(|| {
                     format!("unix socket request failed before HTTP fallback: {socket_error}")
                 });
         }
 
-        self.send_http(request, include_control_auth, timeout_kind)
-            .await
+        self.send_http(request, include_control_auth).await
     }
 
-    async fn send_http(
-        &self,
-        request: RequestSpec,
-        include_control_auth: bool,
-        timeout_kind: TuiTimeoutKind,
-    ) -> Result<Vec<u8>> {
-        let response = self
-            .build_http_request(&request, include_control_auth)
-            .timeout(TUI_TIMEOUTS.request_timeout(timeout_kind))
-            .send()
-            .await
-            .with_context(|| format!("failed to send {}", request.path))?;
+    async fn send_http(&self, request: RequestSpec, include_control_auth: bool) -> Result<Vec<u8>> {
+        let response = tokio::time::timeout(
+            self.network.read_idle_timeout,
+            self.build_http_request(&request, include_control_auth)
+                .send(),
+        )
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "timed out waiting for response headers for {}",
+                request.path
+            )
+        })?
+        .with_context(|| format!("failed to send {}", request.path))?;
         let status = response.status();
-        let bytes = response
-            .bytes()
-            .await
-            .with_context(|| format!("failed to read response body for {}", request.path))?
-            .to_vec();
+        let bytes = read_http_response_body(response, &request.path, self.network).await?;
         decode_or_error(status.as_u16(), bytes, &request.path)
     }
 
@@ -723,21 +707,20 @@ impl LocalClient {
         let builder = self
             .build_http_request(&request, include_control_auth)
             .header(reqwest::header::ACCEPT, "text/event-stream");
-        let response =
-            tokio::time::timeout(TUI_TIMEOUTS.get(TuiTimeoutKind::StreamOpen), builder.send())
-                .await
-                .map_err(|_| anyhow!("timed out opening event stream {}", path))?
-                .with_context(|| format!("failed to open event stream {}", path))?;
+        let response = tokio::time::timeout(self.network.read_idle_timeout, builder.send())
+            .await
+            .map_err(|_| anyhow!("timed out opening event stream {}", path))?
+            .with_context(|| format!("failed to open event stream {}", path))?;
         let status = response.status();
         if !status.is_success() {
-            let bytes = response.bytes().await?.to_vec();
+            let bytes = read_http_response_body(response, path, self.network).await?;
             decode_or_error(status.as_u16(), bytes, path)?;
             unreachable!("decode_or_error returns Ok only for successful responses");
         }
         Ok(LocalEventStream {
             transport: EventStreamTransport::Http(response),
             frame_buffer: Vec::new(),
-            idle_timeout: TUI_TIMEOUTS.get(TuiTimeoutKind::StreamIdle),
+            idle_timeout: self.network.stream_idle_timeout,
         })
     }
 
@@ -774,23 +757,27 @@ impl LocalClient {
     }
 
     #[cfg(unix)]
-    async fn send_unix(
-        &self,
-        request: RequestSpec,
-        include_control_auth: bool,
-        timeout_kind: TuiTimeoutKind,
-    ) -> Result<Vec<u8>> {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    async fn send_unix(&self, request: RequestSpec, include_control_auth: bool) -> Result<Vec<u8>> {
+        use tokio::io::AsyncWriteExt;
         use tokio::net::UnixStream;
 
-        let mut stream = UnixStream::connect(&self.config.socket_path)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to connect to Holon control socket {}",
-                    self.config.socket_path.display()
-                )
-            })?;
+        let mut stream = tokio::time::timeout(
+            self.network.connect_timeout,
+            UnixStream::connect(&self.config.socket_path),
+        )
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "timed out connecting to Holon control socket {}",
+                self.config.socket_path.display()
+            )
+        })?
+        .with_context(|| {
+            format!(
+                "failed to connect to Holon control socket {}",
+                self.config.socket_path.display()
+            )
+        })?;
 
         let method = match request.method {
             HttpMethod::Get => "GET",
@@ -815,24 +802,17 @@ impl LocalClient {
         }
         raw.push_str("\r\n");
 
-        let response = tokio::time::timeout(unix_response_timeout(timeout_kind), async {
+        tokio::time::timeout(self.network.read_idle_timeout, async {
             stream.write_all(raw.as_bytes()).await?;
             if let Some(body) = request.body.as_ref() {
                 stream.write_all(body).await?;
             }
-            stream.flush().await?;
-
-            let mut response = Vec::new();
-            stream.read_to_end(&mut response).await?;
-            Ok::<Vec<u8>, anyhow::Error>(response)
+            stream.flush().await
         })
         .await
-        .map_err(|_| {
-            anyhow!(
-                "timed out waiting for unix-socket response for {}",
-                request.path
-            )
-        })??;
+        .map_err(|_| anyhow!("timed out writing unix-socket request for {}", request.path))??;
+
+        let response = read_unix_response_body(&mut stream, &request.path, self.network).await?;
         let parsed = parse_http_response(&response).with_context(|| {
             format!("failed to parse unix-socket response for {}", request.path)
         })?;
@@ -850,14 +830,23 @@ impl LocalClient {
 
         validate_unix_request_target(path)?;
 
-        let mut stream = UnixStream::connect(&self.config.socket_path)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to connect to Holon control socket {}",
-                    self.config.socket_path.display()
-                )
-            })?;
+        let mut stream = tokio::time::timeout(
+            self.network.connect_timeout,
+            UnixStream::connect(&self.config.socket_path),
+        )
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "timed out connecting to Holon control socket {}",
+                self.config.socket_path.display()
+            )
+        })?
+        .with_context(|| {
+            format!(
+                "failed to connect to Holon control socket {}",
+                self.config.socket_path.display()
+            )
+        })?;
 
         let mut raw = format!(
             "GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\nAccept: text/event-stream\r\n",
@@ -1414,10 +1403,10 @@ fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>> {
 mod tests {
     use super::{
         authorization_header_value, decode_chunked_body, decode_or_error, event_stream_path,
-        normalize_remote_base_url, parse_http_response, parse_sse_frame, take_next_sse_frame,
-        validate_header_value, validate_unix_request_target, EventStreamRequest,
-        EventStreamTransport, LocalEventStream, LocalHttpError, StreamEventEnvelope,
-        TuiTimeoutKind, TUI_TIMEOUTS,
+        normalize_remote_base_url, parse_http_response, parse_sse_frame, read_http_response_body,
+        take_next_sse_frame, validate_header_value, validate_unix_request_target,
+        EventStreamRequest, EventStreamTransport, LocalEventStream, LocalHttpError,
+        StreamEventEnvelope, TuiNetworkPolicy, TUI_LOCAL_NETWORK_POLICY, TUI_REMOTE_NETWORK_POLICY,
     };
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1439,21 +1428,13 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_uses_longer_timeout_than_lightweight_calls() {
-        assert!(TUI_TIMEOUTS.bootstrap > TUI_TIMEOUTS.request);
-        assert!(TUI_TIMEOUTS.stream_open <= TUI_TIMEOUTS.request);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn unix_send_path_uses_timeout_kind_for_response_wait() {
-        assert_eq!(
-            super::unix_response_timeout(TuiTimeoutKind::Request),
-            TUI_TIMEOUTS.request
+    fn remote_policy_has_longer_connect_timeout_than_local_policy() {
+        assert!(
+            TUI_REMOTE_NETWORK_POLICY.connect_timeout > TUI_LOCAL_NETWORK_POLICY.connect_timeout
         );
         assert_eq!(
-            super::unix_response_timeout(TuiTimeoutKind::Bootstrap),
-            TUI_TIMEOUTS.bootstrap
+            TUI_REMOTE_NETWORK_POLICY.read_idle_timeout,
+            TUI_LOCAL_NETWORK_POLICY.read_idle_timeout
         );
     }
 
@@ -1595,6 +1576,48 @@ mod tests {
         server.abort();
 
         assert!(err.contains("event stream idle timeout after 25ms"));
+    }
+
+    #[tokio::test]
+    async fn http_body_reader_allows_slow_continuous_chunks() {
+        let (response, server) = open_test_event_stream(
+            vec![
+                ("hello ".into(), Duration::ZERO),
+                ("world".into(), Duration::from_millis(20)),
+            ],
+            false,
+        )
+        .await;
+        let network = TuiNetworkPolicy {
+            connect_timeout: Duration::from_millis(50),
+            read_idle_timeout: Duration::from_millis(50),
+            stream_idle_timeout: Duration::from_millis(50),
+        };
+
+        let body = read_http_response_body(response, "/slow-json", network)
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert_eq!(body, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn http_body_reader_times_out_on_idle_gap() {
+        let (response, server) = open_test_event_stream(Vec::new(), true).await;
+        let network = TuiNetworkPolicy {
+            connect_timeout: Duration::from_millis(50),
+            read_idle_timeout: Duration::from_millis(25),
+            stream_idle_timeout: Duration::from_millis(50),
+        };
+
+        let err = read_http_response_body(response, "/idle-json", network)
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+
+        assert!(err.contains("read idle timeout after 25ms for /idle-json"));
     }
 
     #[tokio::test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
+use tower_http::compression::CompressionLayer;
 use tracing::error;
 use uuid::Uuid;
 
@@ -213,6 +214,7 @@ pub fn router(state: AppState) -> Router {
         .route("/state", get(state_default))
         .route("/transcript", get(transcript_default))
         .route("/worktree-summary", get(worktree_summary_default))
+        .layer(CompressionLayer::new())
         .with_state(Arc::new(state))
 }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -1,27 +1,36 @@
-use super::projection::{ProjectionSlice, EVENT_LOG_LIMIT};
+use super::projection::ProjectionSlice;
 use super::state::TuiClientState;
 use super::*;
 use crate::client::{
     AgentStateSnapshot, AgentStreamEvent, EventPageRequest, EventPageResponse, EventStreamRequest,
-    LocalEventStream, LocalHttpError, StreamEventEnvelope, TUI_TIMEOUTS,
+    LocalEventStream, LocalHttpError, StreamEventEnvelope,
 };
 use tokio::sync::mpsc;
 
-const STREAM_RECONNECT_DELAY: Duration = TUI_TIMEOUTS.reconnect;
 const REFRESH_RETRY_DELAY: Duration = Duration::from_secs(1);
 const AGENT_LIST_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 const TASK_LIMIT: usize = 40;
 const OPTIMISTIC_OPERATOR_MESSAGE_LIMIT: usize = 64;
+pub(super) const BOOTSTRAP_EVENT_TAIL_LIMIT: usize = 50;
 const EVENT_HISTORY_PAGE_LIMIT: usize = 128;
+const STREAM_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) enum TuiConnectionState {
     Bootstrapping,
     Streaming,
-    Reconnecting { attempt: u32, last_error: String },
-    RefreshRequired { reason: String },
-    Disconnected { reason: String },
+    Reconnecting {
+        attempt: u32,
+        retry_after: Duration,
+        last_error: String,
+    },
+    RefreshRequired {
+        reason: String,
+    },
+    Disconnected {
+        reason: String,
+    },
 }
 
 pub(super) enum TuiRuntimeMessage {
@@ -37,6 +46,11 @@ pub(super) enum TuiRuntimeMessage {
         agent_id: String,
         checkpoint: Option<TuiRuntimeCheckpoint>,
         result: Result<SnapshotBootstrapResult, String>,
+    },
+    SnapshotBootstrapStatus {
+        request_id: u64,
+        agent_id: String,
+        status_line: String,
     },
     EventHistoryPageLoaded {
         request_id: u64,
@@ -61,6 +75,26 @@ type SnapshotBootstrapResult = (
 pub(super) struct EventStreamOpenError {
     message: String,
     cursor_not_found: bool,
+}
+
+pub(super) fn reconnect_delay_for_attempt(attempt: u32) -> Duration {
+    let delay_secs = match attempt {
+        0 | 1 => 1,
+        2 => 2,
+        3 => 4,
+        4 => 8,
+        5 => 15,
+        _ => STREAM_RECONNECT_MAX_DELAY.as_secs(),
+    };
+    Duration::from_secs(delay_secs).min(STREAM_RECONNECT_MAX_DELAY)
+}
+
+fn format_duration(duration: Duration) -> String {
+    if duration.as_secs() > 0 && duration.subsec_millis() == 0 {
+        format!("{}s", duration.as_secs())
+    } else {
+        format!("{}ms", duration.as_millis())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -373,7 +407,7 @@ impl TuiApp {
         self.event_history_request_id = self.event_history_request_id.saturating_add(1);
         let request_id = self.snapshot_refresh_request_id;
         self.connection_state = TuiConnectionState::Bootstrapping;
-        self.status_line = format!("Bootstrapping agent {agent_id} from /state");
+        self.status_line = format!("Loading agent state for {agent_id}");
         let client = self.client.clone();
         let tx = self.runtime_tx.clone();
         tokio::spawn({
@@ -381,11 +415,16 @@ impl TuiApp {
             async move {
                 let result = async {
                     let snapshot = client.agent_state_snapshot(&agent_id).await?;
+                    let _ = tx.send(TuiRuntimeMessage::SnapshotBootstrapStatus {
+                        request_id,
+                        agent_id: agent_id.clone(),
+                        status_line: format!("Loading recent events for {agent_id}"),
+                    });
                     let mut events_page = client
                         .agent_events_page(
                             &agent_id,
                             EventPageRequest {
-                                limit: Some(EVENT_LOG_LIMIT),
+                                limit: Some(BOOTSTRAP_EVENT_TAIL_LIMIT),
                                 order: Some("desc".into()),
                                 ..Default::default()
                             },
@@ -474,6 +513,22 @@ impl TuiApp {
         self.status_line = format!("Bootstrapped agent {agent_id} from /state");
 
         self.begin_connect_event_stream_for(agent_id, cursor);
+    }
+
+    pub(super) fn apply_snapshot_bootstrap_status(
+        &mut self,
+        request_id: u64,
+        agent_id: String,
+        status_line: String,
+    ) {
+        if request_id != self.snapshot_refresh_request_id {
+            return;
+        }
+        if !matches!(self.connection_state, TuiConnectionState::Bootstrapping) {
+            return;
+        }
+        let _ = agent_id;
+        self.status_line = status_line;
     }
 
     pub(super) fn begin_connect_event_stream(&mut self) {
@@ -649,6 +704,11 @@ impl TuiApp {
                     checkpoint,
                     result,
                 ),
+                TuiRuntimeMessage::SnapshotBootstrapStatus {
+                    request_id,
+                    agent_id,
+                    status_line,
+                } => self.apply_snapshot_bootstrap_status(request_id, agent_id, status_line),
                 TuiRuntimeMessage::EventHistoryPageLoaded {
                     request_id,
                     agent_id,
@@ -831,10 +891,12 @@ impl TuiApp {
 
     pub(super) fn schedule_reconnect(&mut self, error: String) {
         self.reconnect_attempt = self.reconnect_attempt.saturating_add(1);
-        self.reconnect_deadline = Some(Instant::now() + STREAM_RECONNECT_DELAY);
+        let retry_after = reconnect_delay_for_attempt(self.reconnect_attempt);
+        self.reconnect_deadline = Some(Instant::now() + retry_after);
         self.refresh_deadline = None;
         self.connection_state = TuiConnectionState::Reconnecting {
             attempt: self.reconnect_attempt,
+            retry_after,
             last_error: error,
         };
     }
@@ -903,8 +965,15 @@ impl TuiApp {
         let state = match &self.connection_state {
             TuiConnectionState::Bootstrapping => "bootstrapping".into(),
             TuiConnectionState::Streaming => "streaming".into(),
-            TuiConnectionState::Reconnecting { attempt, .. } => {
-                format!("reconnecting (attempt {attempt})")
+            TuiConnectionState::Reconnecting {
+                attempt,
+                retry_after,
+                ..
+            } => {
+                format!(
+                    "reconnecting in {} (attempt {attempt})",
+                    format_duration(*retry_after)
+                )
             }
             TuiConnectionState::RefreshRequired { .. } => "refresh-required".into(),
             TuiConnectionState::Disconnected { .. } => "disconnected".into(),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -9,14 +9,17 @@ use super::{
     overlay::{centered_rect_rows, conversation_events_overlay_lines, OverlayState},
     projection::{OperatorDisplayMode, TuiProjection},
     render::draw,
-    runtime::{is_cursor_not_found_error, AgentListChange, TuiConnectionState, TuiRuntimeMessage},
+    runtime::{
+        is_cursor_not_found_error, reconnect_delay_for_attempt, AgentListChange,
+        TuiConnectionState, TuiRuntimeMessage, BOOTSTRAP_EVENT_TAIL_LIMIT,
+    },
     state::{tui_state_path, TuiClientState},
     view_model::{HeaderViewModel, StatusbarViewModel},
 };
 use crate::{
     client::{
         AgentStateSnapshot, AgentStreamEvent, LocalClient, StateSessionSnapshot,
-        StateWorkspaceSnapshot, StreamEventEnvelope,
+        StateWorkspaceSnapshot, StreamEventEnvelope, TUI_LOCAL_NETWORK_POLICY,
     },
     config::{AltScreenMode, AppConfig},
     system::{ExecutionProfile, ExecutionSnapshot},
@@ -901,7 +904,7 @@ async fn agent_overlay_enter_starts_switch_without_awaiting_snapshot() {
         .unwrap();
 
     assert_eq!(app.overlay, OverlayState::None);
-    assert_eq!(app.status_line, "Bootstrapping agent beta from /state");
+    assert_eq!(app.status_line, "Loading agent state for beta");
     assert!(app.snapshot_refresh_in_flight);
 }
 
@@ -922,7 +925,7 @@ async fn agent_overlay_enter_clamps_stale_selection() {
         .unwrap();
 
     assert_eq!(app.overlay, OverlayState::None);
-    assert_eq!(app.status_line, "Bootstrapping agent beta from /state");
+    assert_eq!(app.status_line, "Loading agent state for beta");
     assert_eq!(app.selected_agent_id(), Some("alpha"));
     assert!(app.snapshot_refresh_in_flight);
 }
@@ -2575,9 +2578,45 @@ fn chat_text_cache_reuses_unchanged_content_and_replaces_stale_entries() {
 #[test]
 fn heartbeat_interval_is_less_than_client_stream_idle_timeout() {
     assert!(
-        crate::http::EVENT_STREAM_HEARTBEAT_INTERVAL
-            < crate::client::TUI_TIMEOUTS.get(crate::client::TuiTimeoutKind::StreamIdle)
+        crate::http::EVENT_STREAM_HEARTBEAT_INTERVAL < TUI_LOCAL_NETWORK_POLICY.stream_idle_timeout
     );
+}
+
+#[test]
+fn reconnect_backoff_increases_and_caps() {
+    assert_eq!(
+        reconnect_delay_for_attempt(1),
+        std::time::Duration::from_secs(1)
+    );
+    assert_eq!(
+        reconnect_delay_for_attempt(2),
+        std::time::Duration::from_secs(2)
+    );
+    assert_eq!(
+        reconnect_delay_for_attempt(3),
+        std::time::Duration::from_secs(4)
+    );
+    assert_eq!(
+        reconnect_delay_for_attempt(4),
+        std::time::Duration::from_secs(8)
+    );
+    assert_eq!(
+        reconnect_delay_for_attempt(5),
+        std::time::Duration::from_secs(15)
+    );
+    assert_eq!(
+        reconnect_delay_for_attempt(6),
+        std::time::Duration::from_secs(30)
+    );
+    assert_eq!(
+        reconnect_delay_for_attempt(9),
+        std::time::Duration::from_secs(30)
+    );
+}
+
+#[test]
+fn bootstrap_event_tail_limit_stays_small_for_remote_startup() {
+    assert_eq!(BOOTSTRAP_EVENT_TAIL_LIMIT, 50);
 }
 
 #[test]
@@ -2816,7 +2855,7 @@ async fn agent_switch_starts_snapshot_refresh_without_awaiting_network() {
         TuiConnectionState::Bootstrapping
     ));
     assert!(app.snapshot_refresh_in_flight);
-    assert_eq!(app.status_line, "Bootstrapping agent beta from /state");
+    assert_eq!(app.status_line, "Loading agent state for beta");
 }
 
 #[tokio::test]

--- a/tests/http_client.rs
+++ b/tests/http_client.rs
@@ -14,6 +14,7 @@ macro_rules! http_async_tests {
 http_async_tests!(
     agent_list_entries_are_slim_for_tui_bootstrap,
     agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue,
+    json_responses_support_gzip_without_compressing_sse,
     local_client_over_http_can_read_agent_state_snapshot,
     local_client_over_http_can_stream_events_with_cursor_query,
     local_client_over_http_stream_without_cursor_starts_at_tail,

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -4,7 +4,7 @@
 
 use std::{
     fs::OpenOptions,
-    io::Write,
+    io::{Read, Write},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     process::Command,
@@ -172,6 +172,48 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
         .active_workspace_entry
         .as_ref()
         .is_some_and(|entry| entry.projection_metadata.is_none()));
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn json_responses_support_gzip_without_compressing_sse() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = reqwest::Client::builder().no_gzip().build()?;
+
+    let response = client
+        .get(format!("{base}/agents/list"))
+        .header(reqwest::header::ACCEPT_ENCODING, "gzip")
+        .send()
+        .await?;
+    assert_eq!(
+        response
+            .headers()
+            .get(reqwest::header::CONTENT_ENCODING)
+            .and_then(|value| value.to_str().ok()),
+        Some("gzip")
+    );
+    let compressed = response.bytes().await?;
+    let mut decoder = flate2::read::GzDecoder::new(&compressed[..]);
+    let mut decoded = String::new();
+    decoder.read_to_string(&mut decoded)?;
+    let payload: serde_json::Value = serde_json::from_str(&decoded)?;
+    assert!(payload.as_array().is_some());
+
+    let stream_response = client
+        .get(format!("{base}/agents/default/events/stream"))
+        .header(reqwest::header::ACCEPT, "text/event-stream")
+        .header(reqwest::header::ACCEPT_ENCODING, "gzip")
+        .send()
+        .await?;
+    assert_eq!(stream_response.status(), reqwest::StatusCode::OK);
+    assert!(
+        stream_response
+            .headers()
+            .get(reqwest::header::CONTENT_ENCODING)
+            .is_none(),
+        "SSE responses must remain uncompressed"
+    );
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary

- replace TUI per-request total timeouts with local/remote network policies that separate connect timeout from response body idle timeout
- add exponential event stream reconnect backoff and clearer bootstrap status messages
- reduce bootstrap event tail to 50 events while preserving lazy history loading
- enable gzip compression for JSON responses while leaving SSE uncompressed

## Verification

- cargo fmt --all -- --check
- cargo test -q http_body_reader -- --nocapture
- cargo test -q --test http_client json_responses_support_gzip_without_compressing_sse -- --nocapture
- cargo test -q reconnect_backoff -- --nocapture
- cargo test -q bootstrap_event_tail_limit -- --nocapture
- cargo test -q heartbeat_interval_is_less_than_client_stream_idle_timeout -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets
