### PR TITLE
test: probe configured builtin web search models

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2769,6 +2769,7 @@ fn insert_anthropic_compatible_provider(
     let builtin_web_search = match provider {
         "zai" | "zai-anthropic" => Some(zai_builtin_web_search_config()),
         "bigmodel" | "bigmodel-anthropic" => Some(bigmodel_builtin_web_search_config()),
+        "deepseek" | "deepseek-anthropic" => Some(deepseek_builtin_web_search_config()),
         _ => None,
     };
     insert_builtin_http_provider_with_context_management(
@@ -2897,6 +2898,15 @@ fn bigmodel_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
         kind: ProviderNativeWebSearchKind::Anthropic,
         advertised_tool_type: "web_search_20250305".to_string(),
         backend_kind: "bigmodel_web_search".to_string(),
+    }
+}
+
+fn deepseek_builtin_web_search_config() -> ProviderBuiltinWebSearchConfig {
+    ProviderBuiltinWebSearchConfig {
+        enabled: true,
+        kind: ProviderNativeWebSearchKind::Anthropic,
+        advertised_tool_type: "web_search_20250305".to_string(),
+        backend_kind: "deepseek_web_search".to_string(),
     }
 }
 
@@ -4515,7 +4525,10 @@ mod tests {
         let deepseek = registry
             .get(&ProviderId::parse("deepseek-anthropic").unwrap())
             .unwrap();
-        assert!(deepseek.builtin_web_search.is_none());
+        let deepseek_search = deepseek.builtin_web_search.as_ref().unwrap();
+        assert_eq!(deepseek_search.kind, ProviderNativeWebSearchKind::Anthropic);
+        assert_eq!(deepseek_search.advertised_tool_type, "web_search_20250305");
+        assert_eq!(deepseek_search.backend_kind, "deepseek_web_search");
     }
 
     #[test]

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -3,7 +3,8 @@ use holon::{
     config::{AppConfig, ProviderId, ProviderTransportKind},
     prompt::PromptStability,
     provider::{
-        AgentProvider, AnthropicProvider, ConversationMessage, ModelBlock, PromptContentBlock,
+        AgentProvider, AnthropicProvider, ConversationMessage, ModelBlock, OpenAiCodexProvider,
+        OpenAiProvider, PromptContentBlock, ProviderNativeWebSearchKind,
         ProviderNativeWebSearchRequest, ProviderPromptCache, ProviderPromptFrame,
         ProviderTurnRequest, ToolResultBlock,
     },
@@ -236,6 +237,159 @@ async fn provider_builtin_web_search_reports_backend(
     assert_eq!(diagnostics.backend_kind, expected_backend);
     assert_eq!(diagnostics.advertised_tool_type, "web_search_20250305");
     assert!(!output.blocks.is_empty());
+    Ok(())
+}
+
+fn forced_native_web_search_request(
+    provider_id: &str,
+    model_ref: &str,
+    transport: ProviderTransportKind,
+) -> Option<ProviderNativeWebSearchRequest> {
+    match transport {
+        ProviderTransportKind::AnthropicMessages => Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::Anthropic,
+            provider_id: provider_id.into(),
+            provider_model_ref: model_ref.into(),
+            advertised_tool_type: "web_search_20250305".into(),
+            backend_kind: format!("{provider_id}_forced_web_search_probe"),
+            max_results: Some(3),
+        }),
+        ProviderTransportKind::OpenAiResponses => Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::OpenAi,
+            provider_id: provider_id.into(),
+            provider_model_ref: model_ref.into(),
+            advertised_tool_type: "web_search_preview".into(),
+            backend_kind: format!("{provider_id}_forced_web_search_probe"),
+            max_results: Some(3),
+        }),
+        ProviderTransportKind::OpenAiCodexResponses => Some(ProviderNativeWebSearchRequest {
+            kind: ProviderNativeWebSearchKind::OpenAi,
+            provider_id: provider_id.into(),
+            provider_model_ref: model_ref.into(),
+            advertised_tool_type: "web_search".into(),
+            backend_kind: format!("{provider_id}_forced_web_search_probe"),
+            max_results: Some(3),
+        }),
+        ProviderTransportKind::OpenAiChatCompletions => None,
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires configured provider credentials and network access"]
+async fn live_configured_model_chain_builtin_web_search_support() -> Result<()> {
+    let config = live_config()?;
+    let provider_chain = config.provider_chain();
+    let mut tested = Vec::new();
+    let mut declared_failures = Vec::new();
+
+    for model_ref in provider_chain {
+        let provider_id = model_ref.provider.as_str().to_string();
+        let Some(provider_config) = config.providers.get(&model_ref.provider) else {
+            println!("SKIP {}: provider is not configured", model_ref.as_string());
+            continue;
+        };
+
+        let trace_home_dir = tempfile::tempdir()?;
+        let provider: Box<dyn AgentProvider> = match provider_config.transport {
+            ProviderTransportKind::AnthropicMessages => {
+                Box::new(AnthropicProvider::from_runtime_config(
+                    provider_config,
+                    &model_ref.model,
+                    config.runtime_max_output_tokens,
+                    trace_home_dir.path(),
+                )?)
+            }
+            ProviderTransportKind::OpenAiResponses => {
+                Box::new(OpenAiProvider::from_runtime_config(
+                    provider_config,
+                    &model_ref.model,
+                    config.runtime_max_output_tokens,
+                    trace_home_dir.path(),
+                )?)
+            }
+            ProviderTransportKind::OpenAiCodexResponses => {
+                Box::new(OpenAiCodexProvider::from_runtime_config(
+                    provider_config,
+                    &model_ref.model,
+                    config.runtime_max_output_tokens,
+                    trace_home_dir.path(),
+                )?)
+            }
+            ProviderTransportKind::OpenAiChatCompletions => {
+                println!(
+                    "SKIP {}: transport {:?} has no builtin web search lowering",
+                    model_ref.as_string(),
+                    provider_config.transport
+                );
+                continue;
+            }
+        };
+
+        let declared = provider.builtin_web_search();
+        let request = declared
+            .as_ref()
+            .map(|capability| ProviderNativeWebSearchRequest {
+                kind: capability.kind,
+                provider_id: provider_id.clone(),
+                provider_model_ref: capability.provider_model_ref.clone(),
+                advertised_tool_type: capability.advertised_tool_type.clone(),
+                backend_kind: capability.backend_kind.clone(),
+                max_results: Some(3),
+            })
+            .or_else(|| {
+                forced_native_web_search_request(
+                    &provider_id,
+                    &model_ref.as_string(),
+                    provider_config.transport,
+                )
+            });
+        let Some(request) = request else {
+            println!(
+                "SKIP {}: transport {:?} has no builtin web search probe shape",
+                model_ref.as_string(),
+                provider_config.transport
+            );
+            continue;
+        };
+        let source = if declared.is_some() {
+            "declared"
+        } else {
+            "forced"
+        };
+        let backend_kind = request.backend_kind.clone();
+
+        match provider.probe_builtin_web_search(request).await {
+            Ok(()) => {
+                println!(
+                    "PASS {} builtin_web_search source={} backend={}",
+                    model_ref.as_string(),
+                    source,
+                    backend_kind
+                );
+                tested.push(model_ref.as_string());
+            }
+            Err(error) => {
+                println!(
+                    "FAIL {} builtin_web_search source={}: {error}",
+                    model_ref.as_string(),
+                    source
+                );
+                if declared.is_some() {
+                    declared_failures.push(format!("{}: {error}", model_ref.as_string()));
+                }
+            }
+        }
+    }
+
+    assert!(
+        !tested.is_empty(),
+        "configured provider chain did not include any builtin web search providers"
+    );
+    assert!(
+        declared_failures.is_empty(),
+        "declared builtin web search failures:\n{}",
+        declared_failures.join("\n")
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Add a configured-model-chain live probe that tests builtin web search for every current Holon-configured model, including providers that have not declared builtin search yet.
- Enable provider-declared builtin web search for DeepSeek Anthropic-compatible providers because the forced live probe succeeds for `deepseek-anthropic/deepseek-v4-flash`.
- Keep Minimax and Xiaomi unconfigured for builtin search after the forced live probe returned provider/model errors.

## Live Probe Result
- PASS `openai-codex/gpt-5.4` declared backend `openai_codex_web_search`
- PASS `anthropic/claude-sonnet-4-6` declared backend `anthropic_web_search`
- PASS `bigmodel-anthropic/glm-5.1` declared backend `bigmodel_web_search`
- PASS `deepseek-anthropic/deepseek-v4-flash` forced probe, now declared backend `deepseek_web_search`
- FAIL `minimax/MiniMax-M2.7` forced probe: provider rejected the web search tool params
- FAIL `xiaomi-anthropic/mimo-v2-flash` forced probe: provider reported the model unsupported

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test built_in_provider_registry_declares_provider_specific_builtin_search --lib`
- `cargo test --test live_anthropic_compatible live_configured_model_chain_builtin_web_search_support -- --ignored --nocapture`
- `cargo test --test live_anthropic_compatible live_bigmodel_anthropic_builtin_web_search_reports_backend -- --ignored --nocapture`
