### PR TITLE
docs: document HTTP ingress trust boundaries

### DIFF
--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -12,7 +12,7 @@ recording the route list, request parameters, response shapes, and contract
 gaps that need stabilization before scripts and integrations can rely on the
 API long term.
 
-- **Last reviewed against:** `holon` v0.14.1, `main` at `e544c35`.
+- **Last reviewed against:** `holon` v0.14.1, `main` at `77fe575`.
 - **Primary source:** `src/http.rs` Axum router and request/response structs.
 - **Generated schema:** [`openapi.json`](./openapi.json), produced by
   `holon::openapi::generate_openapi_json()` and checked by
@@ -45,6 +45,16 @@ API long term.
 | Bearer auth | When `require_control_token` is true, read routes and `/control/*` routes require `Authorization: Bearer <token>`. | Candidate stable |
 | Local mode | When no control token is required, the server trusts the local process boundary. | Candidate stable, but should be tied to explicit deployment guidance |
 | Callback capability tokens | `/callbacks/*/:callback_token` routes authenticate by resolving the token to an external trigger record. | Capability |
+
+### Ingress trust/auth boundaries
+
+| Ingress class | Routes | Auth boundary | Runtime provenance | Priority policy | Stability |
+|---------------|--------|---------------|--------------------|-----------------|-----------|
+| Public enqueue | `/enqueue`, `/agents/:agent_id/enqueue` | Bearer token in bearer mode; local process boundary in local mode. | Accepts only channel or webhook origins. Caller-provided `trust` is rejected. Channel origins become untrusted external evidence; webhook origins become integration signals. Runtime-owned message kinds are rejected. | Allows `next`, `normal`, and `background`; rejects `interject`. | Candidate stable |
+| Callback capability | `/callbacks/wake/:callback_token`, `/callbacks/enqueue/:callback_token` | Capability token in path must resolve to an active external trigger and match the route delivery mode. Full callback URLs are secrets. | Admitted as an external-trigger capability and integration signal. Wake mode emits a runtime-owned inspection tick rather than trusting the payload as an operator instruction. | Caller does not choose queue priority. | Capability |
+| Operator transport binding | `/control/agents/:agent_id/operator-bindings` | Control auth. Delivery bearer token is validated on input and redacted in audit events. | Records the binding used by remote operator ingress and delivery callbacks. | N/A. | Experimental |
+| Operator transport ingress | `/control/agents/:agent_id/operator-ingress` | Control auth plus active binding, matching agent, matching actor, and matching provider when supplied. | Enqueues a trusted operator prompt with `operator_instruction` authority and remote-operator transport metadata. | Always `interject`. | Experimental |
+| Generic webhook compatibility | `/webhooks/generic/:agent_id` | Bearer token in bearer mode; local process boundary in local mode. | Converts the JSON payload into a trusted-integration webhook event from `generic_webhook`; route ignores caller-supplied provenance because the whole body is the payload. | Always `normal`. | Internal/debug |
 
 ### Common JSON and response behavior
 
@@ -201,7 +211,7 @@ called stable.
 |--------|------|--------|------------------|-----------|-------|
 | `POST` | `/enqueue` | `EnqueueRequest`; auth header when bearer mode is active. | `{ ok, agent_id, message_id }` | Candidate stable | Enqueues to the default agent. |
 | `POST` | `/agents/:agent_id/enqueue` | Path `agent_id`; `EnqueueRequest`; auth header when bearer mode is active. | `{ ok, agent_id, message_id }` | Candidate stable | Public callers may not set `trust` or `interject` priority. |
-| `POST` | `/webhooks/generic/:agent_id` | Path `agent_id`; JSON payload. | `{ ok, agent_id, message_id }` | Internal/debug | Converts the payload into a trusted integration webhook event. Needs explicit security posture before stable use. |
+| `POST` | `/webhooks/generic/:agent_id` | Path `agent_id`; JSON payload; auth header when bearer mode is active. | `{ ok, agent_id, message_id }` | Internal/debug | Compatibility/debug route that converts the payload into a trusted integration webhook event. Prefer public enqueue or callback capabilities for new integrations. |
 
 `EnqueueRequest` fields:
 
@@ -332,9 +342,10 @@ treated as schema surfaces, not incidental Rust structs:
    routes.
 5. **Timer lifecycle APIs are incomplete.** HTTP can create and list timers, but
    lacks cancellation or detail routes.
-6. **Security posture for public ingress needs clearer boundaries.** Public
-   enqueue, generic webhooks, operator bindings, and capability callbacks should
-   have a single trust/auth table with explicit deployment guidance.
+6. **Deployment guidance still needs hardening.** The HTTP ingress trust/auth
+   table is documented, but production-facing guidance should still describe
+   when to use bearer mode, local mode, callback capabilities, and dedicated
+   operator adapters.
 7. **Tool schema is a separate API surface.** Built-in tool input/result schemas
    are not covered by this HTTP inventory and need their own stability
    inventory.

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -28,6 +28,21 @@ and trusts the local process boundary.
 GET /handshake → { "auth": { "mode": "bearer" | "local", "required": bool } }
 ```
 
+## Ingress trust and auth boundaries
+
+Holon treats authentication, message origin, trust level, priority, and
+authority as separate runtime facts. HTTP ingress handlers may authenticate a
+caller, but they still construct the message provenance explicitly instead of
+trusting caller-supplied provenance fields.
+
+| Ingress class | Routes | Auth boundary | Origin/trust/authority | Priority | Supported posture |
+|---------------|--------|---------------|------------------------|----------|-------------------|
+| Public enqueue | `POST /enqueue`, `POST /agents/:id/enqueue` | Bearer token in bearer mode; local process boundary in local mode. | Caller may provide only channel or webhook origin. Caller-provided `trust` is rejected. Channel origins become untrusted external evidence; webhook origins become integration signals. Runtime-owned kinds such as `system_tick` and `callback_event` are rejected. | `next`, `normal`, or `background`; `interject` is rejected. | Candidate stable external ingress for non-operator evidence. |
+| Callback capability | `POST /callbacks/wake/:callback_token`, `POST /callbacks/enqueue/:callback_token` | Capability token in the URL path resolves to an active external trigger and matching delivery mode. Do not log, repeat, or publish full callback URLs. | Delivery is admitted as an external-trigger capability and an integration signal. Wake callbacks enqueue runtime-owned inspection ticks; callback payload text is untrusted evidence for the agent to inspect. | Runtime-selected by delivery mode; callers do not choose queue priority. | Capability surface for durable external systems that need to wake or notify an agent. |
+| Operator transport binding | `POST /control/agents/:id/operator-bindings` | Control-plane auth. Delivery credentials are stored on the binding and redacted from audit events. | Creates or updates the binding that later authorizes remote operator ingress. | N/A. | Experimental operator adapter setup surface. |
+| Operator transport ingress | `POST /control/agents/:id/operator-ingress` | Control-plane auth plus active binding, matching target agent, matching operator actor, and matching provider when supplied. | Enqueues a `trusted_operator` `operator_prompt` with `operator_instruction` authority and remote-operator transport metadata. | Always `interject`. | Experimental authenticated operator adapter ingress. |
+| Generic webhook compatibility | `POST /webhooks/generic/:agent_id` | Bearer token in bearer mode; local process boundary in local mode. | Converts JSON payload into a trusted-integration webhook event with `generic_webhook` origin. Callers cannot set origin, trust, or priority through this route. | Always `normal`. | Internal/debug compatibility route; prefer public enqueue or a dedicated capability callback for new external integrations. |
+
 ## Endpoint reference
 
 ### Discovery
@@ -167,6 +182,16 @@ Response:
 ```
 
 **`POST /enqueue`** (no agent in path) — Enqueue to default agent.
+
+**`POST /webhooks/generic/:agent_id`** — Generic webhook compatibility
+
+Accepts a JSON payload and converts it to a `webhook_event` from
+`generic_webhook`. This route is kept for local/debug compatibility and simple
+trusted integration tests. It requires the bearer token when bearer mode is
+enabled, but unlike public enqueue it does not let callers provide explicit
+origin/trust/priority fields. New integrations should usually use public
+enqueue for external evidence or a callback capability when the integration
+needs a secret URL.
 
 
 ### Control plane (authenticated)

--- a/src/http.rs
+++ b/src/http.rs
@@ -2705,8 +2705,10 @@ fn is_text_content_type(content_type: &str) -> bool {
 pub async fn generic_webhook(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(payload): Json<Value>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     enqueue_internal(
         state,
         agent_id,

--- a/tests/http_ingress.rs
+++ b/tests/http_ingress.rs
@@ -17,4 +17,5 @@ http_async_tests!(
     generic_webhook_rejects_stopped_public_agent_without_queueing,
     generic_webhook_and_multi_agent_listing_work,
     public_enqueue_rejects_privileged_origin_and_trust_override,
+    generic_webhook_requires_bearer_token_when_configured,
 );

--- a/tests/support/http_ingress.rs
+++ b/tests/support/http_ingress.rs
@@ -321,3 +321,48 @@ pub async fn public_enqueue_rejects_privileged_origin_and_trust_override() -> Re
     server.abort();
     Ok(())
 }
+
+pub async fn generic_webhook_requires_bearer_token_when_configured() -> Result<()> {
+    let config = test_config_with_paths(
+        tempdir().unwrap().keep(),
+        tempdir().unwrap().keep(),
+        "127.0.0.1:0".into(),
+        ControlAuthMode::Required,
+    );
+    let (host, base, server) = spawn_server_with_config(config).await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    let denied = client
+        .post(format!("{base}/webhooks/generic/default"))
+        .json(&serde_json::json!({ "status": "opened" }))
+        .send()
+        .await?;
+    assert_eq!(denied.status(), reqwest::StatusCode::FORBIDDEN);
+    let denied_payload: serde_json::Value = denied.json().await?;
+    assert_eq!(denied_payload["ok"], false);
+    assert!(runtime.storage().read_recent_messages(10)?.is_empty());
+
+    let allowed = client
+        .post(format!("{base}/webhooks/generic/default"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({ "status": "opened" }))
+        .send()
+        .await?;
+    assert!(allowed.status().is_success());
+
+    wait_until(|| {
+        let messages = runtime.storage().read_recent_messages(10)?;
+        Ok(messages.iter().any(|message| {
+            message.kind == MessageKind::WebhookEvent
+                && message.delivery_surface == Some(MessageDeliverySurface::HttpWebhook)
+                && message.admission_context == Some(AdmissionContext::PublicUnauthenticated)
+                && message.trust == TrustLevel::TrustedIntegration
+                && message.authority_class == AuthorityClass::IntegrationSignal
+        }))
+    })
+    .await?;
+
+    server.abort();
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- document trusted-local versus remote HTTP ingress boundaries and bearer-token expectations
- add generic webhook bearer-mode authentication checks
- cover accepted, rejected, and missing-token webhook paths in HTTP ingress tests

Closes #1401

## Verification
- cargo test --test http_ingress -- --test-threads=1
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets}],