### PR TITLE
fix: use unique AgentHome workspace ids

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -305,8 +305,8 @@ impl RuntimeHandle {
         workspace::build_execution_root_id(workspace_id, projection_kind, execution_root)
     }
 
-    fn agent_home_workspace_entry(data_dir: &Path) -> crate::types::WorkspaceEntry {
-        workspace::agent_home_workspace_entry(data_dir)
+    fn agent_home_workspace_entry(data_dir: &Path, agent_id: &str) -> crate::types::WorkspaceEntry {
+        workspace::agent_home_workspace_entry(data_dir, agent_id)
     }
 
     pub fn storage(&self) -> &AppStorage {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -166,9 +166,10 @@ impl RuntimeHandle {
                     .and_then(|name| name.to_str())
                     .map(ToString::to_string),
             )),
-            InitialWorkspaceBinding::Detached => {
-                Some(workspace::agent_home_workspace_entry(storage.data_dir()))
-            }
+            InitialWorkspaceBinding::Detached => Some(workspace::agent_home_workspace_entry(
+                storage.data_dir(),
+                &agent_id,
+            )),
         };
 
         if let Some(workspace) = initial_workspace_entry.as_ref() {
@@ -246,7 +247,7 @@ impl RuntimeHandle {
                 entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot
             }) {
                 let data_dir = storage.data_dir();
-                let workspace_entry = workspace::agent_home_workspace_entry(&data_dir);
+                let workspace_entry = workspace::agent_home_workspace_entry(&data_dir, &agent_id);
                 let kind = WorkspaceProjectionKind::CanonicalRoot;
                 state.active_workspace_entry = Some(ActiveWorkspaceEntry {
                     workspace_id: workspace_entry.workspace_id.clone(),

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -792,8 +792,10 @@ impl RuntimeHandle {
         workspace_id: &str,
     ) -> Result<Option<WorkspaceEntry>> {
         if workspace_id == AGENT_HOME_WORKSPACE_ID {
+            let agent_id = self.agent_id().await?;
             return Ok(Some(Self::agent_home_workspace_entry(
                 self.inner.storage.data_dir(),
+                &agent_id,
             )));
         }
         if let Some(existing) = self
@@ -814,7 +816,7 @@ impl RuntimeHandle {
         cwd: Option<PathBuf>,
     ) -> Result<()> {
         let state = self.agent_state().await?;
-        let workspace = Self::agent_home_workspace_entry(self.inner.storage.data_dir());
+        let workspace = Self::agent_home_workspace_entry(self.inner.storage.data_dir(), &state.id);
         let execution_root = crate::system::workspace::normalize_path(&workspace.workspace_anchor)?;
         let selected_cwd = resolve_enter_cwd(&execution_root, cwd.as_deref())?;
         let execution_root_id = Self::build_execution_root_id(
@@ -843,12 +845,12 @@ impl RuntimeHandle {
                 .state
                 .attached_workspaces
                 .iter()
-                .any(|id| id == AGENT_HOME_WORKSPACE_ID)
+                .any(|id| id == &workspace.workspace_id)
             {
                 guard
                     .state
                     .attached_workspaces
-                    .push(AGENT_HOME_WORKSPACE_ID.to_string());
+                    .push(workspace.workspace_id.clone());
             }
             let known = self.inner.storage.latest_workspace_entries()?;
             if !known

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2,7 +2,7 @@ use super::super::*;
 use super::support::*;
 use crate::types::{
     WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource, WorkItemPlanStatus,
-    WorkItemReadiness, WorkItemSchedulingState,
+    WorkItemReadiness, WorkItemSchedulingState, AGENT_HOME_WORKSPACE_ID,
 };
 
 fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> TaskRecord {
@@ -824,6 +824,22 @@ async fn work_item_tools_use_objective_plan_and_todo_list_shape() {
         .unwrap();
     assert!(std::path::Path::new(plan_path).is_file());
     assert_eq!(
+        create_payload["work_item"]["plan_artifact"]["owner_agent_id"].as_str(),
+        Some("default")
+    );
+    assert_eq!(
+        create_payload["work_item"]["plan_artifact"]["workspace_id"].as_str(),
+        Some(crate::types::agent_home_workspace_id("default").as_str())
+    );
+    assert_eq!(
+        create_payload["work_item"]["plan_artifact"]["workspace_alias"].as_str(),
+        Some(AGENT_HOME_WORKSPACE_ID)
+    );
+    assert_eq!(
+        create_payload["work_item"]["plan_artifact"]["relative_path"].as_str(),
+        Some(format!("work-items/{work_item_id}/plan.md").as_str())
+    );
+    assert_eq!(
         create_payload["work_item"]["todo_list"][0]["state"].as_str(),
         Some("completed")
     );
@@ -1127,7 +1143,9 @@ async fn complete_work_item_refreshes_latest_plan_artifact_snapshot() {
         .unwrap();
     let plan_path = work.plan_artifact.as_ref().unwrap().path.clone();
     std::fs::write(&plan_path, "completion plan after direct edit").unwrap();
-    let expected = crate::work_item_plan::describe_plan_artifact(&plan_path).unwrap();
+    let expected =
+        crate::work_item_plan::describe_plan_artifact(&plan_path, &work.agent_id, &work.id)
+            .unwrap();
 
     let completed = runtime
         .complete_work_item(work.id.clone(), Vec::new())
@@ -1292,7 +1310,9 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
         std::fs::read_to_string(&plan_path).unwrap(),
         "Keep this legacy plan body in the artifact."
     );
-    let artifact = crate::work_item_plan::describe_plan_artifact(&plan_path).unwrap();
+    let artifact =
+        crate::work_item_plan::describe_plan_artifact(&plan_path, &legacy.agent_id, &legacy.id)
+            .unwrap();
     assert_eq!(
         artifact.preview,
         "Keep this legacy plan body in the artifact."

--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -10,13 +10,19 @@ fn openai_max_output_tokens_stop_reason_triggers_recovery() {
 async fn detached_host_runtime_starts_in_agent_home_workspace() {
     let (_home, _host, runtime) = host_backed_test_runtime().await;
     let snapshot = runtime.execution_snapshot().await.unwrap();
+    let expected_workspace_id = crate::types::agent_home_workspace_id("default");
 
     assert_eq!(
         snapshot.workspace_id.as_deref(),
-        Some(AGENT_HOME_WORKSPACE_ID)
+        Some(expected_workspace_id.as_str())
     );
+    assert_ne!(expected_workspace_id, AGENT_HOME_WORKSPACE_ID);
     assert_eq!(snapshot.workspace_anchor, runtime.agent_home());
     assert_eq!(snapshot.execution_root, runtime.agent_home());
+    assert_eq!(
+        snapshot.execution_root_id.as_deref(),
+        Some(format!("canonical_root:{expected_workspace_id}").as_str())
+    );
 }
 
 #[tokio::test]
@@ -81,13 +87,60 @@ async fn use_workspace_agent_home_returns_to_fallback_without_deleting_project()
     .await
     .unwrap();
     let snapshot = runtime.execution_snapshot().await.unwrap();
+    let expected_workspace_id = crate::types::agent_home_workspace_id("default");
 
     assert_eq!(
         snapshot.workspace_id.as_deref(),
-        Some(AGENT_HOME_WORKSPACE_ID)
+        Some(expected_workspace_id.as_str())
     );
     assert_eq!(snapshot.execution_root, runtime.agent_home());
     assert!(retained_file.is_file());
+}
+
+#[tokio::test]
+async fn agent_home_workspace_ids_are_unique_per_agent_while_alias_remains_local() {
+    let (_home, host, default_runtime) = host_backed_test_runtime().await;
+    host.create_named_agent("worker", None).await.unwrap();
+    let worker_runtime = host.get_or_create_agent("worker").await.unwrap();
+
+    let default_snapshot = default_runtime.execution_snapshot().await.unwrap();
+    let worker_snapshot = worker_runtime.execution_snapshot().await.unwrap();
+
+    assert_eq!(
+        default_snapshot.workspace_id.as_deref(),
+        Some(crate::types::agent_home_workspace_id("default").as_str())
+    );
+    assert_eq!(
+        worker_snapshot.workspace_id.as_deref(),
+        Some(crate::types::agent_home_workspace_id("worker").as_str())
+    );
+    assert_ne!(default_snapshot.workspace_id, worker_snapshot.workspace_id);
+    assert_ne!(
+        default_snapshot.execution_root_id,
+        worker_snapshot.execution_root_id
+    );
+
+    crate::tool::tools::execute_builtin_tool(
+        &worker_runtime,
+        "worker",
+        &TrustLevel::TrustedOperator,
+        &crate::tool::ToolCall {
+            id: "use-worker-home".into(),
+            name: "UseWorkspace".into(),
+            input: serde_json::json!({ "workspace_id": AGENT_HOME_WORKSPACE_ID }),
+        },
+    )
+    .await
+    .unwrap();
+    let worker_snapshot = worker_runtime.execution_snapshot().await.unwrap();
+    assert_eq!(
+        worker_snapshot.workspace_id.as_deref(),
+        Some(crate::types::agent_home_workspace_id("worker").as_str())
+    );
+    assert_eq!(
+        worker_snapshot.workspace_anchor,
+        worker_runtime.agent_home()
+    );
 }
 
 #[tokio::test]

--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -8,9 +8,10 @@ fn openai_max_output_tokens_stop_reason_triggers_recovery() {
 
 #[tokio::test]
 async fn detached_host_runtime_starts_in_agent_home_workspace() {
-    let (_home, _host, runtime) = host_backed_test_runtime().await;
+    let (_home, host, runtime) = host_backed_test_runtime().await;
     let snapshot = runtime.execution_snapshot().await.unwrap();
-    let expected_workspace_id = crate::types::agent_home_workspace_id("default");
+    let default_agent_id = host.config().default_agent_id.as_str();
+    let expected_workspace_id = crate::types::agent_home_workspace_id(default_agent_id);
 
     assert_eq!(
         snapshot.workspace_id.as_deref(),
@@ -57,14 +58,15 @@ async fn use_workspace_path_activates_project_workspace() {
 
 #[tokio::test]
 async fn use_workspace_agent_home_returns_to_fallback_without_deleting_project() {
-    let (_home, _host, runtime) = host_backed_test_runtime().await;
+    let (_home, host, runtime) = host_backed_test_runtime().await;
+    let default_agent_id = host.config().default_agent_id.as_str();
     let workspace = tempdir().unwrap();
     let retained_file = workspace.path().join("retained.txt");
     std::fs::write(&retained_file, "keep").unwrap();
 
     crate::tool::tools::execute_builtin_tool(
         &runtime,
-        "default",
+        default_agent_id,
         &TrustLevel::TrustedOperator,
         &crate::tool::ToolCall {
             id: "use-project".into(),
@@ -76,7 +78,7 @@ async fn use_workspace_agent_home_returns_to_fallback_without_deleting_project()
     .unwrap();
     crate::tool::tools::execute_builtin_tool(
         &runtime,
-        "default",
+        default_agent_id,
         &TrustLevel::TrustedOperator,
         &crate::tool::ToolCall {
             id: "use-home".into(),
@@ -87,7 +89,7 @@ async fn use_workspace_agent_home_returns_to_fallback_without_deleting_project()
     .await
     .unwrap();
     let snapshot = runtime.execution_snapshot().await.unwrap();
-    let expected_workspace_id = crate::types::agent_home_workspace_id("default");
+    let expected_workspace_id = crate::types::agent_home_workspace_id(default_agent_id);
 
     assert_eq!(
         snapshot.workspace_id.as_deref(),
@@ -100,6 +102,7 @@ async fn use_workspace_agent_home_returns_to_fallback_without_deleting_project()
 #[tokio::test]
 async fn agent_home_workspace_ids_are_unique_per_agent_while_alias_remains_local() {
     let (_home, host, default_runtime) = host_backed_test_runtime().await;
+    let default_agent_id = host.config().default_agent_id.as_str();
     host.create_named_agent("worker", None).await.unwrap();
     let worker_runtime = host.get_or_create_agent("worker").await.unwrap();
 
@@ -108,7 +111,7 @@ async fn agent_home_workspace_ids_are_unique_per_agent_while_alias_remains_local
 
     assert_eq!(
         default_snapshot.workspace_id.as_deref(),
-        Some(crate::types::agent_home_workspace_id("default").as_str())
+        Some(crate::types::agent_home_workspace_id(default_agent_id).as_str())
     );
     assert_eq!(
         worker_snapshot.workspace_id.as_deref(),

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -11,7 +11,7 @@ use crate::{
         EffectiveExecution, ExecutionProfile, ExecutionScopeKind, ExecutionSnapshot,
         WorkspaceAccessMode, WorkspaceProjectionKind, WorkspaceView,
     },
-    types::{AgentState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID},
+    types::{agent_home_workspace_id, AgentState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID},
 };
 
 pub(crate) fn build_execution_root_id(
@@ -30,12 +30,16 @@ pub(crate) fn build_execution_root_id(
     })
 }
 
-pub(crate) fn agent_home_workspace_entry(data_dir: &Path) -> WorkspaceEntry {
-    WorkspaceEntry::new(
-        AGENT_HOME_WORKSPACE_ID,
+pub(crate) fn agent_home_workspace_entry(data_dir: &Path, agent_id: &str) -> WorkspaceEntry {
+    let mut entry = WorkspaceEntry::new(
+        agent_home_workspace_id(agent_id),
         data_dir.to_path_buf(),
         Some("AgentHome".into()),
-    )
+    );
+    entry.workspace_alias = Some(AGENT_HOME_WORKSPACE_ID.into());
+    entry.workspace_kind = Some("agent_home".into());
+    entry.owner_agent_id = Some(agent_id.to_string());
+    entry
 }
 
 pub(crate) fn detached_execution_root(storage: &AppStorage) -> PathBuf {

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,10 @@ use crate::system::{
 
 pub const AGENT_HOME_WORKSPACE_ID: &str = "agent_home";
 
+pub fn agent_home_workspace_id(agent_id: &str) -> String {
+    format!("{AGENT_HOME_WORKSPACE_ID}:{agent_id}")
+}
+
 fn default_agent_home_workspace_id() -> String {
     AGENT_HOME_WORKSPACE_ID.to_string()
 }
@@ -26,6 +30,12 @@ fn default_work_item_revision() -> u64 {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceEntry {
     pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_alias: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_agent_id: Option<String>,
     pub workspace_anchor: PathBuf,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo_name: Option<String>,
@@ -42,6 +52,9 @@ impl WorkspaceEntry {
         let now = Utc::now();
         Self {
             workspace_id: workspace_id.into(),
+            workspace_alias: None,
+            workspace_kind: None,
+            owner_agent_id: None,
             workspace_anchor,
             repo_name,
             created_at: now,
@@ -3049,6 +3062,11 @@ impl Default for AgentPostureProjection {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkItemPlanArtifact {
+    pub owner_agent_id: String,
+    pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_alias: Option<String>,
+    pub relative_path: PathBuf,
     pub path: PathBuf,
     pub hash: String,
     pub bytes: u64,
@@ -3094,10 +3112,11 @@ impl WorkItemRecord {
         state: WorkItemState,
     ) -> Self {
         let now = Utc::now();
+        let agent_id = agent_id.into();
         Self {
             id: format!("work_{}", Uuid::new_v4().simple()),
-            agent_id: agent_id.into(),
-            workspace_id: AGENT_HOME_WORKSPACE_ID.to_string(),
+            workspace_id: agent_home_workspace_id(&agent_id),
+            agent_id,
             revision: 1,
             objective: objective.into(),
             state,
@@ -3472,10 +3491,11 @@ impl BriefRecord {
         related_message_id: Option<String>,
         related_task_id: Option<String>,
     ) -> Self {
+        let agent_id = agent_id.into();
         Self {
             id: Uuid::new_v4().to_string(),
-            agent_id: agent_id.into(),
-            workspace_id: AGENT_HOME_WORKSPACE_ID.to_string(),
+            workspace_id: agent_home_workspace_id(&agent_id),
+            agent_id,
             work_item_id: None,
             kind,
             created_at: Utc::now(),

--- a/src/work_item_plan.rs
+++ b/src/work_item_plan.rs
@@ -10,13 +10,21 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
 
-use crate::types::{WorkItemPlanArtifact, WorkItemRecord};
+use crate::types::{
+    agent_home_workspace_id, WorkItemPlanArtifact, WorkItemRecord, AGENT_HOME_WORKSPACE_ID,
+};
 
 const PLAN_PREVIEW_CHARS: usize = 1600;
 
 pub(crate) fn plan_path(agent_home: &Path, work_item_id: &str) -> PathBuf {
     agent_home
         .join("work-items")
+        .join(work_item_id)
+        .join("plan.md")
+}
+
+pub(crate) fn plan_relative_path(work_item_id: &str) -> PathBuf {
+    PathBuf::from("work-items")
         .join(work_item_id)
         .join("plan.md")
 }
@@ -38,7 +46,7 @@ pub(crate) fn ensure_plan_artifact(
             .as_bytes();
         fs::write(&path, body).with_context(|| format!("failed to write {}", path.display()))?;
     }
-    describe_plan_artifact(&path)
+    describe_plan_artifact(&path, &record.agent_id, &record.id)
 }
 
 pub(crate) fn refresh_plan_artifact_metadata(
@@ -61,7 +69,11 @@ pub(crate) fn refresh_plan_artifact_metadata(
     Ok(had_inline_plan || record.plan_artifact != previous)
 }
 
-pub(crate) fn describe_plan_artifact(path: &Path) -> Result<WorkItemPlanArtifact> {
+pub(crate) fn describe_plan_artifact(
+    path: &Path,
+    owner_agent_id: &str,
+    work_item_id: &str,
+) -> Result<WorkItemPlanArtifact> {
     let mut file =
         File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
     let metadata = file
@@ -81,6 +93,10 @@ pub(crate) fn describe_plan_artifact(path: &Path) -> Result<WorkItemPlanArtifact
         .map(DateTime::<Utc>::from)
         .unwrap_or_else(|| DateTime::<Utc>::from(SystemTime::UNIX_EPOCH));
     Ok(WorkItemPlanArtifact {
+        owner_agent_id: owner_agent_id.to_string(),
+        workspace_id: agent_home_workspace_id(owner_agent_id),
+        workspace_alias: Some(AGENT_HOME_WORKSPACE_ID.into()),
+        relative_path: plan_relative_path(work_item_id),
         path: path.to_path_buf(),
         hash,
         bytes: metadata.len(),

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -475,6 +475,7 @@ pub async fn exit_worktree_keep_restores_workspace_and_persists_state() -> Resul
 pub async fn exit_worktree_does_not_remove_clean_worktree() -> Result<()> {
     let config = test_config();
     let workspace = config.workspace_dir.clone();
+    let agent_home_id = holon::types::agent_home_workspace_id(config.default_agent_id.as_str());
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
     let branch_name = "feature-exit-remove";
@@ -484,7 +485,7 @@ pub async fn exit_worktree_does_not_remove_clean_worktree() -> Result<()> {
         Arc::new(WorktreeLifecycleProvider::new(
             workspace.clone(),
             branch_name,
-            "\"workspace_id\":\"agent_home\"",
+            format!("\"workspace_id\":\"{agent_home_id}\""),
         )),
     )?;
     attach_default_workspace(&host).await?;
@@ -533,7 +534,7 @@ pub async fn exit_worktree_does_not_remove_clean_worktree() -> Result<()> {
             .as_ref()
             .map(|e| e.workspace_id.clone())
             .as_deref(),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(worktree.worktree_path.exists());
 
@@ -547,7 +548,7 @@ pub async fn exit_worktree_does_not_remove_clean_worktree() -> Result<()> {
             .as_ref()
             .map(|e| e.workspace_id.clone())
             .as_deref(),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(restarted_state.worktree_session.is_none());
     Ok(())
@@ -556,6 +557,7 @@ pub async fn exit_worktree_does_not_remove_clean_worktree() -> Result<()> {
 pub async fn exit_worktree_does_not_remove_dirty_worktree() -> Result<()> {
     let config = test_config();
     let workspace = config.workspace_dir.clone();
+    let agent_home_id = holon::types::agent_home_workspace_id(config.default_agent_id.as_str());
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
     let branch_name = "feature-exit-refuse";
@@ -565,7 +567,7 @@ pub async fn exit_worktree_does_not_remove_dirty_worktree() -> Result<()> {
         Arc::new(WorktreeLifecycleProvider::new(
             workspace.clone(),
             branch_name,
-            "\"workspace_id\":\"agent_home\"",
+            format!("\"workspace_id\":\"{agent_home_id}\""),
         )),
     )?;
     attach_default_workspace(&host).await?;
@@ -615,7 +617,7 @@ pub async fn exit_worktree_does_not_remove_dirty_worktree() -> Result<()> {
             .as_ref()
             .map(|e| e.workspace_id.clone())
             .as_deref(),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(session.active_workspace_entry.is_some());
     assert!(worktree.worktree_path.exists());
@@ -633,7 +635,7 @@ pub async fn exit_worktree_does_not_remove_dirty_worktree() -> Result<()> {
             .as_ref()
             .map(|e| e.workspace_id.clone())
             .as_deref(),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(restarted_state.worktree_session.is_none());
     Ok(())

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -309,6 +309,7 @@ pub async fn enter_workspace_conflict_preserves_existing_occupancy() -> Result<(
 pub async fn detach_workspace_persists_empty_binding_across_restart() -> Result<()> {
     let config = test_config();
     let workspace = config.workspace_dir.clone();
+    let agent_home_id = holon::types::agent_home_workspace_id(config.default_agent_id.as_str());
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
 
@@ -332,10 +333,10 @@ pub async fn detach_workspace_persists_empty_binding_across_restart() -> Result<
             .active_workspace_entry
             .as_ref()
             .map(|e| e.workspace_id.as_str()),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(state.active_workspace_entry.is_some());
-    assert_eq!(state.attached_workspaces, vec!["agent_home".to_string()]);
+    assert_eq!(state.attached_workspaces, vec![agent_home_id.clone()]);
 
     let restarted_host =
         RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("unused")))?;
@@ -347,7 +348,7 @@ pub async fn detach_workspace_persists_empty_binding_across_restart() -> Result<
             .as_ref()
             .map(|e| e.workspace_id.clone())
             .as_deref(),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(restarted_state.active_workspace_entry.is_some());
     Ok(())
@@ -392,6 +393,7 @@ pub async fn enter_worktree_projection_honors_requested_cwd() -> Result<()> {
 pub async fn exit_worktree_keep_restores_workspace_and_persists_state() -> Result<()> {
     let config = test_config();
     let workspace = config.workspace_dir.clone();
+    let agent_home_id = holon::types::agent_home_workspace_id(config.default_agent_id.as_str());
     std::fs::create_dir_all(&workspace)?;
     init_git_repo(&workspace)?;
     let branch_name = "feature-exit-keep";
@@ -401,7 +403,7 @@ pub async fn exit_worktree_keep_restores_workspace_and_persists_state() -> Resul
         Arc::new(WorktreeLifecycleProvider::new(
             workspace.clone(),
             branch_name,
-            "\"workspace_id\":\"agent_home\"",
+            format!("\"workspace_id\":\"{agent_home_id}\""),
         )),
     )?;
     attach_default_workspace(&host).await?;
@@ -450,7 +452,7 @@ pub async fn exit_worktree_keep_restores_workspace_and_persists_state() -> Resul
             .as_ref()
             .map(|e| e.workspace_id.clone())
             .as_deref(),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(worktree.worktree_path.exists());
 
@@ -464,7 +466,7 @@ pub async fn exit_worktree_keep_restores_workspace_and_persists_state() -> Resul
             .as_ref()
             .map(|e| e.workspace_id.clone())
             .as_deref(),
-        Some("agent_home")
+        Some(agent_home_id.as_str())
     );
     assert!(restarted_state.worktree_session.is_none());
     Ok(())


### PR DESCRIPTION
## Summary
- derive AgentHome workspace ids as `agent_home:<agent_id>` while preserving `agent_home` as the local alias
- stamp AgentHome workspace entries with alias/kind/owner metadata
- make WorkItem plan artifacts expose owner, unique workspace id, alias, and relative path descriptors
- add coverage for two agents with distinct AgentHome workspace ids and alias-based return to AgentHome

Closes #1090

## Verification
- `cargo test agents_md -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`