### PR TITLE
feat: add OpenAPI baseline schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aide"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6966317188cdfe54c58c0900a195d021294afb3ece9b7073d09e4018dbb1e3a2"
+dependencies = [
+ "axum",
+ "bytes",
+ "cfg-if",
+ "http",
+ "indexmap",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror 2.0.18",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,12 +611,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -603,6 +640,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -622,8 +687,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -751,6 +821,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "holon"
 version = "0.14.1"
 dependencies = [
+ "aide",
  "anyhow",
  "async-trait",
  "axum",
@@ -1777,6 +1848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "dyn-clone",
+ "indexmap",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -1870,6 +1942,19 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b417bedc008acbdf6d6b4bc482d29859924114bbe2650b7921fb68a261d0aa6"
+dependencies = [
+ "axum",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ unicode-width = "0.2"
 url = "2.5"
 uuid = { version = "1.11", features = ["serde", "v4"] }
 twox-hash = { version = "2.1.2", features = ["std"] }
+aide = { version = "0.15.1", features = ["axum"] }
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -34,6 +34,10 @@ behavior changes.
   How to think about Holon's headless integration surface.
   <!-- mdorigin:index kind=article -->
 
+- [OpenAPI schema](./openapi.json)
+  Generated baseline OpenAPI 3.1 schema for Holon's current HTTP control-plane surface.
+  <!-- mdorigin:index kind=article -->
+
 - [API contract inventory](./api-contract-inventory.md)
   First-pass stability inventory for Holon's HTTP control-plane API parameters, responses, and follow-up contract work.
   <!-- mdorigin:index kind=article -->

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -14,6 +14,9 @@ API long term.
 
 - **Last reviewed against:** `holon` v0.14.1, `main` at `1aa5050`.
 - **Primary source:** `src/http.rs` Axum router and request/response structs.
+- **Generated schema:** [`openapi.json`](./openapi.json), produced by
+  `holon::openapi::generate_openapi_json()` and checked by
+  `cargo test --test openapi_snapshot`.
 - **Client source:** `src/client.rs` for the subset consumed by the TUI/CLI.
 - **Current status:** pre-1.0 baseline. Treat shapes below as observed
   behavior, not a final compatibility promise.

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -10,6 +10,11 @@ Holon is designed to be headless. HTTP and event-driven integration surfaces
 should preserve the same runtime concepts as the CLI: origin, trust, priority,
 work items, tasks, queues, wakeups, and user-facing delivery.
 
+The current generated OpenAPI baseline is checked in at
+[`openapi.json`](./openapi.json). It is a conservative schema for the present
+route surface; some request and response schemas intentionally remain broad
+until the success/error envelope and DTO contracts are stabilized.
+
 ## Authentication
 
 When a control token is configured (e.g. `--token`, `--token-file`, or the

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1,0 +1,2905 @@
+{
+  "components": {
+    "schemas": {
+      "AbortCurrentRunRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "AttachWorkspaceRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "CallbackBody": {
+        "description": "Raw callback request body. JSON and text bodies are parsed; other content types are represented internally as base64 JSON."
+      },
+      "ClearAgentModelRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "ControlPromptRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "ControlRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "ControlWakeRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "CreateAgentRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "CreateCommandTaskRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "CreateTimerRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "CreateWorkItemRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "DebugPromptRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "DetachWorkspaceRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "EnqueueRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "after_seq": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "agent_id": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "event_seq": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "hint": {
+            "type": "string"
+          },
+          "ok": {
+            "const": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "ExitWorkspaceRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "GenericJsonPayload": {
+        "$ref": "#/components/schemas/JsonValue"
+      },
+      "IncomingOrigin": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "InstallSkillRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "JsonValue": {
+        "description": "Arbitrary JSON value. Used as a conservative baseline for routes whose DTO is not yet stabilized."
+      },
+      "OperatorIngressRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "OperatorTransportBindingRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "SetAgentModelRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "UninstallSkillRequest": {
+        "additionalProperties": true,
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "CallbackToken": {
+        "description": "Opaque capability secret path segment. Use placeholders in documentation and tests.",
+        "in": "path",
+        "name": "callback_token",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
+    "title": "Holon HTTP control-plane API",
+    "version": "0.14.1"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Return the default agent id.",
+        "operationId": "root",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Root discovery",
+        "tags": [
+          "discovery"
+        ]
+      }
+    },
+    "/agents/list": {
+      "get": {
+        "description": "Return lightweight public agent entries.",
+        "operationId": "listAgents",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List agents",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/briefs": {
+      "get": {
+        "description": "Return recent user-facing delivery briefs. Query parameter: limit.",
+        "operationId": "agentBriefs",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Recent briefs",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/enqueue": {
+      "post": {
+        "description": "Enqueue a public channel/webhook message for the named agent.",
+        "operationId": "enqueueAgent",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnqueueRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Enqueue agent message",
+        "tags": [
+          "ingress"
+        ]
+      }
+    },
+    "/agents/{agent_id}/events": {
+      "get": {
+        "description": "Return a bounded page of projected runtime events. Query parameters: before_seq, after_seq, limit, order, projection.",
+        "operationId": "agentEvents",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent event page",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/agents/{agent_id}/events/stream": {
+      "get": {
+        "description": "Return Server-Sent Events carrying StreamEventEnvelope JSON data. Query parameters: after_seq, limit, projection.",
+        "operationId": "agentEventsStream",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error before stream establishment."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent event stream",
+        "tags": [
+          "events"
+        ]
+      }
+    },
+    "/agents/{agent_id}/skills": {
+      "get": {
+        "description": "Return installed skills for an agent.",
+        "operationId": "agentSkills",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List skills",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/agents/{agent_id}/state": {
+      "get": {
+        "description": "Return the current bootstrap snapshot for an agent.",
+        "operationId": "agentState",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent state snapshot",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/status": {
+      "get": {
+        "description": "Return the public AgentSummary read model.",
+        "operationId": "agentStatus",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Agent status",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/tasks": {
+      "get": {
+        "description": "Return active task records. Query parameter: limit.",
+        "operationId": "agentTasks",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List active tasks",
+        "tags": [
+          "tasks"
+        ]
+      }
+    },
+    "/agents/{agent_id}/timers": {
+      "get": {
+        "description": "Return recent timer records. Query parameter: limit.",
+        "operationId": "agentTimers",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List timers",
+        "tags": [
+          "timers"
+        ]
+      }
+    },
+    "/agents/{agent_id}/transcript": {
+      "get": {
+        "description": "Return recent transcript entries. Query parameter: limit.",
+        "operationId": "agentTranscript",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Recent transcript",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/worktree-summary": {
+      "get": {
+        "description": "Return managed worktree summary for an agent.",
+        "operationId": "agentWorktreeSummary",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Worktree summary",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/briefs": {
+      "get": {
+        "description": "Compatibility alias for the default agent briefs route. Query parameter: limit.",
+        "operationId": "defaultBriefs",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Default agent briefs alias",
+        "tags": [
+          "compat"
+        ]
+      }
+    },
+    "/callbacks/enqueue/{callback_token}": {
+      "post": {
+        "description": "Capability-token callback ingress for enqueue delivery. The token is a secret path segment and examples intentionally use a placeholder.",
+        "operationId": "callbackEnqueue",
+        "parameters": [
+          {
+            "description": "Opaque callback capability token. This is a secret and must not be exposed in examples.",
+            "in": "path",
+            "name": "callback_token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallbackBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "CallbackToken": []
+          }
+        ],
+        "summary": "Callback enqueue ingress",
+        "tags": [
+          "callbacks"
+        ]
+      }
+    },
+    "/callbacks/wake/{callback_token}": {
+      "post": {
+        "description": "Capability-token callback ingress for wake delivery. The token is a secret path segment and examples intentionally use a placeholder.",
+        "operationId": "callbackWake",
+        "parameters": [
+          {
+            "description": "Opaque callback capability token. This is a secret and must not be exposed in examples.",
+            "in": "path",
+            "name": "callback_token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallbackBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "CallbackToken": []
+          }
+        ],
+        "summary": "Callback wake ingress",
+        "tags": [
+          "callbacks"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/control": {
+      "post": {
+        "description": "Submit a lifecycle control action.",
+        "operationId": "controlAgent",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControlRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Control agent lifecycle",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/create": {
+      "post": {
+        "description": "Create a public named agent, optionally from a template.",
+        "operationId": "createAgent",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create named agent",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/current-run/abort": {
+      "post": {
+        "description": "Request abort for the current agent run.",
+        "operationId": "abortCurrentRun",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AbortCurrentRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Abort current run",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/debug-prompt": {
+      "post": {
+        "description": "Render a diagnostic prompt preview.",
+        "operationId": "debugPrompt",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebugPromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Debug prompt",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/model": {
+      "post": {
+        "description": "Set an agent model override and optional reasoning effort.",
+        "operationId": "setAgentModel",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAgentModelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Set agent model override",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/model/clear": {
+      "post": {
+        "description": "Clear an agent model override.",
+        "operationId": "clearAgentModel",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClearAgentModelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Clear agent model override",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/operator-bindings": {
+      "post": {
+        "description": "Create or update a remote operator transport binding.",
+        "operationId": "createOperatorTransportBinding",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperatorTransportBindingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create operator binding",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/operator-ingress": {
+      "post": {
+        "description": "Deliver an authenticated remote operator prompt.",
+        "operationId": "operatorIngress",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperatorIngressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Operator ingress",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/prompt": {
+      "post": {
+        "description": "Submit a trusted operator prompt through the control plane.",
+        "operationId": "controlPrompt",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControlPromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Submit operator prompt",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/skills/install": {
+      "post": {
+        "description": "Install an agent skill.",
+        "operationId": "installSkill",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Install skill",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/skills/uninstall": {
+      "post": {
+        "description": "Uninstall an agent skill.",
+        "operationId": "uninstallSkill",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UninstallSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Uninstall skill",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/tasks": {
+      "post": {
+        "description": "Schedule a command task for an agent.",
+        "operationId": "createCommandTask",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCommandTaskRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create command task",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/timers": {
+      "post": {
+        "description": "Schedule a timer for an agent.",
+        "operationId": "createTimer",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTimerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create timer",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/wake": {
+      "post": {
+        "description": "Submit a trusted wake hint.",
+        "operationId": "controlWake",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControlWakeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Wake agent",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/work-items": {
+      "post": {
+        "description": "Create or enqueue a public work item objective.",
+        "operationId": "createWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/workspace/attach": {
+      "post": {
+        "description": "Attach a workspace path to an agent.",
+        "operationId": "attachWorkspace",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Attach workspace",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/workspace/detach": {
+      "post": {
+        "description": "Detach a workspace binding by workspace id.",
+        "operationId": "detachWorkspace",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetachWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Detach workspace",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/workspace/exit": {
+      "post": {
+        "description": "Return an agent to its default AgentHome workspace.",
+        "operationId": "exitWorkspace",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExitWorkspaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Exit workspace",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/runtime/readiness": {
+      "get": {
+        "description": "Return daemon readiness metadata.",
+        "operationId": "runtimeReadiness",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime readiness",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/control/runtime/shutdown": {
+      "post": {
+        "description": "Request graceful runtime shutdown.",
+        "operationId": "runtimeShutdown",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime shutdown",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/control/runtime/status": {
+      "get": {
+        "description": "Return daemon status and runtime activity metadata.",
+        "operationId": "runtimeStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime status",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/enqueue": {
+      "post": {
+        "description": "Enqueue a public channel/webhook message for the default agent.",
+        "operationId": "enqueueDefault",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnqueueRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Enqueue default agent message",
+        "tags": [
+          "ingress"
+        ]
+      }
+    },
+    "/handshake": {
+      "get": {
+        "description": "Return auth mode, protocol version, capabilities, and runtime hints.",
+        "operationId": "handshake",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Protocol handshake",
+        "tags": [
+          "discovery"
+        ]
+      }
+    },
+    "/models": {
+      "get": {
+        "description": "Return model catalog entries and runtime availability.",
+        "operationId": "models",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List available models",
+        "tags": [
+          "discovery"
+        ]
+      }
+    },
+    "/state": {
+      "get": {
+        "description": "Compatibility alias for the default agent state route.",
+        "operationId": "defaultState",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Default agent state alias",
+        "tags": [
+          "compat"
+        ]
+      }
+    },
+    "/status": {
+      "get": {
+        "description": "Compatibility alias for the default agent status route.",
+        "operationId": "defaultStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Default agent status alias",
+        "tags": [
+          "compat"
+        ]
+      }
+    },
+    "/transcript": {
+      "get": {
+        "description": "Compatibility alias for the default agent transcript route. Query parameter: limit.",
+        "operationId": "defaultTranscript",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Default agent transcript alias",
+        "tags": [
+          "compat"
+        ]
+      }
+    },
+    "/webhooks/generic/{agent_id}": {
+      "post": {
+        "description": "Convert an arbitrary JSON webhook body into a trusted integration message.",
+        "operationId": "genericWebhook",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJsonPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "summary": "Generic webhook",
+        "tags": [
+          "ingress"
+        ]
+      }
+    },
+    "/worktree-summary": {
+      "get": {
+        "description": "Compatibility alias for the default agent worktree summary route.",
+        "operationId": "defaultWorktreeSummary",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Default agent worktree summary alias",
+        "tags": [
+          "compat"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Local runtime; port is configurable.",
+      "url": "http://127.0.0.1:7878"
+    }
+  ],
+  "tags": [
+    {
+      "name": "discovery"
+    },
+    {
+      "name": "agents"
+    },
+    {
+      "name": "events"
+    },
+    {
+      "name": "ingress"
+    },
+    {
+      "name": "control"
+    },
+    {
+      "name": "runtime"
+    },
+    {
+      "name": "tasks"
+    },
+    {
+      "name": "timers"
+    },
+    {
+      "name": "skills"
+    },
+    {
+      "description": "Capability-token callback ingress. Never publish real callback_token values.",
+      "name": "callbacks"
+    },
+    {
+      "name": "compat"
+    }
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod http;
 pub mod ingress;
 pub mod memory;
 pub mod model_catalog;
+pub mod openapi;
 pub mod operator_event;
 pub mod policy;
 pub mod presentation;

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,0 +1,312 @@
+use serde_json::{json, Value};
+
+const API_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Clone, Copy)]
+struct RouteSpec {
+    method: &'static str,
+    path: &'static str,
+    operation_id: &'static str,
+    tag: &'static str,
+    summary: &'static str,
+    description: &'static str,
+    request_schema: Option<&'static str>,
+    response_kind: ResponseKind,
+    auth: AuthKind,
+}
+
+#[derive(Clone, Copy)]
+enum ResponseKind {
+    Json,
+    EventStream,
+}
+
+#[derive(Clone, Copy)]
+enum AuthKind {
+    RemoteAccess,
+    Control,
+    Capability,
+    None,
+}
+
+const ROUTES: &[RouteSpec] = &[
+    route("get", "/", "root", "discovery", "Root discovery", "Return the default agent id.", None, AuthKind::RemoteAccess),
+    route("get", "/handshake", "handshake", "discovery", "Protocol handshake", "Return auth mode, protocol version, capabilities, and runtime hints.", None, AuthKind::RemoteAccess),
+    route("get", "/models", "models", "discovery", "List available models", "Return model catalog entries and runtime availability.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/list", "listAgents", "agents", "List agents", "Return lightweight public agent entries.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/status", "agentStatus", "agents", "Agent status", "Return the public AgentSummary read model.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/briefs", "agentBriefs", "agents", "Recent briefs", "Return recent user-facing delivery briefs. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/state", "agentState", "agents", "Agent state snapshot", "Return the current bootstrap snapshot for an agent.", None, AuthKind::RemoteAccess),
+    RouteSpec { method: "get", path: "/agents/{agent_id}/events", operation_id: "agentEvents", tag: "events", summary: "Agent event page", description: "Return a bounded page of projected runtime events. Query parameters: before_seq, after_seq, limit, order, projection.", request_schema: None, response_kind: ResponseKind::Json, auth: AuthKind::RemoteAccess },
+    RouteSpec { method: "get", path: "/agents/{agent_id}/events/stream", operation_id: "agentEventsStream", tag: "events", summary: "Agent event stream", description: "Return Server-Sent Events carrying StreamEventEnvelope JSON data. Query parameters: after_seq, limit, projection.", request_schema: None, response_kind: ResponseKind::EventStream, auth: AuthKind::RemoteAccess },
+    route("get", "/agents/{agent_id}/transcript", "agentTranscript", "agents", "Recent transcript", "Return recent transcript entries. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/tasks", "agentTasks", "tasks", "List active tasks", "Return active task records. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/worktree-summary", "agentWorktreeSummary", "agents", "Worktree summary", "Return managed worktree summary for an agent.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List skills", "Return installed skills for an agent.", None, AuthKind::RemoteAccess),
+    route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
+    route("post", "/agents/{agent_id}/enqueue", "enqueueAgent", "ingress", "Enqueue agent message", "Enqueue a public channel/webhook message for the named agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
+    route("post", "/webhooks/generic/{agent_id}", "genericWebhook", "ingress", "Generic webhook", "Convert an arbitrary JSON webhook body into a trusted integration message.", Some("GenericJsonPayload"), AuthKind::None),
+    route("post", "/control/agents/{agent_id}/tasks", "createCommandTask", "control", "Create command task", "Schedule a command task for an agent.", Some("CreateCommandTaskRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/work-items", "createWorkItem", "control", "Create work item", "Create or enqueue a public work item objective.", Some("CreateWorkItemRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/timers", "createTimer", "control", "Create timer", "Schedule a timer for an agent.", Some("CreateTimerRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/create", "createAgent", "control", "Create named agent", "Create a public named agent, optionally from a template.", Some("CreateAgentRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/workspace/attach", "attachWorkspace", "control", "Attach workspace", "Attach a workspace path to an agent.", Some("AttachWorkspaceRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/workspace/exit", "exitWorkspace", "control", "Exit workspace", "Return an agent to its default AgentHome workspace.", Some("ExitWorkspaceRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/workspace/detach", "detachWorkspace", "control", "Detach workspace", "Detach a workspace binding by workspace id.", Some("DetachWorkspaceRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/model", "setAgentModel", "control", "Set agent model override", "Set an agent model override and optional reasoning effort.", Some("SetAgentModelRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/model/clear", "clearAgentModel", "control", "Clear agent model override", "Clear an agent model override.", Some("ClearAgentModelRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/control", "controlAgent", "control", "Control agent lifecycle", "Submit a lifecycle control action.", Some("ControlRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/current-run/abort", "abortCurrentRun", "control", "Abort current run", "Request abort for the current agent run.", Some("AbortCurrentRunRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/prompt", "controlPrompt", "control", "Submit operator prompt", "Submit a trusted operator prompt through the control plane.", Some("ControlPromptRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/operator-bindings", "createOperatorTransportBinding", "control", "Create operator binding", "Create or update a remote operator transport binding.", Some("OperatorTransportBindingRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/operator-ingress", "operatorIngress", "control", "Operator ingress", "Deliver an authenticated remote operator prompt.", Some("OperatorIngressRequest"), AuthKind::Control),
+    route("get", "/control/runtime/readiness", "runtimeReadiness", "runtime", "Runtime readiness", "Return daemon readiness metadata.", None, AuthKind::Control),
+    route("get", "/control/runtime/status", "runtimeStatus", "runtime", "Runtime status", "Return daemon status and runtime activity metadata.", None, AuthKind::Control),
+    route("post", "/control/runtime/shutdown", "runtimeShutdown", "runtime", "Runtime shutdown", "Request graceful runtime shutdown.", None, AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/debug-prompt", "debugPrompt", "control", "Debug prompt", "Render a diagnostic prompt preview.", Some("DebugPromptRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/wake", "controlWake", "control", "Wake agent", "Submit a trusted wake hint.", Some("ControlWakeRequest"), AuthKind::Control),
+    route("post", "/callbacks/enqueue/{callback_token}", "callbackEnqueue", "callbacks", "Callback enqueue ingress", "Capability-token callback ingress for enqueue delivery. The token is a secret path segment and examples intentionally use a placeholder.", Some("CallbackBody"), AuthKind::Capability),
+    route("post", "/callbacks/wake/{callback_token}", "callbackWake", "callbacks", "Callback wake ingress", "Capability-token callback ingress for wake delivery. The token is a secret path segment and examples intentionally use a placeholder.", Some("CallbackBody"), AuthKind::Capability),
+    route("post", "/control/agents/{agent_id}/skills/install", "installSkill", "skills", "Install skill", "Install an agent skill.", Some("InstallSkillRequest"), AuthKind::Control),
+    route("post", "/control/agents/{agent_id}/skills/uninstall", "uninstallSkill", "skills", "Uninstall skill", "Uninstall an agent skill.", Some("UninstallSkillRequest"), AuthKind::Control),
+    route("get", "/status", "defaultStatus", "compat", "Default agent status alias", "Compatibility alias for the default agent status route.", None, AuthKind::RemoteAccess),
+    route("get", "/briefs", "defaultBriefs", "compat", "Default agent briefs alias", "Compatibility alias for the default agent briefs route. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/state", "defaultState", "compat", "Default agent state alias", "Compatibility alias for the default agent state route.", None, AuthKind::RemoteAccess),
+    route("get", "/transcript", "defaultTranscript", "compat", "Default agent transcript alias", "Compatibility alias for the default agent transcript route. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/worktree-summary", "defaultWorktreeSummary", "compat", "Default agent worktree summary alias", "Compatibility alias for the default agent worktree summary route.", None, AuthKind::RemoteAccess),
+];
+
+const fn route(
+    method: &'static str,
+    path: &'static str,
+    operation_id: &'static str,
+    tag: &'static str,
+    summary: &'static str,
+    description: &'static str,
+    request_schema: Option<&'static str>,
+    auth: AuthKind,
+) -> RouteSpec {
+    RouteSpec {
+        method,
+        path,
+        operation_id,
+        tag,
+        summary,
+        description,
+        request_schema,
+        response_kind: ResponseKind::Json,
+        auth,
+    }
+}
+
+pub fn generate_openapi_json() -> Value {
+    openapi_value()
+}
+
+fn openapi_value() -> Value {
+    let mut paths = serde_json::Map::new();
+    for spec in ROUTES {
+        let entry = paths
+            .entry(spec.path.to_string())
+            .or_insert_with(|| json!({}));
+        entry[spec.method] = operation(spec);
+    }
+
+    json!({
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Holon HTTP control-plane API",
+            "version": API_VERSION,
+            "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize."
+        },
+        "servers": [{ "url": "http://127.0.0.1:7878", "description": "Local runtime; port is configurable." }],
+        "tags": [
+            { "name": "discovery" },
+            { "name": "agents" },
+            { "name": "events" },
+            { "name": "ingress" },
+            { "name": "control" },
+            { "name": "runtime" },
+            { "name": "tasks" },
+            { "name": "timers" },
+            { "name": "skills" },
+            { "name": "callbacks", "description": "Capability-token callback ingress. Never publish real callback_token values." },
+            { "name": "compat" }
+        ],
+        "components": {
+            "securitySchemes": {
+                "BearerAuth": { "type": "http", "scheme": "bearer" },
+                "CallbackToken": {
+                    "type": "apiKey",
+                    "in": "path",
+                    "name": "callback_token",
+                    "description": "Opaque capability secret path segment. Use placeholders in documentation and tests."
+                }
+            },
+            "schemas": component_schemas()
+        },
+        "paths": paths
+    })
+}
+
+fn operation(spec: &RouteSpec) -> Value {
+    let mut op = json!({
+        "operationId": spec.operation_id,
+        "tags": [spec.tag],
+        "summary": spec.summary,
+        "description": spec.description,
+        "parameters": path_parameters(spec.path),
+        "responses": responses(spec.response_kind),
+    });
+    if let Some(schema) = spec.request_schema {
+        op["requestBody"] = json!({
+            "required": true,
+            "content": {
+                "application/json": {
+                    "schema": { "$ref": format!("#/components/schemas/{schema}") }
+                }
+            }
+        });
+    }
+    match spec.auth {
+        AuthKind::RemoteAccess | AuthKind::Control => {
+            op["security"] = json!([{ "BearerAuth": [] }])
+        }
+        AuthKind::Capability => op["security"] = json!([{ "CallbackToken": [] }]),
+        AuthKind::None => {}
+    }
+    op
+}
+
+fn path_parameters(path: &str) -> Vec<Value> {
+    let mut params = Vec::new();
+    if path.contains("{agent_id}") {
+        params.push(path_param("agent_id", "Agent id."));
+    }
+    if path.contains("{callback_token}") {
+        params.push(path_param(
+            "callback_token",
+            "Opaque callback capability token. This is a secret and must not be exposed in examples.",
+        ));
+    }
+    params
+}
+
+fn path_param(name: &str, description: &str) -> Value {
+    json!({
+        "name": name,
+        "in": "path",
+        "required": true,
+        "description": description,
+        "schema": { "type": "string" }
+    })
+}
+
+fn responses(kind: ResponseKind) -> Value {
+    match kind {
+        ResponseKind::Json => json!({
+            "200": {
+                "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized.",
+                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonValue" } } }
+            },
+            "4XX": {
+                "description": "Client error JSON response.",
+                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+            },
+            "5XX": {
+                "description": "Server error JSON response.",
+                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+            }
+        }),
+        ResponseKind::EventStream => json!({
+            "200": {
+                "description": "Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object.",
+                "content": { "text/event-stream": { "schema": { "type": "string" } } }
+            },
+            "4XX": {
+                "description": "Client error before stream establishment.",
+                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+            }
+        }),
+    }
+}
+
+fn component_schemas() -> Value {
+    let request_schema = json!({
+        "type": "object",
+        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "additionalProperties": true
+    });
+    let mut schemas = serde_json::Map::new();
+    schemas.insert("JsonValue".into(), json!({
+        "description": "Arbitrary JSON value. Used as a conservative baseline for routes whose DTO is not yet stabilized."
+    }));
+    schemas.insert(
+        "ErrorResponse".into(),
+        json!({
+            "type": "object",
+            "properties": {
+                "ok": { "type": "boolean", "const": false },
+                "error": { "type": "string" },
+                "code": { "type": "string" },
+                "agent_id": { "type": "string" },
+                "hint": { "type": "string" },
+                "after_seq": { "type": "integer", "minimum": 0 },
+                "event_seq": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["error"],
+            "additionalProperties": true
+        }),
+    );
+    schemas.insert(
+        "GenericJsonPayload".into(),
+        json!({ "$ref": "#/components/schemas/JsonValue" }),
+    );
+    schemas.insert("CallbackBody".into(), json!({
+        "description": "Raw callback request body. JSON and text bodies are parsed; other content types are represented internally as base64 JSON."
+    }));
+    for name in [
+        "EnqueueRequest",
+        "IncomingOrigin",
+        "CreateCommandTaskRequest",
+        "CreateWorkItemRequest",
+        "CreateTimerRequest",
+        "CreateAgentRequest",
+        "AttachWorkspaceRequest",
+        "ExitWorkspaceRequest",
+        "DetachWorkspaceRequest",
+        "SetAgentModelRequest",
+        "ClearAgentModelRequest",
+        "ControlRequest",
+        "AbortCurrentRunRequest",
+        "ControlPromptRequest",
+        "OperatorTransportBindingRequest",
+        "OperatorIngressRequest",
+        "DebugPromptRequest",
+        "ControlWakeRequest",
+        "InstallSkillRequest",
+        "UninstallSkillRequest",
+    ] {
+        schemas.insert(name.into(), request_schema.clone());
+    }
+    Value::Object(schemas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_openapi_includes_current_http_surface() {
+        let api = generate_openapi_json();
+        let paths = api["paths"].as_object().expect("paths object");
+        let operation_count = paths
+            .values()
+            .flat_map(|path| path.as_object().into_iter().flat_map(|ops| ops.keys()))
+            .count();
+        assert!(operation_count >= 40, "expected baseline coverage");
+        assert!(paths["/agents/{agent_id}/events/stream"]["get"].is_object());
+        assert!(paths["/callbacks/wake/{callback_token}"]["post"].is_object());
+    }
+}

--- a/tests/openapi_snapshot.rs
+++ b/tests/openapi_snapshot.rs
@@ -1,0 +1,35 @@
+//! OpenAPI baseline drift test.
+//!
+//! Refresh workflow for intentional HTTP surface changes:
+//!
+//! ```bash
+//! cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored
+//! cargo test --test openapi_snapshot
+//! ```
+
+const SNAPSHOT_PATH: &str = "docs/website/reference/openapi.json";
+
+#[test]
+fn openapi_snapshot_matches_generated_schema() {
+    let live = serde_json::to_string_pretty(&holon::openapi::generate_openapi_json())
+        .expect("serialize generated OpenAPI");
+    let stored = std::fs::read_to_string(SNAPSHOT_PATH)
+        .unwrap_or_else(|err| panic!("failed to read {SNAPSHOT_PATH}: {err}"));
+
+    if live.replace("\r\n", "\n") != stored.replace("\r\n", "\n") {
+        eprintln!(
+            "OpenAPI snapshot drift detected. Refresh intentionally with:\n  cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored\n"
+        );
+        eprintln!("=== GENERATED OPENAPI ===");
+        eprintln!("{live}");
+        panic!("generated OpenAPI does not match checked-in snapshot");
+    }
+}
+
+#[test]
+#[ignore]
+fn refresh_openapi_snapshot() {
+    let live = serde_json::to_string_pretty(&holon::openapi::generate_openapi_json())
+        .expect("serialize generated OpenAPI");
+    std::fs::write(SNAPSHOT_PATH, live).expect("write OpenAPI snapshot");
+}


### PR DESCRIPTION
## Summary

- add `aide` and a generated OpenAPI 3.1 baseline for the current HTTP control-plane route surface
- check in `docs/website/reference/openapi.json` and link it from reference docs / API contract inventory
- add `tests/openapi_snapshot.rs` drift coverage with an ignored refresh helper

## Notes

This is intentionally a conservative baseline: route coverage is explicit and checked in, while many request/response DTO schemas stay broad until the success/error envelope and per-route DTO contracts are stabilized in follow-up issues.

## Verification

- `cargo test --test openapi_snapshot`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #1405
