### PR TITLE
fix: lighten daemon startup readiness

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -379,13 +379,17 @@ impl LocalClient {
         self.get_control_json("/control/runtime/status").await
     }
 
+    pub async fn runtime_readiness(&self) -> Result<RuntimeStatusResponse> {
+        self.get_control_json("/control/runtime/readiness").await
+    }
+
     #[cfg(unix)]
-    pub async fn runtime_status_unix_only(&self) -> Result<RuntimeStatusResponse> {
+    pub async fn runtime_readiness_unix_only(&self) -> Result<RuntimeStatusResponse> {
         let body = self
-            .send_unix(RequestSpec::get("/control/runtime/status"), true)
+            .send_unix(RequestSpec::get("/control/runtime/readiness"), true)
             .await?;
         serde_json::from_slice(&body).with_context(|| {
-            "failed to decode response body for GET /control/runtime/status over unix socket"
+            "failed to decode response body for GET /control/runtime/readiness over unix socket"
         })
     }
 

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -793,7 +793,7 @@ pub(crate) async fn probe_runtime(config: &AppConfig) -> ProbeRuntime {
                 }
             }
         };
-        match tokio::time::timeout(UNIX_PROBE_TIMEOUT, client.runtime_status_unix_only()).await {
+        match tokio::time::timeout(UNIX_PROBE_TIMEOUT, client.runtime_readiness_unix_only()).await {
             Ok(Ok(status)) => return ProbeRuntime::Running(Box::new(status)),
             Ok(Err(err)) => {
                 let occupied_socket = unix_probe_indicates_foreign_process(err.root_cause());
@@ -821,7 +821,7 @@ pub(crate) async fn probe_runtime(config: &AppConfig) -> ProbeRuntime {
             }
         }
     };
-    match client.runtime_status().await {
+    match client.runtime_readiness().await {
         Ok(status) => ProbeRuntime::Running(Box::new(status)),
         Err(_) => ProbeRuntime::Stopped {
             occupied_socket: false,

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -210,6 +210,27 @@ impl RuntimeServiceHandle {
         }
     }
 
+    pub fn readiness_response(
+        &self,
+        startup_surface: RuntimeStartupSurface,
+        runtime_surface: RuntimeConfigSurface,
+    ) -> RuntimeStatusResponse {
+        RuntimeStatusResponse {
+            ok: true,
+            healthy: true,
+            pid: self.inner.metadata.pid,
+            home_dir: self.inner.metadata.home_dir.clone(),
+            socket_path: self.inner.metadata.socket_path.clone(),
+            http_addr: self.inner.metadata.http_addr.clone(),
+            started_at: self.inner.metadata.started_at,
+            config_fingerprint: self.inner.metadata.config_fingerprint.clone(),
+            startup_surface: Some(startup_surface),
+            runtime_surface: Some(runtime_surface),
+            activity: None,
+            last_failure: None,
+        }
+    }
+
     pub fn shutdown_response(&self) -> RuntimeShutdownResponse {
         RuntimeShutdownResponse {
             ok: true,

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -492,7 +492,7 @@ async fn daemon_stop_surfaces_incompatible_status_probe_guidance() {
     assert!(err.contains("stale socket with no runtime currently serving it"));
     assert!(err.contains("Probe error:"));
     assert!(err.contains(
-        "failed to decode response body for GET /control/runtime/status over unix socket"
+        "failed to decode response body for GET /control/runtime/readiness over unix socket"
     ));
     assert!(socket_path.exists());
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -183,6 +183,7 @@ pub fn router(state: AppState) -> Router {
             "/control/agents/:agent_id/operator-ingress",
             post(operator_ingress),
         )
+        .route("/control/runtime/readiness", get(runtime_readiness))
         .route("/control/runtime/status", get(runtime_status))
         .route("/control/runtime/shutdown", post(runtime_shutdown))
         .route(
@@ -637,6 +638,33 @@ pub async fn runtime_status(
         .into_iter()
         .filter_map(|agent| agent.last_runtime_failure)
         .max_by(|left, right| left.occurred_at.cmp(&right.occurred_at));
+    let (startup_surface, runtime_surface) = runtime_surfaces(&state);
+    Ok(Json(runtime_service.status_response(
+        activity,
+        last_failure,
+        startup_surface,
+        runtime_surface,
+    )))
+}
+
+pub async fn runtime_readiness(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime_service = state
+        .runtime_service
+        .as_ref()
+        .ok_or_else(|| service_unavailable("runtime service metadata is unavailable"))?;
+    let (startup_surface, runtime_surface) = runtime_surfaces(&state);
+    Ok(Json(
+        runtime_service.readiness_response(startup_surface, runtime_surface),
+    ))
+}
+
+fn runtime_surfaces(
+    state: &AppState,
+) -> (crate::daemon::RuntimeStartupSurface, RuntimeConfigSurface) {
     let config = state.host.config();
     let startup_surface = crate::daemon::RuntimeStartupSurface {
         home_dir: config.home_dir.clone(),
@@ -647,13 +675,7 @@ pub async fn runtime_status(
         control_token_configured: config.control_token.is_some(),
         control_auth_mode: config.control_auth_mode.into(),
     };
-    let runtime_surface = RuntimeConfigSurface::new(config);
-    Ok(Json(runtime_service.status_response(
-        activity,
-        last_failure,
-        startup_surface,
-        runtime_surface,
-    )))
+    (startup_surface, RuntimeConfigSurface::new(config))
 }
 
 pub async fn runtime_shutdown(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1085,6 +1085,9 @@ fn migrate_events_ledger(path: &Path) -> Result<u64> {
     if !path.exists() {
         return Ok(0);
     }
+    if let Some(seq) = read_tail_event_seq(path)? {
+        return Ok(seq);
+    }
 
     let timestamp = Utc::now().format("%Y%m%d%H%M%S%3f");
     let tmp_path = path.with_file_name(format!(".events.jsonl.{timestamp}.tmp"));
@@ -1143,6 +1146,38 @@ fn migrate_events_ledger(path: &Path) -> Result<u64> {
         )
     })?;
     Ok(max_seq)
+}
+
+fn read_tail_event_seq(path: &Path) -> Result<Option<u64>> {
+    let mut file =
+        fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut cursor = file.seek(SeekFrom::End(0))?;
+    if cursor == 0 {
+        return Ok(Some(0));
+    }
+
+    let mut suffix = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    while cursor > 0 {
+        let read_len = usize::try_from(cursor.min(buffer.len() as u64)).unwrap_or(buffer.len());
+        cursor -= read_len as u64;
+        file.seek(SeekFrom::Start(cursor))?;
+        file.read_exact(&mut buffer[..read_len])?;
+        suffix.splice(0..0, buffer[..read_len].iter().copied());
+        if suffix[..suffix.len().saturating_sub(1)].contains(&b'\n') {
+            break;
+        }
+    }
+
+    for line in suffix.split(|byte| *byte == b'\n').rev() {
+        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+            continue;
+        }
+        let value: Value = serde_json::from_slice(line)
+            .with_context(|| format!("failed to parse tail event in {}", path.display()))?;
+        return Ok(value.get("event_seq").and_then(Value::as_u64));
+    }
+    Ok(Some(0))
 }
 
 fn append_jsonl_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
@@ -1553,6 +1588,42 @@ mod tests {
             .unwrap();
         let events = storage.read_recent_events(10).unwrap();
         assert_eq!(events.last().map(|event| event.event_seq), Some(3));
+    }
+
+    #[test]
+    fn storage_uses_tail_event_seq_without_rewriting_migrated_ledger() {
+        let dir = tempdir().unwrap();
+        let ledger_dir = dir.path().join(".holon/ledger");
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let events_path = ledger_dir.join("events.jsonl");
+        let first = AuditEvent {
+            id: "evt-new-1".into(),
+            event_seq: 41,
+            created_at: Utc::now(),
+            kind: "test_event".into(),
+            data: serde_json::json!({ "n": 1 }),
+        };
+        std::fs::write(
+            &events_path,
+            format!("{}\n", serde_json::to_string(&first).unwrap()),
+        )
+        .unwrap();
+
+        let storage = AppStorage::new(dir.path()).unwrap();
+        assert!(!std::fs::read_dir(&ledger_dir).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with("events.jsonl.bak.")));
+
+        storage
+            .append_event(&AuditEvent::new(
+                "test_event",
+                serde_json::json!({ "n": 2 }),
+            ))
+            .unwrap();
+        let events = storage.read_recent_events(10).unwrap();
+        assert_eq!(events.last().map(|event| event.event_seq), Some(42));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1149,35 +1149,10 @@ fn migrate_events_ledger(path: &Path) -> Result<u64> {
 }
 
 fn read_tail_event_seq(path: &Path) -> Result<Option<u64>> {
-    let mut file =
-        fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let mut cursor = file.seek(SeekFrom::End(0))?;
-    if cursor == 0 {
+    let Some(value) = read_latest_jsonl_matching::<Value, _>(path, |_| true)? else {
         return Ok(Some(0));
-    }
-
-    let mut suffix = Vec::new();
-    let mut buffer = [0_u8; 8192];
-    while cursor > 0 {
-        let read_len = usize::try_from(cursor.min(buffer.len() as u64)).unwrap_or(buffer.len());
-        cursor -= read_len as u64;
-        file.seek(SeekFrom::Start(cursor))?;
-        file.read_exact(&mut buffer[..read_len])?;
-        suffix.splice(0..0, buffer[..read_len].iter().copied());
-        if suffix[..suffix.len().saturating_sub(1)].contains(&b'\n') {
-            break;
-        }
-    }
-
-    for line in suffix.split(|byte| *byte == b'\n').rev() {
-        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
-            continue;
-        }
-        let value: Value = serde_json::from_slice(line)
-            .with_context(|| format!("failed to parse tail event in {}", path.display()))?;
-        return Ok(value.get("event_seq").and_then(Value::as_u64));
-    }
-    Ok(Some(0))
+    };
+    Ok(value.get("event_seq").and_then(Value::as_u64))
 }
 
 fn append_jsonl_bytes(path: &Path, bytes: &[u8]) -> Result<()> {

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -29,6 +29,7 @@ http_async_tests!(
     control_start_restores_live_runtime_loop_for_stopped_agent,
     daemon_shutdown_restart_preserves_public_agent_http_runnability,
     runtime_status_route_reports_runtime_metadata,
+    runtime_readiness_route_omits_activity_summary,
     runtime_status_route_reports_waiting_activity_summary,
     runtime_status_route_reports_last_runtime_failure_summary,
     runtime_shutdown_route_requests_shutdown,

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -39,4 +39,5 @@ http_async_tests!(
 http_async_tests!(
     control_prompt_is_open_over_unix_socket_auto,
     control_runtime_status_is_open_over_unix_socket_when_auth_required,
+    control_runtime_readiness_is_open_over_unix_socket_when_auth_required,
 );

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -425,6 +425,42 @@ pub async fn control_runtime_status_is_open_over_unix_socket_when_auth_required(
     Ok(())
 }
 
+#[cfg(unix)]
+pub async fn control_runtime_readiness_is_open_over_unix_socket_when_auth_required() -> Result<()> {
+    let config = test_config_with_paths(
+        tempdir().unwrap().keep(),
+        tempdir().unwrap().keep(),
+        "127.0.0.1:0".into(),
+        ControlAuthMode::Required,
+    );
+    std::fs::create_dir_all(&config.workspace_dir)?;
+    init_git_repo(&config.workspace_dir)?;
+    if let Some(parent) = config.socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let host = RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    let runtime_service = RuntimeServiceHandle::new(&config)?;
+    let router: Router = http::router(AppState::for_unix_with_runtime_service(
+        host.clone(),
+        Some(runtime_service),
+    ));
+    let listener = UnixListener::bind(&config.socket_path)?;
+    let socket_path = config.socket_path.clone();
+    let server = tokio::spawn(async move {
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        http::serve_unix(listener, router, rx).await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let response =
+        unix_request(&socket_path, "GET", "/control/runtime/readiness", &[], None).await?;
+    assert_eq!(response.status, 200);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<()> {
     let config = test_config_with_paths(
         tempdir().unwrap().keep(),

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1011,6 +1011,49 @@ pub async fn runtime_status_route_reports_runtime_metadata() -> Result<()> {
     Ok(())
 }
 
+pub async fn runtime_readiness_route_omits_activity_summary() -> Result<()> {
+    let config = test_config();
+    std::fs::create_dir_all(&config.workspace_dir)?;
+    init_git_repo(&config.workspace_dir)?;
+    let host = RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    let runtime_service = RuntimeServiceHandle::new(&config)?;
+    let router: Router = http::router(AppState::for_tcp_with_runtime_service(
+        host.clone(),
+        Some(runtime_service.clone()),
+    ));
+    let listener = TcpListener::bind(&config.http_addr).await?;
+    let addr = connect_addr(listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://{addr}/control/runtime/readiness"))
+        .bearer_auth("secret")
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let payload: serde_json::Value = response.json().await?;
+    assert_eq!(payload["healthy"], true);
+    assert_eq!(payload["home_dir"], config.home_dir.display().to_string());
+    assert_eq!(
+        payload["startup_surface"]["default_agent_id"],
+        config.default_agent_id
+    );
+    assert_eq!(
+        payload["runtime_surface"]["model_default"],
+        config.default_model.as_string()
+    );
+    assert!(payload.get("activity").is_none());
+    assert!(payload.get("last_failure").is_none());
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn runtime_status_route_reports_waiting_activity_summary() -> Result<()> {
     let config = test_config();
     std::fs::create_dir_all(&config.workspace_dir)?;


### PR DESCRIPTION
## Summary
- add a lightweight `/control/runtime/readiness` endpoint and switch daemon lifecycle probes to it
- keep `/control/runtime/status` as the heavier activity summary endpoint
- avoid full `events.jsonl` scans on migrated ledgers by reading the tail `event_seq` first, falling back to migration only for legacy ledgers

## Verification
- `cargo fmt --all -- --check`
- `cargo test storage::tests::storage_uses_tail_event_seq_without_rewriting_migrated_ledger`
- `cargo test storage::tests::storage_backfills_legacy_events_jsonl_on_open`
- `cargo test runtime_readiness_route_omits_activity_summary`
- `cargo test runtime_status_route_reports_runtime_metadata`
- `cargo test daemon::tests::daemon_stop_surfaces_incompatible_status_probe_guidance`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
