### PR TITLE
fix: add scheduler consistency diagnostics

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -248,11 +248,20 @@ impl SchedulerDiagnosticSeverity {
 /// Diagnostics are advisory observability signals only. They must not be used as
 /// scheduler decisions or as a replacement for the posture/work-item state
 /// derivation itself.
+#[cfg(test)]
 pub(crate) fn scheduling_diagnostics(
     storage: &AppStorage,
     agent: &AgentState,
 ) -> Result<Vec<SchedulerDiagnostic>> {
-    let projection = SchedulerProjection::from_state(storage, agent)?;
+    scheduling_diagnostics_with_queue_len(storage, agent, agent.pending)
+}
+
+pub(crate) fn scheduling_diagnostics_with_queue_len(
+    storage: &AppStorage,
+    agent: &AgentState,
+    queue_len: usize,
+) -> Result<Vec<SchedulerDiagnostic>> {
+    let projection = SchedulerProjection::from_state_with_queue_len(storage, agent, queue_len)?;
     let posture = storage.agent_posture_projection(agent)?;
     let work_queue = storage.work_queue_prompt_projection()?;
     let wait_conditions = storage.latest_wait_conditions()?;
@@ -394,18 +403,23 @@ pub(crate) fn scheduler_diagnostic_event(diagnostic: &SchedulerDiagnostic) -> Au
 pub(crate) fn append_scheduling_diagnostics(
     storage: &AppStorage,
     agent: &AgentState,
+    queue_len: usize,
 ) -> Result<usize> {
-    let diagnostics = scheduling_diagnostics(storage, agent)?;
+    let diagnostics = scheduling_diagnostics_with_queue_len(storage, agent, queue_len)?;
     let recent_events = storage.read_recent_events(64)?;
+    let mut seen_data = Vec::new();
     let mut appended = 0;
 
     for diagnostic in diagnostics {
         let event = scheduler_diagnostic_event(&diagnostic);
+        if seen_data.iter().any(|data| data == &event.data) {
+            continue;
+        }
+        seen_data.push(event.data.clone());
+
         let duplicate = recent_events
             .iter()
-            .rev()
-            .find(|latest| latest.kind == event.kind)
-            .is_some_and(|latest| latest.data == event.data);
+            .any(|latest| latest.kind == event.kind && latest.data == event.data);
         if duplicate {
             continue;
         }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -2,9 +2,11 @@ use super::*;
 use crate::runtime::closure::runtime_error_active;
 use crate::storage::{AppStorage, WorkQueuePromptProjection};
 use crate::types::{
-    AgentStatus, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint, Priority,
-    TaskRecord, TaskStatus, TimerStatus, TrustLevel, TurnTerminalKind, WaitingIntentStatus,
-    WorkItemRecord, WorkItemSchedulingState, WorkReactivationMode, WorkReactivationSignal,
+    AgentPostureProjection, AgentSchedulingPosture, AgentStatus, ExternalWaitRecoverability,
+    MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint, Priority, TaskRecord, TaskStatus,
+    TimerStatus, TrustLevel, TurnTerminalKind, WaitConditionRecord, WaitConditionStatus,
+    WaitingIntentRecord, WaitingIntentStatus, WorkItemRecord, WorkItemSchedulingState,
+    WorkReactivationMode, WorkReactivationSignal,
 };
 use chrono::{DateTime, Utc};
 
@@ -180,6 +182,248 @@ impl SchedulerProjection {
 
     pub(crate) fn current_work_item_waits_for_operator(&self) -> bool {
         self.current_work_item_scheduling_state == Some(WorkItemSchedulingState::WaitingOperator)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SchedulerDiagnostic {
+    pub kind: String,
+    pub severity: SchedulerDiagnosticSeverity,
+    pub message: String,
+    pub work_item_id: Option<String>,
+    pub waiting_intent_id: Option<String>,
+    pub wait_condition_id: Option<String>,
+    pub evidence: Vec<String>,
+}
+
+impl SchedulerDiagnostic {
+    fn warning(kind: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            severity: SchedulerDiagnosticSeverity::Warning,
+            message: message.into(),
+            work_item_id: None,
+            waiting_intent_id: None,
+            wait_condition_id: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    fn work_item_id(mut self, work_item_id: impl Into<String>) -> Self {
+        self.work_item_id = Some(work_item_id.into());
+        self
+    }
+
+    fn waiting_intent_id(mut self, waiting_intent_id: impl Into<String>) -> Self {
+        self.waiting_intent_id = Some(waiting_intent_id.into());
+        self
+    }
+
+    fn wait_condition_id(mut self, wait_condition_id: impl Into<String>) -> Self {
+        self.wait_condition_id = Some(wait_condition_id.into());
+        self
+    }
+
+    fn evidence(mut self, evidence: impl Into<String>) -> Self {
+        self.evidence.push(evidence.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchedulerDiagnosticSeverity {
+    Warning,
+}
+
+impl SchedulerDiagnosticSeverity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Warning => "warning",
+        }
+    }
+}
+
+/// Derive evidence-based scheduler diagnostics from authoritative runtime facts.
+///
+/// Diagnostics are advisory observability signals only. They must not be used as
+/// scheduler decisions or as a replacement for the posture/work-item state
+/// derivation itself.
+pub(crate) fn scheduling_diagnostics(
+    storage: &AppStorage,
+    agent: &AgentState,
+) -> Result<Vec<SchedulerDiagnostic>> {
+    let projection = SchedulerProjection::from_state(storage, agent)?;
+    let posture = storage.agent_posture_projection(agent)?;
+    let work_queue = storage.work_queue_prompt_projection()?;
+    let wait_conditions = storage.latest_wait_conditions()?;
+    let waiting_intents = storage.latest_waiting_intents()?;
+
+    Ok(scheduling_diagnostics_for_facts(
+        agent,
+        &projection,
+        &posture,
+        &work_queue,
+        &wait_conditions,
+        &waiting_intents,
+    ))
+}
+
+pub(crate) fn scheduling_diagnostics_for_facts(
+    agent: &AgentState,
+    projection: &SchedulerProjection,
+    posture: &AgentPostureProjection,
+    work_queue: &WorkQueuePromptProjection,
+    wait_conditions: &[WaitConditionRecord],
+    waiting_intents: &[WaitingIntentRecord],
+) -> Vec<SchedulerDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    if posture.posture == AgentSchedulingPosture::Idle {
+        if let Some(signal) = projection.work_reactivation_signal() {
+            diagnostics.push(
+                SchedulerDiagnostic::warning(
+                    "idle_posture_has_runnable_work",
+                    "agent posture is idle while scheduler facts contain runnable work",
+                )
+                .work_item_id(signal.work_item_id)
+                .evidence("posture=Idle")
+                .evidence(format!("reactivation_mode={:?}", signal.reactivation_mode)),
+            );
+        } else if projection.queue_len > 0 {
+            diagnostics.push(
+                SchedulerDiagnostic::warning(
+                    "idle_posture_has_queued_input",
+                    "agent posture is idle while scheduler facts contain queued input",
+                )
+                .evidence("posture=Idle")
+                .evidence(format!("queue_len={}", projection.queue_len)),
+            );
+        }
+    }
+
+    for condition in wait_conditions.iter().filter(|condition| {
+        condition.agent_id == agent.id && condition.status == WaitConditionStatus::Active
+    }) {
+        match condition.external_recoverability() {
+            Some(ExternalWaitRecoverability::Weak) => {
+                diagnostics.push(
+                    SchedulerDiagnostic::warning(
+                        "external_wait_has_weak_recoverability",
+                        "active external wait lacks a durable recovery path",
+                    )
+                    .wait_condition_id(condition.id.clone())
+                    .maybe_work_item_id(condition.work_item_id.clone())
+                    .evidence("external_recoverability=Weak")
+                    .evidence(format!("wake_sources={:?}", condition.wake_sources)),
+                );
+            }
+            Some(ExternalWaitRecoverability::ExplicitNoFallback) => {
+                let mut diagnostic = SchedulerDiagnostic::warning(
+                    "external_wait_has_no_fallback",
+                    "active external wait explicitly has no fallback recovery path",
+                )
+                .wait_condition_id(condition.id.clone())
+                .maybe_work_item_id(condition.work_item_id.clone())
+                .evidence("external_recoverability=ExplicitNoFallback")
+                .evidence(format!("wake_sources={:?}", condition.wake_sources));
+                if let Some(reason) = condition.no_fallback_reason() {
+                    diagnostic = diagnostic.evidence(format!("no_fallback_reason={reason}"));
+                }
+                diagnostics.push(diagnostic);
+            }
+            Some(ExternalWaitRecoverability::Recoverable) | None => {}
+        }
+    }
+
+    for item in work_queue.readiness.iter().filter(|item| {
+        item.scheduling_state == WorkItemSchedulingState::Blocked
+            && item.work_item.agent_id == agent.id
+            && item.work_item.blocked_by.is_some()
+            && item.work_item.recheck_at.is_none()
+            && !item.has_active_waits
+            && !item.has_active_task_waits
+    }) {
+        diagnostics.push(
+            SchedulerDiagnostic::warning(
+                "blocked_work_item_without_recheck_or_wait",
+                "blocked WorkItem has no recheck deadline or active wait condition",
+            )
+            .work_item_id(item.work_item.id.clone())
+            .evidence("scheduling_state=Blocked")
+            .evidence("blocked_by_present=true")
+            .evidence("recheck_at=None")
+            .evidence("has_active_waits=false"),
+        );
+    }
+
+    for intent in waiting_intents.iter().filter(|intent| {
+        intent.agent_id == agent.id
+            && intent.status == WaitingIntentStatus::Active
+            && intent.external_trigger_id.trim().is_empty()
+    }) {
+        diagnostics.push(
+            SchedulerDiagnostic::warning(
+                "waiting_intent_without_external_trigger",
+                "active waiting intent has no external trigger id",
+            )
+            .waiting_intent_id(intent.id.clone())
+            .maybe_work_item_id(intent.work_item_id.clone())
+            .evidence(format!("scope={:?}", intent.scope))
+            .evidence("external_trigger_id_empty=true"),
+        );
+    }
+
+    diagnostics
+}
+
+pub(crate) fn scheduler_diagnostic_event(diagnostic: &SchedulerDiagnostic) -> AuditEvent {
+    AuditEvent::new(
+        "scheduler_diagnostic",
+        serde_json::json!({
+            "kind": &diagnostic.kind,
+            "severity": diagnostic.severity.as_str(),
+            "message": &diagnostic.message,
+            "work_item_id": &diagnostic.work_item_id,
+            "waiting_intent_id": &diagnostic.waiting_intent_id,
+            "wait_condition_id": &diagnostic.wait_condition_id,
+            "evidence": &diagnostic.evidence,
+        }),
+    )
+}
+
+pub(crate) fn append_scheduling_diagnostics(
+    storage: &AppStorage,
+    agent: &AgentState,
+) -> Result<usize> {
+    let diagnostics = scheduling_diagnostics(storage, agent)?;
+    let recent_events = storage.read_recent_events(64)?;
+    let mut appended = 0;
+
+    for diagnostic in diagnostics {
+        let event = scheduler_diagnostic_event(&diagnostic);
+        let duplicate = recent_events
+            .iter()
+            .rev()
+            .find(|latest| latest.kind == event.kind)
+            .is_some_and(|latest| latest.data == event.data);
+        if duplicate {
+            continue;
+        }
+        storage.append_event(&event)?;
+        appended += 1;
+    }
+
+    Ok(appended)
+}
+
+trait SchedulerDiagnosticExt {
+    fn maybe_work_item_id(self, work_item_id: Option<String>) -> Self;
+}
+
+impl SchedulerDiagnosticExt for SchedulerDiagnostic {
+    fn maybe_work_item_id(mut self, work_item_id: Option<String>) -> Self {
+        self.work_item_id = work_item_id;
+        self
     }
 }
 

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -336,6 +336,11 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 continuation_resolution: dispatch_plan.continuation_resolution.as_ref(),
             },
         );
+        scheduler::append_scheduling_diagnostics(
+            &self.runtime.inner.storage,
+            &candidate.prior_state,
+            candidate.queue_len,
+        )?;
 
         let (message, running_state) = {
             let mut guard = self.runtime.inner.agent.lock().await;
@@ -360,7 +365,6 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 return Ok(RunLoopPoll::Idle);
             }
 
-            scheduler::append_scheduling_diagnostics(&self.runtime.inner.storage, &guard.state)?;
             scheduler::append_scheduler_decision(&self.runtime.inner.storage, &decision)?;
             let message = guard
                 .queue

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -360,6 +360,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 return Ok(RunLoopPoll::Idle);
             }
 
+            scheduler::append_scheduling_diagnostics(&self.runtime.inner.storage, &guard.state)?;
             scheduler::append_scheduler_decision(&self.runtime.inner.storage, &decision)?;
             let message = guard
                 .queue

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -1,7 +1,9 @@
 use super::super::*;
 use super::support::*;
 use crate::types::{
-    ToolExecutionStatus, WorkItemPlanStatus, WorkItemSchedulingState, WorkReactivationMode,
+    AgentPostureProjection, AgentSchedulingPosture, ToolExecutionStatus, WaitConditionKind,
+    WaitConditionRecord, WaitConditionStatus, WakeSource, WorkItemPlanStatus,
+    WorkItemSchedulingState, WorkReactivationMode,
 };
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -899,6 +901,148 @@ fn background_work_item_task_does_not_block_runnable_work() {
         Some(WorkItemSchedulingState::Runnable)
     );
     assert!(scheduler::wait_decision_for_projection(&projection).is_none());
+}
+
+#[test]
+fn scheduling_diagnostics_detect_idle_posture_with_runnable_work() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    let work_item = WorkItemRecord::new("default", "runnable work", WorkItemState::Open);
+    agent.current_work_item_id = Some(work_item.id.clone());
+    storage.write_agent(&agent).unwrap();
+    storage.append_work_item(&work_item).unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let work_queue = storage.work_queue_prompt_projection().unwrap();
+    let posture = AgentPostureProjection {
+        posture: AgentSchedulingPosture::Idle,
+        reason: "fixture intentionally stale posture".into(),
+        work_item_id: None,
+        waiting_intent_id: None,
+        task_id: None,
+        run_id: None,
+    };
+
+    let diagnostics = scheduler::scheduling_diagnostics_for_facts(
+        &agent,
+        &projection,
+        &posture,
+        &work_queue,
+        &[],
+        &[],
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].kind, "idle_posture_has_runnable_work");
+    assert_eq!(
+        diagnostics[0].work_item_id.as_deref(),
+        Some(work_item.id.as_str())
+    );
+}
+
+#[test]
+fn scheduling_diagnostics_detect_weak_external_wait_and_unrecoverable_blocker() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let now = Utc::now();
+
+    let mut external = WorkItemRecord::new("default", "external wait", WorkItemState::Open);
+    external.blocked_by = Some("github".into());
+    storage.append_work_item(&external).unwrap();
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-weak".into(),
+            agent_id: "default".into(),
+            work_item_id: Some(external.id.clone()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pr-1".into()),
+            waiting_for: "merged".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-1".into()),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+        })
+        .unwrap();
+
+    let mut blocked = WorkItemRecord::new("default", "blocked", WorkItemState::Open);
+    blocked.blocked_by = Some("manual blocker".into());
+    storage.append_work_item(&blocked).unwrap();
+
+    let diagnostics = scheduler::scheduling_diagnostics(&storage, &agent).unwrap();
+    let kinds = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.kind.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(kinds.contains(&"external_wait_has_weak_recoverability"));
+    assert!(kinds.contains(&"blocked_work_item_without_recheck_or_wait"));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.kind == "external_wait_has_weak_recoverability"
+            && diagnostic.wait_condition_id.as_deref() == Some("wait-weak")
+            && diagnostic.work_item_id.as_deref() == Some(external.id.as_str())
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.kind == "blocked_work_item_without_recheck_or_wait"
+            && diagnostic.work_item_id.as_deref() == Some(blocked.id.as_str())
+    }));
+}
+
+#[test]
+fn scheduling_diagnostics_do_not_warn_for_common_legal_waits() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let now = Utc::now();
+
+    let mut external =
+        WorkItemRecord::new("default", "recoverable external wait", WorkItemState::Open);
+    external.blocked_by = Some("github".into());
+    storage.append_work_item(&external).unwrap();
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-recoverable".into(),
+            agent_id: "default".into(),
+            work_item_id: Some(external.id.clone()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pr-2".into()),
+            waiting_for: "checks".into(),
+            wake_sources: vec![WakeSource::Timer {
+                wake_at: now + chrono::Duration::hours(1),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+        })
+        .unwrap();
+
+    let mut blocked_with_recheck =
+        WorkItemRecord::new("default", "blocked with recheck", WorkItemState::Open);
+    blocked_with_recheck.blocked_by = Some("manual blocker".into());
+    blocked_with_recheck.recheck_at = Some(now + chrono::Duration::hours(1));
+    storage.append_work_item(&blocked_with_recheck).unwrap();
+
+    let diagnostics = scheduler::scheduling_diagnostics(&storage, &agent).unwrap();
+
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics for legal waits, got {diagnostics:?}"
+    );
 }
 
 #[test]

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -998,6 +998,24 @@ fn scheduling_diagnostics_detect_weak_external_wait_and_unrecoverable_blocker() 
 }
 
 #[test]
+fn scheduling_diagnostics_use_authoritative_queue_len() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+
+    let diagnostics =
+        scheduler::scheduling_diagnostics_with_queue_len(&storage, &agent, 1).unwrap();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].kind, "idle_posture_has_queued_input");
+    assert!(diagnostics[0]
+        .evidence
+        .iter()
+        .any(|entry| entry == "queue_len=1"));
+}
+
+#[test]
 fn scheduling_diagnostics_do_not_warn_for_common_legal_waits() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new(dir.path()).unwrap();
@@ -1043,6 +1061,75 @@ fn scheduling_diagnostics_do_not_warn_for_common_legal_waits() {
         diagnostics.is_empty(),
         "expected no diagnostics for legal waits, got {diagnostics:?}"
     );
+}
+
+#[test]
+fn scheduler_diagnostic_append_dedupes_interleaved_recent_events() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let agent = AgentState::new("default");
+    storage.write_agent(&agent).unwrap();
+    let now = Utc::now();
+
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-weak".into(),
+            agent_id: "default".into(),
+            work_item_id: None,
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pr-1".into()),
+            waiting_for: "review".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-1".into()),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+        })
+        .unwrap();
+    storage
+        .append_waiting_intent(&WaitingIntentRecord {
+            id: "intent-missing-trigger".into(),
+            agent_id: "default".into(),
+            scope: ExternalTriggerScope::Agent,
+            work_item_id: None,
+            description: "fixture waiting intent".into(),
+            source: "github".into(),
+            resource: Some("pr-1".into()),
+            condition: Some("review".into()),
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: "".into(),
+            created_at: now,
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
+        })
+        .unwrap();
+
+    let appended = scheduler::append_scheduling_diagnostics(&storage, &agent, 0).unwrap();
+    assert!(appended >= 2);
+    assert_eq!(
+        scheduler::append_scheduling_diagnostics(&storage, &agent, 0).unwrap(),
+        0
+    );
+
+    let events = storage.read_recent_events(10).unwrap();
+    let diagnostic_kinds = events
+        .iter()
+        .filter(|event| event.kind == "scheduler_diagnostic")
+        .map(|event| event.data["kind"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(diagnostic_kinds.len(), appended);
+    assert!(diagnostic_kinds.contains(&"external_wait_has_weak_recoverability"));
+    assert!(diagnostic_kinds.contains(&"waiting_intent_without_external_trigger"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add advisory scheduler diagnostics for stale idle posture with runnable scheduler facts
- surface weak/no-fallback external waits and blocked work items without rechecks or active waits
- append deduplicated scheduler_diagnostic audit events before scheduler decisions

Fixes #1323

## Verification
- cargo fmt --all -- --check
- cargo test scheduler -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets