### PR TITLE
fix: allow Sleep while waiting on same-WorkItem background command_task (#1416)

### DIFF
--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -5,8 +5,8 @@ use crate::runtime::closure::{derive_closure_decision, ClosureFacts};
 use crate::storage::AppStorage;
 use crate::types::{
     AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
-    ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskKind, TaskRecord, TaskStatus,
-    TokenUsage, WaitingReason, WorkItemState, WorktreeSession,
+    ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskKind, TaskRecord, TaskStatus, TokenUsage,
+    WaitingReason, WorkItemState, WorktreeSession,
 };
 
 fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBuf> {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1294,16 +1294,20 @@ impl RuntimeHandle {
         let projection = self.inner.storage.work_queue_prompt_projection()?;
         let agent = self.inner.storage.read_agent()?;
         if let Some(current) = projection.current_runnable {
-            if let Some(agent) = agent.as_ref() {
-                if Self::active_command_task_for_work_item(
-                    &self.inner.storage,
-                    &agent.id,
-                    &current.work_item.id,
-                )? {
-                    return Ok(None);
-                }
+            let suppress_continue_active = agent
+                .as_ref()
+                .map(|agent| {
+                    Self::active_command_task_for_work_item(
+                        &self.inner.storage,
+                        &agent.id,
+                        &current.work_item.id,
+                    )
+                })
+                .transpose()?
+                .unwrap_or(false);
+            if !suppress_continue_active {
+                return Ok(Some((current.work_item, "continue_active")));
             }
-            return Ok(Some((current.work_item, "continue_active")));
         }
         Ok(projection
             .queued_runnable

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -5,8 +5,8 @@ use crate::runtime::closure::{derive_closure_decision, ClosureFacts};
 use crate::storage::AppStorage;
 use crate::types::{
     AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
-    ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskRecord, TaskStatus, TokenUsage,
-    WaitingReason, WorkItemState, WorktreeSession,
+    ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskKind, TaskRecord, TaskStatus,
+    TokenUsage, WaitingReason, WorkItemState, WorktreeSession,
 };
 
 fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBuf> {
@@ -1292,7 +1292,17 @@ impl RuntimeHandle {
         &self,
     ) -> Result<Option<(crate::types::WorkItemRecord, &'static str)>> {
         let projection = self.inner.storage.work_queue_prompt_projection()?;
+        let agent = self.inner.storage.read_agent()?;
         if let Some(current) = projection.current_runnable {
+            if let Some(agent) = agent.as_ref() {
+                if Self::active_command_task_for_work_item(
+                    &self.inner.storage,
+                    &agent.id,
+                    &current.work_item.id,
+                )? {
+                    return Ok(None);
+                }
+            }
             return Ok(Some((current.work_item, "continue_active")));
         }
         Ok(projection
@@ -1300,6 +1310,20 @@ impl RuntimeHandle {
             .into_iter()
             .next()
             .map(|queued| (queued.work_item, "queued_available")))
+    }
+
+    fn active_command_task_for_work_item(
+        storage: &AppStorage,
+        agent_id: &str,
+        work_item_id: &str,
+    ) -> Result<bool> {
+        Ok(storage
+            .latest_active_task_records_for_agent(agent_id, usize::MAX)?
+            .iter()
+            .any(|task| {
+                task.kind == TaskKind::CommandTask
+                    && task.work_item_id.as_deref() == Some(work_item_id)
+            }))
     }
 
     fn spawn_session_sleep_wake(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -488,8 +488,7 @@ async fn indefinite_sleep_with_runnable_work_item_and_background_command_task_al
 }
 
 #[tokio::test]
-async fn indefinite_sleep_with_background_command_task_and_queued_runnable_emits_selection_tick(
-) {
+async fn indefinite_sleep_with_background_command_task_and_queued_runnable_emits_selection_tick() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -488,6 +488,98 @@ async fn indefinite_sleep_with_runnable_work_item_and_background_command_task_al
 }
 
 #[tokio::test]
+async fn indefinite_sleep_with_background_command_task_and_queued_runnable_emits_selection_tick(
+) {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let current_work_item_id =
+        seed_bound_work_item(&runtime, WorkItemState::Open, None, None).await;
+    let queued = runtime
+        .create_work_item("queued follow-up work".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let now = Utc::now();
+    runtime
+        .storage()
+        .append_task(&TaskRecord {
+            id: "cmd-task-wait".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: Some(current_work_item_id.clone()),
+            summary: Some("background cargo check".into()),
+            detail: Some(serde_json::json!({ "wait_policy": "background" })),
+            recovery: None,
+        })
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeRunning;
+        guard.state.current_run_id = Some("run-1".into());
+        guard.state.current_work_item_id = Some(current_work_item_id.clone());
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+
+    runtime.transition_to_sleep(None).await.unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::AwakeRunning);
+    assert_eq!(state.current_run_id.as_deref(), Some("run-1"));
+    assert_eq!(state.pending, 1);
+    assert_eq!(state.sleeping_until, None);
+    let messages = runtime.storage().read_recent_messages(10).unwrap();
+    let tick = messages
+        .iter()
+        .find(|message| {
+            matches!(
+                (&message.kind, &message.origin),
+                (MessageKind::SystemTick, MessageOrigin::System { subsystem }) if subsystem == "work_queue"
+            )
+        })
+        .expect("work queue tick should be enqueued for queued runnable work");
+    assert_eq!(tick.work_item_id.as_deref(), Some(queued.id.as_str()));
+    assert_ne!(
+        tick.work_item_id.as_deref(),
+        Some(current_work_item_id.as_str())
+    );
+    assert_eq!(
+        tick.metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("work_queue"))
+            .and_then(|metadata| metadata.get("reason"))
+            .and_then(|value| value.as_str()),
+        Some("queued_available")
+    );
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision"
+            && event.data["boundary"] == "lifecycle_sleep"
+            && event.data["reason"] == "sleep_overridden_runnable_work"
+            && event.data["evidence"].as_array().is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| item == "work_queue_reason=queued_available")
+            })
+    }));
+}
+
+#[tokio::test]
 async fn indefinite_sleep_with_queued_runnable_work_item_emits_selection_tick() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -416,6 +416,78 @@ async fn indefinite_sleep_with_current_runnable_work_item_emits_continuation_tic
 }
 
 #[tokio::test]
+async fn indefinite_sleep_with_runnable_work_item_and_background_command_task_allows_sleep() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item_id = seed_bound_work_item(&runtime, WorkItemState::Open, None, None).await;
+    let now = Utc::now();
+    runtime
+        .storage()
+        .append_task(&TaskRecord {
+            id: "cmd-task-wait".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: Some(work_item_id.clone()),
+            summary: Some("background cargo check".into()),
+            detail: Some(serde_json::json!({ "wait_policy": "background" })),
+            recovery: None,
+        })
+        .unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.status = AgentStatus::AwakeRunning;
+        guard.state.current_run_id = Some("run-1".into());
+        guard.state.current_work_item_id = Some(work_item_id.clone());
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+
+    runtime.transition_to_sleep(None).await.unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.status, AgentStatus::Asleep);
+    assert_eq!(state.current_run_id, None);
+    assert_eq!(state.sleeping_until, None);
+    let messages = runtime.storage().read_recent_messages(10).unwrap();
+    assert!(
+        !messages.iter().any(|message| {
+            matches!(
+                (&message.kind, &message.origin),
+                (MessageKind::SystemTick, MessageOrigin::System { subsystem }) if subsystem == "work_queue"
+            )
+        }),
+        "should not emit work queue tick while waiting on background command"
+    );
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision"
+            && event.data["boundary"] == "lifecycle_sleep"
+            && event.data["reason"] == "sleep"
+            && event.data["next_status"] == "asleep"
+    }));
+    assert!(!events.iter().any(|event| {
+        event.kind == "scheduler_posture_decision"
+            && event.data["reason"] == "sleep_overridden_runnable_work"
+    }));
+}
+
+#[tokio::test]
 async fn indefinite_sleep_with_queued_runnable_work_item_emits_selection_tick() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -88,6 +88,16 @@ impl AgentProvider for SleepThenRecordTaskResultProvider {
 
         match call {
             1 => Ok(ProviderTurnResponse {
+                blocks: vec![ModelBlock::Text {
+                    text: "ready for background work".into(),
+                }],
+                stop_reason: None,
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_usage: None,
+                request_diagnostics: None,
+            }),
+            2 => Ok(ProviderTurnResponse {
                 blocks: vec![ModelBlock::ToolUse {
                     id: "sleep-1".into(),
                     name: "Sleep".into(),
@@ -101,7 +111,7 @@ impl AgentProvider for SleepThenRecordTaskResultProvider {
                 cache_usage: None,
                 request_diagnostics: None,
             }),
-            2 => Ok(ProviderTurnResponse {
+            3 => Ok(ProviderTurnResponse {
                 blocks: vec![ModelBlock::Text {
                     text: "background command result observed".into(),
                 }],
@@ -179,7 +189,7 @@ pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reent
             AuthorityClass::OperatorInstruction,
             Priority::Normal,
             MessageBody::Text {
-                text: "sleep until the background command finishes".into(),
+                text: "prepare to wait for a background command".into(),
             },
         ))
         .await?;
@@ -189,10 +199,7 @@ pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reent
         let provider = provider.clone();
         async move {
             let state = runtime.agent_state().await?;
-            Ok(
-                state.status == AgentStatus::Asleep
-                    && provider.captured_requests().await.len() == 1,
-            )
+            Ok(state.current_work_item_id.is_some() && provider.captured_requests().await.len() >= 1)
         }
     })
     .await?;
@@ -215,15 +222,41 @@ pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reent
         )
         .await?;
 
+    runtime
+        .enqueue(MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "sleep until the background command finishes".into(),
+            },
+        ))
+        .await?;
+
+    wait_until_async(|| {
+        let runtime = runtime.clone();
+        let provider = provider.clone();
+        async move {
+            let state = runtime.agent_state().await?;
+            Ok(
+                state.status == AgentStatus::Asleep
+                    && provider.captured_requests().await.len() >= 2,
+            )
+        }
+    })
+    .await?;
+
     wait_until_async(|| {
         let provider = provider.clone();
-        async move { Ok(provider.captured_requests().await.len() >= 2) }
+        async move { Ok(provider.captured_requests().await.len() >= 3) }
     })
     .await?;
 
     let requests = provider.captured_requests().await;
     let reentry_prompt = requests
-        .get(1)
+        .get(2)
         .expect("background task result should trigger model reentry");
     assert!(
         reentry_prompt.contains("background_done"),
@@ -1866,11 +1899,14 @@ pub async fn background_command_task_persists_terminal_state_while_runtime_stopp
         )
         .await?;
 
-    wait_until(|| {
-        let tasks = runtime.storage().latest_task_records()?;
-        Ok(tasks.iter().any(|record| {
-            record.id == task.id && record.status == holon::types::TaskStatus::Completed
-        }))
+    wait_until_async_for(Duration::from_secs(30), || {
+        let runtime = runtime.clone();
+        async move {
+            let tasks = runtime.storage().latest_task_records()?;
+            Ok(tasks.iter().any(|record| {
+                record.id == task.id && record.status == holon::types::TaskStatus::Completed
+            }))
+        }
     })
     .await?;
 

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -199,7 +199,8 @@ pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reent
         let provider = provider.clone();
         async move {
             let state = runtime.agent_state().await?;
-            Ok(state.current_work_item_id.is_some() && provider.captured_requests().await.len() >= 1)
+            Ok(state.current_work_item_id.is_some()
+                && provider.captured_requests().await.len() >= 1)
         }
     })
     .await?;
@@ -1899,12 +1900,14 @@ pub async fn background_command_task_persists_terminal_state_while_runtime_stopp
         )
         .await?;
 
+    let task_id = task.id.clone();
     wait_until_async_for(Duration::from_secs(30), || {
         let runtime = runtime.clone();
+        let task_id = task_id.clone();
         async move {
             let tasks = runtime.storage().latest_task_records()?;
             Ok(tasks.iter().any(|record| {
-                record.id == task.id && record.status == holon::types::TaskStatus::Completed
+                record.id == task_id && record.status == holon::types::TaskStatus::Completed
             }))
         }
     })


### PR DESCRIPTION
## Summary

Fixes #1416 (short-term runtime fix from the issue).

When the agent calls `Sleep` with no duration while the current WorkItem is still runnable, but an active **background `command_task`** is bound to that same WorkItem, the scheduler now **allows sleep** instead of emitting `sleep_overridden_runnable_work` and immediately re-ticking the model in a loop.

The agent stays asleep until the task result wakes it (existing behavior).

## Approach

In `indefinite_sleep_runnable_work`, before treating the current runnable WorkItem as grounds to override indefinite sleep, check for an active `command_task` with matching `work_item_id`. If present, return `None` so the normal sleep transition proceeds.

## Test plan

- [x] `indefinite_sleep_with_runnable_work_item_and_background_command_task_allows_sleep` — asserts `Asleep`, no work-queue tick, no `sleep_overridden_runnable_work` event
- [ ] CI `cargo test` on holon-run/holon

Signed-off-by per DCO.


Made with [Cursor](https://cursor.com)