### PR TITLE
fix: remove blocking task wait policy

### DIFF
--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -343,7 +343,7 @@ Scheduler decisions should use a fixed priority order.
 1. `stopped` or shutdown means `Stop`.
 2. queued operator interjection input may be inserted into a running turn.
 3. a queued model-reentry message may start a turn when no turn is running.
-4. terminal blocking task result may resume the model-reentry wait it satisfies.
+4. terminal task result may resume the model-reentry wait it satisfies.
 5. active waiting intents mean `WaitForExternalChange`.
 6. active timers mean `WaitForTimer`.
 7. pending wake hint means `EmitSystemTick(wake_hint)`.
@@ -368,7 +368,7 @@ Model-visible inputs:
 - contentful external event;
 - timer tick with contentful resume text;
 - runtime-owned internal follow-up intended for the model;
-- terminal blocking task result.
+- terminal task result.
 
 Liveness-only inputs:
 
@@ -406,8 +406,8 @@ Invariants:
 - terminal task records outrank stale non-terminal task messages;
 - task result delivery must not reopen a terminal task;
 - a non-terminal task status is not model-reentry by itself;
-- blocking task truth is derived from latest task records, not from stale
-  active id lists alone;
+- active task truth is derived from latest task records, not from stale active
+  id lists alone;
 - task completion should be persisted before the corresponding model-reentry
   task result is queued.
 
@@ -482,7 +482,7 @@ Waiting belongs to the waiting plane.
 Invariants:
 
 - `awaiting_operator_input` is satisfied by operator input;
-- `awaiting_task_result` is satisfied by a terminal blocking task result;
+- `awaiting_task_result` is satisfied by a terminal task result;
 - `awaiting_timer` is satisfied by a timer fire;
 - `awaiting_external_change` is satisfied by a contentful external event or a
   wake hint tied to an active waiting condition;
@@ -578,11 +578,10 @@ Expected precedence:
 
 1. runtime error;
 2. operator-input wait;
-3. active blocking tasks;
-4. active waiting intents;
-5. active timers;
-6. active turn in progress;
-7. failed terminal turn;
+3. active waiting intents;
+4. active timers;
+5. active turn in progress;
+6. failed terminal turn;
 8. runnable work signal;
 9. completed terminal turn;
 10. no waiting condition.
@@ -658,7 +657,7 @@ Coverage:
 - queue -> dequeued -> processed transitions;
 - provider turn started only when allowed;
 - non-model-reentry task status does not start a turn;
-- terminal blocking task result resumes the expected wait;
+- terminal task result resumes the expected wait;
 - paused runtime persists task terminal state but does not start a provider
   turn;
 - system tick generation does not duplicate across idle loops.
@@ -824,7 +823,7 @@ refinements rather than blockers for the scheduler contract:
 - current run id exists only while a run is active;
 - terminal tasks are absent from active task ids;
 - stale non-terminal task updates do not reopen terminal tasks;
-- blocking task closure is based on latest non-terminal blocking tasks;
+- active task presence alone is not a scheduler waiting condition;
 - completed work items are never runnable;
 - queued work items do not become current without an explicit pick;
 - `needs_input` work items wait for operator input;

--- a/docs/rfcs/runtime-scheduler-contract.md
+++ b/docs/rfcs/runtime-scheduler-contract.md
@@ -582,9 +582,9 @@ Expected precedence:
 4. active timers;
 5. active turn in progress;
 6. failed terminal turn;
-8. runnable work signal;
-9. completed terminal turn;
-10. no waiting condition.
+7. runnable work signal;
+8. completed terminal turn;
+9. no waiting condition.
 
 The result-closure RFC remains the semantic contract. This scheduler RFC
 defines how facts enter that closure derivation and how closure affects the

--- a/docs/website/spec/tasks.md
+++ b/docs/website/spec/tasks.md
@@ -1,15 +1,15 @@
 ---
 title: Tasks
-summary: Current task lifecycle, background blocking, terminal re-entry, and command/child-agent supervision contract.
+summary: Current task lifecycle, terminal re-entry, and command/child-agent supervision contract.
 order: 50
 ---
 
 # Tasks
 
 This page defines the current contract for managed task execution: lifecycle,
-blocking behavior, terminal re-entry, and supervision surfaces.
+terminal re-entry, and supervision surfaces.
 
-> **Last verified:** 2026-05-23 against `src/types.rs` `TaskRecord`,
+> **Last verified:** 2026-05-25 against `src/types.rs` `TaskRecord`,
 > `TaskStatus`, `TaskKind`, `TaskHandle`, `TaskWaitPolicy`, and the tool
 > implementations in `src/tool/tools/{exec_command,task_list,task_status,
 > task_output,task_input,task_stop,spawn_agent}.rs`.
@@ -62,15 +62,15 @@ blocking behavior, terminal re-entry, and supervision surfaces.
 
 ## Wait policy
 
-Each task carries a wait policy that determines whether it blocks the agent:
+Each task carries a wait policy for task-list and task-status compatibility:
 
 | `TaskWaitPolicy` | Behavior |
 |------------------|----------|
-| `Blocking` | Agent enters `AwaitingTask` and cannot re-enter model until task terminal |
 | `Background` | Task runs independently; agent can continue turns while task is active |
 
-Child-agent tasks are always `Background`. Command tasks default to
-`Background` unless explicitly configured as `Blocking`.
+All current task kinds report `Background`. Historical task detail payloads may
+still contain `wait_policy: "blocking"`, but the runtime ignores that value for
+scheduler blocking decisions.
 
 **Key contract:**
 
@@ -112,7 +112,9 @@ Tasks are **execution handles**, not planning objects:
 Tasks often serve WorkItem objectives (running commands, delegating to child
 agents), but task lifecycle is independent of WorkItem lifecycle.
 
-## Known gaps
+## Resolved gaps
 
-- `TaskWaitPolicy::Blocking` is defined in the type system but never used in
-  practice. See [issue #1382](https://github.com/holon-run/holon/issues/1382).
+- [Issue #1382](https://github.com/holon-run/holon/issues/1382) removed the
+  unused `Blocking` task wait policy from the public/runtime contract. Waiting
+  is expressed with `Sleep` plus terminal task re-entry, or with a bounded
+  `TaskOutput(block=true)` call inside the current turn.

--- a/src/agent_template.rs
+++ b/src/agent_template.rs
@@ -1392,15 +1392,13 @@ mod tests {
     use std::{
         io::{Read, Write},
         net::TcpListener,
-        sync::{Arc, LazyLock, Mutex},
+        sync::{Arc, Mutex},
         thread,
     };
 
     use tempfile::tempdir;
 
     use super::*;
-
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     struct EnvGuard {
         key: &'static str,
@@ -1692,9 +1690,7 @@ mod tests {
 
     #[tokio::test]
     async fn github_solve_template_materializes_builtin_skills() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let home = tempdir().unwrap();
         let _guard = EnvGuard::set("HOME", home.path().display().to_string());
         seed_builtin_templates().unwrap();
@@ -1725,9 +1721,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_agent_home_from_template_id_materializes_agents_md_and_local_skill() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let home = tempdir().unwrap();
         let _guard = EnvGuard::set("HOME", home.path().display().to_string());
         let templates = templates_root().unwrap();
@@ -1906,9 +1900,7 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_agent_home_agents_md_from_template_fills_missing_agents_md() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let home = tempdir().unwrap();
         let _guard = EnvGuard::set("HOME", home.path().display().to_string());
         seed_builtin_templates().unwrap();
@@ -1937,9 +1929,7 @@ mod tests {
 
     #[tokio::test]
     async fn ensure_agent_home_agents_md_rolls_back_on_skill_failure() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let home = tempdir().unwrap();
         let _guard = EnvGuard::set("HOME", home.path().display().to_string());
         let templates = templates_root().unwrap();
@@ -1982,9 +1972,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_agent_home_fails_closed_on_invalid_skill_ref() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let home = tempdir().unwrap();
         let _guard = EnvGuard::set("HOME", home.path().display().to_string());
         let templates = templates_root().unwrap();
@@ -2009,9 +1997,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_agent_home_restores_preexisting_empty_agent_home_on_failure() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let home = tempdir().unwrap();
         let _guard = EnvGuard::set("HOME", home.path().display().to_string());
         let templates = templates_root().unwrap();
@@ -2095,9 +2081,7 @@ mod tests {
 
     #[test]
     fn user_home_dir_falls_back_to_userprofile() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let profile = tempdir().unwrap();
         let _home = EnvGuard::set("HOME", String::new());
         let _userprofile = EnvGuard::set("USERPROFILE", profile.path().display().to_string());
@@ -2107,9 +2091,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_agent_home_from_github_url_works() {
-        let _lock = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::test_env::lock_env();
         let home = tempdir().unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -3898,7 +3898,7 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use serde_json::{json, Value};
     use tempfile::tempdir;
@@ -3920,8 +3920,6 @@ mod tests {
         ProviderBuiltinWebSearchConfig, ProviderConfigFile, ProviderId, ProviderRegistry,
         ProviderRuntimeConfig, ProviderTransportKind, RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
     };
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct EnvVarSnapshot {
         key: &'static str,
@@ -3969,12 +3967,9 @@ mod tests {
         }
 
         fn new() -> Self {
-            let lock = ENV_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
             Self {
                 snapshots: Vec::new(),
-                _lock: lock,
+                _lock: crate::test_env::lock_env(),
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,4 +38,7 @@ pub mod web;
 pub mod work_item_plan;
 
 #[cfg(test)]
+mod test_env;
+
+#[cfg(test)]
 mod worktree_tests;

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1093,6 +1093,21 @@ fn exec_command_preview(event: &ProjectionEventRecord) -> Option<String> {
         .get("exec_command_cmd")
         .and_then(|v| v.as_str())
         .or_else(|| event.payload.get("cmd").and_then(|v| v.as_str()))
+        .or_else(|| event.payload.get("cmd_preview").and_then(|v| v.as_str()))
+        .or_else(|| {
+            event
+                .payload
+                .get("command_cost")
+                .and_then(|v| v.get("cmd_preview"))
+                .and_then(|v| v.as_str())
+        })
+        .or_else(|| {
+            event
+                .payload
+                .get("exec_command_cost")
+                .and_then(|v| v.get("cmd_preview"))
+                .and_then(|v| v.as_str())
+        })
         .map(|s| s.to_string())
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -819,9 +819,12 @@ impl RuntimeHandle {
                 }
             }
             "ExecCommandBatch" => {
-                if let Some(batch) = result.envelope.result.as_ref().and_then(|value| {
-                    serde_json::from_value::<ExecCommandBatchResult>(value.clone()).ok()
-                }) {
+                if let Some(batch) = result
+                    .envelope
+                    .result
+                    .as_ref()
+                    .and_then(decode_exec_command_batch_result)
+                {
                     for item in batch.items {
                         if matches!(item.status, ExecCommandBatchItemStatus::Completed) {
                             self.record_skill_command_activation(&item.cmd).await?;
@@ -1173,6 +1176,25 @@ impl RuntimeHandle {
         self.emit_recovered_pending_wake_hint().await?;
         Ok(())
     }
+}
+
+fn decode_exec_command_batch_result(value: &serde_json::Value) -> Option<ExecCommandBatchResult> {
+    let mut value = value.clone();
+    if let serde_json::Value::Object(map) = &mut value {
+        map.entry("summary_text").or_insert(serde_json::Value::Null);
+        if let Some(serde_json::Value::Array(items)) = map.get_mut("items") {
+            for item in items {
+                if let serde_json::Value::Object(item) = item {
+                    if let Some(serde_json::Value::Object(result)) = item.get_mut("result") {
+                        result
+                            .entry("summary_text")
+                            .or_insert(serde_json::Value::Null);
+                    }
+                }
+            }
+        }
+    }
+    serde_json::from_value(value).ok()
 }
 
 fn command_mentions_path(command: &str, path: &Path) -> bool {

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     admission_trigger_kind_for_message_kind, ClosureDecision, ClosureOutcome, ContinuationClass,
     ContinuationResolution, ContinuationTriggerKind, MessageBody, MessageEnvelope, MessageKind,
-    TaskRecord, TaskStatus, TaskWaitPolicy, WaitingReason,
+    TaskRecord, TaskStatus, WaitingReason,
 };
 
 #[derive(Debug, Clone)]
@@ -9,8 +9,6 @@ pub(super) struct ContinuationTrigger {
     pub(super) kind: ContinuationTriggerKind,
     pub(super) contentful: bool,
     pub(super) task_terminal: bool,
-    pub(super) task_blocking: bool,
-    pub(super) task_wait_policy: Option<TaskWaitPolicy>,
     pub(super) wake_hint_source: Option<String>,
 }
 
@@ -24,8 +22,6 @@ impl ContinuationTrigger {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: None,
             }),
             MessageKind::WebhookEvent | MessageKind::CallbackEvent | MessageKind::ChannelEvent => {
@@ -33,8 +29,6 @@ impl ContinuationTrigger {
                     kind: admission_trigger_kind_for_message_kind(&message.kind),
                     contentful: body_is_contentful(&message.body),
                     task_terminal: false,
-                    task_blocking: false,
-                    task_wait_policy: None,
                     wake_hint_source: None,
                 })
             }
@@ -42,24 +36,18 @@ impl ContinuationTrigger {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: None,
             }),
             MessageKind::InternalFollowup => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: None,
             }),
             MessageKind::SystemTick => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: system_tick_is_contentful(message),
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: message
                     .metadata
                     .as_ref()
@@ -82,8 +70,6 @@ impl ContinuationTrigger {
                         )
                     })
                     .unwrap_or(false),
-                task_blocking: task.map(TaskRecord::is_blocking).unwrap_or(false),
-                task_wait_policy: task.map(TaskRecord::wait_policy),
                 wake_hint_source: None,
             }),
             MessageKind::TaskStatus
@@ -107,12 +93,6 @@ pub(super) fn resolve_continuation(
     }
     if trigger.task_terminal {
         evidence.push("task_terminal".to_string());
-    }
-    if trigger.task_blocking {
-        evidence.push("task_blocking".to_string());
-    }
-    if trigger.task_wait_policy == Some(TaskWaitPolicy::Background) {
-        evidence.push("task_background".to_string());
     }
     if let Some(source) = trigger.wake_hint_source.as_ref() {
         evidence.push(format!("wake_hint_source={source}"));
@@ -321,15 +301,13 @@ mod tests {
     }
 
     #[test]
-    fn blocking_task_result_resumes_expected_wait() {
+    fn terminal_task_result_resumes_expected_wait() {
         let resolution = resolve_continuation(
             &waiting(WaitingReason::AwaitingTaskResult),
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
                 task_terminal: true,
-                task_blocking: true,
-                task_wait_policy: Some(TaskWaitPolicy::Blocking),
                 wake_hint_source: None,
             },
         );
@@ -345,8 +323,6 @@ mod tests {
                 kind: ContinuationTriggerKind::SystemTick,
                 contentful: false,
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: Some("callback".into()),
             },
         );
@@ -362,8 +338,6 @@ mod tests {
                 kind: ContinuationTriggerKind::OperatorInput,
                 contentful: true,
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );
@@ -385,8 +359,6 @@ mod tests {
                 kind: ContinuationTriggerKind::ExternalEvent,
                 contentful: false,
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );
@@ -395,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_blocking_task_result_resumes_without_prior_wait() {
+    fn terminal_task_result_resumes_without_prior_wait() {
         let resolution = resolve_continuation(
             &ClosureDecision {
                 outcome: ClosureOutcome::Completed,
@@ -408,8 +380,6 @@ mod tests {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
                 task_terminal: true,
-                task_blocking: true,
-                task_wait_policy: Some(TaskWaitPolicy::Blocking),
                 wake_hint_source: None,
             },
         );
@@ -418,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_background_task_result_resumes_without_prior_wait() {
+    fn terminal_task_result_resumes_from_sleeping_posture() {
         let resolution = resolve_continuation(
             &ClosureDecision {
                 outcome: ClosureOutcome::Completed,
@@ -431,29 +401,21 @@ mod tests {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
                 task_terminal: true,
-                task_blocking: false,
-                task_wait_policy: Some(TaskWaitPolicy::Background),
                 wake_hint_source: None,
             },
         );
         assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
         assert!(resolution.model_reentry);
-        assert!(resolution
-            .evidence
-            .iter()
-            .any(|entry| entry == "task_background"));
     }
 
     #[test]
-    fn terminal_blocking_task_result_overrides_mismatched_wait() {
+    fn terminal_task_result_overrides_mismatched_wait() {
         let resolution = resolve_continuation(
             &waiting(WaitingReason::AwaitingExternalChange),
             &ContinuationTrigger {
                 kind: ContinuationTriggerKind::TaskResult,
                 contentful: true,
                 task_terminal: true,
-                task_blocking: true,
-                task_wait_policy: Some(TaskWaitPolicy::Blocking),
                 wake_hint_source: None,
             },
         );
@@ -469,8 +431,6 @@ mod tests {
                 kind: ContinuationTriggerKind::ExternalEvent,
                 contentful: false,
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );
@@ -487,8 +447,6 @@ mod tests {
                 kind: ContinuationTriggerKind::TimerFire,
                 contentful: true,
                 task_terminal: false,
-                task_blocking: false,
-                task_wait_policy: None,
                 wake_hint_source: None,
             },
         );

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1531,7 +1531,7 @@ mod tests {
     }
 
     #[test]
-    fn child_blocked_reason_prioritizes_cancelling_then_running_then_queued() {
+    fn child_blocked_reason_ignores_background_tasks() {
         let queued = task_with_wait_policy(
             "queued",
             TaskStatus::Queued,
@@ -1551,13 +1551,12 @@ mod tests {
 
         assert_eq!(
             child_blocked_reason(&AgentStatus::AwakeRunning, &active),
-            Some(ChildAgentBlockedReason::ManagedTaskCancelling)
+            None
         );
 
-        let active = vec![&queued, &running];
         assert_eq!(
-            child_blocked_reason(&AgentStatus::AwakeRunning, &active),
-            Some(ChildAgentBlockedReason::ManagedTaskRunning)
+            child_blocked_reason(&AgentStatus::AwaitingTask, &active),
+            Some(ChildAgentBlockedReason::AwaitingManagedTask)
         );
     }
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1535,17 +1535,17 @@ mod tests {
         let queued = task_with_wait_policy(
             "queued",
             TaskStatus::Queued,
-            crate::types::TaskWaitPolicy::Blocking,
+            crate::types::TaskWaitPolicy::Background,
         );
         let running = task_with_wait_policy(
             "running",
             TaskStatus::Running,
-            crate::types::TaskWaitPolicy::Blocking,
+            crate::types::TaskWaitPolicy::Background,
         );
         let cancelling = task_with_wait_policy(
             "cancelling",
             TaskStatus::Cancelling,
-            crate::types::TaskWaitPolicy::Blocking,
+            crate::types::TaskWaitPolicy::Background,
         );
         let active = vec![&queued, &running, &cancelling];
 

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -77,7 +77,6 @@ impl RuntimeHandle {
                 "trigger_kind": trigger.kind,
                 "contentful": trigger.contentful,
                 "task_terminal": trigger.task_terminal,
-                "task_blocking": trigger.task_blocking,
                 "wake_hint_source": trigger.wake_hint_source,
                 "prior_closure_outcome": prior_closure.outcome,
                 "prior_waiting_reason": prior_closure.waiting_reason,

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -258,7 +258,9 @@ impl RuntimeHandle {
                 self.emit_system_tick_from_wake_hint(&pending).await?;
 
                 #[cfg(test)]
-                crate::runtime::test_util::wait_at_checkpoint().await;
+                if crate::runtime::test_util::checkpoint_matches_agent(&self.agent_id().await?) {
+                    crate::runtime::test_util::wait_at_checkpoint().await;
+                }
 
                 let mut guard = self.inner.agent.lock().await;
                 if guard.state.pending_wake_hint.as_ref() == Some(&pending) {

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn has_blocking_active_tasks_uses_storage_backed_task_records() {
+    fn active_tasks_do_not_block_from_legacy_wait_policy_payloads() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
         storage
@@ -299,7 +299,7 @@ mod tests {
             .unwrap();
         assert!(active.iter().any(|task| task.id == "blocking"));
         assert!(active.iter().any(|task| task.id == "background"));
-        assert!(active.iter().any(TaskRecord::is_blocking));
+        assert!(!active.iter().any(TaskRecord::is_blocking));
     }
 
     #[test]

--- a/src/runtime/test_util.rs
+++ b/src/runtime/test_util.rs
@@ -1,6 +1,9 @@
 //! Test utilities for controlling race conditions in tests
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Mutex,
+};
 use tokio::sync::Notify;
 
 /// Atomic flag to enable checkpoint mechanism
@@ -12,22 +15,39 @@ static EMIT_AT_CHECKPOINT: AtomicBool = AtomicBool::new(false);
 /// Counter to track which test iteration we're on
 static CHECKPOINT_GENERATION: AtomicUsize = AtomicUsize::new(0);
 
+/// Optional agent id that owns the active checkpoint.
+static CHECKPOINT_AGENT_ID: Mutex<Option<String>> = Mutex::new(None);
+
 /// Notify to signal that emit thread has reached the checkpoint
 static REACHED_CHECKPOINT: Notify = Notify::const_new();
 
 /// Notify to signal that the test has completed its work and emit can continue
 static ALLOW_CONTINUE: Notify = Notify::const_new();
 
-/// Enable the checkpoint mechanism for testing
-pub fn enable_checkpoint() {
+/// Enable the checkpoint mechanism for a specific test agent.
+pub fn enable_checkpoint_for_agent(agent_id: impl Into<String>) {
     CHECKPOINT_ENABLED.store(true, Ordering::SeqCst);
     CHECKPOINT_GENERATION.fetch_add(1, Ordering::SeqCst);
     EMIT_AT_CHECKPOINT.store(false, Ordering::SeqCst);
+    *CHECKPOINT_AGENT_ID.lock().unwrap() = Some(agent_id.into());
 }
 
 /// Disable the checkpoint mechanism
 pub fn disable_checkpoint() {
     CHECKPOINT_ENABLED.store(false, Ordering::SeqCst);
+    *CHECKPOINT_AGENT_ID.lock().unwrap() = None;
+}
+
+/// Returns true when the enabled checkpoint belongs to `agent_id`.
+pub fn checkpoint_matches_agent(agent_id: &str) -> bool {
+    if !CHECKPOINT_ENABLED.load(Ordering::SeqCst) {
+        return false;
+    }
+    CHECKPOINT_AGENT_ID
+        .lock()
+        .unwrap()
+        .as_deref()
+        .is_some_and(|checkpoint_agent_id| checkpoint_agent_id == agent_id)
 }
 
 /// Wait at the checkpoint in production code (only enabled in tests)

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -878,7 +878,7 @@ async fn latest_task_list_entries_return_compact_projection() {
     assert_eq!(entries[0].summary.as_deref(), Some("watch logs"));
     assert_eq!(
         entries[0].wait_policy,
-        crate::types::TaskWaitPolicy::Blocking
+        crate::types::TaskWaitPolicy::Background
     );
     let command = entries[0]
         .command

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -15,22 +15,26 @@ struct OperatorInterjectionProbeProvider {
     first_tool_round: Arc<tokio::sync::Notify>,
 }
 
-fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> TaskRecord {
-    TaskRecord {
-        id: task_id.into(),
+fn task_wait_condition_for_work_item(task_id: &str, work_item_id: &str) -> WaitConditionRecord {
+    let now = Utc::now();
+    WaitConditionRecord {
+        id: format!("wait-{task_id}"),
         agent_id: "default".into(),
-        kind: TaskKind::CommandTask,
-        status: TaskStatus::Running,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        parent_message_id: None,
-        work_item_id: work_item_id.map(ToString::to_string),
-        summary: Some("blocking command".into()),
-        detail: Some(serde_json::json!({
-            "wait_policy": "blocking",
-            "work_item_id": work_item_id,
-        })),
-        recovery: None,
+        work_item_id: Some(work_item_id.into()),
+        status: WaitConditionStatus::Active,
+        kind: WaitConditionKind::Task,
+        source: None,
+        subject_ref: Some(task_id.into()),
+        waiting_for: "task result".into(),
+        wake_sources: vec![WakeSource::TaskResult {
+            task_id: task_id.into(),
+        }],
+        continuation: None,
+        created_at: now,
+        updated_at: now,
+        expires_at: None,
+        resolved_at: None,
+        cancelled_at: None,
     }
 }
 
@@ -502,7 +506,7 @@ async fn indefinite_sleep_with_waiting_operator_or_task_work_item_can_sleep() {
         } else {
             runtime
                 .storage()
-                .append_task(&blocking_task_for_work_item("task-wait", Some(&work.id)))
+                .append_wait_condition(&task_wait_condition_for_work_item("task-wait", &work.id))
                 .unwrap();
         }
         {
@@ -2250,7 +2254,8 @@ async fn batch_command_reading_discovered_skill_marks_it_active() {
                 "items": [
                     {
                         "cmd": "sed -n '1,8p' .agents/skills/demo/SKILL.md",
-                        "workdir": "."
+                        "workdir": ".",
+                        "yield_time_ms": 30000
                     }
                 ]
             }),
@@ -2504,8 +2509,10 @@ fn runtime_failure_summary_truncates_exact_budget_before_ellipsis() {
 fn wake_hint_preserved_when_replaced_during_critical_window() {
     use tokio::runtime::Runtime;
 
+    let agent_id = "wake-hint-preserved-critical-window";
+
     // Enable checkpoint mechanism for this test
-    crate::runtime::test_util::enable_checkpoint();
+    crate::runtime::test_util::enable_checkpoint_for_agent(agent_id);
 
     // RAII guard to ensure checkpoint is disabled even on panic
     struct CheckpointGuard;
@@ -2522,7 +2529,7 @@ fn wake_hint_preserved_when_replaced_during_critical_window() {
     let rt = Runtime::new().unwrap();
 
     // Create agent with idle status and an initial wake hint
-    let mut agent = AgentState::new("default");
+    let mut agent = AgentState::new(agent_id);
     agent.status = AgentStatus::AwakeIdle;
     agent.pending_wake_hint = Some(PendingWakeHint {
         reason: "original-hint".into(),
@@ -2541,7 +2548,7 @@ fn wake_hint_preserved_when_replaced_during_critical_window() {
     storage.write_agent(&agent).unwrap();
 
     let runtime = RuntimeHandle::new(
-        "default",
+        agent_id,
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
         "http://127.0.0.1:7878".into(),

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -494,6 +494,7 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                         name: "ExecCommand".into(),
                         input: serde_json::json!({
                             "cmd": "printf 'first-round-output-should-not-stay-exact'",
+                            "yield_time_ms": 30000,
                         }),
                     },
                 ],
@@ -513,6 +514,7 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                         name: "ExecCommand".into(),
                         input: serde_json::json!({
                             "cmd": "printf 'second-round-output-should-remain-exact'",
+                            "yield_time_ms": 30000,
                         }),
                     },
                 ],
@@ -532,6 +534,7 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                         name: "ExecCommand".into(),
                         input: serde_json::json!({
                             "cmd": "printf 'third-round-output-should-remain-exact'",
+                            "yield_time_ms": 30000,
                         }),
                     },
                 ],

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -23,7 +23,7 @@ async fn runtime_tracks_background_task() {
                 cmd: "sleep 1".into(),
                 workdir: None,
                 shell: None,
-                login: true,
+                login: false,
                 tty: false,
                 yield_time_ms: 10,
                 max_output_tokens: None,
@@ -34,7 +34,7 @@ async fn runtime_tracks_background_task() {
         )
         .await
         .unwrap();
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         let active_tasks = runtime.active_tasks(10).await.unwrap();
         if !active_tasks.iter().any(|record| record.id == task.id) {

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -592,7 +592,8 @@ async fn turn_local_compaction_rewrites_older_rounds_into_runtime_recap() {
             .expect("missing deterministic recap after compaction");
         assert!(recap.contains("Round 1"), "unexpected recap: {recap}");
         assert!(
-            recap.contains("ExecCommand completed exit_status=0"),
+            recap.contains("ExecCommand completed exit_status=0")
+                || recap.contains("ExecCommand promoted_to_task"),
             "unexpected recap: {recap}"
         );
         assert!(!recap.contains("first-round-output-should-not-stay-exact"));

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -5,7 +5,10 @@ use crate::types::{
     WorkItemReadiness, WorkItemSchedulingState, AGENT_HOME_WORKSPACE_ID,
 };
 
-fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> TaskRecord {
+fn legacy_blocking_payload_task_for_work_item(
+    task_id: &str,
+    work_item_id: Option<&str>,
+) -> TaskRecord {
     TaskRecord {
         id: task_id.into(),
         agent_id: "default".into(),
@@ -15,7 +18,7 @@ fn blocking_task_for_work_item(task_id: &str, work_item_id: Option<&str>) -> Tas
         updated_at: Utc::now(),
         parent_message_id: None,
         work_item_id: work_item_id.map(ToString::to_string),
-        summary: Some("blocking command".into()),
+        summary: Some("legacy blocking command".into()),
         detail: Some(serde_json::json!({
             "wait_policy": "blocking",
             "work_item_id": work_item_id,
@@ -246,7 +249,7 @@ async fn work_queue_projection_derives_scheduling_state_per_work_item() {
         .unwrap();
     runtime
         .storage()
-        .append_task(&blocking_task_for_work_item(
+        .append_task(&legacy_blocking_payload_task_for_work_item(
             "task-wait",
             Some(&task_wait.id),
         ))
@@ -266,10 +269,7 @@ async fn work_queue_projection_derives_scheduling_state_per_work_item() {
         state_for(&external.id),
         WorkItemSchedulingState::WaitingExternal
     );
-    assert_eq!(
-        state_for(&task_wait.id),
-        WorkItemSchedulingState::WaitingTask
-    );
+    assert_eq!(state_for(&task_wait.id), WorkItemSchedulingState::Runnable);
     assert!(projection
         .queued_runnable
         .iter()
@@ -669,11 +669,11 @@ async fn work_item_completion_ignores_running_tasks_and_clears_explicit_waits() 
         .create_work_item("other".into(), None, None, Vec::new())
         .await
         .unwrap();
-    let related_task = blocking_task_for_work_item("task-target", Some(&target.id));
+    let related_task = legacy_blocking_payload_task_for_work_item("task-target", Some(&target.id));
     runtime.storage().append_task(&related_task).unwrap();
-    let unrelated_task = blocking_task_for_work_item("task-other", Some(&other.id));
+    let unrelated_task = legacy_blocking_payload_task_for_work_item("task-other", Some(&other.id));
     runtime.storage().append_task(&unrelated_task).unwrap();
-    let unscoped_task = blocking_task_for_work_item("task-unscoped", None);
+    let unscoped_task = legacy_blocking_payload_task_for_work_item("task-unscoped", None);
     runtime.storage().append_task(&unscoped_task).unwrap();
 
     let completed = runtime

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1044,19 +1044,21 @@ impl AppStorage {
             .iter()
             .find(|item| item.scheduling_state == WorkItemSchedulingState::WaitingTask)
         {
+            let task_id = self
+                .latest_wait_conditions()?
+                .into_iter()
+                .find(|condition| {
+                    condition.status == WaitConditionStatus::Active
+                        && condition.kind == WaitConditionKind::Task
+                        && condition.work_item_id.as_deref() == Some(item.work_item.id.as_str())
+                })
+                .and_then(|condition| condition.subject_ref);
             return Ok(AgentPostureProjection {
                 posture: AgentSchedulingPosture::WaitingForTask,
                 reason: item.posture_reason(),
                 work_item_id: Some(item.work_item.id.clone()),
                 waiting_intent_id: None,
-                task_id: self
-                    .latest_active_task_records_for_agent(&agent.id, usize::MAX)?
-                    .into_iter()
-                    .find(|task| {
-                        task.is_blocking()
-                            && task.effective_work_item_id() == Some(item.work_item.id.as_str())
-                    })
-                    .map(|task| task.id),
+                task_id,
                 run_id: None,
             });
         }
@@ -2989,22 +2991,27 @@ mod tests {
         );
 
         let mut task_wait = WorkItemRecord::new("default", "task", WorkItemState::Open);
-        task_wait.blocked_by = Some("command task".into());
         task_wait.updated_at = now + chrono::Duration::seconds(3);
         storage.append_work_item(&task_wait).unwrap();
         storage
-            .append_task(&TaskRecord {
-                id: "task-1".into(),
+            .append_wait_condition(&WaitConditionRecord {
+                id: "task-condition".into(),
                 agent_id: "default".into(),
-                kind: TaskKind::CommandTask,
-                status: TaskStatus::Running,
+                work_item_id: Some(task_wait.id.clone()),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::Task,
+                source: None,
+                subject_ref: Some("task-1".into()),
+                waiting_for: "task result".into(),
+                wake_sources: vec![WakeSource::TaskResult {
+                    task_id: "task-1".into(),
+                }],
+                continuation: None,
                 created_at: now,
                 updated_at: now,
-                parent_message_id: None,
-                work_item_id: Some(task_wait.id.clone()),
-                summary: Some("blocking task".into()),
-                detail: Some(serde_json::json!({ "wait_policy": "blocking" })),
-                recovery: None,
+                expires_at: None,
+                resolved_at: None,
+                cancelled_at: None,
             })
             .unwrap();
         let task_projection = storage.agent_posture_projection(&agent).unwrap();

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -1,0 +1,9 @@
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1271,9 +1271,6 @@ fn presentation_debug_items_for_event(
     Vec<ProjectionEventRecord>,
     Vec<crate::presentation::TimedItem>,
 ) {
-    if record.kind == "process_execution_requested" {
-        return (Vec::new(), Vec::new());
-    }
     if matches!(
         record.kind.as_str(),
         "tool_executed" | "tool_execution_failed"
@@ -1281,8 +1278,7 @@ fn presentation_debug_items_for_event(
         if let Some(previous) = event_log
             .iter()
             .rev()
-            .nth(1)
-            .filter(|event| event.kind == "process_execution_requested")
+            .find(|event| event.id != record.id && event.kind == "process_execution_requested")
         {
             let reducer_events = vec![previous.clone(), record.clone()];
             let mut reducer = crate::presentation::PresentationReducer::new();

--- a/src/types.rs
+++ b/src/types.rs
@@ -2274,16 +2274,7 @@ pub struct TaskRecord {
 
 impl TaskRecord {
     pub fn wait_policy(&self) -> TaskWaitPolicy {
-        if self.kind.is_legacy_child_agent_compat()
-            || self.kind == TaskKind::ChildAgentTask
-            || self.recovery.as_ref().is_some_and(|recovery| {
-                recovery.is_legacy_child_agent_compat()
-                    || matches!(recovery, TaskRecoverySpec::ChildAgentTask { .. })
-            })
-        {
-            return TaskWaitPolicy::Background;
-        }
-
+        // Active tasks are never scheduler-blocking; terminal results drive re-entry.
         TaskWaitPolicy::Background
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -741,7 +741,6 @@ pub struct ClosureDecision {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskWaitPolicy {
-    Blocking,
     Background,
 }
 
@@ -2285,20 +2284,11 @@ impl TaskRecord {
             return TaskWaitPolicy::Background;
         }
 
-        self.detail
-            .as_ref()
-            .and_then(|detail| detail.get("wait_policy"))
-            .and_then(|value| value.as_str())
-            .map(|value| match value {
-                "blocking" => TaskWaitPolicy::Blocking,
-                _ => TaskWaitPolicy::Background,
-            })
-            .or_else(|| self.recovery.as_ref().map(TaskRecoverySpec::wait_policy))
-            .unwrap_or(TaskWaitPolicy::Background)
+        TaskWaitPolicy::Background
     }
 
     pub fn is_blocking(&self) -> bool {
-        self.wait_policy() == TaskWaitPolicy::Blocking
+        false
     }
 
     pub fn terminal_reentry(&self) -> bool {

--- a/tests/fixtures/scheduler/basic/expected.json
+++ b/tests/fixtures/scheduler/basic/expected.json
@@ -3,6 +3,6 @@
   "current_work_item_revision": 3,
   "queued_work_items": 1,
   "active_tasks": 1,
-  "has_blocking_active_tasks": true,
+  "has_blocking_active_tasks": false,
   "pending_wake_hint": true
 }

--- a/tests/fixtures/scheduler/blocking_task/expected.json
+++ b/tests/fixtures/scheduler/blocking_task/expected.json
@@ -3,7 +3,7 @@
   "current_work_item_revision": null,
   "queued_work_items": 0,
   "active_tasks": 1,
-  "has_blocking_active_tasks": true,
+  "has_blocking_active_tasks": false,
   "pending_wake_hint": false,
   "active_waiting_intents": 0,
   "active_work_item_waiting_intents": 0,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -236,10 +236,6 @@ pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reent
         .is_some_and(|continuation| {
             continuation.trigger_kind == holon::types::ContinuationTriggerKind::TaskResult
                 && continuation.model_reentry
-                && continuation
-                    .evidence
-                    .iter()
-                    .any(|entry| entry == "task_background")
         }));
     let tasks = runtime.storage().latest_task_records()?;
     assert!(tasks.iter().any(|record| {


### PR DESCRIPTION
## Summary
- remove `TaskWaitPolicy::Blocking` from the public/runtime task contract
- treat terminal task results uniformly as model re-entry signals instead of scheduler blocking truth
- update scheduler fixtures and task docs to reflect that active tasks are not waiting conditions

Fixes #1382

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets