### PR TITLE
fix: make default external ingress wake-only

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -2226,37 +2226,42 @@ type ExternalTriggerCapability = {
   externalTriggerId: string
   triggerUrl: string
   targetAgentId: string
-  delivery_mode: 'wake_hint' | 'enqueue_message'
+  delivery_mode: 'wake_hint'
   status: 'active'
 }
 ```
 
-The descriptor is keyed by target agent and delivery mode. The runtime should
-provision or return an existing active descriptor for that pair instead of
-minting duplicate callback URLs. Provisioning may happen at agent creation, on
-first descriptor access, or when a provider adapter needs the descriptor.
+The default descriptor is keyed by target agent and has fixed `wake_hint`
+semantics. The runtime should provision or return the existing active descriptor
+instead of minting duplicate callback URLs. Provisioning may happen at agent
+creation, during agent state/context materialization, or when a provider adapter
+needs the descriptor.
 
 ### Default External Ingress Flow
 
 The normal flow does not require the model to call a trigger-creation tool:
 
 1. Runtime provisions, or lazily ensures, the default
-   `ExternalTriggerRecord` for the target agent and delivery mode:
+   `ExternalTriggerRecord` for the target agent:
    - an `ExternalTriggerRecord` with a secure token
    - a signed callback URL for external delivery
+   - fixed `wake_hint` delivery mode
 
-2. Runtime exposes descriptor status or the callback capability through agent
-   context, status, provider configuration, or another trusted integration
-   surface.
+2. Runtime exposes descriptor status and URL through agent context, status,
+   provider configuration, or another trusted integration surface. Prompt/context
+   rendering must mark the URL as a capability secret: agents should not repeat,
+   store, or forward it unless the current task is explicitly configuring an
+   external system to wake that agent.
 
 3. Provider adapters, skills, MCP servers, or external services register their
    watches using the callback capability.
 
 4. External system calls back when the condition changes.
 
-`CreateExternalTrigger`, if retained, is a compatibility or diagnostic alias for
-returning this default ingress capability for a `delivery_mode`. `source`,
-`description`, and `scope` are not capability creation fields.
+`CreateExternalTrigger` and `CancelExternalTrigger`, if retained internally, are
+compatibility, diagnostic, or control-plane/admin surfaces. They are not ordinary
+agent-facing tools. The model should not need to choose a `delivery_mode` or call
+a tool before configuring an external system with its default wake URL.
 
 This flow does not create a `WaitingIntentRecord`.
 
@@ -2272,13 +2277,16 @@ When an external system delivers to the trigger URL:
 1. Runtime validates the token against stored descriptors
 2. Checks that the descriptor is active and targets an agent that can receive
    the delivery
-3. Based on `delivery_mode`:
-   - `enqueue_message`: enqueues structured content as a message
-   - `wake_hint`: submits a wake hint (may become `SystemTick`)
+3. Submits a wake hint (may become `SystemTick`).
+   - Generic callbacks must not enqueue callback payloads as agent messages.
+   - Legacy `enqueue_message` descriptors or URLs, if still accepted for
+     migration, are mapped to wake-hint behavior and recorded with deprecated
+     provenance.
 4. Updates delivery tracking (trigger count, last triggered at)
 5. Records callback provenance including external trigger id, target agent id,
-   delivery mode, optional source/resource metadata supplied by the delivery or
-   correlated wait, and correlated waiting/work-item ids when present
+   effective delivery mode, descriptor delivery mode when different, optional
+   source/resource metadata supplied by the delivery or correlated wait, and
+   correlated waiting/work-item ids when present
 
 External trigger delivery does not require an active waiting intent. It also
 does not automatically clear `blocked_by`, cancel waiting state, complete the

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,12 +9,12 @@ use crate::{
     system::{execution_policy_summary_lines, ExecutionSnapshot},
     tool::helpers::truncate_text,
     types::{
-        AdmissionContext, AgentState, AuthorityClass, BriefRecord, ContextEpisodeRecord,
-        ContinuationClass, ContinuationResolution, ExternalTriggerScope, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView,
-        TodoItemState, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel,
-        WaitingIntentRecord, WaitingIntentStatus, WorkItemRecord, WorkingMemoryDelta,
-        WorkingMemorySnapshot,
+        AdmissionContext, AgentState, AuthorityClass, BriefRecord, CallbackDeliveryMode,
+        ContextEpisodeRecord, ContinuationClass, ContinuationResolution, ExternalTriggerRecord,
+        ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageDeliverySurface,
+        MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TodoItemState,
+        ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingIntentRecord,
+        WaitingIntentStatus, WorkItemRecord, WorkingMemoryDelta, WorkingMemorySnapshot,
     },
 };
 
@@ -88,6 +88,16 @@ pub fn build_context(
         &mut remaining_budget,
         section("agent", format!("Agent id: {}", agent.id)),
     );
+    if let Some(default_ingress) = default_external_ingress(storage, &agent.id)? {
+        push_budgeted_section(
+            &mut sections,
+            &mut remaining_budget,
+            section(
+                "default_external_ingress",
+                render_default_external_ingress(&default_ingress),
+            ),
+        );
+    }
     let execution_summary = execution_policy_summary_lines(execution).join("\n");
     push_budgeted_section(
         &mut sections,
@@ -408,6 +418,35 @@ fn header_label_value(value: &str) -> String {
             _ => '_',
         })
         .collect()
+}
+
+fn default_external_ingress(
+    storage: &AppStorage,
+    agent_id: &str,
+) -> Result<Option<ExternalTriggerRecord>> {
+    Ok(storage
+        .latest_external_triggers()?
+        .into_iter()
+        .find(|record| {
+            record.target_agent_id == agent_id
+                && record.scope == ExternalTriggerScope::Agent
+                && record.delivery_mode == CallbackDeliveryMode::WakeHint
+                && record.status == ExternalTriggerStatus::Active
+        }))
+}
+
+fn render_default_external_ingress(record: &ExternalTriggerRecord) -> String {
+    let url = record.trigger_url.as_deref().unwrap_or("<unavailable>");
+    format!(
+        "Default external ingress:\n\
+         - url: {url}\n\
+         - mode: wake_hint\n\
+         - status: active\n\
+         - external_trigger_id: {}\n\
+         - capability_secret: true\n\
+         - handling: Treat this URL as a capability secret. Do not repeat, store, or forward it unless the current task is explicitly configuring an external system to wake this agent.",
+        record.external_trigger_id
+    )
 }
 
 pub fn maybe_compact_agent(
@@ -3197,6 +3236,69 @@ mod tests {
         assert!(execution_section
             .content
             .contains("child_process_containment: not_enforced"));
+    }
+
+    #[test]
+    fn build_context_includes_default_external_wake_ingress() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage
+            .append_external_trigger(&ExternalTriggerRecord {
+                external_trigger_id: "wake-default".into(),
+                target_agent_id: "default".into(),
+                waiting_intent_id: None,
+                scope: ExternalTriggerScope::Agent,
+                delivery_mode: CallbackDeliveryMode::WakeHint,
+                trigger_url: Some("http://127.0.0.1:7878/callbacks/wake/token".into()),
+                token_hash: "redacted-token-hash".into(),
+                status: ExternalTriggerStatus::Active,
+                created_at: chrono::Utc::now(),
+                revoked_at: None,
+                last_delivered_at: None,
+                delivery_count: 0,
+            })
+            .unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Inspect ingress".to_string(),
+            },
+        );
+        let session = AgentState::new("default");
+
+        let built = build_context(
+            &storage,
+            &session,
+            &execution_snapshot_for(&session),
+            &crate::types::SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig {
+                recent_messages: 4,
+                recent_briefs: 4,
+                compaction_trigger_messages: 10,
+                compaction_keep_recent_messages: 4,
+                ..ContextConfig::default()
+            },
+        )
+        .unwrap();
+
+        let ingress = built
+            .sections
+            .iter()
+            .find(|section| section.name == "default_external_ingress")
+            .expect("default external ingress section should be present");
+        assert!(ingress
+            .content
+            .contains("http://127.0.0.1:7878/callbacks/wake/token"));
+        assert!(ingress.content.contains("- mode: wake_hint"));
+        assert!(ingress.content.contains("- status: active"));
+        assert!(ingress.content.contains("capability_secret: true"));
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -427,11 +427,16 @@ fn default_external_ingress(
     Ok(storage
         .latest_external_triggers()?
         .into_iter()
-        .find(|record| {
+        .filter(|record| {
             record.target_agent_id == agent_id
                 && record.scope == ExternalTriggerScope::Agent
                 && record.delivery_mode == CallbackDeliveryMode::WakeHint
                 && record.status == ExternalTriggerStatus::Active
+        })
+        .max_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.external_trigger_id.cmp(&right.external_trigger_id))
         }))
 }
 
@@ -3299,6 +3304,86 @@ mod tests {
         assert!(ingress.content.contains("- mode: wake_hint"));
         assert!(ingress.content.contains("- status: active"));
         assert!(ingress.content.contains("capability_secret: true"));
+    }
+
+    #[test]
+    fn build_context_uses_latest_default_external_wake_ingress() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = chrono::Utc::now();
+        storage
+            .append_external_trigger(&ExternalTriggerRecord {
+                external_trigger_id: "aaa-old-wake".into(),
+                target_agent_id: "default".into(),
+                waiting_intent_id: None,
+                scope: ExternalTriggerScope::Agent,
+                delivery_mode: CallbackDeliveryMode::WakeHint,
+                trigger_url: Some("http://127.0.0.1:7878/callbacks/wake/old".into()),
+                token_hash: "redacted-old-token-hash".into(),
+                status: ExternalTriggerStatus::Active,
+                created_at: now - chrono::Duration::seconds(60),
+                revoked_at: None,
+                last_delivered_at: None,
+                delivery_count: 0,
+            })
+            .unwrap();
+        storage
+            .append_external_trigger(&ExternalTriggerRecord {
+                external_trigger_id: "zzz-new-wake".into(),
+                target_agent_id: "default".into(),
+                waiting_intent_id: None,
+                scope: ExternalTriggerScope::Agent,
+                delivery_mode: CallbackDeliveryMode::WakeHint,
+                trigger_url: Some("http://127.0.0.1:7878/callbacks/wake/new".into()),
+                token_hash: "redacted-new-token-hash".into(),
+                status: ExternalTriggerStatus::Active,
+                created_at: now,
+                revoked_at: None,
+                last_delivered_at: None,
+                delivery_count: 0,
+            })
+            .unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            TrustLevel::TrustedOperator,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Inspect ingress".to_string(),
+            },
+        );
+        let session = AgentState::new("default");
+
+        let built = build_context(
+            &storage,
+            &session,
+            &execution_snapshot_for(&session),
+            &crate::types::SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig {
+                recent_messages: 4,
+                recent_briefs: 4,
+                compaction_trigger_messages: 10,
+                compaction_keep_recent_messages: 4,
+                ..ContextConfig::default()
+            },
+        )
+        .unwrap();
+
+        let ingress = built
+            .sections
+            .iter()
+            .find(|section| section.name == "default_external_ingress")
+            .expect("default external ingress section should be present");
+        assert!(ingress
+            .content
+            .contains("http://127.0.0.1:7878/callbacks/wake/new"));
+        assert!(!ingress
+            .content
+            .contains("http://127.0.0.1:7878/callbacks/wake/old"));
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -2524,7 +2524,10 @@ async fn callback_ingress(
             .await
             .map_err(error_response)?
     };
-    if descriptor.delivery_mode != mode.delivery_mode() {
+    if descriptor.delivery_mode != mode.delivery_mode()
+        && !(mode == CallbackIngressMode::Enqueue
+            && descriptor.delivery_mode == crate::types::CallbackDeliveryMode::EnqueueMessage)
+    {
         return Err(forbidden("callback delivery mode mismatch"));
     }
     let result = runtime

--- a/src/http.rs
+++ b/src/http.rs
@@ -2524,10 +2524,7 @@ async fn callback_ingress(
             .await
             .map_err(error_response)?
     };
-    if descriptor.delivery_mode != mode.delivery_mode()
-        && !(mode == CallbackIngressMode::Enqueue
-            && descriptor.delivery_mode == crate::types::CallbackDeliveryMode::EnqueueMessage)
-    {
+    if descriptor.delivery_mode != mode.delivery_mode() {
         return Err(forbidden("callback delivery mode mismatch"));
     }
     let result = runtime

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -494,18 +494,10 @@ fn openai_codex_request_payload_validates_full_tool_matrix_in_strict_mode() {
         }
     }
 
-    let external_trigger = emitted_tools
+    assert!(emitted_tools
         .iter()
-        .find(|tool| tool["name"] == "CreateExternalTrigger")
-        .expect("CreateExternalTrigger tool should be present");
-    let properties = external_trigger["parameters"]["properties"]
-        .as_object()
-        .expect("properties should be an object");
-    assert!(properties.contains_key("description"));
-    assert!(properties.contains_key("source"));
-    assert!(!properties.contains_key("scope"));
-    assert!(properties.contains_key("delivery_mode"));
-    assert!(!properties.contains_key("summary"));
-    assert!(!properties.contains_key("condition"));
-    assert!(!properties.contains_key("resource"));
+        .all(|tool| tool["name"] != "CreateExternalTrigger"));
+    assert!(emitted_tools
+        .iter()
+        .all(|tool| tool["name"] != "CancelExternalTrigger"));
 }

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -496,8 +496,8 @@ fn openai_codex_request_payload_validates_full_tool_matrix_in_strict_mode() {
 
     assert!(emitted_tools
         .iter()
-        .any(|tool| tool["name"] == "CreateExternalTrigger"));
+        .all(|tool| tool["name"] != "CreateExternalTrigger"));
     assert!(emitted_tools
         .iter()
-        .any(|tool| tool["name"] == "CancelExternalTrigger"));
+        .all(|tool| tool["name"] != "CancelExternalTrigger"));
 }

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -496,8 +496,8 @@ fn openai_codex_request_payload_validates_full_tool_matrix_in_strict_mode() {
 
     assert!(emitted_tools
         .iter()
-        .all(|tool| tool["name"] != "CreateExternalTrigger"));
+        .any(|tool| tool["name"] == "CreateExternalTrigger"));
     assert!(emitted_tools
         .iter()
-        .all(|tool| tool["name"] != "CancelExternalTrigger"));
+        .any(|tool| tool["name"] == "CancelExternalTrigger"));
 }

--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -29,15 +29,17 @@ impl RuntimeHandle {
 
     pub async fn default_external_trigger(
         &self,
-        delivery_mode: CallbackDeliveryMode,
+        _delivery_mode: CallbackDeliveryMode,
     ) -> Result<ExternalTriggerCapability> {
-        self.ensure_default_external_ingress(delivery_mode).await
+        self.ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
+            .await
     }
 
     pub async fn ensure_default_external_ingress(
         &self,
-        delivery_mode: CallbackDeliveryMode,
+        _delivery_mode: CallbackDeliveryMode,
     ) -> Result<ExternalTriggerCapability> {
+        let delivery_mode = CallbackDeliveryMode::WakeHint;
         let agent_id = self.agent_id().await?;
         let now = Utc::now();
         if let Some(descriptor) =
@@ -122,68 +124,29 @@ impl RuntimeHandle {
                 .and_then(|waiting| waiting.causation_id.clone())
         });
 
-        let disposition = match descriptor.delivery_mode {
-            CallbackDeliveryMode::EnqueueMessage => {
-                let body = payload
-                    .body
-                    .clone()
-                    .ok_or_else(|| anyhow!("enqueue_message callback requires a request body"))?;
-                let external_trigger_id = descriptor.external_trigger_id.clone();
-
-                let mut message = MessageEnvelope::new(
-                    agent_id.clone(),
-                    MessageKind::CallbackEvent,
-                    MessageOrigin::Callback {
-                        descriptor_id: descriptor.external_trigger_id.clone(),
-                        source: waiting.as_ref().map(|waiting| waiting.source.clone()),
-                    },
-                    TrustLevel::TrustedIntegration,
-                    Priority::Next,
-                    body,
-                )
-                .with_admission(
-                    crate::types::MessageDeliverySurface::HttpCallbackEnqueue,
-                    crate::types::AdmissionContext::ExternalTriggerCapability,
-                );
-                message.metadata = Some(serde_json::json!({
-                    "waiting_intent_id": waiting.as_ref().map(|waiting| waiting.id.clone()),
-                    "external_trigger_id": external_trigger_id,
-                    "work_item_id": waiting.as_ref().and_then(|waiting| waiting.work_item_id.clone()),
-                    "description": waiting.as_ref().map(|waiting| waiting.description.clone()),
-                    "source": waiting.as_ref().map(|waiting| waiting.source.clone()),
-                    "scope": descriptor.scope,
-                    "resource": waiting.as_ref().and_then(|waiting| waiting.resource.clone()),
-                    "content_type": payload.content_type,
-                }));
-                message.correlation_id = correlation_id.clone();
-                message.causation_id = causation_id.clone();
-                self.enqueue(message).await?;
-                CallbackIngressDisposition::Enqueued
-            }
-            CallbackDeliveryMode::WakeHint => {
-                let disposition = self
-                    .submit_wake_hint(WakeHint {
-                        agent_id: agent_id.clone(),
-                        reason: callback_wake_reason(waiting.as_ref(), payload.body.as_ref()),
-                        description: waiting.as_ref().map(|waiting| waiting.description.clone()),
-                        source: waiting.as_ref().map(|waiting| waiting.source.clone()),
-                        scope: Some(descriptor.scope.clone()),
-                        waiting_intent_id: waiting.as_ref().map(|waiting| waiting.id.clone()),
-                        external_trigger_id: Some(descriptor.external_trigger_id.clone()),
-                        resource: waiting
-                            .as_ref()
-                            .and_then(|waiting| waiting.resource.clone()),
-                        body: payload.body.clone(),
-                        content_type: payload.content_type.clone(),
-                        correlation_id: correlation_id.clone(),
-                        causation_id: causation_id.clone(),
-                    })
-                    .await?;
-                match disposition {
-                    WakeDisposition::Triggered => CallbackIngressDisposition::Triggered,
-                    WakeDisposition::Coalesced => CallbackIngressDisposition::Coalesced,
-                    WakeDisposition::Ignored => CallbackIngressDisposition::Ignored,
-                }
+        let disposition = {
+            let disposition = self
+                .submit_wake_hint(WakeHint {
+                    agent_id: agent_id.clone(),
+                    reason: callback_wake_reason(waiting.as_ref(), payload.body.as_ref()),
+                    description: waiting.as_ref().map(|waiting| waiting.description.clone()),
+                    source: waiting.as_ref().map(|waiting| waiting.source.clone()),
+                    scope: Some(descriptor.scope.clone()),
+                    waiting_intent_id: waiting.as_ref().map(|waiting| waiting.id.clone()),
+                    external_trigger_id: Some(descriptor.external_trigger_id.clone()),
+                    resource: waiting
+                        .as_ref()
+                        .and_then(|waiting| waiting.resource.clone()),
+                    body: payload.body.clone(),
+                    content_type: payload.content_type.clone(),
+                    correlation_id: correlation_id.clone(),
+                    causation_id: causation_id.clone(),
+                })
+                .await?;
+            match disposition {
+                WakeDisposition::Triggered => CallbackIngressDisposition::Triggered,
+                WakeDisposition::Coalesced => CallbackIngressDisposition::Coalesced,
+                WakeDisposition::Ignored => CallbackIngressDisposition::Ignored,
             }
         };
 
@@ -214,14 +177,9 @@ impl RuntimeHandle {
             .append_external_trigger(&updated_descriptor)?;
 
         let updated_descriptor_id = updated_descriptor.external_trigger_id.clone();
-        let delivery_surface = match &updated_descriptor.delivery_mode {
-            CallbackDeliveryMode::EnqueueMessage => {
-                crate::types::MessageDeliverySurface::HttpCallbackEnqueue
-            }
-            CallbackDeliveryMode::WakeHint => {
-                crate::types::MessageDeliverySurface::HttpCallbackWake
-            }
-        };
+        let descriptor_delivery_mode = updated_descriptor.delivery_mode.clone();
+        let deprecated_enqueue_message_mapped_to_wake_hint =
+            descriptor_delivery_mode == CallbackDeliveryMode::EnqueueMessage;
         self.inner.storage.append_event(&AuditEvent::new(
             "callback_delivered",
             serde_json::json!({
@@ -230,12 +188,14 @@ impl RuntimeHandle {
                 "work_item_id": waiting.as_ref().and_then(|waiting| waiting.work_item_id.clone()),
                 "external_trigger_id": updated_descriptor_id,
                 "scope": updated_descriptor.scope,
-                "delivery_mode": updated_descriptor.delivery_mode,
+                "delivery_mode": CallbackDeliveryMode::WakeHint,
+                "descriptor_delivery_mode": descriptor_delivery_mode,
+                "deprecated_enqueue_message_mapped_to_wake_hint": deprecated_enqueue_message_mapped_to_wake_hint,
                 "source": waiting.as_ref().map(|waiting| waiting.source.clone()),
                 "resource": waiting.as_ref().and_then(|waiting| waiting.resource.clone()),
                 "trigger_count": updated_waiting.as_ref().map(|waiting| waiting.trigger_count),
                 "origin": "callback",
-                "delivery_surface": delivery_surface,
+                "delivery_surface": crate::types::MessageDeliverySurface::HttpCallbackWake,
                 "disposition": disposition,
                 "admission_context": crate::types::AdmissionContext::ExternalTriggerCapability,
                 "authority_class": crate::types::AuthorityClass::IntegrationSignal,
@@ -247,7 +207,7 @@ impl RuntimeHandle {
             waiting_intent_id: waiting.map(|waiting| waiting.id),
             external_trigger_id: updated_descriptor.external_trigger_id,
             scope: updated_descriptor.scope,
-            delivery_mode: updated_descriptor.delivery_mode,
+            delivery_mode: CallbackDeliveryMode::WakeHint,
             disposition,
         })
     }

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -21,6 +21,8 @@ impl RuntimeHandle {
         self.persist_brief(&ack).await?;
         let context_build_started = std::time::Instant::now();
         let identity = self.agent_identity_view().await?;
+        self.ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
+            .await?;
         let context_config = self.current_context_config().await;
 
         let built = {
@@ -164,6 +166,8 @@ impl RuntimeHandle {
         let continuation = ContinuationTrigger::from_message(&message, None)
             .map(|trigger| resolve_continuation(&prior_closure, &trigger));
         let identity = self.agent_identity_view().await?;
+        self.ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
+            .await?;
         let (provider, available_tools, _) = self.provider_tool_selection(&identity).await?;
         let prompt_tools = provider.prompt_tool_specs(&available_tools);
         let execution = self.execution_snapshot().await?;

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2635,24 +2635,22 @@ async fn legacy_descriptor_preserves_provenance_after_wait_cancel() {
         result.waiting_intent_id.as_deref(),
         Some(waiting_id.as_str())
     );
+    assert_eq!(result.delivery_mode, CallbackDeliveryMode::WakeHint);
+    assert_ne!(result.disposition, CallbackIngressDisposition::Enqueued);
     let messages = runtime.storage().read_recent_messages(10).unwrap();
-    let callback = messages
+    assert!(messages
         .iter()
-        .find(|message| message.kind == MessageKind::CallbackEvent)
-        .expect("callback event should be enqueued");
-    assert_eq!(callback.correlation_id.as_deref(), Some("legacy-corr"));
-    assert_eq!(callback.causation_id.as_deref(), Some("legacy-cause"));
-    let metadata = callback
-        .metadata
-        .as_ref()
-        .expect("callback event metadata should exist");
-    assert_eq!(
-        metadata["waiting_intent_id"].as_str(),
-        Some(waiting_id.as_str())
-    );
-    assert_eq!(metadata["source"].as_str(), Some("github"));
-    assert_eq!(metadata["description"].as_str(), Some("legacy review wait"));
-    assert_eq!(metadata["resource"].as_str(), Some("pull_request:1215"));
+        .all(|message| message.kind != MessageKind::CallbackEvent));
+    assert!(messages.iter().any(|message| {
+        message.kind == MessageKind::SystemTick
+            && message
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("wake_hint"))
+                .and_then(|wake_hint| wake_hint.get("external_trigger_id"))
+                .and_then(serde_json::Value::as_str)
+                == Some(trigger_id.as_str())
+    }));
     let waiting = runtime.latest_waiting_intents().await.unwrap();
     let cancelled = waiting
         .iter()

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -345,8 +345,6 @@ mod tests {
             "CompleteWorkItem",
             "MemorySearch",
             "MemoryGet",
-            "CreateExternalTrigger",
-            "CancelExternalTrigger",
             "ApplyPatch",
             "ExecCommand",
             "WebFetch",
@@ -590,11 +588,11 @@ mod tests {
         assert!(names.iter().any(|name| name == "CompleteWorkItem"));
         assert!(names.iter().any(|name| name == "MemorySearch"));
         assert!(names.iter().any(|name| name == "MemoryGet"));
-        assert!(names.iter().any(|name| name == "CreateExternalTrigger"));
-        assert!(names.iter().any(|name| name == "CancelExternalTrigger"));
         assert!(names.iter().any(|name| name == "ApplyPatch"));
         assert!(names.iter().any(|name| name == "WebFetch"));
         assert!(names.iter().any(|name| name == "WebSearch"));
+        assert!(names.iter().all(|name| name != "CreateExternalTrigger"));
+        assert!(names.iter().all(|name| name != "CancelExternalTrigger"));
         assert!(names.iter().all(|name| name != "CreateTask"));
     }
 
@@ -635,14 +633,6 @@ mod tests {
         assert_eq!(
             family_for("SpawnAgent"),
             ToolCapabilityFamily::AgentCreation
-        );
-        assert_eq!(
-            family_for("CreateExternalTrigger"),
-            ToolCapabilityFamily::ExternalTrigger
-        );
-        assert_eq!(
-            family_for("CancelExternalTrigger"),
-            ToolCapabilityFamily::ExternalTrigger
         );
         assert_eq!(
             family_for("ExecCommand"),

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -588,8 +588,8 @@ mod tests {
         assert!(names.iter().any(|name| name == "CompleteWorkItem"));
         assert!(names.iter().any(|name| name == "MemorySearch"));
         assert!(names.iter().any(|name| name == "MemoryGet"));
-        assert!(names.iter().any(|name| name == "CreateExternalTrigger"));
-        assert!(names.iter().any(|name| name == "CancelExternalTrigger"));
+        assert!(names.iter().all(|name| name != "CreateExternalTrigger"));
+        assert!(names.iter().all(|name| name != "CancelExternalTrigger"));
         assert!(names.iter().any(|name| name == "ApplyPatch"));
         assert!(names.iter().any(|name| name == "WebFetch"));
         assert!(names.iter().any(|name| name == "WebSearch"));
@@ -629,14 +629,6 @@ mod tests {
         assert_eq!(
             family_for("CompleteWorkItem"),
             ToolCapabilityFamily::CoreAgent
-        );
-        assert_eq!(
-            family_for("CreateExternalTrigger"),
-            ToolCapabilityFamily::ExternalTrigger
-        );
-        assert_eq!(
-            family_for("CancelExternalTrigger"),
-            ToolCapabilityFamily::ExternalTrigger
         );
         assert_eq!(
             family_for("SpawnAgent"),

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -588,11 +588,11 @@ mod tests {
         assert!(names.iter().any(|name| name == "CompleteWorkItem"));
         assert!(names.iter().any(|name| name == "MemorySearch"));
         assert!(names.iter().any(|name| name == "MemoryGet"));
+        assert!(names.iter().any(|name| name == "CreateExternalTrigger"));
+        assert!(names.iter().any(|name| name == "CancelExternalTrigger"));
         assert!(names.iter().any(|name| name == "ApplyPatch"));
         assert!(names.iter().any(|name| name == "WebFetch"));
         assert!(names.iter().any(|name| name == "WebSearch"));
-        assert!(names.iter().all(|name| name != "CreateExternalTrigger"));
-        assert!(names.iter().all(|name| name != "CancelExternalTrigger"));
         assert!(names.iter().all(|name| name != "CreateTask"));
     }
 
@@ -629,6 +629,14 @@ mod tests {
         assert_eq!(
             family_for("CompleteWorkItem"),
             ToolCapabilityFamily::CoreAgent
+        );
+        assert_eq!(
+            family_for("CreateExternalTrigger"),
+            ToolCapabilityFamily::ExternalTrigger
+        );
+        assert_eq!(
+            family_for("CancelExternalTrigger"),
+            ToolCapabilityFamily::ExternalTrigger
         );
         assert_eq!(
             family_for("SpawnAgent"),

--- a/src/tool/tools/cancel_external_trigger.rs
+++ b/src/tool/tools/cancel_external_trigger.rs
@@ -23,6 +23,7 @@ pub(crate) struct CancelExternalTriggerArgs {
     pub(crate) waiting_intent_id: Option<String>,
 }
 
+#[allow(dead_code)]
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
     Ok(BuiltinToolDefinition {
         family: ToolCapabilityFamily::ExternalTrigger,

--- a/src/tool/tools/create_external_trigger.rs
+++ b/src/tool/tools/create_external_trigger.rs
@@ -33,6 +33,7 @@ pub(crate) struct CreateExternalTriggerArgs {
     pub(crate) delivery_mode: CallbackDeliveryModeArgs,
 }
 
+#[allow(dead_code)]
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
     Ok(BuiltinToolDefinition {
         family: ToolCapabilityFamily::ExternalTrigger,

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -62,6 +62,8 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         complete_work_item::definition()?,
         memory_search::definition()?,
         memory_get::definition()?,
+        create_external_trigger::definition()?,
+        cancel_external_trigger::definition()?,
         apply_patch_tool::definition()?,
         exec_command::definition()?,
         exec_command_batch::definition()?,

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -62,8 +62,6 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         complete_work_item::definition()?,
         memory_search::definition()?,
         memory_get::definition()?,
-        create_external_trigger::definition()?,
-        cancel_external_trigger::definition()?,
         apply_patch_tool::definition()?,
         exec_command::definition()?,
         exec_command_batch::definition()?,

--- a/tests/runtime_waiting_and_delivery_regressions.rs
+++ b/tests/runtime_waiting_and_delivery_regressions.rs
@@ -45,7 +45,7 @@ runtime_async_tests!(
     notify_operator_prefers_reply_route_for_delivery,
     notify_operator_ignores_reply_route_when_binding_no_longer_matches,
     notify_operator_falls_back_to_default_route_without_reply_route,
-    callback_tools_register_and_revoke_waiting_state,
+    default_external_ingress_register_and_revoke_state,
     timer_wait_surfaces_waiting_reason,
 );
 

--- a/tests/support/http_callback.rs
+++ b/tests/support/http_callback.rs
@@ -441,7 +441,8 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
         .await?;
     assert!(first.status().is_success());
     let first_payload: serde_json::Value = first.json().await?;
-    assert_eq!(first_payload["disposition"], "enqueued");
+    assert_eq!(first_payload["delivery_mode"], "wake_hint");
+    assert_eq!(first_payload["disposition"], "triggered");
 
     wait_until(|| {
         let descriptors = runtime.storage().latest_external_triggers()?;
@@ -494,9 +495,7 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
         let descriptors = runtime2.storage().latest_external_triggers()?;
         Ok(messages
             .iter()
-            .filter(|message| message.kind == MessageKind::CallbackEvent)
-            .count()
-            == 1
+            .all(|message| message.kind != MessageKind::CallbackEvent)
             && descriptors
                 .first()
                 .map(|item| item.delivery_count == 1)

--- a/tests/support/http_callback.rs
+++ b/tests/support/http_callback.rs
@@ -62,7 +62,8 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
             None,
         )
         .await?;
-    assert!(capability.trigger_url.contains("/callbacks/enqueue/"));
+    assert_eq!(capability.delivery_mode, CallbackDeliveryMode::WakeHint);
+    assert!(capability.trigger_url.contains("/callbacks/wake/"));
     let callback_path = callback_path(&capability.trigger_url);
     let client = reqwest::Client::new();
 
@@ -73,7 +74,8 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
         .await?;
     assert!(first.status().is_success());
     let first_payload: serde_json::Value = first.json().await?;
-    assert_eq!(first_payload["disposition"], "enqueued");
+    assert_eq!(first_payload["delivery_mode"], "wake_hint");
+    assert_ne!(first_payload["disposition"], "enqueued");
     assert_eq!(
         first_payload["external_trigger_id"].as_str(),
         Some(capability.external_trigger_id.as_str())
@@ -92,9 +94,7 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
         let descriptors = runtime.storage().latest_external_triggers()?;
         Ok(messages
             .iter()
-            .filter(|message| message.kind == MessageKind::CallbackEvent)
-            .count()
-            >= 2
+            .all(|message| message.kind != MessageKind::CallbackEvent)
             && descriptors
                 .first()
                 .map(|item| item.delivery_count == 2)
@@ -103,29 +103,9 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
     .await?;
 
     let messages = runtime.storage().read_recent_messages(20)?;
-    let callback_message = messages
+    assert!(messages
         .iter()
-        .find(|message| message.kind == MessageKind::CallbackEvent)
-        .expect("callback message");
-    assert_eq!(
-        callback_message.delivery_surface,
-        Some(MessageDeliverySurface::HttpCallbackEnqueue)
-    );
-    assert_eq!(
-        callback_message.admission_context,
-        Some(AdmissionContext::ExternalTriggerCapability)
-    );
-    assert_eq!(
-        callback_message.authority_class,
-        AuthorityClass::IntegrationSignal
-    );
-    assert_eq!(
-        callback_message
-            .metadata
-            .as_ref()
-            .and_then(|metadata| metadata["external_trigger_id"].as_str()),
-        Some(capability.external_trigger_id.as_str())
-    );
+        .all(|message| message.kind != MessageKind::CallbackEvent));
 
     let events = runtime.storage().read_recent_events(100)?;
     let delivered = events
@@ -134,7 +114,8 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
         .find(|event| event.kind == "callback_delivered")
         .expect("callback delivered event");
     assert_eq!(delivered.data["origin"], "callback");
-    assert_eq!(delivered.data["delivery_surface"], "http_callback_enqueue");
+    assert_eq!(delivered.data["delivery_surface"], "http_callback_wake");
+    assert_eq!(delivered.data["delivery_mode"], "wake_hint");
     assert_eq!(
         delivered.data["admission_context"],
         "external_trigger_capability"
@@ -314,7 +295,7 @@ pub async fn callback_mode_mismatch_is_rejected() -> Result<()> {
             "wait for CI callback".into(),
             "github".into(),
             ExternalTriggerScope::Agent,
-            CallbackDeliveryMode::EnqueueMessage,
+            CallbackDeliveryMode::WakeHint,
             None,
             None,
         )
@@ -323,7 +304,7 @@ pub async fn callback_mode_mismatch_is_rejected() -> Result<()> {
     let client = reqwest::Client::new();
 
     let response = client
-        .post(format!("{base}/callbacks/wake/{token}"))
+        .post(format!("{base}/callbacks/enqueue/{token}"))
         .json(&serde_json::json!({ "status": "checks_passed" }))
         .send()
         .await?;

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -27,13 +27,14 @@ use holon::{
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     tool::{ToolCall, ToolError, ToolRegistry, ToolResult},
     types::{
-        AgentKind, AgentProfilePreset, AgentStatus, BriefKind, ChildAgentPhase, ClosureOutcome,
-        CommandTaskSpec, ControlAction, ExternalTriggerStatus, FailureArtifactCategory,
-        MessageBody, MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationBoundary,
-        OperatorTransportBinding, OperatorTransportBindingStatus, OperatorTransportCapabilities,
-        OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority,
-        QueueEntryStatus, TaskStatus, TodoItem, TodoItemState, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, TrustLevel, WaitingReason, WorkItemState,
+        AgentKind, AgentProfilePreset, AgentStatus, BriefKind, CallbackDeliveryMode,
+        ChildAgentPhase, ClosureOutcome, CommandTaskSpec, ControlAction, ExternalTriggerStatus,
+        FailureArtifactCategory, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
+        OperatorNotificationBoundary, OperatorTransportBinding, OperatorTransportBindingStatus,
+        OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
+        OperatorTransportDeliveryAuthKind, Priority, QueueEntryStatus, TaskStatus, TodoItem,
+        TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TrustLevel, WaitingReason,
+        WorkItemState,
     },
 };
 use serde_json::json;
@@ -44,8 +45,8 @@ use tokio::time::{sleep, Duration};
 use crate::support::runtime_compaction_providers::MaxOutputRecoveryProvider;
 use crate::support::runtime_helpers::{
     aggressive_compaction_config, git, init_git_repo, operator_transport_binding,
-    parse_tool_result_payload, parse_tool_result_value, test_config, wait_for_worktree_presence,
-    wait_until, wait_until_async, wait_until_async_for,
+    parse_tool_result_value, test_config, wait_for_worktree_presence, wait_until, wait_until_async,
+    wait_until_async_for,
 };
 use crate::support::runtime_providers::{
     DelayedTextProvider, DelegatedBoundaryProvider, FileEditingProvider, LongShellProvider,
@@ -895,7 +896,7 @@ pub async fn agent_summary_last_turn_token_usage_survives_transcript_windowing()
     Ok(())
 }
 
-pub async fn callback_tools_register_and_revoke_waiting_state() -> Result<()> {
+pub async fn default_external_ingress_register_and_revoke_state() -> Result<()> {
     let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
     let runtime = host.default_runtime().await?;
     let registry = ToolRegistry::new(runtime.workspace_root());
@@ -904,13 +905,13 @@ pub async fn callback_tools_register_and_revoke_waiting_state() -> Result<()> {
         .await?;
     runtime.pick_work_item(work_item.id).await?;
 
-    let (created, _) = registry
+    let create_error = registry
         .execute(
             &runtime,
             "default",
             &TrustLevel::TrustedOperator,
             &ToolCall {
-                id: "tool-create-callback".into(),
+                id: "tool-create-external-trigger-rejected".into(),
                 name: "CreateExternalTrigger".into(),
                 input: json!({
                     "description": "wait for CI callback",
@@ -919,16 +920,14 @@ pub async fn callback_tools_register_and_revoke_waiting_state() -> Result<()> {
                 }),
             },
         )
+        .await
+        .expect_err("ordinary agent tools should not expose CreateExternalTrigger");
+    assert!(create_error.to_string().contains("unknown_tool"));
+
+    let capability = runtime
+        .default_external_trigger(CallbackDeliveryMode::WakeHint)
         .await?;
-    let capability: serde_json::Value = parse_tool_result_payload(&created)?;
-    let trigger_url = capability["trigger_url"]
-        .as_str()
-        .expect("trigger_url should be present");
-    assert!(!capability.as_object().unwrap().contains_key("callback_url"));
-    assert!(!capability
-        .as_object()
-        .unwrap()
-        .contains_key("callback_descriptor_id"));
+    let trigger_url = capability.trigger_url.as_str();
     let callback_token = trigger_url
         .rsplit('/')
         .next()
@@ -970,23 +969,27 @@ pub async fn callback_tools_register_and_revoke_waiting_state() -> Result<()> {
     assert!(!state_text.contains(callback_token));
     assert!(!state_text.contains(trigger_url));
 
-    let (cancelled, _) = registry
+    let cancel_error = registry
         .execute(
             &runtime,
             "default",
             &TrustLevel::TrustedOperator,
             &ToolCall {
-                id: "tool-cancel-waiting".into(),
+                id: "tool-cancel-external-trigger-rejected".into(),
                 name: "CancelExternalTrigger".into(),
                 input: json!({
-                    "external_trigger_id": capability["external_trigger_id"],
+                    "external_trigger_id": capability.external_trigger_id,
                 }),
             },
         )
+        .await
+        .expect_err("ordinary agent tools should not expose CancelExternalTrigger");
+    assert!(cancel_error.to_string().contains("unknown_tool"));
+
+    let cancelled = runtime
+        .revoke_external_trigger(&capability.external_trigger_id)
         .await?;
-    let cancelled: serde_json::Value = parse_tool_result_payload(&cancelled)?;
-    assert_eq!(cancelled["status"], "revoked");
-    assert!(cancelled["external_trigger_id"].is_string());
+    assert_eq!(cancelled.status, ExternalTriggerStatus::Revoked);
     let events = runtime.storage().read_recent_events(20)?;
     let cancelled_event = events
         .iter()

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -702,7 +702,7 @@ pub async fn notify_operator_prefers_reply_route_for_delivery() -> Result<()> {
         async move {
             Ok(runtime
                 .storage()
-                .read_recent_events(20)?
+                .read_recent_events(200)?
                 .iter()
                 .any(|event| event.kind == "message_processing_started"))
         }
@@ -766,7 +766,7 @@ pub async fn notify_operator_ignores_reply_route_when_binding_no_longer_matches(
         async move {
             Ok(runtime
                 .storage()
-                .read_recent_events(20)?
+                .read_recent_events(200)?
                 .iter()
                 .any(|event| event.kind == "message_processing_started"))
         }
@@ -830,7 +830,7 @@ pub async fn notify_operator_falls_back_to_default_route_without_reply_route() -
         async move {
             Ok(runtime
                 .storage()
-                .read_recent_events(20)?
+                .read_recent_events(200)?
                 .iter()
                 .any(|event| event.kind == "message_processing_started"))
         }


### PR DESCRIPTION
## Summary
- make default external trigger capability resolve to a fixed wake_hint ingress
- ensure the default wake ingress is materialized before agent context/prompt construction and render it as a capability-secret context section
- remove CreateExternalTrigger/CancelExternalTrigger from ordinary agent-facing tool specs
- map legacy enqueue-message callback descriptors to wake hints with deprecated provenance instead of enqueuing callback payloads
- update runtime spec and regression coverage for the new contract

Fixes #1329

## Verification
- cargo fmt --all -- --check
- cargo test build_context_includes_default_external_wake_ingress -- --nocapture
- cargo test stable_tool_specs_include_task_control_and_mutating_tools -- --nocapture
- cargo test callback_enqueue_message_repeats_until_cancelled -- --nocapture
- cargo test legacy_descriptor_preserves_provenance_after_wait_cancel -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets