### PR TITLE
feat: audit and surface external wait recoverability

### DIFF
--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -440,6 +440,22 @@ The runtime can then evolve in phases:
 Allow external waits without timer recovery, but surface an audit warning such
 as `external_wait_without_recovery`.
 
+Implemented status surfaces should expose active wait conditions without
+provider-specific interpretation. Each active wait condition may include a
+derived `external_recoverability` value:
+
+- `recoverable` when the wait has a timer, system tick, or opaque
+  provider/user-declared fallback metadata such as a durable queue or recheck
+  source;
+- `weak` when the wait only has external ingress/callback wake sources;
+- `explicit_no_fallback` when opaque metadata records that no fallback exists
+  and includes a reason.
+
+Agent-facing projections such as `AgentGet` and `ListWorkItems` should preserve
+the opaque wait metadata alongside the derived classification so agents and
+skills can reconcile provider-specific details without teaching the scheduler
+about GitHub, CI, or other providers.
+
 ### Phase 2: soft recovery
 
 Allow a generic system tick to re-enter the agent for audit or reconciliation.

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -406,6 +406,7 @@ impl RuntimeHandle {
             skills,
             active_children,
             active_waiting_intents: self.active_waiting_intent_summaries().await?,
+            active_wait_conditions: self.active_wait_condition_summaries().await?,
             active_external_triggers,
             recent_operator_notifications: self.recent_operator_notifications(10).await?,
             recent_brief_count: self.inner.storage.read_recent_briefs(50)?.len(),

--- a/src/runtime/tests/tui_pipeline_e2e.rs
+++ b/src/runtime/tests/tui_pipeline_e2e.rs
@@ -82,6 +82,7 @@ fn minimal_agent_summary(agent_id: &str) -> AgentSummary {
         skills: SkillsRuntimeView::default(),
         active_children: Vec::<ChildAgentSummary>::new(),
         active_waiting_intents: Vec::<WaitingIntentSummary>::new(),
+        active_wait_conditions: Vec::new(),
         active_external_triggers: Vec::<ExternalTriggerSummary>::new(),
         recent_operator_notifications: Vec::<OperatorNotificationRecord>::new(),
         recent_brief_count: 0,

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1,6 +1,9 @@
 use super::super::*;
 use super::support::*;
-use crate::types::{WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState};
+use crate::types::{
+    WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource, WorkItemPlanStatus,
+    WorkItemReadiness, WorkItemSchedulingState,
+};
 
 fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> TaskRecord {
     TaskRecord {
@@ -327,6 +330,73 @@ async fn work_item_query_tools_return_current_open_done_views() {
         active_item["todo_list"][0]["state"].as_str(),
         Some("in_progress")
     );
+
+    let now = Utc::now();
+    runtime
+        .storage()
+        .append_wait_condition(&WaitConditionRecord {
+            id: "weak-external-wait".into(),
+            agent_id: "default".into(),
+            work_item_id: Some(active.id.clone()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pull_request:1313".into()),
+            waiting_for: "PR merged".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-weak".into()),
+            }],
+            continuation: Some(serde_json::json!({
+                "provider": "github",
+                "subscription_id": "sub_1"
+            })),
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+        })
+        .unwrap();
+
+    let (active_wait_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "active-wait".into(),
+                name: "ListWorkItems".into(),
+                input: serde_json::json!({"filter": "current"}),
+            },
+        )
+        .await
+        .unwrap();
+    let active_wait_payload = active_wait_result.envelope.result.unwrap();
+    let wait = &active_wait_payload["work_items"][0]["active_wait_conditions"][0];
+    assert_eq!(wait["id"].as_str(), Some("weak-external-wait"));
+    assert_eq!(wait["external_recoverability"].as_str(), Some("weak"));
+    assert_eq!(
+        wait["continuation"]["subscription_id"].as_str(),
+        Some("sub_1")
+    );
+
+    let (agent_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &TrustLevel::TrustedOperator,
+            &crate::tool::ToolCall {
+                id: "agent-get".into(),
+                name: "AgentGet".into(),
+                input: serde_json::json!({}),
+            },
+        )
+        .await
+        .unwrap();
+    let agent_payload = agent_result.envelope.result.unwrap();
+    let agent_wait = &agent_payload["agent"]["active_wait_conditions"][0];
+    assert_eq!(agent_wait["id"].as_str(), Some("weak-external-wait"));
+    assert_eq!(agent_wait["external_recoverability"].as_str(), Some("weak"));
 
     let (list_result, _) = registry
         .execute(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::ingress::WakeHint;
-use crate::types::{WaitConditionRecord, WaitingReason, WakeSource};
+use crate::types::{WaitConditionRecord, WaitConditionSummary, WaitingReason, WakeSource};
 use std::time::Duration;
 
 impl RuntimeHandle {
@@ -350,6 +350,19 @@ impl RuntimeHandle {
             .filter(|record| record.status == WaitingIntentStatus::Active)
             .filter(|record| record.scope == ExternalTriggerScope::WorkItem)
             .count())
+    }
+
+    pub(super) async fn active_wait_condition_summaries(
+        &self,
+    ) -> Result<Vec<WaitConditionSummary>> {
+        let agent_id = self.agent_id().await?;
+        Ok(self
+            .inner
+            .storage
+            .latest_active_wait_conditions_for_agent(&agent_id)?
+            .into_iter()
+            .map(WaitConditionSummary::from)
+            .collect())
     }
 
     pub(super) async fn active_external_trigger_summaries(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,13 +14,14 @@ use serde_json::Value;
 
 use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, ContextEpisodeRecord,
-    DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope, MessageEnvelope,
-    OperatorDeliveryRecord, OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord,
-    TaskRecord, TaskStatus, TimerRecord, TodoItem, TodoItemState, ToolExecutionRecord,
-    TranscriptEntry, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
-    WaitingIntentRecord, WaitingIntentStatus, WakeSource, WorkItemDelegationRecord,
-    WorkItemDelegationState, WorkItemReadiness, WorkItemRecord, WorkItemSchedulingState,
-    WorkItemState, WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
+    DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope, ExternalWaitRecoverability,
+    MessageEnvelope, OperatorDeliveryRecord, OperatorNotificationRecord, OperatorTransportBinding,
+    QueueEntryRecord, TaskRecord, TaskStatus, TimerRecord, TodoItem, TodoItemState,
+    ToolExecutionRecord, TranscriptEntry, WaitConditionKind, WaitConditionRecord,
+    WaitConditionStatus, WaitingIntentRecord, WaitingIntentStatus, WakeSource,
+    WorkItemDelegationRecord, WorkItemDelegationState, WorkItemReadiness, WorkItemRecord,
+    WorkItemSchedulingState, WorkItemState, WorkingMemoryDelta, WorkspaceEntry,
+    WorkspaceOccupancyRecord,
 };
 
 const RUNTIME_DIR: &str = ".holon";
@@ -335,8 +336,10 @@ impl AppStorage {
 
     pub fn append_waiting_intent(&self, record: &WaitingIntentRecord) -> Result<()> {
         let wait_condition = wait_condition_from_waiting_intent(record);
+        let event = external_wait_recoverability_event(&wait_condition);
         let waiting_intent_bytes = jsonl_bytes(record)?;
         let wait_condition_bytes = jsonl_bytes(&wait_condition)?;
+        let event_bytes = event.as_ref().map(jsonl_bytes).transpose()?;
 
         // Compatibility migration: keep the legacy waiting-intents ledger as the
         // first durable write, then mirror the same state into the internal wait
@@ -350,11 +353,27 @@ impl AppStorage {
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
         append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
-        append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)
+        append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
+        if let Some(event_bytes) = event_bytes {
+            append_jsonl_bytes(&self.events_path, &event_bytes)?;
+        }
+        Ok(())
     }
 
     pub fn append_wait_condition(&self, record: &WaitConditionRecord) -> Result<()> {
-        self.append_jsonl(&self.wait_conditions_path, record)
+        let event = external_wait_recoverability_event(record);
+        let wait_condition_bytes = jsonl_bytes(record)?;
+        let event_bytes = event.as_ref().map(jsonl_bytes).transpose()?;
+
+        let _guard = self
+            .append_mutex
+            .lock()
+            .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
+        if let Some(event_bytes) = event_bytes {
+            append_jsonl_bytes(&self.events_path, &event_bytes)?;
+        }
+        Ok(())
     }
 
     pub fn append_external_trigger(&self, record: &ExternalTriggerRecord) -> Result<()> {
@@ -1475,6 +1494,37 @@ fn wait_condition_from_waiting_intent(record: &WaitingIntentRecord) -> WaitCondi
     }
 }
 
+fn external_wait_recoverability_event(record: &WaitConditionRecord) -> Option<AuditEvent> {
+    match record.external_recoverability()? {
+        ExternalWaitRecoverability::Weak => Some(AuditEvent::new(
+            "external_wait_without_recovery",
+            serde_json::json!({
+                "wait_condition_id": record.id,
+                "work_item_id": record.work_item_id,
+                "source": record.source,
+                "subject_ref": record.subject_ref,
+                "waiting_for": record.waiting_for,
+                "external_recoverability": "weak",
+                "wake_sources": record.wake_sources,
+            }),
+        )),
+        ExternalWaitRecoverability::ExplicitNoFallback => Some(AuditEvent::new(
+            "external_wait_without_recovery",
+            serde_json::json!({
+                "wait_condition_id": record.id,
+                "work_item_id": record.work_item_id,
+                "source": record.source,
+                "subject_ref": record.subject_ref,
+                "waiting_for": record.waiting_for,
+                "external_recoverability": "explicit_no_fallback",
+                "no_fallback_reason": record.no_fallback_reason(),
+                "wake_sources": record.wake_sources,
+            }),
+        )),
+        ExternalWaitRecoverability::Recoverable => None,
+    }
+}
+
 fn scan_jsonl_reverse<T, F>(path: &Path, mut visit: F) -> Result<()>
 where
     T: DeserializeOwned,
@@ -2331,6 +2381,128 @@ mod tests {
         assert_eq!(latest.len(), 1);
         assert_eq!(latest[0].status, WaitConditionStatus::Cancelled);
         assert_eq!(latest[0].cancelled_at, cancelled.cancelled_at);
+    }
+
+    #[test]
+    fn external_wait_recoverability_is_derived_and_audited() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+
+        for record in [
+            WaitConditionRecord {
+                id: "weak".into(),
+                agent_id: "default".into(),
+                work_item_id: Some("work-weak".into()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pr-1".into()),
+                waiting_for: "merged".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("trigger-1".into()),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            },
+            WaitConditionRecord {
+                id: "recoverable".into(),
+                agent_id: "default".into(),
+                work_item_id: Some("work-recoverable".into()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pr-2".into()),
+                waiting_for: "checks".into(),
+                wake_sources: vec![
+                    WakeSource::ExternalIngress {
+                        external_trigger_id: Some("trigger-2".into()),
+                    },
+                    WakeSource::Timer {
+                        wake_at: now + chrono::Duration::hours(1),
+                    },
+                ],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            },
+            WaitConditionRecord {
+                id: "explicit".into(),
+                agent_id: "default".into(),
+                work_item_id: Some("work-explicit".into()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pr-3".into()),
+                waiting_for: "manual merge".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("trigger-3".into()),
+                }],
+                continuation: Some(serde_json::json!({
+                    "no_fallback_reason": "provider has no poll API"
+                })),
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
+            },
+        ] {
+            storage.append_wait_condition(&record).unwrap();
+        }
+
+        let mut conditions = storage.latest_wait_conditions().unwrap();
+        conditions.sort_by(|left, right| left.id.cmp(&right.id));
+        assert_eq!(
+            conditions
+                .iter()
+                .find(|condition| condition.id == "weak")
+                .and_then(WaitConditionRecord::external_recoverability),
+            Some(ExternalWaitRecoverability::Weak)
+        );
+        assert_eq!(
+            conditions
+                .iter()
+                .find(|condition| condition.id == "recoverable")
+                .and_then(WaitConditionRecord::external_recoverability),
+            Some(ExternalWaitRecoverability::Recoverable)
+        );
+        let explicit = conditions
+            .iter()
+            .find(|condition| condition.id == "explicit")
+            .unwrap();
+        assert_eq!(
+            explicit.external_recoverability(),
+            Some(ExternalWaitRecoverability::ExplicitNoFallback)
+        );
+        assert_eq!(
+            explicit.no_fallback_reason().as_deref(),
+            Some("provider has no poll API")
+        );
+
+        let events = storage.read_recent_events(10).unwrap();
+        assert!(events.iter().any(|event| {
+            event.kind == "external_wait_without_recovery"
+                && event.data["wait_condition_id"] == "weak"
+                && event.data["external_recoverability"] == "weak"
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == "external_wait_without_recovery"
+                && event.data["wait_condition_id"] == "explicit"
+                && event.data["external_recoverability"] == "explicit_no_fallback"
+                && event.data["no_fallback_reason"] == "provider has no poll API"
+        }));
+        assert!(!events.iter().any(|event| {
+            event.kind == "external_wait_without_recovery"
+                && event.data["wait_condition_id"] == "recoverable"
+        }));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -265,11 +265,15 @@ impl AppStorage {
     }
 
     pub fn append_event(&self, event: &AuditEvent) -> Result<()> {
-        let mut event = event.clone();
         let _guard = self
             .append_mutex
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        self.append_event_with_append_mutex_held(event)
+    }
+
+    fn append_event_with_append_mutex_held(&self, event: &AuditEvent) -> Result<()> {
+        let mut event = event.clone();
         let mut counter = self
             .event_seq_counter
             .lock()
@@ -339,7 +343,6 @@ impl AppStorage {
         let event = external_wait_recoverability_event(&wait_condition);
         let waiting_intent_bytes = jsonl_bytes(record)?;
         let wait_condition_bytes = jsonl_bytes(&wait_condition)?;
-        let event_bytes = event.as_ref().map(jsonl_bytes).transpose()?;
 
         // Compatibility migration: keep the legacy waiting-intents ledger as the
         // first durable write, then mirror the same state into the internal wait
@@ -354,8 +357,8 @@ impl AppStorage {
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
         append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
         append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
-        if let Some(event_bytes) = event_bytes {
-            append_jsonl_bytes(&self.events_path, &event_bytes)?;
+        if let Some(event) = event.as_ref() {
+            self.append_event_with_append_mutex_held(event)?;
         }
         Ok(())
     }
@@ -363,15 +366,14 @@ impl AppStorage {
     pub fn append_wait_condition(&self, record: &WaitConditionRecord) -> Result<()> {
         let event = external_wait_recoverability_event(record);
         let wait_condition_bytes = jsonl_bytes(record)?;
-        let event_bytes = event.as_ref().map(jsonl_bytes).transpose()?;
 
         let _guard = self
             .append_mutex
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
         append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
-        if let Some(event_bytes) = event_bytes {
-            append_jsonl_bytes(&self.events_path, &event_bytes)?;
+        if let Some(event) = event.as_ref() {
+            self.append_event_with_append_mutex_held(event)?;
         }
         Ok(())
     }
@@ -1737,10 +1739,10 @@ mod tests {
     use chrono::Utc;
 
     use crate::types::{
-        AgentState, AgentStatus, EpisodeBoundaryReason, Priority, QueueEntryRecord,
-        QueueEntryStatus, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TodoItem,
-        TodoItemState, TranscriptEntry, TranscriptEntryKind, TrustLevel, WorkItemPlanStatus,
-        WorkItemState,
+        AgentState, AgentStatus, CallbackDeliveryMode, EpisodeBoundaryReason, Priority,
+        QueueEntryRecord, QueueEntryStatus, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus,
+        TodoItem, TodoItemState, TranscriptEntry, TranscriptEntryKind, TrustLevel,
+        WorkItemPlanStatus, WorkItemState,
     };
 
     use super::*;
@@ -2503,6 +2505,41 @@ mod tests {
             event.kind == "external_wait_without_recovery"
                 && event.data["wait_condition_id"] == "recoverable"
         }));
+        let emitted = events
+            .iter()
+            .filter(|event| event.kind == "external_wait_without_recovery")
+            .collect::<Vec<_>>();
+        assert_eq!(emitted.len(), 2);
+        assert!(emitted[0].event_seq > 0);
+        assert!(emitted[1].event_seq > emitted[0].event_seq);
+
+        storage
+            .append_waiting_intent(&WaitingIntentRecord {
+                id: "legacy-weak".into(),
+                agent_id: "default".into(),
+                scope: ExternalTriggerScope::Agent,
+                work_item_id: Some("work-legacy".into()),
+                description: "legacy weak external wait".into(),
+                source: "github".into(),
+                resource: Some("pr-4".into()),
+                condition: Some("merged".into()),
+                delivery_mode: CallbackDeliveryMode::WakeHint,
+                status: WaitingIntentStatus::Active,
+                external_trigger_id: "trigger-4".into(),
+                created_at: now,
+                cancelled_at: None,
+                last_triggered_at: None,
+                trigger_count: 0,
+                correlation_id: None,
+                causation_id: None,
+            })
+            .unwrap();
+        let legacy_events = storage.read_recent_events(10).unwrap();
+        let legacy_event = legacy_events
+            .iter()
+            .find(|event| event.data["wait_condition_id"] == "waiting_intent:legacy-weak")
+            .expect("legacy mirror should emit recoverability audit event");
+        assert!(legacy_event.event_seq > emitted[1].event_seq);
     }
 
     #[test]

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -67,7 +67,7 @@ pub(crate) async fn execute(
         .complete_work_item(work_item_id, warnings_json(&warnings))
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true, None).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None, None).await?;
     serialize_success(
         NAME,
         &WorkItemMutationResult::with_completion_transition(

--- a/src/tool/tools/create_work_item.rs
+++ b/src/tool/tools/create_work_item.rs
@@ -88,6 +88,6 @@ pub(crate) async fn execute(
         )
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true, None).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None, None).await?;
     serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/get_work_item.rs
+++ b/src/tool/tools/get_work_item.rs
@@ -60,7 +60,14 @@ pub(crate) async fn execute(
             )
         })?;
     let context = query_context(runtime).await?;
-    let work_item =
-        view_for_record(runtime, &context, record, args.include_todo_list, None).await?;
+    let work_item = view_for_record(
+        runtime,
+        &context,
+        record,
+        args.include_todo_list,
+        None,
+        None,
+    )
+    .await?;
     serialize_success(NAME, &GetWorkItemResult { context, work_item })
 }

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -12,8 +12,9 @@ use crate::{
 use super::{
     serialize_success,
     work_item_query::{
-        latest_delivery_summaries_by_work_item, lifecycle_view, query_context, view_for_record,
-        WorkItemFocusView, WorkItemLifecycleView, WorkItemQueryContext, WorkItemView,
+        active_wait_conditions_by_work_item, latest_delivery_summaries_by_work_item,
+        lifecycle_view, query_context, view_for_record, WorkItemFocusView, WorkItemLifecycleView,
+        WorkItemQueryContext, WorkItemView,
     },
     BuiltinToolDefinition,
 };
@@ -94,6 +95,7 @@ pub(crate) async fn execute(
     } else {
         None
     };
+    let wait_conditions = active_wait_conditions_by_work_item(runtime, &selected)?;
     let mut work_items = Vec::with_capacity(selected.len());
     for record in selected {
         work_items.push(
@@ -103,6 +105,7 @@ pub(crate) async fn execute(
                 record,
                 args.include_todo_list,
                 delivery_summaries.as_ref(),
+                Some(&wait_conditions),
             )
             .await?,
         );

--- a/src/tool/tools/update_work_item.rs
+++ b/src/tool/tools/update_work_item.rs
@@ -102,6 +102,6 @@ pub(crate) async fn execute(
         )
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true, None).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None, None).await?;
     serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     runtime::RuntimeHandle,
     types::{
-        DeliverySummaryRecord, TodoItem, WorkItemPlanArtifact, WorkItemPlanStatus,
-        WorkItemReadiness, WorkItemRecord, WorkItemState,
+        DeliverySummaryRecord, TodoItem, WaitConditionSummary, WorkItemPlanArtifact,
+        WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
     },
 };
 
@@ -70,6 +70,8 @@ pub(crate) struct WorkItemView {
     pub(crate) recheck_consumed_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) completion_report: Option<WorkItemCompletionReportView>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) active_wait_conditions: Vec<WaitConditionSummary>,
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) updated_at: DateTime<Utc>,
 }
