### PR TITLE
fix: remove pause resume lifecycle controls

### DIFF
--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -194,19 +194,20 @@ Response:
 
 **`POST /control/agents/:id/control`** — Control action
 
-Sends a control action (pause, resume, or other lifecycle actions). Request body:
+Sends a control action. Request body:
 
 ```json
-{ "action": "pause", "trust": "trusted_operator" }
+{ "action": "stop", "trust": "trusted_operator" }
 ```
 
 **`POST /control/agents/:id/current-run/abort`** — Abort current run
 
-Aborts the current agent run loop. Only `mode: "pause_after_abort"` is
-supported:
+Aborts the current agent run loop. New callers should use
+`mode: "stop_after_abort"`. The legacy `pause_after_abort` value is accepted as
+a compatibility alias and is treated as `stop_after_abort`.
 
 ```json
-{ "mode": "pause_after_abort" }
+{ "mode": "stop_after_abort" }
 ```
 
 **`POST /control/agents/:id/create`** — Create agent

--- a/src/client.rs
+++ b/src/client.rs
@@ -442,7 +442,7 @@ impl LocalClient {
             &format!("/control/agents/{agent_id}/current-run/abort"),
             &crate::http::AbortCurrentRunRequest {
                 run_id,
-                mode: Some("pause_after_abort".into()),
+                mode: Some("stop_after_abort".into()),
                 trust: Some(TrustLevel::TrustedOperator),
             },
         )

--- a/src/host.rs
+++ b/src/host.rs
@@ -2748,14 +2748,14 @@ mod tests {
         let storage =
             AppStorage::new(host.agent_data_dir(&host.config().default_agent_id)).unwrap();
         let mut state = AgentState::new(&host.config().default_agent_id);
-        state.status = AgentStatus::Paused;
+        state.status = AgentStatus::Stopped;
         storage.write_agent(&state).unwrap();
 
         let _runtime = host.default_runtime().await.unwrap();
         host.shutdown().await.unwrap();
 
         let persisted = storage.read_agent().unwrap().unwrap();
-        assert_eq!(persisted.status, AgentStatus::Paused);
+        assert_eq!(persisted.status, AgentStatus::Stopped);
         let events = storage.read_recent_events(16).unwrap();
         assert!(events
             .iter()

--- a/src/http.rs
+++ b/src/http.rs
@@ -1967,11 +1967,12 @@ pub async fn abort_current_run(
     Json(request): Json<AbortCurrentRunRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
-    let mode = match request.mode.as_deref().unwrap_or("pause_after_abort") {
-        "pause_after_abort" => CurrentRunAbortMode::PauseAfterAbort,
+    let mode = match request.mode.as_deref().unwrap_or("stop_after_abort") {
+        "stop_after_abort" => CurrentRunAbortMode::StopAfterAbort,
+        "pause_after_abort" => CurrentRunAbortMode::StopAfterAbort,
         other => {
             return Err(bad_request(format!(
-                "unsupported abort mode {other}; expected pause_after_abort"
+                "unsupported abort mode {other}; expected stop_after_abort or deprecated alias pause_after_abort"
             )))
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,6 @@ struct Cli {
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 enum ControlCommandAction {
     Start,
-    Pause,
-    Resume,
     Stop,
     Abort,
 }
@@ -59,8 +57,6 @@ impl ControlCommandAction {
     fn as_control_action(&self) -> Option<ControlAction> {
         match self {
             Self::Start => Some(ControlAction::Start),
-            Self::Pause => Some(ControlAction::Pause),
-            Self::Resume => Some(ControlAction::Resume),
             Self::Stop => Some(ControlAction::Stop),
             Self::Abort => None,
         }
@@ -410,13 +406,7 @@ enum AgentCommands {
         #[arg(long)]
         template: Option<String>,
     },
-    Pause {
-        agent_id: Option<String>,
-    },
     Start {
-        agent_id: Option<String>,
-    },
-    Resume {
         agent_id: Option<String>,
     },
     Stop {
@@ -651,7 +641,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
                     &format!("/control/agents/{agent}/current-run/abort"),
                     &http::AbortCurrentRunRequest {
                         run_id: None,
-                        mode: Some("pause_after_abort".into()),
+                        mode: Some("stop_after_abort".into()),
                         trust: Some(TrustLevel::TrustedOperator),
                     },
                 )
@@ -1268,24 +1258,6 @@ mod tests {
             panic!("expected agent start command");
         };
         assert_eq!(agent_id, None);
-
-        let cli = Cli::parse_from(["holon", "agent", "pause"]);
-        let Commands::Agent {
-            command: Some(AgentCommands::Pause { agent_id }),
-        } = cli.command
-        else {
-            panic!("expected agent pause command");
-        };
-        assert_eq!(agent_id, None);
-
-        let cli = Cli::parse_from(["holon", "agent", "resume", "foo"]);
-        let Commands::Agent {
-            command: Some(AgentCommands::Resume { agent_id }),
-        } = cli.command
-        else {
-            panic!("expected agent resume command");
-        };
-        assert_eq!(agent_id.as_deref(), Some("foo"));
 
         let cli = Cli::parse_from(["holon", "agent", "stop", "foo"]);
         let Commands::Agent {
@@ -2278,14 +2250,8 @@ async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>
             )
             .await
         }
-        Some(AgentCommands::Pause { agent_id }) => {
-            control_agent_lifecycle(config, agent_id, ControlAction::Pause).await
-        }
         Some(AgentCommands::Start { agent_id }) => {
             control_agent_lifecycle(config, agent_id, ControlAction::Start).await
-        }
-        Some(AgentCommands::Resume { agent_id }) => {
-            control_agent_lifecycle(config, agent_id, ControlAction::Resume).await
         }
         Some(AgentCommands::Stop { agent_id }) => {
             control_agent_lifecycle(config, agent_id, ControlAction::Stop).await
@@ -2297,7 +2263,7 @@ async fn handle_agent_command(config: &AppConfig, command: Option<AgentCommands>
                 &format!("/control/agents/{agent}/current-run/abort"),
                 &http::AbortCurrentRunRequest {
                     run_id: None,
-                    mode: Some("pause_after_abort".into()),
+                    mode: Some("stop_after_abort".into()),
                     trust: Some(TrustLevel::TrustedOperator),
                 },
             )

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -232,20 +232,20 @@ struct CurrentRunAbortHandle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CurrentRunAbortMode {
-    PauseAfterAbort,
+    StopAfterAbort,
 }
 
 impl CurrentRunAbortMode {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::PauseAfterAbort => "pause_after_abort",
+            Self::StopAfterAbort => "stop_after_abort",
         }
     }
 }
 
 impl Default for CurrentRunAbortMode {
     fn default() -> Self {
-        Self::PauseAfterAbort
+        Self::StopAfterAbort
     }
 }
 
@@ -1023,10 +1023,7 @@ impl RuntimeHandle {
                 }
                 let failed_state = {
                     let mut guard = self.inner.agent.lock().await;
-                    if !matches!(
-                        guard.state.status,
-                        AgentStatus::Paused | AgentStatus::Stopped
-                    ) {
+                    if !matches!(guard.state.status, AgentStatus::Stopped) {
                         scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
                     }
                     guard.current_run_abort = None;

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -26,10 +26,7 @@ impl RuntimeHandle {
         let continuation_resolution = continuation_trigger
             .as_ref()
             .map(|trigger| resolve_continuation(&prior_closure, trigger));
-        let model_turn_allowed = !matches!(
-            scheduler_state.status,
-            AgentStatus::Paused | AgentStatus::Stopped
-        );
+        let model_turn_allowed = !matches!(scheduler_state.status, AgentStatus::Stopped);
         Ok(MessageDispatchPlan {
             prior_closure,
             task,
@@ -132,8 +129,7 @@ impl RuntimeHandle {
             }
             MessageKind::Control => {
                 let action = match &message.body {
-                    MessageBody::Text { text } if text == "pause" => ControlAction::Pause,
-                    MessageBody::Text { text } if text == "resume" => ControlAction::Resume,
+                    MessageBody::Text { text } if text == "start" => ControlAction::Start,
                     MessageBody::Text { text } if text == "stop" => ControlAction::Stop,
                     _ => return Err(anyhow!("unknown control action")),
                 };
@@ -152,7 +148,7 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             let status_mutable = !matches!(
                 guard.state.status,
-                AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
+                AgentStatus::Asleep | AgentStatus::Stopped
             );
             if status_mutable {
                 scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -630,12 +630,6 @@ fn decide_idle_signal_action(
     boundary: &'static str,
     signal: SchedulerIdleSignal<'_>,
 ) -> SchedulerDecision {
-    if matches!(projection.status, AgentStatus::Paused) {
-        return SchedulerDecision::new(SchedulerDecisionKind::Noop, "paused")
-            .boundary(boundary)
-            .liveness_only(true)
-            .evidence(format!("status={:?}", projection.status));
-    }
     if projection.turn_in_progress {
         return SchedulerDecision::new(SchedulerDecisionKind::Noop, "turn_in_progress")
             .boundary(boundary)
@@ -808,8 +802,6 @@ pub(crate) fn message_processing_decision(
 pub(crate) fn idle_noop_decision(projection: &SchedulerProjection) -> SchedulerDecision {
     let (kind, reason) = if matches!(projection.status, AgentStatus::Stopped) {
         (SchedulerDecisionKind::Stop, "stopped")
-    } else if matches!(projection.status, AgentStatus::Paused) {
-        (SchedulerDecisionKind::Noop, "paused")
     } else if matches!(projection.status, AgentStatus::Asleep) {
         (SchedulerDecisionKind::StayIdle, "already_asleep")
     } else if projection.queue_len > 0 {
@@ -908,7 +900,7 @@ pub(crate) fn idle_boundary_decision(
 ) -> SchedulerDecision {
     if matches!(
         projection.status,
-        AgentStatus::Stopped | AgentStatus::Paused | AgentStatus::Asleep
+        AgentStatus::Stopped | AgentStatus::Asleep
     ) {
         return idle_noop_decision(projection).boundary(boundary);
     }
@@ -932,10 +924,7 @@ pub(crate) fn projected_status_for_idle(
     state: &AgentState,
     _storage: &AppStorage,
 ) -> Result<AgentStatus> {
-    if matches!(
-        state.status,
-        AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
-    ) {
+    if matches!(state.status, AgentStatus::Asleep | AgentStatus::Stopped) {
         return Ok(state.status.clone());
     }
     Ok(AgentStatus::AwakeIdle)

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -114,9 +114,6 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 }
                 scheduler::apply_stop_projection(&mut guard.state);
             }
-            ControlAction::Pause | ControlAction::Resume => {
-                unreachable!("control actions are canonicalized before posture application")
-            }
         }
 
         self.append_posture_decision(
@@ -124,7 +121,6 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             match action {
                 ControlAction::Start => "start",
                 ControlAction::Stop => "stop",
-                ControlAction::Pause | ControlAction::Resume => unreachable!(),
             },
             &previous_status,
             &guard.state.status,
@@ -230,7 +226,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         let mut guard = self.runtime.inner.agent.lock().await;
         if matches!(
             guard.state.status,
-            AgentStatus::Asleep | AgentStatus::Paused | AgentStatus::Stopped
+            AgentStatus::Asleep | AgentStatus::Stopped
         ) || !guard.queue.is_empty()
         {
             return Ok(None);
@@ -286,9 +282,6 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
             if guard.state.status == AgentStatus::Stopped {
                 return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
-            }
-            if guard.state.status == AgentStatus::Paused {
-                return Ok(RunLoopPoll::Idle);
             }
             let Some(message) = guard.queue.peek().cloned() else {
                 return Ok(RunLoopPoll::Idle);
@@ -347,15 +340,8 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
                 return self.shutdown(guard);
             }
-            if matches!(
-                guard.state.status,
-                AgentStatus::Paused | AgentStatus::Stopped
-            ) {
-                return Ok(if guard.state.status == AgentStatus::Stopped {
-                    RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len())
-                } else {
-                    RunLoopPoll::Idle
-                });
+            if matches!(guard.state.status, AgentStatus::Stopped) {
+                return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
             }
             if !guard
                 .queue
@@ -417,7 +403,7 @@ pub(super) fn apply_bootstrap_recovered_projection(
     state: &mut AgentState,
     facts: BootstrapRecoveryFacts,
 ) -> bool {
-    if matches!(state.status, AgentStatus::Paused | AgentStatus::Stopped) {
+    if matches!(state.status, AgentStatus::Stopped) {
         return false;
     }
 
@@ -470,17 +456,15 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_recovery_preserves_stopped_and_paused_gates() {
-        for status in [AgentStatus::Stopped, AgentStatus::Paused] {
-            let mut state = bootstrap_state(status.clone());
-            state.current_run_id = Some("run-1".into());
-            assert!(!apply_bootstrap_recovered_projection(
-                &mut state,
-                BootstrapRecoveryFacts { queued_messages: 1 },
-            ));
-            assert_eq!(state.status, status);
-            assert_eq!(state.current_run_id.as_deref(), Some("run-1"));
-        }
+    fn bootstrap_recovery_preserves_stopped_gate() {
+        let mut state = bootstrap_state(AgentStatus::Stopped);
+        state.current_run_id = Some("run-1".into());
+        assert!(!apply_bootstrap_recovered_projection(
+            &mut state,
+            BootstrapRecoveryFacts { queued_messages: 1 },
+        ));
+        assert_eq!(state.status, AgentStatus::Stopped);
+        assert_eq!(state.current_run_id.as_deref(), Some("run-1"));
     }
 
     #[test]

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -52,10 +52,7 @@ impl RuntimeHandle {
         self.inner.storage.append_task(task)?;
         {
             let mut guard = self.inner.agent.lock().await;
-            if !matches!(
-                guard.state.status,
-                AgentStatus::Paused | AgentStatus::Stopped
-            ) {
+            if !matches!(guard.state.status, AgentStatus::Stopped) {
                 if guard.state.current_run_id.is_none() {
                     scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
                 }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -506,52 +506,49 @@ async fn message_admission_wakes_asleep_and_booting_agents() {
 }
 
 #[tokio::test]
-async fn message_admission_does_not_wake_stopped_or_paused_agents() {
-    for status in [AgentStatus::Stopped, AgentStatus::Paused] {
-        let dir = tempdir().unwrap();
-        let workspace = tempdir().unwrap();
-        let runtime = RuntimeHandle::new(
-            "default",
-            dir.path().to_path_buf(),
-            workspace.path().to_path_buf(),
-            "http://127.0.0.1:7878".into(),
-            Arc::new(CountingProvider {
-                calls: Mutex::new(0),
-                reply: "unused",
-            }),
-            "default".into(),
-            context_config(),
-        )
-        .unwrap();
-        {
-            let mut guard = runtime.inner.agent.lock().await;
-            guard.state.status = status.clone();
-            runtime.storage().write_agent(&guard.state).unwrap();
-        }
-
-        runtime
-            .enqueue(MessageEnvelope::new(
-                "default",
-                MessageKind::OperatorPrompt,
-                MessageOrigin::Operator { actor_id: None },
-                TrustLevel::TrustedOperator,
-                Priority::Normal,
-                MessageBody::Text {
-                    text: "do not wake".into(),
-                },
-            ))
-            .await
-            .unwrap();
-
-        let state = runtime.agent_state().await.unwrap();
-        assert_eq!(state.status, status);
-        assert_eq!(state.pending, 1);
-        let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
-        assert!(!events.iter().any(|event| {
-            event.kind == "scheduler_posture_decision"
-                && event.data["boundary"] == "message_admission"
-        }));
+async fn message_admission_does_not_wake_stopped_agents() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::Stopped;
+        runtime.storage().write_agent(&guard.state).unwrap();
     }
+
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "do not wake".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::Stopped);
+    assert_eq!(state.pending, 1);
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(!events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision" && event.data["boundary"] == "message_admission"
+    }));
 }
 
 #[tokio::test]
@@ -663,44 +660,6 @@ async fn control_stop_clears_autonomous_sleep_and_wake_posture() {
             && event.data["reason"] == "stop"
             && event.data["previous_status"] == "asleep"
             && event.data["next_status"] == "stopped"
-    }));
-}
-
-#[tokio::test]
-async fn control_pause_is_deprecated_stop_alias() {
-    let dir = tempdir().unwrap();
-    let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
-        "default",
-        dir.path().to_path_buf(),
-        workspace.path().to_path_buf(),
-        "http://127.0.0.1:7878".into(),
-        Arc::new(CountingProvider {
-            calls: Mutex::new(0),
-            reply: "unused",
-        }),
-        "default".into(),
-        context_config(),
-    )
-    .unwrap();
-
-    runtime
-        .control(crate::types::ControlAction::Pause)
-        .await
-        .unwrap();
-
-    let state = runtime.agent_state().await.unwrap();
-    assert_eq!(state.status, AgentStatus::Stopped);
-    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
-    assert!(events.iter().any(|event| {
-        event.kind == "scheduler_posture_decision"
-            && event.data["boundary"] == "lifecycle_control"
-            && event.data["reason"] == "stop"
-            && event.data["evidence"].as_array().is_some_and(|entries| {
-                entries
-                    .iter()
-                    .any(|entry| entry.as_str() == Some("requested_action=Pause"))
-            })
     }));
 }
 
@@ -1208,7 +1167,7 @@ async fn abort_current_run_aborts_provider_turn_and_stops_agent() {
     let outcome = runtime
         .abort_current_run(CurrentRunAbortRequest {
             run_id: Some(run_id.clone()),
-            mode: CurrentRunAbortMode::PauseAfterAbort,
+            mode: CurrentRunAbortMode::StopAfterAbort,
         })
         .await
         .unwrap();
@@ -1423,7 +1382,7 @@ async fn abort_current_run_rejects_stale_run_id() {
     let err = runtime
         .abort_current_run(CurrentRunAbortRequest {
             run_id: Some("stale-run".into()),
-            mode: CurrentRunAbortMode::PauseAfterAbort,
+            mode: CurrentRunAbortMode::StopAfterAbort,
         })
         .await
         .unwrap_err();
@@ -1438,7 +1397,7 @@ async fn abort_current_run_rejects_stale_run_id() {
     runtime
         .abort_current_run(CurrentRunAbortRequest {
             run_id: None,
-            mode: CurrentRunAbortMode::PauseAfterAbort,
+            mode: CurrentRunAbortMode::StopAfterAbort,
         })
         .await
         .unwrap();
@@ -1895,7 +1854,7 @@ async fn task_result_persists_reduced_state_when_agent_status_is_not_mutable() {
         .unwrap();
     {
         let mut guard = runtime.inner.agent.lock().await;
-        guard.state.status = AgentStatus::Paused;
+        guard.state.status = AgentStatus::Stopped;
         runtime.storage().write_agent(&guard.state).unwrap();
     }
 
@@ -1930,7 +1889,7 @@ async fn task_result_persists_reduced_state_when_agent_status_is_not_mutable() {
         .read_agent()
         .unwrap()
         .expect("agent state should be persisted");
-    assert_eq!(persisted.status, AgentStatus::Paused);
+    assert_eq!(persisted.status, AgentStatus::Stopped);
     let active_tasks = runtime.active_tasks(10).await.unwrap();
     assert!(!active_tasks.iter().any(|task| task.id == "task-1"));
 }
@@ -1973,12 +1932,8 @@ async fn unknown_control_action_fails_without_mutating_runtime_state() {
 }
 
 #[tokio::test]
-async fn final_status_rewrite_preserves_paused_stopped_and_asleep_states() {
-    for status in [
-        AgentStatus::Paused,
-        AgentStatus::Stopped,
-        AgentStatus::Asleep,
-    ] {
+async fn final_status_rewrite_preserves_stopped_and_asleep_states() {
+    for status in [AgentStatus::Stopped, AgentStatus::Asleep] {
         let dir = tempdir().unwrap();
         let workspace = tempdir().unwrap();
         let runtime = RuntimeHandle::new(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -29,7 +29,7 @@ impl RuntimeHandle {
         let disposition = {
             let mut guard = self.inner.agent.lock().await;
             match guard.state.status {
-                AgentStatus::Paused | AgentStatus::Stopped => WakeDisposition::Ignored,
+                AgentStatus::Stopped => WakeDisposition::Ignored,
                 AgentStatus::AwakeRunning | AgentStatus::AwaitingTask => {
                     guard.state.pending_wake_hint = Some(pending.clone());
                     self.inner.storage.write_agent(&guard.state)?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2036,6 +2036,24 @@ mod tests {
     }
 
     #[test]
+    fn read_agent_maps_legacy_paused_status_to_stopped() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let mut agent = AgentState::new("default");
+        agent.status = AgentStatus::Stopped;
+        let mut value = serde_json::to_value(&agent).unwrap();
+        value["status"] = serde_json::json!("paused");
+        std::fs::write(
+            dir.path().join(".holon/state/agent.json"),
+            serde_json::to_string_pretty(&value).unwrap(),
+        )
+        .unwrap();
+
+        let restored = storage.read_agent().unwrap().unwrap();
+        assert_eq!(restored.status, AgentStatus::Stopped);
+    }
+
+    #[test]
     fn latest_active_task_records_reduce_by_id_and_filter_terminal_tasks() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -708,7 +708,6 @@ fn active_activity_speaker(agent: &AgentSummary) -> String {
         _ if !agent.active_children.is_empty() => "Holon (delegating)".into(),
         crate::types::AgentStatus::AwakeIdle => "Holon (idle)".into(),
         crate::types::AgentStatus::Asleep => "Holon (sleeping)".into(),
-        crate::types::AgentStatus::Paused => "Holon (paused)".into(),
         crate::types::AgentStatus::Stopped => "Holon (stopped)".into(),
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -309,7 +309,7 @@ fn parse_agent_slash_action(args: &[String]) -> Result<AgentSlashAction> {
         ));
     };
     match first.as_str() {
-        "start" | "pause" | "resume" | "stop" => {
+        "start" | "stop" => {
             if args.len() > 2 {
                 return Err(anyhow!(
                     "/agent {first} accepts at most one agent id; usage: /agent {first} [agent-id]"
@@ -317,8 +317,6 @@ fn parse_agent_slash_action(args: &[String]) -> Result<AgentSlashAction> {
             }
             let action = match first.as_str() {
                 "start" => crate::types::ControlAction::Start,
-                "pause" => crate::types::ControlAction::Pause,
-                "resume" => crate::types::ControlAction::Resume,
                 "stop" => crate::types::ControlAction::Stop,
                 _ => unreachable!("matched lifecycle action"),
             };
@@ -343,6 +341,12 @@ fn parse_agent_slash_action(args: &[String]) -> Result<AgentSlashAction> {
             }
             Ok(AgentSlashAction::Create(args[1].clone()))
         }
+        "pause" => Err(anyhow!(
+            "/agent pause has been removed; use /agent stop [agent-id] instead"
+        )),
+        "resume" => Err(anyhow!(
+            "/agent resume has been removed; use /agent start [agent-id] instead"
+        )),
         _ => Err(anyhow!(
             "unknown /agent subcommand '{first}'; use /agent switch {first} to switch agents"
         )),
@@ -739,10 +743,8 @@ impl TuiApp {
                     self.status_line = format!(
                         "{} agent {agent_id}",
                         match action {
-                            crate::types::ControlAction::Start
-                            | crate::types::ControlAction::Resume => "Started",
-                            crate::types::ControlAction::Pause
-                            | crate::types::ControlAction::Stop => "Stopped",
+                            crate::types::ControlAction::Start => "Started",
+                            crate::types::ControlAction::Stop => "Stopped",
                         }
                     );
                     if self.selected_agent_id() == Some(agent_id.as_str()) {
@@ -1628,13 +1630,6 @@ mod tests {
             ))
         );
         assert_eq!(
-            parse_composer_submission("/agent resume foo").unwrap(),
-            Some(ComposerSubmission::Slash(
-                SlashCommand::Agent,
-                vec!["resume".into(), "foo".into()]
-            ))
-        );
-        assert_eq!(
             parse_composer_submission("/agent stop").unwrap(),
             Some(ComposerSubmission::Slash(
                 SlashCommand::Agent,
@@ -1716,13 +1711,6 @@ mod tests {
             }
         );
         assert_eq!(
-            parse_agent_slash_action(&["resume".into(), "foo".into()]).unwrap(),
-            AgentSlashAction::Control {
-                action: crate::types::ControlAction::Resume,
-                agent_id: Some("foo".into()),
-            }
-        );
-        assert_eq!(
             parse_agent_slash_action(&["stop".into()]).unwrap(),
             AgentSlashAction::Control {
                 action: crate::types::ControlAction::Stop,
@@ -1741,6 +1729,10 @@ mod tests {
         assert!(err
             .to_string()
             .contains("unknown /agent subcommand 'status'"));
+        let err = parse_agent_slash_action(&["pause".into()]).unwrap_err();
+        assert!(err.to_string().contains("use /agent stop [agent-id]"));
+        let err = parse_agent_slash_action(&["resume".into()]).unwrap_err();
+        assert!(err.to_string().contains("use /agent start [agent-id]"));
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -441,9 +441,7 @@ fn slash_argument_hint_lines(
         SlashArgHint::Agent => {
             lines.push(Line::from(vec![
                 Span::styled("  args: ", Style::default().add_modifier(Modifier::DIM)),
-                Span::raw(
-                    "switch <agent-id>  pause [agent-id]  resume [agent-id]  stop [agent-id]",
-                ),
+                Span::raw("switch <agent-id>  start [agent-id]  stop [agent-id]"),
             ]));
             let agents = app
                 .agents

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -56,7 +56,6 @@ fn agent_status_label(agent: &AgentSummary) -> &'static str {
         AgentStatus::AwakeRunning => "running",
         AgentStatus::AwaitingTask => "waiting for task",
         AgentStatus::Asleep => "sleeping",
-        AgentStatus::Paused => "paused",
         AgentStatus::Stopped => "stopped",
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1187,7 +1187,7 @@ pub enum AgentStatus {
     AwakeRunning,
     AwaitingTask,
     Asleep,
-    Paused,
+    #[serde(alias = "paused")]
     Stopped,
 }
 
@@ -3507,22 +3507,16 @@ impl AuditEvent {
 #[serde(rename_all = "snake_case")]
 pub enum ControlAction {
     Start,
-    Pause,
-    Resume,
     Stop,
 }
 
 impl ControlAction {
     pub fn canonical(&self) -> Self {
-        match self {
-            Self::Pause => Self::Stop,
-            Self::Resume => Self::Start,
-            action => action.clone(),
-        }
+        self.clone()
     }
 
     pub fn is_start(&self) -> bool {
-        matches!(self.canonical(), Self::Start)
+        matches!(self, Self::Start)
     }
 }
 

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -1847,7 +1847,7 @@ pub async fn background_command_task_persists_terminal_state_while_runtime_stopp
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
     let runtime = host.default_runtime().await?;
-    runtime.control(ControlAction::Pause).await?;
+    runtime.control(ControlAction::Stop).await?;
 
     let task = runtime
         .schedule_command_task(
@@ -1903,7 +1903,7 @@ pub async fn blocking_command_task_clears_active_state_while_runtime_stopped() -
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
     let runtime = host.default_runtime().await?;
-    runtime.control(ControlAction::Pause).await?;
+    runtime.control(ControlAction::Stop).await?;
 
     let task = runtime
         .schedule_command_task(


### PR DESCRIPTION
## Summary
- remove legacy `Paused` agent status and `Pause`/`Resume` control actions from runtime, scheduler, CLI, TUI, and tests
- switch current-run abort naming to `stop_after_abort` while keeping `pause_after_abort` as an HTTP compatibility alias
- update HTTP control-plane docs for the stop-oriented lifecycle model

Fixes #1324

## Verification
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`