### PR TITLE
fix: converge scheduler on posture facts

### DIFF
--- a/src/runtime/closure.rs
+++ b/src/runtime/closure.rs
@@ -74,36 +74,6 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
         };
     }
 
-    if facts.awaiting_operator_input {
-        return ClosureDecision {
-            outcome: ClosureOutcome::Waiting,
-            waiting_reason: Some(WaitingReason::AwaitingOperatorInput),
-            work_signal: None,
-            runtime_posture,
-            evidence,
-        };
-    }
-
-    if facts.active_agent_waiting_intents > 0 {
-        return ClosureDecision {
-            outcome: ClosureOutcome::Waiting,
-            waiting_reason: Some(WaitingReason::AwaitingExternalChange),
-            work_signal: None,
-            runtime_posture,
-            evidence,
-        };
-    }
-
-    if facts.active_timers > 0 {
-        return ClosureDecision {
-            outcome: ClosureOutcome::Waiting,
-            waiting_reason: Some(WaitingReason::AwaitingTimer),
-            work_signal: None,
-            runtime_posture,
-            evidence,
-        };
-    }
-
     if facts.turn_in_progress {
         evidence.push("turn_in_progress".to_string());
         return ClosureDecision {
@@ -154,6 +124,36 @@ pub(super) fn derive_closure_decision(facts: &ClosureFacts) -> ClosureDecision {
             outcome: ClosureOutcome::Continuable,
             waiting_reason: None,
             work_signal: Some(work_signal),
+            runtime_posture,
+            evidence,
+        };
+    }
+
+    if facts.awaiting_operator_input {
+        return ClosureDecision {
+            outcome: ClosureOutcome::Waiting,
+            waiting_reason: Some(WaitingReason::AwaitingOperatorInput),
+            work_signal: None,
+            runtime_posture,
+            evidence,
+        };
+    }
+
+    if facts.active_agent_waiting_intents > 0 {
+        return ClosureDecision {
+            outcome: ClosureOutcome::Waiting,
+            waiting_reason: Some(WaitingReason::AwaitingExternalChange),
+            work_signal: None,
+            runtime_posture,
+            evidence,
+        };
+    }
+
+    if facts.active_timers > 0 {
+        return ClosureDecision {
+            outcome: ClosureOutcome::Waiting,
+            waiting_reason: Some(WaitingReason::AwaitingTimer),
+            work_signal: None,
             runtime_posture,
             evidence,
         };
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn waiting_conditions_override_runnable_work() {
+    fn runnable_work_overrides_unrelated_agent_waiting_intent() {
         let decision = derive_closure_decision(&ClosureFacts {
             active_waiting_intents: 1,
             active_agent_waiting_intents: 1,
@@ -421,12 +421,15 @@ mod tests {
             ..facts()
         });
 
-        assert_eq!(decision.outcome, ClosureOutcome::Waiting);
+        assert_eq!(decision.outcome, ClosureOutcome::Continuable);
+        assert_eq!(decision.waiting_reason, None);
         assert_eq!(
-            decision.waiting_reason,
-            Some(WaitingReason::AwaitingExternalChange)
+            decision
+                .work_signal
+                .as_ref()
+                .map(|signal| signal.work_item_id.as_str()),
+            Some("work-1")
         );
-        assert_eq!(decision.work_signal, None);
     }
 
     #[test]

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -157,9 +157,7 @@ impl RuntimeHandle {
         let runtime_error = runtime_error_override.unwrap_or(projection.runtime_error);
         Ok(derive_closure_decision(&ClosureFacts {
             runtime_error,
-            awaiting_operator_input: super::memory_refresh::work_queue_waits_for_operator(
-                &work_queue_projection,
-            ),
+            awaiting_operator_input: projection.current_work_item_waits_for_operator(),
             active_blocking_tasks: projection
                 .active_tasks
                 .iter()
@@ -169,9 +167,7 @@ impl RuntimeHandle {
             active_agent_waiting_intents: projection.active_agent_waiting_intents,
             active_timers: projection.active_timers,
             current_work_item_scheduling_state: projection.current_work_item_scheduling_state,
-            work_signal: super::memory_refresh::work_queue_reactivation_signal(
-                &work_queue_projection,
-            ),
+            work_signal: projection.work_reactivation_signal(),
             turn_started: state.turn_index > 0,
             turn_in_progress: state.current_run_id.is_some(),
             turn_terminal_kind: state

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::path::{Path, PathBuf};
 
-use crate::runtime::closure::{derive_closure_decision, runtime_error_active, ClosureFacts};
+use crate::runtime::closure::{derive_closure_decision, ClosureFacts};
 use crate::storage::AppStorage;
 use crate::types::{
     AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
@@ -152,7 +152,7 @@ impl RuntimeHandle {
         let projection = scheduler::SchedulerProjection::from_state_with_work_queue(
             &self.inner.storage,
             state,
-            work_queue_projection.clone(),
+            work_queue_projection,
         )?;
         let runtime_error = runtime_error_override.unwrap_or(projection.runtime_error);
         Ok(derive_closure_decision(&ClosureFacts {
@@ -475,48 +475,17 @@ impl RuntimeHandle {
         storage: &AppStorage,
         state: &AgentState,
     ) -> Result<ChildAgentObservabilitySnapshot> {
-        let latest_tasks = storage.latest_task_records()?;
-        let active_tasks = active_child_tasks(&state.id, &latest_tasks);
-        let active_waiting_intent_count = storage
-            .latest_waiting_intents()?
-            .into_iter()
-            .filter(|record| record.agent_id == state.id)
-            .filter(|record| record.status == WaitingIntentStatus::Active)
-            .filter(|record| record.scope == ExternalTriggerScope::WorkItem)
-            .count();
-        let active_timers = storage
-            .latest_timer_records()?
-            .into_iter()
-            .filter(|timer| timer.agent_id == state.id)
-            .filter(|timer| timer.status == TimerStatus::Active)
-            .count();
-        let work_queue_projection = storage.work_queue_prompt_projection()?;
+        let projection = scheduler::SchedulerProjection::from_state(storage, state)?;
+        let active_tasks = projection.active_tasks.iter().collect::<Vec<_>>();
         let closure = derive_closure_decision(&ClosureFacts {
-            runtime_error: runtime_error_active(
-                &storage.read_recent_events(64)?,
-                &storage.read_recent_briefs(64)?,
-            ),
-            awaiting_operator_input: super::memory_refresh::work_queue_waits_for_operator(
-                &work_queue_projection,
-            ),
+            runtime_error: projection.runtime_error,
+            awaiting_operator_input: projection.current_work_item_waits_for_operator(),
             active_blocking_tasks: blocking_task_count(&active_tasks),
-            active_waiting_intents: active_waiting_intent_count,
-            active_agent_waiting_intents: storage
-                .latest_waiting_intents()?
-                .into_iter()
-                .filter(|record| record.agent_id == state.id)
-                .filter(|record| record.status == WaitingIntentStatus::Active)
-                .filter(|record| record.scope == ExternalTriggerScope::Agent)
-                .count(),
-            active_timers,
-            current_work_item_scheduling_state: work_queue_projection
-                .readiness
-                .iter()
-                .find(|item| item.is_current)
-                .map(|item| item.scheduling_state),
-            work_signal: super::memory_refresh::work_queue_reactivation_signal(
-                &work_queue_projection,
-            ),
+            active_waiting_intents: projection.active_waiting_intents,
+            active_agent_waiting_intents: projection.active_agent_waiting_intents,
+            active_timers: projection.active_timers,
+            current_work_item_scheduling_state: projection.current_work_item_scheduling_state,
+            work_signal: projection.work_reactivation_signal(),
             turn_started: state.turn_index > 0,
             turn_in_progress: state.current_run_id.is_some(),
             turn_terminal_kind: state
@@ -534,7 +503,7 @@ impl RuntimeHandle {
         Ok(build_child_agent_observability_with_active_tasks(
             state,
             closure.waiting_reason,
-            active_waiting_intent_count,
+            projection.active_work_item_waiting_intents,
             &active_tasks,
             &briefs,
         ))

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     storage::WorkQueuePromptProjection,
-    types::{BriefKind, TaskStatus, TodoItemState, WorkReactivationMode, WorkReactivationSignal},
+    types::{BriefKind, TaskStatus, TodoItemState},
 };
 
 const CONTINUE_ACTIVE_SIGNAL_SCAN_LIMIT: usize = 512;
@@ -12,34 +12,6 @@ enum IdleTickTrigger {
     WorkQueueQueued(crate::types::WorkItemRecord),
     BlockedRecheck(Vec<crate::types::WorkItemRecord>),
     WakeHint(PendingWakeHint),
-}
-
-pub(super) fn work_queue_reactivation_signal(
-    projection: &WorkQueuePromptProjection,
-) -> Option<WorkReactivationSignal> {
-    if let Some(current) = projection.current_runnable.as_ref() {
-        return Some(WorkReactivationSignal {
-            work_item_id: current.work_item.id.clone(),
-            state: current.work_item.state.clone(),
-            reactivation_mode: WorkReactivationMode::ContinueActive,
-        });
-    }
-    projection
-        .queued_runnable
-        .iter()
-        .next()
-        .map(|queued| WorkReactivationSignal {
-            work_item_id: queued.work_item.id.clone(),
-            state: queued.work_item.state.clone(),
-            reactivation_mode: WorkReactivationMode::ActivateQueued,
-        })
-}
-
-pub(super) fn work_queue_waits_for_operator(projection: &WorkQueuePromptProjection) -> bool {
-    projection
-        .current
-        .as_ref()
-        .is_some_and(|item| item.is_waiting_for_operator())
 }
 
 fn idle_tick_trigger_from_state(

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -4,7 +4,7 @@ use crate::storage::{AppStorage, WorkQueuePromptProjection};
 use crate::types::{
     AgentStatus, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint, Priority,
     TaskRecord, TaskStatus, TimerStatus, TrustLevel, TurnTerminalKind, WaitingIntentStatus,
-    WorkItemRecord, WorkItemSchedulingState,
+    WorkItemRecord, WorkItemSchedulingState, WorkReactivationMode, WorkReactivationSignal,
 };
 use chrono::{DateTime, Utc};
 
@@ -154,6 +154,32 @@ impl SchedulerProjection {
                 &storage.read_recent_briefs(64)?,
             ),
         })
+    }
+
+    pub(crate) fn work_reactivation_signal(&self) -> Option<WorkReactivationSignal> {
+        self.current_work_item
+            .as_ref()
+            .filter(|_| {
+                self.current_work_item_scheduling_state == Some(WorkItemSchedulingState::Runnable)
+            })
+            .map(|item| WorkReactivationSignal {
+                work_item_id: item.id.clone(),
+                state: item.state.clone(),
+                reactivation_mode: WorkReactivationMode::ContinueActive,
+            })
+            .or_else(|| {
+                self.queued_runnable_work_items
+                    .first()
+                    .map(|item| WorkReactivationSignal {
+                        work_item_id: item.id.clone(),
+                        state: item.state.clone(),
+                        reactivation_mode: WorkReactivationMode::ActivateQueued,
+                    })
+            })
+    }
+
+    pub(crate) fn current_work_item_waits_for_operator(&self) -> bool {
+        self.current_work_item_scheduling_state == Some(WorkItemSchedulingState::WaitingOperator)
     }
 }
 
@@ -545,6 +571,9 @@ pub(crate) fn idle_noop_decision(projection: &SchedulerProjection) -> SchedulerD
 pub(crate) fn wait_decision_for_projection(
     projection: &SchedulerProjection,
 ) -> Option<SchedulerDecision> {
+    if projection.work_reactivation_signal().is_some() {
+        return None;
+    }
     if projection.active_agent_waiting_intents > 0 {
         return Some(
             SchedulerDecision::new(

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1,6 +1,8 @@
 use super::super::*;
 use super::support::*;
-use crate::types::{ToolExecutionStatus, WorkItemPlanStatus};
+use crate::types::{
+    ToolExecutionStatus, WorkItemPlanStatus, WorkItemSchedulingState, WorkReactivationMode,
+};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -764,18 +766,24 @@ fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts()
     assert_eq!(wake_decision.reason, "wake_hint");
 
     storage
-        .append_task(&TaskRecord {
-            id: "blocking-task".into(),
+        .append_waiting_intent(&WaitingIntentRecord {
+            id: "wait-current".into(),
             agent_id: "default".into(),
-            kind: TaskKind::CommandTask,
-            status: TaskStatus::Running,
+            scope: ExternalTriggerScope::Agent,
+            work_item_id: None,
+            description: "unrelated wait".into(),
+            source: "test".into(),
+            resource: None,
+            condition: None,
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: "trigger-wait-current".into(),
             created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id: Some("work-1".into()),
-            summary: Some("fixture task".into()),
-            detail: Some(serde_json::json!({ "wait_policy": "blocking" })),
-            recovery: None,
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
         })
         .unwrap();
     let blocked_projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
@@ -788,12 +796,109 @@ fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts()
             duplicate: None,
         }),
     );
-    assert!(blocked_projection.has_blocking_active_tasks);
+    assert_eq!(blocked_projection.active_agent_waiting_intents, 1);
     assert_eq!(
         work_queue_decision.kind,
         scheduler::SchedulerDecisionKind::EmitSystemTick
     );
     assert_eq!(work_queue_decision.reason, "continue_active");
+}
+
+#[test]
+fn queued_runnable_work_is_not_suppressed_by_unrelated_agent_waiting_intent() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let now = Utc::now();
+
+    let mut work_item = WorkItemRecord::new("default", "queued work", WorkItemState::Open);
+    work_item.id = "work-queued".into();
+    work_item.revision = 4;
+    storage.append_work_item(&work_item).unwrap();
+    storage
+        .append_waiting_intent(&WaitingIntentRecord {
+            id: "agent-wait".into(),
+            agent_id: "default".into(),
+            scope: ExternalTriggerScope::Agent,
+            work_item_id: None,
+            description: "unrelated external wait".into(),
+            source: "github".into(),
+            resource: None,
+            condition: None,
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: "trigger-agent-wait".into(),
+            created_at: now,
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
+        })
+        .unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    assert_eq!(projection.active_agent_waiting_intents, 1);
+    assert_eq!(
+        projection
+            .work_reactivation_signal()
+            .as_ref()
+            .map(|signal| { (signal.work_item_id.as_str(), signal.reactivation_mode,) }),
+        Some(("work-queued", WorkReactivationMode::ActivateQueued))
+    );
+
+    let decision = scheduler::decide_next_action(
+        &projection,
+        scheduler::SchedulerBoundary::IdleTick,
+        scheduler::SchedulerInput::IdleSignal(scheduler::SchedulerIdleSignal::QueuedAvailable {
+            work_item: &work_item,
+            duplicate: None,
+        }),
+    );
+
+    assert_eq!(
+        decision.kind,
+        scheduler::SchedulerDecisionKind::EmitSystemTick
+    );
+    assert_eq!(decision.reason, "queued_available");
+}
+
+#[test]
+fn background_work_item_task_does_not_block_runnable_work() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.current_work_item_id = Some("work-background".into());
+    storage.write_agent(&agent).unwrap();
+    let now = Utc::now();
+
+    let mut work_item = WorkItemRecord::new("default", "runnable work", WorkItemState::Open);
+    work_item.id = "work-background".into();
+    storage.append_work_item(&work_item).unwrap();
+    storage
+        .append_task(&TaskRecord {
+            id: "background-task".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: Some(work_item.id.clone()),
+            summary: Some("background task".into()),
+            detail: Some(serde_json::json!({ "wait_policy": "background" })),
+            recovery: None,
+        })
+        .unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    assert!(!projection.has_blocking_active_tasks);
+    assert_eq!(
+        projection.current_work_item_scheduling_state,
+        Some(WorkItemSchedulingState::Runnable)
+    );
+    assert!(scheduler::wait_decision_for_projection(&projection).is_none());
 }
 
 #[test]


### PR DESCRIPTION
Closes #1322.

## Summary
- derive scheduler work reactivation from the shared SchedulerProjection posture facts
- let closure prefer runnable current/queued work before unrelated agent waiting intents or timers
- replace lifecycle closure inputs with projection helpers and add scheduler regressions for unrelated waits/background tasks

## Verification
- cargo test scheduler -- --nocapture
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets