### PR TITLE
fix: drive idle waits from work item scheduling state

### DIFF
--- a/src/runtime/closure.rs
+++ b/src/runtime/closure.rs
@@ -74,6 +74,16 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
         };
     }
 
+    if facts.awaiting_operator_input {
+        return ClosureDecision {
+            outcome: ClosureOutcome::Waiting,
+            waiting_reason: Some(WaitingReason::AwaitingOperatorInput),
+            work_signal: None,
+            runtime_posture,
+            evidence,
+        };
+    }
+
     if facts.active_agent_waiting_intents > 0 {
         return ClosureDecision {
             outcome: ClosureOutcome::Waiting,
@@ -144,16 +154,6 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
             outcome: ClosureOutcome::Continuable,
             waiting_reason: None,
             work_signal: Some(work_signal),
-            runtime_posture,
-            evidence,
-        };
-    }
-
-    if facts.awaiting_operator_input {
-        return ClosureDecision {
-            outcome: ClosureOutcome::Waiting,
-            waiting_reason: Some(WaitingReason::AwaitingOperatorInput),
-            work_signal: None,
             runtime_posture,
             evidence,
         };
@@ -277,6 +277,7 @@ mod tests {
     fn waiting_intents_map_to_awaiting_external_change() {
         let decision = derive_closure_decision(&ClosureFacts {
             active_waiting_intents: 1,
+            active_agent_waiting_intents: 1,
             ..facts()
         });
 
@@ -384,6 +385,7 @@ mod tests {
     fn waiting_conditions_override_runnable_work() {
         let decision = derive_closure_decision(&ClosureFacts {
             active_waiting_intents: 1,
+            active_agent_waiting_intents: 1,
             work_signal: Some(WorkReactivationSignal {
                 work_item_id: "work-1".into(),
                 state: WorkItemState::Open,

--- a/src/runtime/closure.rs
+++ b/src/runtime/closure.rs
@@ -1,6 +1,6 @@
 use crate::types::{
     AuditEvent, BriefRecord, ClosureDecision, ClosureOutcome, RuntimePosture, TurnTerminalKind,
-    WaitingReason, WorkReactivationSignal,
+    WaitingReason, WorkItemSchedulingState, WorkReactivationSignal,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -9,7 +9,9 @@ pub(super) struct ClosureFacts {
     pub(super) awaiting_operator_input: bool,
     pub(super) active_blocking_tasks: usize,
     pub(super) active_waiting_intents: usize,
+    pub(super) active_agent_waiting_intents: usize,
     pub(super) active_timers: usize,
+    pub(super) current_work_item_scheduling_state: Option<WorkItemSchedulingState>,
     pub(super) work_signal: Option<WorkReactivationSignal>,
     pub(super) turn_started: bool,
     pub(super) turn_in_progress: bool,
@@ -38,8 +40,17 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
             facts.active_waiting_intents
         ));
     }
+    if facts.active_agent_waiting_intents > 0 {
+        evidence.push(format!(
+            "active_agent_waiting_intents={}",
+            facts.active_agent_waiting_intents
+        ));
+    }
     if facts.active_timers > 0 {
         evidence.push(format!("active_timers={}", facts.active_timers));
+    }
+    if let Some(state) = facts.current_work_item_scheduling_state {
+        evidence.push(format!("current_work_item_scheduling_state={state:?}"));
     }
     if let Some(work_signal) = facts.work_signal.as_ref() {
         evidence.push(format!(
@@ -63,17 +74,7 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
         };
     }
 
-    if facts.awaiting_operator_input {
-        return ClosureDecision {
-            outcome: ClosureOutcome::Waiting,
-            waiting_reason: Some(WaitingReason::AwaitingOperatorInput),
-            work_signal: None,
-            runtime_posture,
-            evidence,
-        };
-    }
-
-    if facts.active_waiting_intents > 0 {
+    if facts.active_agent_waiting_intents > 0 {
         return ClosureDecision {
             outcome: ClosureOutcome::Waiting,
             waiting_reason: Some(WaitingReason::AwaitingExternalChange),
@@ -146,6 +147,38 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
             runtime_posture,
             evidence,
         };
+    }
+
+    if facts.awaiting_operator_input {
+        return ClosureDecision {
+            outcome: ClosureOutcome::Waiting,
+            waiting_reason: Some(WaitingReason::AwaitingOperatorInput),
+            work_signal: None,
+            runtime_posture,
+            evidence,
+        };
+    }
+
+    match facts.current_work_item_scheduling_state {
+        Some(WorkItemSchedulingState::WaitingTask) => {
+            return ClosureDecision {
+                outcome: ClosureOutcome::Waiting,
+                waiting_reason: Some(WaitingReason::AwaitingTaskResult),
+                work_signal: None,
+                runtime_posture,
+                evidence,
+            };
+        }
+        Some(WorkItemSchedulingState::WaitingExternal) => {
+            return ClosureDecision {
+                outcome: ClosureOutcome::Waiting,
+                waiting_reason: Some(WaitingReason::AwaitingExternalChange),
+                work_signal: None,
+                runtime_posture,
+                evidence,
+            };
+        }
+        _ => {}
     }
 
     if matches!(facts.turn_terminal_kind, Some(TurnTerminalKind::Completed)) {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -166,7 +166,9 @@ impl RuntimeHandle {
                 .filter(|task| task.is_blocking())
                 .count(),
             active_waiting_intents: projection.active_waiting_intents,
+            active_agent_waiting_intents: projection.active_agent_waiting_intents,
             active_timers: projection.active_timers,
+            current_work_item_scheduling_state: projection.current_work_item_scheduling_state,
             work_signal: super::memory_refresh::work_queue_reactivation_signal(
                 &work_queue_projection,
             ),
@@ -498,7 +500,19 @@ impl RuntimeHandle {
             ),
             active_blocking_tasks: blocking_task_count(&active_tasks),
             active_waiting_intents: active_waiting_intent_count,
+            active_agent_waiting_intents: storage
+                .latest_waiting_intents()?
+                .into_iter()
+                .filter(|record| record.agent_id == state.id)
+                .filter(|record| record.status == WaitingIntentStatus::Active)
+                .filter(|record| record.scope == ExternalTriggerScope::Agent)
+                .count(),
             active_timers,
+            current_work_item_scheduling_state: work_queue_projection
+                .readiness
+                .iter()
+                .find(|item| item.is_current)
+                .map(|item| item.scheduling_state),
             work_signal: super::memory_refresh::work_queue_reactivation_signal(
                 &work_queue_projection,
             ),

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -298,7 +298,16 @@ impl RuntimeHandle {
                 }
                 Ok(true)
             }
-            None => Ok(false),
+            None => {
+                if let Some(decision) =
+                    scheduler::wait_decision_for_projection(&scheduler_projection).map(|decision| {
+                        decision.boundary(scheduler::SchedulerBoundary::IdleTick.as_str())
+                    })
+                {
+                    scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
+                }
+                Ok(false)
+            }
         }
     }
 
@@ -1162,7 +1171,8 @@ mod tests {
             .as_array()
             .unwrap()
             .iter()
-            .any(|value| value.as_str() == Some("work_queue_tick_blocked_by_wait_fact")));
+            .any(|value| value.as_str()
+                == Some("current_work_item_scheduling_state=WaitingExternal")));
     }
 
     #[test]

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -17,14 +17,12 @@ enum IdleTickTrigger {
 pub(super) fn work_queue_reactivation_signal(
     projection: &WorkQueuePromptProjection,
 ) -> Option<WorkReactivationSignal> {
-    if let Some(current) = projection.current.as_ref() {
-        if current.is_runnable() {
-            return Some(WorkReactivationSignal {
-                work_item_id: current.id.clone(),
-                state: current.state.clone(),
-                reactivation_mode: WorkReactivationMode::ContinueActive,
-            });
-        }
+    if let Some(current) = projection.current_runnable.as_ref() {
+        return Some(WorkReactivationSignal {
+            work_item_id: current.work_item.id.clone(),
+            state: current.work_item.state.clone(),
+            reactivation_mode: WorkReactivationMode::ContinueActive,
+        });
     }
     projection
         .queued_runnable
@@ -52,10 +50,8 @@ fn idle_tick_trigger_from_state(
     if let Some(pending) = pending_wake_hint {
         Some(IdleTickTrigger::WakeHint(pending))
     } else {
-        if let Some(current) = projection.current {
-            if current.is_runnable() {
-                return Some(IdleTickTrigger::WorkQueueActive(current));
-            }
+        if let Some(current) = projection.current_runnable {
+            return Some(IdleTickTrigger::WorkQueueActive(current.work_item));
         }
         projection
             .queued_runnable

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -4,7 +4,7 @@ use crate::storage::{AppStorage, WorkQueuePromptProjection};
 use crate::types::{
     AgentStatus, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint, Priority,
     TaskRecord, TaskStatus, TimerStatus, TrustLevel, TurnTerminalKind, WaitingIntentStatus,
-    WorkItemRecord,
+    WorkItemRecord, WorkItemSchedulingState,
 };
 use chrono::{DateTime, Utc};
 
@@ -16,6 +16,7 @@ pub(crate) struct SchedulerProjection {
     pub active_tasks: Vec<TaskRecord>,
     pub has_blocking_active_tasks: bool,
     pub current_work_item: Option<WorkItemRecord>,
+    pub current_work_item_scheduling_state: Option<WorkItemSchedulingState>,
     pub queued_runnable_work_items: Vec<WorkItemRecord>,
     pub queued_work_items: usize,
     pub pending_wake_hint: bool,
@@ -106,6 +107,11 @@ impl SchedulerProjection {
             .iter()
             .map(|item| item.work_item.clone())
             .collect::<Vec<_>>();
+        let current_work_item_scheduling_state = work_queue
+            .readiness
+            .iter()
+            .find(|item| item.is_current)
+            .map(|item| item.scheduling_state);
         let active_waiting_intents = storage
             .latest_waiting_intents()?
             .into_iter()
@@ -133,6 +139,7 @@ impl SchedulerProjection {
             active_tasks,
             has_blocking_active_tasks,
             current_work_item: work_queue.current,
+            current_work_item_scheduling_state,
             queued_work_items: queued_runnable_work_items.len(),
             queued_runnable_work_items,
             pending_wake_hint: snapshot.pending_wake_hint,
@@ -539,15 +546,22 @@ pub(crate) fn wait_decision_for_projection(
     projection: &SchedulerProjection,
 ) -> Option<SchedulerDecision> {
     if projection.active_waiting_intents > 0 {
+        if projection.active_agent_waiting_intents == 0 {
+            return None;
+        }
         return Some(
             SchedulerDecision::new(
                 SchedulerDecisionKind::WaitForExternalChange,
-                "active_waiting_intents",
+                "active_agent_waiting_intents",
             )
             .liveness_only(true)
             .evidence(format!(
                 "active_waiting_intents={}",
                 projection.active_waiting_intents
+            ))
+            .evidence(format!(
+                "active_agent_waiting_intents={}",
+                projection.active_agent_waiting_intents
             )),
         );
     }
@@ -559,17 +573,32 @@ pub(crate) fn wait_decision_for_projection(
         );
     }
     projection.current_work_item.as_ref().and_then(|item| {
-        if item.is_waiting_for_operator() {
-            Some(
+        match projection.current_work_item_scheduling_state {
+            Some(WorkItemSchedulingState::WaitingOperator) => Some(
                 SchedulerDecision::new(
                     SchedulerDecisionKind::WaitForOperator,
                     "work_item_needs_input",
                 )
                 .liveness_only(true)
-                .work_item_id(item.id.clone()),
-            )
-        } else {
-            None
+                .work_item_id(item.id.clone())
+                .evidence("current_work_item_scheduling_state=WaitingOperator"),
+            ),
+            Some(WorkItemSchedulingState::WaitingTask) => Some(
+                SchedulerDecision::new(SchedulerDecisionKind::WaitForTask, "work_item_task_wait")
+                    .liveness_only(true)
+                    .work_item_id(item.id.clone())
+                    .evidence("current_work_item_scheduling_state=WaitingTask"),
+            ),
+            Some(WorkItemSchedulingState::WaitingExternal) => Some(
+                SchedulerDecision::new(
+                    SchedulerDecisionKind::WaitForExternalChange,
+                    "work_item_external_wait",
+                )
+                .liveness_only(true)
+                .work_item_id(item.id.clone())
+                .evidence("current_work_item_scheduling_state=WaitingExternal"),
+            ),
+            _ => None,
         }
     })
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -545,10 +545,7 @@ pub(crate) fn idle_noop_decision(projection: &SchedulerProjection) -> SchedulerD
 pub(crate) fn wait_decision_for_projection(
     projection: &SchedulerProjection,
 ) -> Option<SchedulerDecision> {
-    if projection.active_waiting_intents > 0 {
-        if projection.active_agent_waiting_intents == 0 {
-            return None;
-        }
+    if projection.active_agent_waiting_intents > 0 {
         return Some(
             SchedulerDecision::new(
                 SchedulerDecisionKind::WaitForExternalChange,

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -3349,6 +3349,72 @@ async fn current_needs_input_work_item_waits_for_operator_without_work_signal() 
 }
 
 #[tokio::test]
+async fn current_external_wait_does_not_suppress_queued_runnable_work_item() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let current = WorkItemRecord::new(
+        "default",
+        "waiting for external review",
+        WorkItemState::Open,
+    );
+    let current_id = current.id.clone();
+    storage.append_work_item(&current).unwrap();
+    let queued = WorkItemRecord::new("default", "queued follow-up work", WorkItemState::Open);
+    let queued_id = queued.id.clone();
+    storage.append_work_item(&queued).unwrap();
+    storage
+        .append_waiting_intent(&WaitingIntentRecord {
+            id: "wait-current".into(),
+            agent_id: "default".into(),
+            scope: ExternalTriggerScope::WorkItem,
+            work_item_id: Some(current_id.clone()),
+            description: "wait for current review".into(),
+            source: "github".into(),
+            resource: Some("pull_request:1".into()),
+            condition: None,
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: "trigger-current".into(),
+            created_at: Utc::now(),
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
+        })
+        .unwrap();
+    let mut agent = AgentState::new("default");
+    agent.current_work_item_id = Some(current_id);
+    storage.write_agent(&agent).unwrap();
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("tick done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let closure = runtime.current_closure_decision().await.unwrap();
+    assert_eq!(closure.outcome, ClosureOutcome::Continuable);
+    assert_eq!(closure.waiting_reason, None);
+    let signal = closure.work_signal.expect("work signal should exist");
+    assert_eq!(signal.work_item_id, queued_id);
+    assert_eq!(
+        signal.reactivation_mode,
+        WorkReactivationMode::ActivateQueued
+    );
+    assert!(closure
+        .evidence
+        .iter()
+        .any(|item| item == "current_work_item_scheduling_state=WaitingExternal"));
+}
+
+#[tokio::test]
 async fn current_closure_reports_continuable_for_queued_work_item_without_active_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/tests/fixtures/scheduler/agent_wait/expected.json
+++ b/tests/fixtures/scheduler/agent_wait/expected.json
@@ -10,5 +10,5 @@
   "active_agent_waiting_intents": 1,
   "active_timers": 0,
   "decision": "WaitForExternalChange",
-  "decision_reason": "active_waiting_intents"
+  "decision_reason": "active_agent_waiting_intents"
 }


### PR DESCRIPTION
## Summary
- drive closure wait decisions from `WorkItemSchedulingState` for current WorkItems
- keep agent-scope waiting intents as global waits, but stop work-item-scope waits from suppressing unrelated runnable queued work
- switch idle work reactivation to the derived runnable projections and add regression coverage for queued runnable work behind a current external wait

Closes #1290.

## Verification
- `cargo fmt --all -- --check`
- `cargo test current_external_wait_does_not_suppress_queued_runnable_work_item -- --nocapture`
- `cargo test current_needs_input_work_item_waits_for_operator_without_work_signal -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
