### PR TITLE
Expose agent scheduling posture in agent summaries

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -614,11 +614,13 @@ impl RuntimeHost {
             &self.runtime_context_config(),
             &agent,
         );
+        let scheduling_posture = storage.agent_posture_projection(&agent)?;
         let waiting_reason = crate::runtime::lightweight_agent_list_waiting_reason(&agent);
         Ok(AgentListEntry {
             identity: AgentIdentityView::from_record(identity, &self.config().default_agent_id),
             lifecycle: AgentLifecycleHint::from_status(&agent.id, agent.status.clone()),
             status: agent.status,
+            scheduling_posture,
             pending: agent.pending,
             current_run_id: agent.current_run_id,
             waiting_reason,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -361,6 +361,7 @@ impl RuntimeHandle {
         let agent = self.agent_state().await?;
         let active_task_count = self.inner.storage.active_task_count_for_agent(&agent.id)?;
         let model = self.model_state_for(&agent);
+        let scheduling_posture = self.inner.storage.agent_posture_projection(&agent)?;
         let closure = self.current_closure_decision().await?;
         let execution = self.execution_snapshot().await?;
         let loaded_agents_md = self.loaded_agents_md().await?;
@@ -396,6 +397,7 @@ impl RuntimeHandle {
                 agent.status.clone(),
             ),
             agent,
+            scheduling_posture,
             active_task_count,
             model,
             token_usage,
@@ -417,6 +419,7 @@ impl RuntimeHandle {
     pub async fn agent_list_entry(&self) -> Result<AgentListEntry> {
         let agent = self.agent_state().await?;
         let model = self.model_state_for(&agent);
+        let scheduling_posture = self.inner.storage.agent_posture_projection(&agent)?;
         let identity = self.agent_identity_view().await?;
         let waiting_reason = super::lightweight_agent_list_waiting_reason(&agent);
         Ok(AgentListEntry {
@@ -426,6 +429,7 @@ impl RuntimeHandle {
                 agent.status.clone(),
             ),
             status: agent.status,
+            scheduling_posture,
             pending: agent.pending,
             current_run_id: agent.current_run_id,
             waiting_reason,

--- a/src/runtime/tests/tui_pipeline_e2e.rs
+++ b/src/runtime/tests/tui_pipeline_e2e.rs
@@ -40,6 +40,7 @@ fn minimal_agent_summary(agent_id: &str) -> AgentSummary {
         agent: state,
         active_task_count: 0,
         lifecycle: AgentLifecycleHint::default(),
+        scheduling_posture: Default::default(),
         model: AgentModelState {
             effective_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
             requested_model: None,

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -200,6 +200,7 @@ mod tests {
             agent: AgentState::new("default"),
             active_task_count: 0,
             lifecycle: AgentLifecycleHint::default(),
+            scheduling_posture: Default::default(),
             model: AgentModelState {
                 source: AgentModelSource::RuntimeDefault,
                 runtime_default_model: ModelRef::new(ProviderId::openai(), "gpt-5.4"),

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -2777,6 +2777,7 @@ mod tests {
             agent: state,
             active_task_count: 0,
             lifecycle: AgentLifecycleHint::default(),
+            scheduling_posture: Default::default(),
             model: AgentModelState {
                 effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
                     .unwrap(),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1083,6 +1083,7 @@ mod tests {
             agent: state,
             active_task_count: 0,
             lifecycle: AgentLifecycleHint::default(),
+            scheduling_posture: Default::default(),
             model: AgentModelState {
                 effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6")
                     .unwrap(),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -164,6 +164,7 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
         agent: state,
         active_task_count: 0,
         lifecycle: AgentLifecycleHint::default(),
+        scheduling_posture: Default::default(),
         model: AgentModelState {
             effective_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
             requested_model: Some(

--- a/src/types.rs
+++ b/src/types.rs
@@ -3027,6 +3027,19 @@ pub struct AgentPostureProjection {
     pub run_id: Option<String>,
 }
 
+impl Default for AgentPostureProjection {
+    fn default() -> Self {
+        Self {
+            posture: AgentSchedulingPosture::Idle,
+            reason: "posture projection unavailable".into(),
+            work_item_id: None,
+            waiting_intent_id: None,
+            task_id: None,
+            run_id: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkItemPlanArtifact {
     pub path: PathBuf,
@@ -3611,6 +3624,8 @@ pub struct AgentSummary {
     pub identity: AgentIdentityView,
     pub agent: AgentState,
     #[serde(default)]
+    pub scheduling_posture: AgentPostureProjection,
+    #[serde(default)]
     pub active_task_count: usize,
     #[serde(default)]
     pub lifecycle: AgentLifecycleHint,
@@ -3692,6 +3707,8 @@ pub struct AgentListEntry {
     pub identity: AgentIdentityView,
     pub status: AgentStatus,
     #[serde(default)]
+    pub scheduling_posture: AgentPostureProjection,
+    #[serde(default)]
     pub lifecycle: AgentLifecycleHint,
     #[serde(default)]
     pub pending: usize,
@@ -3709,6 +3726,7 @@ impl AgentListEntry {
         Self {
             identity: summary.identity.clone(),
             status: summary.agent.status.clone(),
+            scheduling_posture: summary.scheduling_posture.clone(),
             lifecycle: summary.lifecycle.clone(),
             pending: summary.agent.pending,
             current_run_id: summary.agent.current_run_id.clone(),
@@ -3780,6 +3798,7 @@ impl AgentListEntry {
         AgentSummary {
             identity: self.identity,
             lifecycle: self.lifecycle,
+            scheduling_posture: self.scheduling_posture,
             model: self.model.into_model_state(),
             token_usage: AgentTokenUsageSummary {
                 total: TokenUsage::new(0, 0),

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -112,6 +112,8 @@ pub async fn agent_list_entries_are_slim_for_tui_bootstrap() -> Result<()> {
         .expect("agent list should contain default agent");
     assert_eq!(entry["identity"]["agent_id"], "default");
     assert!(entry.get("status").is_some());
+    assert_eq!(entry["scheduling_posture"]["posture"], "idle");
+    assert!(entry["scheduling_posture"]["reason"].is_string());
     assert!(entry.get("model").is_some());
     assert!(
         entry.get("model_availability").is_none(),

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -89,6 +89,11 @@ pub async fn agent_state_route_returns_aggregated_snapshot() -> Result<()> {
         .await?;
 
     assert!(state_payload["agent"].is_object());
+    assert_eq!(
+        state_payload["agent"]["scheduling_posture"]["posture"],
+        "idle"
+    );
+    assert!(state_payload["agent"]["scheduling_posture"]["reason"].is_string());
     assert!(state_payload["session"].is_object());
     assert!(state_payload["tasks"].is_array());
     assert!(state_payload.get("transcript_tail").is_none());


### PR DESCRIPTION
## Summary

Fixes #1320.

- Add `scheduling_posture` to `AgentSummary` and `AgentListEntry` while preserving legacy `status` and `waiting_reason` fields.
- Populate the new field from the shared agent posture projection in runtime summary/list assembly and host agent list assembly.
- Cover the HTTP/control-plane contract so `/agents/list` and `/agents/:id/state` expose posture data.

## Verification

- `cargo fmt --all -- --check`
- `cargo test agent_posture_projection -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