@@ -133,6 +135,12 @@ pub(crate) async fn view_for_record(
     let focus = focus_view(&record, is_current);
     let readiness = record.readiness();
     let completion_report = completion_report_for_record(runtime, &record, delivery_summaries)?;
+    let active_wait_conditions = runtime
+        .storage()
+        .latest_active_wait_conditions_for_work_item(&record.agent_id, &record.id)?
+        .into_iter()
+        .map(WaitConditionSummary::from)
+        .collect();
     Ok(WorkItemView {
         id: record.id,
         agent_id: record.agent_id,
@@ -150,6 +158,7 @@ pub(crate) async fn view_for_record(
         recheck_at: record.recheck_at,
         recheck_consumed_at: record.recheck_consumed_at,
         completion_report,
+        active_wait_conditions,
         created_at: record.created_at,
         updated_at: record.updated_at,
     })

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -83,6 +83,7 @@ pub(crate) struct WorkItemQueryContext {
 }
 
 pub(crate) type WorkItemDeliverySummaryMap = BTreeMap<String, DeliverySummaryRecord>;
+pub(crate) type WorkItemWaitConditionSummaryMap = BTreeMap<String, Vec<WaitConditionSummary>>;
 
 pub(crate) async fn query_context(runtime: &RuntimeHandle) -> Result<WorkItemQueryContext> {
     let state = runtime.agent_state().await?;
@@ -114,6 +115,7 @@ pub(crate) async fn view_for_record(
     record: WorkItemRecord,
     include_todo_list: bool,
     delivery_summaries: Option<&WorkItemDeliverySummaryMap>,
+    wait_conditions: Option<&WorkItemWaitConditionSummaryMap>,
 ) -> Result<WorkItemView> {
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
@@ -135,12 +137,15 @@ pub(crate) async fn view_for_record(
     let focus = focus_view(&record, is_current);
     let readiness = record.readiness();
     let completion_report = completion_report_for_record(runtime, &record, delivery_summaries)?;
-    let active_wait_conditions = runtime
-        .storage()
-        .latest_active_wait_conditions_for_work_item(&record.agent_id, &record.id)?
-        .into_iter()
-        .map(WaitConditionSummary::from)
-        .collect();
+    let active_wait_conditions = match wait_conditions {
+        Some(wait_conditions) => wait_conditions.get(&record.id).cloned().unwrap_or_default(),
+        None => runtime
+            .storage()
+            .latest_active_wait_conditions_for_work_item(&record.agent_id, &record.id)?
+            .into_iter()
+            .map(WaitConditionSummary::from)
+            .collect(),
+    };
     Ok(WorkItemView {
         id: record.id,
         agent_id: record.agent_id,
@@ -162,6 +167,31 @@ pub(crate) async fn view_for_record(
         created_at: record.created_at,
         updated_at: record.updated_at,
     })
+}
+
+pub(crate) fn active_wait_conditions_by_work_item(
+    runtime: &RuntimeHandle,
+    records: &[WorkItemRecord],
+) -> Result<WorkItemWaitConditionSummaryMap> {
+    let agent_ids = records
+        .iter()
+        .map(|record| record.agent_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut wait_conditions = BTreeMap::new();
+    for agent_id in agent_ids {
+        for condition in runtime
+            .storage()
+            .latest_active_wait_conditions_for_agent(agent_id)?
+        {
+            if let Some(work_item_id) = condition.work_item_id.as_ref() {
+                wait_conditions
+                    .entry(work_item_id.clone())
+                    .or_insert_with(Vec::new)
+                    .push(WaitConditionSummary::from(condition));
+            }
+        }
+    }
+    Ok(wait_conditions)
 }
 
 pub(crate) fn latest_delivery_summaries_by_work_item(

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -242,6 +242,7 @@ mod tests {
             skills: SkillsRuntimeView::default(),
             active_children: Vec::<ChildAgentSummary>::new(),
             active_waiting_intents: Vec::<WaitingIntentSummary>::new(),
+            active_wait_conditions: Vec::new(),
             active_external_triggers: Vec::new(),
             recent_operator_notifications: Vec::new(),
             recent_brief_count: 0,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -2776,6 +2776,7 @@ mod tests {
             skills: SkillsRuntimeView::default(),
             active_children: Vec::<ChildAgentSummary>::new(),
             active_waiting_intents: Vec::<WaitingIntentSummary>::new(),
+            active_wait_conditions: Vec::new(),
             active_external_triggers: Vec::new(),
             recent_operator_notifications: Vec::new(),
             recent_brief_count: 1,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1177,6 +1177,7 @@ mod tests {
                 },
             }],
             active_waiting_intents: Vec::new(),
+            active_wait_conditions: Vec::new(),
             active_external_triggers: Vec::new(),
             recent_operator_notifications: Vec::new(),
             recent_brief_count: 0,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -228,6 +228,7 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
         skills: SkillsRuntimeView::default(),
         active_children: Vec::<ChildAgentSummary>::new(),
         active_waiting_intents: Vec::<WaitingIntentSummary>::new(),
+        active_wait_conditions: Vec::new(),
         active_external_triggers: Vec::new(),
         recent_operator_notifications: Vec::new(),
         recent_brief_count: 1,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1735,6 +1735,14 @@ pub enum WakeSource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalWaitRecoverability {
+    Recoverable,
+    Weak,
+    ExplicitNoFallback,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WaitConditionRecord {
     pub id: String,
     pub agent_id: String,
@@ -1759,6 +1767,94 @@ pub struct WaitConditionRecord {
     pub resolved_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cancelled_at: Option<DateTime<Utc>>,
+}
+
+impl WaitConditionRecord {
+    pub fn external_recoverability(&self) -> Option<ExternalWaitRecoverability> {
+        if self.kind != WaitConditionKind::External || self.status != WaitConditionStatus::Active {
+            return None;
+        }
+        if explicit_no_fallback_reason(self.continuation.as_ref()).is_some() {
+            return Some(ExternalWaitRecoverability::ExplicitNoFallback);
+        }
+        if self.wake_sources.iter().any(recoverable_wake_source)
+            || continuation_declares_recovery(self.continuation.as_ref())
+        {
+            return Some(ExternalWaitRecoverability::Recoverable);
+        }
+        Some(ExternalWaitRecoverability::Weak)
+    }
+
+    pub fn no_fallback_reason(&self) -> Option<String> {
+        explicit_no_fallback_reason(self.continuation.as_ref()).map(ToString::to_string)
+    }
+}
+
+fn recoverable_wake_source(source: &WakeSource) -> bool {
+    matches!(source, WakeSource::Timer { .. } | WakeSource::SystemTick)
+}
+
+fn continuation_declares_recovery(continuation: Option<&Value>) -> bool {
+    let Some(value) = continuation else {
+        return false;
+    };
+    [
+        "durable_queue",
+        "durable_queue_ref",
+        "recheck_source",
+        "recheck_after",
+        "recheck_at",
+        "fallback",
+        "fallback_source",
+    ]
+    .into_iter()
+    .any(|key| value.get(key).is_some_and(json_truthy))
+        || value
+            .get("recoverability")
+            .or_else(|| value.get("recovery"))
+            .is_some_and(|value| {
+                value
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .is_some_and(|kind| kind == "recoverable")
+                    || value
+                        .get("durable_queue")
+                        .or_else(|| value.get("recheck_source"))
+                        .or_else(|| value.get("fallback_source"))
+                        .is_some_and(json_truthy)
+            })
+}
+
+fn explicit_no_fallback_reason(continuation: Option<&Value>) -> Option<&str> {
+    let value = continuation?;
+    value
+        .get("no_fallback_reason")
+        .or_else(|| value.get("explicit_no_fallback_reason"))
+        .and_then(Value::as_str)
+        .filter(|reason| !reason.trim().is_empty())
+        .or_else(|| {
+            value
+                .get("recoverability")
+                .or_else(|| value.get("recovery"))
+                .and_then(|value| {
+                    let kind = value.get("kind").and_then(Value::as_str)?;
+                    (kind == "explicit_no_fallback" || kind == "no_fallback")
+                        .then(|| value.get("reason").and_then(Value::as_str))
+                        .flatten()
+                })
+                .filter(|reason| !reason.trim().is_empty())
+        })
+}
+
+fn json_truthy(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::Bool(value) => *value,
+        Value::String(value) => !value.trim().is_empty(),
+        Value::Array(value) => !value.is_empty(),
+        Value::Object(value) => !value.is_empty(),
+        Value::Number(_) => true,
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1835,6 +1931,52 @@ pub struct WaitingIntentSummary {
     pub created_at: DateTime<Utc>,
     pub cancelled_at: Option<DateTime<Utc>>,
     pub last_triggered_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WaitConditionSummary {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    pub status: WaitConditionStatus,
+    pub kind: WaitConditionKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_ref: Option<String>,
+    pub waiting_for: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wake_sources: Vec<WakeSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_recoverability: Option<ExternalWaitRecoverability>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_fallback_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<WaitConditionRecord> for WaitConditionSummary {
+    fn from(record: WaitConditionRecord) -> Self {
+        let external_recoverability = record.external_recoverability();
+        let no_fallback_reason = record.no_fallback_reason();
+        Self {
+            id: record.id,
+            work_item_id: record.work_item_id,
+            status: record.status,
+            kind: record.kind,
+            source: record.source,
+            subject_ref: record.subject_ref,
+            waiting_for: record.waiting_for,
+            wake_sources: record.wake_sources,
+            external_recoverability,
+            no_fallback_reason,
+            continuation: record.continuation,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3455,6 +3597,8 @@ pub struct AgentSummary {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub active_children: Vec<ChildAgentSummary>,
     pub active_waiting_intents: Vec<WaitingIntentSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_wait_conditions: Vec<WaitConditionSummary>,
     #[serde(default)]
     pub active_external_triggers: Vec<ExternalTriggerSummary>,
     #[serde(default)]
@@ -3623,6 +3767,7 @@ impl AgentListEntry {
             skills: SkillsRuntimeView::default(),
             active_children: Vec::new(),
             active_waiting_intents: Vec::new(),
+            active_wait_conditions: Vec::new(),
             active_external_triggers: Vec::new(),
             recent_operator_notifications: Vec::new(),
             recent_brief_count: 0,


### PR DESCRIPTION
## Summary

Fixes #1294.

This surfaces external wait recoverability from the internal WaitCondition/WakeSource ledger without adding provider-specific scheduler semantics.

## Changes

- Add derived `ExternalWaitRecoverability` classifications for active external wait conditions:
  - `recoverable` when a timer/system tick or opaque durable queue/recheck/fallback metadata exists
  - `weak` when the wait only has external ingress/callback wake sources
  - `explicit_no_fallback` when opaque metadata records a no-fallback reason
- Expose active wait conditions, recoverability, no-fallback reason, wake sources, and opaque continuation metadata through:
  - `AgentGet` via `active_wait_conditions`
  - `ListWorkItems`/work item views via per-item `active_wait_conditions`
- Emit `external_wait_without_recovery` audit events for weak and explicit-no-fallback external waits.
- Update the scheduler wait-state RFC with the implemented Phase 1 status-surface contract.

## Verification

- `cargo fmt --all -- --check`
- `cargo test external_wait_recoverability_is_derived_and_audited -- --nocapture`
- `cargo test work_item_query_tools_return_current_open_done_views -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
