### PR TITLE
feat: add NEAR AI provider

### DIFF
--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -88,6 +88,7 @@ As an alternative to the credential store, Holon reads API keys from environment
 | Mistral | `MISTRAL_API_KEY` |
 | xAI | `XAI_API_KEY` |
 | Moonshot | `MOONSHOT_API_KEY` |
+| NEAR AI Cloud (TEE inference) | `NEARAI_API_KEY` |
 | Volcengine | `VOLCENGINE_API_KEY` or `ARK_API_KEY` |
 | StepFun | `STEPFUN_API_KEY` |
 | Qwen | `QWEN_API_KEY` or `DASHSCOPE_API_KEY` |

--- a/src/config.rs
+++ b/src/config.rs
@@ -2457,6 +2457,13 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
     )?;
     insert_openai_compatible_provider(
         &mut registry,
+        "nearai",
+        "https://cloud-api.near.ai/v1",
+        &["NEARAI_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
         "nvidia",
         "https://integrate.api.nvidia.com/v1",
         &["NVIDIA_API_KEY"],
@@ -4512,6 +4519,7 @@ mod tests {
         settings_env.insert("ZAI_API_KEY".to_string(), "zai-key".to_string());
         settings_env.insert("BIGMODEL_API_KEY".to_string(), "bigmodel-key".to_string());
         settings_env.insert("DASHSCOPE_API_KEY".to_string(), "dashscope-key".to_string());
+        settings_env.insert("NEARAI_API_KEY".to_string(), "nearai-key".to_string());
 
         let providers = super::built_in_provider_registry(&settings_env).unwrap();
 
@@ -4529,6 +4537,17 @@ mod tests {
         let qwen = providers.get(&ProviderId::parse("qwen").unwrap()).unwrap();
         assert_eq!(qwen.auth.env.as_deref(), Some("DASHSCOPE_API_KEY"));
         assert_eq!(qwen.credential.as_deref(), Some("dashscope-key"));
+
+        let nearai = providers
+            .get(&ProviderId::parse("nearai").unwrap())
+            .unwrap();
+        assert_eq!(
+            nearai.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(nearai.base_url, "https://cloud-api.near.ai/v1");
+        assert_eq!(nearai.auth.env.as_deref(), Some("NEARAI_API_KEY"));
+        assert_eq!(nearai.credential.as_deref(), Some("nearai-key"));
 
         let stepfun_plan = providers
             .get(&ProviderId::parse("stepfun-plan").unwrap())
@@ -4920,6 +4939,7 @@ mod tests {
                 "LITELLM_API_KEY",
                 "MISTRAL_API_KEY",
                 "MOONSHOT_API_KEY",
+                "NEARAI_API_KEY",
                 "NVIDIA_API_KEY",
                 "OPENCODE_GO_API_KEY",
                 "OPENROUTER_API_KEY",

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -994,7 +994,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         catalog_model(
             "nearai",
             "Qwen/Qwen3.5-122B-A10B",
-            "Qwen3.5 122B A10B (NEAR AI Cloud TEE)",
+            "Qwen 3.5 122B A10B (NEAR AI Cloud TEE)",
             131_072,
             65_536,
             true,

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -974,6 +974,51 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
+            "nearai",
+            "zai-org/GLM-5.1-FP8",
+            "GLM 5.1 (NEAR AI Cloud TEE)",
+            202_752,
+            131_100,
+            true,
+            false,
+        ),
+        catalog_model(
+            "nearai",
+            "Qwen/Qwen3.6-35B-A3B-FP8",
+            "Qwen 3.6 35B A3B FP8 (NEAR AI Cloud TEE)",
+            262_144,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
+            "nearai",
+            "Qwen/Qwen3.5-122B-A10B",
+            "Qwen3.5 122B A10B (NEAR AI Cloud TEE)",
+            131_072,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
+            "nearai",
+            "Qwen/Qwen3-VL-30B-A3B-Instruct",
+            "Qwen3 VL 30B A3B Instruct (NEAR AI Cloud TEE)",
+            256_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "nearai",
+            "google/gemma-4-31B-it",
+            "Gemma 4 31B Instruct (NEAR AI Cloud TEE)",
+            262_144,
+            32_768,
+            false,
+            false,
+        ),
+        catalog_model(
             "nvidia",
             "nvidia/nemotron-3-super-120b-a12b",
             "NVIDIA Nemotron 3 Super 120B",
@@ -1834,6 +1879,19 @@ mod tests {
         assert_eq!(policy.runtime_max_output_tokens, 384_000);
         assert!(policy.capabilities.reasoning_summaries);
         assert_eq!(policy.source, ModelMetadataSource::BuiltInCatalog);
+
+        let nearai = catalog.resolve_policy(
+            &ModelRef::parse("nearai/zai-org/GLM-5.1-FP8").unwrap(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(nearai.display_name, "GLM 5.1 (NEAR AI Cloud TEE)");
+        assert_eq!(nearai.context_window_tokens, Some(202_752));
+        assert_eq!(nearai.runtime_max_output_tokens, 131_100);
+        assert!(nearai.capabilities.reasoning_summaries);
+        assert_eq!(nearai.source, ModelMetadataSource::BuiltInCatalog);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `nearai` as a built-in OpenAI-compatible provider using `NEARAI_API_KEY`.
- Register NEAR AI Cloud TEE model metadata for current chat/vision-capable catalog entries.
- Document the NEAR AI Cloud environment variable in the configuration reference.

## Implementation Notes
- Reuses Holon's existing `openai_chat_completions` transport with `https://cloud-api.near.ai/v1`.
- Catalog entries were selected from the public NEAR AI model list and omit utility or non-chat models.

## Testing
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `make test`

Live NEAR AI smoke testing was not run because `NEARAI_API_KEY` was not configured.