### PR TITLE
feat: route wake sources through wait reconciliation

### DIFF
--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,6 +1,9 @@
 use super::super::*;
 use super::support::*;
-use crate::types::{AuthorityClass, SkillLoadReason, WorkItemPlanStatus};
+use crate::types::{
+    AuthorityClass, SkillLoadReason, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
+    WakeSource, WorkItemPlanStatus,
+};
 
 struct BlockingProvider {
     started: Arc<tokio::sync::Notify>,
@@ -1638,6 +1641,222 @@ async fn task_result_routes_through_reduction_and_follow_up_behavior() {
     assert!(events
         .iter()
         .any(|event| event.kind == "task_result_received"));
+}
+
+#[tokio::test]
+async fn task_result_records_wait_reconciliation_without_resolving_wait_condition() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(CountingProvider {
+        calls: Mutex::new(0),
+        reply: "task follow-up",
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let now = Utc::now();
+    runtime
+        .storage()
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-task-1".into(),
+            agent_id: "default".into(),
+            work_item_id: Some("wi-1".into()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::Task,
+            source: None,
+            subject_ref: Some("task-1".into()),
+            waiting_for: "task result".into(),
+            wake_sources: vec![WakeSource::TaskResult {
+                task_id: "task-1".into(),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+        })
+        .unwrap();
+
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task-1".into(),
+        },
+        TrustLevel::TrustedSystem,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "task completed".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+    message.metadata = Some(serde_json::json!({
+        "task_id": "task-1",
+        "task_kind": "child_agent_task",
+        "task_status": "completed",
+    }));
+
+    runtime
+        .process_message(
+            message,
+            closure_decision(
+                ClosureOutcome::Waiting,
+                Some(WaitingReason::AwaitingTaskResult),
+            ),
+        )
+        .await
+        .unwrap();
+
+    let events = runtime.storage().read_recent_events(100).unwrap();
+    let signal = events
+        .iter()
+        .find(|event| {
+            event.kind == "wait_reconciliation_requested"
+                && event.data["wait_condition_id"] == "wait-task-1"
+        })
+        .expect("task result should request wait reconciliation");
+    assert_eq!(signal.data["wake_source"].as_str(), Some("task_result"));
+    assert_eq!(signal.data["subject_ref"].as_str(), Some("task-1"));
+    assert_eq!(signal.data["work_item_id"].as_str(), Some("wi-1"));
+
+    let active_conditions = runtime
+        .storage()
+        .latest_active_wait_conditions_for_agent("default")
+        .unwrap();
+    assert!(active_conditions
+        .iter()
+        .any(|condition| condition.id == "wait-task-1"));
+}
+
+#[tokio::test]
+async fn timer_operator_and_system_ticks_record_wait_reconciliation_signals() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "reconciled",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let now = Utc::now();
+    for (id, kind, wake_sources) in [
+        (
+            "wait-timer",
+            WaitConditionKind::Timer,
+            vec![WakeSource::Timer { wake_at: now }],
+        ),
+        (
+            "wait-operator",
+            WaitConditionKind::Operator,
+            vec![WakeSource::OperatorInput],
+        ),
+        (
+            "wait-system",
+            WaitConditionKind::System,
+            vec![WakeSource::SystemTick],
+        ),
+    ] {
+        runtime
+            .storage()
+            .append_wait_condition(&WaitConditionRecord {
+                id: id.into(),
+                agent_id: "default".into(),
+                work_item_id: Some(format!("{id}-work")),
+                status: WaitConditionStatus::Active,
+                kind,
+                source: None,
+                subject_ref: None,
+                waiting_for: format!("{id} fired"),
+                wake_sources,
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            })
+            .unwrap();
+    }
+
+    for message in [
+        MessageEnvelope::new(
+            "default",
+            MessageKind::TimerTick,
+            MessageOrigin::Timer {
+                timer_id: "timer-1".into(),
+            },
+            TrustLevel::TrustedSystem,
+            Priority::Next,
+            MessageBody::Text {
+                text: "timer fired".into(),
+            },
+        ),
+        MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("operator-1".into()),
+            },
+            TrustLevel::TrustedOperator,
+            Priority::Interject,
+            MessageBody::Text {
+                text: "operator input".into(),
+            },
+        ),
+        MessageEnvelope::new(
+            "default",
+            MessageKind::SystemTick,
+            MessageOrigin::System {
+                subsystem: "scheduler".into(),
+            },
+            TrustLevel::TrustedSystem,
+            Priority::Next,
+            MessageBody::Text {
+                text: "system tick".into(),
+            },
+        ),
+    ] {
+        runtime
+            .process_message(message, closure_decision(ClosureOutcome::Completed, None))
+            .await
+            .unwrap();
+    }
+
+    let events = runtime.storage().read_recent_events(100).unwrap();
+    for (condition_id, wake_source) in [
+        ("wait-timer", "timer"),
+        ("wait-operator", "operator_input"),
+        ("wait-system", "system_tick"),
+    ] {
+        assert!(events.iter().any(|event| {
+            event.kind == "wait_reconciliation_requested"
+                && event.data["wait_condition_id"] == condition_id
+                && event.data["wake_source"] == wake_source
+        }));
+    }
+    let active_conditions = runtime
+        .storage()
+        .latest_active_wait_conditions_for_agent("default")
+        .unwrap();
+    assert_eq!(active_conditions.len(), 3);
 }
 
 #[tokio::test]

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2688,6 +2688,129 @@ async fn default_external_ingress_wakes_without_owning_work_item_wait_state() {
 }
 
 #[tokio::test]
+async fn external_wake_records_wait_reconciliation_without_resolving_wait() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("reconciled")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let now = Utc::now();
+    let work = runtime
+        .create_work_item("wait for CI".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(work.id.clone()).await.unwrap();
+    let waiting_id = "wait-ci".to_string();
+    let trigger_id = "trigger-ci".to_string();
+    runtime
+        .storage()
+        .append_waiting_intent(&WaitingIntentRecord {
+            id: waiting_id.clone(),
+            agent_id: "default".into(),
+            scope: ExternalTriggerScope::WorkItem,
+            work_item_id: Some(work.id.clone()),
+            description: "wait for CI".into(),
+            source: "github".into(),
+            resource: Some("holon-run/holon#1292".into()),
+            condition: Some("checks complete".into()),
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: trigger_id.clone(),
+            created_at: now,
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
+        })
+        .unwrap();
+    runtime
+        .storage()
+        .append_external_trigger(&ExternalTriggerRecord {
+            external_trigger_id: trigger_id.clone(),
+            target_agent_id: "default".into(),
+            waiting_intent_id: Some(waiting_id.clone()),
+            scope: ExternalTriggerScope::WorkItem,
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            trigger_url: Some("http://127.0.0.1:7878/callbacks/wake/ci".into()),
+            token_hash: "token-hash".into(),
+            status: ExternalTriggerStatus::Active,
+            created_at: now,
+            revoked_at: None,
+            last_delivered_at: None,
+            delivery_count: 0,
+        })
+        .unwrap();
+
+    runtime
+        .deliver_callback(
+            &trigger_id,
+            CallbackDeliveryPayload {
+                body: Some(MessageBody::Json {
+                    value: serde_json::json!({"check": "Rust", "conclusion": "success"}),
+                }),
+                content_type: Some("application/json".into()),
+                correlation_id: Some("corr-ci".into()),
+                causation_id: Some("run-123".into()),
+            },
+        )
+        .await
+        .unwrap();
+    let tick = runtime
+        .storage()
+        .read_recent_messages(10)
+        .unwrap()
+        .into_iter()
+        .find(|message| message.kind == MessageKind::SystemTick)
+        .expect("wake hint should enqueue a system tick");
+
+    runtime
+        .process_message(
+            tick,
+            closure_decision(
+                ClosureOutcome::Waiting,
+                Some(WaitingReason::AwaitingExternalChange),
+            ),
+        )
+        .await
+        .unwrap();
+
+    let events = runtime.storage().read_recent_events(100).unwrap();
+    let signal = events
+        .iter()
+        .find(|event| {
+            event.kind == "wait_reconciliation_requested"
+                && event.data["wait_condition_id"] == format!("waiting_intent:{waiting_id}")
+        })
+        .expect("external wake should request wait reconciliation");
+    assert_eq!(
+        signal.data["wake_source"].as_str(),
+        Some("external_ingress")
+    );
+    assert_eq!(signal.data["work_item_id"].as_str(), Some(work.id.as_str()));
+    assert_eq!(
+        signal.data["subject_ref"].as_str(),
+        Some(trigger_id.as_str())
+    );
+    assert_eq!(signal.data["waiting_for"].as_str(), Some("checks complete"));
+
+    let waiting = runtime.latest_waiting_intents().await.unwrap();
+    let active = waiting
+        .iter()
+        .find(|record| record.id == waiting_id)
+        .expect("waiting intent should remain visible after wake firing");
+    assert_eq!(active.status, WaitingIntentStatus::Active);
+    assert_eq!(active.trigger_count, 1);
+}
+
+#[tokio::test]
 async fn completing_work_item_does_not_revoke_agent_external_trigger() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::ingress::WakeHint;
-use crate::types::WaitingReason;
+use crate::types::{WaitConditionRecord, WaitingReason, WakeSource};
 use std::time::Duration;
 
 impl RuntimeHandle {
@@ -380,6 +380,8 @@ impl RuntimeHandle {
         message: &MessageEnvelope,
         pre_cleanup_closure: &ClosureDecision,
     ) -> Result<()> {
+        self.record_wait_reconciliation_signals(message).await?;
+
         let active_waiting = self
             .latest_waiting_intents()
             .await?
@@ -475,6 +477,36 @@ impl RuntimeHandle {
         Ok(())
     }
 
+    async fn record_wait_reconciliation_signals(&self, message: &MessageEnvelope) -> Result<()> {
+        let agent_id = self.agent_id().await?;
+        let active_conditions = self
+            .inner
+            .storage
+            .latest_active_wait_conditions_for_agent(&agent_id)?;
+        if active_conditions.is_empty() {
+            return Ok(());
+        }
+
+        for signal in reconciliation_signals_for_message(message, &active_conditions) {
+            let duplicate = self
+                .inner
+                .storage
+                .read_recent_events(500)?
+                .iter()
+                .any(|event| {
+                    event.kind == "wait_reconciliation_requested"
+                        && event.data["dedupe_key"] == signal["dedupe_key"]
+                });
+            if duplicate {
+                continue;
+            }
+            self.inner
+                .storage
+                .append_event(&AuditEvent::new("wait_reconciliation_requested", signal))?;
+        }
+        Ok(())
+    }
+
     async fn cancel_waiting_intents(&self, waiting_intent_ids: Vec<String>) -> Result<Vec<String>> {
         let mut cancelled = Vec::new();
         for waiting_intent_id in waiting_intent_ids {
@@ -483,6 +515,126 @@ impl RuntimeHandle {
         }
         Ok(cancelled)
     }
+}
+
+fn reconciliation_signals_for_message(
+    message: &MessageEnvelope,
+    active_conditions: &[WaitConditionRecord],
+) -> Vec<serde_json::Value> {
+    active_conditions
+        .iter()
+        .filter_map(|condition| reconciliation_signal_for_condition(message, condition))
+        .collect()
+}
+
+fn reconciliation_signal_for_condition(
+    message: &MessageEnvelope,
+    condition: &WaitConditionRecord,
+) -> Option<serde_json::Value> {
+    let (wake_source, subject_ref) = matching_wake_source(message, condition)?;
+    let dedupe_key = format!(
+        "wait_reconciliation:{}:{}:{}",
+        condition.id, wake_source, message.id
+    );
+    Some(serde_json::json!({
+        "dedupe_key": dedupe_key,
+        "message_id": message.id,
+        "trigger_kind": message.trigger_kind,
+        "wait_condition_id": condition.id,
+        "wake_source": wake_source,
+        "work_item_id": condition.work_item_id,
+        "subject_ref": subject_ref.or_else(|| condition.subject_ref.clone()),
+        "waiting_for": condition.waiting_for,
+        "source": condition.source,
+    }))
+}
+
+fn matching_wake_source(
+    message: &MessageEnvelope,
+    condition: &WaitConditionRecord,
+) -> Option<(String, Option<String>)> {
+    match (&message.kind, &message.origin) {
+        (MessageKind::TaskResult, MessageOrigin::Task { task_id }) => condition
+            .wake_sources
+            .iter()
+            .any(|source| matches!(source, WakeSource::TaskResult { task_id: id } if id == task_id))
+            .then(|| ("task_result".to_string(), Some(task_id.clone()))),
+        (MessageKind::CallbackEvent, _) => {
+            let external_trigger_id = message.source_refs.get("external_trigger_id");
+            let waiting_intent_id = message.source_refs.get("waiting_intent_id");
+            condition
+                .wake_sources
+                .iter()
+                .any(|source| match source {
+                    WakeSource::ExternalIngress {
+                        external_trigger_id: Some(id),
+                    } => external_trigger_id == Some(id),
+                    WakeSource::ExternalIngress {
+                        external_trigger_id: None,
+                    } => true,
+                    _ => false,
+                })
+                .then(|| {
+                    (
+                        "external_ingress".to_string(),
+                        external_trigger_id
+                            .cloned()
+                            .or_else(|| waiting_intent_id.cloned()),
+                    )
+                })
+        }
+        (MessageKind::TimerTick, MessageOrigin::Timer { timer_id }) => condition
+            .wake_sources
+            .iter()
+            .any(|source| matches!(source, WakeSource::Timer { .. }))
+            .then(|| ("timer".to_string(), Some(timer_id.clone()))),
+        (MessageKind::OperatorPrompt, MessageOrigin::Operator { actor_id }) => condition
+            .wake_sources
+            .iter()
+            .any(|source| matches!(source, WakeSource::OperatorInput))
+            .then(|| ("operator_input".to_string(), actor_id.clone())),
+        (MessageKind::SystemTick, MessageOrigin::System { subsystem }) => {
+            if let Some(external) = matching_wake_hint_external_source(message, condition) {
+                return Some(external);
+            }
+            condition
+                .wake_sources
+                .iter()
+                .any(|source| matches!(source, WakeSource::SystemTick))
+                .then(|| ("system_tick".to_string(), Some(subsystem.clone())))
+        }
+        _ => None,
+    }
+}
+
+fn matching_wake_hint_external_source(
+    message: &MessageEnvelope,
+    condition: &WaitConditionRecord,
+) -> Option<(String, Option<String>)> {
+    let wake_hint = message.metadata.as_ref()?.get("wake_hint")?;
+    let external_trigger_id = wake_hint
+        .get("external_trigger_id")
+        .and_then(serde_json::Value::as_str);
+    let waiting_intent_id = wake_hint
+        .get("waiting_intent_id")
+        .and_then(serde_json::Value::as_str);
+    let matches_external = condition.wake_sources.iter().any(|source| match source {
+        WakeSource::ExternalIngress {
+            external_trigger_id: Some(id),
+        } => Some(id.as_str()) == external_trigger_id,
+        WakeSource::ExternalIngress {
+            external_trigger_id: None,
+        } => true,
+        _ => false,
+    });
+    matches_external.then(|| {
+        (
+            "external_ingress".to_string(),
+            external_trigger_id
+                .or(waiting_intent_id)
+                .map(ToString::to_string),
+        )
+    })
 }
 
 fn advance_time(base: chrono::DateTime<Utc>, delta_ms: u64) -> Result<chrono::DateTime<Utc>> {


### PR DESCRIPTION
## Summary
- record wait_reconciliation_requested events when task, external, timer, operator, or system wake sources fire
- include scheduler-neutral context (wait_condition_id, wake_source, work_item_id, subject_ref, waiting_for, dedupe_key) without resolving the wait condition
- add regression coverage for task terminal results, external wake hints/ingress, timer ticks, operator input, and system ticks

Fixes #1292

## Verification
- cargo fmt --all -- --check
- cargo test task_result_records_wait_reconciliation_without_resolving_wait_condition -- --nocapture
- cargo test external_wake_records_wait_reconciliation_without_resolving_wait -- --nocapture
- cargo test timer_operator_and_system_ticks_record_wait_reconciliation_signals -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets