### PR TITLE
feat: derive work item scheduling state

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1721,6 +1721,8 @@ The minimal shape is:
 - `plan?`
 - `todo_list`
 - `blocked_by?`
+- `recheck_at?`
+- `recheck_consumed_at?`
 - `result_summary?`
 - `created_at`
 - `updated_at`
@@ -1757,12 +1759,32 @@ item. Queued and blocked are derived views:
 - blocked: open work with `blocked_by`
 - completed: work whose state is `completed`
 
-Scheduler readiness is also a derived view:
+Scheduler readiness is also a derived view. Internally, the runtime first
+derives a `WorkItemSchedulingState` from WorkItem lifecycle, plan status,
+blockers, active task waits, and active external waits:
+
+- `runnable`
+- `waiting_operator`
+- `waiting_task`
+- `waiting_external`
+- `blocked`
+- `completed`
+
+The older readiness labels are projected from that scheduling state for
+compatibility:
 
 - runnable: open work with no `blocked_by` and `plan_status != needs_input`
 - waiting_for_operator: open work with `plan_status = needs_input`
-- blocked: open work with `blocked_by`
+- blocked: open work with `blocked_by`, an active task wait, or an active
+  external wait
 - completed: completed work
+
+`recheck_at` is a one-shot fallback reminder deadline for open work items with
+`blocked_by`. When due, the runtime may enqueue a low-priority system tick for
+the owning agent to inspect the blocker. The reminder does not make the work
+item runnable and does not clear or interpret `blocked_by`; the agent must
+explicitly refresh or clear the blocker. `recheck_consumed_at` records that the
+current `recheck_at` reminder has already been delivered or consumed.
 
 `open` is a lifecycle state only. It must not be used by itself as evidence
 that scheduler-owned continuation is allowed.
@@ -1845,6 +1867,14 @@ item owned by the agent.
 - `plan_status` is optional
 - `todo_list` is optional and uses full-snapshot replacement semantics
 - `blocked_by` is optional and nullable
+- `recheck_after` is optional and applies only when setting a non-empty
+  `blocked_by`; it is a positive millisecond delay used to compute
+  `recheck_at`
+
+When `blocked_by` is set without `recheck_after`, the runtime assigns a default
+fallback recheck deadline. Updating other WorkItem fields without touching
+`blocked_by` preserves the existing deadline. Clearing `blocked_by` also clears
+`recheck_at` and `recheck_consumed_at`.
 
 `CompleteWorkItem` marks an existing work item completed:
 
@@ -1854,8 +1884,9 @@ item owned by the agent.
   same assistant round as the successful `CompleteWorkItem` call
 - completion is an explicit agent assertion; it is not blocked by generic
   active task `wait_policy`
-- completion clears `blocked_by` and finishes the item; it does not revoke
-  agent-scoped external trigger capabilities
+- completion clears `blocked_by`, `recheck_at`, and `recheck_consumed_at`, and
+  finishes the item; it does not revoke agent-scoped external trigger
+  capabilities
 
 There is no separate agent-facing `UpdateWorkPlan` tool and no separate
 work-plan storage stream. Plan body state lives in the AgentHome plan artifact;

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -10,6 +10,7 @@ const CONTINUE_ACTIVE_SIGNAL_SCAN_LIMIT: usize = 512;
 enum IdleTickTrigger {
     WorkQueueActive(crate::types::WorkItemRecord),
     WorkQueueQueued(crate::types::WorkItemRecord),
+    BlockedRecheck(Vec<crate::types::WorkItemRecord>),
     WakeHint(PendingWakeHint),
 }
 
@@ -46,6 +47,7 @@ pub(super) fn work_queue_waits_for_operator(projection: &WorkQueuePromptProjecti
 fn idle_tick_trigger_from_state(
     pending_wake_hint: Option<PendingWakeHint>,
     projection: WorkQueuePromptProjection,
+    due_rechecks: Vec<crate::types::WorkItemRecord>,
 ) -> Option<IdleTickTrigger> {
     if let Some(pending) = pending_wake_hint {
         Some(IdleTickTrigger::WakeHint(pending))
@@ -60,6 +62,13 @@ fn idle_tick_trigger_from_state(
             .into_iter()
             .next()
             .map(|item| IdleTickTrigger::WorkQueueQueued(item.work_item))
+            .or_else(|| {
+                if due_rechecks.is_empty() {
+                    None
+                } else {
+                    Some(IdleTickTrigger::BlockedRecheck(due_rechecks))
+                }
+            })
     }
 }
 
@@ -147,6 +156,10 @@ impl RuntimeHandle {
         };
 
         let work_queue_projection = self.inner.storage.work_queue_prompt_projection()?;
+        let due_rechecks = self
+            .inner
+            .storage
+            .due_blocked_work_item_rechecks(scheduler_snapshot.id(), chrono::Utc::now())?;
         let scheduler_projection =
             scheduler::SchedulerProjection::from_snapshot_with_queue_len_and_work_queue(
                 &self.inner.storage,
@@ -154,7 +167,8 @@ impl RuntimeHandle {
                 queue_len,
                 work_queue_projection.clone(),
             )?;
-        let trigger = idle_tick_trigger_from_state(pending_wake_hint, work_queue_projection);
+        let trigger =
+            idle_tick_trigger_from_state(pending_wake_hint, work_queue_projection, due_rechecks);
 
         let suppress_continue_active = triggering_continuation
             .is_some_and(|continuation| continuation.model_reentry)
@@ -278,6 +292,13 @@ impl RuntimeHandle {
                 if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
                     guard.state.pending_wake_hint = None;
                     self.inner.storage.write_agent(&guard.state)?;
+                }
+                Ok(true)
+            }
+            Some(IdleTickTrigger::BlockedRecheck(items)) => {
+                self.emit_system_tick_from_blocked_recheck(&items).await?;
+                for item in items {
+                    let _ = self.consume_work_item_recheck(&item.id).await?;
                 }
                 Ok(true)
             }
@@ -648,6 +669,70 @@ impl RuntimeHandle {
                     .metadata
                     .as_ref()
                     .and_then(|value| value.get("work_queue"))
+                    .cloned(),
+            }),
+        ))?;
+        let _ = self.enqueue(message).await?;
+        Ok(())
+    }
+
+    pub(super) async fn emit_system_tick_from_blocked_recheck(
+        &self,
+        work_items: &[crate::types::WorkItemRecord],
+    ) -> Result<()> {
+        let items = work_items
+            .iter()
+            .map(|item| {
+                serde_json::json!({
+                    "work_item_id": item.id,
+                    "work_item_revision": item.revision,
+                    "objective": item.objective,
+                    "blocked_by": item.blocked_by,
+                    "recheck_at": item.recheck_at,
+                })
+            })
+            .collect::<Vec<_>>();
+        let idempotency_key = work_items
+            .iter()
+            .filter_map(|item| item.recheck_at.map(|recheck_at| (item, recheck_at)))
+            .map(|(item, recheck_at)| format!("{}@{}", item.id, recheck_at.to_rfc3339()))
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut message = MessageEnvelope::new(
+            self.agent_id().await?,
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "work_item_recheck".into(),
+            },
+            TrustLevel::TrustedSystem,
+            Priority::Background,
+            MessageBody::Text {
+                text: format!(
+                    "{} blocked WorkItem recheck{} due; inspect blockers and refresh or clear blocked_by.",
+                    work_items.len(),
+                    if work_items.len() == 1 { " is" } else { "s are" }
+                ),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            AdmissionContext::RuntimeOwned,
+        );
+        message.metadata = Some(serde_json::json!({
+            "work_item_recheck": {
+                "idempotency_key": idempotency_key,
+                "count": work_items.len(),
+                "items": items,
+            }
+        }));
+        self.inner.storage.append_event(&AuditEvent::new(
+            "system_tick_emitted",
+            serde_json::json!({
+                "subsystem": "work_item_recheck",
+                "work_item_recheck": message
+                    .metadata
+                    .as_ref()
+                    .and_then(|value| value.get("work_item_recheck"))
                     .cloned(),
             }),
         ))?;

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -37,6 +37,10 @@ pub(crate) struct SchedulerAgentSnapshot {
 }
 
 impl SchedulerAgentSnapshot {
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
     pub(crate) fn from_state(state: &AgentState) -> Self {
         Self {
             id: state.id.clone(),

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2055,6 +2055,28 @@ impl RuntimeHandle {
         todo_list: Option<Vec<TodoItem>>,
         blocked_by: Option<Option<String>>,
     ) -> Result<WorkItemRecord> {
+        self.update_work_item_fields_with_recheck(
+            work_item_id,
+            objective,
+            plan_status,
+            _plan,
+            todo_list,
+            blocked_by,
+            None,
+        )
+        .await
+    }
+
+    pub async fn update_work_item_fields_with_recheck(
+        &self,
+        work_item_id: String,
+        objective: Option<String>,
+        plan_status: Option<WorkItemPlanStatus>,
+        _plan: Option<Option<String>>,
+        todo_list: Option<Vec<TodoItem>>,
+        blocked_by: Option<Option<String>>,
+        recheck_after_ms: Option<u64>,
+    ) -> Result<WorkItemRecord> {
         let agent_id = self.agent_id().await?;
         let existing = self.validate_owned_work_item(&agent_id, &work_item_id)?;
         if existing.state == WorkItemState::Completed {
@@ -2090,6 +2112,20 @@ impl RuntimeHandle {
         }
         if let Some(blocked_by) = blocked_by {
             record.blocked_by = blocked_by;
+            match record.blocked_by {
+                Some(_) => {
+                    let recheck_after_ms = recheck_after_ms.unwrap_or(60 * 60 * 1000);
+                    let recheck_after_ms = i64::try_from(recheck_after_ms).unwrap_or(i64::MAX);
+                    let recheck_after = chrono::Duration::try_milliseconds(recheck_after_ms)
+                        .unwrap_or(chrono::Duration::MAX);
+                    record.recheck_at = Some(Utc::now() + recheck_after);
+                    record.recheck_consumed_at = None;
+                }
+                None => {
+                    record.recheck_at = None;
+                    record.recheck_consumed_at = None;
+                }
+            }
             record.updated_at = Utc::now();
             wrote_item = true;
         }
@@ -2130,6 +2166,61 @@ impl RuntimeHandle {
         Ok(record)
     }
 
+    pub async fn consume_work_item_recheck(
+        &self,
+        work_item_id: &str,
+    ) -> Result<Option<WorkItemRecord>> {
+        let agent_id = self.agent_id().await?;
+        let existing = match self.validate_owned_work_item(&agent_id, work_item_id) {
+            Ok(record) => record,
+            Err(_) => return Ok(None),
+        };
+        if existing.state != WorkItemState::Open || existing.blocked_by.is_none() {
+            return Ok(None);
+        }
+        let Some(recheck_at) = existing.recheck_at else {
+            return Ok(None);
+        };
+        if existing
+            .recheck_consumed_at
+            .is_some_and(|consumed_at| consumed_at >= recheck_at)
+        {
+            return Ok(Some(existing));
+        }
+
+        let mut record = WorkItemRecord {
+            revision: existing.revision + 1,
+            recheck_consumed_at: Some(Utc::now()),
+            updated_at: Utc::now(),
+            ..existing
+        };
+        let plan_artifact_changed = crate::work_item_plan::refresh_plan_artifact_metadata(
+            self.agent_home().as_path(),
+            &mut record,
+        )?;
+        self.inner.storage.append_work_item(&record)?;
+        if plan_artifact_changed {
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_plan_artifact_refreshed",
+                serde_json::json!({
+                    "work_item_id": record.id.clone(),
+                    "revision": record.revision,
+                    "plan_artifact": record.plan_artifact.clone(),
+                }),
+            ))?;
+        }
+        self.inner.storage.append_event(&AuditEvent::new(
+            "work_item_recheck_consumed",
+            serde_json::json!({
+                "work_item_id": record.id.clone(),
+                "revision": record.revision,
+                "recheck_at": record.recheck_at,
+                "recheck_consumed_at": record.recheck_consumed_at,
+            }),
+        ))?;
+        Ok(Some(record))
+    }
+
     pub async fn complete_work_item(
         &self,
         work_item_id: String,
@@ -2144,6 +2235,8 @@ impl RuntimeHandle {
             revision: existing.revision + 1,
             state: WorkItemState::Completed,
             blocked_by: None,
+            recheck_at: None,
+            recheck_consumed_at: None,
             result_summary: existing.result_summary.clone(),
             updated_at: Utc::now(),
             ..existing

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::support::*;
-use crate::types::{WorkItemPlanStatus, WorkItemReadiness};
+use crate::types::{WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState};
 
 fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> TaskRecord {
     TaskRecord {
@@ -78,6 +78,152 @@ fn work_item_record_revision_defaults_for_old_records() {
     let record: WorkItemRecord = serde_json::from_value(value).unwrap();
     assert_eq!(record.revision, 1);
     assert!(record.plan_artifact.is_none());
+    assert!(record.recheck_at.is_none());
+    assert!(record.recheck_consumed_at.is_none());
+}
+
+#[tokio::test]
+async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let work = runtime
+        .create_work_item("wait with fallback".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let before = Utc::now();
+    let blocked = runtime
+        .update_work_item_fields_with_recheck(
+            work.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            Some(Some("waiting for CI".into())),
+            Some(25),
+        )
+        .await
+        .unwrap();
+    let recheck_at = blocked.recheck_at.expect("blocked item has recheck_at");
+    assert!(recheck_at >= before + chrono::Duration::milliseconds(25));
+    assert!(blocked.recheck_consumed_at.is_none());
+
+    let updated = runtime
+        .update_work_item_fields(
+            work.id.clone(),
+            Some("wait with unchanged fallback".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.recheck_at, Some(recheck_at));
+
+    let cleared = runtime
+        .update_work_item_fields(work.id.clone(), None, None, None, None, Some(None))
+        .await
+        .unwrap();
+    assert!(cleared.blocked_by.is_none());
+    assert!(cleared.recheck_at.is_none());
+    assert!(cleared.recheck_consumed_at.is_none());
+}
+
+#[tokio::test]
+async fn work_queue_projection_derives_scheduling_state_per_work_item() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let runnable = runtime
+        .create_work_item("runnable".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let external = runtime
+        .create_work_item("external wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let task_wait = runtime
+        .create_work_item("task wait".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let now = Utc::now();
+    runtime
+        .storage()
+        .append_waiting_intent(&WaitingIntentRecord {
+            id: "wait-external".into(),
+            agent_id: "default".into(),
+            scope: ExternalTriggerScope::WorkItem,
+            work_item_id: Some(external.id.clone()),
+            description: "external callback".into(),
+            source: "github".into(),
+            resource: Some("pull_request:1".into()),
+            condition: Some("checks".into()),
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: "trigger-external".into(),
+            created_at: now,
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
+        })
+        .unwrap();
+    runtime
+        .storage()
+        .append_task(&blocking_task_for_work_item(
+            "task-wait",
+            Some(&task_wait.id),
+        ))
+        .unwrap();
+
+    let projection = runtime.storage().work_queue_prompt_projection().unwrap();
+    let state_for = |id: &str| {
+        projection
+            .readiness
+            .iter()
+            .find(|item| item.work_item.id == id)
+            .map(|item| item.scheduling_state)
+            .unwrap()
+    };
+    assert_eq!(state_for(&runnable.id), WorkItemSchedulingState::Runnable);
+    assert_eq!(
+        state_for(&external.id),
+        WorkItemSchedulingState::WaitingExternal
+    );
+    assert_eq!(
+        state_for(&task_wait.id),
+        WorkItemSchedulingState::WaitingTask
+    );
+    assert!(projection
+        .queued_runnable
+        .iter()
+        .any(|item| item.work_item.id == runnable.id));
+    assert!(!projection
+        .queued_runnable
+        .iter()
+        .any(|item| item.work_item.id == external.id));
 }
 
 #[tokio::test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,8 +18,8 @@ use crate::types::{
     OperatorDeliveryRecord, OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord,
     TaskRecord, TaskStatus, TimerRecord, TodoItem, TodoItemState, ToolExecutionRecord,
     TranscriptEntry, WaitingIntentRecord, WaitingIntentStatus, WorkItemDelegationRecord,
-    WorkItemDelegationState, WorkItemReadiness, WorkItemRecord, WorkItemState, WorkingMemoryDelta,
-    WorkspaceEntry, WorkspaceOccupancyRecord,
+    WorkItemDelegationState, WorkItemReadiness, WorkItemRecord, WorkItemSchedulingState,
+    WorkItemState, WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 
 const RUNTIME_DIR: &str = ".holon";
@@ -57,10 +57,12 @@ impl WorkQueuePromptProjection {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkItemReadinessProjection {
     pub work_item: WorkItemRecord,
+    pub scheduling_state: WorkItemSchedulingState,
     pub readiness: WorkItemReadiness,
     pub candidate_class: WorkItemCandidateClass,
     pub is_current: bool,
     pub has_active_waits: bool,
+    pub has_active_task_waits: bool,
     pub has_triggered_waits: bool,
     pub last_triggered_at: Option<DateTime<Utc>>,
     pub current_todo: Option<TodoItem>,
@@ -731,6 +733,12 @@ impl AppStorage {
                     acc
                 },
             );
+        let active_task_waits = self
+            .latest_active_task_records(usize::MAX)?
+            .into_iter()
+            .filter(|task| task.is_blocking())
+            .filter_map(|task| task.effective_work_item_id().map(str::to_string))
+            .collect::<std::collections::BTreeSet<_>>();
         let mut readiness = latest
             .values()
             .cloned()
@@ -739,28 +747,34 @@ impl AppStorage {
                     && item.state == WorkItemState::Open;
                 let last_triggered_at = active_waits.get(&item.id).copied().flatten();
                 let has_active_waits = active_waits.contains_key(&item.id);
+                let has_active_task_waits = active_task_waits.contains(&item.id);
                 let has_triggered_waits = last_triggered_at.is_some();
-                let readiness = item.readiness();
-                let candidate_class = if is_current && readiness == WorkItemReadiness::Runnable {
-                    WorkItemCandidateClass::CurrentRunnable
-                } else if item.state == WorkItemState::Completed {
-                    WorkItemCandidateClass::CompletedRecent
-                } else if has_triggered_waits && item.blocked_by.is_some() {
-                    WorkItemCandidateClass::TriggeredBlocked
-                } else if readiness == WorkItemReadiness::Runnable {
-                    WorkItemCandidateClass::QueuedRunnable
-                } else if readiness == WorkItemReadiness::WaitingForOperator {
-                    WorkItemCandidateClass::WaitingForOperator
-                } else {
-                    WorkItemCandidateClass::Blocked
-                };
+                let scheduling_state =
+                    item.scheduling_state(has_active_waits, has_active_task_waits);
+                let readiness = readiness_for_scheduling_state(scheduling_state);
+                let candidate_class =
+                    if is_current && scheduling_state == WorkItemSchedulingState::Runnable {
+                        WorkItemCandidateClass::CurrentRunnable
+                    } else if item.state == WorkItemState::Completed {
+                        WorkItemCandidateClass::CompletedRecent
+                    } else if has_triggered_waits && item.blocked_by.is_some() {
+                        WorkItemCandidateClass::TriggeredBlocked
+                    } else if scheduling_state == WorkItemSchedulingState::Runnable {
+                        WorkItemCandidateClass::QueuedRunnable
+                    } else if scheduling_state == WorkItemSchedulingState::WaitingOperator {
+                        WorkItemCandidateClass::WaitingForOperator
+                    } else {
+                        WorkItemCandidateClass::Blocked
+                    };
                 WorkItemReadinessProjection {
                     current_todo: current_todo(&item),
                     work_item: item,
+                    scheduling_state,
                     readiness,
                     candidate_class,
                     is_current,
                     has_active_waits,
+                    has_active_task_waits,
                     has_triggered_waits,
                     last_triggered_at,
                 }
@@ -839,6 +853,32 @@ impl AppStorage {
                         .then_with(|| left.id.cmp(&right.id))
                 })
         }))
+    }
+
+    pub fn due_blocked_work_item_rechecks(
+        &self,
+        agent_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<WorkItemRecord>> {
+        let mut due = self
+            .latest_work_items()?
+            .into_iter()
+            .filter(|item| item.agent_id == agent_id)
+            .filter(|item| item.state == WorkItemState::Open)
+            .filter(|item| item.blocked_by.is_some())
+            .filter(|item| item.recheck_at.is_some_and(|recheck_at| recheck_at <= now))
+            .filter(|item| {
+                item.recheck_consumed_at
+                    .zip(item.recheck_at)
+                    .is_none_or(|(consumed_at, recheck_at)| consumed_at < recheck_at)
+            })
+            .collect::<Vec<_>>();
+        due.sort_by(|left, right| {
+            left.recheck_at
+                .cmp(&right.recheck_at)
+                .then_with(|| compare_queue_display_order(left, right))
+        });
+        Ok(due)
     }
 
     pub fn latest_work_item(&self, work_item_id: &str) -> Result<Option<WorkItemRecord>> {
@@ -1388,6 +1428,17 @@ fn compare_queue_display_order(
 
 fn blocked_rank(record: &WorkItemRecord) -> u8 {
     u8::from(record.blocked_by.is_some())
+}
+
+fn readiness_for_scheduling_state(state: WorkItemSchedulingState) -> WorkItemReadiness {
+    match state {
+        WorkItemSchedulingState::Runnable => WorkItemReadiness::Runnable,
+        WorkItemSchedulingState::WaitingOperator => WorkItemReadiness::WaitingForOperator,
+        WorkItemSchedulingState::WaitingTask
+        | WorkItemSchedulingState::WaitingExternal
+        | WorkItemSchedulingState::Blocked => WorkItemReadiness::Blocked,
+        WorkItemSchedulingState::Completed => WorkItemReadiness::Completed,
+    }
 }
 
 fn candidate_class_rank(class: WorkItemCandidateClass) -> u8 {

--- a/src/tool/tools/update_work_item.rs
+++ b/src/tool/tools/update_work_item.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::{
     runtime::RuntimeHandle,
-    tool::helpers::{normalize_optional_non_empty, validate_non_empty},
+    tool::helpers::{invalid_tool_input, normalize_optional_non_empty, validate_non_empty},
     tool::spec::typed_spec,
     types::{ToolCapabilityFamily, TrustLevel},
 };
@@ -34,6 +34,9 @@ pub(crate) struct UpdateWorkItemArgs {
     pub(crate) todo_list: Option<Vec<TodoItemArgs>>,
     #[serde(default)]
     pub(crate) blocked_by: Option<Option<String>>,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    pub(crate) recheck_after: Option<u64>,
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
@@ -41,7 +44,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<UpdateWorkItemArgs>(
             NAME,
-            "Update mutable state fields for an existing work item. Use objective to refine the short target, plan_status for planning state, todo_list to replace the full progress checklist snapshot, and blocked_by for blockers. Edit the plan_artifact.path file directly for plan body changes.",
+            "Update mutable state fields for an existing work item. Use objective to refine the short target, plan_status for planning state, todo_list to replace the full progress checklist snapshot, blocked_by for blockers, and recheck_after as a positive millisecond fallback deadline when setting blocked_by. Edit the plan_artifact.path file directly for plan body changes.",
         )?,
     })
 }
@@ -61,18 +64,41 @@ pub(crate) async fn execute(
     let blocked_by = args
         .blocked_by
         .map(|value| value.and_then(|inner| normalize_optional_non_empty(Some(inner))));
+    if args.recheck_after == Some(0) {
+        return Err(invalid_tool_input(
+            NAME,
+            "UpdateWorkItem `recheck_after` must be a positive integer when provided",
+            serde_json::json!({
+                "field": "recheck_after",
+                "validation_error": "must be greater than 0",
+            }),
+            "omit `recheck_after`, or provide a positive integer millisecond delay when setting `blocked_by`",
+        ));
+    }
+    if args.recheck_after.is_some() && blocked_by.as_ref().is_none_or(Option::is_none) {
+        return Err(invalid_tool_input(
+            NAME,
+            "UpdateWorkItem `recheck_after` only applies when setting `blocked_by`",
+            serde_json::json!({
+                "field": "recheck_after",
+                "validation_error": "requires non-empty blocked_by",
+            }),
+            "provide `recheck_after` only together with a non-empty `blocked_by` value",
+        ));
+    }
     let todo_list = args
         .todo_list
         .map(|items| convert_todo_list(NAME, items))
         .transpose()?;
     let work_item = runtime
-        .update_work_item_fields(
+        .update_work_item_fields_with_recheck(
             work_item_id,
             objective,
             args.plan_status.map(Into::into),
             None,
             todo_list,
             blocked_by,
+            args.recheck_after,
         )
         .await?;
     let context = query_context(runtime).await?;

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -65,6 +65,10 @@ pub(crate) struct WorkItemView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) blocked_by: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) recheck_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) recheck_consumed_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) completion_report: Option<WorkItemCompletionReportView>,
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) updated_at: DateTime<Utc>,
@@ -143,6 +147,8 @@ pub(crate) async fn view_for_record(
         plan_artifact,
         todo_list,
         blocked_by: record.blocked_by,
+        recheck_at: record.recheck_at,
+        recheck_consumed_at: record.recheck_consumed_at,
         completion_report,
         created_at: record.created_at,
         updated_at: record.updated_at,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2781,6 +2781,17 @@ pub enum WorkItemReadiness {
     Completed,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkItemSchedulingState {
+    Runnable,
+    WaitingOperator,
+    WaitingTask,
+    WaitingExternal,
+    Blocked,
+    Completed,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkItemPlanArtifact {
     pub path: PathBuf,
@@ -2812,6 +2823,10 @@ pub struct WorkItemRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blocked_by: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recheck_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recheck_consumed_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result_summary: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -2836,23 +2851,46 @@ impl WorkItemRecord {
             plan_artifact: None,
             todo_list: Vec::new(),
             blocked_by: None,
+            recheck_at: None,
+            recheck_consumed_at: None,
             result_summary: None,
             created_at: now,
             updated_at: now,
         }
     }
 
-    pub fn readiness(&self) -> WorkItemReadiness {
+    pub fn scheduling_state(
+        &self,
+        has_active_external_wait: bool,
+        has_active_task_wait: bool,
+    ) -> WorkItemSchedulingState {
         if self.state == WorkItemState::Completed {
-            return WorkItemReadiness::Completed;
+            return WorkItemSchedulingState::Completed;
         }
         if self.blocked_by.is_some() {
-            return WorkItemReadiness::Blocked;
+            return WorkItemSchedulingState::Blocked;
         }
         if self.plan_status == WorkItemPlanStatus::NeedsInput {
-            return WorkItemReadiness::WaitingForOperator;
+            return WorkItemSchedulingState::WaitingOperator;
         }
-        WorkItemReadiness::Runnable
+        if has_active_task_wait {
+            return WorkItemSchedulingState::WaitingTask;
+        }
+        if has_active_external_wait {
+            return WorkItemSchedulingState::WaitingExternal;
+        }
+        WorkItemSchedulingState::Runnable
+    }
+
+    pub fn readiness(&self) -> WorkItemReadiness {
+        match self.scheduling_state(false, false) {
+            WorkItemSchedulingState::Runnable => WorkItemReadiness::Runnable,
+            WorkItemSchedulingState::WaitingOperator => WorkItemReadiness::WaitingForOperator,
+            WorkItemSchedulingState::WaitingTask
+            | WorkItemSchedulingState::WaitingExternal
+            | WorkItemSchedulingState::Blocked => WorkItemReadiness::Blocked,
+            WorkItemSchedulingState::Completed => WorkItemReadiness::Completed,
+        }
     }
 
     pub fn is_runnable(&self) -> bool {


### PR DESCRIPTION
## Summary
- add internal WorkItemSchedulingState derivation for runnable/operator/task/external/blocked/completed states
- add blocked WorkItem recheck fallback via UpdateWorkItem recheck_after/recheck_at and one-shot system tick reminders
- surface recheck fields in work item reads and document the runtime contract

Fixes #1289
Fixes #1299

## Verification
- cargo fmt --all -- --check
- cargo test update_work_item_sets_and_preserves_blocked_recheck_deadline -- --nocapture
- cargo test work_queue_projection_derives_scheduling_state_per_work_item -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets
- git diff --check