### PR TITLE
fix: wake runtime for blocked WorkItem rechecks

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1047,12 +1047,13 @@ impl RuntimeHandle {
                     if let Some(next_recheck_at) = next_recheck_at {
                         let now = Utc::now();
                         if next_recheck_at > now {
-                            let wait = (next_recheck_at - now)
-                                .to_std()
-                                .unwrap_or_else(|_| Duration::from_millis(0));
-                            tokio::select! {
-                                _ = self.inner.notify.notified() => {}
-                                _ = tokio::time::sleep(wait) => {}
+                            if let Ok(wait) = (next_recheck_at - now).to_std() {
+                                tokio::select! {
+                                    _ = self.inner.notify.notified() => {}
+                                    _ = tokio::time::sleep(wait) => {}
+                                }
+                            } else {
+                                self.inner.notify.notified().await;
                             }
                         }
                     } else {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1037,13 +1037,27 @@ impl RuntimeHandle {
                     ) {
                         scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                     }
+                    let next_recheck_at = self.next_blocked_work_item_recheck_at().await?;
                     let idle_state = scheduler_executor::SchedulerDecisionExecutor::new(&self)
-                        .transition_run_loop_idle_to_sleep()
+                        .transition_run_loop_idle_to_sleep(next_recheck_at)
                         .await?;
                     if let Some(idle_state) = idle_state {
                         self.append_state_changed_events(&idle_state)?;
                     }
-                    self.inner.notify.notified().await;
+                    if let Some(next_recheck_at) = next_recheck_at {
+                        let now = Utc::now();
+                        if next_recheck_at > now {
+                            let wait = (next_recheck_at - now)
+                                .to_std()
+                                .unwrap_or_else(|_| Duration::from_millis(0));
+                            tokio::select! {
+                                _ = self.inner.notify.notified() => {}
+                                _ = tokio::time::sleep(wait) => {}
+                            }
+                        }
+                    } else {
+                        self.inner.notify.notified().await;
+                    }
                     continue;
                 }
             };

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -299,6 +299,15 @@ impl RuntimeHandle {
         Ok(())
     }
 
+    pub(super) async fn next_blocked_work_item_recheck_at(
+        &self,
+    ) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+        let agent_id = self.agent_id().await?;
+        self.inner
+            .storage
+            .next_blocked_work_item_recheck_at(&agent_id)
+    }
+
     fn duplicate_queued_available_message_id(
         &self,
         work_item: &crate::types::WorkItemRecord,

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -222,7 +222,10 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         Ok(guard.state.clone())
     }
 
-    pub(super) async fn transition_run_loop_idle_to_sleep(&self) -> Result<Option<AgentState>> {
+    pub(super) async fn transition_run_loop_idle_to_sleep(
+        &self,
+        sleeping_until: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Option<AgentState>> {
         let mut guard = self.runtime.inner.agent.lock().await;
         if matches!(
             guard.state.status,
@@ -234,7 +237,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
 
         let previous_status = guard.state.status.clone();
         let previous_run_id = guard.state.current_run_id.clone();
-        scheduler::apply_sleep_projection(&mut guard.state, None);
+        scheduler::apply_sleep_projection(&mut guard.state, sleeping_until);
         self.append_posture_decision(
             SleepTransitionBoundary::RunLoopIdle.as_str(),
             "sleep",

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -233,7 +233,16 @@ impl<'a> SchedulerDecisionExecutor<'a> {
 
         let previous_status = guard.state.status.clone();
         let previous_run_id = guard.state.current_run_id.clone();
-        scheduler::apply_sleep_projection(&mut guard.state, sleeping_until);
+        let next_sleeping_until = if matches!(previous_status, AgentStatus::Asleep) {
+            match (guard.state.sleeping_until, sleeping_until) {
+                (Some(current), Some(proposed)) => Some(current.min(proposed)),
+                (Some(current), None) => Some(current),
+                (None, proposed) => proposed,
+            }
+        } else {
+            sleeping_until
+        };
+        scheduler::apply_sleep_projection(&mut guard.state, next_sleeping_until);
         self.append_posture_decision(
             SleepTransitionBoundary::RunLoopIdle.as_str(),
             "sleep",

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -227,11 +227,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         sleeping_until: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<Option<AgentState>> {
         let mut guard = self.runtime.inner.agent.lock().await;
-        if matches!(
-            guard.state.status,
-            AgentStatus::Asleep | AgentStatus::Stopped
-        ) || !guard.queue.is_empty()
-        {
+        if matches!(guard.state.status, AgentStatus::Stopped) || !guard.queue.is_empty() {
             return Ok(None);
         }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -206,7 +206,7 @@ async fn run_loop_idle_sleep_rechecks_queue_before_transition() {
     }
 
     let transition = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
-        .transition_run_loop_idle_to_sleep()
+        .transition_run_loop_idle_to_sleep(None)
         .await
         .unwrap();
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -268,6 +268,44 @@ async fn run_loop_idle_sleep_refreshes_sleeping_until_when_already_asleep() {
 }
 
 #[tokio::test]
+async fn run_loop_idle_sleep_preserves_existing_timed_sleep_when_no_recheck() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let existing_deadline = Utc::now() + chrono::Duration::milliseconds(50);
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::Asleep;
+        guard.state.sleeping_until = Some(existing_deadline);
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+
+    let transition = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .transition_run_loop_idle_to_sleep(None)
+        .await
+        .unwrap()
+        .expect("already-asleep run loop projection should preserve timed sleep");
+
+    assert_eq!(transition.status, AgentStatus::Asleep);
+    assert_eq!(transition.sleeping_until, Some(existing_deadline));
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::Asleep);
+    assert_eq!(state.sleeping_until, Some(existing_deadline));
+}
+
+#[tokio::test]
 async fn explicit_sleep_transition_records_scheduler_owned_posture_decision() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -221,6 +221,53 @@ async fn run_loop_idle_sleep_rechecks_queue_before_transition() {
 }
 
 #[tokio::test]
+async fn run_loop_idle_sleep_refreshes_sleeping_until_when_already_asleep() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let previous_deadline = Utc::now() + chrono::Duration::seconds(60);
+    let next_deadline = Utc::now() + chrono::Duration::seconds(5);
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::Asleep;
+        guard.state.sleeping_until = Some(previous_deadline);
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+
+    let transition = scheduler_executor::SchedulerDecisionExecutor::new(&runtime)
+        .transition_run_loop_idle_to_sleep(Some(next_deadline))
+        .await
+        .unwrap()
+        .expect("already-asleep run loop projection should refresh sleeping_until");
+
+    assert_eq!(transition.status, AgentStatus::Asleep);
+    assert_eq!(transition.sleeping_until, Some(next_deadline));
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::Asleep);
+    assert_eq!(state.sleeping_until, Some(next_deadline));
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision"
+            && event.data["boundary"] == "run_loop_idle"
+            && event.data["reason"] == "sleep"
+            && event.data["previous_status"] == "asleep"
+            && event.data["next_status"] == "asleep"
+    }));
+}
+
+#[tokio::test]
 async fn explicit_sleep_transition_records_scheduler_owned_posture_decision() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -144,6 +144,57 @@ async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
 }
 
 #[tokio::test]
+async fn runtime_wakes_itself_for_blocked_work_item_recheck_deadline() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut blocked = WorkItemRecord::new(
+        "default",
+        "blocked work with fallback recheck",
+        WorkItemState::Open,
+    );
+    blocked.blocked_by = Some("waiting for external wake".into());
+    blocked.recheck_at = Some(Utc::now() + chrono::Duration::milliseconds(50));
+    storage.append_work_item(&blocked).unwrap();
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("recheck observed")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let runtime_task = tokio::spawn(runtime.clone().run());
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(
+        events.iter().any(|event| {
+            event.kind == "system_tick_emitted"
+                && event.data.get("subsystem").and_then(|value| value.as_str())
+                    == Some("work_item_recheck")
+        }),
+        "runtime should emit a work_item_recheck tick without external input"
+    );
+    let latest = runtime
+        .storage()
+        .latest_work_item(&blocked.id)
+        .unwrap()
+        .expect("blocked work item exists");
+    assert!(
+        latest
+            .recheck_consumed_at
+            .zip(latest.recheck_at)
+            .is_some_and(|(consumed_at, recheck_at)| consumed_at >= recheck_at),
+        "deadline wake should consume the due blocked recheck"
+    );
+    runtime_task.abort();
+}
+
+#[tokio::test]
 async fn work_queue_projection_derives_scheduling_state_per_work_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1139,6 +1139,30 @@ impl AppStorage {
         Ok(due)
     }
 
+    pub fn next_blocked_work_item_recheck_at(
+        &self,
+        agent_id: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        Ok(self
+            .latest_work_items()?
+            .into_iter()
+            .filter(|item| item.agent_id == agent_id)
+            .filter(|item| item.state == WorkItemState::Open)
+            .filter(|item| item.blocked_by.is_some())
+            .filter_map(|item| {
+                let recheck_at = item.recheck_at?;
+                if item
+                    .recheck_consumed_at
+                    .is_some_and(|consumed_at| consumed_at >= recheck_at)
+                {
+                    None
+                } else {
+                    Some(recheck_at)
+                }
+            })
+            .min())
+    }
+
     pub fn latest_work_item(&self, work_item_id: &str) -> Result<Option<WorkItemRecord>> {
         if !self.work_items_path.exists() {
             return Ok(None);


### PR DESCRIPTION
## Summary
- wake the run loop at the next blocked WorkItem `recheck_at` deadline instead of sleeping indefinitely until external input
- project the idle sleep state with the next recheck deadline so the agent state reflects the durable wake target
- add storage lookup for the earliest unconsumed blocked WorkItem recheck and a regression test that waits for runtime idle wake behavior

Closes #1356

## Verification
- `cargo fmt --all -- --check`
- `cargo test recheck -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
