### PR TITLE
fix: remove 40 dead links from docs website

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefix .tools
 
+      - name: Check internal links
+        run: python3 .tools/check-links.py
+
       - name: Build directory indexes
         run: npm --prefix .tools run build:index
 

--- a/docs/website/.tools/check-links.py
+++ b/docs/website/.tools/check-links.py
@@ -87,10 +87,21 @@ def check_trailing_slashes():
                         url = m.group(2)
                         clean = url.split('#')[0].split('?')[0]
                         if clean.endswith('/') and clean not in dir_pages:
+                            # Compute suggestion: strip trailing slash from the
+                            # path portion, then reattach query and fragment.
+                            query = url.split('?')[1].split('#')[0] if '?' in url else ''
+                            fragment = url.split('#')[1] if '#' in url else ''
+                            if '?' in fragment:
+                                fragment = fragment.split('?')[0]
+                            suggested = clean.rstrip('/')
+                            if query:
+                                suggested += '?' + query
+                            if fragment:
+                                suggested += '#' + fragment
                             rel = os.path.relpath(fpath, REPO_ROOT)
                             print(
-                                f"  TRAILING-SLASH: {rel}:{i}: {m.group(2)} "
-                                f"(should be {m.group(2).rstrip('/')})"
+                                f"  TRAILING-SLASH: {rel}:{i}: {url} "
+                                f"(should be {suggested})"
                             )
                             broken += 1
 
@@ -107,8 +118,18 @@ def check_nav_config():
     for nav in config.get('topNav', []):
         href = nav['href']
         clean = href.split('#')[0].split('?')[0]
+        # Skip external links
+        if href.startswith('http'):
+            continue
+        # Accept directory-backed routes
         if clean in dir_pages:
             continue
+        # Accept file-backed routes (non-trailing-slash .md files)
+        if not clean.endswith('/'):
+            file_path = os.path.join(
+                WEBSITE_DIR, clean.lstrip('/') + '.md')
+            if os.path.exists(file_path):
+                continue
         print(f"  BROKEN-NAV: {href} ({nav['label']})")
         broken += 1
 

--- a/docs/website/.tools/check-links.py
+++ b/docs/website/.tools/check-links.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
-"""Lightweight internal markdown link checker for Holon docs.
+"""Lightweight internal link checker for Holon docs website.
 
 Checks README.md and docs/website/ for broken relative/absolute .md links.
 Site-root-absolute links (starting with /) in docs/website/ resolve relative
 to the website content root (docs/website/), matching mdorigin behavior.
 
+Also validates navigation links in mdorigin.config.json and catches
+trailing-slash mismatches (file-page URLs must not end with /).
+
 Run from the repository root:
     python3 docs/website/.tools/check-links.py
 """
 
-import os, re, sys
+import json
+import os
+import re
+import sys
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 WEBSITE_DIR = os.path.join(REPO_ROOT, "docs/website")
 LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]*\.md[^)]*)\)')
 
 broken = 0
+
 
 def check_file(fpath, root_for_absolute):
     global broken
@@ -24,18 +33,85 @@ def check_file(fpath, root_for_absolute):
     curdir = os.path.dirname(fpath)
     with open(fpath) as fh:
         for i, line in enumerate(fh, 1):
-            for m in LINK_RE.finditer(line):
-                target = m.group(2).split('#')[0].split('?')[0]
-                if target.startswith('http'):
-                    continue
-                if target.startswith('/'):
-                    resolved = os.path.normpath(os.path.join(root_for_absolute, target.lstrip('/')))
-                else:
-                    resolved = os.path.normpath(os.path.join(curdir, target))
-                if not os.path.exists(resolved):
-                    rel = os.path.relpath(fpath, REPO_ROOT)
-                    print(f"  BROKEN: {rel}:{i}: {m.group(2)}")
-                    broken += 1
+            check_line(fpath, curdir, root_for_absolute, i, line)
+
+
+def check_line(fpath, curdir, root_for_absolute, lineno, line):
+    global broken
+    for m in LINK_RE.finditer(line):
+        target = m.group(2).split('#')[0].split('?')[0]
+        if target.startswith('http'):
+            continue
+        if target.startswith('/'):
+            resolved = os.path.normpath(
+                os.path.join(root_for_absolute, target.lstrip('/'))
+            )
+        else:
+            resolved = os.path.normpath(os.path.join(curdir, target))
+        if not os.path.exists(resolved):
+            rel = os.path.relpath(fpath, REPO_ROOT)
+            print(f"  BROKEN: {rel}:{lineno}: {m.group(2)}")
+            broken += 1
+
+
+def collect_dir_pages():
+    """Return set of URL paths for directory-based pages (those with README.md/index.md)."""
+    dirs = set()
+    for root, subdirs, files in os.walk(WEBSITE_DIR):
+        if '.tools/node_modules' in root:
+            continue
+        subdirs[:] = [d for d in subdirs if d != 'node_modules']
+        for f in files:
+            if f in ('README.md', 'index.md'):
+                rel = os.path.relpath(root, WEBSITE_DIR).replace('\\', '/')
+                dirs.add('/' if rel == '.' else '/' + rel + '/')
+    return dirs
+
+
+def check_trailing_slashes():
+    """Catch file-page URLs that incorrectly end with /."""
+    global broken
+    dir_pages = collect_dir_pages()
+    TRAILING_LINK_RE = re.compile(r'\[([^\]]*)\]\((/[^)]*)\)')
+    for root, subdirs, files in os.walk(WEBSITE_DIR):
+        if '.tools/node_modules' in root:
+            continue
+        subdirs[:] = [d for d in subdirs if d != 'node_modules']
+        for f in files:
+            if not f.endswith('.md'):
+                continue
+            fpath = os.path.join(root, f)
+            with open(fpath) as fh:
+                for i, line in enumerate(fh, 1):
+                    for m in TRAILING_LINK_RE.finditer(line):
+                        url = m.group(2)
+                        clean = url.split('#')[0].split('?')[0]
+                        if clean.endswith('/') and clean not in dir_pages:
+                            rel = os.path.relpath(fpath, REPO_ROOT)
+                            print(
+                                f"  TRAILING-SLASH: {rel}:{i}: {m.group(2)} "
+                                f"(should be {m.group(2).rstrip('/')})"
+                            )
+                            broken += 1
+
+
+def check_nav_config():
+    """Check navigation links in mdorigin.config.json."""
+    global broken
+    config_path = os.path.join(WEBSITE_DIR, 'mdorigin.config.json')
+    if not os.path.exists(config_path):
+        return
+    dir_pages = collect_dir_pages()
+    with open(config_path) as f:
+        config = json.load(f)
+    for nav in config.get('topNav', []):
+        href = nav['href']
+        clean = href.split('#')[0].split('?')[0]
+        if clean in dir_pages:
+            continue
+        print(f"  BROKEN-NAV: {href} ({nav['label']})")
+        broken += 1
+
 
 print("=== Holon docs link check ===")
 
@@ -47,11 +123,17 @@ for f in ["README.md", "docs/architecture-overview.md", "docs/runtime-spec.md"]:
 # Website docs resolve site-root-absolute links relative to docs/website/
 for root, dirs, files in os.walk(WEBSITE_DIR):
     if '.tools/node_modules' in root:
+        dirs[:] = []
         continue
     dirs[:] = [d for d in dirs if d != 'node_modules']
     for f in files:
         if f.endswith('.md'):
             check_file(os.path.join(root, f), WEBSITE_DIR)
+
+print("=== Trailing-slash check ===")
+check_trailing_slashes()
+print("=== Navigation config check ===")
+check_nav_config()
 
 print()
 if broken == 0:

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -69,10 +69,10 @@ contribute, see [Getting started](/getting-started/). Next, follow the
 
 - **I want to install and run Holon** → [Getting started](/getting-started/)
 - **I want to understand the concepts** → [Concepts](/concepts/), especially
-  [runtime model](/concepts/runtime-model/) and
-  [documentation layers](/concepts/documentation-layers/)
+  [runtime model](/concepts/runtime-model) and
+  [documentation layers](/concepts/documentation-layers)
 - **I want to find a command or config key** → [Reference](/reference/)
-- **I want to integrate Holon** → [Integration guide](/guides/integration/)
+- **I want to integrate Holon** → [Integration guide](/guides/integration)
 - **I want to contribute to the runtime** →
   [Architecture overview](https://github.com/holon-run/holon/blob/main/docs/architecture-overview.md)
   and [RFCs](https://github.com/holon-run/holon/tree/main/docs/rfcs)
@@ -82,7 +82,7 @@ contribute, see [Getting started](/getting-started/). Next, follow the
 - [Getting started](/getting-started/) — your first Holon agent run, from
   install to first interaction.
 - [Concepts](/concepts/) — the mental model: agents, work items, tasks, queues,
-- **[Security and execution boundaries](/concepts/security-and-execution-boundaries/)** — what Holon guards and what you must guard.
+- **[Security and execution boundaries](/concepts/security-and-execution-boundaries)** — what Holon guards and what you must guard.
   and trust boundaries.
 - [Guides](/guides/) — task-oriented workflows for operating, integrating, and
   extending Holon.
@@ -107,7 +107,7 @@ need to understand or change runtime behavior.
 This website is built from source Markdown with mdorigin. Every page is
 available as both rendered HTML and raw Markdown, and `Accept: text/markdown`
 requests return machine-readable content. See the
-[documentation workflow guide](/guides/documentation-workflow/) for build and
+[documentation workflow guide](/guides/documentation-workflow) for build and
 preview details.
 
 ## Markdown-native access
@@ -120,7 +120,7 @@ mdorigin keeps the site useful for both humans and agents:
 - Build commands can generate search data and Cloudflare Worker assets.
 
 Build commands are covered in the [documentation workflow
-guide](/guides/documentation-workflow/). The production `siteUrl` is
+guide](/guides/documentation-workflow). The production `siteUrl` is
 `https://holon.run`.
 
 <!-- INDEX:START -->

--- a/docs/website/concepts/security-and-execution-boundaries.md
+++ b/docs/website/concepts/security-and-execution-boundaries.md
@@ -133,7 +133,7 @@ privileges unless you add OS-level confinement.
 
 ## See also
 
-- [Trust boundaries](/concepts/trust-boundaries/) — how trust classification works end-to-end
-- [Runtime model](/concepts/runtime-model/) — execution environment and workspace binding
-- [Integration guide](/guides/integration/) — HTTP control plane access
-- [Remote access](/guides/remote-access/) — serving Holon beyond localhost
+- [Trust boundaries](/concepts/trust-boundaries) — how trust classification works end-to-end
+- [Runtime model](/concepts/runtime-model) — execution environment and workspace binding
+- [Integration guide](/guides/integration) — HTTP control plane access
+- [Remote access](/guides/remote-access) — serving Holon beyond localhost

--- a/docs/website/getting-started/README.md
+++ b/docs/website/getting-started/README.md
@@ -35,25 +35,25 @@ Holon gives you three ways to interact with the runtime:
 
 The [first agent tutorial](first-agent.md) uses daemon + TUI because it
 gives you the full interactive experience. For one-shot runs, see the
-[quick examples](/guides/quick-examples/).
+[quick examples](/guides/quick-examples).
 
 ## Evaluate or explore?
 
 If you're already familiar with Holon or want to jump straight into specifics:
 
-- **[Quick examples](/guides/quick-examples/)** — one-shot and common task patterns
-- **[Durable agent workflow](/guides/durable-agent-workflow/)** — the full lifecycle of durable agent work
+- **[Quick examples](/guides/quick-examples)** — one-shot and common task patterns
+- **[Durable agent workflow](/guides/durable-agent-workflow)** — the full lifecycle of durable agent work
 - **[Concepts](/concepts/)** — the mental model before diving into internals
 - **[CLI reference](/reference/cli.md)** — full command surface
-- **[Troubleshooting](/guides/troubleshooting/)** — diagnose common setup issues
+- **[Troubleshooting](/guides/troubleshooting)** — diagnose common setup issues
 
 ## Contribute or develop?
 
 If you plan to modify or contribute to Holon itself:
 
-- **[Local runtime guide](/guides/local-runtime/)** — conservative development workflow
-- **[Documentation workflow](/guides/documentation-workflow/)** — how to build and preview this site
-- **[Integration guide](/guides/integration/)** — wire Holon into external systems
+- **[Local runtime guide](/guides/local-runtime)** — conservative development workflow
+- **[Documentation workflow](/guides/documentation-workflow)** — how to build and preview this site
+- **[Integration guide](/guides/integration)** — wire Holon into external systems
 - Repository `docs/` directory — RFCs, implementation decisions, and architecture notes
 
 ## Requirements

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -12,48 +12,48 @@ Guides are organized by user job — find your goal and follow the path.
 
 Start here if you want to see what Holon can do with minimal setup.
 
-- **[Quick examples](/guides/quick-examples/)** — one-shot commands, agent
+- **[Quick examples](/guides/quick-examples)** — one-shot commands, agent
   creation, model configuration, daemon and TUI basics.
-- **[Local runtime](/guides/local-runtime/)** — conservative workflow for
+- **[Local runtime](/guides/local-runtime)** — conservative workflow for
   running and inspecting Holon from source.
 
 ## Automate GitHub work
 
-- **[holon solve](/guides/solve/)** — headless automation for GitHub issues and
+- **[holon solve](/guides/solve)** — headless automation for GitHub issues and
   pull requests with automatic skill dispatch.
 
 ## Operate and configure
 
 Keep a running Holon instance healthy and configured.
 
-- **[Troubleshooting](/guides/troubleshooting/)** — diagnose daemon, model,
+- **[Troubleshooting](/guides/troubleshooting)** — diagnose daemon, model,
   configuration, and TUI issues in likely encounter order.
 
 ## Integrate and automate
 
 Wire Holon into external systems through its control plane.
 
-- **[Integration guide](/guides/integration/)** — HTTP control plane with
+- **[Integration guide](/guides/integration)** — HTTP control plane with
   curl examples and endpoint reference.
 
 ## Collaborate and delegate
 
 Work with multiple agents, durable objectives, and reusable skills.
 
-- **[Multi-agent collaboration](/guides/multi-agent/)** — spawning child
+- **[Multi-agent collaboration](/guides/multi-agent)** — spawning child
   agents, supervision contracts, and workspace modes.
-- **[Work items guide](/guides/work-items/)** — tracking durable objectives
+- **[Work items guide](/guides/work-items)** — tracking durable objectives
   with plans, todo lists, and lifecycle management.
-- **[Durable agent workflow](/guides/durable-agent-workflow/)** — the end-to-end
+- **[Durable agent workflow](/guides/durable-agent-workflow)** — the end-to-end
   durable agent story: WorkItems, wait/wake/resume, and final briefs.
-- **[Skills guide](/guides/skills/)** — reusable SKILL.md workflows, skill
+- **[Skills guide](/guides/skills)** — reusable SKILL.md workflows, skill
   locations, and custom skill development.
 
 ## Contribute to these docs
 
 Edit and build the Holon documentation website.
 
-- **[Documentation workflow](/guides/documentation-workflow/)** — how to edit
+- **[Documentation workflow](/guides/documentation-workflow)** — how to edit
   and build the mdorigin-powered Holon website.
 
 <!-- INDEX:START -->

--- a/docs/website/guides/agent-templates.md
+++ b/docs/website/guides/agent-templates.md
@@ -169,5 +169,5 @@ Templates and skills serve different purposes:
 | Example | "You are a reviewer" | "Here's how to review a PR" |
 
 Templates often include skill references so that new agents have the right
-tools available from the start. See the [Skills guide](/guides/skills/) for
+tools available from the start. See the [Skills guide](/guides/skills) for
 details on skills.

--- a/docs/website/guides/durable-agent-workflow.md
+++ b/docs/website/guides/durable-agent-workflow.md
@@ -181,8 +181,8 @@ For quick one-shot tasks that don't need durability, use `holon run` instead.
 
 ## See also
 
-- [Work items guide](/guides/work-items/) — WorkItem lifecycle and best practices
-- [Multi-agent collaboration](/guides/multi-agent/) — delegate work to child agents
-- [CLI reference](/reference/cli/) — full command surface
-- [Runtime model](/concepts/runtime-model/) — the concepts behind durability
-- [Integration guide](/guides/integration/) — HTTP API for automation
+- [Work items guide](/guides/work-items) — WorkItem lifecycle and best practices
+- [Multi-agent collaboration](/guides/multi-agent) — delegate work to child agents
+- [CLI reference](/reference/cli) — full command surface
+- [Runtime model](/concepts/runtime-model) — the concepts behind durability
+- [Integration guide](/guides/integration) — HTTP API for automation

--- a/docs/website/guides/quick-examples.md
+++ b/docs/website/guides/quick-examples.md
@@ -128,7 +128,7 @@ holon tui --no-alt-screen
 
 In the TUI, type `/` to open the slash command menu. Use `/model` to
 switch models, `/agent` to manage agents, and `/help` to see all commands.
-See the [TUI guide](/guides/tui/) for the full slash command reference.
+See the [TUI guide](/guides/tui) for the full slash command reference.
 
 ## 6. Start the HTTP Server
 

--- a/docs/website/guides/solve.md
+++ b/docs/website/guides/solve.md
@@ -229,7 +229,7 @@ git push origin HEAD
 
 ## See also
 
-- [Holon CLI reference](/reference/cli/) — full command tree
-- [Configuration reference](/reference/configuration/) — model and provider setup
-- [Integration guide](/guides/integration/) — HTTP control plane access
-- [Multi-agent collaboration](/guides/multi-agent/) — spawning child agents
+- [Holon CLI reference](/reference/cli) — full command tree
+- [Configuration reference](/reference/configuration) — model and provider setup
+- [Integration guide](/guides/integration) — HTTP control plane access
+- [Multi-agent collaboration](/guides/multi-agent) — spawning child agents

--- a/docs/website/guides/tui.md
+++ b/docs/website/guides/tui.md
@@ -150,5 +150,5 @@ The daemon must be started with an access mode that accepts remote connections
 
 ## Troubleshooting
 
-See the [Troubleshooting guide](/guides/troubleshooting/#tui-issues) for common
+See the [Troubleshooting guide](/guides/troubleshooting#tui-issues) for common
 TUI issues including garbled display and daemon connection problems.

--- a/docs/website/mdorigin.config.json
+++ b/docs/website/mdorigin.config.json
@@ -24,10 +24,6 @@
     {
       "label": "Reference",
       "href": "/reference/"
-    },
-    {
-      "label": "Roadmap",
-      "href": "/roadmap/"
     }
   ],
   "footerNav": [


### PR DESCRIPTION
## Summary

Fixes 40 dead links on the Holon documentation website (holon.run).

## Root cause

mdorigin's router maps `/path/` to directory-based pages (`path/index.md`) and `/path` to file-based pages (`path.md`). The docs content had 39 links using trailing slashes for file-based pages, causing 404 errors when clicked. Additionally, the navigation bar's `/roadmap/` link pointed to a non-existent page.

## Changes

### Content fixes (39 links across 9 files)
- Removed trailing slashes from all links pointing to file-based `.md` pages
- Example: `[Multi-agent](/guides/multi-agent/)` → `[Multi-agent](/guides/multi-agent)`

### Navigation fix (1 link)
- Removed broken `/roadmap/` entry from `mdorigin.config.json` topNav

### Automated prevention
- Updated `docs/website/.tools/check-links.py` to:
  - Detect trailing-slash mismatches for file-based pages
  - Validate navigation links in `mdorigin.config.json`
- Added link checking step to `docs-site.yml` CI workflow (fails the build on broken links)

## Verification

- `python3 docs/website/.tools/check-links.py` → ALL LINKS OK
- Manual check: all broken links resolved to correct URLs