### PR TITLE
feat: add stable event CLI commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,14 @@ use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 
 use crate::types::AuthorityClass;
 
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    match value.parse::<usize>() {
+        Ok(parsed) if parsed > 0 => Ok(parsed),
+        Ok(_) => Err("value must be greater than zero".to_string()),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Top-level CLI
 // ---------------------------------------------------------------------------
@@ -60,6 +68,11 @@ pub enum Commands {
         limit: usize,
         #[arg(long)]
         agent: Option<String>,
+    },
+    #[command(about = "Read stable runtime event envelopes")]
+    Events {
+        #[command(subcommand)]
+        command: EventsCommands,
     },
     Task {
         #[command(subcommand)]
@@ -404,6 +417,74 @@ pub enum TaskCommands {
     },
     Stop {
         task_id: String,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum EventPageOrderCli {
+    Asc,
+    Desc,
+}
+
+impl std::fmt::Display for EventPageOrderCli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Asc => f.write_str("asc"),
+            Self::Desc => f.write_str("desc"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum EventProjectionCli {
+    Operator,
+    LocalDebug,
+}
+
+impl std::fmt::Display for EventProjectionCli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Operator => f.write_str("operator"),
+            Self::LocalDebug => f.write_str("local_debug"),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EventsCommands {
+    #[command(
+        about = "Fetch a bounded page of stable event envelopes",
+        long_about = "Fetch a bounded page of stable runtime event envelopes.\n\nThe stable fields are the event envelope fields emitted by the API, including sequence, identity, timestamps, origin/trust/priority metadata, and user-facing brief/data payloads. `holon tail` and `holon transcript` remain summary views over recent operator-facing history. Use `--projection local-debug` only for diagnostic/internal payloads; those fields are not a compatibility contract."
+    )]
+    Tail {
+        #[arg(long)]
+        before_seq: Option<u64>,
+        #[arg(long)]
+        after_seq: Option<u64>,
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        #[arg(long, value_enum, default_value_t = EventPageOrderCli::Desc)]
+        order: EventPageOrderCli,
+        #[arg(long, value_enum, default_value_t = EventProjectionCli::Operator)]
+        projection: EventProjectionCli,
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    #[command(
+        about = "Stream stable event envelopes as newline-delimited JSON",
+        long_about = "Stream stable runtime event envelopes as newline-delimited JSON.\n\nThe stable fields are the event envelope fields emitted by the API, including sequence, identity, timestamps, origin/trust/priority metadata, and user-facing brief/data payloads. `holon tail` and `holon transcript` remain summary views over recent operator-facing history. Use `--projection local-debug` only for diagnostic/internal payloads; those fields are not a compatibility contract."
+    )]
+    Stream {
+        #[arg(long)]
+        after_seq: Option<u64>,
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long, value_enum, default_value_t = EventProjectionCli::Operator)]
+        projection: EventProjectionCli,
+        #[arg(long, value_parser = parse_positive_usize)]
+        max_events: Option<usize>,
         #[arg(long)]
         agent: Option<String>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,8 @@ use tracing_subscriber::EnvFilter;
 use holon::cli::{
     AgentCommands, AgentModelCommands, Cli, Commands, ConfigCommands, ConfigCredentialCommands,
     ConfigModelCommands, ConfigProviderCommands, ControlCommandAction, DaemonCommands,
-    DebugCommands, ServeAccess, ServeOptions, SkillsCommands, TaskCommands, WorkItemCommands,
-    WorkspaceCommands,
+    DebugCommands, EventsCommands, ServeAccess, ServeOptions, SkillsCommands, TaskCommands,
+    WorkItemCommands, WorkspaceCommands,
 };
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -168,6 +168,7 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
                 client.agent_transcript(&agent, limit).await?,
             )?)
         }
+        Commands::Events { command } => handle_events_command(&config, command).await,
         Commands::Task { command } => handle_task_command(&config, command).await,
         Commands::WorkItem { command } => handle_work_item_command(&config, command).await,
         Commands::Timer {
@@ -1319,6 +1320,64 @@ mod tests {
             turn.provider_rounds[0].model_ref.as_deref(),
             Some("anthropic/claude-sonnet-4-6")
         );
+    }
+}
+
+async fn handle_events_command(config: &AppConfig, command: EventsCommands) -> Result<()> {
+    match command {
+        EventsCommands::Tail {
+            before_seq,
+            after_seq,
+            limit,
+            order,
+            projection,
+            agent,
+        } => {
+            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let client = LocalClient::new(config.clone())?;
+            let page = client
+                .agent_events_page(
+                    &agent,
+                    holon::client::EventPageRequest {
+                        before_seq,
+                        after_seq,
+                        limit: Some(limit),
+                        order: Some(order.to_string()),
+                        projection: Some(projection.to_string()),
+                    },
+                )
+                .await?;
+            print_json(&serde_json::to_value(page)?)
+        }
+        EventsCommands::Stream {
+            after_seq,
+            limit,
+            projection,
+            max_events,
+            agent,
+        } => {
+            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
+            let client = LocalClient::new(config.clone())?;
+            let mut stream = client
+                .stream_agent_events(
+                    &agent,
+                    holon::client::EventStreamRequest {
+                        after_seq,
+                        limit,
+                        projection: Some(projection.to_string()),
+                    },
+                )
+                .await?;
+            let mut seen = 0usize;
+            loop {
+                let event = stream.next_event().await?;
+                println!("{}", serde_json::to_string(&event.data)?);
+                seen += 1;
+                if max_events.is_some_and(|max| seen >= max) {
+                    return Ok(());
+                }
+            }
+        }
     }
 }
 

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -657,6 +657,112 @@
     "aliases": []
   },
   {
+    "path": "events",
+    "positionals": [],
+    "flags": [],
+    "aliases": []
+  },
+  {
+    "path": "events.stream",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "after-seq",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "limit",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "max-events",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "projection",
+        "short": null,
+        "default_value": "operator",
+        "possible_values": [
+          "operator",
+          "local-debug"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
+    "path": "events.tail",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "after-seq",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "agent",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "before-seq",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "limit",
+        "short": null,
+        "default_value": "20",
+        "possible_values": null,
+        "required": false
+      },
+      {
+        "long": "order",
+        "short": null,
+        "default_value": "desc",
+        "possible_values": [
+          "asc",
+          "desc"
+        ],
+        "required": false
+      },
+      {
+        "long": "projection",
+        "short": null,
+        "default_value": "operator",
+        "possible_values": [
+          "operator",
+          "local-debug"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "prompt",
     "positionals": [
       {


### PR DESCRIPTION
## Summary
- add explicit `holon events tail` and `holon events stream` commands for stable runtime event envelopes
- keep `holon tail` and `holon transcript` as summary/history views, while documenting `local-debug` projection as diagnostic-only
- refresh the CLI command tree snapshot for the stabilized event namespace

Closes #1394

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test cli_snapshot`
- `cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
