### PR TITLE
docs: clarify WorkItem scheduler readiness

### DIFF
--- a/docs/website/guides/work-items.md
+++ b/docs/website/guides/work-items.md
@@ -51,6 +51,7 @@ Each work item can contain:
 - **plan status** — `draft`, `ready`, or `needs_input`
 - **todo list** — checklist of meaningful progress steps
 - **blocked by** — specific blocker when progress cannot continue
+- **recheck deadline** — fallback time for reconsidering a blocked item
 
 Treat the work item as coordination state, not a scratchpad.
 
@@ -85,6 +86,26 @@ Use plan status intentionally:
 This matters because the runtime can distinguish active runnable work from work
 that should pause.
 
+## Scheduler Readiness Model
+
+Work item readiness is scheduler input. An open runnable work item is eligible
+for scheduler resume or a system tick, while blocked or waiting items should
+pause until their unblock condition changes.
+
+`Sleep` only rests the agent. It does not mark the current work item as blocked,
+waiting, or non-runnable. If no immediate progress is possible, update the work
+item state before sleeping:
+
+- use `plan_status=needs_input` when operator input is required
+- set `blocked_by` when waiting on a concrete non-operator blocker
+- add `recheck_after` with `blocked_by` when the blocker should be revisited
+  after a fallback delay
+- use an external trigger when an external system can actively wake the agent
+
+Keep work items runnable only when the next scheduler resume can make useful
+progress. This avoids loops where an agent sleeps while leaving an open item
+eligible for repeated system ticks.
+
 ## Todo List Best Practices
 
 Good todo items are:
@@ -104,6 +125,7 @@ Avoid:
 When a work item cannot proceed:
 
 - set `blocked_by` to the concrete blocker
+- add `recheck_after` when the blocker should be reconsidered later
 - use `needs_input` if operator clarification is required
 - attach external waiting mechanisms only when the work is truly cross-turn
 

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -67,6 +67,19 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         || names.contains(&"PickWorkItem")
         || names.contains(&"UpdateWorkItem")
         || names.contains(&"CompleteWorkItem")
+        || names.contains(&"GetWorkItem")
+        || names.contains(&"ListWorkItems")
+    {
+        sections.push(section(
+            "tool_work_item_scheduling",
+            PromptStability::Stable,
+            "WorkItem scheduler model: an open runnable WorkItem is eligible for scheduler resume or system tick; Sleep only rests the agent and does not change WorkItem readiness. Do not leave a WorkItem runnable when no immediate progress is possible just because you called Sleep. When waiting for operator input, set plan_status=needs_input. When waiting on a concrete non-operator blocker, set blocked_by. When that blocker should be rechecked later, set blocked_by with recheck_after as the fallback deadline. Use an external trigger when an external system can actively wake the agent; the trigger complements, but does not replace, explicitly updating WorkItem blocked/ready/completed state. If you discover progress can continue, clear blockers by updating the WorkItem before proceeding. Keep runnable WorkItems only for work that is actually ready for the scheduler to resume.".to_string(),
+        ));
+    }
+    if names.contains(&"CreateWorkItem")
+        || names.contains(&"PickWorkItem")
+        || names.contains(&"UpdateWorkItem")
+        || names.contains(&"CompleteWorkItem")
     {
         sections.push(section(
             "tool_work_item_write",
@@ -372,6 +385,33 @@ mod tests {
         assert!(section
             .content
             .contains("audit whether the acceptance evidence is present"));
+    }
+
+    #[test]
+    fn test_work_item_scheduling_section_emitted_when_available() {
+        let tools = vec![ToolSpec {
+            name: "UpdateWorkItem".into(),
+            description: String::new(),
+            input_schema: json!({}),
+            freeform_grammar: None,
+        }];
+        let sections = tool_sections(&tools);
+        let section = sections
+            .iter()
+            .find(|s| s.name == "tool_work_item_scheduling")
+            .expect("work item scheduling section");
+        assert!(section.content.contains("open runnable WorkItem"));
+        assert!(section.content.contains("system tick"));
+        assert!(section.content.contains("Sleep only rests the agent"));
+        assert!(section
+            .content
+            .contains("does not change WorkItem readiness"));
+        assert!(section.content.contains("plan_status=needs_input"));
+        assert!(section.content.contains("set blocked_by"));
+        assert!(section.content.contains("recheck_after"));
+        assert!(section
+            .content
+            .contains("Keep runnable WorkItems only for work that is actually ready"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a dedicated prompt section explaining the WorkItem scheduler readiness model
- document how runnable, blocked, needs_input, recheck_after, Sleep, and external triggers interact in the Work Items guide
- add prompt coverage for the new scheduling guidance section

## Verification
- cargo fmt --all -- --check
- cargo test test_work_item_scheduling_section_emitted_when_available
- RUSTFLAGS="-D warnings" cargo check --all-targets