### PR TITLE
fix: surface codex auth fallback failures

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -91,6 +91,8 @@ Current phase-1 retry contract:
 - retry exhaustion is visible in the final aggregated provider failure
 - retry, fail-fast, and fallback decisions are also preserved in a stable
   provider-attempt timeline on transcript and audit surfaces
+- when fallback is deferred to the next turn, Holon emits an operator-visible
+  provider lineage event with the failure summary and queued fallback model
 - `provider_doctor` exposes the current retry policy alongside provider
   availability
 
@@ -116,6 +118,8 @@ Fallback rules:
 - exhausting retries on provider A must still allow fallback to provider B
 - fail-fast errors on provider A may also continue to provider B; only the
   current provider candidate is aborted
+- provider B is not invoked inside the failed turn; `deferred_to_fallback` or
+  `provider_failed_needs_recovery` records the failure and queues the next turn
 - if a provider request still returns `context_length_exceeded`, Holon treats
   that as a turn-level terminal failure, surfaces an operator-visible failure
   brief, and does not auto-reactivate the active work item through
@@ -191,6 +195,10 @@ Phase-1 visibility rules:
 - transport-backed failures may attach structured `transport_diagnostics` per
   attempt so runtime artifacts can distinguish timeout vs connect vs body/read
   failures without expanding operator-facing summaries
+- TUI and other operator surfaces should render `deferred_to_fallback` and
+  `provider_failed_needs_recovery` as turn-result messages; the matching
+  `turn_terminal` record remains state/trace metadata to avoid duplicate
+  operator messages
 - the timeline is attached to:
   - `provider_round_completed`
   - `terminal_delivery_round_completed`

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -139,7 +139,10 @@ impl OperatorEventPresentation {
     pub fn is_error_loggable(&self) -> bool {
         matches!(
             self.source_event_kind.as_str(),
-            "runtime_error" | "turn_terminal"
+            "runtime_error"
+                | "turn_terminal"
+                | "deferred_to_fallback"
+                | "provider_failed_needs_recovery"
         )
     }
 }
@@ -192,6 +195,8 @@ pub fn is_activity_reset_event_kind(kind: &str) -> bool {
             | "brief_created"
             | "turn_terminal"
             | "runtime_error"
+            | "deferred_to_fallback"
+            | "provider_failed_needs_recovery"
     )
 }
 
@@ -291,7 +296,10 @@ fn event_category(kind: &str) -> OperatorEventCategory {
         | "operator_delivery_completed"
         | "operator_notification_mirror_failed"
         | "operator_transport_binding_upserted" => OperatorEventCategory::Delivery,
-        "runtime_error" | "turn_terminal" => OperatorEventCategory::Runtime,
+        "runtime_error"
+        | "turn_terminal"
+        | "deferred_to_fallback"
+        | "provider_failed_needs_recovery" => OperatorEventCategory::Runtime,
         "assistant_round_recorded" | "provider_round_completed" | "text_only_round_observed" => {
             OperatorEventCategory::AssistantProgress
         }
@@ -315,7 +323,13 @@ fn event_visibility(
         ("work_item_written", _) if work_item_completed(payload) => OperatorVisibility::WorkDone,
         ("work_item_written", _) => OperatorVisibility::Trace,
         ("runtime_error", _) => OperatorVisibility::TurnResult,
+        ("deferred_to_fallback" | "provider_failed_needs_recovery", _) => {
+            OperatorVisibility::TurnResult
+        }
         ("turn_terminal", _) if turn_terminal_completed(payload) => OperatorVisibility::Trace,
+        ("turn_terminal", _) if turn_terminal_provider_lineage(payload) => {
+            OperatorVisibility::Trace
+        }
         (_, OperatorEventCategory::AssistantProgress) => OperatorVisibility::Progress,
         (_, OperatorEventCategory::Tool)
         | (_, OperatorEventCategory::Task)
@@ -365,6 +379,18 @@ fn turn_terminal_completed(payload: &Value) -> bool {
         .get("kind")
         .and_then(Value::as_str)
         .is_some_and(|kind| kind == "completed")
+}
+
+fn turn_terminal_provider_lineage(payload: &Value) -> bool {
+    payload
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| {
+            matches!(
+                kind,
+                "deferred_to_fallback" | "provider_failed_needs_recovery"
+            )
+        })
 }
 
 fn event_text(
@@ -536,6 +562,9 @@ fn event_text(
             simple_event_text("Context length exceeded", context_body(payload))
         }
         "runtime_error" => runtime_error_text(payload),
+        "deferred_to_fallback" | "provider_failed_needs_recovery" => {
+            provider_lineage_failure_text(kind, payload)
+        }
         "turn_terminal" => turn_terminal_text(payload),
         "assistant_round_recorded" => assistant_round_recorded_text(payload),
         "provider_round_completed" => provider_round_text(payload),
@@ -1403,6 +1432,31 @@ fn turn_terminal_text(payload: &Value) -> (String, Option<String>, String) {
     (title.into(), body, summary)
 }
 
+fn provider_lineage_failure_text(kind: &str, payload: &Value) -> (String, Option<String>, String) {
+    let title = match kind {
+        "provider_failed_needs_recovery" => "Provider failed; recovery queued",
+        _ => "Provider failed; fallback queued",
+    };
+    let body = payload
+        .get("operator_message")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("error").and_then(Value::as_str))
+        .map(collapse_whitespace)
+        .filter(|message| !message.is_empty())
+        .map(|message| trim_summary(&message))
+        .or_else(|| {
+            payload
+                .get("fallback_model_ref")
+                .and_then(Value::as_str)
+                .map(|fallback| format!("Queued fallback turn on {fallback}."))
+        });
+    let summary = body
+        .as_deref()
+        .map(|body| format!("{title}: {body}"))
+        .unwrap_or_else(|| title.to_string());
+    (title.into(), body, summary)
+}
+
 fn runtime_error_text(payload: &Value) -> (String, Option<String>, String) {
     let body = error_or_message_body(payload);
     simple_event_text("Runtime error", body)
@@ -1962,6 +2016,36 @@ mod tests {
         );
         assert_eq!(aborted.visibility, OperatorVisibility::TurnResult);
         assert_eq!(aborted.summary, "Turn aborted: need more input");
+    }
+
+    #[test]
+    fn provider_lineage_failure_events_are_turn_results() {
+        let context = OperatorPresentationContext::default();
+        let deferred = present_operator_event(
+            "deferred_to_fallback",
+            &json!({
+                "operator_message": "OpenAI Codex authentication failed. Queued fallback turn on anthropic/claude-sonnet-4-6.",
+                "fallback_model_ref": "anthropic/claude-sonnet-4-6"
+            }),
+            "fallback",
+            &context,
+        );
+        assert_eq!(deferred.visibility, OperatorVisibility::TurnResult);
+        assert_eq!(deferred.category, OperatorEventCategory::Runtime);
+        assert!(deferred
+            .summary
+            .contains("Provider failed; fallback queued"));
+        assert!(deferred
+            .summary
+            .contains("OpenAI Codex authentication failed"));
+
+        let terminal = present_operator_event(
+            "turn_terminal",
+            &json!({ "kind": "deferred_to_fallback", "last_assistant_message": "fallback queued" }),
+            "turn terminal",
+            &context,
+        );
+        assert_eq!(terminal.visibility, OperatorVisibility::Trace);
     }
 
     #[test]

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -272,10 +272,23 @@ pub(crate) fn classify_status_error_with_trace(
             status: Some(status.as_u16()),
             reqwest: None,
             http_trace: trace.and_then(|trace| trace.diagnostics(Some(status.as_u16()))),
-            source_chain: Vec::new(),
+            source_chain: status_error_source_chain(provider, status),
         }),
         format!("{context} with status {status}: {body}"),
     )
+}
+
+fn status_error_source_chain(provider: Option<&str>, status: StatusCode) -> Vec<String> {
+    if provider == Some("openai-codex")
+        && matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
+    {
+        return vec![
+            "OpenAI Codex uses Codex CLI authentication.".into(),
+            "The Codex CLI access token may be expired or revoked.".into(),
+            "Run `codex login`, then retry.".into(),
+        ];
+    }
+    Vec::new()
 }
 
 pub(crate) fn invalid_response_error(

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -15,6 +15,7 @@ use crate::provider::retry::{
     classify_provider_error, ProviderFailureKind, RetryDisposition, PROVIDER_MAX_RETRIES,
 };
 use axum::{extract::State, http::header, response::IntoResponse, routing::post, Json, Router};
+use chrono::Utc;
 use serde_json::{json, Value};
 
 #[test]
@@ -113,6 +114,99 @@ fn build_provider_from_config_uses_effective_fallback_order() {
     );
     assert_eq!(providers[2]["model"], "anthropic/claude-sonnet-4-6");
     assert_eq!(providers[2]["availability"]["available"], Value::Bool(true));
+}
+
+#[tokio::test]
+async fn openai_codex_expired_cli_token_fails_fast_with_login_hint() {
+    let fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    let codex_home = fixture
+        .config
+        .providers
+        .get(&ProviderId::openai_codex())
+        .and_then(|provider| provider.codex_home.as_ref())
+        .expect("codex home");
+    write_codex_auth_with_exp(codex_home, Utc::now().timestamp() - 60);
+
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+    let error = provider
+        .complete_turn(provider_turn_request())
+        .await
+        .expect_err("expired Codex CLI token should fail before send");
+
+    assert!(error
+        .to_string()
+        .contains("Codex CLI access token is expired"));
+    assert!(error.to_string().contains("codex login"));
+    let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
+    assert_eq!(timeline.attempts.len(), 1);
+    assert_eq!(
+        timeline.attempts[0].failure_kind.as_deref(),
+        Some("auth_error")
+    );
+    assert_eq!(
+        timeline.attempts[0].outcome,
+        ProviderAttemptOutcome::FailFastAborted
+    );
+    let transport = timeline.attempts[0]
+        .transport_diagnostics
+        .as_ref()
+        .expect("expired credential should carry diagnostics");
+    assert_eq!(transport.provider.as_deref(), Some("openai-codex"));
+    assert_eq!(transport.stage, "credential_expired");
+    assert!(transport
+        .source_chain
+        .iter()
+        .any(|line| line.contains("codex login")));
+}
+
+#[tokio::test]
+async fn openai_codex_unauthorized_status_includes_login_hint_and_diagnostics() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let server_attempts = attempts.clone();
+    let router = Router::new().route(
+        "/codex/responses",
+        post(move || async move {
+            server_attempts.fetch_add(1, Ordering::SeqCst);
+            (axum::http::StatusCode::UNAUTHORIZED, "token_expired")
+        }),
+    );
+    let server = spawn_test_server(router).await;
+
+    let mut fixture = test_config("openai-codex/gpt-5.4", &[], None, None, true);
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::openai_codex())
+        .unwrap()
+        .base_url = server;
+    let provider = build_provider_from_config(&fixture.config).unwrap();
+    let error = provider
+        .complete_turn(provider_turn_request())
+        .await
+        .expect_err("401 should fail fast");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert!(error.to_string().contains("Codex CLI token may be expired"));
+    assert!(error.to_string().contains("codex login"));
+    let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
+    assert_eq!(
+        timeline.attempts[0].failure_kind.as_deref(),
+        Some("auth_error")
+    );
+    assert_eq!(
+        timeline.attempts[0].outcome,
+        ProviderAttemptOutcome::FailFastAborted
+    );
+    let transport = timeline.attempts[0]
+        .transport_diagnostics
+        .as_ref()
+        .expect("401 should preserve transport diagnostics");
+    assert_eq!(transport.provider.as_deref(), Some("openai-codex"));
+    assert_eq!(transport.status, Some(401));
+    assert!(transport
+        .source_chain
+        .iter()
+        .any(|line| line.contains("codex login")));
 }
 
 #[test]

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -228,11 +228,15 @@ fn fake_jwt(payload: serde_json::Value) -> String {
     )
 }
 
-fn write_codex_auth(codex_home: &std::path::Path) {
+pub fn write_codex_auth(codex_home: &std::path::Path) {
+    write_codex_auth_with_exp(codex_home, 4_102_444_800i64);
+}
+
+pub fn write_codex_auth_with_exp(codex_home: &std::path::Path, exp: i64) {
     std::fs::create_dir_all(codex_home).unwrap();
     let token = fake_jwt(json!({
         "account_id": "acct_test",
-        "exp": 4_102_444_800i64
+        "exp": exp
     }));
     std::fs::write(
         codex_home.join("auth.json"),

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use chrono::Utc;
 use reqwest::{Client, RequestBuilder, Response};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -26,7 +27,8 @@ use crate::{
         ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
         ProviderNativeWebSearchRequest, ProviderOpenAiRemoteCompactionDiagnostics,
         ProviderOpenAiRequestControlsDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
-        ProviderTurnRequest, ProviderTurnResponse, ToolSchemaContract,
+        ProviderTransportDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
+        ToolSchemaContract,
     },
     token_estimate::estimate_json_tokens,
 };
@@ -600,7 +602,36 @@ impl AgentProvider for OpenAiProvider {
 #[async_trait]
 impl AgentProvider for OpenAiCodexProvider {
     async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
-        let credential = load_codex_cli_credential(&self.codex_home)?;
+        let model_ref = format!("{}/{}", self.provider_id, self.model);
+        let credential = load_codex_cli_credential(&self.codex_home).map_err(|error| {
+            openai_codex_auth_error(
+                "credential_resolution",
+                &model_ref,
+                vec![
+                    error.to_string(),
+                    "OpenAI Codex uses Codex CLI authentication; run `codex login`, then retry."
+                        .into(),
+                ],
+                "OpenAI Codex authentication failed: Codex CLI credentials are unavailable. Run `codex login`, then retry.",
+            )
+        })?;
+        if let Some(expires_at) = credential.expires_at {
+            if expires_at <= Utc::now() + chrono::Duration::seconds(60) {
+                return Err(openai_codex_auth_error(
+                    "credential_expired",
+                    &model_ref,
+                    vec![
+                        format!(
+                            "Codex CLI credential from {} expired at {}",
+                            credential.source,
+                            expires_at.to_rfc3339()
+                        ),
+                        "Run `codex login`, then retry.".into(),
+                    ],
+                    "OpenAI Codex authentication failed: the Codex CLI access token is expired. Run `codex login`, then retry.",
+                ));
+            }
+        }
         let body = build_openai_responses_request(
             &self.model,
             self.max_output_tokens,
@@ -3772,7 +3803,7 @@ async fn send_openai_responses_streaming_request(
         let body = response.text().await.unwrap_or_default();
         trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error_with_trace(
-            "OpenAI-style streaming request failed",
+            openai_codex_status_error_context(status),
             "response_status",
             Some("openai-codex"),
             Some(&model_ref),
@@ -3786,6 +3817,43 @@ async fn send_openai_responses_streaming_request(
     let terminal_response =
         read_openai_streaming_response(response, request_trace.as_ref()).await?;
     parse_openai_response_with_transport_state(terminal_response)
+}
+
+fn openai_codex_auth_error(
+    stage: &str,
+    model_ref: &str,
+    source_chain: Vec<String>,
+    message: &str,
+) -> anyhow::Error {
+    provider_transport_error(
+        ProviderFailureClassification {
+            kind: ProviderFailureKind::AuthError,
+            disposition: RetryDisposition::FailFast,
+        },
+        None,
+        Some(ProviderTransportDiagnostics {
+            stage: stage.into(),
+            provider: Some("openai-codex".into()),
+            model_ref: Some(model_ref.into()),
+            url: None,
+            status: None,
+            reqwest: None,
+            http_trace: None,
+            source_chain,
+        }),
+        message,
+    )
+}
+
+fn openai_codex_status_error_context(status: reqwest::StatusCode) -> &'static str {
+    if matches!(
+        status,
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+    ) {
+        "OpenAI Codex authentication failed; the Codex CLI token may be expired. Run `codex login`, then retry."
+    } else {
+        "OpenAI-style streaming request failed"
+    }
 }
 
 async fn send_openai_request(

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -979,9 +979,20 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
     assert!(events
         .iter()
         .any(|event| event.kind == "lineage_retry_exhausted"));
-    assert!(events
+    let deferred = events
         .iter()
-        .any(|event| event.kind == "deferred_to_fallback"));
+        .find(|event| event.kind == "deferred_to_fallback")
+        .expect("deferred_to_fallback event");
+    assert_eq!(
+        deferred.data["fallback_model_ref"].as_str(),
+        Some("anthropic/claude-sonnet-4-6")
+    );
+    assert!(deferred.data["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("all configured providers failed")));
+    assert!(deferred.data["operator_message"]
+        .as_str()
+        .is_some_and(|message| message.contains("Queued fallback turn")));
     assert!(events
         .iter()
         .any(|event| event.kind == "recovery_turn_started"));
@@ -1034,9 +1045,13 @@ async fn provider_failure_after_accepted_output_queues_recovery_turn() {
     );
 
     let events = runtime.storage().read_recent_events(30).unwrap();
-    assert!(events
+    let recovery = events
         .iter()
-        .any(|event| event.kind == "provider_failed_needs_recovery"));
+        .find(|event| event.kind == "provider_failed_needs_recovery")
+        .expect("provider_failed_needs_recovery event");
+    assert!(recovery.data["operator_message"]
+        .as_str()
+        .is_some_and(|message| message.contains("Queued recovery turn")));
     let exhausted = events
         .iter()
         .find(|event| event.kind == "lineage_retry_exhausted")

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1433,11 +1433,20 @@ impl RuntimeHandle {
             guard.state.pending_fallback_model = Some(fallback_model.clone());
             self.inner.storage.write_agent(&guard.state)?;
         }
+        let error_text = error.to_string();
+        let provider_failure_text = provider_lineage_failure_text(error);
+        let operator_message = provider_lineage_operator_message(
+            fallback_ref,
+            side_effect_boundary_crossed,
+            &provider_failure_text,
+        );
         self.inner.storage.append_event(&AuditEvent::new(
             "lineage_retry_exhausted",
             serde_json::json!({
                 "agent_id": agent_id,
                 "round": round,
+                "error": error_text.clone(),
+                "operator_message": operator_message.clone(),
                 "requested_model_ref": timeline.requested_model_ref,
                 "active_model_ref": timeline.active_model_ref,
                 "pending_fallback_model_ref": fallback_ref,
@@ -1445,15 +1454,7 @@ impl RuntimeHandle {
                 "provider_attempt_timeline": timeline,
             }),
         ))?;
-        let final_text = if side_effect_boundary_crossed {
-            format!(
-                "Turn stopped after the active provider lineage failed; queued a recovery turn on {fallback_ref}."
-            )
-        } else {
-            format!(
-                "Turn stopped before provider output was accepted; queued fallback turn on {fallback_ref}."
-            )
-        };
+        let final_text = operator_message.clone();
         self.persist_turn_terminal_record(
             terminal_kind,
             last_assistant_message
@@ -1473,6 +1474,8 @@ impl RuntimeHandle {
             serde_json::json!({
                 "agent_id": agent_id,
                 "round": round,
+                "error": error_text,
+                "operator_message": operator_message,
                 "fallback_model_ref": fallback_ref,
                 "side_effect_boundary_crossed": side_effect_boundary_crossed,
                 "last_assistant_preview": last_assistant_message
@@ -1730,6 +1733,33 @@ impl RuntimeHandle {
         .run()
         .await
     }
+}
+
+fn provider_lineage_failure_text(error: &anyhow::Error) -> String {
+    let text = error.to_string();
+    if text.trim().is_empty() {
+        "provider failed".into()
+    } else {
+        truncate_preview(&text, ROUND_TEXT_PREVIEW_LIMIT)
+    }
+}
+
+fn provider_lineage_operator_message(
+    fallback_ref: &str,
+    side_effect_boundary_crossed: bool,
+    failure: &str,
+) -> String {
+    let prefix = if side_effect_boundary_crossed {
+        "Turn stopped after the active provider lineage failed"
+    } else {
+        "Turn stopped before provider output was accepted"
+    };
+    let queued = if side_effect_boundary_crossed {
+        "Queued recovery turn"
+    } else {
+        "Queued fallback turn"
+    };
+    format!("{prefix}: {failure} {queued} on {fallback_ref}.")
 }
 
 struct TurnExecution<'a> {

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -503,7 +503,9 @@ impl TuiProjection {
             "assistant_round_recorded"
             | "text_only_round_observed"
             | "max_output_tokens_recovery"
-            | "runtime_error" => {
+            | "runtime_error"
+            | "deferred_to_fallback"
+            | "provider_failed_needs_recovery" => {
                 // These events already carry enough payload for the active
                 // Conversation preview and event overlays. Avoid forcing a
                 // full /state refresh during normal turn progress.
@@ -2150,6 +2152,20 @@ mod tests {
                 }),
             ),
             (
+                "deferred_to_fallback",
+                json!({
+                    "operator_message": "OpenAI Codex authentication failed. Queued fallback turn on anthropic/claude-sonnet-4-6.",
+                    "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+                }),
+            ),
+            (
+                "provider_failed_needs_recovery",
+                json!({
+                    "operator_message": "Provider failed after output. Queued recovery turn on anthropic/claude-sonnet-4-6.",
+                    "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+                }),
+            ),
+            (
                 "message_admitted",
                 json!({
                     "message_id": "message-1",
@@ -2169,6 +2185,30 @@ mod tests {
         }
 
         assert!(projection.stale_slices.is_empty());
+    }
+
+    #[test]
+    fn provider_lineage_failure_events_are_visible_in_info_conversation() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+
+        projection.apply_event(
+            sample_event(
+                "deferred_to_fallback",
+                json!({
+                    "operator_message": "OpenAI Codex authentication failed. Queued fallback turn on anthropic/claude-sonnet-4-6.",
+                    "fallback_model_ref": "anthropic/claude-sonnet-4-6",
+                }),
+            ),
+            &test_log_writer(),
+        );
+
+        let events = projection.presentation_events(OperatorDisplayMode::Info);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "deferred_to_fallback");
+        assert_eq!(events[0].lane, ProjectionEventLane::Timeline);
+        assert!(events[0]
+            .summary
+            .contains("OpenAI Codex authentication failed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- classify missing, expired, and unauthorized `openai-codex` Codex CLI credentials as explicit provider auth failures with `codex login` guidance
- surface deferred provider fallback/recovery events as operator-visible runtime messages so TUI info mode shows the failure before the next fallback turn
- document that provider B is queued for the next turn and that lineage failure events carry the operator-facing message

Fixes the short-term visibility part of #1426. This does not implement the Holon-managed OAuth profile tracked in #1428.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test openai_codex_ --quiet`
- `cargo test provider_lineage_failure_events --quiet`
- `cargo test provider_failure_ --quiet`
