### PR TITLE
fix: standardize model-visible ToolError rendering

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -397,6 +397,18 @@ The envelope fields are:
 - `recovery_hint`: optional concise next-step guidance
 - `retryable`: whether retrying the same logical action is expected to help
 
+The shared model-visible error receipt renders as bounded JSON:
+
+- `ok: false`
+- `tool_name`: built-in tool name when known
+- `kind`: stable machine-readable failure kind
+- `message`: concise human-readable summary
+- `hint`: optional corrective guidance derived from `recovery_hint`
+- `field`: optional input field/path when present in `details.field`
+- `retryable`: whether retrying the same logical action is expected to help
+- `details`: optional bounded detail; oversized detail is replaced by a
+  preview plus digest instead of echoing the full payload
+
 Runtime expectations:
 
 - the provider-facing `tool_result.content` remains a plain string, but it

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -383,7 +383,11 @@ async fn max_output_mutation_tool_call_is_rejected_without_side_effects() {
     let content = tool_results.data["results"][0]["content"]
         .as_str()
         .expect("tool result content");
-    assert!(content.contains("ApplyPatch failed"));
+    let receipt: serde_json::Value = serde_json::from_str(content).expect("tool error receipt");
+    assert_eq!(receipt["ok"], false);
+    assert_eq!(receipt["tool_name"], "ApplyPatch");
+    assert_eq!(receipt["kind"], "truncated_mutation_tool_call");
+    assert_eq!(receipt["retryable"], true);
     assert!(content.contains("truncated_mutation_tool_call"));
     assert!(content.contains("max_tokens"));
     assert!(content.contains("was not executed"));
@@ -392,7 +396,6 @@ async fn max_output_mutation_tool_call_is_rejected_without_side_effects() {
     assert!(content.contains("bounded ExecCommand/scripted rewrite"));
     assert!(content.contains("Inspect only the necessary context"));
     assert!(!content.contains("inspect the target file before retrying"));
-    assert!(content.contains("retryable: true"));
     assert!(content.len() < 800);
 }
 

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1331,16 +1331,6 @@ fn is_context_management_excluded_tool(tool_name: Option<&str>) -> bool {
     matches!(tool_name, Some("ApplyPatch" | "NotifyOperator"))
 }
 
-fn tool_result_error_envelope(tool_name: &str, error: ToolError) -> ToolResultEnvelope {
-    ToolResultEnvelope {
-        tool_name: tool_name.to_string(),
-        status: ToolResultStatus::Error,
-        summary_text: Some(error.message.clone()),
-        result: None,
-        error: Some(error),
-    }
-}
-
 impl RuntimeHandle {
     async fn maybe_handle_context_length_exceeded(
         &self,
@@ -2595,7 +2585,9 @@ impl TurnExecution<'_> {
                         "request the current tool list again and call only tools exposed in this round",
                     )
                     .with_retryable(false);
-                    let message = error.render();
+                    let audit_error = error.render();
+                    let result = crate::tool::ToolResult::error(&tool_name, error.clone());
+                    let result_content = crate::tool::tools::render_tool_result_for_model(&result)?;
                     let (turn_index, run_id) = {
                         let guard = runtime.inner.agent.lock().await;
                         (guard.state.turn_index, guard.state.current_run_id.clone())
@@ -2614,7 +2606,7 @@ impl TurnExecution<'_> {
                                 runtime.inner.default_tool_output_tokens,
                                 runtime.inner.max_tool_output_tokens
                             ),
-                            "error": message,
+                            "error": audit_error,
                             "error_kind": error.kind.clone(),
                             "tool_error": error.clone(),
                             "reason": "tool_not_exposed_for_round",
@@ -2622,11 +2614,11 @@ impl TurnExecution<'_> {
                     ))?;
                     tool_results.push(ToolResultBlock {
                         tool_use_id: tool_call_id.clone(),
-                        content: message,
+                        content: result_content,
                         is_error: true,
                         error: Some(error.clone()),
                     });
-                    tool_result_envelopes.push(tool_result_error_envelope(&tool_name, error));
+                    tool_result_envelopes.push(result.envelope);
                     continue;
                 }
                 if is_max_output_stop_reason(stop_reason.as_deref())
@@ -2776,7 +2768,10 @@ impl TurnExecution<'_> {
                             return Err(err);
                         }
                         let error = ToolError::from_anyhow(&err);
-                        let message = error.render();
+                        let audit_error = error.render();
+                        let result = crate::tool::ToolResult::error(&tool_name, error.clone());
+                        let result_content =
+                            crate::tool::tools::render_tool_result_for_model(&result)?;
                         let (turn_index, run_id) = {
                             let guard = runtime.inner.agent.lock().await;
                             (guard.state.turn_index, guard.state.current_run_id.clone())
@@ -2795,18 +2790,18 @@ impl TurnExecution<'_> {
                                     runtime.inner.default_tool_output_tokens,
                                     runtime.inner.max_tool_output_tokens
                                 ),
-                                "error": message,
+                                "error": audit_error,
                                 "error_kind": error.kind.clone(),
                                 "tool_error": error.clone(),
                             }),
                         ))?;
                         tool_results.push(ToolResultBlock {
                             tool_use_id: tool_call_id,
-                            content: message,
+                            content: result_content,
                             is_error: true,
                             error: Some(error.clone()),
                         });
-                        tool_result_envelopes.push(tool_result_error_envelope(&tool_name, error));
+                        tool_result_envelopes.push(result.envelope);
                     }
                 }
             }

--- a/src/tool/error.rs
+++ b/src/tool/error.rs
@@ -1,6 +1,9 @@
 use anyhow::Error as AnyhowError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+const MODEL_VISIBLE_DETAILS_MAX_CHARS: usize = 1_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ToolError {
@@ -48,6 +51,43 @@ impl ToolError {
         })
     }
 
+    pub fn render_for_model(&self, tool_name: Option<&str>) -> String {
+        let mut receipt = serde_json::Map::new();
+        receipt.insert("ok".to_string(), Value::Bool(false));
+        if let Some(tool_name) = tool_name {
+            receipt.insert(
+                "tool_name".to_string(),
+                Value::String(tool_name.to_string()),
+            );
+        }
+        receipt.insert("kind".to_string(), Value::String(self.kind.clone()));
+        receipt.insert("message".to_string(), Value::String(self.message.clone()));
+        if let Some(recovery_hint) = self.recovery_hint.as_deref() {
+            receipt.insert("hint".to_string(), Value::String(recovery_hint.to_string()));
+        }
+        if let Some(field) = self
+            .details
+            .as_ref()
+            .and_then(|details| details.get("field"))
+            .and_then(Value::as_str)
+        {
+            receipt.insert("field".to_string(), Value::String(field.to_string()));
+        }
+        receipt.insert("retryable".to_string(), Value::Bool(self.retryable));
+        if let Some(details) = self.details.as_ref() {
+            receipt.insert(
+                "details".to_string(),
+                bounded_model_visible_details(details),
+            );
+        }
+        serde_json::to_string_pretty(&Value::Object(receipt)).unwrap_or_else(|_| {
+            format!(
+                "{{\"ok\":false,\"kind\":\"{}\",\"message\":\"{}\",\"retryable\":{}}}",
+                self.kind, self.message, self.retryable
+            )
+        })
+    }
+
     pub fn audit_fields(&self) -> Value {
         json!({
             "error": self.render(),
@@ -65,6 +105,26 @@ impl ToolError {
                 ToolError::new("tool_execution_failed", error.to_string()).with_retryable(false)
             })
     }
+}
+
+fn bounded_model_visible_details(details: &Value) -> Value {
+    let rendered = serde_json::to_string(details).unwrap_or_else(|_| details.to_string());
+    if rendered.chars().count() <= MODEL_VISIBLE_DETAILS_MAX_CHARS {
+        return details.clone();
+    }
+
+    let digest = Sha256::digest(rendered.as_bytes());
+    let preview: String = rendered
+        .chars()
+        .take(MODEL_VISIBLE_DETAILS_MAX_CHARS)
+        .collect();
+    json!({
+        "omitted": true,
+        "reason": "details exceeded model-visible budget",
+        "char_count": rendered.chars().count(),
+        "sha256": format!("{digest:x}"),
+        "preview": preview,
+    })
 }
 
 impl std::fmt::Display for ToolError {
@@ -89,6 +149,65 @@ mod tests {
         assert!(rendered.contains("\"kind\": \"invalid_tool_input\""));
         assert!(rendered.contains("\"field\": \"cmd\""));
         assert!(rendered.contains("provide a string value"));
+    }
+
+    #[test]
+    fn tool_error_model_rendering_uses_shared_corrective_receipt() {
+        let rendered = ToolError::new("invalid_tool_input", "missing required string field")
+            .with_details(json!({ "field": "cmd", "parse_error": "missing field `cmd`" }))
+            .with_recovery_hint("provide a string value for `cmd`")
+            .render_for_model(Some("ExecCommand"));
+        let receipt: Value = serde_json::from_str(&rendered).unwrap();
+
+        assert_eq!(receipt["ok"], false);
+        assert_eq!(receipt["tool_name"], "ExecCommand");
+        assert_eq!(receipt["kind"], "invalid_tool_input");
+        assert_eq!(receipt["message"], "missing required string field");
+        assert_eq!(receipt["hint"], "provide a string value for `cmd`");
+        assert_eq!(receipt["field"], "cmd");
+        assert_eq!(receipt["retryable"], false);
+        assert_eq!(receipt["details"]["parse_error"], "missing field `cmd`");
+    }
+
+    #[test]
+    fn tool_error_model_rendering_supports_runtime_failures() {
+        let rendered = ToolError::new("command_spawn_failed", "failed to start command process")
+            .with_recovery_hint("check the command path and arguments")
+            .with_retryable(true)
+            .render_for_model(Some("ExecCommand"));
+        let receipt: Value = serde_json::from_str(&rendered).unwrap();
+
+        assert_eq!(receipt["ok"], false);
+        assert_eq!(receipt["kind"], "command_spawn_failed");
+        assert_eq!(receipt["hint"], "check the command path and arguments");
+        assert_eq!(receipt["retryable"], true);
+    }
+
+    #[test]
+    fn tool_error_model_rendering_bounds_long_details_without_changing_canonical_error() {
+        let raw_payload = "x".repeat(MODEL_VISIBLE_DETAILS_MAX_CHARS + 500);
+        let error = ToolError::new("invalid_tool_input", "malformed tool input")
+            .with_details(json!({ "raw_input": raw_payload.clone() }));
+        let canonical = error.render();
+        let rendered = error.render_for_model(Some("ApplyPatch"));
+        let receipt: Value = serde_json::from_str(&rendered).unwrap();
+
+        assert!(canonical.contains(&raw_payload));
+        assert_eq!(receipt["details"]["omitted"], true);
+        assert_eq!(
+            receipt["details"]["reason"],
+            "details exceeded model-visible budget"
+        );
+        assert!(receipt["details"]["sha256"].as_str().unwrap().len() >= 64);
+        assert!(
+            receipt["details"]["preview"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count()
+                <= MODEL_VISIBLE_DETAILS_MAX_CHARS
+        );
+        assert!(!rendered.contains(&raw_payload));
     }
 
     #[test]

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -146,6 +146,13 @@ pub(crate) async fn execute_builtin_tool(
 }
 
 pub(crate) fn render_tool_result_for_model(result: &ToolResult) -> Result<String> {
+    if result.is_error() {
+        let error = result
+            .tool_error()
+            .ok_or_else(|| anyhow!("tool error result missing error payload"))?;
+        return Ok(error.render_for_model(Some(&result.envelope.tool_name)));
+    }
+
     match result.envelope.tool_name.as_str() {
         apply_patch_tool::NAME => apply_patch_tool::render_for_model(result),
         exec_command::NAME => exec_command::render_for_model(result),
@@ -187,5 +194,23 @@ mod tests {
         );
         let rendered = render_tool_result_for_model(&result).unwrap();
         assert!(rendered.starts_with("{\"tool_name\":\"AgentGet\""));
+    }
+
+    #[test]
+    fn tool_errors_use_shared_model_visible_receipt() {
+        let result = ToolResult::error(
+            "ExecCommand",
+            crate::tool::ToolError::new("invalid_tool_input", "missing required field")
+                .with_details(serde_json::json!({ "field": "cmd" }))
+                .with_recovery_hint("provide `cmd`"),
+        );
+        let rendered = render_tool_result_for_model(&result).unwrap();
+        let receipt: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+        assert_eq!(receipt["ok"], false);
+        assert_eq!(receipt["tool_name"], "ExecCommand");
+        assert_eq!(receipt["kind"], "invalid_tool_input");
+        assert_eq!(receipt["field"], "cmd");
+        assert_eq!(receipt["hint"], "provide `cmd`");
     }
 }


### PR DESCRIPTION
Fixes #1247.

## Summary
- add a shared `ToolError::render_for_model` receipt with stable JSON fields, corrective hints, retryability, and bounded details
- route all built-in tool error results through the shared renderer before returning content to the model
- preserve canonical/audit error detail separately from bounded model-visible receipts
- document the model-visible error receipt contract in the runtime spec

## Verification
- `cargo fmt --all -- --check`
- `cargo test tool_error_model_rendering -- --nocapture`
- `cargo test tool_errors_use_shared_model_visible_receipt -- --nocapture`
- `cargo test tool_errors_are_reported_to_model_and_audit_log -- --nocapture`
- `cargo check --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
