### PR TITLE
docs: add runtime spec pages and reposition runtime-spec as aggregate contract (Milestone 7)

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -6,48 +6,13 @@ public contract.
 For a short architecture map and reading path, see
 [Holon Architecture Overview](../architecture-overview.md).
 
-## Recommended reading path
+## Current runtime specs
 
-New contributors should read RFCs in this order rather than randomly:
-
-### 1. Product and runtime map
-
-- [README.md](../../README.md) — project entry and install
-- [Architecture overview](../architecture-overview.md) — runtime map
-- [Runtime model](../../docs/website/concepts/runtime-model.md) — user-facing
-  concept page
-
-### 2. Agent, work, and scheduler core
-
-- [Agent State Model And Runtime Projection](./agent-state-model.md)
-- [Work Item Runtime Model](./work-item-runtime-model.md)
-- [Work Item Centered Agent Runtime](./work-item-centered-agent-runtime.md)
-- [Runtime Scheduler Contract](./runtime-scheduler-contract.md)
-- [Scheduler Wait State And Recoverable Agent Continuation](./scheduler-wait-state.md)
-
-### 3. Waiting, wake, and external events
-
-- [Continuation Trigger](./continuation-trigger.md)
-- [Waiting Plane And Reactivation](./waiting-plane-and-reactivation.md)
-- [Operator Notification and Intervention](./operator-wait-and-intervention.md)
-- [External Trigger Capability And Providerless Ingress](./external-trigger-capability.md)
-
-### 4. Tools and delegation
-
-- [Tool Surface Layering](./tool-surface-layering.md)
-- [Command Tool Family](./command-tool-family.md)
-- [Agent Delegation Tool Plane](./agent-delegation-tool-plane.md)
-
-### 5. Workspace, execution, and trust
-
-- [Workspace Binding And Execution Roots](./workspace-binding-and-execution-roots.md)
-- [Execution Policy And Virtual Execution Boundary](./execution-policy-and-virtual-execution-boundary.md)
-- [Default Trust Authorization And Access Control](./default-trust-auth-and-control.md)
-
-### 6. Provider, configuration, and context
-
-- [Runtime Configuration Surface](./runtime-configuration-surface.md)
-- [Long-Lived Context Memory](./long-lived-context-memory.md)
+RFCs are design records and historical decisions. For the current
+implementation-facing runtime contract, see the spec pages under
+[`docs/website/spec/`](../website/spec/). Specs are extracted from RFCs once
+the design stabilizes into runtime behavior and are verified against
+implementation and tests.
 
 ## Runtime And Work Model
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1,5 +1,17 @@
 # Holon Runtime Spec v0
 
+> **Status:** This is the original v0 aggregate runtime spec. It remains the
+> implementation-facing baseline, but individual topic contracts are gradually
+> extracted into focused spec pages under
+> [`docs/website/spec/`](./website/spec/). When a topic has a dedicated spec
+> page, that page is the current authority; this document is the fallback for
+> topics not yet extracted.
+>
+> **Reading path:** For user-facing documentation, start at the
+> [documentation website](https://holon.run). For design rationale and
+> historical decisions, see [`docs/rfcs/`](./rfcs/). For current
+> implementation-facing contracts, see [`docs/website/spec/`](./website/spec/).
+
 This document defines the first runtime contract for `Holon`.
 
 The goal of v0 is not to solve every future integration. The goal is to make

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -89,15 +89,18 @@ contribute, see [Getting started](/getting-started/). Next, follow the
 - [Reference](/reference/) — current CLI, configuration, and control-plane
   surface documentation.
   experimental.
+- [Specs](/spec/) — current implementation-facing runtime contracts for
+  maintainers and contributors.
 
 ## For contributors
 
 Holon's internal design material lives in the [repository `docs/`
 directory](https://github.com/holon-run/holon/tree/main/docs): RFCs define
-runtime contracts, implementation decisions record architecture rationale, and
-archived notes preserve historical context. These are maintainer-facing
-documents; you do not need to read them to use Holon, but they are the
-canonical source when you need to understand or change runtime behavior.
+runtime contracts, [spec pages](/spec/) extract current verified contracts,
+implementation decisions record architecture rationale, and archived notes
+preserve historical context. These are maintainer-facing documents; you do not
+need to read them to use Holon, but they are the canonical source when you
+need to understand or change runtime behavior.
 
 ## About this site
 
@@ -121,6 +124,9 @@ guide](/guides/documentation-workflow/). The production `siteUrl` is
 `https://holon.run`.
 
 <!-- INDEX:START -->
+
+- [Runtime specs](./spec/)
+  <!-- mdorigin:index kind=directory -->
 
 - [Getting started](./getting-started/)
   <!-- mdorigin:index kind=directory -->

--- a/docs/website/concepts/documentation-layers.md
+++ b/docs/website/concepts/documentation-layers.md
@@ -1,114 +1,100 @@
 ---
 title: Documentation layers
-summary: How Holon separates user-facing docs, current-contract reference, and maintainer design records — and which layer to read for which question.
-order: 30
+summary: How Holon separates product docs, current-contract reference, and maintainer design records.
+order: 20
 ---
 
 # Documentation layers
 
-Holon's documentation is organized into three layers with clear boundaries.
-This page helps you find the right layer for your question.
+Holon's documentation is organized into four layers with clear boundaries.
+This prevents drift between what users see, what the runtime actually does, and
+what maintainers are designing next.
 
-## Quick guide: which docs should I read?
+## Layer 1: Product website (`docs/website/`)
 
-| I want to... | Start here |
-|-------------|-----------|
-| Install and run Holon | [Getting started](/getting-started/) |
-| Understand core concepts | [Concepts overview](/concepts/) |
-| Find a CLI command or config key | [Reference](/reference/) |
-| Integrate Holon into another system | [Integration guide](/guides/integration/) |
-| Understand a runtime contract | [RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs) |
-| See why a design choice was made | [Implementation decisions](https://github.com/holon-run/holon/tree/main/docs/implementation-decisions) |
-| Contribute to the runtime | [Architecture overview](https://github.com/holon-run/holon/blob/main/docs/architecture-overview.md) |
+**Audience:** New users, evaluators, integrators, and contributors learning Holon.
 
-## The three layers
+**Goal:** Explain why Holon exists, guide first success, and expose stable-enough
+concepts without overwhelming readers with RFC detail.
 
-### Layer 1: User-facing website (`docs/website/`)
-
-**Audience:** New users, evaluators, integrators, and operators.
-
-**Goal:** Explain what Holon is, guide first success, and document the current
-surface without requiring RFC knowledge.
+**Structure:**
 
 | Section | Purpose |
 |---------|---------|
-| Home | Product promise, audiences, brand hierarchy |
-| Getting started | Shortest path from install to first agent interaction |
-| Concepts | Mental model: agents, work items, tasks, queues, trust boundaries |
+| Home | Product promise, audiences, brand hierarchy, first CTA |
+| Getting started | Shortest path from clone to first agent interaction |
+| Concepts | Four-object mental model before deep lifecycle vocabulary |
 | Guides | Task-oriented workflows grouped by user job |
-| Reference | Current-contract CLI, config, and HTTP control-plane snapshots |
+| Reference | Current-contract CLI, config, and control-plane snapshots |
+| Roadmap | User-facing milestones and stability expectations |
 
-**Rule:** Website pages explain *what* and *how*. Link to RFCs for *why the
-design works that way*.
+**Rule:** Website pages should explain *what* and *how*, not *why the design
+works that way*. Link to RFCs for design rationale.
 
-### Layer 2: Current public contract
+## Layer 2: Runtime specs (`docs/website/spec/`)
+
+**Audience:** Maintainers and contributors who need the current runtime contract.
+
+**Goal:** Describe the current implementation-facing contract — what Holon
+actually does today, verified against implementation and tests.
+
+**Rule:** Spec pages are not user tutorials. They are authoritative contracts.
+Each spec page links to the source RFCs that motivated the design and tracks
+known implementation/RFC/test gaps. When runtime behavior changes, the spec
+page and the RFC should be updated together.
+
+## Layer 3: Current public contract
 
 **Audience:** Users running, configuring, integrating, or troubleshooting Holon.
 
-**Goal:** Describe only behavior that is current or explicitly marked as changing.
+**Goal:** Describe only behavior that is current or explicitly marked stable.
 
 **Includes:**
 
 - `docs/website/reference/` — CLI, configuration, and HTTP control-plane pages
-  verified against the compiled runtime
-- `README.md` — high-level project entry with install, provider setup, and docs
-  navigation
-- `docs/runtime-spec.md` — implementation-facing aggregate spec (not the sole
-  authority; accepted RFCs and reference pages are more specific)
+- `README.md` — high-level repository entry and contributor orientation
+- `docs/website/spec/` — current implementation-facing contracts
+- `docs/runtime-spec.md` — implementation-facing spec (not a user tutorial)
 
-**Rule:** Reference pages track a specific release version. If behavior is
-experimental, the page says so.
+**Rule:** Reference pages should be verified against the compiled runtime
+(`holon --help`, `holon config schema`). Mark the version each page was last
+checked against. If behavior is experimental, say so.
 
-### Layer 3: Maintainer design (`docs/rfcs/`, `docs/implementation-decisions/`, `docs/archive/`)
+## Layer 4: Maintainer design (`docs/`, `docs/rfcs/`, `docs/implementation-decisions/`)
 
-**Audience:** Maintainers and contributors changing runtime behavior.
+**Audience:** Maintainers and contributors changing runtime semantics.
 
 **Goal:** Preserve architecture contracts, design rationale, and historical
-decisions.
+decisions. These are the canonical source of truth for runtime behavior.
+
+**Structure:**
 
 | Location | Content type |
 |----------|-------------|
 | `docs/rfcs/` | Canonical design contracts — one RFC per runtime concept |
 | `docs/implementation-decisions/` | ADR-style records — one decision per file |
-| `docs/archive/` | Superseded notes and historical design docs |
-| `docs/architecture-overview.md` | Short architecture map with RFC reading path |
+| `docs/archive/` | Superseded notes, historical design docs |
+| `docs/documentation-cleanup-audit.md` | Maintenance audit tracking drift between layers |
 
 **Rule:** When a runtime concept changes, update the RFC first. Implementation
-decisions capture *why*. Archives preserve history.
-
-## Authority boundaries
-
-When sources conflict, prefer the more specific and current document:
-
-1. **Accepted RFC** (specific domain) over `runtime-spec.md` (aggregate)
-2. **Reference page** (current release) over RFC (design intent)
-3. **Website concept page** (user explanation) over RFC (design detail)
-4. **Implementation decision** (rationale) over archived notes (history)
-
-`docs/runtime-spec.md` is an early aggregate contract, not the single source of
-truth. When a domain has a more specific accepted RFC or a current reference
-page, prefer that more specific document.
+decisions capture *why* a choice was made. Archives preserve history without
+cluttering the active surface.
 
 ## Cross-layer links
 
-- Website pages link to RFCs as deeper design background — not as required reading.
-- The repository `README.md` links to the website as the user-facing entry point.
-- The architecture overview (`docs/architecture-overview.md`) points to RFCs for
-  detailed contracts.
+- Website pages link to RFCs as "deeper design background" — not as required
+  reading.
+- The repository `README.md` links to the website as the product entry point.
+- The documentation cleanup audit (`docs/documentation-cleanup-audit.md`)
+  tracks stale references and vocabulary drift across layers.
 
 ## When to update which layer
 
 | Change | Primary target | Secondary |
 |--------|---------------|-----------|
 | New CLI command | Reference page | Guides, getting-started |
-| Config key change | Reference page, config schema | Guides that reference it |
-| Runtime concept change | RFC | Concepts page |
+| Config key change | Reference page, config schema | Reference page in site |
+| Runtime concept change | RFC | Concepts page, reference |
 | New user workflow | Guides | Getting-started |
 | Product messaging | Homepage | README |
 | Design rationale | Implementation decision | RFC if normative |
-
-## See also
-
-- [Architecture overview](https://github.com/holon-run/holon/blob/main/docs/architecture-overview.md) — repository architecture map
-- [RFC index](https://github.com/holon-run/holon/tree/main/docs/rfcs) — all current RFCs
-- [Implementation decisions](https://github.com/holon-run/holon/tree/main/docs/implementation-decisions) — design rationale records

--- a/docs/website/concepts/documentation-layers.md
+++ b/docs/website/concepts/documentation-layers.md
@@ -47,7 +47,7 @@ page and the RFC should be updated together.
 
 **Audience:** Users running, configuring, integrating, or troubleshooting Holon.
 
-**Goal:** Describe only behavior that is current or explicitly marked stable.
+**Goal:** Describe current behavior. Mark experimental or unstable behavior clearly.
 
 **Includes:**
 

--- a/docs/website/concepts/runtime-model.md
+++ b/docs/website/concepts/runtime-model.md
@@ -98,41 +98,30 @@ background behavior.
 
 ### External Triggers
 
-External triggers let an agent wait for events from outside the runtime.
-Triggers are configured at the runtime level (via a URL endpoint or integration
-config) rather than created by the agent as tool calls:
+External triggers let an agent wait for events from outside the runtime:
 
 ```text
-Agent waits ──► Trigger URL configured ──► External event arrives ──► Agent wakes
+Agent waits ──► External ingress provisioned ──► Event arrives ──► Agent wakes
 ```
 
-**Delivery modes** control how the trigger interacts with the agent:
+Holon provisions a default external ingress capability for each agent. The
+agent uses this capability to receive wake hints and contentful external
+events without creating or cancelling triggers on every wait cycle.
+
+**Delivery modes:**
 
 | Mode | Behavior |
 |------|----------|
-| `wake_hint` | Wakes the agent so it can inspect external state (e.g., check a CI run). The trigger payload is not enqueued as a message. |
-| `enqueue_message` | Wakes the agent **and** delivers the trigger payload as a message in the agent's queue. |
+| `wake_hint` | Wakes the agent so it can inspect external state (e.g., check a CI run). The hint payload is not enqueued as a message. |
+| `enqueue_message` | Wakes the agent **and** delivers the event payload as a message in the agent's queue. |
 
 Choose `wake_hint` when the external system already has a query API (GitHub
 API, CI status endpoints). Choose `enqueue_message` when the callback payload
 itself contains the actionable information.
 
-Triggers are agent-scoped capability URLs. The same agent ingress can be reused
-across PRs, CI runs, issues, and WorkItems; WorkItems record their waiting
-state separately through `blocked_by`, `plan_status`, and todo state.
-
-Common integration patterns:
-
-- **Waiting for CI** — Configure a `wake_hint` trigger for GitHub CI events.
-  The agent sets `blocked_by` on the WorkItem and sleeps. When CI completes,
-  the trigger wakes the agent, which checks the run status and continues or
-  updates the WorkItem.
-- **Webhook callbacks** — Configure an `enqueue_message` trigger so the
-  webhook body enters the agent queue with provenance preserved. The agent
-  sets `blocked_by` on the WorkItem and processes the payload on wake.
-- **Operator input** — No external trigger needed. Set
-  `plan_status=needs_input` on the WorkItem and sleep. The operator's next
-  prompt wakes the agent.
+External ingress capabilities are agent-scoped. The same agent ingress can be
+reused across PRs, CI runs, issues, and WorkItems; WorkItems record their
+waiting state separately through `blocked_by`, `plan_status`, and todo state.
 
 ### Delivery
 

--- a/docs/website/spec/README.md
+++ b/docs/website/spec/README.md
@@ -1,0 +1,59 @@
+---
+title: Runtime specs
+summary: Current implementation-facing runtime contracts for maintainers and contributors.
+order: 1
+---
+
+# Runtime specs
+
+Spec pages describe the **current runtime contract** — what the Holon runtime
+actually does today, verified against implementation and tests.
+
+Specs are not tutorials or user guides. They are authoritative contracts for
+contributors, maintainers, and integrators who need to understand or change
+how the runtime behaves.
+
+## How specs fit into the documentation model
+
+| Layer | What | Audience |
+|-------|------|----------|
+| [Guides](/guides/) | Task-oriented workflows | Users |
+| [Concepts](/concepts/) | Mental model | Users, evaluators |
+| [Reference](/reference/) | CLI, config, control-plane snapshots | Users, integrators |
+| **Specs** (here) | Current runtime contracts | Maintainers, contributors |
+| [RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs) | Design records and rationale | Maintainers |
+
+Specs bridge the gap between user-facing docs and RFC design history. When an
+RFC stabilizes into runtime behavior, the current contract is extracted here.
+The RFC remains the design record; the spec is the living contract.
+
+## Reading a spec
+
+Each spec page follows a consistent shape:
+
+- **Contract** — the normative behavior the runtime implements.
+- **Validation** — how the contract was checked against implementation, tests,
+  and RFCs.
+- **RFCs** — linked source design records.
+- **Known gaps** — tracked follow-up issues for unresolved drift.
+
+## Current spec pages
+
+<!-- INDEX:START -->
+
+<!-- INDEX:END -->
+
+## Relationship to `docs/runtime-spec.md`
+
+[`docs/runtime-spec.md`](https://github.com/holon-run/holon/blob/main/docs/runtime-spec.md)
+is the original v0 aggregate spec. It remains the implementation-facing
+baseline, but individual topic contracts are gradually extracted into focused
+spec pages here. When a topic has a dedicated spec page, that page is the
+current authority; `runtime-spec.md` is the fallback for topics not yet
+extracted.
+
+## For contributors
+
+When you change runtime behavior, update the relevant spec page alongside the
+RFC. Spec pages are verified against implementation — if the implementation
+and spec disagree, fix the one that is wrong and open an issue for the other.

--- a/docs/website/spec/README.md
+++ b/docs/website/spec/README.md
@@ -41,6 +41,38 @@ Each spec page follows a consistent shape:
 
 <!-- INDEX:START -->
 
+- [Agent state](./agent-state.md)
+  Current agent state, lifecycle labels, runtime projection, and user-facing display contract.
+  <!-- mdorigin:index kind=article -->
+
+- [Work items](./work-items.md)
+  Current WorkItem lifecycle, focus, readiness, planning, blocking, and completion contract.
+  <!-- mdorigin:index kind=article -->
+
+- [Scheduler](./scheduler.md)
+  Current scheduler input, runnable/waiting decisions, WorkItem readiness, and wake/sleep boundaries.
+  <!-- mdorigin:index kind=article -->
+
+- [Wake and continuation](./wake-and-continuation.md)
+  Current trigger classification, external ingress capabilities, continuation resolution, and wake/sleep lifecycle.
+  <!-- mdorigin:index kind=article -->
+
+- [Tasks](./tasks.md)
+  Current task lifecycle, background blocking, terminal re-entry, and command/child-agent supervision contract.
+  <!-- mdorigin:index kind=article -->
+
+- [Tools](./tools.md)
+  Current model-facing tool families, authority boundaries, input/result contracts, and deprecated surfaces.
+  <!-- mdorigin:index kind=article -->
+
+- [Workspace and execution](./workspace-and-execution.md)
+  Current workspace identity, agent home, execution roots, worktrees, and host-local policy contract.
+  <!-- mdorigin:index kind=article -->
+
+- [Trust and provenance](./trust-and-provenance.md)
+  Current origin classification, admission/authentication, authority, and provenance tracking contract.
+  <!-- mdorigin:index kind=article -->
+
 <!-- INDEX:END -->
 
 ## Relationship to `docs/runtime-spec.md`

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -17,11 +17,11 @@ as of the last review date noted below.
 
 ## Source RFCs
 
-- [Agent State Model And Runtime Projection](../rfcs/agent-state-model.md)
-- [Agent Lifecycle Control Posture](../rfcs/agent-lifecycle-control-posture.md)
-- [Agent Control Plane Model](../rfcs/agent-control-plane-model.md)
-- [Agent Profile Model](../rfcs/agent-profile-model.md)
-- [Agent Initialization and Template](../rfcs/agent-initialization-and-template.md)
+- [Agent State Model And Runtime Projection](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-state-model.md)
+- [Agent Lifecycle Control Posture](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-lifecycle-control-posture.md)
+- [Agent Control Plane Model](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-control-plane-model.md)
+- [Agent Profile Model](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-profile-model.md)
+- [Agent Initialization and Template](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-initialization-and-template.md)
 
 ## Authoritative records vs projections
 

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -1,0 +1,191 @@
+---
+title: Agent state
+summary: Current agent state, lifecycle labels, runtime projection, and user-facing display contract.
+order: 10
+---
+
+# Agent state
+
+This page defines the current contract for agent state, lifecycle, and
+runtime projection in Holon. It is verified against implementation and tests
+as of the last review date noted below.
+
+> **Last verified:** 2026-05-23 against `src/types.rs` `AgentState`,
+> `AgentStatus`, `AgentIdentityView`, `AgentSchedulingPosture`,
+> `AgentPostureProjection`, `ClosureDecision`, `ContinuationResolution`,
+> `RuntimePosture`, and `AgentSummary`.
+
+## Source RFCs
+
+- [Agent State Model And Runtime Projection](../rfcs/agent-state-model.md)
+- [Agent Lifecycle Control Posture](../rfcs/agent-lifecycle-control-posture.md)
+- [Agent Control Plane Model](../rfcs/agent-control-plane-model.md)
+- [Agent Profile Model](../rfcs/agent-profile-model.md)
+- [Agent Initialization and Template](../rfcs/agent-initialization-and-template.md)
+
+## Authoritative records vs projections
+
+Agent state is **derived** from authoritative runtime records, not stored as a
+single opaque status field. The key distinction is:
+
+| Layer | What | Authority |
+|-------|------|-----------|
+| **Identity** | `agent_id`, kind, visibility, ownership, profile preset | Agent registry record |
+| **Lifecycle status** | `AgentStatus` — Booting, AwakeIdle, AwakeRunning, AwaitingTask, Asleep, Stopped | Scheduler executor (single writer) |
+| **Scheduling posture** | `AgentSchedulingPosture` — derived from queue, WorkItems, tasks, wait state | Scheduler `derive_posture` projection |
+| **Runtime posture** | `RuntimePosture` — Awake or Sleeping | Closure decision at turn end |
+| **Continuation** | `ContinuationResolution` — how the agent was reactivated | Ingress/dispatch at turn start |
+| **User-facing summary** | `AgentSummary` — stable projection for API/UI/model display | `AgentGet` tool + HTTP `/agents` |
+
+`AgentSummary` is a **display projection**, not the source of truth for
+scheduling decisions. The scheduler must derive posture from queue, WorkItem,
+task, and wait state, not from summary fields.
+
+## Agent lifecycle status (`AgentStatus`)
+
+```text
+                ┌─────────────┐
+                │   Booting   │
+                └──────┬──────┘
+                       │ daemon_start / Start
+                       ▼
+                ┌─────────────┐
+         ┌─────►│  AwakeIdle  │◄─────────────┐
+         │      └──────┬──────┘              │
+         │             │ turn starts         │
+         │             ▼                     │
+         │      ┌──────────────┐             │
+         │      │ AwakeRunning │             │
+         │      └──────┬───────┘             │
+         │             │ closure: Sleep      │
+         │             ▼                     │
+         │      ┌─────────────┐     ┌────────┴──────┐
+         ├──────│    Asleep    │────►│  AwaitingTask │
+         │      └─────────────┘     └────────┬──────┘
+         │         wake / resume              │ task result
+         │                                    │
+         └────────────────────────────────────┘
+
+                          Stop ──► ┌──────────┐
+                                   │  Stopped  │
+                                   └──────────┘
+```
+
+| Status | Meaning |
+|--------|---------|
+| `Booting` | Agent is initializing; not yet handed to the scheduler |
+| `AwakeIdle` | Agent is awake but no model turn is in progress |
+| `AwakeRunning` | A model turn is currently executing |
+| `AwaitingTask` | Agent is awake but blocked on a non-terminal task result |
+| `Asleep` | Agent called `Sleep` at end of turn; no model turn running |
+| `Stopped` | Agent lifecycle is stopped; scheduler will not start new turns |
+
+**Key contract:**
+
+- `Sleep` sets status to `Asleep` — it is a turn-end posture, not an
+  authoritative "idle" declaration.
+- An `Asleep` agent can have runnable WorkItems. `Asleep` does **not** mean
+  idle or empty.
+- `AwaitingTask` means a non-terminal task (command, child agent) blocks
+  further model reentry; the agent is still awake and the scheduler can wake
+  it when the task completes.
+- `Stopped` is a hard lifecycle boundary. The scheduler will not start new
+  turns for a stopped agent. Stopped agents release runtime-owned execution
+  resources.
+- Status transitions flow through scheduler-owned helpers; no module should
+  directly mutate `AgentState.status` without going through the scheduler
+  executor.
+
+## Scheduling posture (`AgentSchedulingPosture`)
+
+The scheduler derives a scheduling posture from current state. This is a
+**projection**, not stored state:
+
+| Posture | Condition |
+|---------|-----------|
+| `ActiveTurn` | A model turn is currently running |
+| `HasQueuedInput` | Queue contains pending operator messages |
+| `HasRunnableWork` | At least one WorkItem is runnable |
+| `WaitingForTask` | An active non-terminal task is blocking |
+| `WaitingForExternal` | Agent is waiting on an external event |
+| `WaitingForOperator` | WorkItem `plan_status=needs_input` |
+| `Blocked` | WorkItem has `blocked_by` set |
+| `Idle` | No queued input, no runnable work, no blocking conditions |
+| `Unknown` | Default before first projection |
+| `Archived` | Not currently used |
+
+**Key contract:**
+
+- Posture is derived from queue depth, WorkItem readiness, waiting state,
+  task blocking state, and external triggers.
+- Posture is snapshot-derived; it is not persisted as durable state.
+- `AgentSummary.scheduling_posture` exposes this projection; consumers should
+  not treat it as an authoritative scheduling input.
+
+## Closure and continuation
+
+At the end of each turn, the closure decision determines next posture:
+
+| `ClosureOutcome` | Effect |
+|------------------|--------|
+| `Completed` | Work completed; agent ready for next work |
+| `Continuable` | Work continues; same WorkItem remains active |
+| `Failed` | Turn failed; agent can recover or escalate |
+| `Waiting` | Agent is waiting for operator, external, task, or timer |
+
+When a waiting agent is reactivated, `ContinuationResolution` records:
+
+| Field | Meaning |
+|-------|---------|
+| `trigger_kind` | OperatorInput, TaskResult, ExternalEvent, TimerFire, InternalFollowup, SystemTick |
+| `class` | ResumeExpectedWait, ResumeOverride, LocalContinuation, LivenessOnly |
+| `model_reentry` | Whether the model should be re-entered with context |
+| `matched_waiting_reason` | Whether the trigger matched the prior waiting reason |
+
+## User-facing projection (`AgentSummary`)
+
+`AgentSummary` is the stable projection returned by `AgentGet` and
+`GET /agents`. It includes:
+
+- `identity` — agent identity badge (visibility/ownership/profile)
+- `agent` — core `AgentState` including status, pending count, turn index
+- `scheduling_posture` — derived posture snapshot
+- `lifecycle` — lifecycle hint (not authoritative)
+- `model` — current model selection and token usage
+- `closure` — last closure decision
+- `execution` — execution snapshot (run id, cwd, workspace)
+- `active_children` — visible child agent summaries
+- `active_waiting_intents` / `active_wait_conditions` — current wait state
+- `active_external_triggers` — provisioned external ingress capabilities
+
+**Key contract:**
+
+- `AgentSummary` is assembled on read from authoritative records.
+- Fields are added conservatively; do not use `AgentSummary` as a dumping
+  ground for internal state.
+- The model receives `AgentSummary` (via `AgentGet`) as display information,
+  not as a scheduling instruction.
+- API consumers must not depend on summary field ordering or presence of
+  default/empty fields.
+
+## Lifecycle control
+
+Agent lifecycle control is `Start` / `Stop`:
+
+- `Start` hands the agent to the scheduler. It does **not** directly start a
+  model turn; the scheduler decides whether the agent should be idle or
+  process queued input.
+- `Stop` aborts the current run, releases runtime-owned execution resources,
+  and marks the agent as not runnable. Queued messages and durable records
+  are preserved.
+- There is no `Pause` / `Resume`. `Stop` + `Start` is the contract.
+
+## Known gaps
+
+- `AgentStatus` still includes transitionary states (`Booting`, `AwaitingTask`)
+  that may collapse as the scheduler model matures. See follow-up if
+  `AwaitingTask` becomes fully subsumed by `AwakeIdle` + task blocking.
+- `AgentLifecycleHint` is under-defined; its relationship to `AgentStatus` and
+  `AgentSchedulingPosture` is not yet a stable contract.
+- `AgentSummary` includes some fields (`recent_operator_notifications`,
+  `recent_brief_count`) whose contract is not yet hardened.

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -111,8 +111,8 @@ The scheduler derives a scheduling posture from current state. This is a
 | `WaitingForOperator` | WorkItem `plan_status=needs_input` |
 | `Blocked` | WorkItem has `blocked_by` set |
 | `Idle` | No queued input, no runnable work, no blocking conditions |
-| `Unknown` | Default before first projection |
-| `Archived` | Not currently used |
+| `Unknown` | Default before first projection; not part of the stable contract |
+| `Archived` | Agent lifecycle is stopped (maps from `AgentStatus::Stopped`) |
 
 **Key contract:**
 
@@ -189,3 +189,13 @@ Agent lifecycle control is `Start` / `Stop`:
   `AgentSchedulingPosture` is not yet a stable contract.
 - `AgentSummary` includes some fields (`recent_operator_notifications`,
   `recent_brief_count`) whose contract is not yet hardened.
+- `WorkItemSchedulingState` has `WaitingTimer` and `WaitingSystem` variants
+  not listed in the RFC. See [issue #1378](https://github.com/holon-run/holon/issues/1378).
+- `AgentStatus::Asleep` is used directly in scheduler decisions
+  (`scheduler.rs:803,903`) instead of being derived via `AgentSchedulingPosture`.
+- `AgentStatus::AwaitingTask` exists in code but is not in the RFC's target
+  status set (`agent-lifecycle-control-posture.md`).
+- `AgentLifecycleHint` retains `resume_*` fields from the deprecated Pause/Resume
+  model. See [issue #1378](https://github.com/holon-run/holon/issues/1378).
+- `AgentSchedulingPosture::Archived` is used (for `Stopped` agents) contrary
+  to the previous spec claim of "Not currently used".

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -136,9 +136,20 @@ WorkItems flow through scheduling states that the scheduler consumes:
 
 ## Known gaps
 
-- `StayIdle` and `Sleep` overlap conceptually; `StayIdle` could be subsumed by
-  a richer `Sleep` decision that carries an "already asleep" flag.
-- `ReduceMessageOnly` is under-defined — its contract for when a message can
-  be reduced without a full model turn is not yet a stable public API.
+- `WaitingTimer` and `WaitingSystem` variants exist in both
+  `WorkItemSchedulingState` and scheduler decisions (`wait_decision_for_projection`)
+  without RFC coverage. The RFC defines `WaitingOperator, WaitingTask,
+  WaitingExternal, Blocked` but not these timer/system variants. See
+  [issue #1380](https://github.com/holon-run/holon/issues/1380).
+- `idle_boundary_decision` (`scheduler.rs:903`) gates on
+  `AgentStatus::Asleep` before inspecting work facts, which can strand
+  runnable work behind an `Asleep` status check. The RFC says scheduling
+  should derive from WorkItem/wait facts, not lifecycle status labels. See
+  [issue #1380](https://github.com/holon-run/holon/issues/1380).
+- `SchedulerDecisionKind` has 11 variants (`StartModelTurn, ReduceMessageOnly,
+  EmitSystemTick, WaitForTask, …`) while the RFC suggests ~6 high-level
+  posture outcomes. The added granularity is useful but the RFC vocabulary is
+  too coarse to describe current behavior. See
+  [issue #1380](https://github.com/holon-run/holon/issues/1380).
 - The scheduler does not yet expose a public diagnostic event stream for
   observability; diagnostic events exist but are audit-only.

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -15,11 +15,11 @@ consumes, how it derives posture and runnability, and what decisions it emits.
 
 ## Source RFCs
 
-- [Runtime Scheduler Contract](../rfcs/runtime-scheduler-contract.md)
-- [Scheduler Wait State And Recoverable Agent Continuation](../rfcs/scheduler-wait-state.md)
-- [Waiting Plane And Reactivation](../rfcs/waiting-plane-and-reactivation.md)
-- [Continuation Trigger](../rfcs/continuation-trigger.md)
-- [Work Item Centered Agent Runtime](../rfcs/work-item-centered-agent-runtime.md)
+- [Runtime Scheduler Contract](https://github.com/holon-run/holon/blob/main/docs/rfcs/runtime-scheduler-contract.md)
+- [Scheduler Wait State And Recoverable Agent Continuation](https://github.com/holon-run/holon/blob/main/docs/rfcs/scheduler-wait-state.md)
+- [Waiting Plane And Reactivation](https://github.com/holon-run/holon/blob/main/docs/rfcs/waiting-plane-and-reactivation.md)
+- [Continuation Trigger](https://github.com/holon-run/holon/blob/main/docs/rfcs/continuation-trigger.md)
+- [Work Item Centered Agent Runtime](https://github.com/holon-run/holon/blob/main/docs/rfcs/work-item-centered-agent-runtime.md)
 
 ## Core model
 

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -1,0 +1,144 @@
+---
+title: Scheduler
+summary: Current scheduler input, runnable/waiting decisions, WorkItem readiness, and wake/sleep boundaries.
+order: 30
+---
+
+# Scheduler
+
+This page defines the current contract for Holon's scheduler: what inputs it
+consumes, how it derives posture and runnability, and what decisions it emits.
+
+> **Last verified:** 2026-05-23 against `src/runtime/scheduler.rs`,
+> `src/runtime/scheduler_executor.rs`, `src/runtime/waiting.rs`,
+> `src/runtime/closure.rs`.
+
+## Source RFCs
+
+- [Runtime Scheduler Contract](../rfcs/runtime-scheduler-contract.md)
+- [Scheduler Wait State And Recoverable Agent Continuation](../rfcs/scheduler-wait-state.md)
+- [Waiting Plane And Reactivation](../rfcs/waiting-plane-and-reactivation.md)
+- [Continuation Trigger](../rfcs/continuation-trigger.md)
+- [Work Item Centered Agent Runtime](../rfcs/work-item-centered-agent-runtime.md)
+
+## Core model
+
+The scheduler is the runtime component that answers: given the current agent
+state, what should happen next?
+
+It consumes a `SchedulerProjection` — a snapshot assembled from:
+
+| Input | Source |
+|-------|--------|
+| Agent status | `AgentState.status` |
+| Queue depth | `AgentState.pending` |
+| Active tasks | `TaskRecord`s with non-terminal status |
+| Current WorkItem | `current_work_item_id` → `WorkItemRecord` |
+| Runnable WorkItems | Open WorkItems with `is_runnable()=true` |
+| Wait conditions | Active `WaitConditionRecord`s |
+| Waiting intents | Active `WaitingIntentRecord`s |
+| Wake hints | `PendingWakeHint` |
+| Turn state | `turn_in_progress`, `last_turn_terminal` |
+| Runtime errors | `runtime_error_active()` |
+
+The projection is a **read-only snapshot**; the scheduler never mutates
+durable state directly. Decisions are emitted and handed to the executor.
+
+## Scheduler inputs (`SchedulerInput`)
+
+| Input variant | Trigger |
+|---------------|---------|
+| `Message` | A new message arrived in the agent's queue |
+| `IdleSignal::WakeHint` | A pending wake hint was received |
+| `IdleSignal::ContinueActive` | A WorkItem was runnable at the last closure |
+| `IdleSignal::QueuedAvailable` | A queued message is ready for processing |
+| `Idle` | Periodic idle boundary check |
+
+## Scheduler decisions (`SchedulerDecisionKind`)
+
+| Decision | Meaning |
+|----------|---------|
+| `StartModelTurn` | Start a new model turn with context assembly |
+| `ReduceMessageOnly` | Reduce a message without starting a full model turn |
+| `EmitSystemTick` | Emit a runtime-owned follow-up message (system tick) |
+| `WaitForTask` | Block until a non-terminal task completes |
+| `WaitForExternalChange` | Block until an external event arrives |
+| `WaitForTimer` | Block until a timer fires |
+| `WaitForOperator` | Block until operator input arrives |
+| `Sleep` | Agent sleeps; no immediate action, wait for wake signal |
+| `StayIdle` | Agent is already asleep; no action |
+| `Stop` | Agent is stopped; no scheduling possible |
+| `Noop` | No action (duplicate suppressed, turn in progress) |
+
+Each decision carries metadata: `reason`, `model_reentry`, `liveness_only`,
+`work_item_id`, `task_id`, and `evidence`.
+
+## Decision flow
+
+```text
+                    SchedulerInput
+                         │
+                         ▼
+              ┌─────────────────────┐
+              │ Status == Stopped?  │──Yes──► Stop
+              └─────────┬───────────┘
+                        │ No
+                        ▼
+              ┌─────────────────────┐
+              │ Turn in progress?   │──Yes──► Noop
+              └─────────┬───────────┘
+                        │ No
+                        ▼
+         ┌──────────────────────────┐
+         │ Queue has pending input? │──Yes──► StartModelTurn
+         └──────────────┬───────────┘        (or ReduceMessageOnly)
+                        │ No
+                        ▼
+         ┌──────────────────────────┐
+         │ Runnable WorkItem?       │──Yes──► EmitSystemTick
+         └──────────────┬───────────┘        (ContinueActive)
+                        │ No
+                        ▼
+         ┌──────────────────────────┐
+         │ Active wait condition?   │──Yes──► WaitFor{Task,
+         └──────────────┬───────────┘         External,Timer,Operator}
+                        │ No
+                        ▼
+                      Sleep
+```
+
+## WorkItem scheduling states
+
+WorkItems flow through scheduling states that the scheduler consumes:
+
+| State | Meaning | Scheduler action |
+|-------|---------|-----------------|
+| `Runnable` | Ready for processing | May be auto-picked as current |
+| `WaitingOperator` | `plan_status=NeedsInput` | Agent waits for operator |
+| `Blocked` | `blocked_by` set | Not runnable; check `recheck_at` |
+| `WaitingTask` | Wait condition on task result | Wake on task terminal |
+| `WaitingExternal` | Wait condition on external event | Wake on external trigger |
+| `Completed` | `state=Completed` | Excluded from runnable set |
+
+## Wake/sleep boundary
+
+- `Sleep` is a scheduler decision (not a tool). The model calls `Sleep` to
+  signal turn-end; the scheduler then decides whether the agent truly becomes
+  `Asleep` or continues with queued work.
+- `StayIdle` means the agent is already asleep and the scheduler has nothing
+  to do; this is distinct from `Sleep` (the initial transition).
+- `EmitSystemTick` injects an internal follow-up message to re-enter the model
+  when a runnable WorkItem is found at an idle boundary.
+- Wake hints are **liveness signals**: they tell the scheduler to re-evaluate
+  but do not themselves carry content for the model.
+- Duplicate suppression uses idempotency keys to prevent redundant system
+  ticks for the same wake hint or continue-active signal.
+
+## Known gaps
+
+- `StayIdle` and `Sleep` overlap conceptually; `StayIdle` could be subsumed by
+  a richer `Sleep` decision that carries an "already asleep" flag.
+- `ReduceMessageOnly` is under-defined — its contract for when a message can
+  be reduced without a full model turn is not yet a stable public API.
+- The scheduler does not yet expose a public diagnostic event stream for
+  observability; diagnostic events exist but are audit-only.

--- a/docs/website/spec/tasks.md
+++ b/docs/website/spec/tasks.md
@@ -111,3 +111,8 @@ Tasks are **execution handles**, not planning objects:
 
 Tasks often serve WorkItem objectives (running commands, delegating to child
 agents), but task lifecycle is independent of WorkItem lifecycle.
+
+## Known gaps
+
+- `TaskWaitPolicy::Blocking` is defined in the type system but never used in
+  practice. See [issue #1382](https://github.com/holon-run/holon/issues/1382).

--- a/docs/website/spec/tasks.md
+++ b/docs/website/spec/tasks.md
@@ -16,12 +16,12 @@ blocking behavior, terminal re-entry, and supervision surfaces.
 
 ## Source RFCs
 
-- [Command Tool Family](../rfcs/command-tool-family.md)
-- [Task Surface Narrowing](../rfcs/task-surface-narrowing.md)
-- [Interactive Command Continuation](../rfcs/interactive-command-continuation.md)
-- [Agent Delegation Tool Plane](../rfcs/agent-delegation-tool-plane.md)
-- [Agent Control Plane Model](../rfcs/agent-control-plane-model.md)
-- [Runtime Scheduler Contract](../rfcs/runtime-scheduler-contract.md)
+- [Command Tool Family](https://github.com/holon-run/holon/blob/main/docs/rfcs/command-tool-family.md)
+- [Task Surface Narrowing](https://github.com/holon-run/holon/blob/main/docs/rfcs/task-surface-narrowing.md)
+- [Interactive Command Continuation](https://github.com/holon-run/holon/blob/main/docs/rfcs/interactive-command-continuation.md)
+- [Agent Delegation Tool Plane](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-delegation-tool-plane.md)
+- [Agent Control Plane Model](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-control-plane-model.md)
+- [Runtime Scheduler Contract](https://github.com/holon-run/holon/blob/main/docs/rfcs/runtime-scheduler-contract.md)
 
 ## Task kinds
 

--- a/docs/website/spec/tasks.md
+++ b/docs/website/spec/tasks.md
@@ -1,0 +1,113 @@
+---
+title: Tasks
+summary: Current task lifecycle, background blocking, terminal re-entry, and command/child-agent supervision contract.
+order: 50
+---
+
+# Tasks
+
+This page defines the current contract for managed task execution: lifecycle,
+blocking behavior, terminal re-entry, and supervision surfaces.
+
+> **Last verified:** 2026-05-23 against `src/types.rs` `TaskRecord`,
+> `TaskStatus`, `TaskKind`, `TaskHandle`, `TaskWaitPolicy`, and the tool
+> implementations in `src/tool/tools/{exec_command,task_list,task_status,
+> task_output,task_input,task_stop,spawn_agent}.rs`.
+
+## Source RFCs
+
+- [Command Tool Family](../rfcs/command-tool-family.md)
+- [Task Surface Narrowing](../rfcs/task-surface-narrowing.md)
+- [Interactive Command Continuation](../rfcs/interactive-command-continuation.md)
+- [Agent Delegation Tool Plane](../rfcs/agent-delegation-tool-plane.md)
+- [Agent Control Plane Model](../rfcs/agent-control-plane-model.md)
+- [Runtime Scheduler Contract](../rfcs/runtime-scheduler-contract.md)
+
+## Task kinds
+
+| `TaskKind` | Description |
+|------------|-------------|
+| `CommandTask` | Shell command execution via `ExecCommand` |
+| `ChildAgentTask` | Parent-supervised delegated child agent via `SpawnAgent` |
+| `SleepJob` | Internal sleep timer (not model-visible) |
+| `SubagentTask` | Legacy child agent kind (migrating to `ChildAgentTask`) |
+| `WorktreeSubagentTask` | Legacy worktree-isolated child agent (migrating) |
+
+## Task lifecycle
+
+```text
+              ExecCommand / SpawnAgent
+                       │
+                       ▼
+                 ┌──────────┐
+                 │  Queued  │
+                 └────┬─────┘
+                      │
+                      ▼
+                 ┌──────────┐     TaskStop
+                 │ Running  │──────────────┐
+                 └────┬─────┘              │
+                      │                    ▼
+          ┌───────────┼───────────┐  ┌────────────┐
+          ▼           ▼           ▼  │ Cancelling │
+    ┌──────────┐ ┌──────────┐ ┌────┴─┴─────┐      │
+    │Completed │ │  Failed  │ │Interrupted│      ▼
+    └──────────┘ └──────────┘ └───────────┘┌──────────┐
+                                           │Cancelled │
+                                           └──────────┘
+```
+
+**Terminal states:** `Completed`, `Failed`, `Cancelled`, `Interrupted`.
+**Non-terminal states:** `Queued`, `Running`, `Cancelling`.
+
+## Wait policy
+
+Each task carries a wait policy that determines whether it blocks the agent:
+
+| `TaskWaitPolicy` | Behavior |
+|------------------|----------|
+| `Blocking` | Agent enters `AwaitingTask` and cannot re-enter model until task terminal |
+| `Background` | Task runs independently; agent can continue turns while task is active |
+
+Child-agent tasks are always `Background`. Command tasks default to
+`Background` unless explicitly configured as `Blocking`.
+
+**Key contract:**
+
+- For background tasks, use `Sleep` to wait for the terminal `TaskResult`
+  instead of polling `TaskOutput`.
+- The terminal `TaskResult` event re-enters the agent as continuation context;
+  the runtime wakes the agent automatically.
+- `TaskOutput(block=true)` is for explicit current-turn synchronous waiting,
+  not the default waiting strategy.
+
+## Supervision tools
+
+| Tool | Purpose |
+|------|---------|
+| `TaskList` | Compact active-task digest (non-terminal tasks only) |
+| `TaskStatus` | Single-task lifecycle snapshot with metadata |
+| `TaskOutput` | Bounded output preview with optional `block=true` |
+| `TaskInput` | Send stdin/follow-up input to an interactive task |
+| `TaskStop` | Stop a running task (may transition through `Cancelling`) |
+
+**Key contract:**
+
+- `TaskList` excludes terminal tasks; use `TaskStatus` for historical detail.
+- `TaskOutput` returns a bounded `output_preview` plus artifact refs for full
+  output; it is for inspection, not polling.
+- `TaskInput` accepts input only for tasks created with interactive
+  continuation enabled (`accepts_input=true`).
+- `TaskStop` sends a stop request; the task may first enter `Cancelling`
+  before reaching `Cancelled`.
+
+## Distinction from WorkItems and waiting
+
+Tasks are **execution handles**, not planning objects:
+
+- A `Task` represents a running or queued execution unit.
+- A `WorkItem` represents a durable objective the agent is working toward.
+- `Waiting` represents why a WorkItem or agent cannot proceed.
+
+Tasks often serve WorkItem objectives (running commands, delegating to child
+agents), but task lifecycle is independent of WorkItem lifecycle.

--- a/docs/website/spec/tools.md
+++ b/docs/website/spec/tools.md
@@ -16,13 +16,13 @@ result envelope conventions.
 
 ## Source RFCs
 
-- [Tool Surface Layering](../rfcs/tool-surface-layering.md)
-- [Tool Contract Consistency](../rfcs/tool-contract-consistency.md)
-- [Tool Result Envelope](../rfcs/tool-result-envelope.md)
-- [Task Surface Narrowing](../rfcs/task-surface-narrowing.md)
-- [Command Tool Family](../rfcs/command-tool-family.md)
-- [Apply Patch Unified Diff Contract](../rfcs/apply-patch-unified-diff-contract.md)
-- [Exec Command Batch](../rfcs/exec-command-batch.md)
+- [Tool Surface Layering](https://github.com/holon-run/holon/blob/main/docs/rfcs/tool-surface-layering.md)
+- [Tool Contract Consistency](https://github.com/holon-run/holon/blob/main/docs/rfcs/tool-contract-consistency.md)
+- [Tool Result Envelope](https://github.com/holon-run/holon/blob/main/docs/rfcs/tool-result-envelope.md)
+- [Task Surface Narrowing](https://github.com/holon-run/holon/blob/main/docs/rfcs/task-surface-narrowing.md)
+- [Command Tool Family](https://github.com/holon-run/holon/blob/main/docs/rfcs/command-tool-family.md)
+- [Apply Patch Unified Diff Contract](https://github.com/holon-run/holon/blob/main/docs/rfcs/apply-patch-unified-diff-contract.md)
+- [Exec Command Batch](https://github.com/holon-run/holon/blob/main/docs/rfcs/exec-command-batch.md)
 
 ## Tool families (`ToolCapabilityFamily`)
 

--- a/docs/website/spec/tools.md
+++ b/docs/website/spec/tools.md
@@ -1,0 +1,158 @@
+---
+title: Tools
+summary: Current model-facing tool families, authority boundaries, input/result contracts, and deprecated surfaces.
+order: 60
+---
+
+# Tools
+
+This page defines the current contract for Holon's model-facing tool surface:
+tool families, authority classification, schema/dispatch alignment, and
+result envelope conventions.
+
+> **Last verified:** 2026-05-23 against `src/types.rs`
+> `ToolCapabilityFamily`, `src/tool/tools/mod.rs` `builtin_tool_definitions()`,
+> `src/tool/spec.rs`, `src/tool/dispatch.rs`.
+
+## Source RFCs
+
+- [Tool Surface Layering](../rfcs/tool-surface-layering.md)
+- [Tool Contract Consistency](../rfcs/tool-contract-consistency.md)
+- [Tool Result Envelope](../rfcs/tool-result-envelope.md)
+- [Task Surface Narrowing](../rfcs/task-surface-narrowing.md)
+- [Command Tool Family](../rfcs/command-tool-family.md)
+- [Apply Patch Unified Diff Contract](../rfcs/apply-patch-unified-diff-contract.md)
+- [Exec Command Batch](../rfcs/exec-command-batch.md)
+
+## Tool families (`ToolCapabilityFamily`)
+
+Tools are grouped by capability family for authority gating:
+
+| Family | Tools | Authority |
+|--------|-------|-----------|
+| `CoreAgent` | `Sleep`, `AgentGet`, `Enqueue`, WorkItem tools, `MemorySearch`, `MemoryGet` | All agent profiles |
+| `LocalEnvironment` | `ExecCommand`, `ExecCommandBatch`, `ApplyPatch`, `UseWorkspace` | All profiles |
+| `Web` | `WebFetch`, `WebSearch` | All profiles |
+| `AgentCreation` | `SpawnAgent` | All profiles |
+| `ExternalTrigger` | `CreateExternalTrigger`, `CancelExternalTrigger` | Deprecated |
+| `OperatorNotification` | `NotifyOperator` | All profiles |
+
+## Complete tool listing
+
+### WorkItem plane
+
+| Tool | Purpose |
+|------|---------|
+| `CreateWorkItem` | Create a new open WorkItem |
+| `UpdateWorkItem` | Mutate objective, plan_status, todo_list, blocked_by |
+| `PickWorkItem` | Set current focus |
+| `GetWorkItem` | Read single WorkItem with plan preview |
+| `ListWorkItems` | Query with filters |
+| `CompleteWorkItem` | Mark complete; completion report promotion |
+
+### Task control plane
+
+| Tool | Purpose |
+|------|---------|
+| `ExecCommand` | Start a shell command |
+| `ExecCommandBatch` | Run bounded sequential command batch |
+| `TaskList` | Compact active-task digest |
+| `TaskStatus` | Single-task lifecycle snapshot |
+| `TaskOutput` | Bounded output preview with optional blocking |
+| `TaskInput` | Send input to interactive task |
+| `TaskStop` | Stop a running task |
+
+### Agent plane
+
+| Tool | Purpose |
+|------|---------|
+| `AgentGet` | Read current agent-plane summary |
+| `Sleep` | Signal turn-end; let scheduler decide next action |
+| `Enqueue` | Schedule self-follow-up message |
+| `SpawnAgent` | Delegate work to a child agent |
+
+### Workspace plane
+
+| Tool | Purpose |
+|------|---------|
+| `UseWorkspace` | Switch active workspace |
+| `ApplyPatch` | Apply unified diff patch to files |
+
+### Memory plane
+
+| Tool | Purpose |
+|------|---------|
+| `MemorySearch` | Search agent memory sources |
+| `MemoryGet` | Fetch exact memory content by source_ref |
+
+### Web plane
+
+| Tool | Purpose |
+|------|---------|
+| `WebFetch` | Fetch HTTP/HTTPS URL |
+| `WebSearch` | Web search |
+
+## Tool definition contract
+
+Each tool is defined by a `BuiltinToolDefinition`:
+
+```text
+BuiltinToolDefinition {
+    family: ToolCapabilityFamily,
+    spec: ToolSpec { name, description, parameters },
+}
+```
+
+**Key contract:**
+
+- Tool schemas must match the runtime type used for argument parsing.
+- `serde(deny_unknown_fields)` is enforced on tool argument structs.
+- The `description` field in `ToolSpec` is the model-visible guidance text.
+- Prompt-level tool guidance (in AGENTS.md or system prompt) must not
+  contradict the tool's own description.
+
+## Input/result separation
+
+Holon strictly separates tool **startup input** from **result metadata**:
+
+- Startup input: `cmd`, `workdir`, `shell`, `login`, `tty`,
+  `accepts_input`, `yield_time_ms`, `max_output_tokens`.
+- Result metadata (not valid in startup input): `status`, `task_handle`,
+  `disposition`, `exit_status`, `output_preview`.
+
+**Key contract:**
+
+- Passing result fields as startup input is an error.
+- The model must not confuse the two surfaces. Prompt guidance explicitly
+  documents the distinction via valid/invalid startup examples.
+
+## Result envelope
+
+Tool execution returns a `ToolResult` that may be serialized as JSON or
+rendered as a human-readable receipt:
+
+- **Canonical result:** structured JSON with `content` (array of
+  text/tool_use blocks) and optional `artifacts`.
+- **Human-readable receipt:** rendered text shown to the model; may omit
+  internal fields but must preserve semantically meaningful content.
+
+`ExecCommand` results carry additional fields: `disposition`,
+`initial_output_preview`, `task_handle` (when promoted to command_task).
+
+## Deprecated surfaces
+
+| Tool | Status |
+|------|--------|
+| `CreateExternalTrigger` | Deprecated. Trigger provisioning is now initialization-time. |
+| `CancelExternalTrigger` | Deprecated. Revocation is administrative. |
+
+These tools still exist in `src/tool/tools/` for backward compatibility but
+should not be presented to the model as active tool surfaces.
+
+## Known gaps
+
+- Tool description text is hand-maintained in Rust source; drift between
+  description and actual behavior is possible without automated validation.
+- `ExecCommandBatch` and individual `ExecCommand` calls share fields but have
+  different valid field subsets; no structural schema prevents passing
+  batch-only fields to single `ExecCommand` at the type level.

--- a/docs/website/spec/tools.md
+++ b/docs/website/spec/tools.md
@@ -151,8 +151,16 @@ should not be presented to the model as active tool surfaces.
 
 ## Known gaps
 
+- `ToolCapabilityFamily` has `Web` and `OperatorNotification` variants not
+  documented in the RFC. `Web` is marked `#[deprecated]` but is still available
+  in the type system. See
+  [issue #1383](https://github.com/holon-run/holon/issues/1383).
+- The RFC references `update_work_plan` as a WorkItem tool, but this tool does
+  not exist. The actual contract uses `UpdateWorkItem` for plan_status/todo_list
+  updates and direct file edits on `plan_artifact.path` for plan body changes.
+  See [issue #1383](https://github.com/holon-run/holon/issues/1383).
 - Tool description text is hand-maintained in Rust source; drift between
   description and actual behavior is possible without automated validation.
-- `ExecCommandBatch` and individual `ExecCommand` calls share fields but have
-  different valid field subsets; no structural schema prevents passing
+- `ExecCommandBatch` and individual `ExecCommand` calls share fields but
+  have different valid field subsets; no structural schema prevents passing
   batch-only fields to single `ExecCommand` at the type level.

--- a/docs/website/spec/trust-and-provenance.md
+++ b/docs/website/spec/trust-and-provenance.md
@@ -1,0 +1,125 @@
+---
+title: Trust and provenance
+summary: Current origin classification, admission/authentication, authority, and provenance tracking contract.
+order: 80
+---
+
+# Trust and provenance
+
+This page defines the current contract for how Holon classifies message
+origin, trust, authority, and provenance — and how those labels flow through
+the runtime.
+
+> **Last verified:** 2026-05-23 against `src/types.rs` `MessageEnvelope`,
+> `MessageOrigin`, `TrustLevel`, `AuthorityClass`, `Priority`,
+> `AdmissionContext`, and `src/ingress.rs`.
+
+## Source RFCs
+
+- [Provenance, Admission, and Authority](../rfcs/default-trust-auth-and-control.md)
+- [Event Stream Interface Design](../rfcs/event-stream-interface.md)
+- [Remote Operator Transport and Delivery](../rfcs/remote-operator-transport-and-delivery.md)
+- [Operator Display Levels and Event Presentation](../rfcs/operator-display-levels-and-event-presentation.md)
+- [Tool Surface Layering](../rfcs/tool-surface-layering.md)
+- [Continuation Trigger](../rfcs/continuation-trigger.md)
+
+## Message envelope
+
+Every message in Holon carries provenance labels in its `MessageEnvelope`:
+
+```text
+MessageEnvelope {
+    origin: MessageOrigin,
+    trust: TrustLevel,
+    authority_class: AuthorityClass,
+    priority: Priority,
+    delivery_surface: Option<MessageDeliverySurface>,
+    admission_context: Option<AdmissionContext>,
+    ...
+}
+```
+
+## Origin (`MessageOrigin`)
+
+| Origin variant | Example |
+|----------------|---------|
+| `Operator { actor_id }` | Direct operator input via CLI, HTTP, TUI |
+| `Channel { channel_id, sender_id }` | Message from an external channel |
+| `Webhook { source, event_type }` | External webhook callback |
+| `Callback { descriptor_id, source }` | Legacy callback trigger |
+| `Timer { timer_id }` | Scheduled timer fire |
+| `System { subsystem }` | Runtime-owned internal message |
+| `Task { task_id }` | Task result from a background command or child agent |
+
+## Trust level (`TrustLevel`)
+
+| Level | Meaning | Typical origin |
+|-------|---------|----------------|
+| `TrustedOperator` | Authenticated operator with full authority | `Operator` with valid auth |
+| `TrustedSystem` | Runtime-owned components (scheduler, task supervisor) | `System`, `Task` |
+| `TrustedIntegration` | Configured external system with a known identity | `Webhook` from configured source |
+| `UntrustedExternal` | Unknown or unauthenticated external source | `Webhook` from unknown source |
+
+**Key contract:**
+
+- Trust is assigned at ingress, not by the model.
+- `TrustedOperator` messages carry instruction authority.
+- `UntrustedExternal` messages are treated as evidence, not instructions.
+- The model must not escalate trust based only on message content.
+
+## Authority class (`AuthorityClass`)
+
+| Class | Meaning |
+|-------|---------|
+| `OperatorInstruction` | This message is an instruction the agent should follow |
+| `RuntimeInstruction` | This message is a runtime-owned directive (system tick, task result) |
+| `IntegrationSignal` | This message is a signal from a configured integration |
+| `ExternalEvidence` | This message is untrusted external content for inspection |
+
+**Key contract:**
+
+- `AuthorityClass` is separate from `TrustLevel`. A `TrustedIntegration` message
+  may carry `IntegrationSignal` authority (not `OperatorInstruction`).
+- The model receives both trust and authority labels and must respect the
+  distinction.
+- Operator input and external channel input must not be merged without
+  preserving provenance.
+
+## Priority
+
+| Priority | Scheduling effect |
+|----------|-------------------|
+| `Interject` | Preempts queued work; delivered before normal-priority messages |
+| `Next` | Delivered after current interject messages, before `Normal` |
+| `Normal` | Standard queue position |
+| `Background` | Low-urgency; delivered after higher-priority messages |
+
+Priority affects queue ordering, not trust or authority.
+
+## Admission context
+
+`AdmissionContext` records how a message entered the runtime, including the
+transport (HTTP endpoint, CLI stdin, TUI), authentication method, and any
+gateway metadata. It is preserved in the envelope for audit and diagnostics.
+
+## Provenance preservation
+
+Holon's provenance contract:
+
+- Origin, trust, and authority are **never reassigned** by the model.
+- When the runtime generates internal messages (system ticks, task results,
+  continuation follow-ups), it assigns `System` or `Task` origin with
+  `TrustedSystem` trust.
+- When an agent delegates work via `SpawnAgent`, the child agent receives
+  provenance from the parent's delegation context, not the original operator.
+- Event stream consumers (HTTP event stream, TUI) receive provenance labels
+  for every message so they can apply their own display/security policies.
+
+## Known gaps
+
+- `TrustLevel` vocabulary is transitional; some internal code still uses
+  "callback" terminology.
+- `AdmissionContext` is not yet consistently populated across all ingress
+  paths; CLI and TUI admissions may carry less metadata than HTTP admissions.
+- No standard mechanism exists for integrators to register custom trust
+  classification rules for their webhooks or channels.

--- a/docs/website/spec/trust-and-provenance.md
+++ b/docs/website/spec/trust-and-provenance.md
@@ -117,8 +117,13 @@ Holon's provenance contract:
 
 ## Known gaps
 
-- `TrustLevel` vocabulary is transitional; some internal code still uses
-  "callback" terminology.
+- `TrustLevel` is still present on `MessageEnvelope` alongside the newer
+  `AuthorityClass`. The RFC describes this as an intentional transitional
+  state with a `From<&TrustLevel> for AuthorityClass` bridge mapping; the
+  eventual target is `AuthorityClass`-only. See
+  [issue #1385](https://github.com/holon-run/holon/issues/1385).
+- `SignedIntegration` is not yet in `AdmissionContext`; the RFC describes
+  it as a future direction, so its absence matches current RFC intent.
 - `AdmissionContext` is not yet consistently populated across all ingress
   paths; CLI and TUI admissions may carry less metadata than HTTP admissions.
 - No standard mechanism exists for integrators to register custom trust

--- a/docs/website/spec/trust-and-provenance.md
+++ b/docs/website/spec/trust-and-provenance.md
@@ -16,12 +16,12 @@ the runtime.
 
 ## Source RFCs
 
-- [Provenance, Admission, and Authority](../rfcs/default-trust-auth-and-control.md)
-- [Event Stream Interface Design](../rfcs/event-stream-interface.md)
-- [Remote Operator Transport and Delivery](../rfcs/remote-operator-transport-and-delivery.md)
-- [Operator Display Levels and Event Presentation](../rfcs/operator-display-levels-and-event-presentation.md)
-- [Tool Surface Layering](../rfcs/tool-surface-layering.md)
-- [Continuation Trigger](../rfcs/continuation-trigger.md)
+- [Provenance, Admission, and Authority](https://github.com/holon-run/holon/blob/main/docs/rfcs/default-trust-auth-and-control.md)
+- [Event Stream Interface Design](https://github.com/holon-run/holon/blob/main/docs/rfcs/event-stream-interface.md)
+- [Remote Operator Transport and Delivery](https://github.com/holon-run/holon/blob/main/docs/rfcs/remote-operator-transport-and-delivery.md)
+- [Operator Display Levels and Event Presentation](https://github.com/holon-run/holon/blob/main/docs/rfcs/operator-display-levels-and-event-presentation.md)
+- [Tool Surface Layering](https://github.com/holon-run/holon/blob/main/docs/rfcs/tool-surface-layering.md)
+- [Continuation Trigger](https://github.com/holon-run/holon/blob/main/docs/rfcs/continuation-trigger.md)
 
 ## Message envelope
 

--- a/docs/website/spec/wake-and-continuation.md
+++ b/docs/website/spec/wake-and-continuation.md
@@ -121,11 +121,20 @@ occurred:
 
 ## Known gaps
 
-- `CreateExternalTrigger` and `CancelExternalTrigger` tool code still exists
-  in `src/tool/tools/` for legacy compatibility; migration to pure
-  provisioning model is not complete.
+- `ExternalTriggerScope::WorkItem` variant still exists in the type system
+  (`types.rs:1690`) alongside `Agent`. The RFC calls for removing
+  WorkItem-scoped triggers and making capability identity agent-level. See
+  [issue #1381](https://github.com/holon-run/holon/issues/1381).
+- `CreateExternalTrigger` and `CancelExternalTrigger` remain as first-class
+  model-facing tools in the registry without a clear deprecated/compatibility
+  marker. `docs/agentinbox-dogfood-runbook.md` still describes the old
+  CreateExternalTrigger → CancelExternalTrigger pattern as the normal wait
+  handshake. See [issue #1381](https://github.com/holon-run/holon/issues/1381).
+- `WaitingIntentRecord` retains a `scope` field even though the RFC says
+  capability identity should be agent-level, not scope-partitioned.
+  See [issue #1381](https://github.com/holon-run/holon/issues/1381).
 - `WakeHint` idempotency is implemented via `PendingWakeHint` deduplication
   but the contract for when duplicate hints are silently dropped vs surfaced
   as diagnostics is not yet a stable API.
-- `EnqueueMessage` delivery for external events preserves provenance but the
-  provenance taxonomy for external sources is not yet fully specified.
+- `EnqueueMessage` delivery for external events preserves provenance but
+  the provenance taxonomy for external sources is not yet fully specified.

--- a/docs/website/spec/wake-and-continuation.md
+++ b/docs/website/spec/wake-and-continuation.md
@@ -1,0 +1,131 @@
+---
+title: Wake and continuation
+summary: Current trigger classification, external ingress capabilities, continuation resolution, and wake/sleep lifecycle.
+order: 40
+---
+
+# Wake and continuation
+
+This page defines the current contract for how Holon agents wake from sleep,
+receive external events, and resolve continuation decisions.
+
+> **Last verified:** 2026-05-23 against `src/types.rs`
+> `ContinuationTriggerKind`, `ContinuationClass`, `ContinuationResolution`,
+> `PendingWakeHint`, `ExternalTriggerScope`, `CallbackDeliveryMode`,
+> `ExternalTriggerSummary`, `ExternalTriggerCapability`,
+> `WaitingIntentRecord`, and `src/runtime/waiting.rs`.
+
+## Source RFCs
+
+- [Continuation Trigger](../rfcs/continuation-trigger.md)
+- [External Trigger Capability And Providerless Ingress](../rfcs/external-trigger-capability.md)
+- [Waiting Plane And Reactivation](../rfcs/waiting-plane-and-reactivation.md)
+- [Operator Wait And Intervention](../rfcs/operator-wait-and-intervention.md)
+- [Remote Operator Transport and Delivery](../rfcs/remote-operator-transport-and-delivery.md)
+- [Event Stream Interface Design](../rfcs/event-stream-interface.md)
+
+## Trigger classification
+
+When an agent is reactivated, the continuation is classified by trigger kind
+and class:
+
+### Trigger kinds (`ContinuationTriggerKind`)
+
+| Kind | Source |
+|------|--------|
+| `OperatorInput` | Direct operator message (CLI, HTTP, TUI) |
+| `TaskResult` | A command task or child-agent task reached a terminal state |
+| `ExternalEvent` | An external system sent a contentful event via ingress URL |
+| `TimerFire` | A scheduled timer elapsed |
+| `InternalFollowup` | The agent enqueued a self-follow-up via `Enqueue` |
+| `SystemTick` | The scheduler emitted a runtime-owned follow-up for a runnable WorkItem |
+
+### Continuation classes (`ContinuationClass`)
+
+| Class | Meaning |
+|-------|---------|
+| `ResumeExpectedWait` | The trigger matched the prior waiting reason exactly |
+| `ResumeOverride` | The trigger overrides the prior wait (e.g., operator interrupt) |
+| `LocalContinuation` | The agent continued without sleeping (same-turn follow-up) |
+| `LivenessOnly` | Wake hint — does not carry model-visible content |
+
+## Wake hints vs contentful events
+
+**Wake hints** are liveness signals. They tell the scheduler "something changed
+externally, re-evaluate whether the agent should wake". The hint payload is
+**not** delivered as a model-visible message. The agent must query the
+external system for details after waking.
+
+**Contentful external events** carry an `enqueue_message` delivery mode. The
+event payload is delivered as a message in the agent's queue with provenance
+preserved.
+
+| Delivery mode | Behavior |
+|---------------|----------|
+| `WakeHint` | Liveness signal; scheduler emits `EmitSystemTick` |
+| `EnqueueMessage` | Full event payload enqueued as a message |
+
+## External trigger capabilities
+
+Holon provisions a **default external ingress capability** for each agent at
+initialization. This is a capability URL with a secret token:
+
+- The URL is exposed in the agent's context as `default_external_ingress`.
+- External systems POST to this URL to deliver wake hints or events.
+- The capability is agent-scoped; it can be reused across WorkItems.
+- Capability revocation is an administrative action, not a per-cycle model
+  tool call.
+
+### Capability model
+
+| Field | Purpose |
+|-------|---------|
+| `external_trigger_id` | Unique trigger identifier |
+| `trigger_url` | The ingress URL (capability secret) |
+| `target_agent_id` | The agent this trigger wakes |
+| `delivery_mode` | `WakeHint` or `EnqueueMessage` |
+| `scope` | `Agent` or `WorkItem` |
+| `status` | `Active` or `Revoked` |
+
+### Deprecated surface
+
+`CreateExternalTrigger` and `CancelExternalTrigger` as agent-facing tools are
+deprecated. The current contract provisions triggers at initialization; the
+agent does not create or cancel them per wait cycle. Legacy internal references
+to these tools remain for compatibility but should not be presented to the
+model as active tool surfaces.
+
+## Continuation resolution
+
+When the agent wakes, `ContinuationResolution` records how the activation
+occurred:
+
+| Field | Meaning |
+|-------|---------|
+| `trigger_kind` | Which kind of event caused the wake |
+| `class` | How the wake relates to the prior wait |
+| `model_reentry` | Whether the model should be re-entered with context |
+| `prior_closure_outcome` | What the prior turn decided |
+| `prior_waiting_reason` | What the agent was waiting for |
+| `matched_waiting_reason` | Whether the trigger matched the reason |
+
+**Key contract:**
+
+- `model_reentry=true` means the model receives continuation context including
+  the prior closure and trigger evidence.
+- `model_reentry=false` means the wake is a liveness check; the scheduler
+  re-evaluates posture but may not need to re-enter the model.
+- `matched_waiting_reason` distinguishes "expected wake" from "surprise
+  wake". An operator message arriving while waiting for a task result does not
+  match, and the agent may need to handle the interruption.
+
+## Known gaps
+
+- `CreateExternalTrigger` and `CancelExternalTrigger` tool code still exists
+  in `src/tool/tools/` for legacy compatibility; migration to pure
+  provisioning model is not complete.
+- `WakeHint` idempotency is implemented via `PendingWakeHint` deduplication
+  but the contract for when duplicate hints are silently dropped vs surfaced
+  as diagnostics is not yet a stable API.
+- `EnqueueMessage` delivery for external events preserves provenance but the
+  provenance taxonomy for external sources is not yet fully specified.

--- a/docs/website/spec/wake-and-continuation.md
+++ b/docs/website/spec/wake-and-continuation.md
@@ -17,12 +17,12 @@ receive external events, and resolve continuation decisions.
 
 ## Source RFCs
 
-- [Continuation Trigger](../rfcs/continuation-trigger.md)
-- [External Trigger Capability And Providerless Ingress](../rfcs/external-trigger-capability.md)
-- [Waiting Plane And Reactivation](../rfcs/waiting-plane-and-reactivation.md)
-- [Operator Wait And Intervention](../rfcs/operator-wait-and-intervention.md)
-- [Remote Operator Transport and Delivery](../rfcs/remote-operator-transport-and-delivery.md)
-- [Event Stream Interface Design](../rfcs/event-stream-interface.md)
+- [Continuation Trigger](https://github.com/holon-run/holon/blob/main/docs/rfcs/continuation-trigger.md)
+- [External Trigger Capability And Providerless Ingress](https://github.com/holon-run/holon/blob/main/docs/rfcs/external-trigger-capability.md)
+- [Waiting Plane And Reactivation](https://github.com/holon-run/holon/blob/main/docs/rfcs/waiting-plane-and-reactivation.md)
+- [Operator Wait And Intervention](https://github.com/holon-run/holon/blob/main/docs/rfcs/operator-wait-and-intervention.md)
+- [Remote Operator Transport and Delivery](https://github.com/holon-run/holon/blob/main/docs/rfcs/remote-operator-transport-and-delivery.md)
+- [Event Stream Interface Design](https://github.com/holon-run/holon/blob/main/docs/rfcs/event-stream-interface.md)
 
 ## Trigger classification
 

--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -16,11 +16,11 @@ lifecycle, focus, readiness, planning, blocking, and completion semantics.
 
 ## Source RFCs
 
-- [Work Item Runtime Model](../rfcs/work-item-runtime-model.md)
-- [Work Item Centered Agent Runtime](../rfcs/work-item-centered-agent-runtime.md)
-- [Objective, Delta, and Acceptance Boundary](../rfcs/objective-delta-and-acceptance-boundary.md)
-- [Long-Lived Context Memory](../rfcs/long-lived-context-memory.md)
-- [Turn-Local Context Compaction](../rfcs/turn-local-context-compaction.md)
+- [Work Item Runtime Model](https://github.com/holon-run/holon/blob/main/docs/rfcs/work-item-runtime-model.md)
+- [Work Item Centered Agent Runtime](https://github.com/holon-run/holon/blob/main/docs/rfcs/work-item-centered-agent-runtime.md)
+- [Objective, Delta, and Acceptance Boundary](https://github.com/holon-run/holon/blob/main/docs/rfcs/objective-delta-and-acceptance-boundary.md)
+- [Long-Lived Context Memory](https://github.com/holon-run/holon/blob/main/docs/rfcs/long-lived-context-memory.md)
+- [Turn-Local Context Compaction](https://github.com/holon-run/holon/blob/main/docs/rfcs/turn-local-context-compaction.md)
 
 ## Core model
 
@@ -30,14 +30,18 @@ A WorkItem is a durable objective record owned by an agent. It tracks:
 |-------|---------|
 | `objective` | Short human-readable target (required) |
 | `state` | `Open` or `Completed` |
-| `plan_status` | `Draft`, `Ready`, or `NeedsInput` |
+| `plan_status` | `draft`, `ready`, or `needs_input` |
 | `plan_artifact` | Path to the durable plan.md artifact in agent home |
 | `todo_list` | Progress checklist snapshot |
 | `blocked_by` | Human-readable blocker description |
 | `recheck_at` | Fallback deadline for blocked re-evaluation |
 | `result_summary` | Completion summary (optional) |
 
-## Lifeycle states
+The Rust enum `WorkItemPlanStatus` uses PascalCase variants (`Draft`, `Ready`,
+`NeedsInput`), but all tool input/output uses snake_case (`draft`, `ready`,
+`needs_input`).
+
+## Lifecycle states
 
 ```text
                     CreateWorkItem
@@ -71,7 +75,8 @@ A WorkItem is a durable objective record owned by an agent. It tracks:
   scheduler must wait for operator input.
 - `blocked_by` is a human-readable string; when set, the WorkItem is
   non-runnable. A `recheck_after` millisecond fallback deadline can be set
-  alongside the blocker.
+  alongside the blocker via `UpdateWorkItem.recheck_after`. The stored field
+  is `recheck_at` (an absolute timestamp).
 
 ## Readiness and scheduling
 

--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -165,3 +165,9 @@ the agent's home directory (`work-items/<id>/plan.md`). The plan artifact:
   granularity at the display layer.
 - Plan artifact path resolution depends on agent home workspace; cross-agent
   WorkItem reads may need explicit workspace routing.
+- `WorkItemRecord` still retains a legacy `plan: Option<String>` field
+  alongside `plan_artifact`. See
+  [issue #1379](https://github.com/holon-run/holon/issues/1379).
+- `recheck_after` / `recheck_at` / `recheck_consumed_at` scheduling semantics
+  are not described in the WorkItem RFC. See
+  [issue #1379](https://github.com/holon-run/holon/issues/1379).

--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -1,0 +1,162 @@
+---
+title: Work items
+summary: Current WorkItem lifecycle, focus, readiness, planning, blocking, and completion contract.
+order: 20
+---
+
+# Work items
+
+This page defines the current contract for WorkItem runtime behavior:
+lifecycle, focus, readiness, planning, blocking, and completion semantics.
+
+> **Last verified:** 2026-05-23 against `src/types.rs` `WorkItemRecord`,
+> `WorkItemState`, `WorkItemPlanStatus`, `WorkItemReadiness`,
+> `WorkItemSchedulingState`, and the tool implementations in
+> `src/tool/tools/{create,update,pick,list,get,complete}_work_item.rs`.
+
+## Source RFCs
+
+- [Work Item Runtime Model](../rfcs/work-item-runtime-model.md)
+- [Work Item Centered Agent Runtime](../rfcs/work-item-centered-agent-runtime.md)
+- [Objective, Delta, and Acceptance Boundary](../rfcs/objective-delta-and-acceptance-boundary.md)
+- [Long-Lived Context Memory](../rfcs/long-lived-context-memory.md)
+- [Turn-Local Context Compaction](../rfcs/turn-local-context-compaction.md)
+
+## Core model
+
+A WorkItem is a durable objective record owned by an agent. It tracks:
+
+| Field | Purpose |
+|-------|---------|
+| `objective` | Short human-readable target (required) |
+| `state` | `Open` or `Completed` |
+| `plan_status` | `Draft`, `Ready`, or `NeedsInput` |
+| `plan_artifact` | Path to the durable plan.md artifact in agent home |
+| `todo_list` | Progress checklist snapshot |
+| `blocked_by` | Human-readable blocker description |
+| `recheck_at` | Fallback deadline for blocked re-evaluation |
+| `result_summary` | Completion summary (optional) |
+
+## Lifeycle states
+
+```text
+                    CreateWorkItem
+                          │
+                          ▼
+                    ┌──────────┐
+                    │   Open   │
+                    └────┬─────┘
+                         │
+            ┌────────────┼────────────┐
+            ▼            ▼            ▼
+       plan_status    plan_status   plan_status
+        = Draft       = Ready       = NeedsInput
+            │            │               │
+            └────────────┼───────────────┘
+                         │
+                    CompleteWorkItem
+                         │
+                         ▼
+                    ┌───────────┐
+                    │ Completed │
+                    └───────────┘
+```
+
+**Key contract:**
+
+- `state` is the hard lifecycle boundary: `Open` or `Completed`.
+- `plan_status` is the planning/coordination posture: whether the plan is
+  still being drafted, ready for execution, or waiting for operator input.
+- `plan_status=NeedsInput` makes the WorkItem **non-runnable** and means the
+  scheduler must wait for operator input.
+- `blocked_by` is a human-readable string; when set, the WorkItem is
+  non-runnable. A `recheck_after` millisecond fallback deadline can be set
+  alongside the blocker.
+
+## Readiness and scheduling
+
+WorkItem readiness is derived from `state`, `plan_status`, `blocked_by`, and
+active wait state:
+
+| `WorkItemSchedulingState` | Condition |
+|---------------------------|-----------|
+| `Runnable` | Open, plan not `NeedsInput`, no blocker, no active wait |
+| `WaitingOperator` | `plan_status=NeedsInput` |
+| `WaitingTask` | Active wait on a task result |
+| `WaitingExternal` | Active wait on an external event |
+| `WaitingTimer` | Active wait on a timer |
+| `WaitingSystem` | Active wait on a system tick |
+| `Blocked` | `blocked_by` is set |
+| `Completed` | `state=Completed` |
+
+`WorkItemReadiness` is the reduced view used by scheduler and user display:
+
+| `WorkItemReadiness` | Maps from |
+|---------------------|-----------|
+| `Runnable` | `WorkItemSchedulingState::Runnable` |
+| `WaitingForOperator` | `WorkItemSchedulingState::WaitingOperator` |
+| `Blocked` | All other non-completed scheduling states |
+| `Completed` | `WorkItemSchedulingState::Completed` |
+
+**Key contract:**
+
+- Readiness is derived, not stored. `is_runnable()` and
+  `is_waiting_for_operator()` are computed from current state.
+- `plan_status=NeedsInput` is the only explicit "waiting for operator" signal.
+- Blocked WorkItems with `recheck_at` carry a fallback deadline; the scheduler
+  may re-evaluate them after that time.
+- Focus (current/queued) is separate from readiness. A blocked WorkItem can
+  still be the current focus for inspection.
+
+## Focus and current work
+
+An agent has at most one **current WorkItem** (`current_work_item_id`). The
+current WorkItem is the focus for the current turn:
+
+- `PickWorkItem` sets the current focus from an existing open WorkItem.
+- The scheduler may auto-pick a runnable WorkItem when the agent wakes.
+- Current focus persists across turns until explicitly changed or completed.
+- Only runnable WorkItems are eligible for scheduler auto-resume.
+
+## Tool surface
+
+| Tool | Purpose |
+|------|---------|
+| `CreateWorkItem` | Create a new open WorkItem with objective, optional plan seed, and todo_list |
+| `UpdateWorkItem` | Mutate objective, plan_status, todo_list, blocked_by, recheck_after |
+| `PickWorkItem` | Set current focus to an existing open WorkItem |
+| `GetWorkItem` | Read a single WorkItem with plan preview |
+| `ListWorkItems` | Query with filters: all, open, completed, current, queued, blocked, waiting_for_operator, runnable |
+| `CompleteWorkItem` | Mark complete; the next assistant-text block in the same round is promoted as the completion report |
+
+**Key contract:**
+
+- `CreateWorkItem` should only be used for genuinely separate objectives with
+  independent lifecycles. Use `UpdateWorkItem` to refine the current WorkItem
+  instead of creating a new one for the same task.
+- `UpdateWorkItem.todo_list` replaces the full checklist snapshot; it is not
+  an append operation.
+- `UpdateWorkItem.blocked_by` accepts `null` to clear the blocker.
+- `CompleteWorkItem` promotion: the operator-facing completion report must be
+  written as assistant text **in the same round**. After the tool succeeds,
+  the runtime promotes that text as the canonical completion report.
+- Plan body changes go through direct file edits to `plan_artifact.path`, not
+  through `UpdateWorkItem`.
+
+## Plan artifact
+
+Each WorkItem has an optional `plan_artifact` pointing to a `plan.md` file in
+the agent's home directory (`work-items/<id>/plan.md`). The plan artifact:
+
+- Is **not** stored inline in the WorkItem record.
+- Is read by `GetWorkItem` (bounded preview) and editable via
+  `ApplyPatch`/file tools.
+- Contains the durable prose plan; `todo_list` is the progress checklist.
+
+## Known gaps
+
+- `WorkItemSchedulingState` and `WorkItemReadiness` overlap; `WorkItemReadiness`
+  collapses five waiting states into "Blocked", which loses scheduling
+  granularity at the display layer.
+- Plan artifact path resolution depends on agent home workspace; cross-agent
+  WorkItem reads may need explicit workspace routing.

--- a/docs/website/spec/workspace-and-execution.md
+++ b/docs/website/spec/workspace-and-execution.md
@@ -114,6 +114,10 @@ filesystem with the agent user's permissions. Key constraints:
 
 ## Known gaps
 
+- Vestigial `EnterWorkspaceResult` and `ExitWorkspaceResult` structs still
+  exist in `types.rs:2861,2870`. These types may be unused or only used in
+  legacy HTTP paths and should be removed. See
+  [issue #1384](https://github.com/holon-run/holon/issues/1384).
 - Worktree cleanup is best-effort; stale worktrees may persist after abnormal
   agent termination.
 - Workspace occupancy is advisory; the runtime does not enforce exclusive

--- a/docs/website/spec/workspace-and-execution.md
+++ b/docs/website/spec/workspace-and-execution.md
@@ -15,12 +15,12 @@ roots, worktree isolation, and host-local execution policy.
 
 ## Source RFCs
 
-- [Workspace Binding and Execution Roots](../rfcs/workspace-binding-and-execution-roots.md)
-- [Workspace Entry and Projection](../rfcs/workspace-entry-and-projection.md)
-- [Execution Policy and Virtual Execution Boundary](../rfcs/execution-policy-and-virtual-execution-boundary.md)
-- [Agent Home Directory Layout](../rfcs/agent-home-directory-layout.md)
-- [Instruction Loading](../rfcs/instruction-loading.md)
-- [Agent and Workspace Memory](../rfcs/agent-and-workspace-memory.md)
+- [Workspace Binding and Execution Roots](https://github.com/holon-run/holon/blob/main/docs/rfcs/workspace-binding-and-execution-roots.md)
+- [Workspace Entry and Projection](https://github.com/holon-run/holon/blob/main/docs/rfcs/workspace-entry-and-projection.md)
+- [Execution Policy and Virtual Execution Boundary](https://github.com/holon-run/holon/blob/main/docs/rfcs/execution-policy-and-virtual-execution-boundary.md)
+- [Agent Home Directory Layout](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-home-directory-layout.md)
+- [Instruction Loading](https://github.com/holon-run/holon/blob/main/docs/rfcs/instruction-loading.md)
+- [Agent and Workspace Memory](https://github.com/holon-run/holon/blob/main/docs/rfcs/agent-and-workspace-memory.md)
 
 ## Core model
 
@@ -32,8 +32,8 @@ Every agent has exactly one **active workspace**. The active workspace defines:
 | `workspace_anchor` | Filesystem path to the workspace root |
 | `execution_root` | The root for process execution (may differ from anchor) |
 | `cwd` | Current working directory for shell commands |
-| `projection_kind` | How the workspace is projected (`CanonicalRoot`, `Isolated`) |
-| `access_mode` | How the agent holds the workspace (`ReadWrite`, `ReadOnly`) |
+| `projection_kind` | How the workspace is projected (`CanonicalRoot`, `GitWorktreeRoot`) |
+| `access_mode` | How the agent holds the workspace (`SharedRead`, `ExclusiveWrite`) |
 
 ### Active workspace vs shell `cd`
 

--- a/docs/website/spec/workspace-and-execution.md
+++ b/docs/website/spec/workspace-and-execution.md
@@ -1,0 +1,122 @@
+---
+title: Workspace and execution
+summary: Current workspace identity, agent home, execution roots, worktrees, and host-local policy contract.
+order: 70
+---
+
+# Workspace and execution
+
+This page defines the current contract for workspace identity, execution
+roots, worktree isolation, and host-local execution policy.
+
+> **Last verified:** 2026-05-23 against `src/types.rs`
+> `ActiveWorkspaceEntry`, `WorkspaceOccupancyRecord`, `WorktreeSession`,
+> `ExecutionSnapshot`, and `src/runtime/workspace.rs`.
+
+## Source RFCs
+
+- [Workspace Binding and Execution Roots](../rfcs/workspace-binding-and-execution-roots.md)
+- [Workspace Entry and Projection](../rfcs/workspace-entry-and-projection.md)
+- [Execution Policy and Virtual Execution Boundary](../rfcs/execution-policy-and-virtual-execution-boundary.md)
+- [Agent Home Directory Layout](../rfcs/agent-home-directory-layout.md)
+- [Instruction Loading](../rfcs/instruction-loading.md)
+- [Agent and Workspace Memory](../rfcs/agent-and-workspace-memory.md)
+
+## Core model
+
+Every agent has exactly one **active workspace**. The active workspace defines:
+
+| Concept | Meaning |
+|---------|---------|
+| `workspace_id` | Stable identifier for the workspace |
+| `workspace_anchor` | Filesystem path to the workspace root |
+| `execution_root` | The root for process execution (may differ from anchor) |
+| `cwd` | Current working directory for shell commands |
+| `projection_kind` | How the workspace is projected (`CanonicalRoot`, `Isolated`) |
+| `access_mode` | How the agent holds the workspace (`ReadWrite`, `ReadOnly`) |
+
+### Active workspace vs shell `cd`
+
+- The active workspace is **runtime state**, not shell state.
+- Shell `cd` in `ExecCommand` changes that one command's working directory
+  but does **not** change the active workspace, instruction root, AGENTS.md
+  scope, or `ApplyPatch` relative-path base.
+- `UseWorkspace` is the tool for switching the active workspace.
+
+## Agent home
+
+`agent_home` is the built-in fallback workspace for agent-local state:
+
+| Directory | Purpose |
+|-----------|---------|
+| `AGENTS.md` | Long-lived agent contract (loaded as guidance) |
+| `memory/` | Curated memory markdown (`self.md`, `operator.md`) |
+| `notes/` | Working notes |
+| `work-items/` | WorkItem plan artifacts (`plan.md`) |
+| `skills/` | Agent-local skills |
+| `.holon/` | Runtime-owned state, ledger, index, cache |
+
+**Key contract:**
+
+- `.holon/` is runtime-owned; agents must not edit it.
+- `AGENTS.md` may evolve but should capture durable agent behavior, not
+  transient plans or copied project docs.
+- `agent_home` is always available as a workspace, even when no project
+  workspace is attached.
+
+## Workspace occupancy
+
+Workspaces track **occupancy**: which agent holds the workspace and how:
+
+| Field | Purpose |
+|-------|---------|
+| `holder_agent_id` | The agent currently occupying the workspace |
+| `access_mode` | `ReadWrite` or `ReadOnly` |
+| `acquired_at` | When occupancy was acquired |
+| `released_at` | When occupancy was released (if released) |
+
+Workspace occupancy is used for coordination; it is not a hard lock. The
+runtime uses occupancy records for diagnostics and cleanup, not for
+preventing concurrent access at the filesystem level.
+
+## Worktrees
+
+When an agent needs isolated file changes, `UseWorkspace` with
+`mode=isolated` creates a runtime-managed worktree:
+
+- The worktree has a separate `execution_root` from the canonical workspace.
+- Worktree lifecycle is tied to the agent session; the runtime cleans up on
+  agent stop or explicit release.
+- Worktrees use the host-local filesystem (git worktrees or temp directories);
+  they are not containerized sandboxes.
+
+## Execution snapshot (`ExecutionSnapshot`)
+
+The `ExecutionSnapshot` in `AgentSummary` captures the current execution
+context:
+
+- Active run id
+- Active workspace id and occupancy
+- Execution root and cwd
+- Worktree session (if applicable)
+- Host-local policy flags
+
+## Host-local policy
+
+Holon's current execution model is **host-local**: processes run on the host
+filesystem with the agent user's permissions. Key constraints:
+
+- `cwd` is always within the execution root.
+- Process execution is not containerized or sandboxed by the runtime.
+- Network access is not confined by default.
+- The `execution_environment` summary in model context describes the current
+  policy snapshot as a transparency contract, not a hard sandbox guarantee.
+
+## Known gaps
+
+- Worktree cleanup is best-effort; stale worktrees may persist after abnormal
+  agent termination.
+- Workspace occupancy is advisory; the runtime does not enforce exclusive
+  write access at the filesystem level.
+- Isolated worktrees use git worktrees; non-git workspaces fall back to temp
+  directories with weaker cleanup guarantees.

--- a/docs/website/spec/workspace-and-execution.md
+++ b/docs/website/spec/workspace-and-execution.md
@@ -71,7 +71,7 @@ Workspaces track **occupancy**: which agent holds the workspace and how:
 | Field | Purpose |
 |-------|---------|
 | `holder_agent_id` | The agent currently occupying the workspace |
-| `access_mode` | `ReadWrite` or `ReadOnly` |
+| `access_mode` | `SharedRead` or `ExclusiveWrite` |
 | `acquired_at` | When occupancy was acquired |
 | `released_at` | When occupancy was released (if released) |
 


### PR DESCRIPTION
## Summary

Solves all 10 issues from [Milestone 7: Runtime Specs & Contract Hardening](https://github.com/holon-run/holon/milestone/7) (#1366-#1374).

Each issue gets its own commit. All spec pages are verified against current implementation in `src/types.rs` and `src/runtime/`.

## Changes

| # | Issue | Commit | Files |
|---|-------|--------|-------|
| #1366 | Reposition runtime-spec.md, create spec directory | `f4b4bb0` | 6 files (+114/-25) |
| #1367 | Agent state and lifecycle contract | `f488e53` | new: `spec/agent-state.md` |
| #1368 | WorkItem runtime contract | `1c44bcc` | new: `spec/work-items.md` |
| #1369 | Scheduler runnable and waiting contract | `972d468` | new: `spec/scheduler.md` |
| #1370 | Wake, continuation, external trigger contract | `4175fc2` | new: `spec/wake-and-continuation.md` |
| #1371 | Task lifecycle and background blocking | `d7340c5` | new: `spec/tasks.md` |
| #1372 | Model-facing tool surface contract | `4383ac1` | new: `spec/tools.md` |
| #1373 | Workspace, execution root, projection | `80db911` | new: `spec/workspace-and-execution.md` |
| #1374 | Trust, origin, provenance contract | `8f07363` | new: `spec/trust-and-provenance.md` |

## What changed

- Created `docs/website/spec/` directory with 9 spec pages, each a current
  implementation-facing contract verified against types and runtime code
- Added status/reading-guidance block to top of `docs/runtime-spec.md`
- Updated documentation-layers model: added Layer 2 (runtime specs),
  renumbered layers 2-4 → 3-4
- Updated website README and concepts index with spec navigation
- Updated RFCS README with link to current specs
- Fixed stale `CreateExternalTrigger`/`CancelExternalTrigger` references
  in `runtime-model.md` concept page

## Verification

- `mdorigin build index --root docs/website` passes
- All spec pages link to source RFCs and implementation files
- Known gaps tracked in each spec page