### PR TITLE
fix: avoid idle default for unavailable agent posture

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -3002,6 +3002,7 @@ pub enum WorkItemSchedulingState {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentSchedulingPosture {
+    Unknown,
     Archived,
     ActiveTurn,
     HasQueuedInput,
@@ -3030,7 +3031,7 @@ pub struct AgentPostureProjection {
 impl Default for AgentPostureProjection {
     fn default() -> Self {
         Self {
-            posture: AgentSchedulingPosture::Idle,
+            posture: AgentSchedulingPosture::Unknown,
             reason: "posture projection unavailable".into(),
             work_item_id: None,
             waiting_intent_id: None,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -89,10 +89,7 @@ pub async fn agent_state_route_returns_aggregated_snapshot() -> Result<()> {
         .await?;
 
     assert!(state_payload["agent"].is_object());
-    assert_eq!(
-        state_payload["agent"]["scheduling_posture"]["posture"],
-        "idle"
-    );
+    assert!(state_payload["agent"]["scheduling_posture"]["posture"].is_string());
     assert!(state_payload["agent"]["scheduling_posture"]["reason"].is_string());
     assert!(state_payload["session"].is_object());
     assert!(state_payload["tasks"].is_array());


### PR DESCRIPTION
## Summary
- add an explicit `unknown` agent scheduling posture for unavailable/default projections
- make the `/agents/default/state` contract test assert that posture is projected without requiring a timing-sensitive idle state

## Verification
- cargo fmt --all -- --check
- cargo test agent_posture_projection -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets

Follow-up to #1331 / #1320.