### PR TITLE
fix: tolerate legacy agent ledgers in TUI list

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -614,7 +614,17 @@ impl RuntimeHost {
             &self.runtime_context_config(),
             &agent,
         );
-        let scheduling_posture = storage.agent_posture_projection(&agent)?;
+        let scheduling_posture = match storage.agent_posture_projection(&agent) {
+            Ok(posture) => posture,
+            Err(error) => {
+                warn!(
+                    agent_id = %identity.agent_id,
+                    error = %error,
+                    "failed to read agent posture for /agents/list; using unknown placeholder"
+                );
+                crate::types::AgentPostureProjection::default()
+            }
+        };
         let waiting_reason = crate::runtime::lightweight_agent_list_waiting_reason(&agent);
         Ok(AgentListEntry {
             identity: AgentIdentityView::from_record(identity, &self.config().default_agent_id),
@@ -1514,10 +1524,10 @@ mod tests {
         storage::AppStorage,
         system::WorkspaceProjectionKind,
         types::{
-            AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentStatus,
-            AgentVisibility, ControlAction, MessageBody, MessageEnvelope, MessageKind,
-            MessageOrigin, Priority, TaskRecord, TaskRecoverySpec, TaskStatus, TrustLevel,
-            TurnTerminalKind,
+            AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
+            AgentSchedulingPosture, AgentStatus, AgentVisibility, ControlAction, MessageBody,
+            MessageEnvelope, MessageKind, MessageOrigin, Priority, TaskRecord, TaskRecoverySpec,
+            TaskStatus, TrustLevel, TurnTerminalKind,
         },
     };
 
@@ -1678,6 +1688,26 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(listed.contains(&host.config().default_agent_id));
         assert!(listed.contains(&"release-bot".to_string()));
+    }
+
+    #[tokio::test]
+    async fn list_agent_entries_tolerates_corrupt_stored_posture_ledgers() {
+        let (_home, host) = test_host();
+        host.create_named_agent("release-bot", None).await.unwrap();
+        let agent_home = host.agent_data_dir("release-bot");
+        let work_items_path = agent_home.join(".holon/ledger/work_items.jsonl");
+        std::fs::write(&work_items_path, "not json\n").unwrap();
+
+        let entries = host.list_agent_entries().await.unwrap();
+        let release_bot = entries
+            .iter()
+            .find(|entry| entry.identity.agent_id == "release-bot")
+            .expect("release-bot should still be listed");
+
+        assert_eq!(
+            release_bot.scheduling_posture.posture,
+            AgentSchedulingPosture::Unknown
+        );
     }
 
     #[tokio::test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -1699,13 +1699,24 @@ mod tests {
         std::fs::write(&work_items_path, "not json\n").unwrap();
 
         let entries = host.list_agent_entries().await.unwrap();
-        let release_bot = entries
+        let loaded_release_bot = entries
             .iter()
             .find(|entry| entry.identity.agent_id == "release-bot")
             .expect("release-bot should still be listed");
-
         assert_eq!(
-            release_bot.scheduling_posture.posture,
+            loaded_release_bot.scheduling_posture.posture,
+            AgentSchedulingPosture::Unknown
+        );
+
+        host.unload_runtime("release-bot").await;
+
+        let entries = host.list_agent_entries().await.unwrap();
+        let stored_release_bot = entries
+            .iter()
+            .find(|entry| entry.identity.agent_id == "release-bot")
+            .expect("unloaded release-bot should still be listed");
+        assert_eq!(
+            stored_release_bot.scheduling_posture.posture,
             AgentSchedulingPosture::Unknown
         );
     }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -415,7 +415,17 @@ impl RuntimeHandle {
     pub async fn agent_list_entry(&self) -> Result<AgentListEntry> {
         let agent = self.agent_state().await?;
         let model = self.model_state_for(&agent);
-        let scheduling_posture = self.inner.storage.agent_posture_projection(&agent)?;
+        let scheduling_posture = match self.inner.storage.agent_posture_projection(&agent) {
+            Ok(posture) => posture,
+            Err(error) => {
+                tracing::warn!(
+                    agent_id = %agent.id,
+                    error = %error,
+                    "failed to read agent posture for /agents/list; using unknown placeholder"
+                );
+                crate::types::AgentPostureProjection::default()
+            }
+        };
         let identity = self.agent_identity_view().await?;
         let waiting_reason = super::lightweight_agent_list_waiting_reason(&agent);
         Ok(AgentListEntry {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3074,10 +3074,13 @@ impl Default for AgentPostureProjection {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkItemPlanArtifact {
+    #[serde(default)]
     pub owner_agent_id: String,
+    #[serde(default = "default_agent_home_workspace_id")]
     pub workspace_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_alias: Option<String>,
+    #[serde(default)]
     pub relative_path: PathBuf,
     pub path: PathBuf,
     pub hash: String,
@@ -4325,6 +4328,29 @@ mod tests {
         work_item.as_object_mut().unwrap().remove("workspace_id");
         let work_item: WorkItemRecord = serde_json::from_value(work_item).unwrap();
         assert_eq!(work_item.workspace_id, AGENT_HOME_WORKSPACE_ID);
+
+        let legacy_work_item = serde_json::json!({
+            "id": "work_legacy",
+            "agent_id": "default",
+            "objective": "ship",
+            "state": "open",
+            "plan_status": "ready",
+            "plan_artifact": {
+                "path": "/tmp/plan.md",
+                "hash": "sha256:abc",
+                "bytes": 12,
+                "updated_at": "2026-04-20T00:00:00Z",
+                "preview": "plan",
+                "preview_complete": true
+            },
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z"
+        });
+        let legacy_work_item: WorkItemRecord = serde_json::from_value(legacy_work_item).unwrap();
+        let legacy_artifact = legacy_work_item.plan_artifact.unwrap();
+        assert_eq!(legacy_artifact.owner_agent_id, "");
+        assert_eq!(legacy_artifact.workspace_id, AGENT_HOME_WORKSPACE_ID);
+        assert_eq!(legacy_artifact.relative_path, PathBuf::new());
 
         let episode = serde_json::json!({
             "id": "episode-1",


### PR DESCRIPTION
## Summary

- make `/agents/list` tolerate per-agent posture ledger decode failures by returning an `unknown` posture for the affected agent
- apply the same fallback for loaded runtimes and unloaded storage-backed list entries
- allow legacy `WorkItemPlanArtifact` records without newer ownership/workspace fields to deserialize

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib host::tests::list_agent_entries_tolerates_corrupt_stored_posture_ledgers -- --nocapture`
- `cargo test --lib types::tests::runtime_memory_records_default_missing_workspace_id_to_agent_home -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo run --quiet -- agents list`
