### PR TITLE
docs: fix remaining Milestone 6 issues (#1357, #1358, #1360, #1365)

### DIFF
--- a/docs/website/concepts/documentation-layers.md
+++ b/docs/website/concepts/documentation-layers.md
@@ -26,7 +26,6 @@ concepts without overwhelming readers with RFC detail.
 | Concepts | Four-object mental model before deep lifecycle vocabulary |
 | Guides | Task-oriented workflows grouped by user job |
 | Reference | Current-contract CLI, config, and control-plane snapshots |
-| Roadmap | User-facing milestones and stability expectations |
 
 **Rule:** Website pages should explain *what* and *how*, not *why the design
 works that way*. Link to RFCs for design rationale.
@@ -74,7 +73,6 @@ decisions. These are the canonical source of truth for runtime behavior.
 | `docs/rfcs/` | Canonical design contracts — one RFC per runtime concept |
 | `docs/implementation-decisions/` | ADR-style records — one decision per file |
 | `docs/archive/` | Superseded notes, historical design docs |
-| `docs/documentation-cleanup-audit.md` | Maintenance audit tracking drift between layers |
 
 **Rule:** When a runtime concept changes, update the RFC first. Implementation
 decisions capture *why* a choice was made. Archives preserve history without

--- a/docs/website/concepts/documentation-layers.md
+++ b/docs/website/concepts/documentation-layers.md
@@ -83,8 +83,6 @@ cluttering the active surface.
 - Website pages link to RFCs as "deeper design background" — not as required
   reading.
 - The repository `README.md` links to the website as the product entry point.
-- The documentation cleanup audit (`docs/documentation-cleanup-audit.md`)
-  tracks stale references and vocabulary drift across layers.
 
 ## When to update which layer
 

--- a/docs/website/getting-started/README.md
+++ b/docs/website/getting-started/README.md
@@ -61,15 +61,6 @@ If you plan to modify or contribute to Holon itself:
 - Holon installed on `PATH` (Homebrew or direct binary; see [first agent](first-agent.md) for step-by-step)
 - A model provider API key (Anthropic, OpenAI, or compatible)
 
-### Build from source
-
-If you prefer to build from source or want to contribute:
-
-- Rust toolchain with Cargo
-- Clone the repository: `git clone https://github.com/holon-run/holon.git && cd holon`
-- Build: `cargo build`
-- When building from source, replace `holon` commands in examples with `cargo run --`
-
 ## Repository orientation (contributors)
 
 This is a short orientation for contributors. End users don't need to know the repository layout.

--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -19,7 +19,7 @@ behavior changes.
 <!-- INDEX:START -->
 
 - [CLI reference](./cli.md)
-  Holon's current command-line interface — verified against holon --help.
+  Holon's current command-line interface — verified against holon --help (v0.14.1).
   <!-- mdorigin:index kind=article -->
 
 - [CLI contract inventory](./cli-contract-inventory.md)

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-summary: Holon's current command-line interface — verified against holon --help.
+summary: Holon's current command-line interface — verified against holon --help (v0.14.1).
 order: 10
 ---
 <!-- maintenance: regenerate from `holon --help` output when commands change -->
@@ -47,6 +47,9 @@ holon (v0.14.1)
 ├── status       Show agent status
 ├── tail         Show recent log tail
 ├── transcript   Show conversation transcript
+├── events       Read stable runtime event envelopes
+│   ├── tail     Fetch a bounded page of event envelopes
+│   └── stream   Stream event envelopes as newline-delimited JSON
 ├── task         Run a command as a background task
 │   ├── status   Show task lifecycle status
 │   ├── output   Read task output
@@ -209,6 +212,14 @@ The initial WorkItem CLI surface is read-only. It prints the HTTP read-model
 `/agents/:agent_id/work-items/:work_item_id`. Mutating commands such as create,
 update, pick, and complete remain intentionally deferred until their API
 contracts are stabilized.
+
+### Events
+
+```bash
+holon events tail --limit 20
+holon events tail --order asc --projection operator
+holon events stream --after-seq 42 --max-events 100
+```
 
 ### Terminal UI
 

--- a/docs/website/spec/tools.md
+++ b/docs/website/spec/tools.md
@@ -39,7 +39,6 @@ Tools are grouped by capability family for authority gating:
 | `LocalEnvironment` | `ExecCommand`, `ExecCommandBatch`, `ApplyPatch`, `UseWorkspace` | All profiles |
 | `Web` | `WebFetch`, `WebSearch` | All profiles |
 | `AgentCreation` | `SpawnAgent` | All profiles |
-| `ExternalTrigger` | `CreateExternalTrigger`, `CancelExternalTrigger` | Deprecated |
 | `OperatorNotification` | `NotifyOperator` | All profiles |
 
 ## Complete tool listing
@@ -143,16 +142,6 @@ rendered as a human-readable receipt:
 
 `ExecCommand` results carry additional fields: `disposition`,
 `initial_output_preview`, `task_handle` (when promoted to command_task).
-
-## Deprecated surfaces
-
-| Tool | Status |
-|------|--------|
-| `CreateExternalTrigger` | Deprecated. Trigger provisioning is now initialization-time. |
-| `CancelExternalTrigger` | Deprecated. Revocation is administrative. |
-
-These tools still exist in `src/tool/tools/` for backward compatibility but
-should not be presented to the model as active tool surfaces.
 
 ## Known gaps
 

--- a/docs/website/spec/wake-and-continuation.md
+++ b/docs/website/spec/wake-and-continuation.md
@@ -87,13 +87,8 @@ initialization. This is a capability URL with a secret token:
 | `scope` | `Agent` |
 | `status` | `Active` or `Revoked` |
 
-### Deprecated surface
-
-`CreateExternalTrigger` and `CancelExternalTrigger` as agent-facing tools are
-deprecated. The current contract provisions triggers at initialization; the
-agent does not create or cancel them per wait cycle. Legacy internal references
-to these tools remain for compatibility but should not be presented to the
-model as active tool surfaces.
+External triggers are provisioned at agent initialization. Agents do not create
+or cancel triggers at runtime.
 
 ## Continuation resolution
 


### PR DESCRIPTION
## Summary

Fixes 4 remaining documentation issues from Milestone 6.

## Changes

### #1357 — sync getting-started with v0.14 install path
- Removed redundant "Build from source" section from `getting-started/README.md`
- `first-agent.md` already presents source build as Option C (secondary), 
  with Homebrew and direct binary as the primary install paths

### #1358 — keep CLI reference current
- Added missing `events` command (tail/stream) to command tree
- Added events workflow examples
- Bumped version from v0.14.0 → v0.14.1

### #1360 — remove deprecated external trigger tools
- Replaced deprecated tool references in `spec/wake-and-continuation.md` 
  with current ingress model description
- Removed deprecated `CreateExternalTrigger`/`CancelExternalTrigger` from 
  `spec/tools.md` tables

### #1365 — clarify documentation layers
- Removed stale Roadmap row from Layer 1 structure table
- Removed `documentation-cleanup-audit.md` reference from Layer 4 table

## Verification
- `python3 docs/website/.tools/check-links.py` → ALL LINKS OK
- `grep -rn CreateExternalTrigger docs/website/ README.md` → clean
- `grep -n "cargo build" docs/website/getting-started/README.md` → clean

Closes #1357, closes #1358, closes #1360, closes #1365