### PR TITLE
fix: remove vestigial workspace result types

### DIFF
--- a/docs/website/spec/workspace-and-execution.md
+++ b/docs/website/spec/workspace-and-execution.md
@@ -114,10 +114,6 @@ filesystem with the agent user's permissions. Key constraints:
 
 ## Known gaps
 
-- Vestigial `EnterWorkspaceResult` and `ExitWorkspaceResult` structs still
-  exist in `types.rs:2861,2870`. These types may be unused or only used in
-  legacy HTTP paths and should be removed. See
-  [issue #1384](https://github.com/holon-run/holon/issues/1384).
 - Worktree cleanup is best-effort; stale worktrees may persist after abnormal
   agent termination.
 - Workspace occupancy is advisory; the runtime does not enforce exclusive

--- a/src/types.rs
+++ b/src/types.rs
@@ -2835,22 +2835,6 @@ pub struct UseWorkspaceResult {
     pub summary_text: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct EnterWorkspaceResult {
-    pub workspace_id: String,
-    pub projection_kind: String,
-    pub access_mode: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub summary_text: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ExitWorkspaceResult {
-    pub exited: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub summary_text: Option<String>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TaskStopResult {
     pub task: TaskRecord,


### PR DESCRIPTION
## Summary
- Remove unused EnterWorkspaceResult and ExitWorkspaceResult response structs
- Remove the resolved workspace spec known-gap entry for issue #1384

Fixes #1384

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets