### PR TITLE
fix: deduplicate TUI operator messages

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -561,6 +561,7 @@ pub(crate) struct PresentationReducer {
     live_group: Option<LiveGroup>,
     last_ts: Option<DateTime<Utc>>,
     observed_assistant_text_keys: HashSet<String>,
+    observed_user_message_keys: HashSet<String>,
     observed_brief_keys: HashSet<String>,
 }
 
@@ -622,11 +623,13 @@ impl PresentationReducer {
                 }
 
                 "message_enqueued" => {
-                    if let Some(text) = operator_message_text(event) {
-                        items.push(TimedItem {
-                            item: PresentationItem::UserMessage { text },
-                            ts: event.ts,
-                        });
+                    if let Some((key, text)) = operator_message_item(event) {
+                        if self.observed_user_message_keys.insert(key) {
+                            items.push(TimedItem {
+                                item: PresentationItem::UserMessage { text },
+                                ts: event.ts,
+                            });
+                        }
                     }
                 }
 
@@ -925,15 +928,21 @@ fn normalize_text_key(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn operator_message_text(event: &ProjectionEventRecord) -> Option<String> {
+fn operator_message_item(event: &ProjectionEventRecord) -> Option<(String, String)> {
     let message = serde_json::from_value::<MessageEnvelope>(event.payload.clone()).ok()?;
     if !matches!(message.origin, MessageOrigin::Operator { .. }) {
         return None;
     }
-    match message.body {
+    let text = match message.body {
         MessageBody::Text { text } | MessageBody::Brief { text, .. } => Some(text),
         MessageBody::Json { value } => serde_json::to_string(&value).ok(),
-    }
+    }?;
+    let key = if message.id.is_empty() {
+        format!("text:{}", normalize_text_key(&text))
+    } else {
+        format!("message:{}", message.id)
+    };
+    Some((key, text))
 }
 
 fn is_operator_queue_ack(brief: &BriefRecord) -> bool {
@@ -1433,6 +1442,36 @@ mod tests {
                 assert_eq!(body, "completed the task");
             }
             other => panic!("expected AssistantResult, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reducer_deduplicates_repeated_operator_message_by_message_id() {
+        let mut message = MessageEnvelope::new(
+            "default",
+            crate::types::MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            crate::types::TrustLevel::TrustedOperator,
+            crate::types::Priority::Normal,
+            MessageBody::Text {
+                text: "same operator input".into(),
+            },
+        );
+        message.id = "message-1".into();
+        let first = make_event("message_enqueued", "message enqueued", json!(message));
+        let mut second = first.clone();
+        second.id = "evt-2".into();
+        second.event_seq = 2;
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[first, second]);
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::UserMessage { text } => {
+                assert_eq!(text, "same operator input");
+            }
+            other => panic!("expected UserMessage, got {:?}", other),
         }
     }
 

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -146,6 +146,7 @@ pub(super) struct CachedChatText {
 pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
     let mut cells = Vec::new();
     let mut visible_operator_message_ids = std::collections::BTreeSet::new();
+    let mut pending_operator_message_bodies = std::collections::BTreeMap::new();
     let durable_operator_message_ids = app
         .projection
         .as_ref()
@@ -155,7 +156,12 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
         if durable_operator_message_ids.contains(&message.message_id) {
             continue;
         }
-        push_pending_operator_message_cell(&mut cells, &mut visible_operator_message_ids, message);
+        push_pending_operator_message_cell(
+            &mut cells,
+            &mut visible_operator_message_ids,
+            &mut pending_operator_message_bodies,
+            message,
+        );
     }
 
     if let Some(projection) = app.projection.as_ref() {
@@ -173,7 +179,11 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
         for timed in &timed_items {
             if timed.item.is_visible_at(level) {
                 for rendered in timed.item.render(level) {
-                    cells.push(rendered_to_conversation_cell(&rendered, timed.ts));
+                    push_projected_conversation_cell(
+                        &mut cells,
+                        &mut pending_operator_message_bodies,
+                        rendered_to_conversation_cell(&rendered, timed.ts),
+                    );
                 }
             }
         }
@@ -196,6 +206,7 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
 fn push_pending_operator_message_cell(
     cells: &mut Vec<ConversationCell>,
     visible_operator_message_ids: &mut std::collections::BTreeSet<String>,
+    pending_operator_message_bodies: &mut std::collections::BTreeMap<String, usize>,
     message: &OperatorMessageRecord,
 ) {
     if !visible_operator_message_ids.insert(message.message_id.clone()) {
@@ -203,11 +214,35 @@ fn push_pending_operator_message_cell(
     }
     let body = render_operator_message_body(&message.body)
         .unwrap_or_else(|| compact_json(&serde_json::to_value(&message.body).unwrap_or_default()));
+    *pending_operator_message_bodies
+        .entry(normalized_operator_message_body_key(&body))
+        .or_insert(0) += 1;
     cells.push(ConversationCell::UserMessage {
         created_at: message.created_at,
         body,
         status: Some(message.status.clone()),
     });
+}
+
+fn push_projected_conversation_cell(
+    cells: &mut Vec<ConversationCell>,
+    pending_operator_message_bodies: &mut std::collections::BTreeMap<String, usize>,
+    cell: ConversationCell,
+) {
+    if let ConversationCell::UserMessage { body, .. } = &cell {
+        let body_key = normalized_operator_message_body_key(body);
+        if let Some(count) = pending_operator_message_bodies.get_mut(&body_key) {
+            if *count > 0 {
+                *count -= 1;
+                return;
+            }
+        }
+    }
+    cells.push(cell);
+}
+
+fn normalized_operator_message_body_key(body: &str) -> String {
+    body.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 impl ConversationCell {

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -145,24 +145,14 @@ pub(super) struct CachedChatText {
 
 pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
     let mut cells = Vec::new();
+    let mut durable_operator_message_bodies = std::collections::BTreeMap::new();
     let mut visible_operator_message_ids = std::collections::BTreeSet::new();
-    let mut pending_operator_message_bodies = std::collections::BTreeMap::new();
     let durable_operator_message_ids = app
         .projection
         .as_ref()
         .map(|projection| projection.durable_operator_message_ids())
         .unwrap_or_default();
-    for message in &app.optimistic_operator_messages {
-        if durable_operator_message_ids.contains(&message.message_id) {
-            continue;
-        }
-        push_pending_operator_message_cell(
-            &mut cells,
-            &mut visible_operator_message_ids,
-            &mut pending_operator_message_bodies,
-            message,
-        );
-    }
+    let selected_agent_id = app.selected_agent_id();
 
     if let Some(projection) = app.projection.as_ref() {
         let level = app.display_mode.display_level();
@@ -181,12 +171,27 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
                 for rendered in timed.item.render(level) {
                     push_projected_conversation_cell(
                         &mut cells,
-                        &mut pending_operator_message_bodies,
+                        &mut durable_operator_message_bodies,
                         rendered_to_conversation_cell(&rendered, timed.ts),
                     );
                 }
             }
         }
+    }
+
+    for message in &app.optimistic_operator_messages {
+        if Some(message.agent_id.as_str()) != selected_agent_id {
+            continue;
+        }
+        if durable_operator_message_ids.contains(&message.message_id) {
+            continue;
+        }
+        push_pending_operator_message_cell(
+            &mut cells,
+            &mut visible_operator_message_ids,
+            &mut durable_operator_message_bodies,
+            message,
+        );
     }
 
     cells.sort_by(|left, right| {
@@ -206,7 +211,7 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
 fn push_pending_operator_message_cell(
     cells: &mut Vec<ConversationCell>,
     visible_operator_message_ids: &mut std::collections::BTreeSet<String>,
-    pending_operator_message_bodies: &mut std::collections::BTreeMap<String, usize>,
+    durable_operator_message_bodies: &mut std::collections::BTreeMap<String, usize>,
     message: &OperatorMessageRecord,
 ) {
     if !visible_operator_message_ids.insert(message.message_id.clone()) {
@@ -214,9 +219,13 @@ fn push_pending_operator_message_cell(
     }
     let body = render_operator_message_body(&message.body)
         .unwrap_or_else(|| compact_json(&serde_json::to_value(&message.body).unwrap_or_default()));
-    *pending_operator_message_bodies
-        .entry(normalized_operator_message_body_key(&body))
-        .or_insert(0) += 1;
+    let body_key = normalized_operator_message_body_key(&body);
+    if let Some(count) = durable_operator_message_bodies.get_mut(&body_key) {
+        if *count > 0 {
+            *count -= 1;
+            return;
+        }
+    }
     cells.push(ConversationCell::UserMessage {
         created_at: message.created_at,
         body,
@@ -226,17 +235,13 @@ fn push_pending_operator_message_cell(
 
 fn push_projected_conversation_cell(
     cells: &mut Vec<ConversationCell>,
-    pending_operator_message_bodies: &mut std::collections::BTreeMap<String, usize>,
+    durable_operator_message_bodies: &mut std::collections::BTreeMap<String, usize>,
     cell: ConversationCell,
 ) {
     if let ConversationCell::UserMessage { body, .. } = &cell {
-        let body_key = normalized_operator_message_body_key(body);
-        if let Some(count) = pending_operator_message_bodies.get_mut(&body_key) {
-            if *count > 0 {
-                *count -= 1;
-                return;
-            }
-        }
+        *durable_operator_message_bodies
+            .entry(normalized_operator_message_body_key(body))
+            .or_insert(0) += 1;
     }
     cells.push(cell);
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2419,7 +2419,57 @@ fn projection_operator_message_deduplicates_unreconciled_optimistic_entry_by_bod
         user_messages[0],
         ConversationCell::UserMessage {
             body,
-            status: Some(OperatorMessageStatus::Queued),
+            status: None,
+            ..
+        } if body == "same operator text"
+    ));
+}
+
+#[test]
+fn projection_operator_message_filters_optimistic_entries_to_selected_agent() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let ts = Utc::now();
+    app.agents = vec![sample_agent_summary("alpha"), sample_agent_summary("beta")];
+    app.selected_agent = 1;
+    app.optimistic_operator_messages = vec![OperatorMessageRecord {
+        message_id: "local-alpha-message-1".into(),
+        agent_id: "alpha".into(),
+        status: OperatorMessageStatus::Queued,
+        created_at: ts,
+        updated_at: ts,
+        body: MessageBody::Text {
+            text: "same operator text".into(),
+        },
+        error: None,
+    }];
+
+    let snapshot = sample_snapshot("beta", "evt-0");
+    let mut projection = TuiProjection::from_snapshot(snapshot);
+    projection.replace_event_window(
+        vec![operator_message_event_envelope(
+            "beta-message-1",
+            0,
+            "beta",
+            "same operator text",
+        )],
+        Some(0),
+    );
+    app.projection = Some(projection);
+
+    let user_messages = collect_chat_items(&app)
+        .into_iter()
+        .filter(|item| matches!(item, ConversationCell::UserMessage { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(user_messages.len(), 1);
+    assert!(matches!(
+        &user_messages[0],
+        ConversationCell::UserMessage {
+            body,
+            status: None,
             ..
         } if body == "same operator text"
     ));

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2377,6 +2377,89 @@ fn projection_operator_message_prunes_reconciled_optimistic_entry() {
 }
 
 #[test]
+fn projection_operator_message_deduplicates_unreconciled_optimistic_entry_by_body() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let ts = Utc::now();
+    app.optimistic_operator_messages = vec![OperatorMessageRecord {
+        message_id: "local-message-1".into(),
+        agent_id: "default".into(),
+        status: OperatorMessageStatus::Queued,
+        created_at: ts,
+        updated_at: ts,
+        body: MessageBody::Text {
+            text: "same operator text".into(),
+        },
+        error: None,
+    }];
+
+    let snapshot = sample_snapshot("default", "evt-0");
+    let mut projection = TuiProjection::from_snapshot(snapshot);
+    projection.replace_event_window(
+        vec![operator_message_event_envelope(
+            "message-1",
+            0,
+            "default",
+            "same operator text",
+        )],
+        Some(0),
+    );
+    app.projection = Some(projection);
+
+    let items = collect_chat_items(&app);
+    let user_messages = items
+        .iter()
+        .filter(|item| matches!(item, ConversationCell::UserMessage { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(user_messages.len(), 1);
+    assert!(matches!(
+        user_messages[0],
+        ConversationCell::UserMessage {
+            body,
+            status: Some(OperatorMessageStatus::Queued),
+            ..
+        } if body == "same operator text"
+    ));
+}
+
+#[test]
+fn projection_operator_message_keeps_distinct_durable_messages_with_same_body() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let snapshot = sample_snapshot("default", "evt-0");
+    let mut projection = TuiProjection::from_snapshot(snapshot);
+    projection.replace_event_window(
+        vec![
+            operator_message_event_envelope("message-1", 0, "default", "repeat"),
+            operator_message_event_envelope("message-2", 1, "default", "repeat"),
+        ],
+        Some(0),
+    );
+    app.projection = Some(projection);
+
+    let user_message_count = collect_chat_items(&app)
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                ConversationCell::UserMessage {
+                    body,
+                    status: None,
+                    ..
+                } if body == "repeat"
+            )
+        })
+        .count();
+    assert_eq!(user_message_count, 2);
+}
+
+#[test]
 fn events_overlay_selection_stays_pinned_to_same_event_id() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(


### PR DESCRIPTION
## Summary

- Deduplicate operator `message_enqueued` presentation items by `MessageEnvelope.id`.
- Suppress TUI optimistic operator echo once the matching durable event body arrives, even when the local optimistic id was not reconciled.
- Preserve distinct durable operator messages that intentionally have the same body.

## Validation

- `cargo fmt --all -- --check`
- `cargo test reducer_deduplicates_repeated_operator_message_by_message_id --quiet`
- `cargo test projection_operator_message_deduplicates_unreconciled_optimistic_entry_by_body --quiet`
- `cargo test projection_operator_message --quiet`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
