### PR TITLE
feat: add internal wait condition ledger

### DIFF
--- a/src/runtime/closure.rs
+++ b/src/runtime/closure.rs
@@ -178,6 +178,33 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
                 evidence,
             };
         }
+        Some(WorkItemSchedulingState::WaitingTimer) => {
+            return ClosureDecision {
+                outcome: ClosureOutcome::Waiting,
+                waiting_reason: Some(WaitingReason::AwaitingTimer),
+                work_signal: None,
+                runtime_posture,
+                evidence,
+            };
+        }
+        Some(WorkItemSchedulingState::WaitingOperator) => {
+            return ClosureDecision {
+                outcome: ClosureOutcome::Waiting,
+                waiting_reason: Some(WaitingReason::AwaitingOperatorInput),
+                work_signal: None,
+                runtime_posture,
+                evidence,
+            };
+        }
+        Some(WorkItemSchedulingState::WaitingSystem) => {
+            return ClosureDecision {
+                outcome: ClosureOutcome::Waiting,
+                waiting_reason: None,
+                work_signal: None,
+                runtime_posture,
+                evidence,
+            };
+        }
         _ => {}
     }
 

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -595,6 +595,21 @@ pub(crate) fn wait_decision_for_projection(
                 .work_item_id(item.id.clone())
                 .evidence("current_work_item_scheduling_state=WaitingExternal"),
             ),
+            Some(WorkItemSchedulingState::WaitingTimer) => Some(
+                SchedulerDecision::new(SchedulerDecisionKind::WaitForTimer, "work_item_timer_wait")
+                    .liveness_only(true)
+                    .work_item_id(item.id.clone())
+                    .evidence("current_work_item_scheduling_state=WaitingTimer"),
+            ),
+            Some(WorkItemSchedulingState::WaitingSystem) => Some(
+                SchedulerDecision::new(
+                    SchedulerDecisionKind::EmitSystemTick,
+                    "work_item_system_wait",
+                )
+                .liveness_only(true)
+                .work_item_id(item.id.clone())
+                .evidence("current_work_item_scheduling_state=WaitingSystem"),
+            ),
             _ => None,
         }
     })

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -79,6 +79,43 @@ pub enum WorkItemCandidateClass {
     CompletedRecent,
 }
 
