### PR TITLE
chore: prepare v0.14.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"


### PR DESCRIPTION
## Summary
- bump Holon crate version to 0.14.1
- prepare patch release for the blocked WorkItem recheck wake fix from #1375

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test --all-targets -- --test-threads=1
