### PR TITLE
fix: normalize control-plane JSON CLI output

### DIFF
--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -40,7 +40,7 @@ support policy behind these labels.
 | Command parser | Clap-derived command tree with `--help` and `--version` at the root. | `stable` | Command and flag names are the highest-value CLI contract. |
 | Help text | Human-readable Clap output. | `experimental` | Useful for users; exact spacing and prose should not be treated as machine-readable. |
 | Errors | Clap validation errors or `anyhow` errors rendered by the binary runtime. | `experimental` | Exit code shape needs explicit tests before declaring stable. |
-| JSON output | Many commands pretty-print JSON to stdout via `serde_json::to_string_pretty`. | `experimental` | JSON field shape usually comes from runtime/control-plane structs and needs API inventory alignment. |
+| JSON output | Script-facing JSON commands pretty-print JSON to stdout via the shared `print_json` path. | `experimental` | JSON field shape usually comes from runtime/control-plane structs and needs API inventory alignment. |
 | Human output | `run`, `solve`, `serve`, `debug latency`, `debug prompt`, and some debug/export commands write human text to stdout. | `experimental` | Do not snapshot full prose unless the command is intentionally script-facing. |
 | stderr | Tracing logs, Clap errors, credential prompt, and some provider/runtime diagnostics. | `experimental` | Credential prompt intentionally writes to stderr. |
 | stdin | Only `config credentials set --stdin` currently reads from stdin. | `stable` candidate | Interaction details need a focused test. |
@@ -109,8 +109,8 @@ These commands require a reachable local control plane unless noted otherwise.
 | `holon status` | none | `--agent <AGENT>` | JSON agent status | `stable` candidate | Agent summary is a key operator/API surface. |
 | `holon tail` | none | `--limit <LIMIT>` default `20`; `--agent <AGENT>` | JSON recent briefs/log tail | `stable` candidate | Result shape should align with brief/output contract. |
 | `holon transcript` | none | `--limit <LIMIT>` default `50`; `--agent <AGENT>` | JSON transcript entries | `stable` candidate | Transcript entry stability needs API inventory. |
-| `holon task` | `<SUMMARY>` | required `--cmd <CMD>`; `--workdir <WORKDIR>`; `--shell <SHELL>`; `--login <true\|false>`; `--tty`; `--yield-time-ms <MS>`; `--max-output-tokens <N>`; `--agent <AGENT>` | raw HTTP response body printed to stdout | `experimental` | CLI currently posts control-plane JSON; output is not normalized through `print_json`. |
-| `holon timer` | none | required `--after-ms <MS>`; `--every-ms <MS>`; `--summary <SUMMARY>`; `--agent <AGENT>` | raw HTTP response body printed to stdout | `experimental` | Timer surface should be aligned with WorkItem/waiting-plane contract. |
+| `holon task` | `<SUMMARY>` | required `--cmd <CMD>`; `--workdir <WORKDIR>`; `--shell <SHELL>`; `--login <true\|false>`; `--tty`; `--yield-time-ms <MS>`; `--max-output-tokens <N>`; `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | CLI posts control-plane JSON and normalizes successful JSON responses through `print_json`. |
+| `holon timer` | none | required `--after-ms <MS>`; `--every-ms <MS>`; `--summary <SUMMARY>`; `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Timer surface should be aligned with WorkItem/waiting-plane contract. |
 
 ### Agent lifecycle and model selection
 
@@ -119,14 +119,14 @@ These commands require a reachable local control plane unless noted otherwise.
 | `holon agent` / `holon agents` | optional subcommand | none | defaults to `agent list` JSON | `stable` candidate | `agents` is an alias. |
 | `holon agent list` | none | none | JSON agent entries | `stable` candidate | Public multi-agent inspection surface. |
 | `holon agent status` | optional `[AGENT_ID]` | none | JSON agent status | `stable` candidate | Positional agent id; defaults to configured default agent. |
-| `holon agent create` | `<AGENT_ID>` | `--template <TEMPLATE>` | raw HTTP response body printed to stdout | `stable` candidate | Template identifier contract should align with agent initialization docs. |
+| `holon agent create` | `<AGENT_ID>` | `--template <TEMPLATE>` | pretty JSON control-plane response | `stable` candidate | Template identifier contract should align with agent initialization docs. |
 | `holon agent start` | optional `[AGENT_ID]` | none | JSON lifecycle control response | `stable` candidate | Replacement for deprecated `control start`. |
 | `holon agent stop` | optional `[AGENT_ID]` | none | JSON lifecycle control response | `stable` candidate | Replacement for deprecated `control stop`. |
-| `holon agent abort` | optional `[AGENT_ID]` | none | raw HTTP abort response body printed to stdout | `stable` candidate | Replacement for deprecated `control abort`; output normalization differs from start/stop. |
+| `holon agent abort` | optional `[AGENT_ID]` | none | pretty JSON control-plane response | `stable` candidate | Replacement for deprecated `control abort`; shares the lifecycle JSON output path with start/stop. |
 | `holon agent model get` | optional `[AGENT_ID]` | none | JSON model override/status fragment | `stable` candidate | Reads `summary.model` from agent status. |
 | `holon agent model set` | `<MODEL> [AGENT_ID]` | none | JSON model override response | `stable` candidate | Positional `AGENT_ID` is tested. |
 | `holon agent model clear` | optional `[AGENT_ID]` | none | JSON model override response | `stable` candidate | Should share contract with set/get. |
-| `holon control` | `<start\|stop\|abort>` | `--agent <AGENT>` | JSON or raw HTTP response depending on action | `deprecated` | Use `holon agent start|stop|abort [agent-id]`. |
+| `holon control` | `<start\|stop\|abort>` | `--agent <AGENT>` | pretty JSON lifecycle response | `deprecated` | Use `holon agent start|stop|abort [agent-id]`. |
 
 Deprecated `holon control` compatibility is documented in
 [CLI stability policy](./cli-stability-policy.md#deprecated-holon-control).
@@ -137,8 +137,8 @@ New automation should use the `holon agent ...` lifecycle commands.
 | Command | Args | Options | Output | Initial stability | Notes |
 |---|---|---|---|---:|---|
 | `holon skills list` | none | `--agent <AGENT>` | JSON installed-skill response | `experimental` | Skill discovery/install contract is still active design work. |
-| `holon skills install` | `<NAME_OR_PATH>` | `--builtin`; `--remote`; `--skill <SKILL>`; `--copy`; `--agent <AGENT>` | raw HTTP response body printed to stdout | `experimental` | Local paths are resolved relative to cwd when they are directories; otherwise treated as named skills. |
-| `holon skills uninstall` | `<NAME>` | `--agent <AGENT>` | raw HTTP response body printed to stdout | `experimental` | Output should be normalized or documented before stabilization. |
+| `holon skills install` | `<NAME_OR_PATH>` | `--builtin`; `--remote`; `--skill <SKILL>`; `--copy`; `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Local paths are resolved relative to cwd when they are directories; otherwise treated as named skills. |
+| `holon skills uninstall` | `<NAME>` | `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Shares the normalized JSON output path with install/list. |
 
 ### One-shot and solve workflows
 
@@ -190,8 +190,9 @@ that visibly affect CLI behavior while invoking commands.
 
 ## Output contract gaps
 
-1. **JSON responses are not uniformly normalized.** Some commands use
-   `print_json` while others print raw HTTP response bodies.
+1. **JSON responses now share the normalized stdout path for script-facing
+   commands.** The remaining output work is assigning schema owners and
+   stability levels to each response shape.
 2. **Exit codes now have a baseline process contract.** See
    [CLI exit codes](./cli-exit-codes.md). Command-specific business-state
    promotion to non-zero exits remains intentionally opt-in and must be

--- a/src/main.rs
+++ b/src/main.rs
@@ -2018,9 +2018,22 @@ async fn post_json_with_auth<T: serde::Serialize>(
         .send()
         .await
         .with_context(|| format!("failed to post {}", path))?;
-    let body = response.text().await?;
-    println!("{body}");
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .with_context(|| format!("failed to read response body from POST {path}"))?;
+    if !status.is_success() {
+        anyhow::bail!("POST {path} returned {status}: {body}");
+    }
+    let value = parse_json_response_body("POST", path, &body)?;
+    print_json(&value)?;
     Ok(())
+}
+
+fn parse_json_response_body(method: &str, path: &str, body: &str) -> Result<serde_json::Value> {
+    serde_json::from_str(body)
+        .with_context(|| format!("failed to parse JSON response body from {method} {path}"))
 }
 
 async fn handle_config_command(command: ConfigCommands) -> Result<()> {

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -5,8 +5,11 @@
 //! rendering.
 
 use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
     path::PathBuf,
     process::{Command, Output},
+    thread,
 };
 
 fn holon_bin() -> PathBuf {
@@ -14,6 +17,39 @@ fn holon_bin() -> PathBuf {
         .map(PathBuf::from)
         .or_else(|| option_env!("CARGO_BIN_EXE_holon").map(PathBuf::from))
         .expect("CARGO_BIN_EXE_holon should be set for integration tests")
+}
+
+#[test]
+fn control_plane_post_commands_pretty_print_json_stdout() {
+    let cases: &[(&[&str], &str)] = &[
+        (
+            &["task", "summary", "--cmd", "echo hi"],
+            "/control/agents/main/tasks",
+        ),
+        (&["timer", "--after-ms", "1"], "/control/agents/main/timers"),
+        (
+            &["agent", "create", "worker"],
+            "/control/agents/worker/create",
+        ),
+        (
+            &["agent", "abort"],
+            "/control/agents/main/current-run/abort",
+        ),
+        (
+            &["skills", "install", "demo"],
+            "/control/agents/main/skills/install",
+        ),
+        (
+            &["skills", "uninstall", "demo"],
+            "/control/agents/main/skills/uninstall",
+        ),
+    ];
+
+    for (args, expected_path) in cases {
+        let (output, actual_path) = run_with_mock_control_plane(args);
+        assert_eq!(actual_path, *expected_path, "args: {args:?}");
+        assert_pretty_json_stdout(output, expected_path);
+    }
 }
 
 fn isolated_holon_command() -> (Command, tempfile::TempDir) {
@@ -38,6 +74,79 @@ fn output_text(output: &Output) -> (String, String) {
         String::from_utf8_lossy(&output.stdout).into_owned(),
         String::from_utf8_lossy(&output.stderr).into_owned(),
     )
+}
+
+fn run_with_mock_control_plane(args: &[&str]) -> (Output, String) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock control plane");
+    let addr = listener.local_addr().expect("mock control plane address");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept CLI request");
+        let request = read_http_request(&mut stream);
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("<missing-path>")
+            .to_string();
+        let body = format!(r#"{{"ok":true,"path":"{path}","nested":{{"value":1}}}}"#);
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .expect("write mock response");
+        path
+    });
+
+    let (mut command, _home) = isolated_holon_command();
+    let output = command
+        .env("HOLON_HTTP_ADDR", addr.to_string())
+        .args(args)
+        .output()
+        .expect("run holon");
+    let path = handle.join().expect("mock control plane thread");
+    (output, path)
+}
+
+fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut buffer = [0; 1024];
+    loop {
+        let n = stream.read(&mut buffer).expect("read CLI request");
+        assert_ne!(n, 0, "request ended before headers");
+        bytes.extend_from_slice(&buffer[..n]);
+        if let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            let headers = String::from_utf8_lossy(&bytes[..header_end]).into_owned();
+            let content_length = headers
+                .lines()
+                .find_map(|line| line.split_once(':'))
+                .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+                .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+                .unwrap_or(0);
+            while bytes.len().saturating_sub(header_end + 4) < content_length {
+                let n = stream.read(&mut buffer).expect("read CLI request body");
+                assert_ne!(n, 0, "request ended before declared body");
+                bytes.extend_from_slice(&buffer[..n]);
+            }
+            return String::from_utf8_lossy(&bytes).into_owned();
+        }
+    }
+}
+
+fn assert_pretty_json_stdout(output: Output, expected_path: &str) {
+    let (stdout, stderr) = output_text(&output);
+    assert_eq!(output.status.code(), Some(0), "stderr:\n{stderr}");
+    assert!(stderr.is_empty(), "stderr should stay empty: {stderr}");
+    let expected = serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "path": expected_path,
+        "nested": {
+            "value": 1
+        }
+    }))
+    .expect("serialize expected JSON");
+    assert_eq!(stdout, format!("{expected}\n"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- normalize shared control-plane POST command output through `print_json`
- fail non-2xx POST responses before attempting script-facing JSON output
- add CLI regression coverage for task/timer/agent/skills POST commands
- update the CLI contract inventory to remove the raw-body exception

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test cli_exit_codes`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #1388
