### PR TITLE
feat: add WorkItem inspection CLI commands

### DIFF
--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -243,7 +243,9 @@ called stable.
 | Method | Path | Request body | Success response | Stability | Notes |
 |--------|------|--------------|------------------|-----------|-------|
 | `POST` | `/control/agents/:agent_id/tasks` | `CreateCommandTaskRequest` | `TaskRecord` | Candidate stable for creation; Gap for lifecycle management | `serde(deny_unknown_fields)` rejects legacy fields. |
-| `POST` | `/control/agents/:agent_id/work-items` | `{ objective, trust? }` | `WorkItemRecord` | Experimental | Only creates/enqueues work items; no HTTP get/update/complete API yet. |
+| `GET` | `/agents/:agent_id/work-items` | none | `WorkItemRecord[]` | Experimental read model; CLI schema owner | Query parameter: `limit`; used by `holon work-item list`. |
+| `GET` | `/agents/:agent_id/work-items/:work_item_id` | none | `WorkItemRecord` | Experimental read model; CLI schema owner | Used by `holon work-item get`; returns 404 when the id is not found for the target agent. |
+| `POST` | `/control/agents/:agent_id/work-items` | `{ objective, trust? }` | `WorkItemRecord` | Experimental | Only creates/enqueues work items; update/pick/complete APIs remain deferred. |
 | `POST` | `/control/agents/:agent_id/timers` | `{ duration_ms, interval_ms?, summary?, trust? }` | `TimerRecord` | Candidate stable for creation; Gap for cancellation/list detail | `duration_ms` is required; `interval_ms` makes a repeating timer. |
 
 `CreateCommandTaskRequest` fields:
@@ -337,9 +339,9 @@ treated as schema surfaces, not incidental Rust structs:
 3. **Task lifecycle APIs are incomplete.** HTTP can create and list tasks, but
    lacks task status/output/input/stop routes that correspond to runtime tool
    operations.
-4. **WorkItem APIs are incomplete.** HTTP can create/enqueue work items and
-   include them in state snapshots, but lacks list/get/update/pick/complete
-   routes.
+4. **WorkItem mutation APIs are incomplete.** HTTP can list/get/create/enqueue
+   work items and include them in state snapshots, but update/pick/complete
+   routes remain deferred.
 5. **Timer lifecycle APIs are incomplete.** HTTP can create and list timers, but
    lacks cancellation or detail routes.
 6. **Deployment guidance still needs hardening.** The HTTP ingress trust/auth

--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -114,6 +114,8 @@ These commands require a reachable local control plane unless noted otherwise.
 | `holon task output` | `<TASK_ID>` | `--block`; `--timeout-ms <MS>`; `--agent <AGENT>` | pretty JSON `TaskOutputResult` | `experimental` | Output preview length follows the task's creation-time `--max-output-tokens`; this command controls readiness waiting only. |
 | `holon task input` | `<TASK_ID>` | required `--text <TEXT>`; `--agent <AGENT>` | pretty JSON `TaskInputResult` | `experimental` | Sends trusted operator text to command-task stdin/TTY or supervised child-agent follow-up input. |
 | `holon task stop` | `<TASK_ID>` | `--agent <AGENT>` | pretty JSON `TaskStopResult` | `experimental` | Requests managed-task cancellation through the control plane. |
+| `holon work-item list` | none | `--limit <LIMIT>` default `50`; `--agent <AGENT>` | pretty JSON array of `WorkItemRecord` | `experimental` | Initial WorkItem CLI surface is read-only. The JSON schema owner is the HTTP/API `WorkItemRecord` read model returned by `/agents/:agent_id/work-items`. |
+| `holon work-item get` | `<WORK_ITEM_ID>` | `--agent <AGENT>` | pretty JSON `WorkItemRecord` | `experimental` | Reads a single work item through `/agents/:agent_id/work-items/:work_item_id`; create/update/pick/complete commands are deferred until those mutation API contracts are stabilized. |
 | `holon timer` | none | required `--after-ms <MS>`; `--every-ms <MS>`; `--summary <SUMMARY>`; `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Timer surface should be aligned with WorkItem/waiting-plane contract. |
 
 ### Agent lifecycle and model selection

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -52,6 +52,9 @@ holon (v0.14.0)
 │   ├── output   Read task output
 │   ├── input    Send text input to a task
 │   └── stop     Stop a task
+├── work-item    Inspect WorkItems
+│   ├── list     List WorkItems
+│   └── get      Show a WorkItem
 ├── timer        Create a delayed or recurring timer
 ├── control      [deprecated] use `holon agent start|stop|abort`
 ├── agent        Agent management
@@ -191,6 +194,21 @@ Task lifecycle commands default to the configured default agent. Pass
 `--agent <AGENT>` to inspect or control a task owned by a different public
 agent. All task lifecycle commands print the corresponding JSON control-plane
 or read-model response.
+
+### WorkItems
+
+```bash
+holon work-item list
+holon work-item list --limit 10 --agent planner
+holon work-item get <WORK_ITEM_ID>
+holon work-item get <WORK_ITEM_ID> --agent planner
+```
+
+The initial WorkItem CLI surface is read-only. It prints the HTTP read-model
+`WorkItemRecord` JSON shape returned by `/agents/:agent_id/work-items` and
+`/agents/:agent_id/work-items/:work_item_id`. Mutating commands such as create,
+update, pick, and complete remain intentionally deferred until their API
+contracts are stabilized.
 
 ### Terminal UI
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,6 +65,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: TaskCommands,
     },
+    #[command(name = "work-item")]
+    WorkItem {
+        #[command(subcommand)]
+        command: WorkItemCommands,
+    },
     Timer {
         #[arg(long)]
         after_ms: u64,
@@ -399,6 +404,21 @@ pub enum TaskCommands {
     },
     Stop {
         task_id: String,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkItemCommands {
+    List {
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    Get {
+        work_item_id: String,
         #[arg(long)]
         agent: Option<String>,
     },

--- a/src/client.rs
+++ b/src/client.rs
@@ -427,6 +427,20 @@ impl LocalClient {
             .await
     }
 
+    pub async fn agent_work_items(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<WorkItemRecord>> {
+        self.get_json(&format!("/agents/{agent_id}/work-items?limit={limit}"))
+            .await
+    }
+
+    pub async fn work_item(&self, agent_id: &str, work_item_id: &str) -> Result<WorkItemRecord> {
+        self.get_json(&format!("/agents/{agent_id}/work-items/{work_item_id}"))
+            .await
+    }
+
     pub async fn task_status(&self, agent_id: &str, task_id: &str) -> Result<TaskStatusSnapshot> {
         self.get_json(&format!("/agents/{agent_id}/tasks/{task_id}"))
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,8 @@ use tracing_subscriber::EnvFilter;
 use holon::cli::{
     AgentCommands, AgentModelCommands, Cli, Commands, ConfigCommands, ConfigCredentialCommands,
     ConfigModelCommands, ConfigProviderCommands, ControlCommandAction, DaemonCommands,
-    DebugCommands, ServeAccess, ServeOptions, SkillsCommands, TaskCommands, WorkspaceCommands,
+    DebugCommands, ServeAccess, ServeOptions, SkillsCommands, TaskCommands, WorkItemCommands,
+    WorkspaceCommands,
 };
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -168,6 +169,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
             )?)
         }
         Commands::Task { command } => handle_task_command(&config, command).await,
+        Commands::WorkItem { command } => handle_work_item_command(&config, command).await,
         Commands::Timer {
             after_ms,
             every_ms,
@@ -958,6 +960,51 @@ mod tests {
             panic!("expected task stop command");
         };
         assert_eq!(task_id, "task-4");
+        assert_eq!(agent, None);
+    }
+
+    #[test]
+    fn work_item_inspection_commands_parse_with_agent_options() {
+        let cli = Cli::parse_from(["holon", "work-item", "list", "--agent", "runner"]);
+        let Commands::WorkItem {
+            command: WorkItemCommands::List { limit, agent },
+        } = cli.command
+        else {
+            panic!("expected work-item list command");
+        };
+        assert_eq!(limit, 50);
+        assert_eq!(agent.as_deref(), Some("runner"));
+
+        let cli = Cli::parse_from([
+            "holon",
+            "work-item",
+            "list",
+            "--limit",
+            "10",
+            "--agent",
+            "runner",
+        ]);
+        let Commands::WorkItem {
+            command: WorkItemCommands::List { limit, agent },
+        } = cli.command
+        else {
+            panic!("expected work-item list command");
+        };
+        assert_eq!(limit, 10);
+        assert_eq!(agent.as_deref(), Some("runner"));
+
+        let cli = Cli::parse_from(["holon", "work-item", "get", "work_123"]);
+        let Commands::WorkItem {
+            command:
+                WorkItemCommands::Get {
+                    work_item_id,
+                    agent,
+                },
+        } = cli.command
+        else {
+            panic!("expected work-item get command");
+        };
+        assert_eq!(work_item_id, "work_123");
         assert_eq!(agent, None);
     }
 
@@ -1943,6 +1990,27 @@ async fn handle_task_command(config: &AppConfig, command: TaskCommands) -> Resul
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
             print_json(&serde_json::to_value(
                 client.task_stop(&agent, &task_id).await?,
+            )?)
+        }
+    }
+}
+
+async fn handle_work_item_command(config: &AppConfig, command: WorkItemCommands) -> Result<()> {
+    let client = LocalClient::new(config.clone())?;
+    match command {
+        WorkItemCommands::List { limit, agent } => {
+            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            print_json(&serde_json::to_value(
+                client.agent_work_items(&agent, limit).await?,
+            )?)
+        }
+        WorkItemCommands::Get {
+            work_item_id,
+            agent,
+        } => {
+            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            print_json(&serde_json::to_value(
+                client.work_item(&agent, &work_item_id).await?,
             )?)
         }
     }

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -1396,6 +1396,54 @@
     "aliases": []
   },
   {
+    "path": "work-item",
+    "positionals": [],
+    "flags": [],
+    "aliases": []
+  },
+  {
+    "path": "work-item.get",
+    "positionals": [
+      {
+        "name": "work_item_id",
+        "value_name": "WORK_ITEM_ID",
+        "index": null,
+        "required": true
+      }
+    ],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "work-item.list",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "limit",
+        "short": null,
+        "default_value": "50",
+        "possible_values": null,
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "workspace",
     "positionals": [],
     "flags": [],


### PR DESCRIPTION
## Summary
- add `holon work-item list` and `holon work-item get` read-only CLI commands
- wire the commands through `LocalClient` to the existing WorkItem read-model endpoints
- update CLI/API contract docs and refresh the normalized CLI command tree snapshot

## Verification
- `cargo fmt --all -- --check`
- `cargo test cli_snapshot -- --test-threads=1`
- `cargo test work_item_inspection_commands_parse_with_agent_options -- --test-threads=1`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #1393
