### PR TITLE
feat: default-enable provider builtin web search

### DIFF
--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1867,9 +1867,13 @@ mod tests {
         fs::write(template_dir.join("AGENTS.md"), "role only").unwrap();
 
         let agent_home = home.path().join("agent");
-        initialize_agent_home_from_template(&agent_home, template_dir.to_str().unwrap())
-            .await
-            .unwrap();
+        initialize_agent_home_from_template_with_home(
+            &agent_home,
+            home.path(),
+            template_dir.to_str().unwrap(),
+        )
+        .await
+        .unwrap();
 
         let agents_md = fs::read_to_string(agent_home.join("AGENTS.md")).unwrap();
         assert!(agents_md.starts_with("role only"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -390,6 +390,11 @@ impl WebFetchConfigFile {
 pub struct WebSearchConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+    #[serde(
+        default,
+        skip_serializing_if = "WebSearchBuiltinProviderConfigFile::is_empty"
+    )]
+    pub builtin_provider: WebSearchBuiltinProviderConfigFile,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -402,9 +407,22 @@ pub struct WebSearchConfigFile {
     pub max_provider_attempts: Option<usize>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WebSearchBuiltinProviderConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+impl WebSearchBuiltinProviderConfigFile {
+    pub fn is_empty(&self) -> bool {
+        self.enabled.is_none()
+    }
+}
+
 impl WebSearchConfigFile {
     pub fn is_empty(&self) -> bool {
         self.enabled.is_none()
+            && self.builtin_provider.is_empty()
             && self.provider.is_none()
             && self.mode.is_none()
             && self.providers.is_empty()
@@ -1527,6 +1545,13 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
             allowed_values: vec!["true", "false"],
         },
         ConfigSchemaEntry {
+            key: "web.search.builtin_provider.enabled",
+            kind: "boolean",
+            description: "Enable provider-declared builtin web search by default when the active model provider supports it.",
+            default: json!(true),
+            allowed_values: vec!["true", "false"],
+        },
+        ConfigSchemaEntry {
             key: "web.search.provider",
             kind: "string",
             description: "Default WebSearch provider id, or auto for configured routing policy.",
@@ -1778,6 +1803,13 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
             .enabled
             .map(Value::Bool)
             .unwrap_or(Value::Null)),
+        "web.search.builtin_provider.enabled" => Ok(config
+            .web
+            .search
+            .builtin_provider
+            .enabled
+            .map(Value::Bool)
+            .unwrap_or(Value::Null)),
         "web.search.provider" => Ok(config
             .web
             .search
@@ -1993,6 +2025,11 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
                 parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
             );
         }
+        "web.search.builtin_provider.enabled" => {
+            config.web.search.builtin_provider.enabled = Some(
+                parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
+            );
+        }
         "web.search.provider" => {
             let provider = raw_value.trim();
             if provider.is_empty() {
@@ -2172,6 +2209,7 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
         "web.fetch.allowed_hosts" => config.web.fetch.allowed_hosts.clear(),
         "web.fetch.denied_hosts" => config.web.fetch.denied_hosts.clear(),
         "web.search.enabled" => config.web.search.enabled = None,
+        "web.search.builtin_provider.enabled" => config.web.search.builtin_provider.enabled = None,
         "web.search.provider" => config.web.search.provider = None,
         "web.search.mode" => config.web.search.mode = None,
         "web.search.providers" => config.web.search.providers.clear(),
@@ -4258,6 +4296,7 @@ mod tests {
         )
         .unwrap();
         set_config_key(&mut config, "web.search.provider", "duckduckgo").unwrap();
+        set_config_key(&mut config, "web.search.builtin_provider.enabled", "false").unwrap();
         set_config_key(&mut config, "web.search.max_results", "3").unwrap();
         set_config_key(&mut config, "web.search.mode", "aggregate").unwrap();
         set_config_key(&mut config, "web.search.providers", "searx,brave").unwrap();
@@ -4278,6 +4317,10 @@ mod tests {
         assert_eq!(
             get_config_key(&config, "web.search.provider").unwrap(),
             json!("duckduckgo")
+        );
+        assert_eq!(
+            get_config_key(&config, "web.search.builtin_provider.enabled").unwrap(),
+            Value::Bool(false)
         );
         assert_eq!(
             get_config_key(&config, "web.search.max_results").unwrap(),
@@ -4344,6 +4387,7 @@ mod tests {
 
         unset_config_key(&mut config, "web.fetch.allowed_hosts").unwrap();
         unset_config_key(&mut config, "web.search.provider").unwrap();
+        unset_config_key(&mut config, "web.search.builtin_provider.enabled").unwrap();
         unset_config_key(&mut config, "web.search.mode").unwrap();
         unset_config_key(&mut config, "web.search.providers").unwrap();
         unset_config_key(&mut config, "web.search.max_provider_attempts").unwrap();
@@ -4357,6 +4401,10 @@ mod tests {
         );
         assert_eq!(
             get_config_key(&config, "web.search.provider").unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            get_config_key(&config, "web.search.builtin_provider.enabled").unwrap(),
             Value::Null
         );
         assert_eq!(
@@ -4649,6 +4697,45 @@ mod tests {
 
         let err = validate_provider_config(&id, &config).unwrap_err();
         assert!(err.to_string().contains("web_search for OpenAI Codex"));
+    }
+
+    #[test]
+    fn materialize_provider_config_can_disable_builtin_web_search_for_builtin_provider() {
+        let id = ProviderId::openai_codex();
+        let built_in = built_in_provider_registry(&HashMap::new())
+            .unwrap()
+            .remove(&id)
+            .unwrap();
+        assert!(built_in.builtin_web_search.is_some());
+
+        let runtime = super::materialize_provider_config(
+            id.clone(),
+            ProviderConfigFile {
+                transport: ProviderTransportKind::OpenAiCodexResponses,
+                base_url: "https://chatgpt.com/backend-api/codex".into(),
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::ExternalCli,
+                    kind: CredentialKind::SessionToken,
+                    env: None,
+                    profile: None,
+                    external: Some("codex_cli".into()),
+                },
+                reasoning_effort: None,
+                builtin_web_search: Some(ProviderBuiltinWebSearchConfig {
+                    enabled: false,
+                    kind: ProviderNativeWebSearchKind::OpenAi,
+                    advertised_tool_type: "web_search".into(),
+                    backend_kind: "openai_codex_web_search".into(),
+                }),
+            },
+            &HashMap::new(),
+            &CredentialStoreFile::default(),
+            Some(built_in),
+        )
+        .unwrap();
+
+        assert_eq!(runtime.id, id);
+        assert!(runtime.builtin_web_search.is_none());
     }
 
     #[test]

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -14,7 +14,7 @@ use super::{
     },
     AgentProvider, PromptContentBlock, ProviderAttemptOutcome, ProviderAttemptRecord,
     ProviderAttemptTimeline, ProviderBuiltinWebSearchCapability, ProviderContextManagementPolicy,
-    ProviderTurnRequest, ProviderTurnResponse,
+    ProviderNativeWebSearchRequest, ProviderTurnRequest, ProviderTurnResponse,
 };
 use crate::prompt::PromptStability;
 
@@ -564,6 +564,18 @@ impl AgentProvider for FallbackProvider {
 
     fn builtin_web_search(&self) -> Option<ProviderBuiltinWebSearchCapability> {
         self.candidates.first()?.provider.builtin_web_search()
+    }
+
+    async fn probe_builtin_web_search(
+        &self,
+        request: ProviderNativeWebSearchRequest,
+    ) -> Result<()> {
+        self.candidates
+            .first()
+            .ok_or_else(|| anyhow!("fallback provider has no candidates"))?
+            .provider
+            .probe_builtin_web_search(request)
+            .await
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -174,6 +174,8 @@ mod tests {
             kind: ProviderNativeWebSearchKind::Anthropic,
             provider_id: provider_id.into(),
             provider_model_ref: model_ref.into(),
+            provider_transport: "anthropic_messages".into(),
+            provider_base_url: "https://api.example.test".into(),
             advertised_tool_type: "web_search_20250305".into(),
             backend_kind: backend_kind.into(),
         }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -170,6 +170,8 @@ pub struct ProviderBuiltinWebSearchCapability {
     pub kind: ProviderNativeWebSearchKind,
     pub provider_id: String,
     pub provider_model_ref: String,
+    pub provider_transport: String,
+    pub provider_base_url: String,
     pub advertised_tool_type: String,
     pub backend_kind: String,
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -382,6 +382,15 @@ pub trait AgentProvider: Send + Sync {
         None
     }
 
+    async fn probe_builtin_web_search(
+        &self,
+        _request: ProviderNativeWebSearchRequest,
+    ) -> Result<()> {
+        Err(anyhow!(
+            "active provider does not support builtin web search probing"
+        ))
+    }
+
     fn native_web_search_kind(&self) -> Option<ProviderNativeWebSearchKind> {
         self.builtin_web_search().map(|capability| capability.kind)
     }
@@ -402,6 +411,19 @@ pub trait AgentProvider: Send + Sync {
     #[cfg(test)]
     fn configured_model_refs(&self) -> Vec<String> {
         Vec::new()
+    }
+}
+
+pub(crate) fn builtin_web_search_probe_turn_request(
+    native_web_search: ProviderNativeWebSearchRequest,
+) -> ProviderTurnRequest {
+    ProviderTurnRequest {
+        prompt_frame: ProviderPromptFrame::plain("Reply with exactly OK."),
+        conversation: vec![ConversationMessage::UserText(
+            "Reply with exactly OK.".into(),
+        )],
+        tools: Vec::new(),
+        native_web_search: Some(native_web_search),
     }
 }
 
@@ -597,6 +619,10 @@ pub(crate) use catalog::build_candidate;
 pub(crate) use retry::classify_provider_error;
 #[cfg(test)]
 pub(crate) use retry::provider_max_attempts;
+#[cfg(test)]
+pub(crate) use retry::{
+    provider_transport_error, ProviderFailureClassification, ProviderFailureKind, RetryDisposition,
+};
 #[cfg(test)]
 pub(crate) use tool_schema::validate_emitted_tool_schema;
 pub(crate) use tool_schema::{emitted_tool_json_schema, ToolSchemaContract};

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -18,6 +18,7 @@ mod transports;
 pub use catalog::{build_provider_from_config, build_provider_from_model_chain};
 pub use diagnostics::{provider_doctor, resolved_model_availability};
 pub use http_trace::ProviderHttpTraceDiagnostics;
+pub(crate) use retry::sanitize_transport_url;
 pub use transports::{
     AnthropicProvider, OpenAiChatCompletionsProvider, OpenAiCodexProvider, OpenAiProvider,
 };

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -358,6 +358,8 @@ impl AgentProvider for AnthropicProvider {
             kind: config.kind,
             provider_id: self.provider_id.clone(),
             provider_model_ref: format!("{}/{}", self.provider_id, self.model),
+            provider_transport: "anthropic_messages".into(),
+            provider_base_url: self.base_url.clone(),
             advertised_tool_type: config.advertised_tool_type.clone(),
             backend_kind: config.backend_kind.clone(),
         })

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -16,10 +16,11 @@ use crate::{
     },
     prompt::PromptStability,
     provider::{
-        http_trace::ProviderHttpTrace, AgentProvider, AnthropicPromptCacheDiagnostics,
-        CacheBreakpointInfo, ConversationMessage, ModelBlock, PromptContentBlock,
-        ProviderBuiltinWebSearchCapability, ProviderCacheUsage, ProviderContextManagementPolicy,
-        ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind, ProviderPromptCapability,
+        builtin_web_search_probe_turn_request, http_trace::ProviderHttpTrace, AgentProvider,
+        AnthropicPromptCacheDiagnostics, CacheBreakpointInfo, ConversationMessage, ModelBlock,
+        PromptContentBlock, ProviderBuiltinWebSearchCapability, ProviderCacheUsage,
+        ProviderContextManagementPolicy, ProviderNativeWebSearchDiagnostics,
+        ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest, ProviderPromptCapability,
         ProviderTurnRequest, ProviderTurnResponse,
     },
 };
@@ -363,6 +364,15 @@ impl AgentProvider for AnthropicProvider {
             advertised_tool_type: config.advertised_tool_type.clone(),
             backend_kind: config.backend_kind.clone(),
         })
+    }
+
+    async fn probe_builtin_web_search(
+        &self,
+        request: ProviderNativeWebSearchRequest,
+    ) -> Result<()> {
+        self.complete_turn(builtin_web_search_probe_turn_request(request))
+            .await?;
+        Ok(())
     }
 
     fn context_management_policy(&self) -> Option<ProviderContextManagementPolicy> {

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -558,6 +558,8 @@ impl AgentProvider for OpenAiProvider {
             kind: config.kind,
             provider_id: self.provider_id.clone(),
             provider_model_ref: format!("{}/{}", self.provider_id, self.model),
+            provider_transport: "openai_responses".into(),
+            provider_base_url: self.base_url.clone(),
             advertised_tool_type: config.advertised_tool_type.clone(),
             backend_kind: config.backend_kind.clone(),
         })
@@ -669,6 +671,8 @@ impl AgentProvider for OpenAiCodexProvider {
             kind: config.kind,
             provider_id: self.provider_id.clone(),
             provider_model_ref: format!("{}/{}", self.provider_id, self.model),
+            provider_transport: "openai_codex_responses".into(),
+            provider_base_url: self.base_url.clone(),
             advertised_tool_type: config.advertised_tool_type.clone(),
             backend_kind: config.backend_kind.clone(),
         })

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -19,14 +19,14 @@ use crate::{
     context::ContextConfig,
     model_catalog::BuiltInModelCatalog,
     provider::{
-        emitted_tool_json_schema,
+        builtin_web_search_probe_turn_request, emitted_tool_json_schema,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
         AgentProvider, ConversationMessage, ModelBlock, ProviderBuiltinWebSearchCapability,
         ProviderCacheUsage, ProviderIncrementalContinuationDiagnostics,
         ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
-        ProviderOpenAiRemoteCompactionDiagnostics, ProviderOpenAiRequestControlsDiagnostics,
-        ProviderPromptFrame, ProviderRequestDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
-        ToolSchemaContract,
+        ProviderNativeWebSearchRequest, ProviderOpenAiRemoteCompactionDiagnostics,
+        ProviderOpenAiRequestControlsDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
+        ProviderTurnRequest, ProviderTurnResponse, ToolSchemaContract,
     },
     token_estimate::estimate_json_tokens,
 };
@@ -564,6 +564,37 @@ impl AgentProvider for OpenAiProvider {
             backend_kind: config.backend_kind.clone(),
         })
     }
+
+    async fn probe_builtin_web_search(
+        &self,
+        request: ProviderNativeWebSearchRequest,
+    ) -> Result<()> {
+        let probe_request = builtin_web_search_probe_turn_request(request);
+        let body = build_openai_responses_request(
+            &self.model,
+            16,
+            &probe_request,
+            OpenAiResponsesTransportContract::StandardJson,
+            ToolSchemaContract::Relaxed,
+            None,
+        )?;
+        let headers = self
+            .api_key
+            .as_ref()
+            .map(|api_key| vec![("authorization", format!("Bearer {api_key}"))])
+            .unwrap_or_default();
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        send_openai_responses_request(
+            &self.client,
+            openai_responses_url(&self.base_url),
+            body,
+            headers,
+            trace.as_ref(),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -676,6 +707,42 @@ impl AgentProvider for OpenAiCodexProvider {
             advertised_tool_type: config.advertised_tool_type.clone(),
             backend_kind: config.backend_kind.clone(),
         })
+    }
+
+    async fn probe_builtin_web_search(
+        &self,
+        request: ProviderNativeWebSearchRequest,
+    ) -> Result<()> {
+        let credential = load_codex_cli_credential(&self.codex_home)?;
+        let probe_request = builtin_web_search_probe_turn_request(request);
+        let body = build_openai_responses_request(
+            &self.model,
+            16,
+            &probe_request,
+            OpenAiResponsesTransportContract::CodexStreaming,
+            ToolSchemaContract::Relaxed,
+            self.reasoning_effort.as_deref(),
+        )?;
+        let headers = vec![
+            (
+                "authorization",
+                format!("Bearer {}", credential.access_token),
+            ),
+            ("chatgpt-account-id", credential.account_id.clone()),
+            ("OpenAI-Beta", "responses=experimental".to_string()),
+            ("originator", self.originator.clone()),
+        ];
+        let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
+        send_openai_responses_streaming_request(
+            &self.client,
+            openai_codex_responses_url(&self.base_url),
+            body,
+            headers,
+            trace.as_ref(),
+            None,
+        )
+        .await?;
+        Ok(())
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -40,6 +40,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use bootstrap::ProviderReconfigurator;
 use chrono::Utc;
+use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -59,8 +60,8 @@ use crate::{
     memory::{mark_working_memory_prompted, refresh_episode_memory, refresh_working_memory},
     prompt::{build_effective_prompt, EffectivePrompt},
     provider::{
-        provider_attempt_timeline, AgentProvider, ModelBlock, ProviderNativeWebSearchKind,
-        ProviderNativeWebSearchRequest,
+        provider_attempt_timeline, AgentProvider, ModelBlock, ProviderBuiltinWebSearchCapability,
+        ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
     },
     queue::RuntimeQueue,
     skills::{
@@ -204,6 +205,8 @@ struct RuntimeInner {
     default_tool_output_tokens: u64,
     max_tool_output_tokens: u64,
     web_config: WebConfig,
+    builtin_web_search_probe_cache:
+        Mutex<HashMap<BuiltinWebSearchProbeKey, BuiltinWebSearchProbeCacheEntry>>,
     callback_base_url: String,
     tools: ToolRegistry,
     system: Arc<LocalSystem>,
@@ -214,6 +217,83 @@ struct RuntimeInner {
     recovered_timers: Mutex<Option<Vec<TimerRecord>>>,
     suppress_next_continue_active_tick: Mutex<bool>,
     shutdown_requested: AtomicBool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BuiltinWebSearchProbeKey {
+    provider_id: String,
+    provider_model_ref: String,
+    provider_transport: String,
+    provider_base_url: String,
+    advertised_tool_type: String,
+    backend_kind: String,
+}
+
+impl BuiltinWebSearchProbeKey {
+    fn from_capability(capability: &ProviderBuiltinWebSearchCapability) -> Self {
+        Self {
+            provider_id: capability.provider_id.clone(),
+            provider_model_ref: capability.provider_model_ref.clone(),
+            provider_transport: capability.provider_transport.clone(),
+            provider_base_url: capability.provider_base_url.clone(),
+            advertised_tool_type: capability.advertised_tool_type.clone(),
+            backend_kind: capability.backend_kind.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BuiltinWebSearchProbeCacheEntry {
+    status: BuiltinWebSearchProbeStatus,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[allow(dead_code)]
+#[serde(rename_all = "snake_case")]
+enum BuiltinWebSearchProbeStatus {
+    Supported,
+    Unsupported,
+    TransientFailure,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum BuiltinWebSearchSelectionStatus {
+    Selected,
+    Disabled,
+    Unsupported,
+    NotDeclared,
+    NotRequested,
+    TransientProbeFailure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BuiltinWebSearchSelectionDiagnostics {
+    status: BuiltinWebSearchSelectionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_model_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_transport: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider_base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    advertised_tool_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    backend_kind: Option<String>,
+    probe_status: BuiltinWebSearchProbeStatus,
+    probe_cache_hit: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BuiltinWebSearchSelection {
+    request: Option<ProviderNativeWebSearchRequest>,
+    diagnostics: BuiltinWebSearchSelectionDiagnostics,
 }
 
 #[derive(Debug)]

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -320,6 +320,7 @@ impl RuntimeHandle {
                 default_tool_output_tokens,
                 max_tool_output_tokens,
                 web_config,
+                builtin_web_search_probe_cache: Mutex::new(HashMap::new()),
                 callback_base_url,
                 tools: ToolRegistry::new(PathBuf::new()),
                 system: Arc::new(LocalSystem::new()),

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -34,7 +34,7 @@ impl RuntimeHandle {
             }
             let state = guard.state.clone();
             drop(guard);
-            let (provider, available_tools, _) = self.provider_tool_selection(&identity).await?;
+            let (provider, available_tools, _, _) = self.provider_tool_selection(&identity).await?;
             let prompt_tools = provider.prompt_tool_specs(&available_tools);
             let workspace = self.workspace_view_from_state(&state)?;
             let execution = self.execution_snapshot_for_view(
@@ -168,7 +168,7 @@ impl RuntimeHandle {
         let identity = self.agent_identity_view().await?;
         self.ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
             .await?;
-        let (provider, available_tools, _) = self.provider_tool_selection(&identity).await?;
+        let (provider, available_tools, _, _) = self.provider_tool_selection(&identity).await?;
         let prompt_tools = provider.prompt_tool_specs(&available_tools);
         let execution = self.execution_snapshot().await?;
         let loaded_agents_md = self.loaded_agents_md_for_state(&agent)?;
@@ -274,13 +274,25 @@ impl RuntimeHandle {
         Arc<dyn AgentProvider>,
         Vec<ToolSpec>,
         Option<ProviderNativeWebSearchRequest>,
+        BuiltinWebSearchSelectionDiagnostics,
     )> {
         let provider = self.current_provider().await;
         let native_search_provider = self.web_config().native_search_provider();
-        let native_web_search = self.native_web_search_request_for_provider(
-            provider.as_ref(),
-            native_search_provider.as_ref(),
-        );
+        let builtin_capability = provider.builtin_web_search();
+        let native_web_search_selection = {
+            let mut cache = self.inner.builtin_web_search_probe_cache.lock().await;
+            native_web_search_request_for_config(
+                builtin_capability,
+                native_search_provider.as_ref(),
+                &self.web_config().search,
+                &mut cache,
+                BuiltinWebSearchProbeCacheEntry {
+                    status: BuiltinWebSearchProbeStatus::Supported,
+                    reason: None,
+                },
+            )
+        };
+        let native_web_search = native_web_search_selection.request;
         let apply_patch_surface = {
             let guard = self.inner.agent.lock().await;
             self.apply_patch_surface_for_state(&guard.state)
@@ -289,19 +301,12 @@ impl RuntimeHandle {
             self.filtered_tool_specs_for_apply_patch_surface(identity, apply_patch_surface)?,
             native_web_search.is_some(),
         );
-        Ok((provider, available_tools, native_web_search))
-    }
-
-    fn native_web_search_request_for_provider(
-        &self,
-        provider: &dyn AgentProvider,
-        native_search_provider: Option<&(String, WebProviderKind)>,
-    ) -> Option<ProviderNativeWebSearchRequest> {
-        native_web_search_request_for_config(
-            provider.builtin_web_search(),
-            native_search_provider,
-            self.web_config().search.max_results,
-        )
+        Ok((
+            provider,
+            available_tools,
+            native_web_search,
+            native_web_search_selection.diagnostics,
+        ))
     }
 
     fn filter_native_web_search_tools(
@@ -319,64 +324,276 @@ impl RuntimeHandle {
 fn native_web_search_request_for_config(
     provider_capability: Option<crate::provider::ProviderBuiltinWebSearchCapability>,
     native_search_provider: Option<&(String, WebProviderKind)>,
-    max_results: usize,
-) -> Option<ProviderNativeWebSearchRequest> {
-    let (provider_id, provider_kind) = native_search_provider?;
-    let kind = match *provider_kind {
-        WebProviderKind::OpenAiNative => ProviderNativeWebSearchKind::OpenAi,
-        WebProviderKind::AnthropicNative => ProviderNativeWebSearchKind::Anthropic,
-        WebProviderKind::GeminiNative => ProviderNativeWebSearchKind::Gemini,
-        _ => return None,
+    web_search: &crate::web::WebSearchConfig,
+    probe_cache: &mut HashMap<BuiltinWebSearchProbeKey, BuiltinWebSearchProbeCacheEntry>,
+    probe_result: BuiltinWebSearchProbeCacheEntry,
+) -> BuiltinWebSearchSelection {
+    let Some(capability) = provider_capability else {
+        return builtin_web_search_selection(
+            None,
+            BuiltinWebSearchSelectionStatus::NotDeclared,
+            "active provider does not declare builtin web search",
+            BuiltinWebSearchProbeStatus::Skipped,
+            false,
+        );
     };
 
-    let capability = provider_capability?;
-    (capability.kind == kind).then_some(ProviderNativeWebSearchRequest {
-        kind,
-        provider_id: provider_id.clone(),
-        provider_model_ref: capability.provider_model_ref,
-        advertised_tool_type: capability.advertised_tool_type,
-        backend_kind: capability.backend_kind,
-        max_results: Some(max_results.max(1)),
-    })
+    if !web_search.enabled {
+        return builtin_web_search_selection(
+            Some(&capability),
+            BuiltinWebSearchSelectionStatus::Disabled,
+            "web.search.enabled is false",
+            BuiltinWebSearchProbeStatus::Skipped,
+            false,
+        );
+    }
+
+    let explicit_native = native_search_provider.and_then(|(provider_id, provider_kind)| {
+        provider_kind
+            .is_native_search()
+            .then_some((provider_id, *provider_kind))
+    });
+    let explicit_non_auto_provider = web_search.provider.trim() != "auto";
+    let (provider_id, required_kind, selection_reason) =
+        if let Some((provider_id, provider_kind)) = explicit_native {
+            (
+                provider_id.clone(),
+                provider_kind_to_native_web_search_kind(provider_kind),
+                "explicit native web search provider",
+            )
+        } else if explicit_non_auto_provider {
+            return builtin_web_search_selection(
+                Some(&capability),
+                BuiltinWebSearchSelectionStatus::NotRequested,
+                "web.search.provider explicitly selects managed WebSearch",
+                BuiltinWebSearchProbeStatus::Skipped,
+                false,
+            );
+        } else if web_search.builtin_provider_enabled {
+            (
+                capability.provider_id.clone(),
+                Some(capability.kind),
+                "provider-declared builtin web search default",
+            )
+        } else {
+            return builtin_web_search_selection(
+                Some(&capability),
+                BuiltinWebSearchSelectionStatus::Disabled,
+                "web.search.builtin_provider.enabled is false",
+                BuiltinWebSearchProbeStatus::Skipped,
+                false,
+            );
+        };
+
+    if required_kind != Some(capability.kind) {
+        return builtin_web_search_selection(
+            Some(&capability),
+            BuiltinWebSearchSelectionStatus::NotRequested,
+            "configured native web search provider kind does not match active provider capability",
+            BuiltinWebSearchProbeStatus::Skipped,
+            false,
+        );
+    }
+
+    let probe_key = BuiltinWebSearchProbeKey::from_capability(&capability);
+    let (probe, cache_hit) = if let Some(cached) = probe_cache.get(&probe_key).cloned() {
+        (cached, true)
+    } else {
+        if matches!(
+            probe_result.status,
+            BuiltinWebSearchProbeStatus::Supported | BuiltinWebSearchProbeStatus::Unsupported
+        ) {
+            probe_cache.insert(probe_key, probe_result.clone());
+        }
+        (probe_result, false)
+    };
+
+    match probe.status {
+        BuiltinWebSearchProbeStatus::Supported => {
+            let request = ProviderNativeWebSearchRequest {
+                kind: capability.kind,
+                provider_id,
+                provider_model_ref: capability.provider_model_ref.clone(),
+                advertised_tool_type: capability.advertised_tool_type.clone(),
+                backend_kind: capability.backend_kind.clone(),
+                max_results: Some(web_search.max_results.max(1)),
+            };
+            BuiltinWebSearchSelection {
+                request: Some(request),
+                diagnostics: builtin_web_search_selection_diagnostics(
+                    Some(&capability),
+                    BuiltinWebSearchSelectionStatus::Selected,
+                    Some(selection_reason.into()),
+                    BuiltinWebSearchProbeStatus::Supported,
+                    cache_hit,
+                ),
+            }
+        }
+        BuiltinWebSearchProbeStatus::Unsupported => builtin_web_search_selection(
+            Some(&capability),
+            BuiltinWebSearchSelectionStatus::Unsupported,
+            probe
+                .reason
+                .as_deref()
+                .unwrap_or("builtin web search probe reported unsupported"),
+            BuiltinWebSearchProbeStatus::Unsupported,
+            cache_hit,
+        ),
+        BuiltinWebSearchProbeStatus::TransientFailure => builtin_web_search_selection(
+            Some(&capability),
+            BuiltinWebSearchSelectionStatus::TransientProbeFailure,
+            probe
+                .reason
+                .as_deref()
+                .unwrap_or("builtin web search probe failed transiently"),
+            BuiltinWebSearchProbeStatus::TransientFailure,
+            cache_hit,
+        ),
+        BuiltinWebSearchProbeStatus::Skipped => builtin_web_search_selection(
+            Some(&capability),
+            BuiltinWebSearchSelectionStatus::NotRequested,
+            probe
+                .reason
+                .as_deref()
+                .unwrap_or("builtin web search probe skipped"),
+            BuiltinWebSearchProbeStatus::Skipped,
+            cache_hit,
+        ),
+    }
+}
+
+fn provider_kind_to_native_web_search_kind(
+    kind: WebProviderKind,
+) -> Option<ProviderNativeWebSearchKind> {
+    match kind {
+        WebProviderKind::OpenAiNative => Some(ProviderNativeWebSearchKind::OpenAi),
+        WebProviderKind::AnthropicNative => Some(ProviderNativeWebSearchKind::Anthropic),
+        WebProviderKind::GeminiNative => Some(ProviderNativeWebSearchKind::Gemini),
+        _ => None,
+    }
+}
+
+fn builtin_web_search_selection(
+    capability: Option<&crate::provider::ProviderBuiltinWebSearchCapability>,
+    status: BuiltinWebSearchSelectionStatus,
+    reason: &str,
+    probe_status: BuiltinWebSearchProbeStatus,
+    probe_cache_hit: bool,
+) -> BuiltinWebSearchSelection {
+    BuiltinWebSearchSelection {
+        request: None,
+        diagnostics: builtin_web_search_selection_diagnostics(
+            capability,
+            status,
+            Some(reason.into()),
+            probe_status,
+            probe_cache_hit,
+        ),
+    }
+}
+
+fn builtin_web_search_selection_diagnostics(
+    capability: Option<&crate::provider::ProviderBuiltinWebSearchCapability>,
+    status: BuiltinWebSearchSelectionStatus,
+    reason: Option<String>,
+    probe_status: BuiltinWebSearchProbeStatus,
+    probe_cache_hit: bool,
+) -> BuiltinWebSearchSelectionDiagnostics {
+    BuiltinWebSearchSelectionDiagnostics {
+        status,
+        reason,
+        provider_id: capability.map(|capability| capability.provider_id.clone()),
+        provider_model_ref: capability.map(|capability| capability.provider_model_ref.clone()),
+        provider_transport: capability.map(|capability| capability.provider_transport.clone()),
+        provider_base_url: capability.map(|capability| capability.provider_base_url.clone()),
+        advertised_tool_type: capability.map(|capability| capability.advertised_tool_type.clone()),
+        backend_kind: capability.map(|capability| capability.backend_kind.clone()),
+        probe_status,
+        probe_cache_hit,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn capability(
+        kind: ProviderNativeWebSearchKind,
+        provider_id: &str,
+        model_ref: &str,
+        tool_type: &str,
+        backend_kind: &str,
+    ) -> crate::provider::ProviderBuiltinWebSearchCapability {
+        crate::provider::ProviderBuiltinWebSearchCapability {
+            kind,
+            provider_id: provider_id.into(),
+            provider_model_ref: model_ref.into(),
+            provider_transport: "test_transport".into(),
+            provider_base_url: "https://api.example.test".into(),
+            advertised_tool_type: tool_type.into(),
+            backend_kind: backend_kind.into(),
+        }
+    }
+
+    fn search_config() -> crate::web::WebSearchConfig {
+        crate::web::WebSearchConfig::default()
+    }
+
+    fn probe(status: BuiltinWebSearchProbeStatus) -> BuiltinWebSearchProbeCacheEntry {
+        BuiltinWebSearchProbeCacheEntry {
+            status,
+            reason: (!matches!(status, BuiltinWebSearchProbeStatus::Supported))
+                .then(|| "probe result".into()),
+        }
+    }
+
     #[test]
     fn native_web_search_request_requires_matching_model_provider() {
         let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
+        let mut cache = HashMap::new();
 
-        assert!(native_web_search_request_for_config(
-            Some(crate::provider::ProviderBuiltinWebSearchCapability {
-                kind: ProviderNativeWebSearchKind::Anthropic,
-                provider_id: "anthropic".into(),
-                provider_model_ref: "anthropic/claude-test".into(),
-                advertised_tool_type: "web_search_20250305".into(),
-                backend_kind: "anthropic_web_search".into(),
-            }),
+        let selection = native_web_search_request_for_config(
+            Some(capability(
+                ProviderNativeWebSearchKind::Anthropic,
+                "anthropic",
+                "anthropic/claude-test",
+                "web_search_20250305",
+                "anthropic_web_search",
+            )),
             Some(&native_provider),
-            5,
-        )
-        .is_none());
+            &search_config(),
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::Supported),
+        );
+
+        assert!(selection.request.is_none());
+        assert_eq!(
+            selection.diagnostics.status,
+            BuiltinWebSearchSelectionStatus::NotRequested
+        );
     }
 
     #[test]
     fn native_web_search_request_clamps_max_results() {
         let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
+        let mut config = search_config();
+        config.max_results = 0;
+        let mut cache = HashMap::new();
 
         let request = native_web_search_request_for_config(
-            Some(crate::provider::ProviderBuiltinWebSearchCapability {
-                kind: ProviderNativeWebSearchKind::OpenAi,
-                provider_id: "openai".into(),
-                provider_model_ref: "openai/gpt-test".into(),
-                advertised_tool_type: "web_search_preview".into(),
-                backend_kind: "openai_web_search".into(),
-            }),
+            Some(capability(
+                ProviderNativeWebSearchKind::OpenAi,
+                "openai",
+                "openai/gpt-test",
+                "web_search_preview",
+                "openai_web_search",
+            )),
             Some(&native_provider),
-            0,
+            &config,
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::Supported),
         )
+        .request
         .unwrap();
 
         assert_eq!(request.max_results, Some(1));
@@ -388,23 +605,151 @@ mod tests {
     #[test]
     fn native_web_search_request_uses_codex_provider_capability_metadata() {
         let native_provider = ("openai-native".to_string(), WebProviderKind::OpenAiNative);
+        let mut cache = HashMap::new();
 
         let request = native_web_search_request_for_config(
-            Some(crate::provider::ProviderBuiltinWebSearchCapability {
-                kind: ProviderNativeWebSearchKind::OpenAi,
-                provider_id: "openai-codex".into(),
-                provider_model_ref: "openai-codex/gpt-codex-test".into(),
-                advertised_tool_type: "web_search".into(),
-                backend_kind: "openai_codex_web_search".into(),
-            }),
+            Some(capability(
+                ProviderNativeWebSearchKind::OpenAi,
+                "openai-codex",
+                "openai-codex/gpt-codex-test",
+                "web_search",
+                "openai_codex_web_search",
+            )),
             Some(&native_provider),
-            5,
+            &search_config(),
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::Supported),
         )
+        .request
         .unwrap();
 
         assert_eq!(request.provider_id, "openai-native");
         assert_eq!(request.provider_model_ref, "openai-codex/gpt-codex-test");
         assert_eq!(request.advertised_tool_type, "web_search");
         assert_eq!(request.backend_kind, "openai_codex_web_search");
+    }
+
+    #[test]
+    fn native_web_search_request_defaults_to_declared_provider_capability() {
+        let mut cache = HashMap::new();
+
+        let selection = native_web_search_request_for_config(
+            Some(capability(
+                ProviderNativeWebSearchKind::OpenAi,
+                "openai-codex",
+                "openai-codex/gpt-codex-test",
+                "web_search",
+                "openai_codex_web_search",
+            )),
+            None,
+            &search_config(),
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::Supported),
+        );
+        let request = selection.request.unwrap();
+
+        assert_eq!(request.provider_id, "openai-codex");
+        assert_eq!(request.advertised_tool_type, "web_search");
+        assert_eq!(
+            selection.diagnostics.status,
+            BuiltinWebSearchSelectionStatus::Selected
+        );
+        assert!(!selection.diagnostics.probe_cache_hit);
+    }
+
+    #[test]
+    fn native_web_search_request_respects_global_builtin_disable() {
+        let mut config = search_config();
+        config.builtin_provider_enabled = false;
+        let mut cache = HashMap::new();
+
+        let selection = native_web_search_request_for_config(
+            Some(capability(
+                ProviderNativeWebSearchKind::OpenAi,
+                "openai-codex",
+                "openai-codex/gpt-codex-test",
+                "web_search",
+                "openai_codex_web_search",
+            )),
+            None,
+            &config,
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::Supported),
+        );
+
+        assert!(selection.request.is_none());
+        assert_eq!(
+            selection.diagnostics.status,
+            BuiltinWebSearchSelectionStatus::Disabled
+        );
+    }
+
+    #[test]
+    fn native_web_search_request_uses_cached_unsupported_probe_decision() {
+        let mut cache = HashMap::new();
+        let capability = capability(
+            ProviderNativeWebSearchKind::OpenAi,
+            "openai-codex",
+            "openai-codex/gpt-codex-test",
+            "web_search",
+            "openai_codex_web_search",
+        );
+        let key = BuiltinWebSearchProbeKey::from_capability(&capability);
+        cache.insert(key, probe(BuiltinWebSearchProbeStatus::Unsupported));
+
+        let selection = native_web_search_request_for_config(
+            Some(capability),
+            None,
+            &search_config(),
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::Supported),
+        );
+
+        assert!(selection.request.is_none());
+        assert_eq!(
+            selection.diagnostics.status,
+            BuiltinWebSearchSelectionStatus::Unsupported
+        );
+        assert!(selection.diagnostics.probe_cache_hit);
+    }
+
+    #[test]
+    fn native_web_search_request_does_not_cache_transient_probe_failure() {
+        let mut cache = HashMap::new();
+
+        let first = native_web_search_request_for_config(
+            Some(capability(
+                ProviderNativeWebSearchKind::OpenAi,
+                "openai-codex",
+                "openai-codex/gpt-codex-test",
+                "web_search",
+                "openai_codex_web_search",
+            )),
+            None,
+            &search_config(),
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::TransientFailure),
+        );
+        let second = native_web_search_request_for_config(
+            Some(capability(
+                ProviderNativeWebSearchKind::OpenAi,
+                "openai-codex",
+                "openai-codex/gpt-codex-test",
+                "web_search",
+                "openai_codex_web_search",
+            )),
+            None,
+            &search_config(),
+            &mut cache,
+            probe(BuiltinWebSearchProbeStatus::Supported),
+        );
+
+        assert!(first.request.is_none());
+        assert_eq!(
+            first.diagnostics.status,
+            BuiltinWebSearchSelectionStatus::TransientProbeFailure
+        );
+        assert!(second.request.is_some());
+        assert!(!second.diagnostics.probe_cache_hit);
     }
 }

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -279,13 +279,37 @@ impl RuntimeHandle {
         let provider = self.current_provider().await;
         let native_search_provider = self.web_config().native_search_provider();
         let builtin_capability = provider.builtin_web_search();
-        let probe_result = builtin_capability
-            .as_ref()
-            .map(probe_builtin_web_search_capability)
-            .unwrap_or(BuiltinWebSearchProbeCacheEntry {
+        let probe_result = if let Some(capability) = builtin_capability.as_ref() {
+            let probe_key = BuiltinWebSearchProbeKey::from_capability(capability);
+            let cached_probe = {
+                let cache = self.inner.builtin_web_search_probe_cache.lock().await;
+                cache.get(&probe_key).cloned()
+            };
+            if let Some(cached_probe) = cached_probe {
+                cached_probe
+            } else if !builtin_web_search_probe_requested(
+                capability,
+                native_search_provider.as_ref(),
+                &self.web_config().search,
+            ) {
+                BuiltinWebSearchProbeCacheEntry {
+                    status: BuiltinWebSearchProbeStatus::Skipped,
+                    reason: Some("builtin web search is not requested by current config".into()),
+                }
+            } else {
+                probe_builtin_web_search_capability(
+                    provider.as_ref(),
+                    capability,
+                    self.web_config().search.max_results,
+                )
+                .await
+            }
+        } else {
+            BuiltinWebSearchProbeCacheEntry {
                 status: BuiltinWebSearchProbeStatus::Skipped,
                 reason: Some("active provider does not declare builtin web search".into()),
-            });
+            }
+        };
         let native_web_search_selection = {
             let mut cache = self.inner.builtin_web_search_probe_cache.lock().await;
             native_web_search_request_for_config(
@@ -301,7 +325,7 @@ impl RuntimeHandle {
             let guard = self.inner.agent.lock().await;
             self.apply_patch_surface_for_state(&guard.state)
         };
-        let available_tools = self.filter_native_web_search_tools(
+        let available_tools = filter_native_web_search_tools(
             self.filtered_tool_specs_for_apply_patch_surface(identity, apply_patch_surface)?,
             native_web_search.is_some(),
         );
@@ -312,21 +336,22 @@ impl RuntimeHandle {
             native_web_search_selection.diagnostics,
         ))
     }
-
-    fn filter_native_web_search_tools(
-        &self,
-        mut tools: Vec<ToolSpec>,
-        native_search_configured: bool,
-    ) -> Vec<ToolSpec> {
-        if native_search_configured {
-            tools.retain(|tool| tool.name != crate::tool::tools::web_search::NAME);
-        }
-        tools
-    }
 }
 
-fn probe_builtin_web_search_capability(
+fn filter_native_web_search_tools(
+    mut tools: Vec<ToolSpec>,
+    native_search_configured: bool,
+) -> Vec<ToolSpec> {
+    if native_search_configured {
+        tools.retain(|tool| tool.name != crate::tool::tools::web_search::NAME);
+    }
+    tools
+}
+
+async fn probe_builtin_web_search_capability(
+    provider: &dyn AgentProvider,
     capability: &crate::provider::ProviderBuiltinWebSearchCapability,
+    max_results: usize,
 ) -> BuiltinWebSearchProbeCacheEntry {
     if capability.provider_model_ref.trim().is_empty() {
         return unsupported_builtin_web_search_probe(
@@ -354,7 +379,7 @@ fn probe_builtin_web_search_capability(
         );
     }
 
-    let supported = match (
+    let locally_supported = match (
         capability.kind,
         capability.provider_transport.as_str(),
         capability.advertised_tool_type.as_str(),
@@ -367,16 +392,39 @@ fn probe_builtin_web_search_capability(
         _ => false,
     };
 
-    if supported {
-        BuiltinWebSearchProbeCacheEntry {
-            status: BuiltinWebSearchProbeStatus::Supported,
-            reason: None,
-        }
-    } else {
-        unsupported_builtin_web_search_probe(format!(
+    if !locally_supported {
+        return unsupported_builtin_web_search_probe(format!(
             "builtin web search capability is incompatible with transport {} and advertised tool type {}",
             capability.provider_transport, capability.advertised_tool_type
-        ))
+        ));
+    }
+
+    let request = ProviderNativeWebSearchRequest {
+        kind: capability.kind,
+        provider_id: capability.provider_id.clone(),
+        provider_model_ref: capability.provider_model_ref.clone(),
+        advertised_tool_type: capability.advertised_tool_type.clone(),
+        backend_kind: capability.backend_kind.clone(),
+        max_results: Some(max_results.max(1)),
+    };
+
+    match provider.probe_builtin_web_search(request).await {
+        Ok(()) => BuiltinWebSearchProbeCacheEntry {
+            status: BuiltinWebSearchProbeStatus::Supported,
+            reason: None,
+        },
+        Err(error) => {
+            let classification = crate::provider::classify_provider_error(&error);
+            let status = if classification.disposition.as_str() == "retryable" {
+                BuiltinWebSearchProbeStatus::TransientFailure
+            } else {
+                BuiltinWebSearchProbeStatus::Unsupported
+            };
+            BuiltinWebSearchProbeCacheEntry {
+                status,
+                reason: Some(format!("builtin web search provider probe failed: {error}")),
+            }
+        }
     }
 }
 
@@ -387,6 +435,29 @@ fn unsupported_builtin_web_search_probe(
         status: BuiltinWebSearchProbeStatus::Unsupported,
         reason: Some(reason.into()),
     }
+}
+
+fn builtin_web_search_probe_requested(
+    capability: &crate::provider::ProviderBuiltinWebSearchCapability,
+    native_search_provider: Option<&(String, WebProviderKind)>,
+    web_search: &crate::web::WebSearchConfig,
+) -> bool {
+    if !web_search.enabled {
+        return false;
+    }
+
+    if let Some((_, provider_kind)) = native_search_provider {
+        if provider_kind.is_native_search() {
+            return provider_kind_to_native_web_search_kind(*provider_kind)
+                == Some(capability.kind);
+        }
+    }
+
+    if web_search.provider.trim() != "auto" {
+        return false;
+    }
+
+    web_search.builtin_provider_enabled
 }
 
 fn native_web_search_request_for_config(
@@ -587,6 +658,46 @@ fn builtin_web_search_selection_diagnostics(
 mod tests {
     use super::*;
 
+    struct ProbeProvider {
+        result: std::result::Result<(), &'static str>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::provider::AgentProvider for ProbeProvider {
+        async fn complete_turn(
+            &self,
+            _request: crate::provider::ProviderTurnRequest,
+        ) -> Result<crate::provider::ProviderTurnResponse> {
+            Ok(crate::provider::ProviderTurnResponse {
+                blocks: vec![crate::provider::ModelBlock::Text { text: "OK".into() }],
+                stop_reason: None,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_usage: None,
+                request_diagnostics: None,
+            })
+        }
+
+        async fn probe_builtin_web_search(
+            &self,
+            _request: ProviderNativeWebSearchRequest,
+        ) -> Result<()> {
+            match self.result {
+                Ok(()) => Ok(()),
+                Err("transient") => Err(crate::provider::provider_transport_error(
+                    crate::provider::ProviderFailureClassification {
+                        kind: crate::provider::ProviderFailureKind::RateLimited,
+                        disposition: crate::provider::RetryDisposition::Retryable,
+                    },
+                    Some(429),
+                    None,
+                    "rate limited",
+                )),
+                Err(message) => Err(anyhow::anyhow!(message)),
+            }
+        }
+    }
+
     fn capability(
         kind: ProviderNativeWebSearchKind,
         provider_id: &str,
@@ -615,6 +726,46 @@ mod tests {
             reason: (!matches!(status, BuiltinWebSearchProbeStatus::Supported))
                 .then(|| "probe result".into()),
         }
+    }
+
+    fn tool_spec(name: &str) -> ToolSpec {
+        ToolSpec {
+            name: name.into(),
+            description: "test tool".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            freeform_grammar: None,
+        }
+    }
+
+    #[test]
+    fn managed_web_search_tool_stays_visible_when_builtin_search_not_selected() {
+        let tools = filter_native_web_search_tools(
+            vec![
+                tool_spec(crate::tool::tools::web_search::NAME),
+                tool_spec("read_file"),
+            ],
+            false,
+        );
+
+        assert!(tools
+            .iter()
+            .any(|tool| tool.name == crate::tool::tools::web_search::NAME));
+    }
+
+    #[test]
+    fn managed_web_search_tool_is_hidden_when_builtin_search_selected() {
+        let tools = filter_native_web_search_tools(
+            vec![
+                tool_spec(crate::tool::tools::web_search::NAME),
+                tool_spec("read_file"),
+            ],
+            true,
+        );
+
+        assert!(!tools
+            .iter()
+            .any(|tool| tool.name == crate::tool::tools::web_search::NAME));
+        assert!(tools.iter().any(|tool| tool.name == "read_file"));
     }
 
     #[test]
@@ -783,8 +934,8 @@ mod tests {
         assert!(selection.diagnostics.probe_cache_hit);
     }
 
-    #[test]
-    fn native_web_search_request_uses_contract_probe_result_on_cache_miss() {
+    #[tokio::test]
+    async fn builtin_web_search_probe_rejects_invalid_contract_without_backend_call() {
         let mut cache = HashMap::new();
         let unsupported_capability = capability(
             ProviderNativeWebSearchKind::OpenAi,
@@ -793,7 +944,12 @@ mod tests {
             "web_search_preview",
             "openai_codex_web_search",
         );
-        let probe_result = probe_builtin_web_search_capability(&unsupported_capability);
+        let probe_result = probe_builtin_web_search_capability(
+            &ProbeProvider { result: Ok(()) },
+            &unsupported_capability,
+            search_config().max_results,
+        )
+        .await;
 
         let selection = native_web_search_request_for_config(
             Some(unsupported_capability),
@@ -813,6 +969,49 @@ mod tests {
             BuiltinWebSearchProbeStatus::Unsupported
         );
         assert!(!selection.diagnostics.probe_cache_hit);
+    }
+
+    #[tokio::test]
+    async fn builtin_web_search_probe_uses_backend_result() {
+        let capability = crate::provider::ProviderBuiltinWebSearchCapability {
+            kind: ProviderNativeWebSearchKind::OpenAi,
+            provider_id: "openai-codex".into(),
+            provider_model_ref: "openai-codex/gpt-codex-test".into(),
+            provider_transport: "openai_codex_responses".into(),
+            provider_base_url: "https://api.example.test".into(),
+            advertised_tool_type: "web_search".into(),
+            backend_kind: "openai_codex_web_search".into(),
+        };
+
+        let supported = probe_builtin_web_search_capability(
+            &ProbeProvider { result: Ok(()) },
+            &capability,
+            search_config().max_results,
+        )
+        .await;
+        let unsupported = probe_builtin_web_search_capability(
+            &ProbeProvider {
+                result: Err("unsupported"),
+            },
+            &capability,
+            search_config().max_results,
+        )
+        .await;
+        let transient = probe_builtin_web_search_capability(
+            &ProbeProvider {
+                result: Err("transient"),
+            },
+            &capability,
+            search_config().max_results,
+        )
+        .await;
+
+        assert_eq!(supported.status, BuiltinWebSearchProbeStatus::Supported);
+        assert_eq!(unsupported.status, BuiltinWebSearchProbeStatus::Unsupported);
+        assert_eq!(
+            transient.status,
+            BuiltinWebSearchProbeStatus::TransientFailure
+        );
     }
 
     #[test]

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -279,6 +279,13 @@ impl RuntimeHandle {
         let provider = self.current_provider().await;
         let native_search_provider = self.web_config().native_search_provider();
         let builtin_capability = provider.builtin_web_search();
+        let probe_result = builtin_capability
+            .as_ref()
+            .map(probe_builtin_web_search_capability)
+            .unwrap_or(BuiltinWebSearchProbeCacheEntry {
+                status: BuiltinWebSearchProbeStatus::Skipped,
+                reason: Some("active provider does not declare builtin web search".into()),
+            });
         let native_web_search_selection = {
             let mut cache = self.inner.builtin_web_search_probe_cache.lock().await;
             native_web_search_request_for_config(
@@ -286,10 +293,7 @@ impl RuntimeHandle {
                 native_search_provider.as_ref(),
                 &self.web_config().search,
                 &mut cache,
-                BuiltinWebSearchProbeCacheEntry {
-                    status: BuiltinWebSearchProbeStatus::Supported,
-                    reason: None,
-                },
+                probe_result,
             )
         };
         let native_web_search = native_web_search_selection.request;
@@ -318,6 +322,70 @@ impl RuntimeHandle {
             tools.retain(|tool| tool.name != crate::tool::tools::web_search::NAME);
         }
         tools
+    }
+}
+
+fn probe_builtin_web_search_capability(
+    capability: &crate::provider::ProviderBuiltinWebSearchCapability,
+) -> BuiltinWebSearchProbeCacheEntry {
+    if capability.provider_model_ref.trim().is_empty() {
+        return unsupported_builtin_web_search_probe(
+            "builtin web search capability has empty provider model ref",
+        );
+    }
+    if capability.provider_transport.trim().is_empty() {
+        return unsupported_builtin_web_search_probe(
+            "builtin web search capability has empty provider transport",
+        );
+    }
+    if capability.provider_base_url.trim().is_empty() {
+        return unsupported_builtin_web_search_probe(
+            "builtin web search capability has empty provider base URL",
+        );
+    }
+    if capability.advertised_tool_type.trim().is_empty() {
+        return unsupported_builtin_web_search_probe(
+            "builtin web search capability has empty advertised tool type",
+        );
+    }
+    if capability.backend_kind.trim().is_empty() {
+        return unsupported_builtin_web_search_probe(
+            "builtin web search capability has empty backend kind",
+        );
+    }
+
+    let supported = match (
+        capability.kind,
+        capability.provider_transport.as_str(),
+        capability.advertised_tool_type.as_str(),
+    ) {
+        (ProviderNativeWebSearchKind::OpenAi, "openai_responses", "web_search_preview")
+        | (ProviderNativeWebSearchKind::OpenAi, "openai_codex_responses", "web_search")
+        | (ProviderNativeWebSearchKind::Anthropic, "anthropic_messages", "web_search_20250305") => {
+            true
+        }
+        _ => false,
+    };
+
+    if supported {
+        BuiltinWebSearchProbeCacheEntry {
+            status: BuiltinWebSearchProbeStatus::Supported,
+            reason: None,
+        }
+    } else {
+        unsupported_builtin_web_search_probe(format!(
+            "builtin web search capability is incompatible with transport {} and advertised tool type {}",
+            capability.provider_transport, capability.advertised_tool_type
+        ))
+    }
+}
+
+fn unsupported_builtin_web_search_probe(
+    reason: impl Into<String>,
+) -> BuiltinWebSearchProbeCacheEntry {
+    BuiltinWebSearchProbeCacheEntry {
+        status: BuiltinWebSearchProbeStatus::Unsupported,
+        reason: Some(reason.into()),
     }
 }
 
@@ -505,7 +573,9 @@ fn builtin_web_search_selection_diagnostics(
         provider_id: capability.map(|capability| capability.provider_id.clone()),
         provider_model_ref: capability.map(|capability| capability.provider_model_ref.clone()),
         provider_transport: capability.map(|capability| capability.provider_transport.clone()),
-        provider_base_url: capability.map(|capability| capability.provider_base_url.clone()),
+        provider_base_url: capability.map(|capability| {
+            crate::provider::sanitize_transport_url(&capability.provider_base_url)
+        }),
         advertised_tool_type: capability.map(|capability| capability.advertised_tool_type.clone()),
         backend_kind: capability.map(|capability| capability.backend_kind.clone()),
         probe_status,
@@ -714,6 +784,38 @@ mod tests {
     }
 
     #[test]
+    fn native_web_search_request_uses_contract_probe_result_on_cache_miss() {
+        let mut cache = HashMap::new();
+        let unsupported_capability = capability(
+            ProviderNativeWebSearchKind::OpenAi,
+            "openai-codex",
+            "openai-codex/gpt-codex-test",
+            "web_search_preview",
+            "openai_codex_web_search",
+        );
+        let probe_result = probe_builtin_web_search_capability(&unsupported_capability);
+
+        let selection = native_web_search_request_for_config(
+            Some(unsupported_capability),
+            None,
+            &search_config(),
+            &mut cache,
+            probe_result,
+        );
+
+        assert!(selection.request.is_none());
+        assert_eq!(
+            selection.diagnostics.status,
+            BuiltinWebSearchSelectionStatus::Unsupported
+        );
+        assert_eq!(
+            selection.diagnostics.probe_status,
+            BuiltinWebSearchProbeStatus::Unsupported
+        );
+        assert!(!selection.diagnostics.probe_cache_hit);
+    }
+
+    #[test]
     fn native_web_search_request_does_not_cache_transient_probe_failure() {
         let mut cache = HashMap::new();
 
@@ -751,5 +853,31 @@ mod tests {
         );
         assert!(second.request.is_some());
         assert!(!second.diagnostics.probe_cache_hit);
+    }
+
+    #[test]
+    fn builtin_web_search_selection_diagnostics_sanitizes_base_url() {
+        let capability = crate::provider::ProviderBuiltinWebSearchCapability {
+            kind: ProviderNativeWebSearchKind::OpenAi,
+            provider_id: "openai-codex".into(),
+            provider_model_ref: "openai-codex/gpt-codex-test".into(),
+            provider_transport: "openai_codex_responses".into(),
+            provider_base_url: "https://user:secret@example.test/path?token=abc#frag".into(),
+            advertised_tool_type: "web_search".into(),
+            backend_kind: "openai_codex_web_search".into(),
+        };
+
+        let diagnostics = builtin_web_search_selection_diagnostics(
+            Some(&capability),
+            BuiltinWebSearchSelectionStatus::Selected,
+            None,
+            BuiltinWebSearchProbeStatus::Supported,
+            false,
+        );
+
+        assert_eq!(
+            diagnostics.provider_base_url.as_deref(),
+            Some("https://example.test/path")
+        );
     }
 }

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1774,7 +1774,7 @@ impl TurnExecution<'_> {
         };
         runtime.reconfigure_provider_for_current_state().await?;
         let identity = runtime.agent_identity_view().await?;
-        let (provider, available_tools, native_web_search) =
+        let (provider, available_tools, native_web_search, builtin_web_search_selection) =
             runtime.provider_tool_selection(&identity).await?;
         let allowed_tool_names = available_tools
             .iter()
@@ -1787,6 +1787,7 @@ impl TurnExecution<'_> {
                 "model_override": turn_model_override,
                 "pending_fallback_model": turn_pending_fallback_model,
                 "model": turn_model_state,
+                "builtin_web_search_selection": builtin_web_search_selection,
             }),
         ))?;
         if let Some(pending) = turn_pending_fallback_model.as_ref() {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -105,6 +105,7 @@ impl From<&crate::config::WebFetchConfigFile> for WebFetchConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WebSearchConfig {
     pub enabled: bool,
+    pub builtin_provider_enabled: bool,
     pub provider: String,
     pub mode: WebSearchMode,
     pub providers: Vec<String>,
@@ -116,6 +117,7 @@ impl Default for WebSearchConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            builtin_provider_enabled: true,
             provider: "auto".into(),
             mode: WebSearchMode::Fallback,
             providers: Vec::new(),
@@ -130,6 +132,10 @@ impl From<&crate::config::WebSearchConfigFile> for WebSearchConfig {
         let fallback = Self::default();
         Self {
             enabled: value.enabled.unwrap_or(fallback.enabled),
+            builtin_provider_enabled: value
+                .builtin_provider
+                .enabled
+                .unwrap_or(fallback.builtin_provider_enabled),
             provider: value
                 .provider
                 .as_deref()

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -108,6 +108,18 @@ async fn live_openai_codex_builtin_web_search_reports_backend() -> Result<()> {
         .expect("openai codex provider should declare builtin search");
     assert_eq!(capability.advertised_tool_type, "web_search");
     assert_eq!(capability.backend_kind, "openai_codex_web_search");
+    let native_web_search = ProviderNativeWebSearchRequest {
+        kind: capability.kind,
+        provider_id: "openai-codex-native".into(),
+        provider_model_ref: capability.provider_model_ref,
+        advertised_tool_type: capability.advertised_tool_type,
+        backend_kind: capability.backend_kind,
+        max_results: Some(3),
+    };
+
+    provider
+        .probe_builtin_web_search(native_web_search.clone())
+        .await?;
 
     let output = provider
         .complete_turn(ProviderTurnRequest {
@@ -118,14 +130,7 @@ async fn live_openai_codex_builtin_web_search_reports_backend() -> Result<()> {
                 "Search the web and name today's date.".into(),
             )],
             tools: vec![],
-            native_web_search: Some(ProviderNativeWebSearchRequest {
-                kind: capability.kind,
-                provider_id: "openai-codex-native".into(),
-                provider_model_ref: capability.provider_model_ref,
-                advertised_tool_type: capability.advertised_tool_type,
-                backend_kind: capability.backend_kind,
-                max_results: Some(3),
-            }),
+            native_web_search: Some(native_web_search),
         })
         .await?;
     let diagnostics = output


### PR DESCRIPTION
## Summary

- Default-enable provider-declared builtin web search when the active model provider advertises a compatible capability and `web.search.provider` is left on `auto`.
- Add global `web.search.builtin_provider.enabled` plus provider-level `providers.<id>.builtin_web_search.enabled = false` opt-out support.
- Add builtin search selection diagnostics and an in-runtime probe decision cache keyed by provider/model/transport/base URL/tool/backend identity.
- Keep managed `WebSearch` visible when builtin search is disabled, unsupported, not declared, or an explicit managed search provider is selected.

Closes #1347

## Notes

This keeps builtin-search provider turn failure handling unchanged, per the issue scope. The probe cache records supported/unsupported decisions and deliberately does not persist transient probe failures.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test native_web_search_request_ --lib`
- `cargo test --lib`
- `cargo test --test live_codex live_openai_codex_builtin_web_search_reports_backend -- --ignored --nocapture` passed once against live Codex builtin search; a later rerun failed with transient `server_is_overloaded` from the Codex service.
