### PR TITLE
docs: define HTTP error envelope contract

### DIFF
--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -57,7 +57,7 @@ Most successful responses are JSON. There is no single success envelope:
 - `/agents/:id/events/stream` returns Server-Sent Events rather than a JSON
   response body after the stream opens.
 
-Error responses use one shared JSON envelope:
+Handler-produced control-plane errors use one shared JSON envelope:
 
 ```json
 {
@@ -68,9 +68,12 @@ Error responses use one shared JSON envelope:
 }
 ```
 
-`ok` is always `false`; `error` is a human-readable message. `code` and
-`hint` are optional shared fields. Routes may add documented route-specific
-extension fields alongside the shared fields.
+For those handler-produced errors, `ok` is always `false`; `error` is a
+human-readable message. `code` and `hint` are optional shared fields. Routes may
+add documented route-specific extension fields alongside the shared fields.
+Framework-level rejections produced before a handler runs, such as Axum
+extractor failures for malformed JSON or request bodies rejected by
+`DefaultBodyLimit`, are not yet normalized into this envelope.
 
 Status-code mapping:
 

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -57,15 +57,61 @@ Most successful responses are JSON. There is no single success envelope:
 - `/agents/:id/events/stream` returns Server-Sent Events rather than a JSON
   response body after the stream opens.
 
-Error responses are JSON and generally use:
+Error responses use one shared JSON envelope:
 
 ```json
-{ "ok": false, "error": "message" }
+{
+  "ok": false,
+  "error": "message",
+  "code": "machine_readable_code",
+  "hint": "optional operator guidance"
+}
 ```
 
-Some errors add stable-looking fields such as `code`, `agent_id`, `hint`,
-`after_seq`, or `event_seq`, but those fields are not yet documented as a
-shared error schema.
+`ok` is always `false`; `error` is a human-readable message. `code` and
+`hint` are optional shared fields. Routes may add documented route-specific
+extension fields alongside the shared fields.
+
+Status-code mapping:
+
+| Status | Class | Current mapping |
+|--------|-------|-----------------|
+| `400 Bad Request` | Validation | Malformed or unsupported request fields, empty required strings, invalid callback body, unsupported operator delivery auth. |
+| `403 Forbidden` | Authentication/authorization | Missing, malformed, or invalid bearer token; private agent access; invalid callback capability token; ingress policy rejection. |
+| `404 Not Found` | Missing resource/cursor | Unknown public agent, archived public agent, unknown compatibility route, or event cursor outside the replay window. |
+| `409 Conflict` | State conflict | Stopped agent, stale or missing current run for abort, duplicate skill install, active workspace detach conflict when surfaced as a conflict. |
+| `424 Failed Dependency` | Dependency unavailable | Skill manager is unavailable. |
+| `502 Bad Gateway` | Upstream failure | Remote skill installer failed. |
+| `504 Gateway Timeout` | Upstream timeout | Remote skill installer timed out. |
+| `503 Service Unavailable` | Runtime service unavailable | Runtime service metadata is required but absent. |
+| `500 Internal Server Error` | Internal/runtime error | Unexpected runtime, storage, workspace, or handler errors. |
+
+Common route-specific error extensions currently include:
+
+| Field | Used by | Meaning |
+|-------|---------|---------|
+| `agent_id` | stopped-agent and no-current-run conflicts | Agent related to the rejected operation. |
+| `after_seq` / `event_seq` | event page/SSE cursor errors | Cursor sequence that was not available in the replay window. |
+| `requested_run_id` / `current_run_id` | current-run abort conflicts | Stale requested run and current active run. |
+| `skill_name`, `destination`, `manager`, `package`, `exit_status`, `stdout`, `stderr`, `timeout_seconds` | skill install errors | Skill-manager or remote-installer diagnostics. |
+
+Known stable error `code` values:
+
+| Code | Status | Meaning |
+|------|--------|---------|
+| `agent_stopped` | `409` | The target agent is stopped and must be started before prompts or wakes. |
+| `cursor_not_found` | `404` | Requested event cursor is outside the retained replay window. |
+| `stale_run_id` | `409` | Abort request named a run that is no longer current. |
+| `no_current_run` | `409` | Abort request found no active run to abort. |
+| `skill_already_installed` | `409` | Skill destination already exists. |
+| `skill_manager_unavailable` | `424` | Required skill manager executable is unavailable. |
+| `remote_skill_install_failed` | `502` | Remote skill installer exited unsuccessfully. |
+| `remote_skill_install_timeout` | `504` | Remote skill installer exceeded its timeout. |
+
+`src/client.rs` decodes this envelope compatibly: it requires only `error` for
+display and preserves optional `code` and `hint` in `LocalHttpError`. Unknown
+extension fields are ignored by the client unless a caller inspects the raw
+response directly.
 
 ## Endpoint inventory
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,7 +19,7 @@ use axum::{
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
 use tower_http::compression::CompressionLayer;
@@ -78,6 +78,45 @@ pub struct AppState {
     pub require_control_token: bool,
     pub runtime_service: Option<RuntimeServiceHandle>,
     pub advertise_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HttpErrorEnvelope {
+    pub ok: bool,
+    pub error: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+    #[serde(flatten)]
+    pub extensions: Map<String, Value>,
+}
+
+impl HttpErrorEnvelope {
+    fn new(error: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            error: error.into(),
+            code: None,
+            hint: None,
+            extensions: Map::new(),
+        }
+    }
+
+    fn code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+
+    fn hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    fn extension(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.extensions.insert(key.into(), value.into());
+        self
+    }
 }
 
 const CALLBACK_BODY_LIMIT_BYTES: usize = 256 * 1024;
@@ -218,6 +257,7 @@ pub fn router(state: AppState) -> Router {
         .route("/state", get(state_default))
         .route("/transcript", get(transcript_default))
         .route("/worktree-summary", get(worktree_summary_default))
+        .fallback(not_found_handler)
         .layer(CompressionLayer::new())
         .with_state(Arc::new(state))
 }
@@ -1591,16 +1631,19 @@ fn clone_payload_field(payload: &Value, field: &str) -> Option<Value> {
 }
 
 fn event_seq_not_found(event_seq: u64) -> (StatusCode, Json<Value>) {
-    (
+    http_error(
         StatusCode::NOT_FOUND,
-        Json(json!({
-            "ok": false,
-            "error": format!("after_seq {event_seq} was not found in the replay window"),
-            "code": "cursor_not_found",
-            "after_seq": event_seq,
-            "event_seq": event_seq,
-        })),
+        HttpErrorEnvelope::new(format!(
+            "after_seq {event_seq} was not found in the replay window"
+        ))
+        .code("cursor_not_found")
+        .extension("after_seq", event_seq)
+        .extension("event_seq", event_seq),
     )
+}
+
+async fn not_found_handler() -> (StatusCode, Json<Value>) {
+    not_found("Not Found")
 }
 
 pub async fn transcript(
@@ -2494,12 +2537,8 @@ async fn callback_ingress(
     State(state): State<Arc<AppState>>,
     body: Bytes,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
-    let payload = build_callback_delivery_payload(&headers, body).map_err(|err| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": err.to_string() })),
-        )
-    })?;
+    let payload = build_callback_delivery_payload(&headers, body)
+        .map_err(|err| bad_request(err.to_string()))?;
     let (agent_id, descriptor) = state
         .host
         .resolve_external_trigger_record(&callback_token)
@@ -2796,43 +2835,22 @@ fn validate_operator_transport_delivery_auth(
 }
 
 fn forbidden(reason: impl Into<String>) -> (StatusCode, Json<Value>) {
-    (
-        StatusCode::FORBIDDEN,
-        Json(json!({
-            "ok": false,
-            "error": reason.into(),
-        })),
-    )
+    http_error(StatusCode::FORBIDDEN, HttpErrorEnvelope::new(reason))
 }
 
 fn bad_request(reason: impl Into<String>) -> (StatusCode, Json<Value>) {
-    (
-        StatusCode::BAD_REQUEST,
-        Json(json!({
-            "ok": false,
-            "error": reason.into(),
-        })),
-    )
+    http_error(StatusCode::BAD_REQUEST, HttpErrorEnvelope::new(reason))
 }
 
 fn service_unavailable(reason: impl Into<String>) -> (StatusCode, Json<Value>) {
-    (
+    http_error(
         StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({
-            "ok": false,
-            "error": reason.into(),
-        })),
+        HttpErrorEnvelope::new(reason),
     )
 }
 
 fn not_found(reason: impl Into<String>) -> (StatusCode, Json<Value>) {
-    (
-        StatusCode::NOT_FOUND,
-        Json(json!({
-            "ok": false,
-            "error": reason.into(),
-        })),
-    )
+    http_error(StatusCode::NOT_FOUND, HttpErrorEnvelope::new(reason))
 }
 
 fn stopped_agent_conflict(
@@ -2844,15 +2862,12 @@ fn stopped_agent_conflict(
         "start with `holon agent start {}` or POST /control/agents/{}/control with JSON body {{\"action\":\"start\"}}",
         agent_id, agent_id
     );
-    (
+    http_error(
         StatusCode::CONFLICT,
-        Json(json!({
-            "ok": false,
-            "error": reason.into(),
-            "code": "agent_stopped",
-            "agent_id": agent_id,
-            "hint": hint,
-        })),
+        HttpErrorEnvelope::new(reason)
+            .code("agent_stopped")
+            .hint(hint)
+            .extension("agent_id", agent_id),
     )
 }
 
@@ -2880,24 +2895,20 @@ fn abort_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
         Ok(CurrentRunAbortError::StaleRunId {
             requested_run_id,
             current_run_id,
-        }) => (
+        }) => http_error(
             StatusCode::CONFLICT,
-            Json(json!({
-                "ok": false,
-                "code": "stale_run_id",
-                "error": format!("stale run_id {requested_run_id}; current run is {current_run_id}"),
-                "requested_run_id": requested_run_id,
-                "current_run_id": current_run_id,
-            })),
+            HttpErrorEnvelope::new(format!(
+                "stale run_id {requested_run_id}; current run is {current_run_id}"
+            ))
+            .code("stale_run_id")
+            .extension("requested_run_id", requested_run_id)
+            .extension("current_run_id", current_run_id),
         ),
-        Ok(CurrentRunAbortError::NoCurrentRun { agent_id }) => (
+        Ok(CurrentRunAbortError::NoCurrentRun { agent_id }) => http_error(
             StatusCode::CONFLICT,
-            Json(json!({
-                "ok": false,
-                "code": "no_current_run",
-                "error": format!("agent {agent_id} has no current run to abort"),
-                "agent_id": agent_id,
-            })),
+            HttpErrorEnvelope::new(format!("agent {agent_id} has no current run to abort"))
+                .code("no_current_run")
+                .extension("agent_id", agent_id),
         ),
         Err(error) => error_response(error),
     }
@@ -2905,51 +2916,39 @@ fn abort_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
 
 fn skill_install_error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
     match error.downcast::<crate::skills::SkillInstallConflict>() {
-        Ok(conflict) => (
+        Ok(conflict) => http_error(
             StatusCode::CONFLICT,
-            Json(json!({
-                "ok": false,
-                "code": "skill_already_installed",
-                "error": conflict.to_string(),
-                "skill_name": conflict.skill_name,
-                "destination": conflict.destination,
-                "hint": "uninstall the existing skill first or choose a different skill name",
-            })),
+            HttpErrorEnvelope::new(conflict.to_string())
+                .code("skill_already_installed")
+                .hint("uninstall the existing skill first or choose a different skill name")
+                .extension("skill_name", conflict.skill_name)
+                .extension("destination", conflict.destination.to_string_lossy().to_string()),
         ),
         Err(error) => match error.downcast::<crate::skills::SkillManagerUnavailable>() {
-            Ok(unavailable) => (
+            Ok(unavailable) => http_error(
                 StatusCode::FAILED_DEPENDENCY,
-                Json(json!({
-                    "ok": false,
-                    "code": "skill_manager_unavailable",
-                    "error": unavailable.to_string(),
-                    "manager": unavailable.manager,
-                    "hint": "Install Node.js/npm so `npx skills` is available, or install the skill manually into ~/.agents/skills and link it by name.",
-                })),
+                HttpErrorEnvelope::new(unavailable.to_string())
+                    .code("skill_manager_unavailable")
+                    .hint("Install Node.js/npm so `npx skills` is available, or install the skill manually into ~/.agents/skills and link it by name.")
+                    .extension("manager", unavailable.manager),
             ),
             Err(error) => match error.downcast::<crate::skills::RemoteSkillInstallFailed>() {
-                Ok(failed) => (
+                Ok(failed) => http_error(
                     StatusCode::BAD_GATEWAY,
-                    Json(json!({
-                        "ok": false,
-                        "code": "remote_skill_install_failed",
-                        "error": failed.to_string(),
-                        "package": failed.package,
-                        "exit_status": failed.status,
-                        "stdout": failed.stdout,
-                        "stderr": failed.stderr,
-                    })),
+                    HttpErrorEnvelope::new(failed.to_string())
+                        .code("remote_skill_install_failed")
+                        .extension("package", failed.package)
+                        .extension("exit_status", failed.status)
+                        .extension("stdout", failed.stdout)
+                        .extension("stderr", failed.stderr),
                 ),
                 Err(error) => match error.downcast::<crate::skills::RemoteSkillInstallTimedOut>() {
-                    Ok(timeout) => (
+                    Ok(timeout) => http_error(
                         StatusCode::GATEWAY_TIMEOUT,
-                        Json(json!({
-                            "ok": false,
-                            "code": "remote_skill_install_timeout",
-                            "error": timeout.to_string(),
-                            "package": timeout.package,
-                            "timeout_seconds": timeout.timeout.as_secs(),
-                        })),
+                        HttpErrorEnvelope::new(timeout.to_string())
+                            .code("remote_skill_install_timeout")
+                            .extension("package", timeout.package)
+                            .extension("timeout_seconds", timeout.timeout.as_secs()),
                     ),
                     Err(error) => error_response(error),
                 },
@@ -2959,13 +2958,15 @@ fn skill_install_error_response(error: anyhow::Error) -> (StatusCode, Json<Value
 }
 
 fn error_response(error: anyhow::Error) -> (StatusCode, Json<Value>) {
-    (
+    http_error(
         StatusCode::INTERNAL_SERVER_ERROR,
-        Json(json!({
-            "ok": false,
-            "error": error.to_string(),
-        })),
+        HttpErrorEnvelope::new(error.to_string()),
     )
+}
+
+fn http_error(status: StatusCode, envelope: HttpErrorEnvelope) -> (StatusCode, Json<Value>) {
+    let value = serde_json::to_value(envelope).expect("HTTP error envelope serializes");
+    (status, Json(value))
 }
 
 #[cfg(unix)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -81,15 +81,15 @@ pub struct AppState {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct HttpErrorEnvelope {
-    pub ok: bool,
-    pub error: String,
+pub(crate) struct HttpErrorEnvelope {
+    ok: bool,
+    error: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub code: Option<String>,
+    code: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hint: Option<String>,
+    hint: Option<String>,
     #[serde(flatten)]
-    pub extensions: Map<String, Value>,
+    extensions: Map<String, Value>,
 }
 
 impl HttpErrorEnvelope {
@@ -1630,15 +1630,15 @@ fn clone_payload_field(payload: &Value, field: &str) -> Option<Value> {
     payload.get(field).filter(|value| !value.is_null()).cloned()
 }
 
-fn event_seq_not_found(event_seq: u64) -> (StatusCode, Json<Value>) {
+fn event_seq_not_found(after_seq: u64) -> (StatusCode, Json<Value>) {
     http_error(
         StatusCode::NOT_FOUND,
         HttpErrorEnvelope::new(format!(
-            "after_seq {event_seq} was not found in the replay window"
+            "after_seq {after_seq} was not found in the replay window"
         ))
         .code("cursor_not_found")
-        .extension("after_seq", event_seq)
-        .extension("event_seq", event_seq),
+        .extension("after_seq", after_seq)
+        .extension("event_seq", after_seq),
     )
 }
 

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -510,6 +510,12 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
             reqwest::StatusCode::FORBIDDEN,
             "{path} should require bearer auth"
         );
+        let body: serde_json::Value = denied.json().await?;
+        assert_eq!(body["ok"], false, "{path} error should use envelope");
+        assert!(
+            body["error"].is_string(),
+            "{path} error should include message: {body}"
+        );
     }
 
     let handshake: serde_json::Value = client
@@ -536,6 +542,9 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         .send()
         .await?;
     assert_eq!(removed_agents.status(), reqwest::StatusCode::NOT_FOUND);
+    let removed_body: serde_json::Value = removed_agents.json().await?;
+    assert_eq!(removed_body["ok"], false);
+    assert_eq!(removed_body["error"], "Not Found");
 
     let invalid_runtime_status = client
         .get(format!("{base}/control/runtime/status"))
@@ -546,6 +555,12 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         invalid_runtime_status.status(),
         reqwest::StatusCode::FORBIDDEN
     );
+    let invalid_body: serde_json::Value = invalid_runtime_status.json().await?;
+    assert_eq!(invalid_body["ok"], false);
+    assert!(invalid_body["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("invalid control token"));
 
     let runtime_status = client
         .get(format!("{base}/control/runtime/status"))
@@ -560,6 +575,9 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         .send()
         .await?;
     assert_eq!(denied_enqueue.status(), reqwest::StatusCode::FORBIDDEN);
+    let denied_enqueue_body: serde_json::Value = denied_enqueue.json().await?;
+    assert_eq!(denied_enqueue_body["ok"], false);
+    assert!(denied_enqueue_body["error"].is_string());
     let allowed_enqueue = client
         .post(format!("{base}/enqueue"))
         .bearer_auth("secret")


### PR DESCRIPTION
## Summary
- introduce a shared `HttpErrorEnvelope` for control-plane JSON errors
- route existing HTTP error helpers and fallback 404s through the shared envelope
- document the error envelope, status-code mapping, route-specific extensions, and known error codes
- extend HTTP control tests to assert JSON error envelopes for auth and missing-route errors

Fixes #1397

## Verification
- cargo fmt --all -- --check
- cargo test --test http_control
- cargo test --test http_route_snapshot refresh_http_route_inventory_snapshot -- --ignored
- cargo test --test openapi_snapshot
- RUSTFLAGS="-D warnings" cargo check --all-targets