### PR TITLE
fix: use durable event sequences

### DIFF
--- a/docs/rfc-implementation-notes/event-and-operator-transport.md
+++ b/docs/rfc-implementation-notes/event-and-operator-transport.md
@@ -26,10 +26,13 @@ The v0.14 replay/projection minimum is:
 
 - `/events` is a recent replay projection surface, not the raw append-only log
   as a public API.
-- replay preserves safe provenance outside the event payload: cursor/id,
-  sequence, timestamp, event kind, agent id, origin, trust, authority class,
-  delivery surface, admission context, transport/source, reply route, message
-  id, task id, work item id, correlation id, and causation id when available.
+- replay preserves safe provenance outside the event payload: event id,
+  per-agent durable `event_seq`, timestamp, event kind, agent id, origin, trust,
+  authority class, delivery surface, admission context, transport/source, reply
+  route, message id, task id, work item id, correlation id, and causation id
+  when available.
+- replay and SSE cursors use ledger-assigned `event_seq`; response-local
+  sequence numbers must not drive ordering, paging, or TUI truncation.
 - operator replay is the default projection and includes canonical standard
   event payloads.
 - client display density is handled by presentation policy, not by clipping the

--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -102,12 +102,12 @@ projection.
 
 Use Server-Sent Events:
 
-`GET /agents/:id/events?since=<cursor>`
+`GET /agents/:id/events/stream?after_seq=<event_seq>`
 
 with:
 
 - `Content-Type: text/event-stream`
-- standard SSE `id:` field for cursor replay
+- standard SSE `id:` field set to the durable `event_seq`
 - optional `Last-Event-ID` support
 
 SSE is the preferred first transport because Holon's immediate problem is a
@@ -170,7 +170,7 @@ replaying arbitrary historical events.
 
 ### Endpoint
 
-`GET /agents/:id/events?since=<cursor>`
+`GET /agents/:id/events/stream?after_seq=<event_seq>`
 
 ### Purpose
 
@@ -182,10 +182,11 @@ append-only internal log as a public API.
 
 ### Replay Behavior
 
-- if `since` is present and still available in the recent-event buffer, replay
-  events after that cursor
-- if `since` is missing, stream only new events after connection establishment
-- if `since` is too old and no longer replayable, the server should explicitly
+- if `after_seq` is present and still available in the recent-event buffer,
+  replay events with larger `event_seq`
+- if `after_seq` is missing, stream only new events after connection
+  establishment
+- if `after_seq` is too old and no longer replayable, the server should explicitly
   require a snapshot refresh
 
 Replay failure must be explicit and deterministic. A client must know when it
@@ -206,10 +207,12 @@ and replay authorization are related but separate concerns:
   raw standard event payload was included.
 
 Every replay envelope should preserve safe provenance needed for recovery and
-audit, including event cursor/id, sequence, timestamp, event kind, agent id,
-and any available origin, trust, authority class, delivery surface, admission
-context, transport/source, reply route, message id, task id, work item id,
-correlation id, and causation id.
+audit, including event id, per-agent durable `event_seq`, timestamp, event
+kind, agent id, and any available origin, trust, authority class, delivery
+surface, admission context, transport/source, reply route, message id, task id,
+work item id, correlation id, and causation id. Replay cursors are
+`event_seq` values assigned by the append-only ledger, not event UUIDs or
+transport-local response sequence numbers.
 
 Runtime events should have clear, standard payload schemas that first-party
 clients and integrations can consume directly. The default replay projection is
@@ -228,7 +231,7 @@ Every stream event should use one canonical envelope.
 ```json
 {
   "id": "evt_12346",
-  "seq": 12,
+  "event_seq": 12,
   "ts": "2026-04-18T14:00:00Z",
   "agent_id": "default",
   "type": "task_status_updated",
@@ -250,10 +253,10 @@ Every stream event should use one canonical envelope.
 ### Fields
 
 - `id`
-  - stable event cursor used for replay and SSE `id:`
-- `seq`
-  - stream ordering hint
-  - clients must not depend on this field for replay correctness
+  - stable event UUID used for deduplication and references
+- `event_seq`
+  - per-agent durable ledger sequence used for replay, paging, ordering, and
+    SSE `id:`
 - `ts`
   - event timestamp
 - `agent_id`
@@ -274,9 +277,9 @@ Every stream event should use one canonical envelope.
 The envelope should be projected to SSE as:
 
 ```text
-id: evt_12346
+id: 12
 event: task_status_updated
-data: {"id":"evt_12346","seq":12,"ts":"2026-04-18T14:00:00Z","agent_id":"default","type":"task_status_updated","payload":{}}
+data: {"id":"evt_12346","event_seq":12,"ts":"2026-04-18T14:00:00Z","agent_id":"default","type":"task_status_updated","payload":{}}
 ```
 
 ## Raw Event Families
@@ -733,7 +736,7 @@ bootstrap from a single request.
   "waiting_intents": [],
   "external_triggers": [],
   "workspace": null,
-  "cursor": "evt_12345"
+  "newest_seq": 12345
 }
 ```
 
@@ -760,7 +763,7 @@ bootstrap from a single request.
   - current callback delivery state
 - `workspace`
   - current workspace/worktree summary needed by the TUI
-- `cursor`
+- `newest_seq`
   - replay cursor for the subsequent event stream
 
 Explicit brief record retrieval remains available through

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -455,10 +455,12 @@ Event replay is a separate authorization/projection boundary. A replayed event
 is historical state recovery, not re-ingress, re-execution, or a new operator
 instruction. The stream envelope carries provenance independently of the event
 payload so clients can index and recover replayed records consistently.
-Required replay provenance includes the event cursor/id, sequence, timestamp,
-event kind, agent id, and any available origin, trust, authority class,
-delivery surface, admission context, transport/source, reply route, message id,
-task id, work item id, correlation id, and causation id.
+Required replay provenance includes the event id, per-agent durable
+`event_seq`, timestamp, event kind, agent id, and any available origin, trust,
+authority class, delivery surface, admission context, transport/source, reply
+route, message id, task id, work item id, correlation id, and causation id.
+Replay cursors use `event_seq`; transport-local sequence numbers are diagnostic
+only and must not determine replay order.
 
 Operator replay is the default projection and includes the canonical standard
 event payload. Event payloads should be explicit, schema-stable runtime

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -113,7 +113,7 @@ Returns recent runtime events (turn entries, system events). Query parameters:
 
 SSE stream of agent events. Supports `after_seq`, `limit`, and `projection`
 query params. The SSE `id` field is the per-agent durable `event_seq`, and the
-SSE `type` field is set to the raw audit event kind (e.g. `turn_entry`,
+SSE `event` field is set to the raw audit event kind (e.g. `turn_entry`,
 `wake_requested`, `task_create_requested`), not a limited set of names.
 
 **`GET /agents/:id/transcript`** — Turn transcript

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -103,14 +103,16 @@ Returns recent runtime events (turn entries, system events). Query parameters:
 
 | Param | Description |
 |-------|-------------|
-| `cursor` | Cursor for pagination |
+| `before_seq` | Return events with durable `event_seq` lower than this value |
+| `after_seq` | Return events with durable `event_seq` higher than this value |
 | `limit` | Max events to return (default 128) |
 | `order` | `asc` or `desc` (default) |
 | `projection` | `local_debug` (control token required) or `operator` (default) |
 
 **`GET /agents/:id/events/stream`** — Server-sent events
 
-SSE stream of agent events. Supports `cursor`, `limit`, and `projection` query params. The
+SSE stream of agent events. Supports `after_seq`, `limit`, and `projection`
+query params. The SSE `id` field is the per-agent durable `event_seq`, and the
 SSE `type` field is set to the raw audit event kind (e.g. `turn_entry`,
 `wake_requested`, `task_create_requested`), not a limited set of names.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -143,14 +143,15 @@ pub struct ControlPromptResponse {
 
 #[derive(Debug, Clone, Default)]
 pub struct EventStreamRequest {
-    pub cursor: Option<String>,
+    pub after_seq: Option<u64>,
     pub limit: Option<usize>,
     pub projection: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct EventPageRequest {
-    pub cursor: Option<String>,
+    pub before_seq: Option<u64>,
+    pub after_seq: Option<u64>,
     pub limit: Option<usize>,
     pub order: Option<String>,
     pub projection: Option<String>,
@@ -159,8 +160,8 @@ pub struct EventPageRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EventPageResponse {
     pub events: Vec<StreamEventEnvelope>,
-    pub oldest_cursor: Option<String>,
-    pub newest_cursor: Option<String>,
+    pub oldest_seq: Option<u64>,
+    pub newest_seq: Option<u64>,
     pub has_older: bool,
     pub has_newer: bool,
     pub order: String,
@@ -170,7 +171,7 @@ pub struct EventPageResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StreamEventEnvelope {
     pub id: String,
-    pub seq: u64,
+    pub event_seq: u64,
     pub ts: chrono::DateTime<Utc>,
     pub agent_id: String,
     #[serde(rename = "type")]
@@ -1124,8 +1125,8 @@ fn event_stream_path(agent_id: &str, request: &EventStreamRequest) -> Result<Str
         if let Some(limit) = request.limit {
             query.append_pair("limit", &limit.to_string());
         }
-        if let Some(cursor) = request.cursor.as_deref() {
-            query.append_pair("cursor", cursor);
+        if let Some(after_seq) = request.after_seq {
+            query.append_pair("after_seq", &after_seq.to_string());
         }
         if let Some(projection) = request.projection.as_deref() {
             query.append_pair("projection", projection);
@@ -1151,8 +1152,11 @@ fn event_page_path(agent_id: &str, request: &EventPageRequest) -> Result<String>
         if let Some(limit) = request.limit {
             query.append_pair("limit", &limit.to_string());
         }
-        if let Some(cursor) = request.cursor.as_deref() {
-            query.append_pair("cursor", cursor);
+        if let Some(before_seq) = request.before_seq {
+            query.append_pair("before_seq", &before_seq.to_string());
+        }
+        if let Some(after_seq) = request.after_seq {
+            query.append_pair("after_seq", &after_seq.to_string());
         }
         if let Some(order) = request.order.as_deref() {
             query.append_pair("order", order);
@@ -1491,7 +1495,7 @@ mod tests {
         let path = event_stream_path(
             "default",
             &EventStreamRequest {
-                cursor: Some("evt_123".into()),
+                after_seq: Some(123),
                 limit: Some(20),
                 projection: Some("local_debug".into()),
             },
@@ -1499,25 +1503,22 @@ mod tests {
         .unwrap();
         assert_eq!(
             path,
-            "/agents/default/events/stream?limit=20&cursor=evt_123&projection=local_debug"
+            "/agents/default/events/stream?limit=20&after_seq=123&projection=local_debug"
         );
     }
 
     #[test]
-    fn event_stream_path_encodes_reserved_query_characters() {
+    fn event_stream_path_includes_seq_cursor() {
         let path = event_stream_path(
             "default",
             &EventStreamRequest {
-                cursor: Some("evt?x=1&y=2".into()),
+                after_seq: Some(42),
                 limit: None,
                 projection: None,
             },
         )
         .unwrap();
-        assert_eq!(
-            path,
-            "/agents/default/events/stream?cursor=evt%3Fx%3D1%26y%3D2"
-        );
+        assert_eq!(path, "/agents/default/events/stream?after_seq=42");
     }
 
     #[test]
@@ -1624,7 +1625,7 @@ mod tests {
     async fn sse_comment_heartbeat_does_not_emit_event_and_preserves_liveness() {
         let event = StreamEventEnvelope {
             id: "evt-1".into(),
-            seq: 1,
+            event_seq: 1,
             ts: chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
                 .unwrap()
                 .with_timezone(&chrono::Utc),
@@ -1707,9 +1708,9 @@ mod tests {
 
     #[test]
     fn parse_sse_frame_ignores_comments_and_multiline_data() {
-        let frame = b": heartbeat\nid: evt_123\nevent: message_admitted\ndata: {\"id\":\"evt_123\",\ndata: \"seq\":1,\ndata: \"ts\":\"2026-04-19T08:00:00Z\",\ndata: \"agent_id\":\"default\",\ndata: \"type\":\"message_admitted\",\ndata: \"payload\":{}}\n";
+        let frame = b": heartbeat\nid: 1\nevent: message_admitted\ndata: {\"id\":\"evt_123\",\ndata: \"event_seq\":1,\ndata: \"ts\":\"2026-04-19T08:00:00Z\",\ndata: \"agent_id\":\"default\",\ndata: \"type\":\"message_admitted\",\ndata: \"payload\":{}}\n";
         let parsed = parse_sse_frame(frame).unwrap().unwrap();
-        assert_eq!(parsed.id, "evt_123");
+        assert_eq!(parsed.id, "1");
         assert_eq!(parsed.event, "message_admitted");
         assert_eq!(parsed.data.event_type, "message_admitted");
         assert_eq!(parsed.data.agent_id, "default");

--- a/src/http.rs
+++ b/src/http.rs
@@ -1405,7 +1405,7 @@ fn initial_buffered_events(
         } else {
             match events.iter().position(|event| event.event_seq == after_seq) {
                 Some(position) => position + 1,
-                None => return Err(cursor_not_found(after_seq.to_string())),
+                None => return Err(event_seq_not_found(after_seq)),
             }
         }
     } else {
@@ -1454,14 +1454,14 @@ fn event_page(
         .filter(|event| event.event_seq > lower && event.event_seq < upper)
         .cloned()
         .collect::<Vec<_>>();
-    let total = filtered.len();
+    let has_more = filtered.len() > limit;
     match order {
         EventPageOrder::Asc => {
             filtered.truncate(limit);
             EventPage {
                 events: filtered,
-                has_older: lower > 0,
-                has_newer: total > limit || before_seq.is_some(),
+                has_older: false,
+                has_newer: has_more,
             }
         }
         EventPageOrder::Desc => {
@@ -1469,8 +1469,8 @@ fn event_page(
             filtered.truncate(limit);
             EventPage {
                 events: filtered,
-                has_older: total > limit || after_seq.is_some_and(|seq| seq > 0),
-                has_newer: before_seq.is_some(),
+                has_older: has_more,
+                has_newer: false,
             }
         }
     }
@@ -1565,14 +1565,15 @@ fn clone_payload_field(payload: &Value, field: &str) -> Option<Value> {
     payload.get(field).filter(|value| !value.is_null()).cloned()
 }
 
-fn cursor_not_found(cursor: String) -> (StatusCode, Json<Value>) {
+fn event_seq_not_found(event_seq: u64) -> (StatusCode, Json<Value>) {
     (
         StatusCode::NOT_FOUND,
         Json(json!({
             "ok": false,
-            "error": format!("cursor {cursor} was not found"),
+            "error": format!("after_seq {event_seq} was not found in the replay window"),
             "code": "cursor_not_found",
-            "cursor": cursor,
+            "after_seq": event_seq,
+            "event_seq": event_seq,
         })),
     )
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -334,16 +334,19 @@ pub struct LimitQuery {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EventsQuery {
-    cursor: Option<String>,
+    before_seq: Option<u64>,
+    after_seq: Option<u64>,
     limit: Option<usize>,
     order: Option<EventPageOrder>,
     projection: Option<EventReplayProjection>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EventStreamQuery {
-    cursor: Option<String>,
+    after_seq: Option<u64>,
     limit: Option<usize>,
     projection: Option<EventReplayProjection>,
 }
@@ -372,8 +375,8 @@ struct EventReplayProjectionRecord {
 #[derive(Debug, Serialize)]
 struct EventsPageResponse {
     events: Vec<StreamEventEnvelope>,
-    oldest_cursor: Option<String>,
-    newest_cursor: Option<String>,
+    oldest_seq: Option<u64>,
+    newest_seq: Option<u64>,
     has_older: bool,
     has_newer: bool,
     order: EventPageOrder,
@@ -443,7 +446,7 @@ struct AgentStateSnapshot {
 #[derive(Debug, Serialize)]
 struct StreamEventEnvelope {
     id: String,
-    seq: u64,
+    event_seq: u64,
     ts: chrono::DateTime<Utc>,
     agent_id: String,
     #[serde(rename = "type")]
@@ -459,8 +462,7 @@ struct EventStreamState {
     event_window_limit: usize,
     projection: EventReplayProjection,
     event_marker: FileActivityMarker,
-    last_seen_cursor: Option<String>,
-    next_seq: u64,
+    last_seen_seq: u64,
     buffered: VecDeque<AuditEvent>,
 }
 
@@ -1248,38 +1250,38 @@ pub async fn events(
         authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     }
 
-    let cursor = query.cursor.filter(|value| !value.is_empty());
-    let page = if cursor.is_none() && order == EventPageOrder::Desc {
-        let mut tail = runtime
-            .storage()
-            .read_recent_events(limit.saturating_add(1))
-            .map_err(error_response)?;
-        let has_older = tail.len() > limit;
-        if has_older {
-            tail.remove(0);
-        }
-        tail.reverse();
-        EventPage {
-            events: tail,
-            has_older,
-            has_newer: false,
-        }
-    } else {
-        let all_events = runtime.all_events().map_err(error_response)?;
-        event_page(&all_events, cursor.as_deref(), limit, order)?
-    };
-    let oldest_cursor = oldest_cursor(&page.events, order);
-    let newest_cursor = newest_cursor(&page.events, order);
+    let page =
+        if query.before_seq.is_none() && query.after_seq.is_none() && order == EventPageOrder::Desc
+        {
+            let mut tail = runtime
+                .storage()
+                .read_recent_events(limit.saturating_add(1))
+                .map_err(error_response)?;
+            let has_older = tail.len() > limit;
+            if has_older {
+                tail.remove(0);
+            }
+            tail.reverse();
+            EventPage {
+                events: tail,
+                has_older,
+                has_newer: false,
+            }
+        } else {
+            let all_events = runtime.all_events().map_err(error_response)?;
+            event_page(&all_events, query.before_seq, query.after_seq, limit, order)
+        };
+    let oldest_seq = oldest_seq(&page.events, order);
+    let newest_seq = newest_seq(&page.events, order);
     let events = page
         .events
         .iter()
-        .enumerate()
-        .map(|(seq, event)| stream_event_envelope(seq as u64, &agent_id, event, projection))
+        .map(|event| stream_event_envelope(&agent_id, event, projection))
         .collect();
     Ok(Json(EventsPageResponse {
         events,
-        oldest_cursor,
-        newest_cursor,
+        oldest_seq,
+        newest_seq,
         has_older: page.has_older,
         has_newer: page.has_newer,
         order,
@@ -1297,7 +1299,7 @@ pub async fn events_stream(
         .limit
         .unwrap_or(DEFAULT_EVENT_STREAM_WINDOW)
         .clamp(1, MAX_EVENT_STREAM_WINDOW);
-    let cursor = query.cursor.filter(|value| !value.is_empty());
+    let after_seq = query.after_seq;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
@@ -1316,8 +1318,9 @@ pub async fn events_stream(
         .storage()
         .read_recent_events(event_window_limit.saturating_add(1))
         .map_err(error_response)?;
-    let buffered = initial_buffered_events(&events, cursor.as_deref())?;
-    let last_seen_cursor = cursor.or_else(|| events.last().map(|event| event.id.clone()));
+    let buffered = initial_buffered_events(&events, after_seq)?;
+    let last_seen_seq =
+        after_seq.unwrap_or_else(|| events.last().map_or(0, |event| event.event_seq));
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(32);
     tokio::spawn(async move {
         let mut state = EventStreamState {
@@ -1326,24 +1329,17 @@ pub async fn events_stream(
             event_window_limit,
             projection,
             event_marker: initial_event_marker,
-            last_seen_cursor,
-            next_seq: 0,
+            last_seen_seq,
             buffered,
         };
         loop {
             if let Some(event) = state.buffered.pop_front() {
-                let envelope = stream_event_envelope(
-                    state.next_seq,
-                    &state.runtime_id,
-                    &event,
-                    state.projection,
-                );
-                state.next_seq += 1;
-                state.last_seen_cursor = Some(event.id.clone());
+                let envelope = stream_event_envelope(&state.runtime_id, &event, state.projection);
+                state.last_seen_seq = event.event_seq;
                 let payload = serde_json::to_string(&envelope).unwrap_or_else(|_| "{}".to_string());
                 if tx
                     .send(Ok(Event::default()
-                        .id(envelope.id)
+                        .id(envelope.event_seq.to_string())
                         .event(envelope.event_type)
                         .data(payload)))
                     .await
@@ -1384,8 +1380,8 @@ pub async fn events_stream(
                         continue;
                     }
                 }
-                Err(cursor) => {
-                    error!("event stream cursor fell out of replay window: {cursor}");
+                Err(seq) => {
+                    error!("event stream cursor fell out of replay window: {seq}");
                     break;
                 }
             }
@@ -1401,12 +1397,16 @@ pub async fn events_stream(
 
 fn initial_buffered_events(
     events: &[AuditEvent],
-    cursor: Option<&str>,
+    after_seq: Option<u64>,
 ) -> std::result::Result<VecDeque<AuditEvent>, (StatusCode, Json<Value>)> {
-    let start_index = if let Some(cursor) = cursor {
-        match events.iter().position(|event| event.id == cursor) {
-            Some(position) => position + 1,
-            None => return Err(cursor_not_found(cursor.to_string())),
+    let start_index = if let Some(after_seq) = after_seq {
+        if after_seq == 0 {
+            0
+        } else {
+            match events.iter().position(|event| event.event_seq == after_seq) {
+                Some(position) => position + 1,
+                None => return Err(cursor_not_found(after_seq.to_string())),
+            }
         }
     } else {
         events.len()
@@ -1417,15 +1417,15 @@ fn initial_buffered_events(
 fn refresh_buffered_events(
     state: &mut EventStreamState,
     latest_events: Vec<AuditEvent>,
-) -> std::result::Result<(), String> {
-    let start_index = if let Some(cursor) = state.last_seen_cursor.as_deref() {
+) -> std::result::Result<(), u64> {
+    let start_index = if state.last_seen_seq == 0 {
+        0
+    } else {
         latest_events
             .iter()
-            .position(|event| event.id == cursor)
+            .position(|event| event.event_seq == state.last_seen_seq)
             .map(|position| position + 1)
-            .ok_or_else(|| cursor.to_string())?
-    } else {
-        0
+            .ok_or(state.last_seen_seq)?
     };
     state
         .buffered
@@ -1442,62 +1442,57 @@ struct EventPage {
 
 fn event_page(
     events: &[AuditEvent],
-    cursor: Option<&str>,
+    before_seq: Option<u64>,
+    after_seq: Option<u64>,
     limit: usize,
     order: EventPageOrder,
-) -> std::result::Result<EventPage, (StatusCode, Json<Value>)> {
-    let cursor_index = match cursor {
-        Some(cursor) => Some(
-            events
-                .iter()
-                .position(|event| event.id == cursor)
-                .ok_or_else(|| cursor_not_found(cursor.to_string()))?,
-        ),
-        None => None,
-    };
-    let page = match order {
+) -> EventPage {
+    let lower = after_seq.unwrap_or(0);
+    let upper = before_seq.unwrap_or(u64::MAX);
+    let mut filtered = events
+        .iter()
+        .filter(|event| event.event_seq > lower && event.event_seq < upper)
+        .cloned()
+        .collect::<Vec<_>>();
+    let total = filtered.len();
+    match order {
         EventPageOrder::Asc => {
-            let start = cursor_index.map_or(0, |index| index + 1);
-            let end = (start + limit).min(events.len());
+            filtered.truncate(limit);
             EventPage {
-                events: events[start..end].to_vec(),
-                has_older: start > 0,
-                has_newer: end < events.len(),
+                events: filtered,
+                has_older: lower > 0,
+                has_newer: total > limit || before_seq.is_some(),
             }
         }
         EventPageOrder::Desc => {
-            let end = cursor_index.unwrap_or(events.len());
-            let start = end.saturating_sub(limit);
-            let mut page_events = events[start..end].to_vec();
-            page_events.reverse();
+            filtered.reverse();
+            filtered.truncate(limit);
             EventPage {
-                events: page_events,
-                has_older: start > 0,
-                has_newer: end < events.len(),
+                events: filtered,
+                has_older: total > limit || after_seq.is_some_and(|seq| seq > 0),
+                has_newer: before_seq.is_some(),
             }
         }
-    };
-    Ok(page)
+    }
 }
 
-fn oldest_cursor(events: &[AuditEvent], order: EventPageOrder) -> Option<String> {
+fn oldest_seq(events: &[AuditEvent], order: EventPageOrder) -> Option<u64> {
     match order {
         EventPageOrder::Asc => events.first(),
         EventPageOrder::Desc => events.last(),
     }
-    .map(|event| event.id.clone())
+    .map(|event| event.event_seq)
 }
 
-fn newest_cursor(events: &[AuditEvent], order: EventPageOrder) -> Option<String> {
+fn newest_seq(events: &[AuditEvent], order: EventPageOrder) -> Option<u64> {
     match order {
         EventPageOrder::Asc => events.last(),
         EventPageOrder::Desc => events.first(),
     }
-    .map(|event| event.id.clone())
+    .map(|event| event.event_seq)
 }
 
 fn stream_event_envelope(
-    seq: u64,
     agent_id: &str,
     event: &AuditEvent,
     projection: EventReplayProjection,
@@ -1505,7 +1500,7 @@ fn stream_event_envelope(
     let projected = project_event_payload_for_replay(event, projection);
     StreamEventEnvelope {
         id: event.id.clone(),
-        seq,
+        event_seq: event.event_seq,
         ts: event.created_at,
         agent_id: agent_id.to_string(),
         event_type: event.kind.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1557,6 +1557,7 @@ mod tests {
         };
         let event = |kind: &str, created_at, data| AuditEvent {
             id: uuid::Uuid::new_v4().to_string(),
+            event_seq: 0,
             created_at,
             kind: kind.into(),
             data,

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1245,7 +1245,7 @@ mod tests {
         );
         ProjectionEventRecord {
             id: "evt-1".into(),
-            seq: 1,
+            event_seq: 1,
             ts: Utc::now(),
             lane: crate::tui::projection::ProjectionEventLane::Debug,
             kind: kind.into(),

--- a/src/runtime/tests/tui_pipeline_e2e.rs
+++ b/src/runtime/tests/tui_pipeline_e2e.rs
@@ -112,7 +112,7 @@ fn minimal_snapshot(agent_id: &str, _cursor: &str) -> AgentStateSnapshot {
 /// Convert an `AuditEvent` from storage into an `AgentStreamEvent` for the TUI projection.
 fn audit_to_stream_event(
     event: &crate::types::AuditEvent,
-    seq: u64,
+    event_seq: u64,
     agent_id: &str,
 ) -> AgentStreamEvent {
     AgentStreamEvent {
@@ -120,7 +120,7 @@ fn audit_to_stream_event(
         event: event.kind.clone(),
         data: StreamEventEnvelope {
             id: event.id.clone(),
-            seq,
+            event_seq,
             ts: event.created_at,
             agent_id: agent_id.into(),
             event_type: event.kind.clone(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -156,8 +156,7 @@ impl AppStorage {
         }
 
         let events_path = ledger_dir.join("events.jsonl");
-        migrate_events_ledger(&events_path)?;
-        let event_seq_counter = max_event_seq(&events_path)?;
+        let event_seq_counter = migrate_events_ledger(&events_path)?;
 
         Ok(Self {
             events_path,
@@ -1082,40 +1081,26 @@ impl AppStorage {
     }
 }
 
-fn max_event_seq(path: &Path) -> Result<u64> {
+fn migrate_events_ledger(path: &Path) -> Result<u64> {
     if !path.exists() {
         return Ok(0);
     }
+
+    let timestamp = Utc::now().format("%Y%m%d%H%M%S%3f");
+    let tmp_path = path.with_file_name(format!(".events.jsonl.{timestamp}.tmp"));
     let file =
         fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut tmp = fs::File::create(&tmp_path)
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
     let mut max_seq = 0;
+    let mut changed = false;
+
     for line in BufReader::new(file).lines() {
         let line = line.with_context(|| format!("failed to read {}", path.display()))?;
         if line.trim().is_empty() {
             continue;
         }
-        let event: AuditEvent = serde_json::from_str(&line)?;
-        max_seq = max_seq.max(event.event_seq);
-    }
-    Ok(max_seq)
-}
-
-fn migrate_events_ledger(path: &Path) -> Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-
-    let content =
-        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let mut max_seq = 0;
-    let mut changed = false;
-    let mut migrated = Vec::new();
-
-    for line in content.lines() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let mut value: Value = serde_json::from_str(line)?;
+        let mut value: Value = serde_json::from_str(&line)?;
         let object = value
             .as_object_mut()
             .ok_or_else(|| anyhow::anyhow!("event ledger line is not a JSON object"))?;
@@ -1134,16 +1119,15 @@ fn migrate_events_ledger(path: &Path) -> Result<()> {
                 changed = true;
             }
         }
-        migrated.push(serde_json::to_string(&value)?);
+        writeln!(tmp, "{}", serde_json::to_string(&value)?)?;
     }
 
     if !changed {
-        return Ok(());
+        let _ = fs::remove_file(&tmp_path);
+        return Ok(max_seq);
     }
 
-    let timestamp = Utc::now().format("%Y%m%d%H%M%S%3f");
     let backup_path = path.with_file_name(format!("events.jsonl.bak.{timestamp}"));
-    let tmp_path = path.with_file_name(format!(".events.jsonl.{timestamp}.tmp"));
     fs::copy(path, &backup_path).with_context(|| {
         format!(
             "failed to back up {} to {}",
@@ -1151,10 +1135,6 @@ fn migrate_events_ledger(path: &Path) -> Result<()> {
             backup_path.display()
         )
     })?;
-    let mut bytes = migrated.join("\n").into_bytes();
-    bytes.push(b'\n');
-    fs::write(&tmp_path, bytes)
-        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
     fs::rename(&tmp_path, path).with_context(|| {
         format!(
             "failed to replace {} with {}",
@@ -1162,7 +1142,7 @@ fn migrate_events_ledger(path: &Path) -> Result<()> {
             tmp_path.display()
         )
     })?;
-    Ok(())
+    Ok(max_seq)
 }
 
 fn append_jsonl_bytes(path: &Path, bytes: &[u8]) -> Result<()> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -118,6 +118,7 @@ pub struct AppStorage {
     agent_identities_path: PathBuf,
     agent_path: PathBuf,
     append_mutex: Arc<Mutex<()>>,
+    event_seq_counter: Arc<Mutex<u64>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,8 +155,12 @@ impl AppStorage {
                 .with_context(|| format!("failed to create {}", dir.display()))?;
         }
 
+        let events_path = ledger_dir.join("events.jsonl");
+        migrate_events_ledger(&events_path)?;
+        let event_seq_counter = max_event_seq(&events_path)?;
+
         Ok(Self {
-            events_path: ledger_dir.join("events.jsonl"),
+            events_path,
             briefs_path: ledger_dir.join("briefs.jsonl"),
             messages_path: ledger_dir.join("messages.jsonl"),
             tasks_path: ledger_dir.join("tasks.jsonl"),
@@ -178,6 +183,7 @@ impl AppStorage {
             agent_identities_path: ledger_dir.join("agent_identities.jsonl"),
             agent_path: state_dir.join("agent.json"),
             append_mutex: Arc::new(Mutex::new(())),
+            event_seq_counter: Arc::new(Mutex::new(event_seq_counter)),
             data_dir,
         })
     }
@@ -217,7 +223,23 @@ impl AppStorage {
     }
 
     pub fn append_event(&self, event: &AuditEvent) -> Result<()> {
-        self.append_jsonl(&self.events_path, event)
+        let mut event = event.clone();
+        let _guard = self
+            .append_mutex
+            .lock()
+            .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        let mut counter = self
+            .event_seq_counter
+            .lock()
+            .map_err(|_| anyhow::anyhow!("event sequence counter mutex poisoned"))?;
+        *counter += 1;
+        event.event_seq = *counter;
+        let line = serde_json::to_string(&event)?;
+        let mut bytes = Vec::with_capacity(line.len() + 1);
+        bytes.extend_from_slice(line.as_bytes());
+        bytes.push(b'\n');
+        append_jsonl_bytes(&self.events_path, &bytes)?;
+        Ok(())
     }
 
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
@@ -1060,6 +1082,89 @@ impl AppStorage {
     }
 }
 
+fn max_event_seq(path: &Path) -> Result<u64> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let file =
+        fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut max_seq = 0;
+    for line in BufReader::new(file).lines() {
+        let line = line.with_context(|| format!("failed to read {}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event: AuditEvent = serde_json::from_str(&line)?;
+        max_seq = max_seq.max(event.event_seq);
+    }
+    Ok(max_seq)
+}
+
+fn migrate_events_ledger(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut max_seq = 0;
+    let mut changed = false;
+    let mut migrated = Vec::new();
+
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut value: Value = serde_json::from_str(line)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("event ledger line is not a JSON object"))?;
+        match object.get("event_seq").and_then(Value::as_u64) {
+            Some(seq) if seq > max_seq => {
+                max_seq = seq;
+            }
+            Some(seq) => {
+                anyhow::bail!(
+                    "event ledger sequence must be strictly increasing; found {seq} after {max_seq}"
+                );
+            }
+            None => {
+                max_seq += 1;
+                object.insert("event_seq".to_string(), Value::from(max_seq));
+                changed = true;
+            }
+        }
+        migrated.push(serde_json::to_string(&value)?);
+    }
+
+    if !changed {
+        return Ok(());
+    }
+
+    let timestamp = Utc::now().format("%Y%m%d%H%M%S%3f");
+    let backup_path = path.with_file_name(format!("events.jsonl.bak.{timestamp}"));
+    let tmp_path = path.with_file_name(format!(".events.jsonl.{timestamp}.tmp"));
+    fs::copy(path, &backup_path).with_context(|| {
+        format!(
+            "failed to back up {} to {}",
+            path.display(),
+            backup_path.display()
+        )
+    })?;
+    let mut bytes = migrated.join("\n").into_bytes();
+    bytes.push(b'\n');
+    fs::write(&tmp_path, bytes)
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed to replace {} with {}",
+            path.display(),
+            tmp_path.display()
+        )
+    })?;
+    Ok(())
+}
+
 fn append_jsonl_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -1378,6 +1483,97 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn append_event_assigns_monotonic_event_seq() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+
+        storage
+            .append_event(&AuditEvent::new(
+                "test_event",
+                serde_json::json!({ "n": 1 }),
+            ))
+            .unwrap();
+        storage
+            .append_event(&AuditEvent::new(
+                "test_event",
+                serde_json::json!({ "n": 2 }),
+            ))
+            .unwrap();
+
+        let events = storage.read_recent_events(10).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.event_seq)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        let reopened = AppStorage::new(dir.path()).unwrap();
+        reopened
+            .append_event(&AuditEvent::new(
+                "test_event",
+                serde_json::json!({ "n": 3 }),
+            ))
+            .unwrap();
+        let events = reopened.read_recent_events(10).unwrap();
+        assert_eq!(events.last().map(|event| event.event_seq), Some(3));
+    }
+
+    #[test]
+    fn storage_backfills_legacy_events_jsonl_on_open() {
+        let dir = tempdir().unwrap();
+        let ledger_dir = dir.path().join(".holon/ledger");
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let events_path = ledger_dir.join("events.jsonl");
+        std::fs::write(
+            &events_path,
+            [
+                serde_json::json!({
+                    "id": "evt-old-1",
+                    "created_at": "2026-05-20T00:00:00Z",
+                    "kind": "test_event",
+                    "data": { "n": 1 }
+                })
+                .to_string(),
+                serde_json::json!({
+                    "id": "evt-old-2",
+                    "created_at": "2026-05-20T00:00:01Z",
+                    "kind": "test_event",
+                    "data": { "n": 2 }
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let events = storage.read_recent_events(10).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| (event.id.as_str(), event.event_seq))
+                .collect::<Vec<_>>(),
+            vec![("evt-old-1", 1), ("evt-old-2", 2)]
+        );
+        assert!(std::fs::read_dir(&ledger_dir).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with("events.jsonl.bak.")));
+
+        storage
+            .append_event(&AuditEvent::new(
+                "test_event",
+                serde_json::json!({ "n": 3 }),
+            ))
+            .unwrap();
+        let events = storage.read_recent_events(10).unwrap();
+        assert_eq!(events.last().map(|event| event.event_seq), Some(3));
+    }
 
     #[test]
     fn storage_round_trip_agent() {

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -807,7 +807,7 @@ mod tests {
         );
         ProjectionEventRecord {
             id: "evt-1".into(),
-            seq: 1,
+            event_seq: 1,
             ts: Utc::now(),
             lane: ProjectionEventLane::Debug,
             kind: kind.into(),

--- a/src/tui/logging.rs
+++ b/src/tui/logging.rs
@@ -117,7 +117,7 @@ impl TuiLogWriter {
 struct PersistedTuiEventLogRecord<'a> {
     ts: DateTime<Utc>,
     event_id: &'a str,
-    seq: u64,
+    event_seq: u64,
     kind: &'a str,
     summary: &'a str,
     payload: &'a Value,
@@ -128,7 +128,7 @@ impl<'a> PersistedTuiEventLogRecord<'a> {
         Self {
             ts: event.ts,
             event_id: &event.id,
-            seq: event.seq,
+            event_seq: event.event_seq,
             kind: &event.kind,
             summary: &event.summary,
             payload: &event.payload,
@@ -180,7 +180,7 @@ impl<'a> PersistedPresentationLogRecord<'a> {
                 reducer_events
                     .iter()
                     .take(MAX_REDUCER_EVENT_SUMMARIES)
-                    .map(|e| e.seq)
+                    .map(|e| e.event_seq)
                     .collect()
             },
             reducer_event_summaries: if MAX_REDUCER_EVENT_SUMMARIES == 0 {
@@ -413,7 +413,7 @@ mod tests {
         let writer = TuiLogWriter::new_temp().unwrap();
         let event = ProjectionEventRecord {
             id: "evt_1".into(),
-            seq: 7,
+            event_seq: 7,
             ts: Utc::now(),
             kind: "brief_created".into(),
             lane: ProjectionEventLane::Timeline,
@@ -453,7 +453,7 @@ mod tests {
         let writer = TuiLogWriter::new_temp_with_presentation_logging(4096).unwrap();
         let event = ProjectionEventRecord {
             id: "evt_1".into(),
-            seq: 7,
+            event_seq: 7,
             ts: Utc::now(),
             kind: "brief_created".into(),
             lane: ProjectionEventLane::Timeline,
@@ -506,7 +506,7 @@ mod tests {
         let writer = TuiLogWriter::new_temp_with_presentation_logging(4096).unwrap();
         let event = ProjectionEventRecord {
             id: "evt_debug".into(),
-            seq: 9,
+            event_seq: 9,
             ts: Utc::now(),
             kind: "provider_round_completed".into(),
             lane: ProjectionEventLane::Debug,
@@ -546,7 +546,7 @@ mod tests {
         let writer = TuiLogWriter::new_temp_with_presentation_logging(1800).unwrap();
         let event = ProjectionEventRecord {
             id: "evt_debug".into(),
-            seq: 9,
+            event_seq: 9,
             ts: Utc::now(),
             kind: "provider_round_completed".into(),
             lane: ProjectionEventLane::Debug,
@@ -588,7 +588,7 @@ mod tests {
         let writer = TuiLogWriter::new_temp_with_presentation_logging(128).unwrap();
         let event = ProjectionEventRecord {
             id: "evt_large".into(),
-            seq: 9,
+            event_seq: 9,
             ts: Utc::now(),
             kind: "provider_round_completed".into(),
             lane: ProjectionEventLane::Debug,
@@ -623,7 +623,7 @@ mod tests {
         let writer = TuiLogWriter::new_temp().unwrap();
         let event = ProjectionEventRecord {
             id: "evt_terminal".into(),
-            seq: 10,
+            event_seq: 10,
             ts: Utc::now(),
             kind: "turn_terminal".into(),
             lane: ProjectionEventLane::Debug,
@@ -652,7 +652,7 @@ mod tests {
         let writer = TuiLogWriter::new_temp().unwrap();
         let event = ProjectionEventRecord {
             id: "evt_error".into(),
-            seq: 11,
+            event_seq: 11,
             ts: Utc::now(),
             kind: "runtime_error".into(),
             lane: ProjectionEventLane::Debug,

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -193,7 +193,7 @@ fn draw_events_overlay(
             format!(
                 "Id: {}\nSeq: {}\nTime: {}\nLane: {:?}\nType: {}\nSummary: {}\n\nPayload:\n{}",
                 event.id,
-                event.seq,
+                event.event_seq,
                 event.ts.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S"),
                 event.lane,
                 event.kind,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -61,7 +61,7 @@ pub(crate) enum ProjectionEventLane {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ProjectionEventRecord {
     pub(crate) id: String,
-    pub(crate) seq: u64,
+    pub(crate) event_seq: u64,
     pub(crate) ts: DateTime<Utc>,
     pub(crate) kind: String,
     pub(crate) lane: ProjectionEventLane,
@@ -82,8 +82,8 @@ pub(crate) struct TuiProjection {
     pub(crate) external_triggers: Vec<ExternalTriggerStateSnapshot>,
     pub(crate) operator_notifications: Vec<crate::types::OperatorNotificationRecord>,
     pub(crate) workspace: StateWorkspaceSnapshot,
-    pub(crate) cursor: Option<String>,
-    pub(crate) history_oldest_cursor: Option<String>,
+    pub(crate) cursor: Option<u64>,
+    pub(crate) history_oldest_cursor: Option<u64>,
     pub(crate) history_has_older: bool,
     history_paging_active: bool,
     pub(crate) stale_slices: BTreeSet<ProjectionSlice>,
@@ -141,7 +141,7 @@ impl TuiProjection {
     pub(crate) fn replace_event_window(
         &mut self,
         events_tail: Vec<StreamEventEnvelope>,
-        cursor: Option<String>,
+        cursor: Option<u64>,
     ) {
         self.event_log.clear();
         self.durable_conversation_log.clear();
@@ -152,7 +152,7 @@ impl TuiProjection {
     pub(crate) fn merge_event_tail(
         &mut self,
         events_tail: Vec<StreamEventEnvelope>,
-        cursor: Option<String>,
+        cursor: Option<u64>,
     ) {
         self.cursor = cursor.or_else(|| self.cursor.clone());
         let event_log_limit = if self.history_paging_active {
@@ -173,8 +173,8 @@ impl TuiProjection {
             self.event_log.push(record);
         }
         self.event_log.sort_by(|left, right| {
-            left.seq
-                .cmp(&right.seq)
+            left.event_seq
+                .cmp(&right.event_seq)
                 .then_with(|| left.ts.cmp(&right.ts))
                 .then_with(|| left.id.cmp(&right.id))
         });
@@ -184,22 +184,18 @@ impl TuiProjection {
         }
         self.rebuild_durable_conversation_log();
         if self.cursor.is_none() {
-            self.cursor = self.event_log.last().map(|event| event.id.clone());
+            self.cursor = self.event_log.last().map(|event| event.event_seq);
         }
     }
 
-    pub(crate) fn set_event_history_state(
-        &mut self,
-        oldest_cursor: Option<String>,
-        has_older: bool,
-    ) {
+    pub(crate) fn set_event_history_state(&mut self, oldest_cursor: Option<u64>, has_older: bool) {
         self.history_oldest_cursor = oldest_cursor;
         self.history_has_older = has_older;
     }
 
     pub(crate) fn set_event_history_state_from_tail(
         &mut self,
-        oldest_cursor: Option<String>,
+        oldest_cursor: Option<u64>,
         has_older: bool,
     ) {
         if self.history_paging_active && self.history_oldest_cursor.is_some() {
@@ -212,7 +208,7 @@ impl TuiProjection {
     pub(crate) fn prepend_event_history_page(
         &mut self,
         mut events: Vec<StreamEventEnvelope>,
-        oldest_cursor: Option<String>,
+        oldest_cursor: Option<u64>,
         has_older: bool,
     ) -> usize {
         self.history_paging_active = true;
@@ -253,7 +249,7 @@ impl TuiProjection {
             return 0;
         }
 
-        self.history_oldest_cursor = prepended.first().map(|event| event.id.clone());
+        self.history_oldest_cursor = prepended.first().map(|event| event.event_seq);
         self.history_has_older = has_older
             && !capped
             && self.event_log.len().saturating_add(added) < EVENT_HISTORY_LOG_LIMIT;
@@ -301,7 +297,7 @@ impl TuiProjection {
                 }
             }
         }
-        self.cursor = Some(event.id.clone());
+        self.cursor = Some(event.data.event_seq);
 
         match event.data.event_type.as_str() {
             "agent_state_changed" | "session_state_changed" => {
@@ -498,7 +494,7 @@ impl TuiProjection {
         self.rebuild_durable_conversation_log();
         if let Some(last_event) = self.event_log.last() {
             if self.cursor.is_none() {
-                self.cursor = Some(last_event.id.clone());
+                self.cursor = Some(last_event.event_seq);
             }
         }
     }
@@ -571,7 +567,7 @@ impl TuiProjection {
         events.sort_by(|left, right| {
             left.ts
                 .cmp(&right.ts)
-                .then_with(|| left.seq.cmp(&right.seq))
+                .then_with(|| left.event_seq.cmp(&right.event_seq))
                 .then_with(|| left.id.cmp(&right.id))
         });
         events
@@ -1215,7 +1211,7 @@ fn projection_event_record_from_stream_event(
     );
     ProjectionEventRecord {
         id: event.id.clone(),
-        seq: event.data.seq,
+        event_seq: event.data.event_seq,
         ts: event.data.ts,
         kind: event.data.event_type.clone(),
         lane: classify_event_lane(&presentation),
@@ -1483,7 +1479,7 @@ mod tests {
         let snapshot = sample_snapshot();
         let events_tail = vec![StreamEventEnvelope {
             id: "evt-tail-1".into(),
-            seq: 0,
+            event_seq: 0,
             ts: Utc::now(),
             agent_id: "default".into(),
             event_type: "assistant_round_recorded".into(),
@@ -1502,7 +1498,7 @@ mod tests {
             }),
         }];
         let mut projection = TuiProjection::from_snapshot(snapshot);
-        projection.replace_event_window(events_tail, Some("evt-tail-1".into()));
+        projection.replace_event_window(events_tail, Some(0));
 
         assert_eq!(projection.event_log().len(), 1);
         assert_eq!(
@@ -1512,7 +1508,7 @@ mod tests {
                 .map(|event| event.summary.as_str()),
             Some("Assistant requested tools: ExecCommand")
         );
-        assert_eq!(projection.cursor.as_deref(), Some("evt-tail-1"));
+        assert_eq!(projection.cursor, Some(0));
         assert!(projection.durable_conversation_events().next().is_none());
     }
 
@@ -1596,14 +1592,14 @@ mod tests {
         let snapshot = sample_snapshot();
         let events_tail = vec![sample_event_envelope("evt-newer", 3)];
         let mut projection = TuiProjection::from_snapshot(snapshot);
-        projection.replace_event_window(events_tail, Some("evt-newer".into()));
+        projection.replace_event_window(events_tail, Some(3));
 
         let added = projection.prepend_event_history_page(
             vec![
                 sample_event_envelope("evt-older-2", 2),
                 sample_event_envelope("evt-older-1", 1),
             ],
-            Some("evt-older-1".into()),
+            Some(1),
             true,
         );
 
@@ -1614,10 +1610,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(added, 2);
         assert_eq!(ids, vec!["evt-older-1", "evt-older-2", "evt-newer"]);
-        assert_eq!(
-            projection.history_oldest_cursor.as_deref(),
-            Some("evt-older-1")
-        );
+        assert_eq!(projection.history_oldest_cursor, Some(1));
         assert!(projection.history_has_older);
     }
 
@@ -1626,15 +1619,15 @@ mod tests {
         let snapshot = sample_snapshot();
         let events_tail = vec![sample_event_envelope("evt-newer", 3)];
         let mut projection = TuiProjection::from_snapshot(snapshot);
-        projection.replace_event_window(events_tail, Some("evt-newer".into()));
-        projection.set_event_history_state(Some("evt-newer".into()), true);
+        projection.replace_event_window(events_tail, Some(3));
+        projection.set_event_history_state(Some(3), true);
 
         let added = projection.prepend_event_history_page(
             vec![
                 sample_event_envelope("evt-older-2", 2),
                 sample_event_envelope("evt-older-1", 1),
             ],
-            Some("evt-older-1".into()),
+            Some(1),
             true,
         );
         assert_eq!(added, 2);
@@ -1644,7 +1637,7 @@ mod tests {
                 sample_event_envelope("evt-newer", 3),
                 sample_event_envelope("evt-live", 4),
             ],
-            Some("evt-live".into()),
+            Some(4),
         );
 
         let ids = projection
@@ -1656,7 +1649,7 @@ mod tests {
             ids,
             vec!["evt-older-1", "evt-older-2", "evt-newer", "evt-live"]
         );
-        assert_eq!(projection.cursor.as_deref(), Some("evt-live"));
+        assert_eq!(projection.cursor, Some(4));
     }
 
     #[test]
@@ -1667,10 +1660,7 @@ mod tests {
                 sample_event_envelope(&format!("evt-existing-{index}"), (index + 100) as u64)
             })
             .collect::<Vec<_>>();
-        projection.replace_event_window(
-            events_tail,
-            Some(format!("evt-existing-{}", EVENT_LOG_LIMIT - 1)),
-        );
+        projection.replace_event_window(events_tail, Some((EVENT_LOG_LIMIT + 99) as u64));
 
         projection.merge_event_tail(vec![sample_event_envelope("evt-old-refresh", 1)], None);
 
@@ -1687,18 +1677,46 @@ mod tests {
     }
 
     #[test]
+    fn projection_refresh_keeps_latest_live_event_at_log_cap() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let events_tail = (1..=EVENT_LOG_LIMIT as u64)
+            .map(|seq| sample_event_envelope(&format!("evt-existing-{seq}"), seq))
+            .collect::<Vec<_>>();
+        projection.replace_event_window(events_tail, Some(EVENT_LOG_LIMIT as u64));
+
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "evt-live".into(),
+                event: "assistant_round_recorded".into(),
+                data: sample_event_envelope("evt-live", EVENT_LOG_LIMIT as u64 + 1),
+            },
+            &test_log_writer(),
+        );
+        projection.merge_event_tail(vec![sample_event_envelope("evt-old-refresh", 1)], None);
+
+        let ids = projection
+            .event_log()
+            .iter()
+            .map(|event| event.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(projection.event_log().len(), EVENT_LOG_LIMIT);
+        assert!(ids.contains(&"evt-live"));
+        assert!(!ids.contains(&"evt-old-refresh"));
+        assert_eq!(projection.cursor, Some(EVENT_LOG_LIMIT as u64 + 1));
+    }
+
+    #[test]
     fn projection_caps_prepended_history_and_keeps_cursor_on_retained_oldest() {
         let snapshot = sample_snapshot();
         let events_tail = vec![sample_event_envelope("evt-live", 5000)];
         let mut projection = TuiProjection::from_snapshot(snapshot);
-        projection.replace_event_window(events_tail, Some("evt-live".into()));
+        projection.replace_event_window(events_tail, Some(5000));
 
         let first_page = (0..16_378)
             .rev()
             .map(|seq| sample_event_envelope(&format!("evt-page-a-{seq}"), seq))
             .collect::<Vec<_>>();
-        let first_added =
-            projection.prepend_event_history_page(first_page, Some("evt-page-a-0".into()), true);
+        let first_added = projection.prepend_event_history_page(first_page, Some(0), true);
         assert_eq!(first_added, 16_378);
         assert_eq!(projection.event_log().len(), 16_379);
         assert!(projection.history_has_older);
@@ -1707,11 +1725,7 @@ mod tests {
             .rev()
             .map(|seq| sample_event_envelope(&format!("evt-page-b-{seq}"), seq))
             .collect::<Vec<_>>();
-        let second_added = projection.prepend_event_history_page(
-            second_page,
-            Some("evt-page-b-16378".into()),
-            true,
-        );
+        let second_added = projection.prepend_event_history_page(second_page, Some(16_378), true);
 
         assert_eq!(second_added, 5);
         assert_eq!(projection.event_log().len(), 16_384);
@@ -1722,10 +1736,7 @@ mod tests {
                 .map(|event| event.id.as_str()),
             Some("evt-page-b-16393")
         );
-        assert_eq!(
-            projection.history_oldest_cursor.as_deref(),
-            Some("evt-page-b-16393")
-        );
+        assert_eq!(projection.history_oldest_cursor, Some(16_393));
         assert!(!projection.history_has_older);
         assert!(projection.event_history_at_local_cap());
     }
@@ -2157,7 +2168,7 @@ mod tests {
                     event: "provider_round_completed".into(),
                     data: StreamEventEnvelope {
                         id: format!("evt-debug-{index}"),
-                        seq: (index + 2) as u64,
+                        event_seq: (index + 2) as u64,
                         ts: Utc::now(),
                         agent_id: "default".into(),
                         event_type: "provider_round_completed".into(),
@@ -2485,10 +2496,10 @@ mod tests {
         }
     }
 
-    fn sample_event_envelope(id: &str, seq: u64) -> StreamEventEnvelope {
+    fn sample_event_envelope(id: &str, event_seq: u64) -> StreamEventEnvelope {
         sample_event_envelope_with_payload(
             id,
-            seq,
+            event_seq,
             "tool_executed",
             json!({ "tool_name": "ExecCommand" }),
         )
@@ -2496,13 +2507,13 @@ mod tests {
 
     fn sample_event_envelope_with_payload(
         id: &str,
-        seq: u64,
+        event_seq: u64,
         kind: &str,
         payload: Value,
     ) -> StreamEventEnvelope {
         StreamEventEnvelope {
             id: id.into(),
-            seq,
+            event_seq,
             ts: Utc::now(),
             agent_id: "default".into(),
             event_type: kind.into(),
@@ -2521,7 +2532,7 @@ mod tests {
         );
         super::ProjectionEventRecord {
             id: format!("evt-{kind}"),
-            seq: 1,
+            event_seq: 1,
             ts: Utc::now(),
             kind: kind.to_string(),
             lane: super::classify_event_lane(&presentation),

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -67,8 +67,8 @@ pub(super) enum TuiRuntimeMessage {
 type SnapshotBootstrapResult = (
     AgentStateSnapshot,
     Vec<StreamEventEnvelope>,
-    Option<String>,
-    Option<String>,
+    Option<u64>,
+    Option<u64>,
     bool,
 );
 
@@ -430,9 +430,9 @@ impl TuiApp {
                             },
                         )
                         .await?;
-                    let newest_cursor = events_page.newest_cursor.clone();
+                    let newest_cursor = events_page.newest_seq;
                     events_page.events.reverse();
-                    let oldest_cursor = events_page.oldest_cursor;
+                    let oldest_cursor = events_page.oldest_seq;
                     let has_older = events_page.has_older;
                     anyhow::Ok((
                         snapshot,
@@ -543,17 +543,13 @@ impl TuiApp {
         self.begin_connect_event_stream_for(agent_id, cursor);
     }
 
-    pub(super) fn begin_connect_event_stream_for(
-        &mut self,
-        agent_id: String,
-        cursor: Option<String>,
-    ) {
+    pub(super) fn begin_connect_event_stream_for(&mut self, agent_id: String, cursor: Option<u64>) {
         self.stream_connect_in_flight = true;
         self.stream_connect_request_id = self.stream_connect_request_id.saturating_add(1);
         let request_id = self.stream_connect_request_id;
         self.reconnect_deadline = None;
         let request = EventStreamRequest {
-            cursor,
+            after_seq: cursor,
             ..Default::default()
         };
         let client = self.client.clone();
@@ -775,7 +771,7 @@ impl TuiApp {
                     .agent_events_page(
                         &agent_id,
                         EventPageRequest {
-                            cursor: Some(cursor),
+                            before_seq: Some(cursor),
                             limit: Some(EVENT_HISTORY_PAGE_LIMIT),
                             order: Some("desc".into()),
                             ..Default::default()
@@ -818,11 +814,8 @@ impl TuiApp {
             if projection.agent.identity.agent_id != agent_id {
                 return;
             }
-            let added = projection.prepend_event_history_page(
-                page.events,
-                page.oldest_cursor,
-                page.has_older,
-            );
+            let added =
+                projection.prepend_event_history_page(page.events, page.oldest_seq, page.has_older);
             (added, projection.history_has_older)
         };
         if added > 0 {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -430,15 +430,15 @@ impl TuiApp {
                             },
                         )
                         .await?;
-                    let newest_cursor = events_page.newest_seq;
+                    let newest_seq = events_page.newest_seq;
                     events_page.events.reverse();
-                    let oldest_cursor = events_page.oldest_seq;
+                    let oldest_seq = events_page.oldest_seq;
                     let has_older = events_page.has_older;
                     anyhow::Ok((
                         snapshot,
                         events_page.events,
-                        newest_cursor,
-                        oldest_cursor,
+                        newest_seq,
+                        oldest_seq,
                         has_older,
                     ))
                 }
@@ -467,7 +467,7 @@ impl TuiApp {
             return;
         }
         self.snapshot_refresh_in_flight = false;
-        let (snapshot, events_tail, newest_cursor, oldest_cursor, has_older) = match result {
+        let (snapshot, events_tail, newest_seq, oldest_seq, has_older) = match result {
             Ok(result) => result,
             Err(err) => {
                 if let Some(checkpoint) = checkpoint {
@@ -497,8 +497,8 @@ impl TuiApp {
         } else {
             TuiProjection::from_snapshot(snapshot)
         };
-        projection.merge_event_tail(events_tail, newest_cursor);
-        projection.set_event_history_state_from_tail(oldest_cursor, has_older);
+        projection.merge_event_tail(events_tail, newest_seq);
+        projection.set_event_history_state_from_tail(oldest_seq, has_older);
         let cursor = projection.cursor.clone();
 
         self.stop_stream_task();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -256,7 +256,7 @@ fn sample_snapshot(agent_id: &str, _cursor: &str) -> AgentStateSnapshot {
 
 fn operator_message_event_envelope(
     id: &str,
-    seq: u64,
+    event_seq: u64,
     agent_id: &str,
     text: &str,
 ) -> StreamEventEnvelope {
@@ -271,7 +271,7 @@ fn operator_message_event_envelope(
     message.id = id.into();
     pipeline_event_envelope(
         id,
-        seq,
+        event_seq,
         agent_id,
         "message_enqueued",
         serde_json::to_value(message).unwrap(),
@@ -289,7 +289,7 @@ fn apply_brief_event(app: &mut TuiApp, brief: BriefRecord) {
             event: "brief_created".into(),
             data: StreamEventEnvelope {
                 id: event_id,
-                seq: 0,
+                event_seq: 0,
                 ts: brief.created_at,
                 agent_id: brief.agent_id.clone(),
                 event_type: "brief_created".into(),
@@ -343,7 +343,7 @@ fn collect_chat_items_does_not_write_presentation_debug_log() {
     let snapshot = sample_snapshot("default", "evt-assistant");
     let events_tail = vec![StreamEventEnvelope {
         id: "evt-assistant".into(),
-        seq: 1,
+        event_seq: 1,
         ts: Utc::now(),
         agent_id: "default".into(),
         event_type: "assistant_round_recorded".into(),
@@ -352,7 +352,7 @@ fn collect_chat_items_does_not_write_presentation_debug_log() {
         payload: json!({ "round": 1, "text_preview": "history progress" }),
     }];
     let mut projection = TuiProjection::from_snapshot(snapshot);
-    projection.replace_event_window(events_tail, Some("evt-assistant".into()));
+    projection.replace_event_window(events_tail, Some(1));
     app.projection = Some(projection);
 
     let first = collect_chat_items(&app);
@@ -1545,7 +1545,7 @@ fn chat_text_shows_active_assistant_preview_without_durable_system_event() {
             event: "work_item_written".into(),
             data: StreamEventEnvelope {
                 id: "evt-work".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "work_item_written".into(),
@@ -1575,7 +1575,7 @@ fn chat_text_shows_active_assistant_preview_without_durable_system_event() {
             event: "assistant_round_recorded".into(),
             data: StreamEventEnvelope {
                 id: "evt-assistant".into(),
-                seq: 3,
+                event_seq: 3,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "assistant_round_recorded".into(),
@@ -1615,7 +1615,7 @@ fn chat_display_mode_debug_shows_debug_events_and_keeps_working_row() {
             event: "tool_executed".into(),
             data: StreamEventEnvelope {
                 id: "evt-tool".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "tool_executed".into(),
@@ -1635,7 +1635,7 @@ fn chat_display_mode_debug_shows_debug_events_and_keeps_working_row() {
             event: "agent_state_changed".into(),
             data: StreamEventEnvelope {
                 id: "evt-state".into(),
-                seq: 3,
+                event_seq: 3,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "agent_state_changed".into(),
@@ -1678,7 +1678,7 @@ fn chat_text_omits_task_system_events() {
             event: "task_result_received".into(),
             data: StreamEventEnvelope {
                 id: "evt-task".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "task_result_received".into(),
@@ -1732,7 +1732,7 @@ fn chat_text_keeps_active_activity_after_brief_event() {
             event: "tool_executed".into(),
             data: StreamEventEnvelope {
                 id: "evt-tool".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "tool_executed".into(),
@@ -1752,7 +1752,7 @@ fn chat_text_keeps_active_activity_after_brief_event() {
             event: "brief_created".into(),
             data: StreamEventEnvelope {
                 id: "evt-brief".into(),
-                seq: 3,
+                event_seq: 3,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "brief_created".into(),
@@ -1808,7 +1808,7 @@ fn chat_text_keeps_active_action_after_snapshot_refresh() {
             event: "tool_executed".into(),
             data: StreamEventEnvelope {
                 id: "evt-tool".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "tool_executed".into(),
@@ -1849,7 +1849,7 @@ fn chat_text_uses_selected_agent_events_tail_after_switch() {
             event: "tool_executed".into(),
             data: StreamEventEnvelope {
                 id: "evt-a-tool".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "agent-a".into(),
                 event_type: "tool_executed".into(),
@@ -1875,7 +1875,7 @@ fn chat_text_uses_selected_agent_events_tail_after_switch() {
     switched_snapshot.agent.agent.status = AgentStatus::AwakeRunning;
     let events_tail = vec![StreamEventEnvelope {
         id: "evt-b-tool".into(),
-        seq: 0,
+        event_seq: 0,
         ts: Utc::now(),
         agent_id: "agent-b".into(),
         event_type: "tool_executed".into(),
@@ -1893,7 +1893,7 @@ fn chat_text_uses_selected_agent_events_tail_after_switch() {
     // Switching agents must use the selected agent's event page rather
     // than inheriting the previous agent's event log.
     let mut switched_projection = TuiProjection::from_snapshot(switched_snapshot);
-    switched_projection.replace_event_window(events_tail, Some("evt-b-tool".into()));
+    switched_projection.replace_event_window(events_tail, Some(0));
     app.projection = Some(switched_projection);
 
     let rendered: String = build_chat_text(&collect_chat_items(&app))
@@ -1923,7 +1923,7 @@ fn chat_text_does_not_show_stale_activity_when_agent_is_idle() {
             event: "tool_executed".into(),
             data: StreamEventEnvelope {
                 id: "evt-tool".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "tool_executed".into(),
@@ -2004,7 +2004,7 @@ fn active_activity_timestamp_does_not_sort_before_tail_history() {
             event: "tool_executed".into(),
             data: StreamEventEnvelope {
                 id: "evt-tool".into(),
-                seq: 2,
+                event_seq: 2,
                 ts,
                 agent_id: "default".into(),
                 event_type: "tool_executed".into(),
@@ -2203,7 +2203,7 @@ fn chat_includes_pending_operator_message_from_snapshot() {
             "default",
             "please stop soon",
         )],
-        Some("evt-message-queued".into()),
+        Some(0),
     );
     app.projection = Some(projection);
 
@@ -2240,7 +2240,7 @@ fn conversation_events_overlay_uses_event_projection() {
             "default",
             "event sourced transcript",
         )],
-        Some("evt-message-1".into()),
+        Some(0),
     );
     app.projection = Some(projection);
 
@@ -2267,7 +2267,7 @@ fn chat_dedupes_pending_operator_message_when_event_log_contains_it() {
             "default",
             "persisted operator text",
         )],
-        Some("evt-message-1".into()),
+        Some(0),
     );
     app.projection = Some(projection);
     app.apply_projection_view();
@@ -2309,7 +2309,7 @@ fn chat_text_omits_processing_and_processed_operator_status_labels() {
                 "default",
                 "operator text",
             )],
-            Some("evt-message-1".into()),
+            Some(0),
         );
         app.projection = Some(projection);
         app.apply_projection_view();
@@ -2354,7 +2354,7 @@ fn projection_operator_message_prunes_reconciled_optimistic_entry() {
             "default",
             "durable text",
         )],
-        Some("message-1".into()),
+        Some(0),
     );
     app.projection = Some(projection);
     app.apply_projection_view();
@@ -2390,7 +2390,7 @@ fn events_overlay_selection_stays_pinned_to_same_event_id() {
             event: "provider_round_completed".into(),
             data: StreamEventEnvelope {
                 id: "evt-old".into(),
-                seq: 2,
+                event_seq: 2,
                 ts: Utc::now(),
                 agent_id: "default".into(),
                 event_type: "provider_round_completed".into(),
@@ -2414,7 +2414,7 @@ fn events_overlay_selection_stays_pinned_to_same_event_id() {
                 event: "provider_round_completed".into(),
                 data: StreamEventEnvelope {
                     id: "evt-new".into(),
-                    seq: 3,
+                    event_seq: 3,
                     ts: Utc::now(),
                     agent_id: "default".into(),
                     event_type: "provider_round_completed".into(),
@@ -2723,7 +2723,7 @@ fn stale_projection_event_schedules_refresh() {
         event: "waiting_intent_created".into(),
         data: StreamEventEnvelope {
             id: "evt-stale".into(),
-            seq: 2,
+            event_seq: 2,
             ts: Utc::now(),
             agent_id: "default".into(),
             event_type: "waiting_intent_created".into(),
@@ -2977,14 +2977,14 @@ fn history_navigation_browses_multiple_entries() {
 /// Helper: build a `StreamEventEnvelope` with the given fields.
 fn pipeline_event_envelope(
     id: &str,
-    seq: u64,
+    event_seq: u64,
     agent_id: &str,
     event_type: &str,
     payload: serde_json::Value,
 ) -> StreamEventEnvelope {
     StreamEventEnvelope {
         id: id.into(),
-        seq,
+        event_seq,
         ts: Utc::now(),
         agent_id: agent_id.into(),
         event_type: event_type.into(),
@@ -2997,7 +2997,7 @@ fn pipeline_event_envelope(
 /// Helper: build an `AgentStreamEvent` for a known kind.
 fn pipeline_event(
     id: &str,
-    seq: u64,
+    event_seq: u64,
     agent_id: &str,
     kind: &str,
     payload: serde_json::Value,
@@ -3005,7 +3005,7 @@ fn pipeline_event(
     AgentStreamEvent {
         id: id.into(),
         event: kind.into(),
-        data: pipeline_event_envelope(id, seq, agent_id, kind, payload),
+        data: pipeline_event_envelope(id, event_seq, agent_id, kind, payload),
     }
 }
 
@@ -4067,9 +4067,9 @@ fn pipeline_stress_50_tool_calls() {
     let start = std::time::Instant::now();
 
     // Feed 55 pairs of process_execution_requested + tool_executed.
-    let mut seq: u64 = 0;
+    let mut event_seq: u64 = 0;
     for step in 1..=TOOL_COUNT {
-        seq += 1;
+        event_seq += 1;
         let cmd = format!("echo step {step}");
         let stdout = format!("step {step}");
         let req_id = format!("evt-req-{step}");
@@ -4078,7 +4078,7 @@ fn pipeline_stress_50_tool_calls() {
         projection.apply_event(
             pipeline_event(
                 &req_id,
-                seq,
+                event_seq,
                 "default",
                 "process_execution_requested",
                 json!({ "exec_command_cmd": cmd }),
@@ -4086,11 +4086,11 @@ fn pipeline_stress_50_tool_calls() {
             &app.log_writer,
         );
 
-        seq += 1;
+        event_seq += 1;
         projection.apply_event(
             pipeline_event(
                 &tool_id,
-                seq,
+                event_seq,
                 "default",
                 "tool_executed",
                 json!({
@@ -4106,11 +4106,11 @@ fn pipeline_stress_50_tool_calls() {
     }
 
     // End the turn.
-    seq += 1;
+    event_seq += 1;
     projection.apply_event(
         pipeline_event(
             "evt-assistant",
-            seq,
+            event_seq,
             "default",
             "assistant_round_recorded",
             json!({ "round": 1, "text_preview": "All 55 steps completed." }),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3199,6 +3199,8 @@ impl BriefRecord {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditEvent {
     pub id: String,
+    #[serde(default)]
+    pub event_seq: u64,
     pub created_at: DateTime<Utc>,
     pub kind: String,
     pub data: Value,
@@ -3208,6 +3210,7 @@ impl AuditEvent {
     pub fn new(kind: impl Into<String>, data: Value) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
+            event_seq: 0,
             created_at: Utc::now(),
             kind: kind.into(),
             data,

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -326,7 +326,7 @@ pub async fn local_client_over_http_can_read_agent_state_snapshot() -> Result<()
             },
         )
         .await?;
-    assert!(events_page.newest_cursor.is_some());
+    assert!(events_page.newest_seq.is_some());
 
     let raw_state: serde_json::Value = reqwest::Client::new()
         .get(format!("{base}/agents/default/state"))
@@ -364,7 +364,7 @@ pub async fn local_client_over_http_can_stream_events_with_cursor_query() -> Res
         .control_prompt("default", "http stream bootstrap")
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
-    let cursor = client
+    let after_seq = client
         .agent_events_page(
             "default",
             EventPageRequest {
@@ -374,8 +374,8 @@ pub async fn local_client_over_http_can_stream_events_with_cursor_query() -> Res
             },
         )
         .await?
-        .newest_cursor
-        .expect("cursor should be present");
+        .newest_seq
+        .expect("event seq should be present");
 
     client
         .control_prompt("default", "http stream replay")
@@ -384,7 +384,7 @@ pub async fn local_client_over_http_can_stream_events_with_cursor_query() -> Res
         .stream_agent_events(
             "default",
             EventStreamRequest {
-                cursor: Some(cursor),
+                after_seq: Some(after_seq),
                 ..Default::default()
             },
         )
@@ -464,7 +464,7 @@ pub async fn local_client_over_unix_socket_can_stream_events_with_cursor_query()
         .control_prompt("default", "unix stream bootstrap")
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
-    let cursor = client
+    let after_seq = client
         .agent_events_page(
             "default",
             EventPageRequest {
@@ -474,8 +474,8 @@ pub async fn local_client_over_unix_socket_can_stream_events_with_cursor_query()
             },
         )
         .await?
-        .newest_cursor
-        .expect("cursor should be present");
+        .newest_seq
+        .expect("event seq should be present");
 
     client
         .control_prompt("default", "unix stream replay")
@@ -484,7 +484,7 @@ pub async fn local_client_over_unix_socket_can_stream_events_with_cursor_query()
         .stream_agent_events(
             "default",
             EventStreamRequest {
-                cursor: Some(cursor),
+                after_seq: Some(after_seq),
                 ..Default::default()
             },
         )

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -57,17 +57,16 @@ async fn next_sse_event_kind(
     .await?
 }
 
-async fn newest_event_cursor(base: &str, client: &Client) -> Result<String> {
+async fn newest_event_seq(base: &str, client: &Client) -> Result<u64> {
     let page: serde_json::Value = client
         .get(format!("{base}/agents/default/events?limit=1&order=desc"))
         .send()
         .await?
         .json()
         .await?;
-    page["newest_cursor"]
-        .as_str()
-        .map(str::to_string)
-        .ok_or_else(|| anyhow::anyhow!("newest_cursor should be present"))
+    page["newest_seq"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("newest_seq should be present"))
 }
 
 pub async fn events_route_supports_cursor_pagination() -> Result<()> {
@@ -95,17 +94,17 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
         .await?;
     let latest_events = latest["events"].as_array().expect("events");
     assert_eq!(latest_events.len(), 2);
-    let latest_newest = latest_events[0]["id"].as_str().expect("newest id");
-    let latest_oldest = latest_events[1]["id"].as_str().expect("oldest id");
-    assert_eq!(latest["newest_cursor"], latest_newest);
-    assert_eq!(latest["oldest_cursor"], latest_oldest);
+    let latest_newest = latest_events[0]["event_seq"].as_u64().expect("newest seq");
+    let latest_oldest = latest_events[1]["event_seq"].as_u64().expect("oldest seq");
+    assert_eq!(latest["newest_seq"], latest_newest);
+    assert_eq!(latest["oldest_seq"], latest_oldest);
     assert_eq!(latest["has_older"], true);
     assert_eq!(latest["has_newer"], false);
 
     let older: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/events?cursor={}&limit=2&order=desc",
-            latest["oldest_cursor"].as_str().expect("oldest cursor")
+            "{base}/agents/default/events?before_seq={}&limit=2&order=desc",
+            latest["oldest_seq"].as_u64().expect("oldest seq")
         ))
         .send()
         .await?
@@ -113,16 +112,18 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
         .await?;
     let older_events = older["events"].as_array().expect("events");
     assert!(!older_events.is_empty());
-    let older_newest = older_events[0]["id"].as_str().expect("older newest id");
+    let older_newest = older_events[0]["event_seq"]
+        .as_u64()
+        .expect("older newest seq");
     assert_ne!(older_newest, latest_newest);
     assert_ne!(older_newest, latest_oldest);
-    assert_eq!(older["newest_cursor"], older_newest);
+    assert_eq!(older["newest_seq"], older_newest);
     assert_eq!(older["has_newer"], true);
 
     let newer: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/events?cursor={}&limit=2&order=asc",
-            older["newest_cursor"].as_str().expect("newest cursor")
+            "{base}/agents/default/events?after_seq={}&limit=2&order=asc",
+            older["newest_seq"].as_u64().expect("newest seq")
         ))
         .send()
         .await?
@@ -130,22 +131,20 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
         .await?;
     let newer_events = newer["events"].as_array().expect("events");
     assert_eq!(newer_events.len(), 2);
-    assert_eq!(newer_events[0]["id"], latest_oldest);
-    assert_eq!(newer_events[1]["id"], latest_newest);
-    assert_eq!(newer["oldest_cursor"], latest_oldest);
-    assert_eq!(newer["newest_cursor"], latest_newest);
+    assert_eq!(newer_events[0]["event_seq"], latest_oldest);
+    assert_eq!(newer_events[1]["event_seq"], latest_newest);
+    assert_eq!(newer["oldest_seq"], latest_oldest);
+    assert_eq!(newer["newest_seq"], latest_newest);
 
     let empty_cursor: serde_json::Value = client
-        .get(format!(
-            "{base}/agents/default/events?cursor=&limit=2&order=desc"
-        ))
+        .get(format!("{base}/agents/default/events?limit=2&order=desc"))
         .send()
         .await?
         .json()
         .await?;
     assert_eq!(empty_cursor["events"].as_array().expect("events").len(), 2);
-    assert_eq!(empty_cursor["newest_cursor"], latest_newest);
-    assert_eq!(empty_cursor["oldest_cursor"], latest_oldest);
+    assert_eq!(empty_cursor["newest_seq"], latest_newest);
+    assert_eq!(empty_cursor["oldest_seq"], latest_oldest);
 
     server.abort();
     Ok(())
@@ -163,7 +162,7 @@ pub async fn events_route_supports_cursor_replay() -> Result<()> {
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
 
-    let cursor = newest_event_cursor(&base, &client).await?;
+    let after_seq = newest_event_seq(&base, &client).await?;
 
     client
         .post(format!("{base}/control/agents/default/prompt"))
@@ -172,7 +171,7 @@ pub async fn events_route_supports_cursor_replay() -> Result<()> {
         .await?;
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?cursor={cursor}"
+            "{base}/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -196,7 +195,7 @@ pub async fn events_stream_supports_cursor_and_rfc3339_ts() -> Result<()> {
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
 
-    let cursor = newest_event_cursor(&base, &client).await?;
+    let after_seq = newest_event_seq(&base, &client).await?;
 
     client
         .post(format!("{base}/control/agents/default/prompt"))
@@ -206,7 +205,7 @@ pub async fn events_stream_supports_cursor_and_rfc3339_ts() -> Result<()> {
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?cursor={cursor}"
+            "{base}/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -234,7 +233,7 @@ pub async fn events_route_preserves_replay_provenance() -> Result<()> {
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
 
-    let cursor = newest_event_cursor(&base, &client).await?;
+    let after_seq = newest_event_seq(&base, &client).await?;
 
     client
         .post(format!("{base}/control/agents/default/prompt"))
@@ -244,7 +243,7 @@ pub async fn events_route_preserves_replay_provenance() -> Result<()> {
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?cursor={cursor}"
+            "{base}/agents/default/events/stream?after_seq={after_seq}"
         ))
         .send()
         .await?;
@@ -286,7 +285,7 @@ pub async fn events_route_operator_projection_preserves_tool_payload() -> Result
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
 
-    let cursor = newest_event_cursor(&base, &client).await?;
+    let after_seq = newest_event_seq(&base, &client).await?;
 
     runtime.storage().append_event(&AuditEvent::new(
         "tool_executed",
@@ -303,7 +302,7 @@ pub async fn events_route_operator_projection_preserves_tool_payload() -> Result
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?cursor={cursor}&projection=operator"
+            "{base}/agents/default/events/stream?after_seq={after_seq}&projection=operator"
         ))
         .send()
         .await?;
@@ -347,7 +346,7 @@ pub async fn events_route_operator_projection_preserves_assistant_round_payload(
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
 
-    let cursor = newest_event_cursor(&base, &client).await?;
+    let after_seq = newest_event_seq(&base, &client).await?;
 
     runtime.storage().append_event(&AuditEvent::new(
         "assistant_round_recorded",
@@ -371,7 +370,7 @@ pub async fn events_route_operator_projection_preserves_assistant_round_payload(
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?cursor={cursor}&projection=operator"
+            "{base}/agents/default/events/stream?after_seq={after_seq}&projection=operator"
         ))
         .send()
         .await?;
@@ -427,7 +426,7 @@ pub async fn events_route_operator_projection_preserves_workspace_payload() -> R
         .await?;
     wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
 
-    let cursor = newest_event_cursor(&base, &client).await?;
+    let after_seq = newest_event_seq(&base, &client).await?;
 
     runtime.storage().append_event(&AuditEvent::new(
         "workspace_used",
@@ -444,7 +443,7 @@ pub async fn events_route_operator_projection_preserves_workspace_payload() -> R
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?cursor={cursor}&projection=operator"
+            "{base}/agents/default/events/stream?after_seq={after_seq}&projection=operator"
         ))
         .send()
         .await?;
@@ -506,10 +505,9 @@ pub async fn state_snapshot_seeds_projected_events_tail_and_stream_resumes_after
         .iter()
         .find(|event| event["type"] == "assistant_round_recorded")
         .expect("events page should include the appended assistant round");
-    let cursor = assistant_tail["id"]
-        .as_str()
-        .expect("assistant round cursor should be present")
-        .to_string();
+    let after_seq = assistant_tail["event_seq"]
+        .as_u64()
+        .expect("assistant round event seq should be present");
     assert_eq!(assistant_tail["projection"]["name"], "operator");
     assert_eq!(
         assistant_tail["projection"]["raw_payload_included"],
@@ -536,13 +534,13 @@ pub async fn state_snapshot_seeds_projected_events_tail_and_stream_resumes_after
 
     let mut stream = client
         .get(format!(
-            "{base}/agents/default/events/stream?cursor={cursor}&projection=operator"
+            "{base}/agents/default/events/stream?after_seq={after_seq}&projection=operator"
         ))
         .send()
         .await?;
     let replayed = next_sse_event_kind(&mut stream, "tool_executed").await?;
     assert_eq!(replayed.event, "tool_executed");
-    assert_ne!(replayed._id, cursor);
+    assert_ne!(replayed._id, after_seq.to_string());
 
     server.abort();
     Ok(())
@@ -630,9 +628,7 @@ pub async fn events_stream_with_missing_cursor_returns_not_found() -> Result<()>
     let (_host, base, server) = spawn_server().await?;
     let client = reqwest::Client::new();
     let response = client
-        .get(format!(
-            "{base}/agents/default/events/stream?cursor=evt_missing"
-        ))
+        .get(format!("{base}/agents/default/events/stream?after_seq=999"))
         .send()
         .await?;
     let status = response.status();

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -118,7 +118,7 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
     assert_ne!(older_newest, latest_newest);
     assert_ne!(older_newest, latest_oldest);
     assert_eq!(older["newest_seq"], older_newest);
-    assert_eq!(older["has_newer"], true);
+    assert_eq!(older["has_newer"], false);
 
     let newer: serde_json::Value = client
         .get(format!(
@@ -135,6 +135,32 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
     assert_eq!(newer_events[1]["event_seq"], latest_newest);
     assert_eq!(newer["oldest_seq"], latest_oldest);
     assert_eq!(newer["newest_seq"], latest_newest);
+    assert_eq!(newer["has_older"], false);
+    assert_eq!(newer["has_newer"], false);
+
+    let bounded_newer: serde_json::Value = client
+        .get(format!(
+            "{base}/agents/default/events?after_seq={latest_oldest}&limit=10&order=desc"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(bounded_newer["events"].as_array().expect("events").len(), 1);
+    assert_eq!(bounded_newer["has_older"], false);
+    assert_eq!(bounded_newer["has_newer"], false);
+
+    let bounded_older: serde_json::Value = client
+        .get(format!(
+            "{base}/agents/default/events?after_seq={older_newest}&before_seq={latest_newest}&limit=10&order=asc"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(bounded_older["events"].as_array().expect("events").len(), 1);
+    assert_eq!(bounded_older["has_older"], false);
+    assert_eq!(bounded_older["has_newer"], false);
 
     let empty_cursor: serde_json::Value = client
         .get(format!("{base}/agents/default/events?limit=2&order=desc"))


### PR DESCRIPTION
## Summary
- assign per-agent durable event_seq values when audit events are appended, including automatic legacy events.jsonl backfill with backups
- replace HTTP/SSE event cursors with seq-based before_seq/after_seq and expose event_seq in envelopes
- update TUI event projection/history logic to sort, trim, and reconnect by event_seq so live messages are not dropped after refresh
- update event replay docs to define ledger-assigned event_seq semantics

## Tests
- cargo fmt --all -- --check
- cargo check -q --all-targets
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test -q --test http_events -- --nocapture
- cargo test -q --test http_client -- --nocapture
- cargo test -q tui::projection -- --nocapture
- cargo test -q append_event_assigns_monotonic_event_seq -- --nocapture
- cargo test -q storage_backfills_legacy_events_jsonl_on_open -- --nocapture
- cargo test -q projection_refresh_keeps_latest_live_event_at_log_cap -- --nocapture