### PR TITLE
fix: load user-global agents guidance

### DIFF
--- a/src/agents_md.rs
+++ b/src/agents_md.rs
@@ -13,18 +13,18 @@ pub fn load_agents_md(
     workspace_anchor: Option<&Path>,
 ) -> Result<LoadedAgentsMd> {
     Ok(LoadedAgentsMd {
-        global_source: load_global_agents_md(user_home)?,
+        user_global_source: load_user_global_agents_md(user_home)?,
         agent_source: load_agent_agents_md(agent_home)?,
         workspace_source: load_workspace_agents_md(workspace_anchor)?,
     })
 }
 
-fn load_global_agents_md(user_home: Option<&Path>) -> Result<Option<AgentsMdSource>> {
+fn load_user_global_agents_md(user_home: Option<&Path>) -> Result<Option<AgentsMdSource>> {
     let Some(user_home) = user_home else {
         return Ok(None);
     };
     let path = user_home.join(".agents").join(AGENTS_MD_FILENAME);
-    load_source(AgentsMdScope::Global, AgentsMdKind::AgentsMd, &path)
+    load_source(AgentsMdScope::UserGlobal, AgentsMdKind::AgentsMd, &path)
 }
 
 fn load_agent_agents_md(agent_home: &Path) -> Result<Option<AgentsMdSource>> {
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn loaded_agents_md_does_not_serialize_content() {
         let loaded = LoadedAgentsMd {
-            global_source: None,
+            user_global_source: None,
             agent_source: Some(AgentsMdSource {
                 scope: AgentsMdScope::Agent,
                 kind: AgentsMdKind::AgentsMd,
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn loads_global_agent_and_workspace_guidance_layers() {
+    fn loads_user_global_agent_and_workspace_guidance_layers() {
         let dir = tempdir().unwrap();
         let user_home = dir.path().join("user");
         let agent_home = dir.path().join("agent");
@@ -172,17 +172,17 @@ mod tests {
 
         assert_eq!(
             loaded
-                .global_source
+                .user_global_source
                 .as_ref()
                 .map(|source| source.scope.clone()),
-            Some(AgentsMdScope::Global)
+            Some(AgentsMdScope::UserGlobal)
         );
         assert!(loaded.agent_source.is_some());
         assert!(loaded.workspace_source.is_some());
     }
 
     #[test]
-    fn global_and_agent_guidance_survive_workspace_switches() {
+    fn user_global_and_agent_guidance_survive_workspace_switches() {
         let dir = tempdir().unwrap();
         let user_home = dir.path().join("user");
         let agent_home = dir.path().join("agent");
@@ -192,11 +192,11 @@ mod tests {
         std::fs::create_dir_all(&agent_home).unwrap();
         std::fs::create_dir_all(&workspace_a).unwrap();
         std::fs::create_dir_all(&workspace_b).unwrap();
-        let global_path = user_home.join(".agents").join(AGENTS_MD_FILENAME);
+        let user_global_path = user_home.join(".agents").join(AGENTS_MD_FILENAME);
         let agent_path = agent_home.join(AGENTS_MD_FILENAME);
         let workspace_a_path = workspace_a.join(AGENTS_MD_FILENAME);
         let workspace_b_path = workspace_b.join(AGENTS_MD_FILENAME);
-        std::fs::write(&global_path, "global\n").unwrap();
+        std::fs::write(&user_global_path, "global\n").unwrap();
         std::fs::write(&agent_path, "agent\n").unwrap();
         std::fs::write(&workspace_a_path, "workspace a\n").unwrap();
         std::fs::write(&workspace_b_path, "workspace b\n").unwrap();
@@ -205,12 +205,18 @@ mod tests {
         let loaded_b = load_agents_md(Some(&user_home), &agent_home, Some(&workspace_b)).unwrap();
 
         assert_eq!(
-            loaded_a.global_source.as_ref().map(|source| &source.path),
-            Some(&global_path)
+            loaded_a
+                .user_global_source
+                .as_ref()
+                .map(|source| &source.path),
+            Some(&user_global_path)
         );
         assert_eq!(
-            loaded_b.global_source.as_ref().map(|source| &source.path),
-            Some(&global_path)
+            loaded_b
+                .user_global_source
+                .as_ref()
+                .map(|source| &source.path),
+            Some(&user_global_path)
         );
         assert_eq!(
             loaded_a.agent_source.as_ref().map(|source| &source.path),

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -876,6 +876,64 @@ mod tests {
     }
 
     #[test]
+    fn prompt_cache_key_changes_when_user_global_agents_md_changes() {
+        let session = AgentState::new("default");
+        let execution = sample_execution_snapshot();
+        let mut first_loaded = LoadedAgentsMd::default();
+        first_loaded.user_global_source = Some(AgentsMdSource {
+            scope: crate::types::AgentsMdScope::UserGlobal,
+            kind: AgentsMdKind::AgentsMd,
+            path: PathBuf::from("/tmp/user/.agents/AGENTS.md"),
+            content: "first user-global guidance".into(),
+        });
+        let mut second_loaded = first_loaded.clone();
+        second_loaded
+            .user_global_source
+            .as_mut()
+            .expect("test source")
+            .content = "second user-global guidance".into();
+        let first_system_sections = build_system_sections(
+            &sample_identity(),
+            &sample_message(),
+            Path::new("/tmp/agent-home"),
+            &first_loaded,
+            &SkillsRuntimeView::default(),
+            &[],
+        );
+        let second_system_sections = build_system_sections(
+            &sample_identity(),
+            &sample_message(),
+            Path::new("/tmp/agent-home"),
+            &second_loaded,
+            &SkillsRuntimeView::default(),
+            &[],
+        );
+        let context_sections = Vec::new();
+        let tools = Vec::new();
+
+        let first_scope = prompt_cache_scope_fingerprint(
+            &session,
+            &execution,
+            &first_system_sections,
+            &context_sections,
+            &tools,
+        );
+        let second_scope = prompt_cache_scope_fingerprint(
+            &session,
+            &execution,
+            &second_system_sections,
+            &context_sections,
+            &tools,
+        );
+
+        assert_ne!(first_scope, second_scope);
+        assert_ne!(
+            prompt_cache_key(&session.id, &first_scope),
+            prompt_cache_key(&session.id, &second_scope)
+        );
+    }
+
+    #[test]
     fn prompt_cache_key_ignores_execution_root_bookkeeping_id_changes() {
         let session = AgentState::new("default");
         let mut first_execution = sample_execution_snapshot();

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -122,8 +122,8 @@ impl EffectivePrompt {
         ));
         output.extend(execution_policy_summary_lines(&self.execution));
         output.push(format!(
-            "Global AGENTS.md: {}",
-            describe_agents_md_source(self.loaded_agents_md.global_source.as_ref())
+            "User-global AGENTS.md: {}",
+            describe_agents_md_source(self.loaded_agents_md.user_global_source.as_ref())
         ));
         output.push(format!(
             "Agent AGENTS.md: {}",
@@ -459,7 +459,9 @@ fn build_system_sections(
     if let Some(section) = constrained_repair_section(current_message) {
         sections.push(section);
     }
-    if let Some(section) = global_agents_md_section(loaded_agents_md.global_source.as_ref()) {
+    if let Some(section) =
+        user_global_agents_md_section(loaded_agents_md.user_global_source.as_ref())
+    {
         sections.push(section);
     }
     if let Some(section) = agent_agents_md_section(loaded_agents_md.agent_source.as_ref()) {
@@ -502,13 +504,13 @@ fn agent_agents_md_section(source: Option<&AgentsMdSource>) -> Option<PromptSect
     })
 }
 
-fn global_agents_md_section(source: Option<&AgentsMdSource>) -> Option<PromptSection> {
+fn user_global_agents_md_section(source: Option<&AgentsMdSource>) -> Option<PromptSection> {
     source.map(|source| {
         section(
-            "global_agents_md",
+            "user_global_agents_md",
             PromptStability::Stable,
             format!(
-                "Apply the following global operator AGENTS.md guidance from {}:\n\n{}",
+                "Apply the following user-global AGENTS.md guidance from {}. Treat it as default cross-agent, cross-workspace guidance with lower precedence than agent-scoped, workspace-scoped, or turn-scoped instructions:\n\n{}",
                 source.path.display(),
                 source.content
             ),
@@ -1374,11 +1376,11 @@ mod tests {
             &sample_message(),
             Path::new("."),
             &LoadedAgentsMd {
-                global_source: Some(AgentsMdSource {
-                    scope: crate::types::AgentsMdScope::Global,
+                user_global_source: Some(AgentsMdSource {
+                    scope: crate::types::AgentsMdScope::UserGlobal,
                     kind: AgentsMdKind::AgentsMd,
                     path: PathBuf::from("/tmp/user/.agents/AGENTS.md"),
-                    content: "global guidance".into(),
+                    content: "user-global guidance".into(),
                 }),
                 agent_source: Some(AgentsMdSource {
                     scope: crate::types::AgentsMdScope::Agent,
@@ -1417,7 +1419,7 @@ mod tests {
             .collect::<Vec<_>>();
         let global_idx = names
             .iter()
-            .position(|name| *name == "global_agents_md")
+            .position(|name| *name == "user_global_agents_md")
             .unwrap();
         let agent_idx = names
             .iter()
@@ -1461,7 +1463,7 @@ mod tests {
                 worktree_root: None,
             },
             loaded_agents_md: LoadedAgentsMd {
-                global_source: None,
+                user_global_source: None,
                 agent_source: Some(AgentsMdSource {
                     scope: crate::types::AgentsMdScope::Agent,
                     kind: AgentsMdKind::AgentsMd,
@@ -1499,7 +1501,7 @@ mod tests {
         assert!(dump.contains("Workspace anchor: /repo"));
         assert!(dump.contains("Execution root: /repo"));
         assert!(dump.contains("Cwd: /repo/src"));
-        assert!(dump.contains("Global AGENTS.md: none"));
+        assert!(dump.contains("User-global AGENTS.md: none"));
         assert!(dump.contains("Agent AGENTS.md: /tmp/agent-home/AGENTS.md (AGENTS.md)"));
         assert!(dump.contains("Workspace AGENTS.md: /repo/CLAUDE.md (CLAUDE.md fallback)"));
         assert!(dump.contains("Section inventory:"));
@@ -1572,7 +1574,7 @@ mod tests {
                 worktree_root: None,
             },
             loaded_agents_md: LoadedAgentsMd {
-                global_source: None,
+                user_global_source: None,
                 agent_source: Some(AgentsMdSource {
                     scope: crate::types::AgentsMdScope::Agent,
                     kind: AgentsMdKind::AgentsMd,

--- a/src/types.rs
+++ b/src/types.rs
@@ -411,6 +411,7 @@ pub struct ChildAgentSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentsMdScope {
+    #[serde(alias = "global")]
     UserGlobal,
     Agent,
     Workspace,
@@ -434,7 +435,11 @@ pub struct AgentsMdSource {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LoadedAgentsMd {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "global_source",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub user_global_source: Option<AgentsMdSource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSource>,
@@ -461,7 +466,11 @@ impl From<&AgentsMdSource> for AgentsMdSourceView {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LoadedAgentsMdView {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "global_source",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub user_global_source: Option<AgentsMdSourceView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSourceView>,
@@ -3898,6 +3907,46 @@ mod tests {
         assert_eq!(
             serde_json::to_value(status).unwrap(),
             serde_json::json!("aborted")
+        );
+    }
+
+    #[test]
+    fn legacy_agents_md_global_names_deserialize_to_user_global() {
+        let loaded: LoadedAgentsMd = serde_json::from_value(serde_json::json!({
+            "global_source": {
+                "scope": "global",
+                "kind": "agents_md",
+                "path": "/tmp/user/.agents/AGENTS.md"
+            }
+        }))
+        .unwrap();
+        let source = loaded
+            .user_global_source
+            .as_ref()
+            .expect("legacy global_source should map to user_global_source");
+        assert_eq!(source.scope, AgentsMdScope::UserGlobal);
+        assert_eq!(source.path, PathBuf::from("/tmp/user/.agents/AGENTS.md"));
+
+        let encoded = serde_json::to_value(&loaded).unwrap();
+        assert!(encoded.get("global_source").is_none());
+        assert_eq!(
+            encoded["user_global_source"]["scope"],
+            serde_json::json!("user_global")
+        );
+
+        let view: LoadedAgentsMdView = serde_json::from_value(serde_json::json!({
+            "global_source": {
+                "scope": "global",
+                "kind": "agents_md",
+                "path": "/tmp/user/.agents/AGENTS.md"
+            }
+        }))
+        .unwrap();
+        assert_eq!(
+            view.user_global_source
+                .expect("legacy view global_source should map to user_global_source")
+                .scope,
+            AgentsMdScope::UserGlobal
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -411,7 +411,7 @@ pub struct ChildAgentSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentsMdScope {
-    Global,
+    UserGlobal,
     Agent,
     Workspace,
 }
@@ -435,7 +435,7 @@ pub struct AgentsMdSource {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LoadedAgentsMd {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub global_source: Option<AgentsMdSource>,
+    pub user_global_source: Option<AgentsMdSource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -462,7 +462,7 @@ impl From<&AgentsMdSource> for AgentsMdSourceView {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LoadedAgentsMdView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub global_source: Option<AgentsMdSourceView>,
+    pub user_global_source: Option<AgentsMdSourceView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_source: Option<AgentsMdSourceView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -472,7 +472,10 @@ pub struct LoadedAgentsMdView {
 impl From<&LoadedAgentsMd> for LoadedAgentsMdView {
     fn from(value: &LoadedAgentsMd) -> Self {
         Self {
-            global_source: value.global_source.as_ref().map(AgentsMdSourceView::from),
+            user_global_source: value
+                .user_global_source
+                .as_ref()
+                .map(AgentsMdSourceView::from),
             agent_source: value.agent_source.as_ref().map(AgentsMdSourceView::from),
             workspace_source: value
                 .workspace_source


### PR DESCRIPTION
## Summary
- Fixes #1326.
- Load `~/.agents/AGENTS.md` as an explicit user-global AGENTS.md source/scope.
- Render the source as a separate `user_global_agents_md` system section with precedence text below turn/agent/workspace guidance.
- Rename the loaded guidance metadata from generic `global_source` to `user_global_source` and expose the `user_global` scope through views.

## Verification
- `cargo test agents_md -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
