### PR TITLE
fix: clarify prompt cache workspace identity

### DIFF
--- a/docs/implementation-decisions/056-prompt-cache-workspace-guidance-boundary.md
+++ b/docs/implementation-decisions/056-prompt-cache-workspace-guidance-boundary.md
@@ -1,0 +1,38 @@
+# 056 Prompt Cache Workspace and Guidance Boundary
+
+## Choice
+
+Prompt cache identity is tied to rendered prompt content, tool surfaces, loaded
+guidance content, and execution fields that affect visible prompt text or
+relative tool behavior. Workspace bookkeeping ids are not semantic cache inputs
+unless they are rendered to the model or change execution semantics.
+
+Guidance is loaded as three explicit layers at prompt assembly time:
+
+1. global operator guidance from `~/.agents/AGENTS.md` when present;
+2. agent-home guidance from `<agent_home>/AGENTS.md` when present;
+3. active workspace guidance from `<workspace_anchor>/AGENTS.md`, falling back
+   to `<workspace_anchor>/CLAUDE.md` only when `AGENTS.md` is absent.
+
+`UseWorkspace` changes active workspace state. The next prompt assembly reloads
+the guidance stack from disk; switching workspaces replaces only the workspace
+layer and does not suppress global or agent-home guidance.
+
+## Reason
+
+Prompt caches should invalidate when model-visible instructions, loaded guidance
+content, tool contracts, paths, cwd, projection mode, access mode, or worktree
+roots change. They should not invalidate merely because an internal
+`execution_root_id` changes while the rendered prompt and tool semantics remain
+the same.
+
+Keeping guidance as layered prompt sections makes repeated workspace switching
+legible: unchanged global and agent-home layers stay stable, while the active
+workspace layer changes or refreshes when its file content changes.
+
+## Boundary
+
+`workspace_id` remains in the cache payload while it is rendered in the
+execution environment summary. `execution_root_id` remains available in runtime
+state and diagnostics, but it is not part of prompt cache identity because it is
+bookkeeping rather than a relative-path or projection semantic.

--- a/src/agents_md.rs
+++ b/src/agents_md.rs
@@ -8,13 +8,23 @@ const AGENTS_MD_FILENAME: &str = "AGENTS.md";
 const CLAUDE_MD_FILENAME: &str = "CLAUDE.md";
 
 pub fn load_agents_md(
+    user_home: Option<&Path>,
     agent_home: &Path,
     workspace_anchor: Option<&Path>,
 ) -> Result<LoadedAgentsMd> {
     Ok(LoadedAgentsMd {
+        global_source: load_global_agents_md(user_home)?,
         agent_source: load_agent_agents_md(agent_home)?,
         workspace_source: load_workspace_agents_md(workspace_anchor)?,
     })
+}
+
+fn load_global_agents_md(user_home: Option<&Path>) -> Result<Option<AgentsMdSource>> {
+    let Some(user_home) = user_home else {
+        return Ok(None);
+    };
+    let path = user_home.join(".agents").join(AGENTS_MD_FILENAME);
+    load_source(AgentsMdScope::Global, AgentsMdKind::AgentsMd, &path)
 }
 
 fn load_agent_agents_md(agent_home: &Path) -> Result<Option<AgentsMdSource>> {
@@ -75,7 +85,7 @@ mod tests {
         std::fs::write(agent_home.join(AGENTS_MD_FILENAME), "agent rules\n").unwrap();
         std::fs::write(workspace.join(AGENTS_MD_FILENAME), "workspace rules\n").unwrap();
 
-        let loaded = load_agents_md(&agent_home, Some(&workspace)).unwrap();
+        let loaded = load_agents_md(None, &agent_home, Some(&workspace)).unwrap();
 
         assert_eq!(
             loaded
@@ -102,7 +112,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join(CLAUDE_MD_FILENAME), "legacy rules\n").unwrap();
 
-        let loaded = load_agents_md(&agent_home, Some(&workspace)).unwrap();
+        let loaded = load_agents_md(None, &agent_home, Some(&workspace)).unwrap();
 
         assert_eq!(
             loaded
@@ -113,7 +123,7 @@ mod tests {
         );
 
         std::fs::write(workspace.join(AGENTS_MD_FILENAME), "new rules\n").unwrap();
-        let loaded = load_agents_md(&agent_home, Some(&workspace)).unwrap();
+        let loaded = load_agents_md(None, &agent_home, Some(&workspace)).unwrap();
         assert_eq!(
             loaded
                 .workspace_source
@@ -126,6 +136,7 @@ mod tests {
     #[test]
     fn loaded_agents_md_does_not_serialize_content() {
         let loaded = LoadedAgentsMd {
+            global_source: None,
             agent_source: Some(AgentsMdSource {
                 scope: AgentsMdScope::Agent,
                 kind: AgentsMdKind::AgentsMd,
@@ -138,5 +149,90 @@ mod tests {
         let json = serde_json::to_value(&loaded).unwrap();
         assert_eq!(json["agent_source"]["path"], "/tmp/agent/AGENTS.md");
         assert!(json["agent_source"]["content"].is_null());
+    }
+
+    #[test]
+    fn loads_global_agent_and_workspace_guidance_layers() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("user");
+        let agent_home = dir.path().join("agent");
+        let workspace = dir.path().join("workspace");
+        std::fs::create_dir_all(user_home.join(".agents")).unwrap();
+        std::fs::create_dir_all(&agent_home).unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(
+            user_home.join(".agents").join(AGENTS_MD_FILENAME),
+            "global\n",
+        )
+        .unwrap();
+        std::fs::write(agent_home.join(AGENTS_MD_FILENAME), "agent\n").unwrap();
+        std::fs::write(workspace.join(AGENTS_MD_FILENAME), "workspace\n").unwrap();
+
+        let loaded = load_agents_md(Some(&user_home), &agent_home, Some(&workspace)).unwrap();
+
+        assert_eq!(
+            loaded
+                .global_source
+                .as_ref()
+                .map(|source| source.scope.clone()),
+            Some(AgentsMdScope::Global)
+        );
+        assert!(loaded.agent_source.is_some());
+        assert!(loaded.workspace_source.is_some());
+    }
+
+    #[test]
+    fn global_and_agent_guidance_survive_workspace_switches() {
+        let dir = tempdir().unwrap();
+        let user_home = dir.path().join("user");
+        let agent_home = dir.path().join("agent");
+        let workspace_a = dir.path().join("workspace-a");
+        let workspace_b = dir.path().join("workspace-b");
+        std::fs::create_dir_all(user_home.join(".agents")).unwrap();
+        std::fs::create_dir_all(&agent_home).unwrap();
+        std::fs::create_dir_all(&workspace_a).unwrap();
+        std::fs::create_dir_all(&workspace_b).unwrap();
+        let global_path = user_home.join(".agents").join(AGENTS_MD_FILENAME);
+        let agent_path = agent_home.join(AGENTS_MD_FILENAME);
+        let workspace_a_path = workspace_a.join(AGENTS_MD_FILENAME);
+        let workspace_b_path = workspace_b.join(AGENTS_MD_FILENAME);
+        std::fs::write(&global_path, "global\n").unwrap();
+        std::fs::write(&agent_path, "agent\n").unwrap();
+        std::fs::write(&workspace_a_path, "workspace a\n").unwrap();
+        std::fs::write(&workspace_b_path, "workspace b\n").unwrap();
+
+        let loaded_a = load_agents_md(Some(&user_home), &agent_home, Some(&workspace_a)).unwrap();
+        let loaded_b = load_agents_md(Some(&user_home), &agent_home, Some(&workspace_b)).unwrap();
+
+        assert_eq!(
+            loaded_a.global_source.as_ref().map(|source| &source.path),
+            Some(&global_path)
+        );
+        assert_eq!(
+            loaded_b.global_source.as_ref().map(|source| &source.path),
+            Some(&global_path)
+        );
+        assert_eq!(
+            loaded_a.agent_source.as_ref().map(|source| &source.path),
+            Some(&agent_path)
+        );
+        assert_eq!(
+            loaded_b.agent_source.as_ref().map(|source| &source.path),
+            Some(&agent_path)
+        );
+        assert_eq!(
+            loaded_a
+                .workspace_source
+                .as_ref()
+                .map(|source| &source.path),
+            Some(&workspace_a_path)
+        );
+        assert_eq!(
+            loaded_b
+                .workspace_source
+                .as_ref()
+                .map(|source| &source.path),
+            Some(&workspace_b_path)
+        );
     }
 }

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -122,6 +122,10 @@ impl EffectivePrompt {
         ));
         output.extend(execution_policy_summary_lines(&self.execution));
         output.push(format!(
+            "Global AGENTS.md: {}",
+            describe_agents_md_source(self.loaded_agents_md.global_source.as_ref())
+        ));
+        output.push(format!(
             "Agent AGENTS.md: {}",
             describe_agents_md_source(self.loaded_agents_md.agent_source.as_ref())
         ));
@@ -296,10 +300,7 @@ fn prompt_cache_scope_fingerprint(
         .collect::<Vec<_>>();
     let payload = json!({
         "agent_id": session.id,
-        "workspace_id": execution.workspace_id,
-        "execution_root_id": execution.execution_root_id,
-        "workspace_anchor": execution.workspace_anchor,
-        "execution_root": execution.execution_root,
+        "execution_semantics": execution_semantic_cache_payload(execution),
         "stable_system_sections": stable_system_sections,
         "stable_context_sections": stable_context_sections,
         "tools": available_tools,
@@ -321,10 +322,7 @@ fn prompt_context_fingerprint(
         "compacted_message_count": session.compacted_message_count,
         "working_memory_revision": session.working_memory.working_memory_revision,
         "compression_epoch": session.working_memory.compression_epoch,
-        "workspace_id": execution.workspace_id,
-        "execution_root_id": execution.execution_root_id,
-        "workspace_anchor": execution.workspace_anchor,
-        "execution_root": execution.execution_root,
+        "execution_semantics": execution_semantic_cache_payload(execution),
         "system_sections": system_sections,
         "context_sections": context_sections,
         "tools": available_tools,
@@ -332,6 +330,23 @@ fn prompt_context_fingerprint(
     let canonical =
         serde_json::to_vec(&payload).expect("prompt cache fingerprint should serialize");
     format!("{:x}", Sha256::digest(canonical))
+}
+
+fn execution_semantic_cache_payload(execution: &ExecutionSnapshot) -> serde_json::Value {
+    json!({
+        // `workspace_id` is included because it is rendered in the execution environment summary.
+        "rendered_workspace_id": execution.workspace_id,
+        // Attached workspace ids and anchors are rendered when multiple workspaces are visible.
+        "rendered_attached_workspaces": execution.attached_workspaces,
+        // These paths are rendered and define default cwd / relative path tool behavior.
+        "workspace_anchor": execution.workspace_anchor,
+        "execution_root": execution.execution_root,
+        "cwd": execution.cwd,
+        "worktree_root": execution.worktree_root,
+        // These shape relative path and workspace projection semantics; bookkeeping ids do not.
+        "projection_kind": execution.projection_kind,
+        "access_mode": execution.access_mode,
+    })
 }
 
 fn build_system_sections(
@@ -444,6 +459,9 @@ fn build_system_sections(
     if let Some(section) = constrained_repair_section(current_message) {
         sections.push(section);
     }
+    if let Some(section) = global_agents_md_section(loaded_agents_md.global_source.as_ref()) {
+        sections.push(section);
+    }
     if let Some(section) = agent_agents_md_section(loaded_agents_md.agent_source.as_ref()) {
         sections.push(section);
     }
@@ -477,6 +495,20 @@ fn agent_agents_md_section(source: Option<&AgentsMdSource>) -> Option<PromptSect
             PromptStability::Stable,
             format!(
                 "Apply the following agent-scoped AGENTS.md guidance from {}:\n\n{}",
+                source.path.display(),
+                source.content
+            ),
+        )
+    })
+}
+
+fn global_agents_md_section(source: Option<&AgentsMdSource>) -> Option<PromptSection> {
+    source.map(|source| {
+        section(
+            "global_agents_md",
+            PromptStability::Stable,
+            format!(
+                "Apply the following global operator AGENTS.md guidance from {}:\n\n{}",
                 source.path.display(),
                 source.content
             ),
@@ -839,6 +871,81 @@ mod tests {
             prompt_cache_key(&session.id, &first_scope),
             prompt_cache_key(&session.id, &second_scope)
         );
+    }
+
+    #[test]
+    fn prompt_cache_key_ignores_execution_root_bookkeeping_id_changes() {
+        let session = AgentState::new("default");
+        let mut first_execution = sample_execution_snapshot();
+        let mut second_execution = sample_execution_snapshot();
+        first_execution.execution_root_id = Some("canonical_root:workspace-1".into());
+        second_execution.execution_root_id = Some("canonical_root:workspace-2".into());
+        let system_sections = vec![section(
+            "identity",
+            PromptStability::Stable,
+            "stable system".into(),
+        )];
+        let context_sections = vec![section(
+            "working_memory",
+            PromptStability::AgentScoped,
+            "durable plan".into(),
+        )];
+        let tools = Vec::new();
+
+        let first_scope = prompt_cache_scope_fingerprint(
+            &session,
+            &first_execution,
+            &system_sections,
+            &context_sections,
+            &tools,
+        );
+        let second_scope = prompt_cache_scope_fingerprint(
+            &session,
+            &second_execution,
+            &system_sections,
+            &context_sections,
+            &tools,
+        );
+
+        assert_eq!(first_scope, second_scope);
+    }
+
+    #[test]
+    fn prompt_cache_key_changes_when_workspace_path_semantics_change() {
+        let session = AgentState::new("default");
+        let first_execution = sample_execution_snapshot();
+        let mut second_execution = sample_execution_snapshot();
+        second_execution.workspace_anchor = PathBuf::from("/other-repo");
+        second_execution.execution_root = PathBuf::from("/other-repo");
+        second_execution.cwd = PathBuf::from("/other-repo/src");
+        let system_sections = vec![section(
+            "identity",
+            PromptStability::Stable,
+            "stable system".into(),
+        )];
+        let context_sections = vec![section(
+            "working_memory",
+            PromptStability::AgentScoped,
+            "durable plan".into(),
+        )];
+        let tools = Vec::new();
+
+        let first_scope = prompt_cache_scope_fingerprint(
+            &session,
+            &first_execution,
+            &system_sections,
+            &context_sections,
+            &tools,
+        );
+        let second_scope = prompt_cache_scope_fingerprint(
+            &session,
+            &second_execution,
+            &system_sections,
+            &context_sections,
+            &tools,
+        );
+
+        assert_ne!(first_scope, second_scope);
     }
 
     #[test]
@@ -1267,6 +1374,12 @@ mod tests {
             &sample_message(),
             Path::new("."),
             &LoadedAgentsMd {
+                global_source: Some(AgentsMdSource {
+                    scope: crate::types::AgentsMdScope::Global,
+                    kind: AgentsMdKind::AgentsMd,
+                    path: PathBuf::from("/tmp/user/.agents/AGENTS.md"),
+                    content: "global guidance".into(),
+                }),
                 agent_source: Some(AgentsMdSource {
                     scope: crate::types::AgentsMdScope::Agent,
                     kind: AgentsMdKind::AgentsMd,
@@ -1302,6 +1415,10 @@ mod tests {
             .iter()
             .map(|section| section.name.as_str())
             .collect::<Vec<_>>();
+        let global_idx = names
+            .iter()
+            .position(|name| *name == "global_agents_md")
+            .unwrap();
         let agent_idx = names
             .iter()
             .position(|name| *name == "agent_agents_md")
@@ -1319,6 +1436,7 @@ mod tests {
             .position(|name| *name == "tool_exec_command")
             .unwrap();
 
+        assert!(global_idx < agent_idx);
         assert!(agent_idx < workspace_idx);
         assert!(workspace_idx < skills_idx);
         assert!(skills_idx < tools_idx);
@@ -1343,6 +1461,7 @@ mod tests {
                 worktree_root: None,
             },
             loaded_agents_md: LoadedAgentsMd {
+                global_source: None,
                 agent_source: Some(AgentsMdSource {
                     scope: crate::types::AgentsMdScope::Agent,
                     kind: AgentsMdKind::AgentsMd,
@@ -1380,6 +1499,7 @@ mod tests {
         assert!(dump.contains("Workspace anchor: /repo"));
         assert!(dump.contains("Execution root: /repo"));
         assert!(dump.contains("Cwd: /repo/src"));
+        assert!(dump.contains("Global AGENTS.md: none"));
         assert!(dump.contains("Agent AGENTS.md: /tmp/agent-home/AGENTS.md (AGENTS.md)"));
         assert!(dump.contains("Workspace AGENTS.md: /repo/CLAUDE.md (CLAUDE.md fallback)"));
         assert!(dump.contains("Section inventory:"));
@@ -1452,6 +1572,7 @@ mod tests {
                 worktree_root: None,
             },
             loaded_agents_md: LoadedAgentsMd {
+                global_source: None,
                 agent_source: Some(AgentsMdSource {
                     scope: crate::types::AgentsMdScope::Agent,
                     kind: AgentsMdKind::AgentsMd,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -585,6 +585,7 @@ impl RuntimeHandle {
 
     fn loaded_agents_md_for_state(&self, state: &AgentState) -> Result<LoadedAgentsMd> {
         load_agents_md(
+            self.user_home().as_deref(),
             self.agent_home().as_path(),
             self.workspace_anchor_for_state_ref(state),
         )

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -209,6 +209,7 @@ impl RuntimeHandle {
             AdmissionContext::RuntimeOwned,
         );
         let loaded_agents_md = load_agents_md(
+            self.user_home().as_deref(),
             self.agent_home().as_path(),
             execution
                 .workspace

--- a/src/types.rs
+++ b/src/types.rs
@@ -398,6 +398,7 @@ pub struct ChildAgentSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentsMdScope {
+    Global,
     Agent,
     Workspace,
 }
@@ -420,6 +421,8 @@ pub struct AgentsMdSource {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LoadedAgentsMd {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub global_source: Option<AgentsMdSource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -446,6 +449,8 @@ impl From<&AgentsMdSource> for AgentsMdSourceView {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LoadedAgentsMdView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub global_source: Option<AgentsMdSourceView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSourceView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_source: Option<AgentsMdSourceView>,
@@ -454,6 +459,7 @@ pub struct LoadedAgentsMdView {
 impl From<&LoadedAgentsMd> for LoadedAgentsMdView {
     fn from(value: &LoadedAgentsMd) -> Self {
         Self {
+            global_source: value.global_source.as_ref().map(AgentsMdSourceView::from),
             agent_source: value.agent_source.as_ref().map(AgentsMdSourceView::from),
             workspace_source: value
                 .workspace_source


### PR DESCRIPTION
## Summary
- clarify prompt cache identity so workspace bookkeeping ids do not invalidate caches when rendered prompt text/tool semantics are unchanged
- include rendered execution semantics (workspace id, attached workspaces, paths, cwd, projection/access/worktree state) in cache fingerprints
- document the prompt cache workspace/guidance boundary and make guidance layering explicit, including global/agent/workspace AGENTS.md layers

Fixes #1239.

## Verification
- `cargo fmt --all -- --check`
- `cargo test agents_md -- --nocapture`
- `cargo test prompt_cache_key_ignores_execution_root_bookkeeping_id_changes -- --nocapture`
- `cargo test prompt_cache_key_changes_when_workspace_path_semantics_change -- --nocapture`
- `cargo test system_sections_keep_agent_and_workspace_guidance_before_skills_and_tools -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
