### PR TITLE
fix: deduplicate replayed TUI events

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -140,6 +140,29 @@ pub enum ItemState {
 pub struct TimedItem {
     pub item: PresentationItem,
     pub ts: DateTime<Utc>,
+    pub dedupe_key: String,
+}
+
+impl TimedItem {
+    pub(crate) fn from_event(item: PresentationItem, event: &ProjectionEventRecord) -> Self {
+        Self {
+            item,
+            ts: event.ts,
+            dedupe_key: event_dedupe_key(event),
+        }
+    }
+
+    pub(crate) fn with_key(
+        item: PresentationItem,
+        ts: DateTime<Utc>,
+        dedupe_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            item,
+            ts,
+            dedupe_key: dedupe_key.into(),
+        }
+    }
 }
 
 // ── RenderedCell: surface-neutral intermediate ─────────────────────────────
@@ -606,8 +629,8 @@ impl PresentationReducer {
                             let full_stdout = tool_full_output(next);
                             let full_stderr = tool_full_stderr(next);
 
-                            items.push(TimedItem {
-                                item: PresentationItem::CommandExecuted {
+                            items.push(TimedItem::from_event(
+                                PresentationItem::CommandExecuted {
                                     cmd_preview: exec_preview,
                                     duration_ms,
                                     exit_code,
@@ -615,8 +638,8 @@ impl PresentationReducer {
                                     full_stdout,
                                     full_stderr,
                                 },
-                                ts: next.ts,
-                            });
+                                next,
+                            ));
                             i += 2;
                             continue;
                         }
@@ -626,10 +649,10 @@ impl PresentationReducer {
                 "message_enqueued" => {
                     if let Some((key, text)) = operator_message_item(event) {
                         if self.observed_user_message_keys.insert(key) {
-                            items.push(TimedItem {
-                                item: PresentationItem::UserMessage { text },
-                                ts: event.ts,
-                            });
+                            items.push(TimedItem::from_event(
+                                PresentationItem::UserMessage { text },
+                                event,
+                            ));
                         }
                     }
                 }
@@ -643,21 +666,21 @@ impl PresentationReducer {
                             _ => false,
                         };
                         if !duplicates_observed_preview && self.observed_brief_keys.insert(key) {
-                            items.push(TimedItem { item, ts: event.ts });
+                            items.push(TimedItem::from_event(item, event));
                         }
                     }
                 }
 
                 "tool_executed" | "tool_execution_failed" => {
                     if is_sleep_tool_event(event) {
-                        items.push(TimedItem {
-                            item: PresentationItem::InternalTransition {
+                        items.push(TimedItem::from_event(
+                            PresentationItem::InternalTransition {
                                 what: "Sleep".into(),
                                 from: "tool".into(),
                                 to: event.summary.clone(),
                             },
-                            ts: event.ts,
-                        });
+                            event,
+                        ));
                         i += 1;
                         continue;
                     }
@@ -671,8 +694,8 @@ impl PresentationReducer {
                     let full_stdout = tool_full_output(event);
                     let full_stderr = tool_full_stderr(event);
 
-                    items.push(TimedItem {
-                        item: PresentationItem::CommandExecuted {
+                    items.push(TimedItem::from_event(
+                        PresentationItem::CommandExecuted {
                             cmd_preview,
                             duration_ms: tool_duration_ms(event),
                             exit_code,
@@ -680,8 +703,8 @@ impl PresentationReducer {
                             full_stdout,
                             full_stderr,
                         },
-                        ts: event.ts,
-                    });
+                        event,
+                    ));
                 }
 
                 "assistant_round_recorded" | "text_only_round_observed" => {
@@ -693,13 +716,13 @@ impl PresentationReducer {
                         {
                             self.observed_assistant_texts
                                 .insert(strip_preview_ellipsis(normalized_text(&text).as_str()));
-                            items.push(TimedItem {
-                                item: PresentationItem::AssistantProgress {
+                            items.push(TimedItem::from_event(
+                                PresentationItem::AssistantProgress {
                                     text,
                                     state: ItemState::Stable,
                                 },
-                                ts: event.ts,
-                            });
+                                event,
+                            ));
                         }
                     }
                 }
@@ -721,13 +744,13 @@ impl PresentationReducer {
                         "command_task_runner_failed" => TaskTransition::RunnerFailed,
                         _ => TaskTransition::StatusUpdated,
                     };
-                    items.push(TimedItem {
-                        item: PresentationItem::TaskLifecycle {
+                    items.push(TimedItem::from_event(
+                        PresentationItem::TaskLifecycle {
                             task_id: task_id.to_string(),
                             transition,
                         },
-                        ts: event.ts,
-                    });
+                        event,
+                    ));
                 }
 
                 "task_status_updated" => {
@@ -736,18 +759,18 @@ impl PresentationReducer {
                         .get("task_id")
                         .and_then(|v| v.as_str())
                         .unwrap_or("?");
-                    items.push(TimedItem {
-                        item: PresentationItem::TaskLifecycle {
+                    items.push(TimedItem::from_event(
+                        PresentationItem::TaskLifecycle {
                             task_id: task_id.to_string(),
                             transition: TaskTransition::StatusUpdated,
                         },
-                        ts: event.ts,
-                    });
+                        event,
+                    ));
                 }
 
                 "provider_round_completed" => {
                     if let Some(item) = provider_round_item(event) {
-                        items.push(TimedItem { item, ts: event.ts });
+                        items.push(TimedItem::from_event(item, event));
                     }
                 }
 
@@ -756,14 +779,14 @@ impl PresentationReducer {
                         "continuation_resolved" => "continuation",
                         _ => "closure",
                     };
-                    items.push(TimedItem {
-                        item: PresentationItem::InternalTransition {
+                    items.push(TimedItem::from_event(
+                        PresentationItem::InternalTransition {
                             what: what.to_string(),
                             from: "?".to_string(),
                             to: event.summary.clone(),
                         },
-                        ts: event.ts,
-                    });
+                        event,
+                    ));
                 }
 
                 "work_item_written" => {
@@ -779,21 +802,21 @@ impl PresentationReducer {
                         .unwrap_or("updated");
                     let summary = event.summary.clone();
                     if action == "created" || action == "completed" {
-                        items.push(TimedItem {
-                            item: PresentationItem::WorkItemCard {
+                        items.push(TimedItem::from_event(
+                            PresentationItem::WorkItemCard {
                                 action: action.to_string(),
                                 summary,
                             },
-                            ts: event.ts,
-                        });
+                            event,
+                        ));
                     } else {
-                        items.push(TimedItem {
-                            item: PresentationItem::WorkItemBookkeeping {
+                        items.push(TimedItem::from_event(
+                            PresentationItem::WorkItemBookkeeping {
                                 item_id: item_id.to_string(),
                                 transition: WorkItemTransition::Created,
                             },
-                            ts: event.ts,
-                        });
+                            event,
+                        ));
                     }
                 }
 
@@ -814,22 +837,22 @@ impl PresentationReducer {
                         "worktree_exited" => "exited worktree",
                         _ => "changed",
                     };
-                    items.push(TimedItem {
-                        item: PresentationItem::WorkspaceChange {
+                    items.push(TimedItem::from_event(
+                        PresentationItem::WorkspaceChange {
                             path: path.to_string(),
                             action: action.to_string(),
                         },
-                        ts: event.ts,
-                    });
+                        event,
+                    ));
                 }
 
                 kind if is_suppressed_known_runtime_event(kind) => {}
 
                 _ => {
-                    items.push(TimedItem {
-                        item: self.event_to_presentation(event),
-                        ts: event.ts,
-                    });
+                    items.push(TimedItem::from_event(
+                        self.event_to_presentation(event),
+                        event,
+                    ));
                 }
             }
 
@@ -845,27 +868,31 @@ impl PresentationReducer {
 
     /// Return the current live group as a `TimedItem`, if one is accumulating.
     pub(crate) fn current_live_item(&self) -> Option<TimedItem> {
-        self.live_group.as_ref().map(|group| TimedItem {
-            item: PresentationItem::ActionGroup {
-                heading: group.heading.clone(),
-                items: group.items.clone(),
-                state: ItemState::Live,
-            },
-            ts: self.last_ts.unwrap_or_else(Utc::now),
+        self.live_group.as_ref().map(|group| {
+            TimedItem::with_key(
+                PresentationItem::ActionGroup {
+                    heading: group.heading.clone(),
+                    items: group.items.clone(),
+                    state: ItemState::Live,
+                },
+                self.last_ts.unwrap_or_else(Utc::now),
+                "live-group",
+            )
         })
     }
 
     pub(crate) fn flush(&mut self) -> Vec<TimedItem> {
         let mut items: Vec<TimedItem> = Vec::new();
         if let Some(group) = self.live_group.take() {
-            items.push(TimedItem {
-                item: PresentationItem::ActionGroup {
+            items.push(TimedItem::with_key(
+                PresentationItem::ActionGroup {
                     heading: group.heading,
                     items: group.items,
                     state: ItemState::Stable,
                 },
-                ts: self.last_ts.unwrap_or_else(Utc::now),
-            });
+                self.last_ts.unwrap_or_else(Utc::now),
+                "flushed-live-group",
+            ));
         }
         items
     }
@@ -931,6 +958,13 @@ fn brief_result_item(event: &ProjectionEventRecord) -> Option<(String, Presentat
             },
         )),
     }
+}
+
+fn event_dedupe_key(event: &ProjectionEventRecord) -> String {
+    if !event.id.is_empty() {
+        return format!("event-id:{}", event.id);
+    }
+    format!("event-seq:{}:{}", event.event_seq, event.kind)
 }
 
 fn normalize_text_key(text: &str) -> String {

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -146,6 +146,7 @@ pub(super) struct CachedChatText {
 pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
     let mut cells = Vec::new();
     let mut durable_operator_message_bodies = std::collections::BTreeMap::new();
+    let mut projected_cell_keys = std::collections::BTreeSet::new();
     let mut visible_operator_message_ids = std::collections::BTreeSet::new();
     let durable_operator_message_ids = app
         .projection
@@ -172,6 +173,8 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
                     push_projected_conversation_cell(
                         &mut cells,
                         &mut durable_operator_message_bodies,
+                        &mut projected_cell_keys,
+                        &timed.dedupe_key,
                         rendered_to_conversation_cell(&rendered, timed.ts),
                     );
                 }
@@ -236,14 +239,29 @@ fn push_pending_operator_message_cell(
 fn push_projected_conversation_cell(
     cells: &mut Vec<ConversationCell>,
     durable_operator_message_bodies: &mut std::collections::BTreeMap<String, usize>,
+    projected_cell_keys: &mut std::collections::BTreeSet<String>,
+    source_key: &str,
     cell: ConversationCell,
 ) {
+    if !projected_cell_keys.insert(projected_conversation_cell_key(source_key, &cell)) {
+        return;
+    }
     if let ConversationCell::UserMessage { body, .. } = &cell {
         *durable_operator_message_bodies
             .entry(normalized_operator_message_body_key(body))
             .or_insert(0) += 1;
     }
     cells.push(cell);
+}
+
+fn projected_conversation_cell_key(source_key: &str, cell: &ConversationCell) -> String {
+    format!(
+        "{}|{:?}|{}|{}",
+        source_key,
+        cell.role(),
+        cell.sort_speaker(),
+        normalized_operator_message_body_key(cell.sort_body())
+    )
 }
 
 fn normalized_operator_message_body_key(body: &str) -> String {

--- a/src/tui/logging.rs
+++ b/src/tui/logging.rs
@@ -428,14 +428,15 @@ mod tests {
             },
             payload: json!({ "id": "brief_1", "text": "completed work" }),
         };
-        let item = TimedItem {
-            ts: event.ts,
-            item: PresentationItem::AssistantResult {
+        let item = TimedItem::with_key(
+            PresentationItem::AssistantResult {
                 brief_id: Some("brief_1".into()),
                 body: "completed work".into(),
                 outcome: Outcome::Success,
             },
-        };
+            event.ts,
+            "test-item",
+        );
 
         writer
             .write_event(&event)
@@ -468,14 +469,15 @@ mod tests {
             },
             payload: json!({ "id": "brief_1", "text": "completed work" }),
         };
-        let item = TimedItem {
-            ts: event.ts,
-            item: PresentationItem::AssistantResult {
+        let item = TimedItem::with_key(
+            PresentationItem::AssistantResult {
                 brief_id: Some("brief_1".into()),
                 body: "completed work".into(),
                 outcome: Outcome::Success,
             },
-        };
+            event.ts,
+            "test-item",
+        );
 
         writer
             .write_event(&event)
@@ -521,13 +523,14 @@ mod tests {
             },
             payload: json!({ "model": "test-model" }),
         };
-        let item = TimedItem {
-            ts: event.ts,
-            item: PresentationItem::GenericEvent {
+        let item = TimedItem::with_key(
+            PresentationItem::GenericEvent {
                 kind: "provider_round_completed".into(),
                 summary: "provider completed".into(),
             },
-        };
+            event.ts,
+            "test-item",
+        );
 
         writer
             .write_presentation_items(std::slice::from_ref(&event), &[item])
@@ -561,13 +564,14 @@ mod tests {
             },
             payload: json!({ "model": "test-model" }),
         };
-        let item = TimedItem {
-            ts: event.ts,
-            item: PresentationItem::GenericEvent {
+        let item = TimedItem::with_key(
+            PresentationItem::GenericEvent {
                 kind: "provider_round_completed".into(),
                 summary: "provider completed".into(),
             },
-        };
+            event.ts,
+            "test-item",
+        );
 
         for _ in 0..8 {
             writer
@@ -603,13 +607,14 @@ mod tests {
             },
             payload: json!({ "model": "test-model" }),
         };
-        let item = TimedItem {
-            ts: event.ts,
-            item: PresentationItem::GenericEvent {
+        let item = TimedItem::with_key(
+            PresentationItem::GenericEvent {
                 kind: "provider_round_completed".into(),
                 summary: "provider completed".repeat(100),
             },
-        };
+            event.ts,
+            "test-item",
+        );
 
         writer
             .write_presentation_items(std::slice::from_ref(&event), std::slice::from_ref(&item))

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -163,10 +163,24 @@ impl TuiProjection {
         let mut existing_ids = self
             .event_log
             .iter()
+            .filter(|event| !event.id.is_empty())
             .map(|event| event.id.clone())
             .collect::<BTreeSet<_>>();
+        let mut existing_seqs_without_ids = self
+            .event_log
+            .iter()
+            .filter_map(|event| {
+                (event.id.is_empty() && event.event_seq != 0).then_some(event.event_seq)
+            })
+            .collect::<BTreeSet<_>>();
         for envelope in events_tail {
-            if !existing_ids.insert(envelope.id.clone()) {
+            if !envelope.id.is_empty() && !existing_ids.insert(envelope.id.clone()) {
+                continue;
+            }
+            if envelope.id.is_empty()
+                && envelope.event_seq != 0
+                && !existing_seqs_without_ids.insert(envelope.event_seq)
+            {
                 continue;
             }
             let record = self.projection_event_record_from_envelope(envelope);
@@ -226,13 +240,27 @@ impl TuiProjection {
         let existing_ids = self
             .event_log
             .iter()
+            .filter(|event| !event.id.is_empty())
             .map(|event| event.id.clone())
+            .collect::<BTreeSet<_>>();
+        let existing_seqs_without_ids = self
+            .event_log
+            .iter()
+            .filter_map(|event| {
+                (event.id.is_empty() && event.event_seq != 0).then_some(event.event_seq)
+            })
             .collect::<BTreeSet<_>>();
         events.reverse();
 
         let mut prepended = Vec::new();
         for envelope in events {
-            if existing_ids.contains(&envelope.id) {
+            if !envelope.id.is_empty() && existing_ids.contains(&envelope.id) {
+                continue;
+            }
+            if envelope.id.is_empty()
+                && envelope.event_seq != 0
+                && existing_seqs_without_ids.contains(&envelope.event_seq)
+            {
                 continue;
             }
             prepended.push(self.projection_event_record_from_envelope(envelope));
@@ -260,6 +288,9 @@ impl TuiProjection {
     }
 
     pub(crate) fn apply_event(&mut self, event: AgentStreamEvent, log_writer: &TuiLogWriter) {
+        if self.has_event_identity(&event.data.id, event.data.event_seq) {
+            return;
+        }
         let presentation_context = self.operator_presentation_context();
         let record = projection_event_record_from_stream_event(&event, &presentation_context);
         let event_log_limit = if self.history_paging_active {
@@ -486,8 +517,30 @@ impl TuiProjection {
         }
     }
 
+    fn has_event_identity(&self, id: &str, event_seq: u64) -> bool {
+        if !id.is_empty() {
+            return self.event_log.iter().any(|event| event.id == id);
+        }
+        event_seq != 0
+            && self
+                .event_log
+                .iter()
+                .any(|event| event.id.is_empty() && event.event_seq == event_seq)
+    }
+
     fn seed_event_log(&mut self, events_tail: Vec<StreamEventEnvelope>) {
+        let mut seen_ids = BTreeSet::new();
+        let mut seen_seqs_without_ids = BTreeSet::new();
         for envelope in events_tail {
+            if !envelope.id.is_empty() && !seen_ids.insert(envelope.id.clone()) {
+                continue;
+            }
+            if envelope.id.is_empty()
+                && envelope.event_seq != 0
+                && !seen_seqs_without_ids.insert(envelope.event_seq)
+            {
+                continue;
+            }
             let record = self.projection_event_record_from_envelope(envelope);
             push_limited(&mut self.event_log, record, EVENT_LOG_LIMIT);
         }
@@ -1210,7 +1263,11 @@ fn projection_event_record_from_stream_event(
         presentation_context,
     );
     ProjectionEventRecord {
-        id: event.id.clone(),
+        id: if event.data.id.is_empty() {
+            event.id.clone()
+        } else {
+            event.data.id.clone()
+        },
         event_seq: event.data.event_seq,
         ts: event.data.ts,
         kind: event.data.event_type.clone(),
@@ -1828,7 +1885,8 @@ mod tests {
         let mut projection = TuiProjection::from_snapshot(snapshot);
 
         projection.apply_event(
-            sample_event(
+            sample_event_with_id(
+                "evt-prev-assistant-round",
                 "assistant_round_recorded",
                 json!({
                     "run_id": "run-1",
@@ -1851,7 +1909,8 @@ mod tests {
             &test_log_writer(),
         );
         projection.apply_event(
-            sample_event(
+            sample_event_with_id(
+                "evt-current-assistant-round",
                 "assistant_round_recorded",
                 json!({
                     "run_id": "run-2",
@@ -1954,7 +2013,8 @@ mod tests {
         let mut projection = TuiProjection::from_snapshot(sample_snapshot());
 
         projection.apply_event(
-            sample_event(
+            sample_event_with_id(
+                "evt-assistant-tools",
                 "assistant_round_recorded",
                 json!({
                     "redacted": true,
@@ -1976,7 +2036,8 @@ mod tests {
         );
 
         projection.apply_event(
-            sample_event(
+            sample_event_with_id(
+                "evt-assistant-empty",
                 "assistant_round_recorded",
                 json!({
                     "redacted": true,
@@ -2489,10 +2550,14 @@ mod tests {
     }
 
     fn sample_event(kind: &str, payload: Value) -> AgentStreamEvent {
+        sample_event_with_id(&format!("evt-{kind}"), kind, payload)
+    }
+
+    fn sample_event_with_id(id: &str, kind: &str, payload: Value) -> AgentStreamEvent {
         AgentStreamEvent {
-            id: format!("evt-{kind}"),
+            id: id.to_string(),
             event: kind.to_string(),
-            data: sample_event_envelope_with_payload(&format!("evt-{kind}"), 1, kind, payload),
+            data: sample_event_envelope_with_payload(id, 1, kind, payload),
         }
     }
 

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -237,13 +237,13 @@ impl TuiProjection {
             return 0;
         }
 
-        let existing_ids = self
+        let mut existing_ids = self
             .event_log
             .iter()
             .filter(|event| !event.id.is_empty())
             .map(|event| event.id.clone())
             .collect::<BTreeSet<_>>();
-        let existing_seqs_without_ids = self
+        let mut existing_seqs_without_ids = self
             .event_log
             .iter()
             .filter_map(|event| {
@@ -254,12 +254,12 @@ impl TuiProjection {
 
         let mut prepended = Vec::new();
         for envelope in events {
-            if !envelope.id.is_empty() && existing_ids.contains(&envelope.id) {
+            if !envelope.id.is_empty() && !existing_ids.insert(envelope.id.clone()) {
                 continue;
             }
             if envelope.id.is_empty()
                 && envelope.event_seq != 0
-                && existing_seqs_without_ids.contains(&envelope.event_seq)
+                && !existing_seqs_without_ids.insert(envelope.event_seq)
             {
                 continue;
             }
@@ -288,7 +288,7 @@ impl TuiProjection {
     }
 
     pub(crate) fn apply_event(&mut self, event: AgentStreamEvent, log_writer: &TuiLogWriter) {
-        if self.has_event_identity(&event.data.id, event.data.event_seq) {
+        if self.has_event_identity(effective_stream_event_id(&event), event.data.event_seq) {
             return;
         }
         let presentation_context = self.operator_presentation_context();
@@ -1263,11 +1263,7 @@ fn projection_event_record_from_stream_event(
         presentation_context,
     );
     ProjectionEventRecord {
-        id: if event.data.id.is_empty() {
-            event.id.clone()
-        } else {
-            event.data.id.clone()
-        },
+        id: effective_stream_event_id(event).to_string(),
         event_seq: event.data.event_seq,
         ts: event.data.ts,
         kind: event.data.event_type.clone(),
@@ -1275,6 +1271,14 @@ fn projection_event_record_from_stream_event(
         summary: presentation.summary.clone(),
         presentation,
         payload: event.data.payload.clone(),
+    }
+}
+
+fn effective_stream_event_id(event: &AgentStreamEvent) -> &str {
+    if event.data.id.is_empty() {
+        &event.id
+    } else {
+        &event.data.id
     }
 }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2484,6 +2484,41 @@ fn chat_deduplicates_bootstrap_event_when_stream_replays_it() {
 }
 
 #[test]
+fn projection_deduplicates_stream_events_using_outer_id_fallback() {
+    let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
+    projection.replace_event_window(Vec::new(), None);
+    let mut envelope = work_item_written_event_envelope("", 0, "default", "outer id work");
+    envelope.id.clear();
+
+    for _ in 0..2 {
+        projection.apply_event(
+            AgentStreamEvent {
+                id: "sse-event-1".into(),
+                event: envelope.event_type.clone(),
+                data: envelope.clone(),
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+    }
+
+    assert_eq!(projection.event_log().len(), 1);
+    assert_eq!(projection.event_log()[0].id, "sse-event-1");
+}
+
+#[test]
+fn projection_deduplicates_duplicates_within_history_page() {
+    let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
+    projection.replace_event_window(Vec::new(), None);
+    let event = work_item_written_event_envelope("evt-history-work", 42, "default", "history work");
+
+    let added = projection.prepend_event_history_page(vec![event.clone(), event], Some(42), true);
+
+    assert_eq!(added, 1);
+    assert_eq!(projection.event_log().len(), 1);
+    assert_eq!(projection.event_log()[0].id, "evt-history-work");
+}
+
+#[test]
 fn chat_text_omits_processing_and_processed_operator_status_labels() {
     for _status in [
         OperatorMessageStatus::Processing,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -279,6 +279,54 @@ fn operator_message_event_envelope(
     )
 }
 
+fn work_item_written_event_envelope(
+    id: &str,
+    event_seq: u64,
+    agent_id: &str,
+    objective: &str,
+) -> StreamEventEnvelope {
+    pipeline_event_envelope(
+        id,
+        event_seq,
+        agent_id,
+        "work_item_written",
+        json!({
+            "action": "created",
+            "record": {
+                "id": "work-1",
+                "agent_id": agent_id,
+                "workspace_id": crate::types::AGENT_HOME_WORKSPACE_ID,
+                "objective": objective,
+                "state": "open",
+                "plan_status": "draft",
+                "todo_list": [],
+                "created_at": Utc::now(),
+                "updated_at": Utc::now()
+            }
+        }),
+    )
+}
+
+fn tool_executed_event_envelope(
+    id: &str,
+    event_seq: u64,
+    agent_id: &str,
+    tool_name: &str,
+) -> StreamEventEnvelope {
+    pipeline_event_envelope(
+        id,
+        event_seq,
+        agent_id,
+        "tool_executed",
+        json!({
+            "duration_ms": 0,
+            "status": "success",
+            "summary": tool_name,
+            "tool_name": tool_name,
+        }),
+    )
+}
+
 fn apply_brief_event(app: &mut TuiApp, brief: BriefRecord) {
     let event_id = format!("evt-{}", brief.id);
     let projection = app.projection.get_or_insert_with(|| {
@@ -2291,6 +2339,151 @@ fn chat_dedupes_pending_operator_message_when_event_log_contains_it() {
 }
 
 #[test]
+fn chat_deduplicates_replayed_projected_work_item_events() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let event = work_item_written_event_envelope(
+        "evt-work-item",
+        42,
+        "default",
+        "Resolve and close the M1.15 GitHub issue list",
+    );
+    let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
+    for _ in 0..2 {
+        projection.apply_event(
+            AgentStreamEvent {
+                id: event.id.clone(),
+                event: event.event_type.clone(),
+                data: event.clone(),
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+    }
+    assert_eq!(projection.event_log().len(), 1);
+    app.projection = Some(projection);
+
+    let matching = collect_chat_items(&app)
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                ConversationCell::SystemNotice { body, .. }
+                    if body.contains("Resolve and close the M1.15 GitHub issue list")
+            )
+        })
+        .count();
+    assert_eq!(matching, 1);
+}
+
+#[test]
+fn chat_deduplicates_replayed_projected_tool_events() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let event = tool_executed_event_envelope("evt-tool", 43, "default", "PickWorkItem");
+    let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
+    for _ in 0..2 {
+        projection.apply_event(
+            AgentStreamEvent {
+                id: event.id.clone(),
+                event: event.event_type.clone(),
+                data: event.clone(),
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+    }
+    assert_eq!(projection.event_log().len(), 1);
+    app.display_mode = OperatorDisplayMode::Verbose;
+    app.projection = Some(projection);
+
+    let matching = collect_chat_items(&app)
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                ConversationCell::SystemNotice { body, .. }
+                    if body.contains("PickWorkItem")
+            )
+        })
+        .count();
+    assert_eq!(matching, 1);
+}
+
+#[test]
+fn chat_keeps_distinct_projected_tool_events_with_same_body() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
+    for (id, event_seq) in [("evt-tool-1", 43), ("evt-tool-2", 44)] {
+        let event = tool_executed_event_envelope(id, event_seq, "default", "PickWorkItem");
+        projection.apply_event(
+            AgentStreamEvent {
+                id: event.id.clone(),
+                event: event.event_type.clone(),
+                data: event,
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+    }
+    app.display_mode = OperatorDisplayMode::Verbose;
+    app.projection = Some(projection);
+
+    let matching = collect_chat_items(&app)
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                ConversationCell::SystemNotice { body, .. }
+                    if body.contains("PickWorkItem")
+            )
+        })
+        .count();
+    assert_eq!(matching, 2);
+}
+
+#[test]
+fn chat_deduplicates_bootstrap_event_when_stream_replays_it() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    let event = work_item_written_event_envelope("evt-work-item", 42, "default", "bootstrap work");
+    let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
+    projection.replace_event_window(vec![event.clone()], Some(42));
+    projection.apply_event(
+        AgentStreamEvent {
+            id: event.id.clone(),
+            event: event.event_type.clone(),
+            data: event,
+        },
+        &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    assert_eq!(projection.event_log().len(), 1);
+    app.projection = Some(projection);
+
+    let matching = collect_chat_items(&app)
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                ConversationCell::SystemNotice { body, .. }
+                    if body.contains("bootstrap work")
+            )
+        })
+        .count();
+    assert_eq!(matching, 1);
+}
+
+#[test]
 fn chat_text_omits_processing_and_processed_operator_status_labels() {
     for _status in [
         OperatorMessageStatus::Processing,
@@ -3795,13 +3988,14 @@ fn pipeline_reducer_aggregation() {
 
     // Write with empty reducer_events but non-empty items
     use crate::presentation::{PresentationItem, TimedItem};
-    let dummy_item = TimedItem {
-        item: PresentationItem::AssistantProgress {
+    let dummy_item = TimedItem::with_key(
+        PresentationItem::AssistantProgress {
             text: "empty test".into(),
             state: crate::presentation::ItemState::Stable,
         },
-        ts: chrono::Utc::now(),
-    };
+        chrono::Utc::now(),
+        "empty-test",
+    );
     let result2 = empty_writer.write_presentation_items(&[], &[dummy_item]);
     assert!(
         result2.is_ok(),


### PR DESCRIPTION
## Summary
- preserve projection event identity through presentation items and use it for chat cell dedupe
- dedupe TUI event windows across bootstrap, pagination, and stream replay using envelope id with legacy seq fallback
- add regression tests for replayed work item/tool events, bootstrap stream replay, and distinct same-body tool events

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo test tui::projection --lib -- --nocapture
- cargo test chat_deduplicates_replayed_projected --quiet
- cargo test chat_keeps_distinct_projected_tool_events_with_same_body --quiet
- cargo test chat_deduplicates_bootstrap_event_when_stream_replays_it --quiet
- RUSTFLAGS="-D warnings" cargo check --all-targets