### PR TITLE
Enable Codex builtin web search

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2335,7 +2335,7 @@ fn built_in_provider_registry(settings_env: &HashMap<String, String>) -> Result<
             originator: Some("codex_cli_rs".into()),
             reasoning_effort: openai_codex_reasoning_effort,
             context_management: Default::default(),
-            builtin_web_search: None,
+            builtin_web_search: Some(openai_codex_builtin_web_search_config()),
         },
     );
     let openai = ProviderId::openai();
@@ -2826,6 +2826,15 @@ fn openai_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
     }
 }
 
+fn openai_codex_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::OpenAi,
+        advertised_tool_type: "web_search".to_string(),
+        backend_kind: "openai_codex_web_search".to_string(),
+    }
+}
+
 fn anthropic_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
     ProviderBuiltinWebSearchConfig {
         enabled: true,
@@ -2961,6 +2970,16 @@ fn validate_provider_builtin_web_search(
             } else {
                 Err(anyhow!(
                     "providers.{}.builtin_web_search.advertised_tool_type must be web_search_preview for OpenAI Responses native search",
+                    provider_id.as_str()
+                ))
+            }
+        }
+        (ProviderTransportKind::OpenAiCodexResponses, ProviderNativeWebSearchKind::OpenAi) => {
+            if search.advertised_tool_type == "web_search" {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "providers.{}.builtin_web_search.advertised_tool_type must be web_search for OpenAI Codex Responses native search",
                     provider_id.as_str()
                 ))
             }
@@ -3106,7 +3125,7 @@ pub fn provider_registry_for_tests(
             originator: Some("codex_cli_rs".into()),
             reasoning_effort: Some("low".into()),
             context_management: Default::default(),
-            builtin_web_search: None,
+            builtin_web_search: Some(openai_codex_builtin_web_search_config()),
         },
     );
     let openai = ProviderId::openai();
@@ -4419,6 +4438,15 @@ mod tests {
     fn built_in_provider_registry_declares_provider_specific_builtin_search() {
         let registry = built_in_provider_registry(&HashMap::new()).unwrap();
 
+        let openai_codex = registry.get(&ProviderId::openai_codex()).unwrap();
+        let openai_codex_search = openai_codex.builtin_web_search.as_ref().unwrap();
+        assert_eq!(
+            openai_codex_search.kind,
+            ProviderNativeWebSearchKind::OpenAi
+        );
+        assert_eq!(openai_codex_search.advertised_tool_type, "web_search");
+        assert_eq!(openai_codex_search.backend_kind, "openai_codex_web_search");
+
         let anthropic = registry.get(&ProviderId::anthropic()).unwrap();
         let anthropic_search = anthropic.builtin_web_search.as_ref().unwrap();
         assert_eq!(
@@ -4570,6 +4598,57 @@ mod tests {
 
         let err = validate_provider_config(&id, &config).unwrap_err();
         assert!(err.to_string().contains("web_search_preview"));
+    }
+
+    #[test]
+    fn provider_builtin_web_search_accepts_codex_tool_type() {
+        let id = ProviderId::openai_codex();
+        let config = ProviderConfigFile {
+            transport: ProviderTransportKind::OpenAiCodexResponses,
+            base_url: "https://chatgpt.com/backend-api/codex".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::ExternalCli,
+                kind: CredentialKind::SessionToken,
+                env: None,
+                profile: None,
+                external: Some("codex_cli".into()),
+            },
+            reasoning_effort: None,
+            builtin_web_search: Some(ProviderBuiltinWebSearchConfig {
+                enabled: true,
+                kind: ProviderNativeWebSearchKind::OpenAi,
+                advertised_tool_type: "web_search".into(),
+                backend_kind: "openai_codex_web_search".into(),
+            }),
+        };
+
+        validate_provider_config(&id, &config).unwrap();
+    }
+
+    #[test]
+    fn provider_builtin_web_search_rejects_wrong_codex_tool_type() {
+        let id = ProviderId::openai_codex();
+        let config = ProviderConfigFile {
+            transport: ProviderTransportKind::OpenAiCodexResponses,
+            base_url: "https://chatgpt.com/backend-api/codex".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::ExternalCli,
+                kind: CredentialKind::SessionToken,
+                env: None,
+                profile: None,
+                external: Some("codex_cli".into()),
+            },
+            reasoning_effort: None,
+            builtin_web_search: Some(ProviderBuiltinWebSearchConfig {
+                enabled: true,
+                kind: ProviderNativeWebSearchKind::OpenAi,
+                advertised_tool_type: "web_search_preview".into(),
+                backend_kind: "openai_codex_web_search".into(),
+            }),
+        };
+
+        let err = validate_provider_config(&id, &config).unwrap_err();
+        assert!(err.to_string().contains("web_search for OpenAI Codex"));
     }
 
     #[test]

--- a/src/provider/tests/openai_responses.rs
+++ b/src/provider/tests/openai_responses.rs
@@ -10,6 +10,7 @@ use super::*;
 use crate::config::{ModelRef, ProviderId};
 use crate::model_catalog::ModelRuntimeOverride;
 use crate::provider::transports::set_stream_idle_timeout_override_for_tests;
+use crate::provider::ProviderNativeWebSearchKind;
 use axum::{http::StatusCode, response::IntoResponse, routing::post, Json, Router};
 use serde_json::{json, Value};
 
@@ -192,6 +193,21 @@ fn provider_text_followup_with_prompt_frame(previous_text: &str) -> ProviderTurn
         ConversationMessage::UserText("continue".into()),
     ]);
     request
+}
+
+#[test]
+fn openai_codex_provider_declares_builtin_web_search_capability() {
+    let fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    let provider = OpenAiCodexProvider::from_config(&fixture.config, "gpt-5.4").unwrap();
+
+    let capability = provider
+        .builtin_web_search()
+        .expect("openai codex provider should declare builtin search");
+    assert_eq!(capability.kind, ProviderNativeWebSearchKind::OpenAi);
+    assert_eq!(capability.provider_id, "openai-codex");
+    assert_eq!(capability.provider_model_ref, "openai-codex/gpt-5.4");
+    assert_eq!(capability.advertised_tool_type, "web_search");
+    assert_eq!(capability.backend_kind, "openai_codex_web_search");
 }
 
 #[tokio::test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -55,12 +55,14 @@ pub struct OpenAiProvider {
 #[derive(Clone)]
 pub struct OpenAiCodexProvider {
     client: Client,
+    provider_id: String,
     base_url: String,
     codex_home: std::path::PathBuf,
     originator: String,
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
+    builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
     continuation: Arc<Mutex<OpenAiContinuationState>>,
@@ -341,6 +343,7 @@ impl OpenAiCodexProvider {
         load_codex_cli_credential(&codex_home)?;
         Ok(Self {
             client,
+            provider_id: provider_config.id.as_str().to_string(),
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             codex_home,
             originator: provider_config
@@ -350,6 +353,7 @@ impl OpenAiCodexProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
+            builtin_web_search: provider_config.builtin_web_search.clone(),
             compaction_policy,
             trace_home_dir: trace_home_dir.to_path_buf(),
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
@@ -658,6 +662,17 @@ impl AgentProvider for OpenAiCodexProvider {
     fn supports_freeform_grammar_tools(&self) -> bool {
         true
     }
+
+    fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
+        let config = self.builtin_web_search.as_ref()?;
+        Some(ProviderBuiltinWebSearchCapability {
+            kind: config.kind,
+            provider_id: self.provider_id.clone(),
+            provider_model_ref: format!("{}/{}", self.provider_id, self.model),
+            advertised_tool_type: config.advertised_tool_type.clone(),
+            backend_kind: config.backend_kind.clone(),
+        })
+    }
 }
 
 #[async_trait]
@@ -853,6 +868,7 @@ fn plan_chat_completion_request(
                     full_message_count,
                     None,
                     None,
+                    None,
                 ),
             },
         ));
@@ -878,6 +894,7 @@ fn plan_chat_completion_request(
                     "not_applicable_initial_request",
                     None,
                     full_message_count,
+                    None,
                     None,
                     None,
                 ),
@@ -907,6 +924,7 @@ fn plan_chat_completion_request(
                         ..OpenAiContinuationMismatchDiagnostics::default()
                     }),
                     None,
+                    None,
                 ),
             },
         ));
@@ -935,6 +953,7 @@ fn plan_chat_completion_request(
                     request_shape_hash: Some(request_shape_hash),
                     ..OpenAiContinuationMismatchDiagnostics::default()
                 }),
+                None,
                 None,
             ),
         },
@@ -1188,6 +1207,7 @@ fn plan_openai_responses_request(
                 full_input_items,
                 None,
                 request_controls,
+                native_web_search_diagnostics(request),
             ),
         });
     };
@@ -1209,6 +1229,7 @@ fn plan_openai_responses_request(
                 full_input_items,
                 None,
                 request_controls,
+                native_web_search_diagnostics(request),
             ),
         });
     };
@@ -1231,6 +1252,7 @@ fn plan_openai_responses_request(
                     ..OpenAiContinuationMismatchDiagnostics::default()
                 }),
                 request_controls,
+                native_web_search_diagnostics(request),
             ),
         });
     }
@@ -1258,6 +1280,7 @@ fn plan_openai_responses_request(
                 full_input_items,
                 Some(mismatch),
                 request_controls,
+                native_web_search_diagnostics(request),
             ),
         });
     }
@@ -1568,6 +1591,7 @@ fn incremental_diagnostics(
     full_input_items: usize,
     mismatch: Option<OpenAiContinuationMismatchDiagnostics>,
     openai_request_controls: Option<ProviderOpenAiRequestControlsDiagnostics>,
+    native_web_search: Option<ProviderNativeWebSearchDiagnostics>,
 ) -> ProviderRequestDiagnostics {
     let mismatch = mismatch.unwrap_or_default();
     ProviderRequestDiagnostics {
@@ -1593,7 +1617,7 @@ fn incremental_diagnostics(
             first_mismatch_path: mismatch.first_mismatch_path,
             mismatch_kind: mismatch.mismatch_kind,
         }),
-        native_web_search: None,
+        native_web_search,
     }
 }
 
@@ -4240,7 +4264,8 @@ mod tests {
         build_openai_responses_request, chat_completions_url, incremental_diagnostics,
         latest_openai_compaction_index, openai_compaction_trigger_for_request_plan,
         openai_compaction_trigger_for_window, openai_provider_window_compaction_candidate,
-        OpenAiCompactionPolicy, OpenAiProviderWindow, OpenAiRequestPlan, OpenAiRequestShape,
+        plan_openai_responses_request, OpenAiCompactionPolicy, OpenAiContinuationState,
+        OpenAiProviderWindow, OpenAiRequestPlan, OpenAiRequestShape,
         OpenAiResponsesTransportContract, ToolSchemaContract,
     };
     use crate::provider::{
@@ -4248,6 +4273,7 @@ mod tests {
         ProviderTurnRequest,
     };
     use serde_json::json;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn chat_completions_url_accepts_openai_compatible_base_urls() {
@@ -4308,6 +4334,82 @@ mod tests {
             .expect("tools should be an array")
             .iter()
             .any(|tool| tool == &json!({ "type": "web_search_preview" })));
+    }
+
+    #[test]
+    fn openai_codex_responses_request_lowers_native_web_search_tool() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("search the web".into())],
+            vec![],
+        );
+        request.native_web_search = Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::OpenAi,
+            provider_id: "openai_codex_native".into(),
+            provider_model_ref: "openai-codex/gpt-codex-test".into(),
+            advertised_tool_type: "web_search".into(),
+            backend_kind: "openai_codex_web_search".into(),
+            max_results: Some(5),
+        });
+
+        let body = build_openai_responses_request(
+            "gpt-codex-test",
+            1024,
+            &request,
+            OpenAiResponsesTransportContract::CodexStreaming,
+            ToolSchemaContract::Relaxed,
+            Some("low"),
+        )
+        .expect("openai codex responses request should build");
+
+        assert!(body["tools"]
+            .as_array()
+            .expect("tools should be an array")
+            .iter()
+            .any(|tool| tool == &json!({ "type": "web_search" })));
+        assert_eq!(body["stream"], json!(true));
+    }
+
+    #[test]
+    fn openai_responses_full_request_records_native_web_search_diagnostics() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("search the web".into())],
+            vec![],
+        );
+        request.native_web_search = Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::OpenAi,
+            provider_id: "openai_codex_native".into(),
+            provider_model_ref: "openai-codex/gpt-codex-test".into(),
+            advertised_tool_type: "web_search".into(),
+            backend_kind: "openai_codex_web_search".into(),
+            max_results: Some(5),
+        });
+
+        let body = build_openai_responses_request(
+            "gpt-codex-test",
+            1024,
+            &request,
+            OpenAiResponsesTransportContract::CodexStreaming,
+            ToolSchemaContract::Relaxed,
+            Some("low"),
+        )
+        .expect("openai codex responses request should build");
+        let plan = plan_openai_responses_request(
+            body,
+            &request,
+            &Arc::new(Mutex::new(OpenAiContinuationState::default())),
+            false,
+        )
+        .expect("openai codex responses request should plan");
+
+        let diagnostics = plan
+            .diagnostics
+            .native_web_search
+            .expect("native web search diagnostics should be recorded");
+        assert!(diagnostics.lowered);
+        assert_eq!(diagnostics.advertised_tool_type, "web_search");
+        assert_eq!(diagnostics.backend_kind, "openai_codex_web_search");
     }
 
     #[test]
@@ -4429,6 +4531,7 @@ mod tests {
                 "test",
                 None,
                 0,
+                None,
                 None,
                 None,
             ),

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -380,4 +380,27 @@ mod tests {
         assert_eq!(request.advertised_tool_type, "web_search_preview");
         assert_eq!(request.backend_kind, "openai_web_search");
     }
+
+    #[test]
+    fn native_web_search_request_uses_codex_provider_capability_metadata() {
+        let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
+
+        let request = native_web_search_request_for_config(
+            Some(crate::provider::ProviderBuiltinWebSearchCapability {
+                kind: ProviderNativeWebSearchKind::OpenAi,
+                provider_id: "openai-codex".into(),
+                provider_model_ref: "openai-codex/gpt-codex-test".into(),
+                advertised_tool_type: "web_search".into(),
+                backend_kind: "openai_codex_web_search".into(),
+            }),
+            Some(&native_provider),
+            5,
+        )
+        .unwrap();
+
+        assert_eq!(request.provider_id, "openai-native");
+        assert_eq!(request.provider_model_ref, "openai-codex/gpt-codex-test");
+        assert_eq!(request.advertised_tool_type, "web_search");
+        assert_eq!(request.backend_kind, "openai_codex_web_search");
+    }
 }

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -4,7 +4,8 @@ use holon::{
     prompt::PromptStability,
     provider::{
         AgentProvider, ConversationMessage, ModelBlock, OpenAiCodexProvider, PromptContentBlock,
-        ProviderPromptCache, ProviderPromptFrame, ProviderTurnRequest,
+        ProviderNativeWebSearchRequest, ProviderPromptCache, ProviderPromptFrame,
+        ProviderTurnRequest,
     },
     tool::ToolSpec,
 };
@@ -93,6 +94,48 @@ async fn live_openai_codex_provider_returns_real_response() -> Result<()> {
             vec![],
         ))
         .await?;
+    assert!(!output.blocks.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires real Codex auth state, network access, and Codex builtin web search support"]
+async fn live_openai_codex_builtin_web_search_reports_backend() -> Result<()> {
+    let config = live_config()?;
+    let provider = OpenAiCodexProvider::from_config(&config, &live_openai_codex_model())?;
+    let capability = provider
+        .builtin_web_search()
+        .expect("openai codex provider should declare builtin search");
+    assert_eq!(capability.advertised_tool_type, "web_search");
+    assert_eq!(capability.backend_kind, "openai_codex_web_search");
+
+    let output = provider
+        .complete_turn(ProviderTurnRequest {
+            prompt_frame: ProviderPromptFrame::plain(
+                "Use web search if needed. Reply in one short sentence.",
+            ),
+            conversation: vec![ConversationMessage::UserText(
+                "Search the web and name today's date.".into(),
+            )],
+            tools: vec![],
+            native_web_search: Some(ProviderNativeWebSearchRequest {
+                kind: capability.kind,
+                provider_id: "openai-codex-native".into(),
+                provider_model_ref: capability.provider_model_ref,
+                advertised_tool_type: capability.advertised_tool_type,
+                backend_kind: capability.backend_kind,
+                max_results: Some(3),
+            }),
+        })
+        .await?;
+    let diagnostics = output
+        .request_diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.native_web_search.as_ref())
+        .expect("native web search diagnostics should be recorded");
+    assert!(diagnostics.lowered);
+    assert_eq!(diagnostics.advertised_tool_type, "web_search");
+    assert_eq!(diagnostics.backend_kind, "openai_codex_web_search");
     assert!(!output.blocks.is_empty());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- enable builtin web search for the built-in `openai-codex` provider using Codex Responses `web_search`
- wire Codex provider-declared search capability through request lowering, tool filtering metadata, and diagnostics
- preserve native web search diagnostics for OpenAI Responses full-request fallback plans
- add unit coverage plus an ignored live Codex builtin search test

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test --lib`
- `cargo test --test live_codex --no-run`
- `cargo test --test live_codex live_openai_codex_builtin_web_search_reports_backend -- --ignored --nocapture`

Closes #1346
