### PR TITLE
docs: define CLI exit code contract

### DIFF
--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -30,6 +30,10 @@ behavior changes.
   Support policy for Holon's command-line surfaces and machine-readable output contracts.
   <!-- mdorigin:index kind=article -->
 
+- [CLI exit codes](./cli-exit-codes.md)
+  Exit-code and stream-routing contract for Holon's command-line interface.
+  <!-- mdorigin:index kind=article -->
+
 - [Configuration](./configuration.md)
   Holon configuration files, keys, credentials, environment variables, and diagnostics.
   <!-- mdorigin:index kind=article -->

--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -192,8 +192,10 @@ that visibly affect CLI behavior while invoking commands.
 
 1. **JSON responses are not uniformly normalized.** Some commands use
    `print_json` while others print raw HTTP response bodies.
-2. **Exit codes are implicit.** Clap and `anyhow` failures produce non-zero
-   exits, but command-specific exit-code guarantees are not documented.
+2. **Exit codes now have a baseline process contract.** See
+   [CLI exit codes](./cli-exit-codes.md). Command-specific business-state
+   promotion to non-zero exits remains intentionally opt-in and must be
+   documented per command.
 3. **Machine-readable outputs need schema owners.** CLI JSON often mirrors
    control-plane/runtime structs. The API inventory should decide which fields
    are stable, diagnostic, or internal.
@@ -215,7 +217,7 @@ milestone:
 | Priority | Issue | Scope |
 |---:|---|---|
 | 0 | [#1388](https://github.com/holon-run/holon/issues/1388) | Normalize or explicitly document raw HTTP response output paths. |
-| 0 | [#1389](https://github.com/holon-run/holon/issues/1389) | Define and test CLI exit-code behavior. |
+| 0 | [#1389](https://github.com/holon-run/holon/issues/1389) | Define and test baseline CLI exit-code behavior. |
 | 0 | [#1390](https://github.com/holon-run/holon/issues/1390) | Add normalized command tree snapshot tests. |
 | 0 | [#1391](https://github.com/holon-run/holon/issues/1391) | Publish CLI stability levels and support policy. |
 | 1 | [#1392](https://github.com/holon-run/holon/issues/1392) | Add task lifecycle management commands. |
@@ -232,7 +234,7 @@ milestone:
 | 1 | `--json` smoke tests for `run`/`solve` with a fake provider or fixture | Confirm machine-readable mode remains parseable. |
 | 2 | Config command golden JSON for `get`, `set`, `unset`, `schema`, provider remove, credential list/remove | Lock offline scripting surfaces. |
 | 2 | Daemon/status/log JSON shape tests | Lock local operations surfaces. |
-| 2 | Error behavior tests for invalid flags, invalid provider config, and missing token cases | Establish exit-code and stderr expectations. |
+| 2 | More error behavior tests for missing token and command-specific business states | Extend the baseline exit-code contract where commands promote domain failures to process failures. |
 | 3 | Normalize or document raw HTTP-body commands (`task`, `timer`, `agent create/abort`, skills install/uninstall) | Reduce output contract drift. |
 
 ## Follow-up inventory scope

--- a/docs/website/reference/cli-exit-codes.md
+++ b/docs/website/reference/cli-exit-codes.md
@@ -1,0 +1,89 @@
+---
+title: CLI exit codes
+summary: Exit-code and stream-routing contract for Holon's command-line interface.
+order: 13
+---
+
+# CLI exit codes
+
+This page defines the current exit-code contract for `holon` commands. It is a
+script-facing companion to the [CLI stability policy](./cli-stability-policy.md)
+and [CLI contract inventory](./cli-contract-inventory.md).
+
+Holon keeps the contract intentionally small while the runtime is pre-1.0:
+
+| Exit code | Meaning | Stream contract |
+|---:|---|---|
+| `0` | The CLI command completed successfully. | Machine-readable commands write their JSON or documented raw response to stdout. Human commands may write prose to stdout. Stderr remains diagnostic/log output. |
+| `1` | The command was accepted by the parser, but execution failed before a successful CLI result was produced. This includes unreachable control-plane requests, invalid runtime/config/provider setup, failed file IO, malformed stored config, and HTTP/control-plane errors surfaced by the client. | Stdout is not script-safe and should usually be empty. Diagnostics are written to stderr by the top-level error renderer and may include chained context. |
+| `2` | Clap rejected the invocation before command execution, for example an unknown flag, missing required argument, invalid enum value, or invalid numeric range. | Stdout is empty. Clap writes usage/error text to stderr. |
+
+Codes outside this table are not part of Holon's stable CLI contract. In
+particular, POSIX signal-derived exit statuses are owned by the operating system
+and should not be interpreted as Holon business results.
+
+## Representative cases
+
+### Invalid arguments
+
+Parser failures exit with code `2`:
+
+```bash
+holon --definitely-not-a-holon-flag
+echo $? # 2
+```
+
+Use this class for invocation-shape problems only. Scripts should treat stderr
+as human-readable help/error text, not as a machine-readable schema.
+
+### Unreachable control plane
+
+Commands that need the local or remote control plane exit with code `1` when
+transport fails:
+
+```bash
+HOLON_HTTP_ADDR=127.0.0.1:9 holon status
+echo $? # 1
+```
+
+The CLI does not synthesize a JSON error envelope on stdout for transport
+failures. Use stderr for operator diagnostics and retry/backoff decisions in the
+calling script.
+
+### Invalid configuration or provider setup
+
+Configuration that parses as a CLI invocation but is rejected by Holon's config
+validators exits with code `1`:
+
+```bash
+holon config providers set script-test \
+  --transport openai_responses \
+  --base-url not-a-url
+echo $? # 1
+```
+
+Commands that validate stored config during startup also use code `1` for
+malformed or unsupported config.
+
+### Successful transport with failed business state
+
+When a command successfully talks to the control plane, Holon's CLI exit code
+reports the command transport/result-rendering outcome, not every business
+state embedded in the returned JSON. For example, a command that successfully
+creates, inspects, or returns a task record exits `0` if the HTTP request and
+response rendering succeeded, even if the returned task or runtime object has a
+domain state such as `failed`, `cancelled`, `blocked`, or `waiting`.
+
+Scripts must inspect the documented JSON fields for business state. Holon will
+only promote a business state to a non-zero process exit when a command's
+specific reference page documents that behavior.
+
+## Stdout and stderr
+
+- Treat stdout as machine-readable only for commands whose reference or
+  inventory row says they emit JSON or a documented raw response body.
+- Treat stderr as human diagnostics. It may contain Clap usage text, anyhow
+  context chains, tracing logs, provider diagnostics, or operating-system
+  errors.
+- Do not parse exact stderr prose for stable automation. Prefer JSON output or
+  HTTP/API error envelopes when a stable machine contract is required.

--- a/docs/website/reference/cli-stability-policy.md
+++ b/docs/website/reference/cli-stability-policy.md
@@ -16,6 +16,8 @@ Use this page with:
 - [CLI reference](./cli.md) for the current command tree and common workflows.
 - [CLI contract inventory](./cli-contract-inventory.md) for per-command
   stability levels, output modes, and known contract gaps.
+- [CLI exit codes](./cli-exit-codes.md) for process exit codes and stdout/stderr
+  routing.
 - [API contract inventory](./api-contract-inventory.md) for HTTP response
   shapes that many CLI JSON outputs mirror.
 
@@ -42,7 +44,8 @@ Scripts should prefer surfaces that have all of these properties:
    JSON printing path rather than a raw HTTP response passthrough.
 3. A documented response owner, either in the CLI contract inventory or the
    HTTP/API inventory when the CLI mirrors a control-plane response.
-4. Explicit exit-code behavior once the exit-code contract is published.
+4. Explicit exit-code behavior from the
+   [CLI exit-code contract](./cli-exit-codes.md).
 
 Current script-facing candidates include:
 

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -1,0 +1,101 @@
+//! CLI exit-code contract tests.
+//!
+//! These tests exercise the compiled binary because the contract includes
+//! clap's process exits, stdout/stderr routing, and anyhow's top-level error
+//! rendering.
+
+use std::{
+    path::PathBuf,
+    process::{Command, Output},
+};
+
+fn holon_bin() -> PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_holon")
+        .map(PathBuf::from)
+        .or_else(|| option_env!("CARGO_BIN_EXE_holon").map(PathBuf::from))
+        .expect("CARGO_BIN_EXE_holon should be set for integration tests")
+}
+
+fn isolated_holon_command() -> (Command, tempfile::TempDir) {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+    let mut command = Command::new(holon_bin());
+    command
+        .env("HOLON_HOME", home.path())
+        .env(
+            "HOLON_SOCKET_PATH",
+            home.path().join("run").join("missing.sock"),
+        )
+        .env_remove("HOLON_CONTROL_TOKEN")
+        .env_remove("HOLON_CONTROL_AUTH_MODE")
+        .env_remove("RUST_LOG");
+    (command, home)
+}
+
+fn output_text(output: &Output) -> (String, String) {
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn invalid_arguments_exit_with_clap_usage_code() {
+    let (mut command, _home) = isolated_holon_command();
+    let output = command
+        .arg("--definitely-not-a-holon-flag")
+        .output()
+        .expect("run holon");
+
+    let (stdout, stderr) = output_text(&output);
+    assert_eq!(output.status.code(), Some(2), "stderr:\n{stderr}");
+    assert!(stdout.is_empty(), "stdout should stay empty: {stdout}");
+    assert!(
+        stderr.contains("unexpected argument") || stderr.contains("Usage:"),
+        "stderr should be a clap usage error:\n{stderr}"
+    );
+}
+
+#[test]
+fn unreachable_control_plane_exits_nonzero_without_machine_stdout() {
+    let (mut command, _home) = isolated_holon_command();
+    let output = command
+        .env("HOLON_HTTP_ADDR", "127.0.0.1:9")
+        .arg("status")
+        .output()
+        .expect("run holon");
+
+    let (stdout, stderr) = output_text(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr:\n{stderr}");
+    assert!(stdout.is_empty(), "stdout should stay empty: {stdout}");
+    assert!(
+        stderr.contains("failed to send /agents/main/status")
+            || stderr.contains("error sending request"),
+        "stderr should explain the failed control-plane request:\n{stderr}"
+    );
+}
+
+#[test]
+fn invalid_provider_configuration_exits_nonzero_without_machine_stdout() {
+    let (mut command, _home) = isolated_holon_command();
+    let output = command
+        .args([
+            "config",
+            "providers",
+            "set",
+            "script-test",
+            "--transport",
+            "openai_responses",
+            "--base-url",
+            "not-a-url",
+        ])
+        .output()
+        .expect("run holon");
+
+    let (stdout, stderr) = output_text(&output);
+    assert_eq!(output.status.code(), Some(1), "stderr:\n{stderr}");
+    assert!(stdout.is_empty(), "stdout should stay empty: {stdout}");
+    assert!(
+        stderr.contains("providers.<id>.base_url") || stderr.contains("not-a-url"),
+        "stderr should explain the invalid provider setup:\n{stderr}"
+    );
+}

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -21,6 +21,7 @@ fn isolated_holon_command() -> (Command, tempfile::TempDir) {
     let mut command = Command::new(holon_bin());
     command
         .env("HOLON_HOME", home.path())
+        .env("HOLON_AGENT_ID", "main")
         .env("HOLON_MODEL", "openai/gpt-5.4")
         .env(
             "HOLON_SOCKET_PATH",

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -21,6 +21,7 @@ fn isolated_holon_command() -> (Command, tempfile::TempDir) {
     let mut command = Command::new(holon_bin());
     command
         .env("HOLON_HOME", home.path())
+        .env("HOLON_MODEL", "openai/gpt-5.4")
         .env(
             "HOLON_SOCKET_PATH",
             home.path().join("run").join("missing.sock"),


### PR DESCRIPTION
Closes #1389

## Summary
- document the baseline CLI exit-code and stdout/stderr routing contract
- link the contract from the CLI reference index, stability policy, and inventory
- add integration tests for clap argument errors, unreachable control-plane failures, and invalid provider configuration

## Verification
- cargo test --test cli_exit_codes
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets