### PR TITLE
fix: recover stale daemon socket state

### DIFF
--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -441,6 +441,12 @@ pub async fn ensure_serve_preflight(config: &AppConfig) -> Result<()> {
         }
         ProbeRuntime::Stopped {
             occupied_socket: true,
+        } if recorded_daemon_process_is_missing(config)? => {
+            cleanup_daemon_state(config)?;
+            Ok(())
+        }
+        ProbeRuntime::Stopped {
+            occupied_socket: true,
         } => Err(anyhow!(
             "control socket {} is occupied by a non-Holon process",
             config.socket_path.display()
@@ -455,6 +461,22 @@ pub async fn ensure_serve_preflight(config: &AppConfig) -> Result<()> {
             "runtime is already running but incompatible with the daemon lifecycle contract: {details}; stop or restart it explicitly"
         )),
     }
+}
+
+#[cfg(unix)]
+fn recorded_daemon_process_is_missing(config: &AppConfig) -> Result<bool> {
+    let Some(metadata) = load_daemon_metadata(config)? else {
+        return Ok(false);
+    };
+    Ok(matches!(
+        send_signal(metadata.pid, 0, "0")?,
+        SignalOutcome::MissingProcess
+    ))
+}
+
+#[cfg(not(unix))]
+fn recorded_daemon_process_is_missing(_config: &AppConfig) -> Result<bool> {
+    Ok(false)
 }
 
 pub async fn graceful_runtime_shutdown(
@@ -796,13 +818,11 @@ pub(crate) async fn probe_runtime(config: &AppConfig) -> ProbeRuntime {
         match tokio::time::timeout(UNIX_PROBE_TIMEOUT, client.runtime_readiness_unix_only()).await {
             Ok(Ok(status)) => return ProbeRuntime::Running(Box::new(status)),
             Ok(Err(err)) => {
-                let occupied_socket = unix_probe_indicates_foreign_process(err.root_cause());
-                return if occupied_socket {
-                    ProbeRuntime::Stopped { occupied_socket }
-                } else {
-                    ProbeRuntime::Incompatible {
+                return match unix_probe_stopped_socket_occupancy(err.root_cause()) {
+                    Some(occupied_socket) => ProbeRuntime::Stopped { occupied_socket },
+                    None => ProbeRuntime::Incompatible {
                         details: err.to_string(),
-                    }
+                    },
                 };
             }
             Err(_) => {
@@ -830,17 +850,17 @@ pub(crate) async fn probe_runtime(config: &AppConfig) -> ProbeRuntime {
 }
 
 #[cfg(unix)]
-fn unix_probe_indicates_foreign_process(root: &(dyn std::error::Error + 'static)) -> bool {
+fn unix_probe_stopped_socket_occupancy(root: &(dyn std::error::Error + 'static)) -> Option<bool> {
     if let Some(io_error) = root.downcast_ref::<std::io::Error>() {
-        return !matches!(
+        return Some(!matches!(
             io_error.kind(),
             ErrorKind::ConnectionRefused
                 | ErrorKind::ConnectionAborted
                 | ErrorKind::ConnectionReset
                 | ErrorKind::NotFound
-        );
+        ));
     }
-    false
+    None
 }
 
 fn merge_latest_failure(

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -63,6 +63,14 @@ fn test_config() -> AppConfig {
     }
 }
 
+#[cfg(unix)]
+fn dead_pid() -> u32 {
+    let mut child = Command::new("true").spawn().unwrap();
+    let pid = child.id();
+    child.wait().unwrap();
+    pid
+}
+
 #[test]
 fn config_fingerprint_changes_when_effective_config_changes() {
     let mut left = test_config();
@@ -390,10 +398,11 @@ async fn probe_runtime_treats_non_socket_path_as_stale() {
 async fn daemon_status_surfaces_dead_pid_and_leftover_socket_as_stale() {
     let config = test_config();
     let paths = daemon_paths(&config);
+    let pid = dead_pid();
     fs::create_dir_all(config.run_dir()).unwrap();
-    fs::write(&paths.pid_path, b"999999\n").unwrap();
+    fs::write(&paths.pid_path, format!("{pid}\n")).unwrap();
     let metadata = RuntimeServiceMetadata {
-        pid: 999_999,
+        pid,
         home_dir: config.home_dir.clone(),
         socket_path: config.socket_path.clone(),
         http_addr: config.http_addr.clone(),
@@ -407,7 +416,7 @@ async fn daemon_status_surfaces_dead_pid_and_leftover_socket_as_stale() {
     let status = daemon_status(&config).await.unwrap();
 
     assert_eq!(status.state, DaemonLifecycleState::Stale);
-    assert_eq!(status.pid, Some(999_999));
+    assert_eq!(status.pid, Some(pid));
     assert!(!status.control_connectivity);
     assert_eq!(status.message, "stale daemon state detected");
     assert!(status.stale_files.contains(&paths.pid_path));
@@ -420,10 +429,11 @@ async fn daemon_status_surfaces_dead_pid_and_leftover_socket_as_stale() {
 async fn serve_preflight_cleans_dead_pid_and_leftover_socket_state() {
     let config = test_config();
     let paths = daemon_paths(&config);
+    let pid = dead_pid();
     fs::create_dir_all(config.run_dir()).unwrap();
-    fs::write(&paths.pid_path, b"999999\n").unwrap();
+    fs::write(&paths.pid_path, format!("{pid}\n")).unwrap();
     let metadata = RuntimeServiceMetadata {
-        pid: 999_999,
+        pid,
         home_dir: config.home_dir.clone(),
         socket_path: config.socket_path.clone(),
         http_addr: config.http_addr.clone(),
@@ -501,10 +511,11 @@ async fn daemon_stop_refuses_foreign_socket_cleanup() {
 async fn daemon_stop_treats_missing_pid_process_as_stale_state() {
     let config = test_config();
     let paths = daemon_paths(&config);
+    let pid = dead_pid();
     fs::create_dir_all(config.run_dir()).unwrap();
-    fs::write(&paths.pid_path, b"999999\n").unwrap();
+    fs::write(&paths.pid_path, format!("{pid}\n")).unwrap();
     let metadata = RuntimeServiceMetadata {
-        pid: 999_999,
+        pid,
         home_dir: config.home_dir.clone(),
         socket_path: config.socket_path.clone(),
         http_addr: config.http_addr.clone(),

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -7,7 +7,7 @@ use super::state::{
 };
 use super::{
     clear_persisted_daemon_lifecycle_failures, config_fingerprint, daemon_log_hint, daemon_logs,
-    daemon_paths, daemon_status, daemon_stop, load_last_runtime_failure,
+    daemon_paths, daemon_status, daemon_stop, ensure_serve_preflight, load_last_runtime_failure,
     persist_daemon_lifecycle_failure, runtime_activity_summary, DaemonLifecycleState,
     RuntimeActivityState, RuntimeConfigSurface, RuntimeControlAuthMode, RuntimeServiceMetadata,
     RuntimeStartupSurface, RuntimeStatusResponse,
@@ -383,6 +383,62 @@ async fn probe_runtime_treats_non_socket_path_as_stale() {
             panic!("expected stale runtime probe, got incompatible: {details}")
         }
     }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn daemon_status_surfaces_dead_pid_and_leftover_socket_as_stale() {
+    let config = test_config();
+    let paths = daemon_paths(&config);
+    fs::create_dir_all(config.run_dir()).unwrap();
+    fs::write(&paths.pid_path, b"999999\n").unwrap();
+    let metadata = RuntimeServiceMetadata {
+        pid: 999_999,
+        home_dir: config.home_dir.clone(),
+        socket_path: config.socket_path.clone(),
+        http_addr: config.http_addr.clone(),
+        started_at: Utc::now(),
+        config_fingerprint: config_fingerprint(&config).unwrap(),
+    };
+    fs::write(&paths.metadata_path, serde_json::to_vec(&metadata).unwrap()).unwrap();
+    let listener = tokio::net::UnixListener::bind(&config.socket_path).unwrap();
+    drop(listener);
+
+    let status = daemon_status(&config).await.unwrap();
+
+    assert_eq!(status.state, DaemonLifecycleState::Stale);
+    assert_eq!(status.pid, Some(999_999));
+    assert!(!status.control_connectivity);
+    assert_eq!(status.message, "stale daemon state detected");
+    assert!(status.stale_files.contains(&paths.pid_path));
+    assert!(status.stale_files.contains(&paths.metadata_path));
+    assert!(status.stale_files.contains(&paths.socket_path));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn serve_preflight_cleans_dead_pid_and_leftover_socket_state() {
+    let config = test_config();
+    let paths = daemon_paths(&config);
+    fs::create_dir_all(config.run_dir()).unwrap();
+    fs::write(&paths.pid_path, b"999999\n").unwrap();
+    let metadata = RuntimeServiceMetadata {
+        pid: 999_999,
+        home_dir: config.home_dir.clone(),
+        socket_path: config.socket_path.clone(),
+        http_addr: config.http_addr.clone(),
+        started_at: Utc::now(),
+        config_fingerprint: config_fingerprint(&config).unwrap(),
+    };
+    fs::write(&paths.metadata_path, serde_json::to_vec(&metadata).unwrap()).unwrap();
+    let listener = tokio::net::UnixListener::bind(&config.socket_path).unwrap();
+    drop(listener);
+
+    ensure_serve_preflight(&config).await.unwrap();
+
+    assert!(!paths.pid_path.exists());
+    assert!(!paths.metadata_path.exists());
+    assert!(!paths.socket_path.exists());
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- classify refused/reset Unix socket probes as stopped daemon state instead of incompatible runtime state
- clean stale daemon pid/metadata/socket files during serve preflight when recorded daemon pid is gone
- add Unix regression coverage for stale daemon status and serve preflight cleanup

Fixes #1251

## Verification
- cargo fmt --all -- --check
- cargo test daemon -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets