### PR TITLE
Fix provider builtin web search capability

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1271,7 +1271,8 @@ pub fn validate_provider_config(
     provider_config: &ProviderConfigFile,
 ) -> Result<()> {
     parse_url_value("providers.<id>.base_url", &provider_config.base_url)?;
-    validate_provider_auth(provider_id, &provider_config.auth)
+    validate_provider_auth(provider_id, &provider_config.auth)?;
+    validate_provider_builtin_web_search(provider_id, provider_config)
 }
 
 pub fn built_in_provider_default_config(
@@ -2907,6 +2908,7 @@ fn materialize_provider_config(
     if let Some(reasoning_effort) = provider_config.reasoning_effort.as_deref() {
         validate_openai_reasoning_effort(reasoning_effort)?;
     }
+    validate_provider_builtin_web_search(&id, &provider_config)?;
     runtime.id = id;
     runtime.transport = provider_config.transport;
     runtime.base_url = provider_config.base_url;
@@ -2926,6 +2928,58 @@ fn validate_openai_reasoning_effort(value: &str) -> Result<()> {
         "low" | "medium" | "high" | "xhigh" => Ok(()),
         _ => Err(anyhow!(
             "invalid OpenAI Codex reasoning_effort '{value}'; must be one of low, medium, high, xhigh"
+        )),
+    }
+}
+
+fn validate_provider_builtin_web_search(
+    provider_id: &ProviderId,
+    provider_config: &ProviderConfigFile,
+) -> Result<()> {
+    let Some(search) = provider_config.builtin_web_search.as_ref() else {
+        return Ok(());
+    };
+    if !search.enabled {
+        return Ok(());
+    }
+    if search.advertised_tool_type.trim().is_empty() {
+        return Err(anyhow!(
+            "providers.{}.builtin_web_search.advertised_tool_type must not be empty",
+            provider_id.as_str()
+        ));
+    }
+    if search.backend_kind.trim().is_empty() {
+        return Err(anyhow!(
+            "providers.{}.builtin_web_search.backend_kind must not be empty",
+            provider_id.as_str()
+        ));
+    }
+    match (provider_config.transport, search.kind) {
+        (ProviderTransportKind::OpenAiResponses, ProviderNativeWebSearchKind::OpenAi) => {
+            if search.advertised_tool_type == "web_search_preview" {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "providers.{}.builtin_web_search.advertised_tool_type must be web_search_preview for OpenAI Responses native search",
+                    provider_id.as_str()
+                ))
+            }
+        }
+        (ProviderTransportKind::AnthropicMessages, ProviderNativeWebSearchKind::Anthropic) => {
+            if search.advertised_tool_type == "web_search_20250305" {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "providers.{}.builtin_web_search.advertised_tool_type must be web_search_20250305 for Anthropic Messages native search",
+                    provider_id.as_str()
+                ))
+            }
+        }
+        _ => Err(anyhow!(
+            "providers.{}.builtin_web_search kind {:?} is incompatible with transport {:?}",
+            provider_id.as_str(),
+            search.kind,
+            provider_config.transport
         )),
     }
 }
@@ -3793,9 +3847,10 @@ mod tests {
         parse_comma_separated_values, parse_url_value, persisted_config_path,
         provider_registry_for_tests, resolve_anthropic_context_management_config,
         save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
-        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig, ControlAuthMode,
-        CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile, ModelConfigFile,
-        ModelRef, ProviderAuthConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
+        validate_provider_config, AnthropicCacheStrategy, AnthropicContextManagementConfig,
+        AppConfig, ControlAuthMode, CredentialKind, CredentialSource, CredentialStoreFile,
+        HolonConfigFile, ModelConfigFile, ModelRef, ProviderAuthConfig,
+        ProviderBuiltinWebSearchConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
         ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
     };
 
@@ -4436,6 +4491,85 @@ mod tests {
         };
         let err = super::validate_provider_auth(&id, &auth).unwrap_err();
         assert!(err.to_string().contains("requires auth.env"));
+    }
+
+    #[test]
+    fn provider_builtin_web_search_rejects_empty_tool_metadata() {
+        let id = ProviderId::parse("custom-anthropic").unwrap();
+        let config = ProviderConfigFile {
+            transport: ProviderTransportKind::AnthropicMessages,
+            base_url: "https://api.example.com".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::Env,
+                kind: CredentialKind::ApiKey,
+                env: Some("CUSTOM_API_KEY".into()),
+                profile: None,
+                external: None,
+            },
+            reasoning_effort: None,
+            builtin_web_search: Some(ProviderBuiltinWebSearchConfig {
+                enabled: true,
+                kind: ProviderNativeWebSearchKind::Anthropic,
+                advertised_tool_type: String::new(),
+                backend_kind: "custom_backend".into(),
+            }),
+        };
+
+        let err = validate_provider_config(&id, &config).unwrap_err();
+        assert!(err.to_string().contains("advertised_tool_type"));
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn provider_builtin_web_search_rejects_transport_kind_mismatch() {
+        let id = ProviderId::parse("custom-openai").unwrap();
+        let config = ProviderConfigFile {
+            transport: ProviderTransportKind::OpenAiResponses,
+            base_url: "https://api.example.com".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::Env,
+                kind: CredentialKind::ApiKey,
+                env: Some("CUSTOM_API_KEY".into()),
+                profile: None,
+                external: None,
+            },
+            reasoning_effort: None,
+            builtin_web_search: Some(ProviderBuiltinWebSearchConfig {
+                enabled: true,
+                kind: ProviderNativeWebSearchKind::Anthropic,
+                advertised_tool_type: "web_search_20250305".into(),
+                backend_kind: "custom_backend".into(),
+            }),
+        };
+
+        let err = validate_provider_config(&id, &config).unwrap_err();
+        assert!(err.to_string().contains("incompatible with transport"));
+    }
+
+    #[test]
+    fn provider_builtin_web_search_rejects_wrong_tool_type() {
+        let id = ProviderId::parse("custom-openai").unwrap();
+        let config = ProviderConfigFile {
+            transport: ProviderTransportKind::OpenAiResponses,
+            base_url: "https://api.example.com".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::Env,
+                kind: CredentialKind::ApiKey,
+                env: Some("CUSTOM_API_KEY".into()),
+                profile: None,
+                external: None,
+            },
+            reasoning_effort: None,
+            builtin_web_search: Some(ProviderBuiltinWebSearchConfig {
+                enabled: true,
+                kind: ProviderNativeWebSearchKind::OpenAi,
+                advertised_tool_type: "web_search_20250305".into(),
+                backend_kind: "custom_backend".into(),
+            }),
+        };
+
+        let err = validate_provider_config(&id, &config).unwrap_err();
+        assert!(err.to_string().contains("web_search_preview"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use crate::{
     model_catalog::{
         BuiltInModelCatalog, BuiltInModelMetadata, ModelRuntimeOverride, ResolvedRuntimeModelPolicy,
     },
+    provider::ProviderNativeWebSearchKind,
     web::{WebProviderKind, WebSearchMode},
 };
 
@@ -142,6 +143,7 @@ pub struct ProviderRuntimeConfig {
     pub originator: Option<String>,
     pub reasoning_effort: Option<String>,
     pub context_management: AnthropicContextManagementConfig,
+    pub builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
 }
 
 impl ProviderRuntimeConfig {
@@ -250,6 +252,21 @@ pub struct ProviderConfigFile {
     pub auth: ProviderAuthConfig,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderBuiltinWebSearchConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub kind: ProviderNativeWebSearchKind,
+    pub advertised_tool_type: String,
+    pub backend_kind: String,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1276,6 +1293,7 @@ fn built_in_provider_default_config_with_settings(
             base_url: provider.base_url.clone(),
             auth: ProviderAuthConfig::default(),
             reasoning_effort: None,
+            builtin_web_search: None,
         }))
 }
 
@@ -2316,6 +2334,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
             originator: Some("codex_cli_rs".into()),
             reasoning_effort: openai_codex_reasoning_effort,
             context_management: Default::default(),
+            builtin_web_search: None,
         },
     );
     let openai = ProviderId::openai();
@@ -2340,6 +2359,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
             originator: None,
             reasoning_effort: None,
             context_management: Default::default(),
+            builtin_web_search: Some(openai_builtin_web_search_config()),
         },
     );
     let anthropic = ProviderId::anthropic();
@@ -2362,6 +2382,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
             originator: None,
             reasoning_effort: None,
             context_management: resolve_anthropic_context_management_config()?,
+            builtin_web_search: Some(anthropic_builtin_web_search_config()),
         },
     );
     insert_openai_compatible_provider(
@@ -2706,6 +2727,11 @@ fn insert_anthropic_compatible_provider(
     env_names: &[&str],
     settings_env: &HashMap<String, String>,
 ) -> Result<()> {
+    let builtin_web_search = match provider {
+        "zai" | "zai-anthropic" => Some(zai_builtin_web_search_config()),
+        "bigmodel" | "bigmodel-anthropic" => Some(bigmodel_builtin_web_search_config()),
+        _ => None,
+    };
     insert_builtin_http_provider_with_context_management(
         registry,
         provider,
@@ -2714,6 +2740,7 @@ fn insert_anthropic_compatible_provider(
         env_names,
         settings_env,
         resolve_anthropic_compatible_context_management_config()?,
+        builtin_web_search,
     )
 }
 
@@ -2733,6 +2760,7 @@ fn insert_builtin_http_provider(
         env_names,
         settings_env,
         Default::default(),
+        None,
     )
 }
 
@@ -2744,6 +2772,7 @@ fn insert_builtin_http_provider_with_context_management(
     env_names: &[&str],
     settings_env: &HashMap<String, String>,
     context_management: AnthropicContextManagementConfig,
+    builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
 ) -> Result<()> {
     let id = ProviderId::parse(provider)?;
     let base_url_env = format!("HOLON_{}_BASE_URL", env_key_fragment(provider));
@@ -2781,9 +2810,46 @@ fn insert_builtin_http_provider_with_context_management(
             originator: None,
             reasoning_effort: None,
             context_management,
+            builtin_web_search,
         },
     );
     Ok(())
+}
+
+fn openai_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::OpenAi,
+        advertised_tool_type: "web_search_preview".to_string(),
+        backend_kind: "openai_web_search".to_string(),
+    }
+}
+
+fn anthropic_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::Anthropic,
+        advertised_tool_type: "web_search_20250305".to_string(),
+        backend_kind: "anthropic_web_search".to_string(),
+    }
+}
+
+fn zai_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::Anthropic,
+        advertised_tool_type: "web_search_20250305".to_string(),
+        backend_kind: "zai_web_search_prime".to_string(),
+    }
+}
+
+fn bigmodel_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::Anthropic,
+        advertised_tool_type: "web_search_20250305".to_string(),
+        backend_kind: "bigmodel_web_search".to_string(),
+    }
 }
 
 fn env_key_fragment(provider: &str) -> String {
@@ -2836,6 +2902,7 @@ fn materialize_provider_config(
         originator: None,
         reasoning_effort: None,
         context_management: Default::default(),
+        builtin_web_search: None,
     });
     if let Some(reasoning_effort) = provider_config.reasoning_effort.as_deref() {
         validate_openai_reasoning_effort(reasoning_effort)?;
@@ -2847,6 +2914,9 @@ fn materialize_provider_config(
     runtime.credential = credential;
     if provider_config.reasoning_effort.is_some() {
         runtime.reasoning_effort = provider_config.reasoning_effort;
+    }
+    if let Some(builtin_web_search) = provider_config.builtin_web_search {
+        runtime.builtin_web_search = builtin_web_search.enabled.then_some(builtin_web_search);
     }
     Ok(runtime)
 }
@@ -2982,6 +3052,7 @@ pub fn provider_registry_for_tests(
             originator: Some("codex_cli_rs".into()),
             reasoning_effort: Some("low".into()),
             context_management: Default::default(),
+            builtin_web_search: None,
         },
     );
     let openai = ProviderId::openai();
@@ -3003,6 +3074,7 @@ pub fn provider_registry_for_tests(
             originator: None,
             reasoning_effort: None,
             context_management: Default::default(),
+            builtin_web_search: Some(openai_builtin_web_search_config()),
         },
     );
     let anthropic = ProviderId::anthropic();
@@ -3024,6 +3096,7 @@ pub fn provider_registry_for_tests(
             originator: None,
             reasoning_effort: None,
             context_management: Default::default(),
+            builtin_web_search: Some(anthropic_builtin_web_search_config()),
         },
     );
     registry
@@ -3711,17 +3784,18 @@ mod tests {
 
     use crate::context::ContextConfig;
     use crate::model_catalog::ModelRuntimeOverride;
+    use crate::provider::ProviderNativeWebSearchKind;
 
     use super::{
-        config_schema, credential_store_path, default_holon_home, get_config_key, get_config_value,
-        list_credential_profiles_at, load_persisted_config_at, parse_anthropic_cache_strategy,
-        parse_anthropic_cache_strategy_env, parse_comma_separated_values, parse_url_value,
-        persisted_config_path, provider_registry_for_tests,
-        resolve_anthropic_context_management_config, save_persisted_config_at, set_config_key,
-        set_credential_profile_at, unset_config_key, AnthropicCacheStrategy,
-        AnthropicContextManagementConfig, AppConfig, ControlAuthMode, CredentialKind,
-        CredentialSource, CredentialStoreFile, HolonConfigFile, ModelConfigFile, ModelRef,
-        ProviderAuthConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
+        built_in_provider_registry, config_schema, credential_store_path, default_holon_home,
+        get_config_key, get_config_value, list_credential_profiles_at, load_persisted_config_at,
+        parse_anthropic_cache_strategy, parse_anthropic_cache_strategy_env,
+        parse_comma_separated_values, parse_url_value, persisted_config_path,
+        provider_registry_for_tests, resolve_anthropic_context_management_config,
+        save_persisted_config_at, set_config_key, set_credential_profile_at, unset_config_key,
+        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig, ControlAuthMode,
+        CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile, ModelConfigFile,
+        ModelRef, ProviderAuthConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
         ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
     };
 
@@ -4287,6 +4361,33 @@ mod tests {
     }
 
     #[test]
+    fn built_in_provider_registry_declares_provider_specific_builtin_search() {
+        let registry = built_in_provider_registry(&HashMap::new()).unwrap();
+
+        let anthropic = registry.get(&ProviderId::anthropic()).unwrap();
+        let anthropic_search = anthropic.builtin_web_search.as_ref().unwrap();
+        assert_eq!(
+            anthropic_search.kind,
+            ProviderNativeWebSearchKind::Anthropic
+        );
+        assert_eq!(anthropic_search.advertised_tool_type, "web_search_20250305");
+        assert_eq!(anthropic_search.backend_kind, "anthropic_web_search");
+
+        let zai = registry
+            .get(&ProviderId::parse("zai-anthropic").unwrap())
+            .unwrap();
+        let zai_search = zai.builtin_web_search.as_ref().unwrap();
+        assert_eq!(zai_search.kind, ProviderNativeWebSearchKind::Anthropic);
+        assert_eq!(zai_search.advertised_tool_type, "web_search_20250305");
+        assert_eq!(zai_search.backend_kind, "zai_web_search_prime");
+
+        let deepseek = registry
+            .get(&ProviderId::parse("deepseek-anthropic").unwrap())
+            .unwrap();
+        assert!(deepseek.builtin_web_search.is_none());
+    }
+
+    #[test]
     fn set_get_and_unset_round_trip_models_catalog_object() {
         let mut config = HolonConfigFile::default();
         set_config_key(
@@ -4355,6 +4456,7 @@ mod tests {
                     external: None,
                 },
                 reasoning_effort: None,
+                builtin_web_search: None,
             },
             &settings_env,
             &CredentialStoreFile::default(),
@@ -4442,6 +4544,7 @@ mod tests {
                     external: None,
                 },
                 reasoning_effort: None,
+                builtin_web_search: None,
             },
             &settings_env,
             &credential_store,
@@ -4491,6 +4594,7 @@ mod tests {
                     external: None,
                 },
                 reasoning_effort: None,
+                builtin_web_search: None,
             },
         );
         save_persisted_config_at(&persisted_config_path(dir.path()), &config).unwrap();
@@ -4836,6 +4940,7 @@ mod tests {
                     external: Some("codex_cli".into()),
                 },
                 reasoning_effort: None,
+                builtin_web_search: None,
             },
             &settings_env,
             &CredentialStoreFile::default(),
@@ -4983,6 +5088,7 @@ mod tests {
                             external: None,
                         },
                         reasoning_effort: None,
+                        builtin_web_search: None,
                     },
                 )]),
                 ..HolonConfigFile::default()
@@ -5029,6 +5135,7 @@ mod tests {
                 originator: None,
                 reasoning_effort: None,
                 context_management: Default::default(),
+                builtin_web_search: None,
             },
         );
         let mut overrides = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2583,6 +2583,7 @@ async fn handle_config_providers_command(command: ConfigProviderCommands) -> Res
                     external: credential_external,
                 },
                 reasoning_effort: None,
+                builtin_web_search: None,
             };
             validate_provider_config(&id, &provider_config)?;
 

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -13,7 +13,7 @@ use super::{
         provider_retry_backoff, RetryDisposition,
     },
     AgentProvider, PromptContentBlock, ProviderAttemptOutcome, ProviderAttemptRecord,
-    ProviderAttemptTimeline, ProviderContextManagementPolicy, ProviderNativeWebSearchKind,
+    ProviderAttemptTimeline, ProviderBuiltinWebSearchCapability, ProviderContextManagementPolicy,
     ProviderTurnRequest, ProviderTurnResponse,
 };
 use crate::prompt::PromptStability;
@@ -484,13 +484,19 @@ impl AgentProvider for FallbackProvider {
                 .all(|candidate| candidate.provider.supports_freeform_grammar_tools())
     }
 
-    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
-        let mut kinds = self
+    fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
+        let mut capabilities = self
             .candidates
             .iter()
