### PR TITLE
fix: align scheduler wait contract

### DIFF
--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -184,12 +184,16 @@ The scheduler does not understand what the external source means. It only knows:
 ### WaitingTimer
 
 A WorkItem is waiting for a timer when progress is intentionally delayed until
-a runtime-owned timer fires, such as a blocked-work recheck fallback.
+a runtime-owned timer fires.
+
+Blocked WorkItem `recheck_at` deadlines are not part of `WaitingTimer`; they
+remain `Blocked` and only create a fallback reminder for the owning agent to
+inspect the blocker.
 
 ### WaitingSystem
 
 A WorkItem is waiting for a runtime-owned system tick when progress should
-continue through scheduler-generated maintenance or recovery instead of
+continue by emitting scheduler-generated maintenance or recovery instead of
 operator input, task completion, a wall-clock timer, or an external callback.
 
 ### Blocked
@@ -545,8 +549,8 @@ Replace ad hoc runnable-work checks with state-derived closure behavior:
 - `WaitingTask` -> sleep until task result;
 - `WaitingOperator` -> wait for operator input;
 - `WaitingExternal` -> wait for wake source and surface recoverability;
-- `WaitingTimer` -> wait until the timer or recheck fallback fires;
-- `WaitingSystem` -> emit or await a runtime-owned system tick;
+- `WaitingTimer` -> wait until the runtime timer fires;
+- `WaitingSystem` -> emit a runtime-owned system tick;
 - `Blocked` -> expose blocker and do not auto-continue;
 - `Completed` -> ignore for scheduling.
 

--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -119,6 +119,8 @@ WorkItemSchedulingState =
   WaitingOperator
   WaitingTask
   WaitingExternal
+  WaitingTimer
+  WaitingSystem
   Blocked
   Completed
 ```
@@ -178,6 +180,17 @@ The scheduler does not understand what the external source means. It only knows:
 - one or more wake sources may reactivate the agent;
 - a continuation should run when a wake source fires;
 - the wait may be auditable as weak if it lacks a durable recovery path.
+
+### WaitingTimer
+
+A WorkItem is waiting for a timer when progress is intentionally delayed until
+a runtime-owned timer fires, such as a blocked-work recheck fallback.
+
+### WaitingSystem
+
+A WorkItem is waiting for a runtime-owned system tick when progress should
+continue through scheduler-generated maintenance or recovery instead of
+operator input, task completion, a wall-clock timer, or an external callback.
 
 ### Blocked
 
@@ -380,6 +393,18 @@ Complete
 Idle
 ```
 
+These posture labels are the coarse turn-end contract. The implementation may
+use a more granular `SchedulerDecisionKind` to express the concrete action that
+realizes the posture:
+
+- `ContinueNow` -> `StartModelTurn`, `ReduceMessageOnly`, or `EmitSystemTick`;
+- `Wait` -> `WaitForTask`, `WaitForExternalChange`, or `WaitForTimer`;
+- `NeedOperator` -> `WaitForOperator`;
+- `Blocked` -> a liveness-only wait or sleep decision with blocker evidence;
+- `Complete` -> no scheduling for completed WorkItems;
+- `Idle` -> `Sleep`, `StayIdle`, `Stop`, or `Noop` depending on lifecycle and
+  duplicate-suppression facts.
+
 The preferred durable forms are:
 
 - runnable WorkItem exists -> `ContinueNow`;
@@ -520,6 +545,8 @@ Replace ad hoc runnable-work checks with state-derived closure behavior:
 - `WaitingTask` -> sleep until task result;
 - `WaitingOperator` -> wait for operator input;
 - `WaitingExternal` -> wait for wake source and surface recoverability;
+- `WaitingTimer` -> wait until the timer or recheck fallback fires;
+- `WaitingSystem` -> emit or await a runtime-owned system tick;
 - `Blocked` -> expose blocker and do not auto-continue;
 - `Completed` -> ignore for scheduling.
 

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -189,10 +189,9 @@ Agent lifecycle control is `Start` / `Stop`:
   `AgentSchedulingPosture` is not yet a stable contract.
 - `AgentSummary` includes some fields (`recent_operator_notifications`,
   `recent_brief_count`) whose contract is not yet hardened.
-- `WorkItemSchedulingState` has `WaitingTimer` and `WaitingSystem` variants
-  not listed in the RFC. See [issue #1378](https://github.com/holon-run/holon/issues/1378).
-- `AgentStatus::Asleep` is used directly in scheduler decisions
-  (`scheduler.rs:803,903`) instead of being derived via `AgentSchedulingPosture`.
+- `AgentStatus::Asleep` remains a lifecycle/display projection, but scheduler
+  idle-boundary decisions inspect wait and work facts before treating an
+  already-asleep agent as idle.
 - `AgentStatus::AwaitingTask` exists in code but is not in the RFC's target
   status set (`agent-lifecycle-control-posture.md`).
 - `AgentLifecycleHint` retains `resume_*` fields from the deprecated Pause/Resume

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -118,8 +118,8 @@ WorkItems flow through scheduling states that the scheduler consumes:
 | `Blocked` | `blocked_by` set | Not runnable; check `recheck_at` |
 | `WaitingTask` | Wait condition on task result | Wake on task terminal |
 | `WaitingExternal` | Wait condition on external event | Wake on external trigger |
-| `WaitingTimer` | Runtime timer wait | Wake when timer or recheck fires |
-| `WaitingSystem` | Runtime system-tick wait | Emit or await system tick |
+| `WaitingTimer` | Runtime timer wait | Wake when timer fires |
+| `WaitingSystem` | Runtime system-tick wait | Emit system tick |
 | `Completed` | `state=Completed` | Excluded from runnable set |
 
 ## Wake/sleep boundary

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -118,6 +118,8 @@ WorkItems flow through scheduling states that the scheduler consumes:
 | `Blocked` | `blocked_by` set | Not runnable; check `recheck_at` |
 | `WaitingTask` | Wait condition on task result | Wake on task terminal |
 | `WaitingExternal` | Wait condition on external event | Wake on external trigger |
+| `WaitingTimer` | Runtime timer wait | Wake when timer or recheck fires |
+| `WaitingSystem` | Runtime system-tick wait | Emit or await system tick |
 | `Completed` | `state=Completed` | Excluded from runnable set |
 
 ## Wake/sleep boundary
@@ -136,20 +138,9 @@ WorkItems flow through scheduling states that the scheduler consumes:
 
 ## Known gaps
 
-- `WaitingTimer` and `WaitingSystem` variants exist in both
-  `WorkItemSchedulingState` and scheduler decisions (`wait_decision_for_projection`)
-  without RFC coverage. The RFC defines `WaitingOperator, WaitingTask,
-  WaitingExternal, Blocked` but not these timer/system variants. See
-  [issue #1380](https://github.com/holon-run/holon/issues/1380).
-- `idle_boundary_decision` (`scheduler.rs:903`) gates on
-  `AgentStatus::Asleep` before inspecting work facts, which can strand
-  runnable work behind an `Asleep` status check. The RFC says scheduling
-  should derive from WorkItem/wait facts, not lifecycle status labels. See
-  [issue #1380](https://github.com/holon-run/holon/issues/1380).
-- `SchedulerDecisionKind` has 11 variants (`StartModelTurn, ReduceMessageOnly,
-  EmitSystemTick, WaitForTask, …`) while the RFC suggests ~6 high-level
-  posture outcomes. The added granularity is useful but the RFC vocabulary is
-  too coarse to describe current behavior. See
-  [issue #1380](https://github.com/holon-run/holon/issues/1380).
+- `SchedulerDecisionKind` intentionally has more variants than the coarse
+  RFC posture labels. The RFC posture is the stable turn-end vocabulary;
+  decision variants are concrete runtime actions and duplicate-suppression
+  outcomes.
 - The scheduler does not yet expose a public diagnostic event stream for
   observability; diagnostic events exist but are audit-only.

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -802,12 +802,12 @@ pub(crate) fn message_processing_decision(
 pub(crate) fn idle_noop_decision(projection: &SchedulerProjection) -> SchedulerDecision {
     let (kind, reason) = if matches!(projection.status, AgentStatus::Stopped) {
         (SchedulerDecisionKind::Stop, "stopped")
-    } else if matches!(projection.status, AgentStatus::Asleep) {
-        (SchedulerDecisionKind::StayIdle, "already_asleep")
     } else if projection.queue_len > 0 {
         (SchedulerDecisionKind::Noop, "queue_not_empty")
     } else if projection.turn_in_progress {
         (SchedulerDecisionKind::Noop, "turn_in_progress")
+    } else if matches!(projection.status, AgentStatus::Asleep) {
+        (SchedulerDecisionKind::StayIdle, "already_asleep")
     } else {
         (SchedulerDecisionKind::Sleep, "no_pending_scheduler_facts")
     };
@@ -898,14 +898,20 @@ pub(crate) fn idle_boundary_decision(
     projection: &SchedulerProjection,
     boundary: impl Into<String>,
 ) -> SchedulerDecision {
-    if matches!(
-        projection.status,
-        AgentStatus::Stopped | AgentStatus::Asleep
-    ) {
+    let boundary = boundary.into();
+    if matches!(projection.status, AgentStatus::Stopped) {
         return idle_noop_decision(projection).boundary(boundary);
     }
     if let Some(decision) = wait_decision_for_projection(projection) {
         return decision.boundary(boundary);
+    }
+    if let Some(signal) = projection.work_reactivation_signal() {
+        return SchedulerDecision::new(SchedulerDecisionKind::EmitSystemTick, "runnable_work")
+            .boundary(boundary)
+            .model_reentry(true)
+            .work_item_id(signal.work_item_id)
+            .evidence("runtime_idle")
+            .evidence("work_item_runnable");
     }
     idle_noop_decision(projection).boundary(boundary)
 }

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -725,6 +725,68 @@ fn idle_boundary_decision_prefers_controlled_status_over_wait_facts() {
 }
 
 #[test]
+fn idle_boundary_decision_inspects_wait_facts_while_asleep() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.status = AgentStatus::Asleep;
+    storage.write_agent(&agent).unwrap();
+    storage
+        .append_waiting_intent(&WaitingIntentRecord {
+            id: "wait-current".into(),
+            agent_id: "default".into(),
+            scope: WaitingIntentScope::Agent,
+            work_item_id: None,
+            description: "wait".into(),
+            source: "test".into(),
+            resource: None,
+            condition: None,
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            status: WaitingIntentStatus::Active,
+            external_trigger_id: "trigger-wait-current".into(),
+            created_at: Utc::now(),
+            cancelled_at: None,
+            last_triggered_at: None,
+            trigger_count: 0,
+            correlation_id: None,
+            causation_id: None,
+        })
+        .unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let decision = scheduler::idle_boundary_decision(&projection, "fixture");
+    assert_eq!(
+        decision.kind,
+        scheduler::SchedulerDecisionKind::WaitForExternalChange
+    );
+    assert_eq!(decision.reason, "active_agent_waiting_intents");
+}
+
+#[test]
+fn idle_boundary_decision_reactivates_runnable_work_while_asleep() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.status = AgentStatus::Asleep;
+    agent.current_work_item_id = Some("work-current".into());
+    storage.write_agent(&agent).unwrap();
+    let mut work_item = WorkItemRecord::new("default", "continue work", WorkItemState::Open);
+    work_item.id = "work-current".into();
+    work_item.plan_status = WorkItemPlanStatus::Ready;
+    storage.append_work_item(&work_item).unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let decision = scheduler::idle_boundary_decision(&projection, "fixture");
+    assert_eq!(
+        decision.kind,
+        scheduler::SchedulerDecisionKind::EmitSystemTick
+    );
+    assert_eq!(decision.reason, "runnable_work");
+    assert_eq!(decision.work_item_id.as_deref(), Some("work-current"));
+    assert!(decision.model_reentry);
+}
+
+#[test]
 fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new(dir.path()).unwrap();


### PR DESCRIPTION
Fixes #1380.

## Summary
- Stop treating `AgentStatus::Asleep` as an idle-boundary gate before scheduler facts are inspected.
- Reactivate runnable work from idle-boundary projection by emitting a system tick even if the agent was previously asleep.
- Preserve `Stopped` as the hard lifecycle gate.
- Update scheduler RFC/spec docs so `WaitingTimer`, `WaitingSystem`, and granular `SchedulerDecisionKind` are part of the documented contract instead of known gaps.

## Verification
- `cargo fmt --all -- --check`
- `cargo test scheduler:: --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