+#[derive(Debug, Default)]
+struct ActiveWaitConditionStates {
+    task: bool,
+    external: bool,
+    operator: bool,
+    timer: bool,
+    system: bool,
+}
+
+impl ActiveWaitConditionStates {
+    fn record(&mut self, kind: WaitConditionKind) {
+        match kind {
+            WaitConditionKind::Task => self.task = true,
+            WaitConditionKind::External => self.external = true,
+            WaitConditionKind::Operator => self.operator = true,
+            WaitConditionKind::Timer => self.timer = true,
+            WaitConditionKind::System => self.system = true,
+        }
+    }
+
+    fn scheduling_state(&self) -> Option<WorkItemSchedulingState> {
+        if self.task {
+            Some(WorkItemSchedulingState::WaitingTask)
+        } else if self.operator {
+            Some(WorkItemSchedulingState::WaitingOperator)
+        } else if self.timer {
+            Some(WorkItemSchedulingState::WaitingTimer)
+        } else if self.external {
+            Some(WorkItemSchedulingState::WaitingExternal)
+        } else if self.system {
+            Some(WorkItemSchedulingState::WaitingSystem)
+        } else {
+            None
+        }
+    }
+}
+
 impl WorkItemReadinessProjection {
     pub fn record(&self) -> &WorkItemRecord {
         &self.work_item
@@ -297,8 +334,23 @@ impl AppStorage {
     }
 
     pub fn append_waiting_intent(&self, record: &WaitingIntentRecord) -> Result<()> {
-        self.append_jsonl(&self.waiting_intents_path, record)?;
-        self.append_wait_condition(&wait_condition_from_waiting_intent(record))
+        let wait_condition = wait_condition_from_waiting_intent(record);
+        let waiting_intent_bytes = jsonl_bytes(record)?;
+        let wait_condition_bytes = jsonl_bytes(&wait_condition)?;
+
+        // Compatibility migration: keep the legacy waiting-intents ledger as the
+        // first durable write, then mirror the same state into the internal wait
+        // condition ledger while holding the storage append mutex so no other
+        // append can observe or interleave with the ordered pair. A filesystem
+        // failure on the second write can still leave the legacy append present;
+        // callers should treat the returned error as a mirror consistency failure,
+        // not proof that the legacy intent was absent.
+        let _guard = self
+            .append_mutex
+            .lock()
+            .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
+        append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)
     }
 
     pub fn append_wait_condition(&self, record: &WaitConditionRecord) -> Result<()> {
@@ -347,10 +399,7 @@ impl AppStorage {
     }
 
     fn append_jsonl<T: Serialize>(&self, path: &Path, value: &T) -> Result<()> {
-        let line = serde_json::to_string(value)?;
-        let mut bytes = Vec::with_capacity(line.len() + 1);
-        bytes.extend_from_slice(line.as_bytes());
-        bytes.push(b'\n');
+        let bytes = jsonl_bytes(value)?;
 
         let _guard = self
             .append_mutex
@@ -751,14 +800,9 @@ impl AppStorage {
             .filter(|condition| condition.status == WaitConditionStatus::Active)
             .filter_map(|condition| condition.work_item_id.map(|id| (id, condition.kind)))
             .fold(
-                std::collections::BTreeMap::<String, (bool, bool)>::new(),
+                std::collections::BTreeMap::<String, ActiveWaitConditionStates>::new(),
                 |mut acc, (id, kind)| {
-                    let slot = acc.entry(id).or_insert((false, false));
-                    if kind == WaitConditionKind::Task {
-                        slot.0 = true;
-                    } else {
-                        slot.1 = true;
-                    }
+                    acc.entry(id).or_default().record(kind);
                     acc
                 },
             );
@@ -776,13 +820,22 @@ impl AppStorage {
                     && item.state == WorkItemState::Open;
                 let last_triggered_at = active_waits.get(&item.id).copied().flatten();
                 let wait_condition = active_wait_conditions.get(&item.id);
-                let has_active_waits = active_waits.contains_key(&item.id)
-                    || wait_condition.is_some_and(|(_, external)| *external);
+                let wait_condition_state =
+                    wait_condition.and_then(ActiveWaitConditionStates::scheduling_state);
+                let has_active_waits =
+                    active_waits.contains_key(&item.id) || wait_condition_state.is_some();
                 let has_active_task_waits = active_task_waits.contains(&item.id)
-                    || wait_condition.is_some_and(|(task, _)| *task);
+                    || wait_condition.is_some_and(|states| states.task);
                 let has_triggered_waits = last_triggered_at.is_some();
-                let scheduling_state =
-                    item.scheduling_state(has_active_waits, has_active_task_waits);
+                let scheduling_state = item.scheduling_state(if has_active_task_waits {
+                    Some(WorkItemSchedulingState::WaitingTask)
+                } else {
+                    wait_condition_state.or_else(|| {
+                        active_waits
+                            .contains_key(&item.id)
+                            .then_some(WorkItemSchedulingState::WaitingExternal)
+                    })
+                });
                 let readiness = readiness_for_scheduling_state(scheduling_state);
                 let candidate_class =
                     if is_current && scheduling_state == WorkItemSchedulingState::Runnable {
@@ -857,7 +910,7 @@ impl AppStorage {
                     && !active_task_waits.contains(&item.id)
                     && !active_wait_conditions
                         .get(&item.id)
-                        .is_some_and(|(task, _)| *task)
+                        .is_some_and(|states| states.task)
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -1265,6 +1318,14 @@ fn read_tail_event_seq(path: &Path) -> Result<Option<u64>> {
     Ok(value.get("event_seq").and_then(Value::as_u64))
 }
 
+fn jsonl_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    let line = serde_json::to_string(value)?;
+    let mut bytes = Vec::with_capacity(line.len() + 1);
+    bytes.extend_from_slice(line.as_bytes());
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
 fn append_jsonl_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -1543,6 +1604,8 @@ fn readiness_for_scheduling_state(state: WorkItemSchedulingState) -> WorkItemRea
         WorkItemSchedulingState::WaitingOperator => WorkItemReadiness::WaitingForOperator,
         WorkItemSchedulingState::WaitingTask
         | WorkItemSchedulingState::WaitingExternal
+        | WorkItemSchedulingState::WaitingTimer
+        | WorkItemSchedulingState::WaitingSystem
         | WorkItemSchedulingState::Blocked => WorkItemReadiness::Blocked,
         WorkItemSchedulingState::Completed => WorkItemReadiness::Completed,
     }
@@ -2283,9 +2346,22 @@ mod tests {
             WorkItemRecord::new("default", "external wait", WorkItemState::Open);
         external_wait.blocked_by = Some("ci".into());
         external_wait.updated_at = now + chrono::Duration::seconds(1);
+        let mut operator_wait =
+            WorkItemRecord::new("default", "operator wait", WorkItemState::Open);
+        operator_wait.blocked_by = Some("operator input".into());
+        operator_wait.updated_at = now + chrono::Duration::seconds(2);
+        let mut timer_wait = WorkItemRecord::new("default", "timer wait", WorkItemState::Open);
+        timer_wait.blocked_by = Some("timer".into());
+        timer_wait.updated_at = now + chrono::Duration::seconds(3);
+        let mut system_wait = WorkItemRecord::new("default", "system wait", WorkItemState::Open);
+        system_wait.blocked_by = Some("system tick".into());
+        system_wait.updated_at = now + chrono::Duration::seconds(4);
 
         storage.append_work_item(&task_wait).unwrap();
         storage.append_work_item(&external_wait).unwrap();
+        storage.append_work_item(&operator_wait).unwrap();
+        storage.append_work_item(&timer_wait).unwrap();
+        storage.append_work_item(&system_wait).unwrap();
         storage
             .append_wait_condition(&WaitConditionRecord {
                 id: "task-condition".into(),
@@ -2328,15 +2404,94 @@ mod tests {
                 cancelled_at: None,
             })
             .unwrap();
+        storage
+            .append_wait_condition(&WaitConditionRecord {
+                id: "operator-condition".into(),
+                agent_id: "default".into(),
+                work_item_id: Some(operator_wait.id.clone()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::Operator,
+                source: None,
+                subject_ref: None,
+                waiting_for: "operator input".into(),
+                wake_sources: vec![WakeSource::OperatorInput],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            })
+            .unwrap();
+        storage
+            .append_wait_condition(&WaitConditionRecord {
+                id: "timer-condition".into(),
+                agent_id: "default".into(),
+                work_item_id: Some(timer_wait.id.clone()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::Timer,
+                source: None,
+                subject_ref: None,
+                waiting_for: "timer".into(),
+                wake_sources: vec![WakeSource::Timer {
+                    wake_at: now + chrono::Duration::minutes(5),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            })
+            .unwrap();
+        storage
+            .append_wait_condition(&WaitConditionRecord {
+                id: "system-condition".into(),
+                agent_id: "default".into(),
+                work_item_id: Some(system_wait.id.clone()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::System,
+                source: None,
+                subject_ref: None,
+                waiting_for: "system tick".into(),
+                wake_sources: vec![WakeSource::SystemTick],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            })
+            .unwrap();
 
         let projection = storage.work_queue_prompt_projection().unwrap();
+        let state_for = |id: &str| {
+            projection
+                .readiness
+                .iter()
+                .find(|item| item.work_item.id == id)
+                .map(|item| item.scheduling_state)
+                .unwrap()
+        };
+        assert_eq!(
+            state_for(&operator_wait.id),
+            WorkItemSchedulingState::WaitingOperator
+        );
+        assert_eq!(
+            state_for(&timer_wait.id),
+            WorkItemSchedulingState::WaitingTimer
+        );
+        assert_eq!(
+            state_for(&system_wait.id),
+            WorkItemSchedulingState::WaitingSystem
+        );
         assert_eq!(
             projection
                 .blocked
                 .iter()
                 .map(|item| item.work_item.objective.as_str())
                 .collect::<Vec<_>>(),
-            vec!["external wait"]
+            vec!["system wait", "timer wait", "external wait"]
         );
         assert!(projection
             .queued_blocked

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -17,7 +17,8 @@ use crate::types::{
     DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope, MessageEnvelope,
     OperatorDeliveryRecord, OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord,
     TaskRecord, TaskStatus, TimerRecord, TodoItem, TodoItemState, ToolExecutionRecord,
-    TranscriptEntry, WaitingIntentRecord, WaitingIntentStatus, WorkItemDelegationRecord,
+    TranscriptEntry, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
+    WaitingIntentRecord, WaitingIntentStatus, WakeSource, WorkItemDelegationRecord,
     WorkItemDelegationState, WorkItemReadiness, WorkItemRecord, WorkItemSchedulingState,
     WorkItemState, WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
@@ -109,6 +110,7 @@ pub struct AppStorage {
     transcript_path: PathBuf,
     queue_entries_path: PathBuf,
     waiting_intents_path: PathBuf,
+    wait_conditions_path: PathBuf,
     external_triggers_path: PathBuf,
     operator_notifications_path: PathBuf,
     operator_transport_bindings_path: PathBuf,
@@ -173,6 +175,7 @@ impl AppStorage {
             transcript_path: ledger_dir.join("transcript.jsonl"),
             queue_entries_path: ledger_dir.join("queue_entries.jsonl"),
             waiting_intents_path: ledger_dir.join("waiting_intents.jsonl"),
+            wait_conditions_path: ledger_dir.join("wait_conditions.jsonl"),
             external_triggers_path: ledger_dir.join("external_triggers.jsonl"),
             operator_notifications_path: ledger_dir.join("operator_notifications.jsonl"),
             operator_transport_bindings_path: ledger_dir.join("operator_transport_bindings.jsonl"),
@@ -294,7 +297,12 @@ impl AppStorage {
     }
 
     pub fn append_waiting_intent(&self, record: &WaitingIntentRecord) -> Result<()> {
-        self.append_jsonl(&self.waiting_intents_path, record)
+        self.append_jsonl(&self.waiting_intents_path, record)?;
+        self.append_wait_condition(&wait_condition_from_waiting_intent(record))
+    }
+
+    pub fn append_wait_condition(&self, record: &WaitConditionRecord) -> Result<()> {
+        self.append_jsonl(&self.wait_conditions_path, record)
     }
 
     pub fn append_external_trigger(&self, record: &ExternalTriggerRecord) -> Result<()> {
@@ -452,6 +460,10 @@ impl AppStorage {
 
     pub fn read_recent_waiting_intents(&self, limit: usize) -> Result<Vec<WaitingIntentRecord>> {
         read_recent_jsonl(&self.waiting_intents_path, limit)
+    }
+
+    pub fn read_recent_wait_conditions(&self, limit: usize) -> Result<Vec<WaitConditionRecord>> {
+        read_recent_jsonl(&self.wait_conditions_path, limit)
     }
 
     pub fn read_recent_queue_entries(&self, limit: usize) -> Result<Vec<QueueEntryRecord>> {
@@ -733,6 +745,23 @@ impl AppStorage {
                     acc
                 },
             );
+        let active_wait_conditions = self
+            .latest_wait_conditions()?
+            .into_iter()
+            .filter(|condition| condition.status == WaitConditionStatus::Active)
+            .filter_map(|condition| condition.work_item_id.map(|id| (id, condition.kind)))
+            .fold(
+                std::collections::BTreeMap::<String, (bool, bool)>::new(),
+                |mut acc, (id, kind)| {
+                    let slot = acc.entry(id).or_insert((false, false));
+                    if kind == WaitConditionKind::Task {
+                        slot.0 = true;
+                    } else {
+                        slot.1 = true;
+                    }
+                    acc
+                },
+            );
         let active_task_waits = self
             .latest_active_task_records(usize::MAX)?
             .into_iter()
@@ -746,8 +775,11 @@ impl AppStorage {
                 let is_current = current_work_item_id.as_deref() == Some(item.id.as_str())
                     && item.state == WorkItemState::Open;
                 let last_triggered_at = active_waits.get(&item.id).copied().flatten();
-                let has_active_waits = active_waits.contains_key(&item.id);
-                let has_active_task_waits = active_task_waits.contains(&item.id);
+                let wait_condition = active_wait_conditions.get(&item.id);
+                let has_active_waits = active_waits.contains_key(&item.id)
+                    || wait_condition.is_some_and(|(_, external)| *external);
+                let has_active_task_waits = active_task_waits.contains(&item.id)
+                    || wait_condition.is_some_and(|(task, _)| *task);
                 let has_triggered_waits = last_triggered_at.is_some();
                 let scheduling_state =
                     item.scheduling_state(has_active_waits, has_active_task_waits);
@@ -806,6 +838,7 @@ impl AppStorage {
         let blocked = readiness
             .iter()
             .filter(|item| item.candidate_class == WorkItemCandidateClass::Blocked)
+            .filter(|item| item.scheduling_state != WorkItemSchedulingState::WaitingTask)
             .take(3)
             .cloned()
             .collect::<Vec<_>>();
@@ -821,6 +854,10 @@ impl AppStorage {
             .filter(|item| {
                 item.state == WorkItemState::Open
                     && Some(item.id.as_str()) != current_work_item_id.as_deref()
+                    && !active_task_waits.contains(&item.id)
+                    && !active_wait_conditions
+                        .get(&item.id)
+                        .is_some_and(|(task, _)| *task)
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -978,6 +1015,39 @@ impl AppStorage {
             latest.insert(record.id.clone(), record);
         }
         Ok(latest.into_values().collect())
+    }
+
+    pub fn latest_wait_conditions(&self) -> Result<Vec<WaitConditionRecord>> {
+        let records = self.read_recent_wait_conditions(usize::MAX)?;
+        let mut latest = std::collections::BTreeMap::new();
+        for record in records {
+            latest.insert(record.id.clone(), record);
+        }
+        Ok(latest.into_values().collect())
+    }
+
+    pub fn latest_active_wait_conditions_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<WaitConditionRecord>> {
+        Ok(self
+            .latest_wait_conditions()?
+            .into_iter()
+            .filter(|record| record.agent_id == agent_id)
+            .filter(|record| record.status == WaitConditionStatus::Active)
+            .collect())
+    }
+
+    pub fn latest_active_wait_conditions_for_work_item(
+        &self,
+        agent_id: &str,
+        work_item_id: &str,
+    ) -> Result<Vec<WaitConditionRecord>> {
+        Ok(self
+            .latest_active_wait_conditions_for_agent(agent_id)?
+            .into_iter()
+            .filter(|record| record.work_item_id.as_deref() == Some(work_item_id))
+            .collect())
     }
 
     pub fn latest_waiting_intent(
@@ -1305,6 +1375,43 @@ where
     }
 
     parse_jsonl_match(&prefix, path, &mut matches)
+}
+
+fn wait_condition_from_waiting_intent(record: &WaitingIntentRecord) -> WaitConditionRecord {
+    let updated_at = record
+        .cancelled_at
+        .or(record.last_triggered_at)
+        .unwrap_or(record.created_at);
+    WaitConditionRecord {
+        id: format!("waiting_intent:{}", record.id),
+        agent_id: record.agent_id.clone(),
+        work_item_id: record.work_item_id.clone(),
+        status: match record.status {
+            WaitingIntentStatus::Active => WaitConditionStatus::Active,
+            WaitingIntentStatus::Cancelled => WaitConditionStatus::Cancelled,
+        },
+        kind: WaitConditionKind::External,
+        source: Some(record.source.clone()),
+        subject_ref: record.resource.clone(),
+        waiting_for: record
+            .condition
+            .clone()
+            .unwrap_or_else(|| record.description.clone()),
+        wake_sources: vec![WakeSource::ExternalIngress {
+            external_trigger_id: Some(record.external_trigger_id.clone()),
+        }],
+        continuation: Some(serde_json::json!({
+            "waiting_intent_id": record.id,
+            "external_trigger_id": record.external_trigger_id,
+            "scope": record.scope,
+            "delivery_mode": record.delivery_mode,
+        })),
+        created_at: record.created_at,
+        updated_at,
+        expires_at: None,
+        resolved_at: None,
+        cancelled_at: record.cancelled_at,
+    }
 }
 
 fn scan_jsonl_reverse<T, F>(path: &Path, mut visit: F) -> Result<()>
@@ -2097,6 +2204,144 @@ mod tests {
             .expect("latest waiting intent should be found");
         assert_eq!(found.work_item_id.as_deref(), Some("work-new"));
         assert_eq!(found.trigger_count, 1);
+    }
+
+    #[test]
+    fn append_waiting_intent_mirrors_internal_wait_condition_ledger() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+        let active = WaitingIntentRecord {
+            id: "wait-1".into(),
+            agent_id: "default".into(),
+            scope: ExternalTriggerScope::WorkItem,
+            work_item_id: Some("work-1".into()),
+            description: "waiting for github".into(),
+            source: "github".into(),
+            resource: Some("pr-1".into()),
+            condition: Some("ci passed".into()),
+            delivery_mode: crate::types::CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: "trigger-1".into(),
+            created_at: now,
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
+        };
+        let cancelled = WaitingIntentRecord {
+            status: WaitingIntentStatus::Cancelled,
+            cancelled_at: Some(now + chrono::Duration::seconds(10)),
+            ..active.clone()
+        };
+
+        storage.append_waiting_intent(&active).unwrap();
+        let mirrored = storage.latest_wait_conditions().unwrap();
+        assert_eq!(mirrored.len(), 1);
+        assert_eq!(mirrored[0].id, "waiting_intent:wait-1");
+        assert_eq!(mirrored[0].status, WaitConditionStatus::Active);
+        assert_eq!(mirrored[0].kind, WaitConditionKind::External);
+        assert_eq!(mirrored[0].source.as_deref(), Some("github"));
+        assert_eq!(mirrored[0].subject_ref.as_deref(), Some("pr-1"));
+        assert_eq!(mirrored[0].waiting_for, "ci passed");
+        assert_eq!(
+            mirrored[0].wake_sources,
+            vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-1".into()),
+            }]
+        );
+        assert_eq!(
+            mirrored[0]
+                .continuation
+                .as_ref()
+                .and_then(|value| value.get("waiting_intent_id").and_then(|id| id.as_str())),
+            Some("wait-1")
+        );
+
+        storage.append_waiting_intent(&cancelled).unwrap();
+        let active_for_work = storage
+            .latest_active_wait_conditions_for_work_item("default", "work-1")
+            .unwrap();
+        assert!(active_for_work.is_empty());
+        let latest = storage.latest_wait_conditions().unwrap();
+        assert_eq!(latest.len(), 1);
+        assert_eq!(latest[0].status, WaitConditionStatus::Cancelled);
+        assert_eq!(latest[0].cancelled_at, cancelled.cancelled_at);
+    }
+
+    #[test]
+    fn work_queue_projection_uses_internal_wait_conditions_for_wait_state() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+
+        let mut task_wait = WorkItemRecord::new("default", "task wait", WorkItemState::Open);
+        task_wait.blocked_by = Some("command task".into());
+        task_wait.updated_at = now;
+        let mut external_wait =
+            WorkItemRecord::new("default", "external wait", WorkItemState::Open);
+        external_wait.blocked_by = Some("ci".into());
+        external_wait.updated_at = now + chrono::Duration::seconds(1);
+
+        storage.append_work_item(&task_wait).unwrap();
+        storage.append_work_item(&external_wait).unwrap();
+        storage
+            .append_wait_condition(&WaitConditionRecord {
+                id: "task-condition".into(),
+                agent_id: "default".into(),
+                work_item_id: Some(task_wait.id.clone()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::Task,
+                source: None,
+                subject_ref: Some("task-1".into()),
+                waiting_for: "task result".into(),
+                wake_sources: vec![WakeSource::TaskResult {
+                    task_id: "task-1".into(),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            })
+            .unwrap();
+        storage
+            .append_wait_condition(&WaitConditionRecord {
+                id: "external-condition".into(),
+                agent_id: "default".into(),
+                work_item_id: Some(external_wait.id.clone()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pr-1".into()),
+                waiting_for: "ci".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("trigger-1".into()),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            })
+            .unwrap();
+
+        let projection = storage.work_queue_prompt_projection().unwrap();
+        assert_eq!(
+            projection
+                .blocked
+                .iter()
+                .map(|item| item.work_item.objective.as_str())
+                .collect::<Vec<_>>(),
+            vec!["external wait"]
+        );
+        assert!(projection
+            .queued_blocked
+            .iter()
+            .all(|item| item.objective != "task wait"));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1700,6 +1700,69 @@ pub struct WaitingIntentRecord {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum WaitConditionStatus {
+    Active,
+    Resolved,
+    Cancelled,
+    Expired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WaitConditionKind {
+    Task,
+    External,
+    Operator,
+    Timer,
+    System,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WakeSource {
+    TaskResult {
+        task_id: String,
+    },
+    ExternalIngress {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        external_trigger_id: Option<String>,
+    },
+    Timer {
+        wake_at: DateTime<Utc>,
+    },
+    OperatorInput,
+    SystemTick,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WaitConditionRecord {
+    pub id: String,
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    pub status: WaitConditionStatus,
+    pub kind: WaitConditionKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_ref: Option<String>,
+    pub waiting_for: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wake_sources: Vec<WakeSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancelled_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum ExternalTriggerStatus {
     Active,
     Revoked,
@@ -2867,9 +2930,6 @@ impl WorkItemRecord {
         if self.state == WorkItemState::Completed {
             return WorkItemSchedulingState::Completed;
         }
-        if self.blocked_by.is_some() {
-            return WorkItemSchedulingState::Blocked;
-        }
         if self.plan_status == WorkItemPlanStatus::NeedsInput {
             return WorkItemSchedulingState::WaitingOperator;
         }
@@ -2878,6 +2938,9 @@ impl WorkItemRecord {
         }
         if has_active_external_wait {
             return WorkItemSchedulingState::WaitingExternal;
+        }
+        if self.blocked_by.is_some() {
+            return WorkItemSchedulingState::Blocked;
         }
         WorkItemSchedulingState::Runnable
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2851,6 +2851,8 @@ pub enum WorkItemSchedulingState {
     WaitingOperator,
     WaitingTask,
     WaitingExternal,
+    WaitingTimer,
+    WaitingSystem,
     Blocked,
     Completed,
 }
@@ -2924,8 +2926,7 @@ impl WorkItemRecord {
 
     pub fn scheduling_state(
         &self,
-        has_active_external_wait: bool,
-        has_active_task_wait: bool,
+        active_wait_state: Option<WorkItemSchedulingState>,
     ) -> WorkItemSchedulingState {
         if self.state == WorkItemState::Completed {
             return WorkItemSchedulingState::Completed;
@@ -2933,11 +2934,8 @@ impl WorkItemRecord {
         if self.plan_status == WorkItemPlanStatus::NeedsInput {
             return WorkItemSchedulingState::WaitingOperator;
         }
-        if has_active_task_wait {
-            return WorkItemSchedulingState::WaitingTask;
-        }
-        if has_active_external_wait {
-            return WorkItemSchedulingState::WaitingExternal;
+        if let Some(wait_state) = active_wait_state {
+            return wait_state;
         }
         if self.blocked_by.is_some() {
             return WorkItemSchedulingState::Blocked;
@@ -2946,11 +2944,13 @@ impl WorkItemRecord {
     }
 
     pub fn readiness(&self) -> WorkItemReadiness {
-        match self.scheduling_state(false, false) {
+        match self.scheduling_state(None) {
             WorkItemSchedulingState::Runnable => WorkItemReadiness::Runnable,
             WorkItemSchedulingState::WaitingOperator => WorkItemReadiness::WaitingForOperator,
             WorkItemSchedulingState::WaitingTask
             | WorkItemSchedulingState::WaitingExternal
+            | WorkItemSchedulingState::WaitingTimer
+            | WorkItemSchedulingState::WaitingSystem
             | WorkItemSchedulingState::Blocked => WorkItemReadiness::Blocked,
             WorkItemSchedulingState::Completed => WorkItemReadiness::Completed,
         }


### PR DESCRIPTION
## Summary
- add internal WaitCondition/WakeSource record types backed by a wait_conditions JSONL ledger
- mirror existing WaitingIntent writes into internal wait condition records for compatibility
- use active internal wait conditions when projecting work queue wait state and queued blocked items

Closes #1291

## Verification
- cargo test append_waiting_intent_mirrors_internal_wait_condition_ledger -- --nocapture
- cargo test work_queue_projection_uses_internal_wait_conditions_for_wait_state -- --nocapture
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets