### PR TITLE
feat: expose lifecycle inspection endpoints

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -724,6 +724,140 @@
         ]
       }
     },
+    "/agents/{agent_id}/tasks/{task_id}": {
+      "get": {
+        "description": "Return a task lifecycle snapshot by id.",
+        "operationId": "agentTaskStatus",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Task id.",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Task status",
+        "tags": [
+          "tasks"
+        ]
+      }
+    },
+    "/agents/{agent_id}/tasks/{task_id}/output": {
+      "get": {
+        "description": "Return a task output snapshot. Query parameters: block, timeout_ms.",
+        "operationId": "agentTaskOutput",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Task id.",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Task output",
+        "tags": [
+          "tasks"
+        ]
+      }
+    },
     "/agents/{agent_id}/timers": {
       "get": {
         "description": "Return recent timer records. Query parameter: limit.",
@@ -777,6 +911,73 @@
           }
         ],
         "summary": "List timers",
+        "tags": [
+          "timers"
+        ]
+      }
+    },
+    "/agents/{agent_id}/timers/{timer_id}": {
+      "get": {
+        "description": "Return a timer record by id.",
+        "operationId": "agentTimer",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Timer id.",
+            "in": "path",
+            "name": "timer_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Timer detail",
         "tags": [
           "timers"
         ]
@@ -837,6 +1038,131 @@
         "summary": "Recent transcript",
         "tags": [
           "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/work-items": {
+      "get": {
+        "description": "Return latest work item records for the agent. Query parameter: limit.",
+        "operationId": "agentWorkItems",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List work items",
+        "tags": [
+          "work-items"
+        ]
+      }
+    },
+    "/agents/{agent_id}/work-items/{work_item_id}": {
+      "get": {
+        "description": "Return a work item record by id.",
+        "operationId": "agentWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "WorkItem id.",
+            "in": "path",
+            "name": "work_item_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Work item detail",
+        "tags": [
+          "work-items"
         ]
       }
     },
@@ -2887,6 +3213,9 @@
     },
     {
       "name": "tasks"
+    },
+    {
+      "name": "work-items"
     },
     {
       "name": "timers"

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1114,7 +1114,7 @@
             }
           },
           {
-            "description": "WorkItem id.",
+            "description": "Work item id.",
             "in": "path",
             "name": "work_item_id",
             "required": true,

--- a/src/http.rs
+++ b/src/http.rs
@@ -182,8 +182,19 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/{agent_id}/events/stream", get(events_stream))
         .route("/agents/{agent_id}/transcript", get(transcript))
         .route("/agents/{agent_id}/tasks", get(tasks))
+        .route("/agents/{agent_id}/tasks/{task_id}", get(task_status))
+        .route(
+            "/agents/{agent_id}/tasks/{task_id}/output",
+            get(task_output),
+        )
+        .route("/agents/{agent_id}/work-items", get(work_items))
+        .route(
+            "/agents/{agent_id}/work-items/{work_item_id}",
+            get(work_item),
+        )
         .route("/agents/{agent_id}/worktree-summary", get(worktree_summary))
         .route("/agents/{agent_id}/timers", get(timers))
+        .route("/agents/{agent_id}/timers/{timer_id}", get(timer))
         .route(
             "/control/agents/{agent_id}/tasks",
             post(create_command_task),
@@ -375,6 +386,13 @@ pub struct DebugPromptRequest {
 #[derive(Debug, Deserialize)]
 pub struct LimitQuery {
     limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskOutputQuery {
+    block: Option<bool>,
+    timeout_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1703,6 +1721,65 @@ pub async fn tasks(
     ))
 }
 
+pub async fn task_status(
+    Path((agent_id, task_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    if !runtime
+        .task_record(&task_id)
+        .await
+        .map_err(error_response)?
+        .is_some_and(|task| task.agent_id == agent_id)
+    {
+        return Err(not_found(format!("task {task_id} not found")));
+    }
+    let snapshot = runtime
+        .managed_tasks()
+        .task_status_snapshot(&task_id)
+        .await
+        .map_err(task_lifecycle_error)?;
+    Ok(Json(snapshot))
+}
+
+pub async fn task_output(
+    Path((agent_id, task_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(query): Query<TaskOutputQuery>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    if !runtime
+        .task_record(&task_id)
+        .await
+        .map_err(error_response)?
+        .is_some_and(|task| task.agent_id == agent_id)
+    {
+        return Err(not_found(format!("task {task_id} not found")));
+    }
+    let output = runtime
+        .managed_tasks()
+        .task_output(
+            &task_id,
+            query.block.unwrap_or(false),
+            query.timeout_ms.unwrap_or(0),
+        )
+        .await
+        .map_err(task_lifecycle_error)?;
+    Ok(Json(output))
+}
+
 pub async fn create_command_task(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -1794,6 +1871,52 @@ pub async fn create_work_item(
     Ok(Json(record))
 }
 
+pub async fn work_items(
+    Path(agent_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(query): Query<LimitQuery>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let mut work_items = runtime
+        .latest_work_items()
+        .await
+        .map_err(error_response)?
+        .into_iter()
+        .filter(|item| item.agent_id == agent_id)
+        .collect::<Vec<_>>();
+    sort_state_work_items(&mut work_items);
+    work_items.truncate(query.limit.unwrap_or(50));
+    Ok(Json(work_items))
+}
+
+pub async fn work_item(
+    Path((agent_id, work_item_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let Some(work_item) = runtime
+        .latest_work_item(&work_item_id)
+        .await
+        .map_err(error_response)?
+        .filter(|item| item.agent_id == agent_id)
+    else {
+        return Err(not_found(format!("work item {work_item_id} not found")));
+    };
+    Ok(Json(work_item))
+}
+
 pub async fn timers(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -1812,6 +1935,28 @@ pub async fn timers(
             .await
             .map_err(error_response)?,
     ))
+}
+
+pub async fn timer(
+    Path((agent_id, timer_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let Some(timer) = runtime
+        .latest_timer(&timer_id)
+        .await
+        .map_err(error_response)?
+        .filter(|timer| timer.agent_id == agent_id)
+    else {
+        return Err(not_found(format!("timer {timer_id} not found")));
+    };
+    Ok(Json(timer))
 }
 
 pub async fn create_timer(
@@ -2853,6 +2998,15 @@ fn service_unavailable(reason: impl Into<String>) -> (StatusCode, Json<Value>) {
 
 fn not_found(reason: impl Into<String>) -> (StatusCode, Json<Value>) {
     http_error(StatusCode::NOT_FOUND, HttpErrorEnvelope::new(reason))
+}
+
+fn task_lifecycle_error(error: anyhow::Error) -> (StatusCode, Json<Value>) {
+    let message = error.to_string();
+    if message.starts_with("task ") && message.ends_with(" not found") {
+        not_found(message)
+    } else {
+        error_response(error)
+    }
 }
 
 fn stopped_agent_conflict(

--- a/src/http.rs
+++ b/src/http.rs
@@ -395,6 +395,8 @@ pub struct TaskOutputQuery {
     timeout_ms: Option<u64>,
 }
 
+const TASK_OUTPUT_DEFAULT_TIMEOUT_MS: u64 = 30_000;
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EventsQuery {
@@ -1773,7 +1775,7 @@ pub async fn task_output(
         .task_output(
             &task_id,
             query.block.unwrap_or(false),
-            query.timeout_ms.unwrap_or(0),
+            query.timeout_ms.unwrap_or(TASK_OUTPUT_DEFAULT_TIMEOUT_MS),
         )
         .await
         .map_err(task_lifecycle_error)?;
@@ -1884,14 +1886,10 @@ pub async fn work_items(
         .await
         .map_err(agent_access_error)?;
     let mut work_items = runtime
-        .latest_work_items()
+        .latest_work_items_for_agent(&agent_id, query.limit.unwrap_or(50))
         .await
-        .map_err(error_response)?
-        .into_iter()
-        .filter(|item| item.agent_id == agent_id)
-        .collect::<Vec<_>>();
+        .map_err(error_response)?;
     sort_state_work_items(&mut work_items);
-    work_items.truncate(query.limit.unwrap_or(50));
     Ok(Json(work_items))
 }
 

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -41,8 +41,13 @@ const ROUTES: &[RouteSpec] = &[
     RouteSpec { method: "get", path: "/agents/{agent_id}/events/stream", operation_id: "agentEventsStream", tag: "events", summary: "Agent event stream", description: "Return Server-Sent Events carrying StreamEventEnvelope JSON data. Query parameters: after_seq, limit, projection.", request_schema: None, response_kind: ResponseKind::EventStream, auth: AuthKind::RemoteAccess },
     route("get", "/agents/{agent_id}/transcript", "agentTranscript", "agents", "Recent transcript", "Return recent transcript entries. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/tasks", "agentTasks", "tasks", "List active tasks", "Return active task records. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/tasks/{task_id}", "agentTaskStatus", "tasks", "Task status", "Return a task lifecycle snapshot by id.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/tasks/{task_id}/output", "agentTaskOutput", "tasks", "Task output", "Return a task output snapshot. Query parameters: block, timeout_ms.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/work-items", "agentWorkItems", "work-items", "List work items", "Return latest work item records for the agent. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/work-items/{work_item_id}", "agentWorkItem", "work-items", "Work item detail", "Return a work item record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/worktree-summary", "agentWorktreeSummary", "agents", "Worktree summary", "Return managed worktree summary for an agent.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List skills", "Return installed skills for an agent.", None, AuthKind::RemoteAccess),
     route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
     route("post", "/agents/{agent_id}/enqueue", "enqueueAgent", "ingress", "Enqueue agent message", "Enqueue a public channel/webhook message for the named agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
@@ -129,6 +134,7 @@ fn openapi_value() -> Value {
             { "name": "control" },
             { "name": "runtime" },
             { "name": "tasks" },
+            { "name": "work-items" },
             { "name": "timers" },
             { "name": "skills" },
             { "name": "callbacks", "description": "Capability-token callback ingress. Never publish real callback_token values." },
@@ -183,6 +189,15 @@ fn path_parameters(path: &str) -> Vec<Value> {
     let mut params = Vec::new();
     if path.contains("{agent_id}") {
         params.push(path_param("agent_id", "Agent id."));
+    }
+    if path.contains("{task_id}") {
+        params.push(path_param("task_id", "Task id."));
+    }
+    if path.contains("{work_item_id}") {
+        params.push(path_param("work_item_id", "WorkItem id."));
+    }
+    if path.contains("{timer_id}") {
+        params.push(path_param("timer_id", "Timer id."));
     }
     if path.contains("{callback_token}") {
         params.push(path_param(

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -194,7 +194,7 @@ fn path_parameters(path: &str) -> Vec<Value> {
         params.push(path_param("task_id", "Task id."));
     }
     if path.contains("{work_item_id}") {
-        params.push(path_param("work_item_id", "WorkItem id."));
+        params.push(path_param("work_item_id", "Work item id."));
     }
     if path.contains("{timer_id}") {
         params.push(path_param("timer_id", "Timer id."));

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -594,6 +594,15 @@ impl RuntimeHandle {
         self.inner.storage.read_recent_timers(limit)
     }
 
+    pub async fn latest_timer(&self, timer_id: &str) -> Result<Option<TimerRecord>> {
+        Ok(self
+            .inner
+            .storage
+            .latest_timer_records()?
+            .into_iter()
+            .find(|timer| timer.id == timer_id))
+    }
+
     pub async fn set_model_override(
         &self,
         model_override: crate::config::ModelRef,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -523,6 +523,16 @@ impl RuntimeHandle {
         self.inner.storage.latest_work_items()
     }
 
+    pub async fn latest_work_items_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<crate::types::WorkItemRecord>> {
+        self.inner
+            .storage
+            .latest_work_items_for_agent(agent_id, limit)
+    }
+
     pub async fn latest_work_item(
         &self,
         work_item_id: &str,
@@ -595,12 +605,7 @@ impl RuntimeHandle {
     }
 
     pub async fn latest_timer(&self, timer_id: &str) -> Result<Option<TimerRecord>> {
-        Ok(self
-            .inner
-            .storage
-            .latest_timer_records()?
-            .into_iter()
-            .find(|timer| timer.id == timer_id))
+        self.inner.storage.latest_timer_record(timer_id)
     }
 
     pub async fn set_model_override(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -782,6 +782,29 @@ impl AppStorage {
         Ok(latest.into_values().collect())
     }
 
+    pub fn latest_work_items_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<WorkItemRecord>> {
+        if limit == 0 || !self.work_items_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut seen = std::collections::BTreeSet::<String>::new();
+        let mut records = Vec::<WorkItemRecord>::new();
+        scan_jsonl_reverse::<WorkItemRecord, _>(&self.work_items_path, |record| {
+            if !seen.insert(record.id.clone()) {
+                return records.len() < limit;
+            }
+            if record.agent_id == agent_id {
+                records.push(record);
+            }
+            records.len() < limit
+        })?;
+        Ok(records)
+    }
+
     pub fn work_queue_prompt_projection(&self) -> Result<WorkQueuePromptProjection> {
         if !self.work_items_path.exists() {
             return Ok(WorkQueuePromptProjection::default());
@@ -1251,6 +1274,12 @@ impl AppStorage {
             latest.insert(record.id.clone(), record);
         }
         Ok(latest.into_values().collect())
+    }
+
+    pub fn latest_timer_record(&self, timer_id: &str) -> Result<Option<TimerRecord>> {
+        read_latest_jsonl_matching(&self.timers_path, |record: &TimerRecord| {
+            record.id == timer_id
+        })
     }
 
     pub fn latest_waiting_intents(&self) -> Result<Vec<WaitingIntentRecord>> {
@@ -3224,6 +3253,80 @@ mod tests {
         assert_eq!(latest[0].id, item.id);
         assert_eq!(latest[0].state, WorkItemState::Open);
         assert_eq!(latest[0].blocked_by.as_deref(), Some("working"));
+    }
+
+    #[test]
+    fn storage_latest_work_items_for_agent_scans_tail_until_limit() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        fs::write(
+            &storage.work_items_path,
+            "{not valid json and should not be parsed}\n",
+        )
+        .unwrap();
+        let older = WorkItemRecord::new("default", "older", WorkItemState::Open);
+        let mut updated = older.clone();
+        updated.objective = "updated".into();
+        updated.updated_at = Utc::now();
+        let other_agent = WorkItemRecord::new("other", "other agent", WorkItemState::Open);
+        let newest = WorkItemRecord::new("default", "newest", WorkItemState::Open);
+
+        storage.append_work_item(&older).unwrap();
+        storage.append_work_item(&updated).unwrap();
+        storage.append_work_item(&other_agent).unwrap();
+        storage.append_work_item(&newest).unwrap();
+
+        let latest = storage.latest_work_items_for_agent("default", 2).unwrap();
+        let objectives = latest
+            .iter()
+            .map(|item| item.objective.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(objectives, vec!["newest", "updated"]);
+    }
+
+    #[test]
+    fn storage_latest_timer_record_scans_from_tail_for_id() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        fs::write(
+            &storage.timers_path,
+            "{not valid json and should not be parsed}\n",
+        )
+        .unwrap();
+        let now = Utc::now();
+        let older = TimerRecord {
+            id: "timer-1".into(),
+            agent_id: "default".into(),
+            created_at: now,
+            duration_ms: 1000,
+            interval_ms: None,
+            repeat: false,
+            status: crate::types::TimerStatus::Active,
+            summary: Some("older".into()),
+            next_fire_at: Some(now),
+            last_fired_at: None,
+            fire_count: 0,
+        };
+        let mut updated = older.clone();
+        updated.status = crate::types::TimerStatus::Completed;
+        updated.summary = Some("updated".into());
+        let other = TimerRecord {
+            id: "timer-2".into(),
+            summary: Some("other".into()),
+            ..older.clone()
+        };
+
+        storage.append_timer(&older).unwrap();
+        storage.append_timer(&other).unwrap();
+        storage.append_timer(&updated).unwrap();
+
+        let latest = storage
+            .latest_timer_record("timer-1")
+            .unwrap()
+            .expect("timer should be found");
+        assert_eq!(latest.status, crate::types::TimerStatus::Completed);
+        assert_eq!(latest.summary.as_deref(), Some("updated"));
     }
 
     #[test]

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 45, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 50, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/http_tasks.rs
+++ b/tests/http_tasks.rs
@@ -18,7 +18,10 @@ http_async_tests!(
     create_command_task_route_accepts_integration_authority,
     create_command_task_route_accepts_command_request,
     tasks_and_state_routes_return_active_latest_tasks_only,
+    task_status_and_output_routes_return_task_lifecycle_snapshots,
     create_work_item_route_persists_queued_item_without_message_ingress,
+    work_item_routes_list_and_return_work_item_detail,
     create_work_item_route_does_not_replace_existing_active_item,
     create_work_item_route_rejects_empty_objective_with_bad_request,
+    timer_detail_route_returns_latest_timer_record,
 );

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -188,6 +188,60 @@
   },
   {
     "method": "get",
+    "path": "/agents/{agent_id}/tasks/{task_id}",
+    "handler": "task_status",
+    "operation_id": "agentTaskStatus",
+    "tag": "tasks",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "task_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/agents/{agent_id}/tasks/{task_id}/output",
+    "handler": "task_output",
+    "operation_id": "agentTaskOutput",
+    "tag": "tasks",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "task_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/agents/{agent_id}/timers",
     "handler": "timers",
     "operation_id": "agentTimers",
@@ -210,6 +264,33 @@
   },
   {
     "method": "get",
+    "path": "/agents/{agent_id}/timers/{timer_id}",
+    "handler": "timer",
+    "operation_id": "agentTimer",
+    "tag": "timers",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "timer_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/agents/{agent_id}/transcript",
     "handler": "transcript",
     "operation_id": "agentTranscript",
@@ -217,6 +298,55 @@
     "parameters": [
       {
         "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/agents/{agent_id}/work-items",
+    "handler": "work_items",
+    "operation_id": "agentWorkItems",
+    "tag": "work-items",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
+    "path": "/agents/{agent_id}/work-items/{work_item_id}",
+    "handler": "work_item",
+    "operation_id": "agentWorkItem",
+    "tag": "work-items",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "work_item_id",
         "location": "path",
         "required": true
       }

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -243,6 +243,66 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
     Ok(())
 }
 
+pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{base}/control/agents/default/tasks"))
+        .json(&serde_json::json!({
+            "summary": "inspect task lifecycle",
+            "cmd": "printf lifecycle_output",
+            "login": false,
+            "yield_time_ms": 1000
+        }))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let created: serde_json::Value = response.json().await?;
+    let task_id = created["id"]
+        .as_str()
+        .expect("task creation returns id")
+        .to_string();
+
+    let runtime = host.default_runtime().await?;
+    wait_until(|| {
+        let task = runtime.storage().latest_task_record(&task_id)?;
+        Ok(task.is_some_and(|task| task.status == TaskStatus::Completed))
+    })
+    .await?;
+
+    let status: serde_json::Value = client
+        .get(format!("{base}/agents/default/tasks/{task_id}"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(status["task_id"], task_id);
+    assert_eq!(status["status"], "completed");
+    assert_eq!(status["wait_policy"], "background");
+
+    let output: serde_json::Value = client
+        .get(format!(
+            "{base}/agents/default/tasks/{task_id}/output?block=false"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(output["retrieval_status"], "success");
+    assert_eq!(output["task"]["task_id"], task_id);
+    assert_eq!(output["task"]["output_preview"], "lifecycle_output");
+
+    let missing = client
+        .get(format!("{base}/agents/default/tasks/missing-task"))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn create_work_item_route_persists_queued_item_without_message_ingress() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let client = reqwest::Client::new();
@@ -283,6 +343,55 @@ pub async fn create_work_item_route_persists_queued_item_without_message_ingress
     assert!(messages
         .iter()
         .all(|message| { matches!(message.kind, holon::types::MessageKind::SystemTick) }));
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn work_item_routes_list_and_return_work_item_detail() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{base}/control/agents/default/work-items"))
+        .json(&serde_json::json!({
+            "objective": "inspect lifecycle work item"
+        }))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let created: serde_json::Value = response.json().await?;
+    let work_item_id = created["id"]
+        .as_str()
+        .expect("work item creation returns id")
+        .to_string();
+
+    let list: serde_json::Value = client
+        .get(format!("{base}/agents/default/work-items"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert!(list
+        .as_array()
+        .expect("work-items returns an array")
+        .iter()
+        .any(|item| item["id"] == work_item_id));
+
+    let detail: serde_json::Value = client
+        .get(format!("{base}/agents/default/work-items/{work_item_id}"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(detail["id"], work_item_id);
+    assert_eq!(detail["objective"], "inspect lifecycle work item");
+
+    let missing = client
+        .get(format!("{base}/agents/default/work-items/missing-work"))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
 
     server.abort();
     Ok(())
@@ -345,6 +454,35 @@ pub async fn create_work_item_route_rejects_empty_objective_with_bad_request() -
     let body: serde_json::Value = response.json().await?;
     assert_eq!(body["ok"], false);
     assert_eq!(body["error"], "objective must not be empty");
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn timer_detail_route_returns_latest_timer_record() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    let timer = runtime
+        .schedule_timer(5_000, None, Some("inspect lifecycle timer".into()))
+        .await?;
+
+    let detail: serde_json::Value = client
+        .get(format!("{base}/agents/default/timers/{}", timer.id))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(detail["id"], timer.id);
+    assert_eq!(detail["status"], "active");
+    assert_eq!(detail["summary"], "inspect lifecycle timer");
+
+    let missing = client
+        .get(format!("{base}/agents/default/timers/missing-timer"))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
 
     server.abort();
     Ok(())

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -293,6 +293,37 @@ pub async fn task_status_and_output_routes_return_task_lifecycle_snapshots() -> 
     assert_eq!(output["task"]["task_id"], task_id);
     assert_eq!(output["task"]["output_preview"], "lifecycle_output");
 
+    let response = client
+        .post(format!("{base}/control/agents/default/tasks"))
+        .json(&serde_json::json!({
+            "summary": "inspect delayed task output",
+            "cmd": "sleep 0.2; printf delayed_lifecycle_output",
+            "login": false,
+            "yield_time_ms": 1
+        }))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let delayed: serde_json::Value = response.json().await?;
+    let delayed_task_id = delayed["id"]
+        .as_str()
+        .expect("task creation returns id")
+        .to_string();
+
+    let delayed_output: serde_json::Value = client
+        .get(format!(
+            "{base}/agents/default/tasks/{delayed_task_id}/output?block=true"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(delayed_output["retrieval_status"], "success");
+    assert_eq!(
+        delayed_output["task"]["output_preview"],
+        "delayed_lifecycle_output"
+    );
+
     let missing = client
         .get(format!("{base}/agents/default/tasks/missing-task"))
         .send()


### PR DESCRIPTION
## Summary
- add read-only task status and task output HTTP endpoints
- add WorkItem list/detail and timer detail HTTP endpoints
- include the new lifecycle endpoints in the OpenAPI route inventory snapshot

Closes #1400

## Verification
- cargo fmt --all -- --check
- cargo test --test http_route_snapshot
- RUSTFLAGS="-D warnings" cargo check --all-targets