### PR TITLE
fix: close WebSearch provider routing gaps

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1545,9 +1545,9 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
         ConfigSchemaEntry {
             key: "web.providers.<name>.kind",
             kind: "string",
-            description: "Web search provider kind: duck_duck_go, searxng, brave, tavily, exa, perplexity, firecrawl, open_ai_native, anthropic_native, gemini_native.",
+            description: "Web search provider kind: duck_duck_go, searxng, brave, tavily, exa, perplexity, firecrawl, open_ai_native, anthropic_native, gemini_native, command.",
             default: Value::Null,
-            allowed_values: vec!["duck_duck_go", "searxng", "brave", "tavily", "exa", "perplexity", "firecrawl", "open_ai_native", "anthropic_native", "gemini_native"],
+            allowed_values: vec!["duck_duck_go", "searxng", "brave", "tavily", "exa", "perplexity", "firecrawl", "open_ai_native", "anthropic_native", "gemini_native", "command"],
         },
         ConfigSchemaEntry {
             key: "web.providers.<name>.base_url",
@@ -1568,6 +1568,62 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             kind: "string",
             description: "Named credential profile to load the API key from. The profile must be of kind api_key.",
             default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.command.argv",
+            kind: "string_list",
+            description: "Fixed command argv template for kind=command WebSearch providers. Supports {{query}} and {{max_results}} substitutions.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.output.format",
+            kind: "enum",
+            description: "Command provider stdout format.",
+            default: json!("json"),
+            allowed_values: vec!["json"],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.output.mapping.title",
+            kind: "string",
+            description: "JSON path used to map each command result title.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.output.mapping.url",
+            kind: "string",
+            description: "JSON path used to map each command result URL.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.output.mapping.snippet",
+            kind: "string",
+            description: "Optional JSON path used to map each command result snippet.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.output.mapping.published_at",
+            kind: "string",
+            description: "Optional JSON path used to map each command result publication timestamp.",
+            default: Value::Null,
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.limits.timeout_ms",
+            kind: "positive_integer",
+            description: "Command provider execution timeout in milliseconds.",
+            default: json!(crate::web::WebProviderLimitsConfig::default().timeout_ms),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "web.providers.<name>.limits.max_output_bytes",
+            kind: "positive_integer",
+            description: "Command provider stdout byte limit.",
+            default: json!(crate::web::WebProviderLimitsConfig::default().max_output_bytes),
             allowed_values: vec![],
         },
     ]
@@ -1762,6 +1818,52 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
                     .get(provider_name)
                     .and_then(|p| p.credential_profile.as_ref())
                     .map(|v| Value::String(v.clone()))
+                    .unwrap_or(Value::Null));
+            }
+            if let Some(provider_name) = name.strip_suffix(".command.argv") {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .and_then(|p| p.command.as_ref())
+                    .map(|command| json!(command.argv))
+                    .unwrap_or(Value::Null));
+            }
+            if let Some(provider_name) = name.strip_suffix(".output.format") {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .and_then(|p| p.output.as_ref())
+                    .map(|output| json!(output.format))
+                    .unwrap_or(Value::Null));
+            }
+            if let Some((provider_name, field)) = web_provider_output_mapping_key(name) {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .and_then(|p| p.output.as_ref())
+                    .and_then(|output| output_mapping_field(&output.mapping, field))
+                    .map(|value| Value::String(value.to_string()))
+                    .unwrap_or(Value::Null));
+            }
+            if let Some(provider_name) = name.strip_suffix(".limits.timeout_ms") {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .and_then(|p| p.limits.timeout_ms)
+                    .map(|value| json!(value))
+                    .unwrap_or(Value::Null));
+            }
+            if let Some(provider_name) = name.strip_suffix(".limits.max_output_bytes") {
+                return Ok(config
+                    .web
+                    .providers
+                    .get(provider_name)
+                    .and_then(|p| p.limits.max_output_bytes)
+                    .map(|value| json!(value))
                     .unwrap_or(Value::Null));
             }
             if name.is_empty() {
@@ -1959,6 +2061,46 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 Some(value.to_string())
             };
         }
+        key if key.starts_with("web.providers.") && key.ends_with(".command.argv") => {
+            let provider = web_provider_config_mut(config, key, ".command.argv")?;
+            provider.command = Some(WebCommandProviderConfigFile {
+                argv: parse_string_list(raw_value)?,
+            });
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".output.format") => {
+            let provider = web_provider_config_mut(config, key, ".output.format")?;
+            let output = provider
+                .output
+                .get_or_insert_with(default_web_command_output);
+            output.format =
+                serde_json::from_value(serde_json::Value::String(raw_value.trim().to_string()))
+                    .with_context(|| format!("invalid web command output format: {}", raw_value))?;
+        }
+        key if key.starts_with("web.providers.") && key.contains(".output.mapping.") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let (name, field) =
+                web_provider_output_mapping_key(rest).ok_or_else(|| unknown_config_key(key))?;
+            if name.is_empty() {
+                return Err(anyhow!(
+                    "web.providers.<name>.output.mapping requires a non-empty provider name"
+                ));
+            }
+            let provider = config.web.providers.get_mut(name).ok_or_else(|| {
+                anyhow!("web provider {name} not found; set web.providers.{name}.kind first")
+            })?;
+            let output = provider
+                .output
+                .get_or_insert_with(default_web_command_output);
+            set_output_mapping_field(&mut output.mapping, field, raw_value.trim());
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".limits.timeout_ms") => {
+            let provider = web_provider_config_mut(config, key, ".limits.timeout_ms")?;
+            provider.limits.timeout_ms = Some(parse_positive_u64_key(key, raw_value)?);
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".limits.max_output_bytes") => {
+            let provider = web_provider_config_mut(config, key, ".limits.max_output_bytes")?;
+            provider.limits.max_output_bytes = Some(parse_positive_usize_key(key, raw_value)?);
+        }
         _ => return Err(unknown_config_key(key)),
     }
     Ok(())
@@ -2045,6 +2187,37 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
             } else {
                 return Err(anyhow!("web provider {name} not found"));
             }
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".command.argv") => {
+            let provider = web_provider_config_mut(config, key, ".command.argv")?;
+            provider.command = None;
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".output.format") => {
+            let provider = web_provider_config_mut(config, key, ".output.format")?;
+            if let Some(output) = provider.output.as_mut() {
+                output.format = WebCommandOutputFormatFile::Json;
+            }
+        }
+        key if key.starts_with("web.providers.") && key.contains(".output.mapping.") => {
+            let rest = key.strip_prefix("web.providers.").unwrap();
+            let (name, field) =
+                web_provider_output_mapping_key(rest).ok_or_else(|| unknown_config_key(key))?;
+            let provider = config
+                .web
+                .providers
+                .get_mut(name)
+                .ok_or_else(|| anyhow!("web provider {name} not found"))?;
+            if let Some(output) = provider.output.as_mut() {
+                unset_output_mapping_field(&mut output.mapping, field);
+            }
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".limits.timeout_ms") => {
+            let provider = web_provider_config_mut(config, key, ".limits.timeout_ms")?;
+            provider.limits.timeout_ms = None;
+        }
+        key if key.starts_with("web.providers.") && key.ends_with(".limits.max_output_bytes") => {
+            let provider = web_provider_config_mut(config, key, ".limits.max_output_bytes")?;
+            provider.limits.max_output_bytes = None;
         }
         key if key.starts_with("web.providers.") => {
             let name = key.strip_prefix("web.providers.").unwrap();
@@ -3066,6 +3239,77 @@ fn parse_string_list(raw_value: &str) -> Result<Vec<String>> {
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
         .collect())
+}
+
+fn web_provider_config_mut<'a>(
+    config: &'a mut HolonConfigFile,
+    key: &str,
+    suffix: &str,
+) -> Result<&'a mut WebProviderConfigFile> {
+    let rest = key.strip_prefix("web.providers.").unwrap();
+    let name = rest.strip_suffix(suffix).unwrap();
+    if name.is_empty() {
+        return Err(anyhow!(
+            "web.providers.<name>{suffix} requires a non-empty provider name"
+        ));
+    }
+    config.web.providers.get_mut(name).ok_or_else(|| {
+        anyhow!("web provider {name} not found; set web.providers.{name}.kind first")
+    })
+}
+
+fn default_web_command_output() -> WebCommandOutputConfigFile {
+    WebCommandOutputConfigFile {
+        format: WebCommandOutputFormatFile::Json,
+        mapping: WebCommandResultMappingFile {
+            title: String::new(),
+            url: String::new(),
+            snippet: None,
+            published_at: None,
+        },
+    }
+}
+
+fn web_provider_output_mapping_key(rest: &str) -> Option<(&str, &str)> {
+    let (name, field) = rest.split_once(".output.mapping.")?;
+    matches!(field, "title" | "url" | "snippet" | "published_at").then_some((name, field))
+}
+
+fn output_mapping_field<'a>(
+    mapping: &'a WebCommandResultMappingFile,
+    field: &str,
+) -> Option<&'a str> {
+    match field {
+        "title" => (!mapping.title.is_empty()).then_some(mapping.title.as_str()),
+        "url" => (!mapping.url.is_empty()).then_some(mapping.url.as_str()),
+        "snippet" => mapping.snippet.as_deref(),
+        "published_at" => mapping.published_at.as_deref(),
+        _ => None,
+    }
+}
+
+fn set_output_mapping_field(mapping: &mut WebCommandResultMappingFile, field: &str, value: &str) {
+    match field {
+        "title" => mapping.title = value.to_string(),
+        "url" => mapping.url = value.to_string(),
+        "snippet" => {
+            mapping.snippet = (!value.is_empty()).then(|| value.to_string());
+        }
+        "published_at" => {
+            mapping.published_at = (!value.is_empty()).then(|| value.to_string());
+        }
+        _ => {}
+    }
+}
+
+fn unset_output_mapping_field(mapping: &mut WebCommandResultMappingFile, field: &str) {
+    match field {
+        "title" => mapping.title.clear(),
+        "url" => mapping.url.clear(),
+        "snippet" => mapping.snippet = None,
+        "published_at" => mapping.published_at = None,
+        _ => {}
+    }
 }
 
 fn parse_model_catalog_value(raw_value: &str) -> Result<BTreeMap<String, ModelRuntimeOverride>> {

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -282,7 +282,7 @@ impl RuntimeHandle {
         };
         let available_tools = self.filter_native_web_search_tools(
             self.filtered_tool_specs_for_apply_patch_surface(identity, apply_patch_surface)?,
-            native_search_provider.is_some(),
+            native_web_search.is_some(),
         );
         Ok((provider, available_tools, native_web_search))
     }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -553,7 +553,7 @@ impl WebProviderKind {
                 supports_full_content: false,
                 supports_native_citations: false,
                 default_priority: 40,
-                status: WebProviderSupportStatus::Unsupported,
+                status: WebProviderSupportStatus::Supported,
             },
         }
     }
@@ -788,7 +788,7 @@ mod tests {
         assert_eq!(WebProviderKind::Brave.capabilities().default_priority, 80);
         assert_eq!(
             WebProviderKind::Command.capabilities().status,
-            WebProviderSupportStatus::Unsupported
+            WebProviderSupportStatus::Supported
         );
     }
 }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeSet;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
@@ -53,6 +53,16 @@ pub struct WebSearchProviderAttempt {
     pub error_message: Option<String>,
     pub provider_kind: Option<WebProviderKind>,
     pub capabilities: Option<WebProviderCapabilityMetadata>,
+    pub command: Option<WebSearchCommandAttempt>,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct WebSearchCommandAttempt {
+    pub argv_template: Vec<String>,
+    pub exit_status: Option<i32>,
+    pub exit_status_text: Option<String>,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -147,9 +157,40 @@ struct RoutedSearchOutcome {
     winning_provider: Option<String>,
 }
 
+#[derive(Debug)]
+struct ProviderSearchOutput {
+    results: Vec<WebSearchResult>,
+    diagnostics: Option<ProviderSearchDiagnostics>,
+}
+
+#[derive(Debug)]
+enum ProviderSearchDiagnostics {
+    Command(WebSearchCommandAttempt),
+}
+
+impl ProviderSearchOutput {
+    fn new(results: Vec<WebSearchResult>) -> Self {
+        Self {
+            results,
+            diagnostics: None,
+        }
+    }
+
+    fn command(results: Vec<WebSearchResult>, command: WebSearchCommandAttempt) -> Self {
+        Self {
+            results,
+            diagnostics: Some(ProviderSearchDiagnostics::Command(command)),
+        }
+    }
+}
+
 fn provider_order(provider: &str, config: &WebConfig) -> Vec<String> {
     if provider != "auto" {
-        return vec![provider.trim().to_string()];
+        let mut providers = vec![provider.trim().to_string()];
+        providers.extend(default_provider_order(config));
+        providers = dedupe_provider_order(providers);
+        providers.truncate(config.search.max_provider_attempts.max(1));
+        return providers;
     }
     let configured = dedupe_provider_order(&config.search.providers);
     let mut providers = if configured.is_empty() {
@@ -218,13 +259,18 @@ where
 fn routed_single(
     provider_id: String,
     kind: Option<WebProviderKind>,
-    outcome: Result<Vec<WebSearchResult>>,
+    outcome: Result<ProviderSearchOutput>,
 ) -> Result<RoutedSearchOutcome> {
     match outcome {
-        Ok(results) => Ok(RoutedSearchOutcome {
-            provider_attempts: vec![successful_attempt(&provider_id, kind, results.len())],
+        Ok(output) => Ok(RoutedSearchOutcome {
+            provider_attempts: vec![successful_attempt(
+                &provider_id,
+                kind,
+                output.results.len(),
+                output.diagnostics,
+            )],
             winning_provider: Some(provider_id),
-            results,
+            results: output.results,
         }),
         Err(error) => Err(single_provider_error(&provider_id, kind, error)),
     }
@@ -240,10 +286,15 @@ async fn search_fallback(
     for provider_id in provider_order {
         let kind = provider_kind(&provider_id, config);
         match search_one_provider(query, max_results, &provider_id, config).await {
-            Ok(results) => {
-                attempts.push(successful_attempt(&provider_id, kind, results.len()));
+            Ok(output) => {
+                attempts.push(successful_attempt(
+                    &provider_id,
+                    kind,
+                    output.results.len(),
+                    output.diagnostics,
+                ));
                 return Ok(RoutedSearchOutcome {
-                    results,
+                    results: output.results,
                     provider_attempts: attempts,
                     winning_provider: Some(provider_id),
                 });
@@ -267,13 +318,14 @@ async fn search_aggregate(
     for provider_id in provider_order {
         let kind = provider_kind(&provider_id, config);
         match search_one_provider(query, max_results, &provider_id, config).await {
-            Ok(provider_results) => {
+            Ok(output) => {
                 attempts.push(successful_attempt(
                     &provider_id,
                     kind,
-                    provider_results.len(),
+                    output.results.len(),
+                    output.diagnostics,
                 ));
-                for result in provider_results {
+                for result in output.results {
                     if seen_urls.insert(result.url.clone()) {
                         results.push(result);
                     }
@@ -304,6 +356,7 @@ fn successful_attempt(
     provider: &str,
     kind: Option<WebProviderKind>,
     result_count: usize,
+    diagnostics: Option<ProviderSearchDiagnostics>,
 ) -> WebSearchProviderAttempt {
     WebSearchProviderAttempt {
         provider: provider.to_string(),
@@ -313,6 +366,7 @@ fn successful_attempt(
         error_message: None,
         provider_kind: kind,
         capabilities: kind.map(|kind| kind.capabilities()),
+        command: command_attempt_from_diagnostics(diagnostics),
     }
 }
 
@@ -330,7 +384,22 @@ fn failed_attempt(
         error_message: Some(tool_error.message),
         provider_kind: kind,
         capabilities: kind.map(|kind| kind.capabilities()),
+        command: command_attempt_from_details(tool_error.details.as_ref()),
     }
+}
+
+fn command_attempt_from_diagnostics(
+    diagnostics: Option<ProviderSearchDiagnostics>,
+) -> Option<WebSearchCommandAttempt> {
+    match diagnostics {
+        Some(ProviderSearchDiagnostics::Command(command)) => Some(command),
+        None => None,
+    }
+}
+
+fn command_attempt_from_details(details: Option<&Value>) -> Option<WebSearchCommandAttempt> {
+    let command = details?.get("command")?;
+    serde_json::from_value(command.clone()).ok()
 }
 
 fn single_provider_error(
@@ -415,9 +484,11 @@ async fn search_one_provider(
     max_results: usize,
     provider_id: &str,
     config: &WebConfig,
-) -> Result<Vec<WebSearchResult>> {
+) -> Result<ProviderSearchOutput> {
     match provider_id {
-        DUCKDUCKGO_PROVIDER_ID => duckduckgo_search(query, max_results, &config.fetch).await,
+        DUCKDUCKGO_PROVIDER_ID => duckduckgo_search(query, max_results, &config.fetch)
+            .await
+            .map(ProviderSearchOutput::new),
         provider_id => {
             let provider_config = config.providers.get(provider_id).ok_or_else(|| {
                 search_error(
@@ -445,8 +516,8 @@ async fn search_configured_provider(
     provider_id: &str,
     provider_config: &WebProviderConfig,
     fetch_config: &WebFetchConfig,
-) -> Result<Vec<WebSearchResult>> {
-    match provider_config.kind {
+) -> Result<ProviderSearchOutput> {
+    let results = match provider_config.kind {
         WebProviderKind::Searxng => {
             searxng_search(query, max_results, provider_id, provider_config, fetch_config).await
         }
@@ -467,7 +538,7 @@ async fn search_configured_provider(
             firecrawl_search(query, max_results, provider_id, provider_config, fetch_config).await
         }
         WebProviderKind::Command => {
-            command_search(query, max_results, provider_id, provider_config).await
+            return command_search(query, max_results, provider_id, provider_config).await;
         }
         kind => Err(search_error(
             "provider_unavailable",
@@ -475,7 +546,8 @@ async fn search_configured_provider(
             provider_id,
             "configure a duckduckgo, searxng, brave, tavily, exa, perplexity, or firecrawl provider for this Holon version",
         )),
-    }
+    }?;
+    Ok(ProviderSearchOutput::new(results))
 }
 
 async fn command_search(
@@ -483,7 +555,7 @@ async fn command_search(
     max_results: usize,
     provider_id: &str,
     provider: &WebProviderConfig,
-) -> Result<Vec<WebSearchResult>> {
+) -> Result<ProviderSearchOutput> {
     let command = provider.command.as_ref().ok_or_else(|| {
         search_error(
             "provider_unavailable",
@@ -585,18 +657,21 @@ async fn command_search(
             "retry later or check the configured command provider",
         )
     })??;
+    let command_attempt =
+        command_attempt(&command.argv, &status, stdout.truncated, stderr.truncated);
     if stdout.truncated || stderr.truncated {
-        return Err(search_error(
+        return Err(command_search_error(
             "response_too_large",
             format!(
                 "WebSearch command provider output exceeded limits (stdout limit: {stdout_limit} bytes; stderr limit: {stderr_limit} bytes)"
             ),
             provider_id,
             "narrow the query, reduce stderr output, or increase web.providers.<id>.limits.max_output_bytes",
+            command_attempt,
         ));
     }
     if !status.success() {
-        return Err(search_error(
+        return Err(command_search_error(
             "provider_unavailable",
             format!(
                 "WebSearch command provider exited with status {}; stderr: {}",
@@ -605,6 +680,7 @@ async fn command_search(
             ),
             provider_id,
             "check the configured command provider and its arguments",
+            command_attempt,
         ));
     }
     let stdout = String::from_utf8(stdout.bytes).map_err(|error| {
@@ -616,6 +692,22 @@ async fn command_search(
         )
     })?;
     parse_command_results(&stdout, output, provider_id, max_results)
+        .map(|results| ProviderSearchOutput::command(results, command_attempt))
+}
+
+fn command_attempt(
+    argv_template: &[String],
+    status: &ExitStatus,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+) -> WebSearchCommandAttempt {
+    WebSearchCommandAttempt {
+        argv_template: argv_template.to_vec(),
+        exit_status: status.code(),
+        exit_status_text: Some(status.to_string()),
+        stdout_truncated,
+        stderr_truncated,
+    }
 }
 
 fn expand_command_argv(
@@ -1626,6 +1718,25 @@ fn search_error(
     )
 }
 
+fn command_search_error(
+    kind: &'static str,
+    message: impl Into<String>,
+    provider: impl Into<String>,
+    recovery_hint: impl Into<String>,
+    command: WebSearchCommandAttempt,
+) -> anyhow::Error {
+    let provider = provider.into();
+    anyhow::Error::from(
+        ToolError::new(kind, message)
+            .with_details(json!({
+                "provider": provider,
+                "command": command,
+            }))
+            .with_recovery_hint(recovery_hint)
+            .with_retryable(matches!(kind, "rate_limited" | "network_failed")),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1973,11 +2084,11 @@ mod tests {
 
         let results = command_search("holon", 3, "cmd", &provider).await.unwrap();
 
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].title, "holon");
-        assert_eq!(results[0].url, "https://example.com/3");
-        assert_eq!(results[0].snippet.as_deref(), Some("Snippet"));
-        assert_eq!(results[0].source, "cmd");
+        assert_eq!(results.results.len(), 1);
+        assert_eq!(results.results[0].title, "holon");
+        assert_eq!(results.results[0].url, "https://example.com/3");
+        assert_eq!(results.results[0].snippet.as_deref(), Some("Snippet"));
+        assert_eq!(results.results[0].source, "cmd");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1278.\n\n## Summary\n- keep managed WebSearch available when native search is configured but incompatible with the current model provider, while allowing native providers to participate in ordered fallback\n- expose command WebSearch provider fields through config schema/get/set/unset\n- record command provider argv template, exit status, and truncation diagnostics on WebSearch provider attempts\n\n## Verification\n- cargo fmt --all -- --check\n- cargo test -q native_web_search -- --nocapture\n- cargo test -q command_provider -- --nocapture\n- cargo test -q set_get_and_unset_round_trip_web_config -- --nocapture\n- RUSTFLAGS="-D warnings" cargo check --all-targets