### PR TITLE
fix: harden serve fd limits

### DIFF
--- a/src/fd_limit.rs
+++ b/src/fd_limit.rs
@@ -1,0 +1,182 @@
+use std::io;
+
+pub const DEFAULT_NOFILE_TARGET: u64 = 8192;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileDescriptorLimit {
+    pub soft: u64,
+    pub hard: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileDescriptorLimitReport {
+    pub target: u64,
+    pub before: Option<FileDescriptorLimit>,
+    pub after: Option<FileDescriptorLimit>,
+    pub raised: bool,
+    pub unsupported: bool,
+    pub error: Option<String>,
+}
+
+impl FileDescriptorLimitReport {
+    pub fn startup_summary(&self) -> String {
+        if self.unsupported {
+            return "fd limits: unsupported on this platform".into();
+        }
+        if let Some(error) = &self.error {
+            return format!("fd limits: failed to inspect or raise NOFILE limit: {error}");
+        }
+
+        let Some(before) = self.before else {
+            return "fd limits: unavailable".into();
+        };
+        let after = self.after.unwrap_or(before);
+        let action = if self.raised {
+            format!("raised soft limit from {} to {}", before.soft, after.soft)
+        } else if after.soft < self.target && after.hard < self.target {
+            format!(
+                "soft limit remains {} because OS hard limit {} is below target {}",
+                after.soft, after.hard, self.target
+            )
+        } else {
+            format!("soft limit already {}", after.soft)
+        };
+        format!(
+            "fd limits: {action}; hard limit {}; target {}",
+            after.hard, self.target
+        )
+    }
+}
+
+pub fn apply_nofile_limit_policy(target: u64) -> FileDescriptorLimitReport {
+    platform::apply_nofile_limit_policy(target)
+}
+
+pub fn is_fd_exhaustion_error(error: &io::Error) -> bool {
+    platform::is_fd_exhaustion_error(error)
+}
+
+#[cfg(unix)]
+mod platform {
+    use super::{FileDescriptorLimit, FileDescriptorLimitReport};
+    use std::io;
+
+    pub(super) fn apply_nofile_limit_policy(target: u64) -> FileDescriptorLimitReport {
+        let before = match current_nofile_limit() {
+            Ok(limit) => limit,
+            Err(error) => {
+                return FileDescriptorLimitReport {
+                    target,
+                    before: None,
+                    after: None,
+                    raised: false,
+                    unsupported: false,
+                    error: Some(error.to_string()),
+                };
+            }
+        };
+
+        let desired_soft = desired_soft_limit(before.soft, before.hard, target);
+        let mut raised = false;
+        let mut error = None;
+        if desired_soft > before.soft {
+            let rlim = libc::rlimit {
+                rlim_cur: desired_soft as libc::rlim_t,
+                rlim_max: before.hard as libc::rlim_t,
+            };
+            // SAFETY: setrlimit reads the provided rlimit value and does not retain pointers.
+            let result = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) };
+            if result == 0 {
+                raised = true;
+            } else {
+                error = Some(io::Error::last_os_error().to_string());
+            }
+        }
+
+        let after = current_nofile_limit().ok();
+        FileDescriptorLimitReport {
+            target,
+            before: Some(before),
+            after,
+            raised,
+            unsupported: false,
+            error,
+        }
+    }
+
+    fn current_nofile_limit() -> io::Result<FileDescriptorLimit> {
+        let mut limit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: getrlimit writes into the provided rlimit struct.
+        let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) };
+        if result != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(FileDescriptorLimit {
+            soft: limit.rlim_cur as u64,
+            hard: limit.rlim_max as u64,
+        })
+    }
+
+    fn desired_soft_limit(soft: u64, hard: u64, target: u64) -> u64 {
+        soft.max(target.min(hard))
+    }
+
+    pub(super) fn is_fd_exhaustion_error(error: &io::Error) -> bool {
+        matches!(
+            error.raw_os_error(),
+            Some(code) if code == libc::EMFILE || code == libc::ENFILE
+        )
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn desired_soft_limit_raises_to_target_when_hard_allows() {
+            assert_eq!(desired_soft_limit(256, 65_536, 8192), 8192);
+        }
+
+        #[test]
+        fn desired_soft_limit_caps_at_hard_limit() {
+            assert_eq!(desired_soft_limit(256, 1024, 8192), 1024);
+        }
+
+        #[test]
+        fn fd_exhaustion_error_matches_emfile_and_enfile() {
+            assert!(is_fd_exhaustion_error(&io::Error::from_raw_os_error(
+                libc::EMFILE
+            )));
+            assert!(is_fd_exhaustion_error(&io::Error::from_raw_os_error(
+                libc::ENFILE
+            )));
+            assert!(!is_fd_exhaustion_error(&io::Error::from_raw_os_error(
+                libc::ECONNREFUSED
+            )));
+        }
+    }
+}
+
+#[cfg(not(unix))]
+mod platform {
+    use super::FileDescriptorLimitReport;
+    use std::io;
+
+    pub(super) fn apply_nofile_limit_policy(target: u64) -> FileDescriptorLimitReport {
+        FileDescriptorLimitReport {
+            target,
+            before: None,
+            after: None,
+            raised: false,
+            unsupported: true,
+            error: None,
+        }
+    }
+
+    pub(super) fn is_fd_exhaustion_error(_error: &io::Error) -> bool {
+        false
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -23,7 +23,7 @@ use serde_json::{json, Value};
 use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
 use tower_http::compression::CompressionLayer;
-use tracing::error;
+use tracing::{error, warn};
 use uuid::Uuid;
 
 #[cfg(unix)]
@@ -2979,7 +2979,21 @@ pub async fn serve_unix(
                     Err(_) => return Ok(()),
                 }
             }
-            accepted = listener.accept() => accepted?,
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok(accepted) => accepted,
+                    Err(err) if crate::fd_limit::is_fd_exhaustion_error(&err) => {
+                        warn!(
+                            error = %err,
+                            backoff_ms = 100,
+                            "unix control server accept hit file descriptor limit; backing off"
+                        );
+                        sleep(Duration::from_millis(100)).await;
+                        continue;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
         };
         let router = router.clone();
         tokio::spawn(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod client;
 pub mod config;
 pub mod context;
 pub mod daemon;
+pub mod fd_limit;
 pub mod host;
 mod host_registry;
 pub mod http;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use holon::{
         daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
         ensure_serve_preflight, RuntimeServiceHandle,
     },
+    fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
     http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
     provider::{provider_doctor, resolved_model_availability},
@@ -1039,6 +1040,10 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
         .with_context(|| format!("failed to create {}", config.agent_root_dir().display()))?;
     std::fs::create_dir_all(config.run_dir())
         .with_context(|| format!("failed to create {}", config.run_dir().display()))?;
+    println!(
+        "{}",
+        apply_nofile_limit_policy(DEFAULT_NOFILE_TARGET).startup_summary()
+    );
     ensure_serve_preflight(&config).await?;
 
     let host = RuntimeHost::new(config.clone())?;


### PR DESCRIPTION
## Summary

Fixes #1279.

- add a serve-startup NOFILE policy that best-effort raises the soft limit to `min(hard, 8192)` and reports the effective limit state
- expose a small fd-limit module with platform-gated behavior and unit coverage for soft-limit decisions and fd exhaustion detection
- harden the Unix control server accept loop so `EMFILE`/`ENFILE` triggers a short backoff instead of terminating the runtime server

## Verification

- `cargo fmt --all && cargo test fd_limit -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