-            .map(|candidate| candidate.provider.native_web_search_kind());
-        let first = kinds.next().flatten()?;
-        if kinds.all(|kind| kind == Some(first)) {
+            .map(|candidate| candidate.provider.builtin_web_search());
+        let first = capabilities.next().flatten()?;
+        if capabilities.all(|capability| {
+            capability.as_ref().is_some_and(|capability| {
+                capability.kind == first.kind
+                    && capability.advertised_tool_type == first.advertised_tool_type
+                    && capability.backend_kind == first.backend_kind
+            })
+        }) {
             Some(first)
         } else {
             None

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -32,7 +32,9 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
-    use crate::provider::{ModelBlock, ProviderCacheUsage, ProviderPromptFrame};
+    use crate::provider::{
+        ModelBlock, ProviderCacheUsage, ProviderNativeWebSearchKind, ProviderPromptFrame,
+    };
 
     #[derive(Clone)]
     struct PolicyProvider {
@@ -45,6 +47,11 @@ mod tests {
         fail: bool,
         prompts: Arc<Mutex<Vec<String>>>,
         system_blocks: Arc<Mutex<Vec<Vec<PromptContentBlock>>>>,
+    }
+
+    #[derive(Clone)]
+    struct SearchProvider {
+        capability: Option<ProviderBuiltinWebSearchCapability>,
     }
 
     #[async_trait]
@@ -102,6 +109,30 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl AgentProvider for SearchProvider {
+        async fn complete_turn(
+            &self,
+            _request: ProviderTurnRequest,
+        ) -> Result<ProviderTurnResponse> {
+            Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text { text: "ok".into() }],
+                stop_reason: None,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_usage: Some(ProviderCacheUsage {
+                    read_input_tokens: 0,
+                    creation_input_tokens: 0,
+                }),
+                request_diagnostics: None,
+            })
+        }
+
+        fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
+            self.capability.clone()
+        }
+    }
+
     fn policy(trigger_input_tokens: u32) -> ProviderContextManagementPolicy {
         ProviderContextManagementPolicy {
             provider: "anthropic".into(),
@@ -134,6 +165,20 @@ mod tests {
         }
     }
 
+    fn search_capability(
+        provider_id: &str,
+        model_ref: &str,
+        backend_kind: &str,
+    ) -> ProviderBuiltinWebSearchCapability {
+        ProviderBuiltinWebSearchCapability {
+            kind: ProviderNativeWebSearchKind::Anthropic,
+            provider_id: provider_id.into(),
+            provider_model_ref: model_ref.into(),
+            advertised_tool_type: "web_search_20250305".into(),
+            backend_kind: backend_kind.into(),
+        }
+    }
+
     #[test]
     fn context_management_policy_requires_full_policy_match() {
         let provider = FallbackProvider {
@@ -144,6 +189,37 @@ mod tests {
         };
 
         assert_eq!(provider.context_management_policy(), None);
+    }
+
+    #[test]
+    fn builtin_web_search_uses_current_turn_candidate() {
+        let provider = FallbackProvider {
+            candidates: vec![
+                ProviderCandidate {
+                    model_ref: "zai-anthropic/glm-4.7".into(),
+                    provider_name: "zai-anthropic".into(),
+                    provider: Arc::new(SearchProvider {
+                        capability: Some(search_capability(
+                            "zai-anthropic",
+                            "zai-anthropic/glm-4.7",
+                            "zai_web_search_prime",
+                        )),
+                    }),
+                },
+                ProviderCandidate {
+                    model_ref: "deepseek-anthropic/deepseek-chat".into(),
+                    provider_name: "deepseek-anthropic".into(),
+                    provider: Arc::new(SearchProvider { capability: None }),
+                },
+            ],
+        };
+
+        let capability = provider
+            .builtin_web_search()
+            .expect("active candidate should expose builtin search");
+        assert_eq!(capability.provider_id, "zai-anthropic");
+        assert_eq!(capability.provider_model_ref, "zai-anthropic/glm-4.7");
+        assert_eq!(capability.backend_kind, "zai_web_search_prime");
     }
 
     #[tokio::test]
@@ -485,22 +561,7 @@ impl AgentProvider for FallbackProvider {
     }
 
     fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
-        let mut capabilities = self
-            .candidates
-            .iter()
-            .map(|candidate| candidate.provider.builtin_web_search());
-        let first = capabilities.next().flatten()?;
-        if capabilities.all(|capability| {
-            capability.as_ref().is_some_and(|capability| {
-                capability.kind == first.kind
-                    && capability.advertised_tool_type == first.advertised_tool_type
-                    && capability.backend_kind == first.backend_kind
-            })
-        }) {
-            Some(first)
-        } else {
-            None
-        }
+        self.candidates.first()?.provider.builtin_web_search()
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -146,6 +146,9 @@ pub enum ProviderNativeWebSearchKind {
 pub struct ProviderNativeWebSearchRequest {
     pub kind: ProviderNativeWebSearchKind,
     pub provider_id: String,
+    pub provider_model_ref: String,
+    pub advertised_tool_type: String,
+    pub backend_kind: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_results: Option<usize>,
 }
@@ -154,9 +157,21 @@ pub struct ProviderNativeWebSearchRequest {
 pub struct ProviderNativeWebSearchDiagnostics {
     pub kind: ProviderNativeWebSearchKind,
     pub provider_id: String,
+    pub provider_model_ref: String,
+    pub advertised_tool_type: String,
+    pub backend_kind: String,
     pub lowered: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderBuiltinWebSearchCapability {
+    pub kind: ProviderNativeWebSearchKind,
+    pub provider_id: String,
+    pub provider_model_ref: String,
+    pub advertised_tool_type: String,
+    pub backend_kind: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -360,8 +375,12 @@ pub trait AgentProvider: Send + Sync {
             .collect()
     }
 
-    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
+    fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
         None
+    }
+
+    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
+        self.builtin_web_search().map(|capability| capability.kind)
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -1368,6 +1368,7 @@ fn build_provider_from_config_uses_custom_openai_responses_provider() {
             originator: None,
             reasoning_effort: None,
             context_management: Default::default(),
+            builtin_web_search: None,
         },
     );
 
@@ -1411,6 +1412,7 @@ fn build_candidate_accepts_openai_responses_without_auth() {
             originator: None,
             reasoning_effort: None,
             context_management: Default::default(),
+            builtin_web_search: None,
         },
     );
 

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -11,16 +11,16 @@ use twox_hash::XxHash64;
 
 use crate::{
     config::{
-        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig, ProviderId,
-        ProviderRuntimeConfig,
+        AnthropicCacheStrategy, AnthropicContextManagementConfig, AppConfig,
+        ProviderBuiltinWebSearchConfig, ProviderId, ProviderRuntimeConfig,
     },
     prompt::PromptStability,
     provider::{
         http_trace::ProviderHttpTrace, AgentProvider, AnthropicPromptCacheDiagnostics,
         CacheBreakpointInfo, ConversationMessage, ModelBlock, PromptContentBlock,
-        ProviderCacheUsage, ProviderContextManagementPolicy, ProviderNativeWebSearchDiagnostics,
-        ProviderNativeWebSearchKind, ProviderPromptCapability, ProviderTurnRequest,
-        ProviderTurnResponse,
+        ProviderBuiltinWebSearchCapability, ProviderCacheUsage, ProviderContextManagementPolicy,
+        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind, ProviderPromptCapability,
+        ProviderTurnRequest, ProviderTurnResponse,
     },
 };
 
@@ -33,11 +33,13 @@ use crate::provider::retry::{
 #[derive(Clone)]
 pub struct AnthropicProvider {
     client: Client,
+    provider_id: String,
     base_url: String,
     auth_token: String,
     model: String,
     max_output_tokens: u32,
     context_management: AnthropicContextManagementConfig,
+    builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     trace_home_dir: PathBuf,
 }
 
@@ -157,11 +159,13 @@ impl AnthropicProvider {
             })?;
         Ok(Self {
             client,
+            provider_id: provider_config.id.as_str().to_string(),
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             auth_token,
             model: model.to_string(),
             max_output_tokens,
             context_management: provider_config.context_management.clone(),
+            builtin_web_search: provider_config.builtin_web_search.clone(),
             trace_home_dir: trace_home_dir.to_path_buf(),
         })
     }
@@ -348,8 +352,15 @@ impl AgentProvider for AnthropicProvider {
         capabilities
     }
 
-    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
-        Some(ProviderNativeWebSearchKind::Anthropic)
+    fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
+        let config = self.builtin_web_search.as_ref()?;
+        Some(ProviderBuiltinWebSearchCapability {
+            kind: config.kind,
+            provider_id: self.provider_id.clone(),
+            provider_model_ref: format!("{}/{}", self.provider_id, self.model),
+            advertised_tool_type: config.advertised_tool_type.clone(),
+            backend_kind: config.backend_kind.clone(),
+        })
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {
@@ -578,7 +589,11 @@ fn build_anthropic_tools(request: &ProviderTurnRequest) -> Vec<Value> {
         Some(ProviderNativeWebSearchKind::Anthropic)
     ) {
         tools.push(json!({
-            "type": "web_search_20250305",
+            "type": request
+                .native_web_search
+                .as_ref()
+                .map(|native| native.advertised_tool_type.as_str())
+                .unwrap_or("web_search_20250305"),
             "name": "web_search"
         }));
     }
@@ -593,6 +608,9 @@ fn native_web_search_diagnostics(
     Some(ProviderNativeWebSearchDiagnostics {
         kind: native.kind,
         provider_id: native.provider_id.clone(),
+        provider_model_ref: native.provider_model_ref.clone(),
+        advertised_tool_type: native.advertised_tool_type.clone(),
+        backend_kind: native.backend_kind.clone(),
         lowered,
         fallback_reason: (!lowered)
             .then(|| "anthropic transport only supports Anthropic-native web search".into()),
@@ -1762,6 +1780,9 @@ mod tests {
         request.native_web_search = Some(ProviderNativeWebSearchRequest {
             kind: ProviderNativeWebSearchKind::Anthropic,
             provider_id: "anthropic_native".into(),
+            provider_model_ref: "anthropic/claude-test".into(),
+            advertised_tool_type: "web_search_20250305".into(),
+            backend_kind: "anthropic_web_search".into(),
             max_results: None,
         });
 

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -13,18 +13,20 @@ use std::{
 use crate::{
     auth::load_codex_cli_credential,
     config::{
-        AppConfig, CredentialKind, CredentialSource, ModelRef, ProviderId, ProviderRuntimeConfig,
+        AppConfig, CredentialKind, CredentialSource, ModelRef, ProviderBuiltinWebSearchConfig,
+        ProviderId, ProviderRuntimeConfig,
     },
     context::ContextConfig,
     model_catalog::BuiltInModelCatalog,
     provider::{
         emitted_tool_json_schema,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
-        AgentProvider, ConversationMessage, ModelBlock, ProviderCacheUsage,
-        ProviderIncrementalContinuationDiagnostics, ProviderNativeWebSearchDiagnostics,
-        ProviderNativeWebSearchKind, ProviderOpenAiRemoteCompactionDiagnostics,
-        ProviderOpenAiRequestControlsDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
-        ProviderTurnRequest, ProviderTurnResponse, ToolSchemaContract,
+        AgentProvider, ConversationMessage, ModelBlock, ProviderBuiltinWebSearchCapability,
+        ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
+        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
+        ProviderOpenAiRemoteCompactionDiagnostics, ProviderOpenAiRequestControlsDiagnostics,
+        ProviderPromptFrame, ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
+        ToolSchemaContract,
     },
     token_estimate::estimate_json_tokens,
 };
@@ -39,10 +41,12 @@ use crate::provider::retry::{
 #[derive(Clone)]
 pub struct OpenAiProvider {
     client: Client,
+    provider_id: String,
     base_url: String,
     api_key: Option<String>,
     model: String,
     max_output_tokens: u32,
+    builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
@@ -275,10 +279,12 @@ impl OpenAiProvider {
         };
         Ok(Self {
             client,
+            provider_id: provider_config.id.as_str().to_string(),
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             api_key,
             model: model.to_string(),
             max_output_tokens,
+            builtin_web_search: provider_config.builtin_web_search.clone(),
             compaction_policy,
             trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
@@ -542,8 +548,15 @@ impl AgentProvider for OpenAiProvider {
         true
     }
 
-    fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
-        Some(ProviderNativeWebSearchKind::OpenAi)
+    fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
+        let config = self.builtin_web_search.as_ref()?;
+        Some(ProviderBuiltinWebSearchCapability {
+            kind: config.kind,
+            provider_id: self.provider_id.clone(),
+            provider_model_ref: format!("{}/{}", self.provider_id, self.model),
+            advertised_tool_type: config.advertised_tool_type.clone(),
+            backend_kind: config.backend_kind.clone(),
+        })
     }
 }
 
@@ -1112,7 +1125,7 @@ fn openai_native_web_search_tool(request: &ProviderTurnRequest) -> Option<Value>
     if native.kind != ProviderNativeWebSearchKind::OpenAi {
         return None;
     }
-    Some(json!({ "type": "web_search_preview" }))
+    Some(json!({ "type": native.advertised_tool_type }))
 }
 
 fn openai_request_controls_diagnostics(body: &Value) -> ProviderOpenAiRequestControlsDiagnostics {
@@ -1592,6 +1605,9 @@ fn native_web_search_diagnostics(
     Some(ProviderNativeWebSearchDiagnostics {
         kind: native.kind,
         provider_id: native.provider_id.clone(),
+        provider_model_ref: native.provider_model_ref.clone(),
+        advertised_tool_type: native.advertised_tool_type.clone(),
+        backend_kind: native.backend_kind.clone(),
         lowered,
         fallback_reason: (!lowered)
             .then(|| "openai responses transport only supports OpenAI-native web search".into()),
@@ -4271,6 +4287,9 @@ mod tests {
         request.native_web_search = Some(ProviderNativeWebSearchRequest {
             kind: ProviderNativeWebSearchKind::OpenAi,
             provider_id: "openai_native".into(),
+            provider_model_ref: "openai/gpt-test".into(),
+            advertised_tool_type: "web_search_preview".into(),
+            backend_kind: "openai_web_search".into(),
             max_results: Some(5),
         });
 

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -293,7 +293,7 @@ impl RuntimeHandle {
         native_search_provider: Option<&(String, WebProviderKind)>,
     ) -> Option<ProviderNativeWebSearchRequest> {
         native_web_search_request_for_config(
-            provider.native_web_search_kind(),
+            provider.builtin_web_search(),
             native_search_provider,
             self.web_config().search.max_results,
         )
@@ -312,7 +312,7 @@ impl RuntimeHandle {
 }
 
 fn native_web_search_request_for_config(
-    provider_native_kind: Option<ProviderNativeWebSearchKind>,
+    provider_capability: Option<crate::provider::ProviderBuiltinWebSearchCapability>,
     native_search_provider: Option<&(String, WebProviderKind)>,
     max_results: usize,
 ) -> Option<ProviderNativeWebSearchRequest> {
@@ -324,9 +324,13 @@ fn native_web_search_request_for_config(
         _ => return None,
     };
 
-    (provider_native_kind == Some(kind)).then_some(ProviderNativeWebSearchRequest {
+    let capability = provider_capability?;
+    (capability.kind == kind).then_some(ProviderNativeWebSearchRequest {
         kind,
         provider_id: provider_id.clone(),
+        provider_model_ref: capability.provider_model_ref,
+        advertised_tool_type: capability.advertised_tool_type,
+        backend_kind: capability.backend_kind,
         max_results: Some(max_results.max(1)),
     })
 }
@@ -340,7 +344,13 @@ mod tests {
         let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
 
         assert!(native_web_search_request_for_config(
-            Some(ProviderNativeWebSearchKind::Anthropic),
+            Some(crate::provider::ProviderBuiltinWebSearchCapability {
+                kind: ProviderNativeWebSearchKind::Anthropic,
+                provider_id: "anthropic".into(),
+                provider_model_ref: "anthropic/claude-test".into(),
+                advertised_tool_type: "web_search_20250305".into(),
+                backend_kind: "anthropic_web_search".into(),
+            }),
             Some(&native_provider),
             5,
         )
@@ -352,12 +362,21 @@ mod tests {
         let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
 
         let request = native_web_search_request_for_config(
-            Some(ProviderNativeWebSearchKind::OpenAi),
+            Some(crate::provider::ProviderBuiltinWebSearchCapability {
+                kind: ProviderNativeWebSearchKind::OpenAi,
+                provider_id: "openai".into(),
+                provider_model_ref: "openai/gpt-test".into(),
+                advertised_tool_type: "web_search_preview".into(),
+                backend_kind: "openai_web_search".into(),
+            }),
             Some(&native_provider),
             0,
         )
         .unwrap();
 
         assert_eq!(request.max_results, Some(1));
+        assert_eq!(request.provider_model_ref, "openai/gpt-test");
+        assert_eq!(request.advertised_tool_type, "web_search_preview");
+        assert_eq!(request.backend_kind, "openai_web_search");
     }
 }

--- a/src/web/search.rs
+++ b/src/web/search.rs
@@ -684,14 +684,16 @@ async fn command_search(
         ));
     }
     let stdout = String::from_utf8(stdout.bytes).map_err(|error| {
-        search_error(
+        command_search_error(
             "parse_failed",
             format!("WebSearch command provider returned non-UTF-8 stdout: {error}"),
             provider_id,
             "configure the command provider to emit UTF-8 JSON",
+            command_attempt.clone(),
         )
     })?;
     parse_command_results(&stdout, output, provider_id, max_results)
+        .map_err(|error| command_parse_error_with_attempt(error, command_attempt.clone()))
         .map(|results| ProviderSearchOutput::command(results, command_attempt))
 }
 
@@ -1737,6 +1739,27 @@ fn command_search_error(
     )
 }
 
+fn command_parse_error_with_attempt(
+    error: anyhow::Error,
+    command: WebSearchCommandAttempt,
+) -> anyhow::Error {
+    let original = ToolError::from_anyhow(&error);
+    let mut details = original
+        .details
+        .unwrap_or_else(|| json!({}))
+        .as_object()
+        .cloned()
+        .unwrap_or_default();
+    details.insert("command".to_string(), json!(command));
+    let mut tool_error = ToolError::new(original.kind, original.message)
+        .with_details(Value::Object(details))
+        .with_retryable(original.retryable);
+    if let Some(recovery_hint) = original.recovery_hint {
+        tool_error = tool_error.with_recovery_hint(recovery_hint);
+    }
+    anyhow::Error::from(tool_error)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2106,6 +2129,68 @@ mod tests {
             tool_error.details.as_ref().unwrap()["provider"],
             json!("cmd")
         );
+        assert_eq!(
+            tool_error.details.as_ref().unwrap()["command"]["argv_template"],
+            json!(["false"])
+        );
+    }
+
+    #[tokio::test]
+    async fn command_provider_invalid_json_keeps_command_attempt() {
+        let provider = command_test_provider(vec!["printf".into(), "not-json".into()]);
+
+        let err = command_search("holon", 3, "cmd", &provider)
+            .await
+            .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&err);
+
+        assert_eq!(tool_error.kind, "parse_failed");
+        let details = tool_error.details.as_ref().unwrap();
+        assert_eq!(details["provider"], json!("cmd"));
+        assert_eq!(
+            details["command"]["argv_template"],
+            json!(["printf", "not-json"])
+        );
+        assert_eq!(details["command"]["exit_status"], json!(0));
+    }
+
+    #[tokio::test]
+    async fn command_provider_invalid_utf8_keeps_command_attempt() {
+        let provider = command_test_provider(vec!["printf".into(), "\\377".into()]);
+
+        let err = command_search("holon", 3, "cmd", &provider)
+            .await
+            .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&err);
+
+        assert_eq!(tool_error.kind, "parse_failed");
+        let details = tool_error.details.as_ref().unwrap();
+        assert_eq!(details["provider"], json!("cmd"));
+        assert_eq!(
+            details["command"]["argv_template"],
+            json!(["printf", "\\377"])
+        );
+        assert_eq!(details["command"]["exit_status"], json!(0));
+    }
+
+    #[tokio::test]
+    async fn command_provider_mapping_failure_keeps_command_attempt() {
+        let provider =
+            command_test_provider(vec!["printf".into(), r#"[{"title":"No URL"}]"#.into()]);
+
+        let err = command_search("holon", 3, "cmd", &provider)
+            .await
+            .unwrap_err();
+        let tool_error = ToolError::from_anyhow(&err);
+
+        assert_eq!(tool_error.kind, "parse_failed");
+        let details = tool_error.details.as_ref().unwrap();
+        assert_eq!(details["provider"], json!("cmd"));
+        assert_eq!(
+            details["command"]["argv_template"],
+            json!(["printf", r#"[{"title":"No URL"}]"#])
+        );
+        assert_eq!(details["command"]["exit_status"], json!(0));
     }
 
     #[test]

--- a/tests/live_anthropic.rs
+++ b/tests/live_anthropic.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
 use holon::{
-    config::AppConfig,
+    config::{AppConfig, ProviderId, ProviderTransportKind},
     host::RuntimeHost,
     prompt::PromptStability,
     provider::{
         AgentProvider, AnthropicProvider, ConversationMessage, ModelBlock, PromptContentBlock,
-        ProviderPromptCache, ProviderPromptFrame, ProviderTurnRequest, ToolResultBlock,
+        ProviderNativeWebSearchRequest, ProviderPromptCache, ProviderPromptFrame,
+        ProviderTurnRequest, ToolResultBlock,
     },
     tool::ToolRegistry,
     types::{
@@ -17,6 +18,14 @@ use std::path::PathBuf;
 
 fn live_config() -> Result<AppConfig> {
     AppConfig::load()
+}
+
+fn provider_model_env(provider: &str, default_model: &str) -> String {
+    let env_name = format!(
+        "HOLON_LIVE_{}_MODEL",
+        provider.replace('-', "_").to_ascii_uppercase()
+    );
+    std::env::var(env_name).unwrap_or_else(|_| default_model.into())
 }
 
 async fn wait_until_asleep(runtime: &holon::runtime::RuntimeHandle) -> Result<AgentStatus> {
@@ -44,6 +53,64 @@ async fn live_provider_returns_real_response() -> Result<()> {
             vec![],
         ))
         .await?;
+    assert!(!output.blocks.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires ANTHROPIC_AUTH_TOKEN and network access"]
+async fn live_anthropic_builtin_web_search_reports_backend() -> Result<()> {
+    let mut config = live_config()?;
+    let provider_id = ProviderId::anthropic();
+    let model = provider_model_env("anthropic", "claude-sonnet-4-6");
+    let runtime_max_output_tokens = config.runtime_max_output_tokens;
+    let provider_config = config
+        .providers
+        .get_mut(&provider_id)
+        .expect("built-in anthropic provider should exist");
+    assert_eq!(
+        provider_config.transport,
+        ProviderTransportKind::AnthropicMessages
+    );
+    let trace_home_dir = tempfile::tempdir()?;
+    let provider = AnthropicProvider::from_runtime_config(
+        provider_config,
+        &model,
+        runtime_max_output_tokens,
+        trace_home_dir.path(),
+    )?;
+    let capability = provider
+        .builtin_web_search()
+        .expect("anthropic provider should declare builtin search");
+    assert_eq!(capability.backend_kind, "anthropic_web_search");
+
+    let output = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: ProviderPromptFrame::plain(
+                "Use web search if needed. Reply in one short sentence.",
+            ),
+            conversation: vec![ConversationMessage::UserText(
+                "Search the web and name today's date.".into(),
+            )],
+            tools: vec![],
+            native_web_search: Some(ProviderNativeWebSearchRequest {
+                kind: capability.kind,
+                provider_id: "anthropic-native".into(),
+                provider_model_ref: capability.provider_model_ref,
+                advertised_tool_type: capability.advertised_tool_type,
+                backend_kind: capability.backend_kind,
+                max_results: Some(3),
+            }),
+        })
+        .await?;
+    let diagnostics = output
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.native_web_search.as_ref())
+        .expect("native web search diagnostics should be recorded");
+    assert!(diagnostics.lowered);
+    assert_eq!(diagnostics.backend_kind, "anthropic_web_search");
+    assert_eq!(diagnostics.advertised_tool_type, "web_search_20250305");
     assert!(!output.blocks.is_empty());
     Ok(())
 }

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -4,7 +4,8 @@ use holon::{
     prompt::PromptStability,
     provider::{
         AgentProvider, AnthropicProvider, ConversationMessage, ModelBlock, PromptContentBlock,
-        ProviderPromptCache, ProviderPromptFrame, ProviderTurnRequest, ToolResultBlock,
+        ProviderNativeWebSearchRequest, ProviderPromptCache, ProviderPromptFrame,
+        ProviderTurnRequest, ToolResultBlock,
     },
     tool::ToolSpec,
 };
@@ -161,6 +162,68 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
     Ok(())
 }
 
+async fn provider_builtin_web_search_reports_backend(
+    provider_id: &str,
+    model: &str,
+    expected_backend: &str,
+) -> Result<()> {
+    let mut config = live_config()?;
+    let provider_id = ProviderId::parse(provider_id)?;
+    let provider_id_text = provider_id.as_str().to_string();
+    let runtime_max_output_tokens = config.runtime_max_output_tokens;
+    let provider_config = config
+        .providers
+        .get_mut(&provider_id)
+        .with_context(|| format!("missing {provider_id_text} provider config"))?;
+    assert_eq!(
+        provider_config.transport,
+        ProviderTransportKind::AnthropicMessages,
+        "{provider_id_text} is not configured with Anthropic Messages transport"
+    );
+
+    let trace_home_dir = tempfile::tempdir()?;
+    let provider = AnthropicProvider::from_runtime_config(
+        provider_config,
+        model,
+        runtime_max_output_tokens,
+        trace_home_dir.path(),
+    )?;
+    let capability = provider.builtin_web_search().with_context(|| {
+        format!("{provider_id_text}/{model} did not declare builtin web search")
+    })?;
+    assert_eq!(capability.backend_kind, expected_backend);
+
+    let output = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: ProviderPromptFrame::plain(
+                "Use web search if needed. Reply in one short sentence.",
+            ),
+            conversation: vec![ConversationMessage::UserText(
+                "Search the web and name today's date.".into(),
+            )],
+            tools: vec![],
+            native_web_search: Some(ProviderNativeWebSearchRequest {
+                kind: capability.kind,
+                provider_id: format!("{provider_id_text}-native"),
+                provider_model_ref: capability.provider_model_ref,
+                advertised_tool_type: capability.advertised_tool_type,
+                backend_kind: capability.backend_kind,
+                max_results: Some(3),
+            }),
+        })
+        .await?;
+    let diagnostics = output
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.native_web_search.as_ref())
+        .expect("native web search diagnostics should be recorded");
+    assert!(diagnostics.lowered);
+    assert_eq!(diagnostics.backend_kind, expected_backend);
+    assert_eq!(diagnostics.advertised_tool_type, "web_search_20250305");
+    assert!(!output.blocks.is_empty());
+    Ok(())
+}
+
 #[tokio::test]
 #[ignore = "requires DEEPSEEK_API_KEY and network access"]
 async fn live_deepseek_anthropic_accepts_context_management() -> Result<()> {
@@ -207,6 +270,17 @@ async fn live_zai_anthropic_accepts_context_management() -> Result<()> {
     provider_accepts_context_management(
         "zai-anthropic",
         &provider_model_env("zai-anthropic", "glm-4.7"),
+    )
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires ZAI_API_KEY and network access"]
+async fn live_zai_anthropic_builtin_web_search_reports_prime_backend() -> Result<()> {
+    provider_builtin_web_search_reports_backend(
+        "zai-anthropic",
+        &provider_model_env("zai-anthropic", "glm-4.7"),
+        "zai_web_search_prime",
     )
     .await
 }


### PR DESCRIPTION
## Summary

- Move builtin web search capability from transport-level inference to provider/model-level config.
- Declare official OpenAI/Anthropic and ZAI/GLM builtin search backends separately, including ZAI `web_search_prime` diagnostics.
- Keep managed `WebSearch` hidden only when selected provider capability is compatible, and preserve provider/model/tool/backend metadata in native search diagnostics.
- Attach command provider attempt diagnostics for successful-exit parse failures, including invalid UTF-8, invalid JSON, and mapping failures.
- Add ignored live tests for official Anthropic and ZAI Anthropic-compatible builtin search diagnostics.

Fixes #1325

## Scope Update

During review we changed the native/builtin search plan:

- Provider-declared builtin search should become a model-provider capability that Holon can enable by default, with user disable overrides and capability probe/cache. That follow-up is tracked separately in #1347.
- OpenAI Codex Responses transport builtin search support is tracked separately in #1346.
- We will **not** implement builtin-search failure recovery into a later managed `WebSearch` recovery turn. Provider builtin search runs server-side inside the model provider request, while managed `WebSearch` is a Holon client-side tool. If a selected builtin search request fails during the provider turn, normal provider failure handling applies; Holon should not add a special later managed-search recovery turn for this case.

With that scope decision, this PR closes #1325 by delivering the provider capability/diagnostics and command diagnostics pieces, while the default-enable/probe work continues in #1347.

## Verification

- `cargo check`
- `cargo test -q command_provider`
- `cargo test -q native_web_search_request`
- `cargo test -q built_in_provider_registry_declares_provider_specific_builtin_search`
- `cargo test -q provider_builtin_web_search`
- `cargo test -q builtin_web_search_uses_current_turn_candidate`
- `cargo test -q --test live_anthropic live_anthropic_builtin_web_search_reports_backend -- --ignored` passed against official Anthropic
- `cargo test -q --test live_anthropic_compatible live_zai_anthropic_builtin_web_search_reports_prime_backend -- --ignored` attempted, but this environment is missing `ZAI_API_KEY`, so it failed before the provider request was sent

Latest CI is green: Rust, Coverage, Holon Trigger, Vercel.
