### PR TITLE
fix: align work item plan contract

### DIFF
--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -141,6 +141,8 @@ The minimal WorkItem state is:
 - `plan_artifact`
 - `todo_list`
 - `blocked_by`
+- `recheck_at`
+- `recheck_consumed_at`
 - `result_summary`
 - `created_at`
 - `updated_at`
@@ -182,6 +184,16 @@ Blocked and queued are derived views, not lifecycle states:
 
 - blocked work is `open` work with `blocked_by` set;
 - queued work is `open` work that is not the current focus and has no blocker.
+
+Blocked WorkItems may also carry a one-shot fallback recheck deadline:
+
+- `recheck_at` records the next absolute time when the runtime should wake the
+  agent to re-evaluate the blocker;
+- `recheck_consumed_at` records that the current `recheck_at` reminder has
+  already been delivered or consumed;
+- clearing `blocked_by` clears both recheck fields;
+- a due recheck never makes the WorkItem runnable by itself. The WorkItem stays
+  blocked until the agent explicitly refreshes or clears the blocker.
 
 ### `plan_status`
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1922,7 +1922,7 @@ fallback recheck deadline. Updating other WorkItem fields without touching
 
 There is no separate agent-facing `UpdateWorkPlan` tool and no separate
 work-plan storage stream. Plan body state lives in the AgentHome plan artifact;
-`WorkItemRecord.plan` is legacy compatibility state and is not the current
+`plan_artifact` is the only persisted WorkItem plan reference in the current
 agent-facing read/write contract. `plan_status` and `todo_list` remain explicit
 WorkItem state. Agent-scoped external trigger capabilities are cancelled only
 by explicit revoke or rotation.

--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -9,7 +9,7 @@ order: 20
 This page defines the current contract for WorkItem runtime behavior:
 lifecycle, focus, readiness, planning, blocking, and completion semantics.
 
-> **Last verified:** 2026-05-23 against `src/types.rs` `WorkItemRecord`,
+> **Last verified:** 2026-05-26 against `src/types.rs` `WorkItemRecord`,
 > `WorkItemState`, `WorkItemPlanStatus`, `WorkItemReadiness`,
 > `WorkItemSchedulingState`, and the tool implementations in
 > `src/tool/tools/{create,update,pick,list,get,complete}_work_item.rs`.
@@ -35,6 +35,7 @@ A WorkItem is a durable objective record owned by an agent. It tracks:
 | `todo_list` | Progress checklist snapshot |
 | `blocked_by` | Human-readable blocker description |
 | `recheck_at` | Fallback deadline for blocked re-evaluation |
+| `recheck_consumed_at` | Marker that the current recheck reminder was delivered |
 | `result_summary` | Completion summary (optional) |
 
 The Rust enum `WorkItemPlanStatus` uses PascalCase variants (`Draft`, `Ready`,
@@ -165,9 +166,6 @@ the agent's home directory (`work-items/<id>/plan.md`). The plan artifact:
   granularity at the display layer.
 - Plan artifact path resolution depends on agent home workspace; cross-agent
   WorkItem reads may need explicit workspace routing.
-- `WorkItemRecord` still retains a legacy `plan: Option<String>` field
-  alongside `plan_artifact`. See
-  [issue #1379](https://github.com/holon-run/holon/issues/1379).
-- `recheck_after` / `recheck_at` / `recheck_consumed_at` scheduling semantics
-  are not described in the WorkItem RFC. See
-  [issue #1379](https://github.com/holon-run/holon/issues/1379).
+- Older ledger snapshots that contain inline `plan` text are migrated into the
+  AgentHome plan artifact when the WorkItem is refreshed. Current snapshots do
+  not serialize inline plan body state.

--- a/src/context.rs
+++ b/src/context.rs
@@ -2820,8 +2820,14 @@ mod tests {
             "storage and recovery foundation",
             crate::types::WorkItemState::Open,
         );
-        active.legacy_inline_plan =
-            Some("Persist the work item store and project it into prompts.".into());
+        active.plan_artifact = Some(
+            crate::work_item_plan::ensure_plan_artifact(
+                dir.path(),
+                &active,
+                Some("Persist the work item store and project it into prompts."),
+            )
+            .unwrap(),
+        );
         active.todo_list = vec![
             TodoItem {
                 text: "Persist work-item store".into(),
@@ -3059,23 +3065,44 @@ mod tests {
             crate::types::WorkItemState::Open,
         );
         triggered.blocked_by = Some("waiting for CI".into());
-        triggered.legacy_inline_plan = Some("Handle the triggered CI result.".into());
+        triggered.plan_artifact = Some(
+            crate::work_item_plan::ensure_plan_artifact(
+                dir.path(),
+                &triggered,
+                Some("Handle the triggered CI result."),
+            )
+            .unwrap(),
+        );
         let mut queued = crate::types::WorkItemRecord::new(
             "default",
             "Queue follow-up verification",
             crate::types::WorkItemState::Open,
         );
-        queued.legacy_inline_plan = Some(format!(
-            "Verify the queued path.\n{}",
-            "queued detail ".repeat(200)
-        ));
+        queued.plan_artifact = Some(
+            crate::work_item_plan::ensure_plan_artifact(
+                dir.path(),
+                &queued,
+                Some(&format!(
+                    "Verify the queued path.\n{}",
+                    "queued detail ".repeat(200)
+                )),
+            )
+            .unwrap(),
+        );
         let mut waiting = crate::types::WorkItemRecord::new(
             "default",
             "Wait for operator confirmation",
             crate::types::WorkItemState::Open,
         );
         waiting.plan_status = crate::types::WorkItemPlanStatus::NeedsInput;
-        waiting.legacy_inline_plan = Some("Wait for the operator answer before retrying.".into());
+        waiting.plan_artifact = Some(
+            crate::work_item_plan::ensure_plan_artifact(
+                dir.path(),
+                &waiting,
+                Some("Wait for the operator answer before retrying."),
+            )
+            .unwrap(),
+        );
         let mut completed = crate::types::WorkItemRecord::new(
             "default",
             "Already finished item",

--- a/src/context.rs
+++ b/src/context.rs
@@ -2820,7 +2820,8 @@ mod tests {
             "storage and recovery foundation",
             crate::types::WorkItemState::Open,
         );
-        active.plan = Some("Persist the work item store and project it into prompts.".into());
+        active.legacy_inline_plan =
+            Some("Persist the work item store and project it into prompts.".into());
         active.todo_list = vec![
             TodoItem {
                 text: "Persist work-item store".into(),
@@ -3058,13 +3059,13 @@ mod tests {
             crate::types::WorkItemState::Open,
         );
         triggered.blocked_by = Some("waiting for CI".into());
-        triggered.plan = Some("Handle the triggered CI result.".into());
+        triggered.legacy_inline_plan = Some("Handle the triggered CI result.".into());
         let mut queued = crate::types::WorkItemRecord::new(
             "default",
             "Queue follow-up verification",
             crate::types::WorkItemState::Open,
         );
-        queued.plan = Some(format!(
+        queued.legacy_inline_plan = Some(format!(
             "Verify the queued path.\n{}",
             "queued detail ".repeat(200)
         ));
@@ -3074,7 +3075,7 @@ mod tests {
             crate::types::WorkItemState::Open,
         );
         waiting.plan_status = crate::types::WorkItemPlanStatus::NeedsInput;
-        waiting.plan = Some("Wait for the operator answer before retrying.".into());
+        waiting.legacy_inline_plan = Some("Wait for the operator answer before retrying.".into());
         let mut completed = crate::types::WorkItemRecord::new(
             "default",
             "Already finished item",

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -705,9 +705,11 @@ fn work_item_document_body(item: &WorkItemRecord) -> String {
             work_item_plan_status_label(item.plan_status)
         ),
     ];
-    if let Some(plan) = item.plan.as_deref().filter(|plan| !plan.trim().is_empty()) {
-        lines.push("Plan:".into());
-        lines.push(plan.to_string());
+    if let Some(plan_artifact) = item.plan_artifact.as_ref() {
+        if !plan_artifact.preview.trim().is_empty() {
+            lines.push("Plan preview:".into());
+            lines.push(plan_artifact.preview.clone());
+        }
     }
     if !item.todo_list.is_empty() {
         lines.push("Todo list:".into());
@@ -1276,7 +1278,18 @@ mod tests {
         );
         work_item.workspace_id = "ws-holon".into();
         work_item.plan_status = WorkItemPlanStatus::Ready;
-        work_item.plan = Some("Persist checksum-oriented task understanding in recall.".into());
+        work_item.plan_artifact = Some(crate::types::WorkItemPlanArtifact {
+            owner_agent_id: "default".into(),
+            workspace_id: crate::types::agent_home_workspace_id("default"),
+            workspace_alias: Some(crate::types::AGENT_HOME_WORKSPACE_ID.into()),
+            relative_path: PathBuf::from("work-items/work-memory/plan.md"),
+            path: dir.path().join("work-items/work-memory/plan.md"),
+            hash: "sha256:test".into(),
+            bytes: 54,
+            updated_at: Utc::now(),
+            preview: "Persist checksum-oriented task understanding in recall.".into(),
+            preview_complete: true,
+        });
         work_item.todo_list = vec![
             TodoItem {
                 text: "Index durable objective plan text".into(),

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -844,7 +844,14 @@ mod tests {
             "repair benchmark export output",
             WorkItemState::Open,
         );
-        active.legacy_inline_plan = Some("Patch exporter and run focused test.".into());
+        active.plan_artifact = Some(
+            crate::work_item_plan::ensure_plan_artifact(
+                dir.path(),
+                &active,
+                Some("Patch exporter and run focused test."),
+            )
+            .unwrap(),
+        );
         active.todo_list = vec![
             TodoItem {
                 text: "patch exporter".into(),

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -154,7 +154,10 @@ pub fn derive_working_memory_snapshot(
     let memory_tools = collect_memory_tools(&recent_tools, current_work_item_id);
 
     let work_summary = current_work_item.map(|item| item.objective.clone());
-    let plan = current_work_item.and_then(|item| item.plan.clone());
+    let plan = current_work_item
+        .and_then(|item| item.plan_artifact.as_ref())
+        .map(|artifact| artifact.preview.clone())
+        .filter(|preview| !preview.trim().is_empty());
     let todo_list = current_work_item
         .map(|item| item.todo_list.clone())
         .unwrap_or_default();
@@ -841,7 +844,7 @@ mod tests {
             "repair benchmark export output",
             WorkItemState::Open,
         );
-        active.plan = Some("Patch exporter and run focused test.".into());
+        active.legacy_inline_plan = Some("Patch exporter and run focused test.".into());
         active.todo_list = vec![
             TodoItem {
                 text: "patch exporter".into(),

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1949,7 +1949,7 @@ impl RuntimeHandle {
             &record,
             plan.as_deref(),
         )?);
-        record.plan = None;
+        record.legacy_inline_plan = None;
         record.todo_list = todo_list;
         record.workspace_id = self
             .agent_state()

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -4,6 +4,7 @@ use crate::types::{
     WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WaitingIntentScope, WakeSource,
     WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState, AGENT_HOME_WORKSPACE_ID,
 };
+use std::{fs::OpenOptions, io::Write};
 
 fn legacy_blocking_payload_task_for_work_item(
     task_id: &str,
@@ -1335,8 +1336,20 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
 
     let mut legacy = WorkItemRecord::new("default", "Migrate inline plan", WorkItemState::Open);
     legacy.id = "legacy-plan-item".into();
-    legacy.plan = Some("Keep this legacy plan body in the artifact.".into());
-    runtime.inner.storage.append_work_item(&legacy).unwrap();
+    legacy.legacy_inline_plan = Some("Keep this legacy plan body in the artifact.".into());
+    let mut legacy_json = serde_json::to_value(&legacy).unwrap();
+    legacy_json["plan"] = serde_json::json!("Keep this legacy plan body in the artifact.");
+    let work_items_path = dir
+        .path()
+        .join(".holon")
+        .join("ledger")
+        .join("work_items.jsonl");
+    let mut work_items_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&work_items_path)
+        .unwrap();
+    writeln!(work_items_file, "{}", legacy_json).unwrap();
 
     let updated = runtime
         .update_work_item_fields(
@@ -1351,9 +1364,9 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
         .unwrap();
 
     assert_eq!(updated.revision, legacy.revision + 1);
-    assert!(updated.plan.is_none());
+    assert!(updated.legacy_inline_plan.is_none());
     let latest = runtime.latest_work_item(&legacy.id).await.unwrap().unwrap();
-    assert!(latest.plan.is_none());
+    assert!(latest.legacy_inline_plan.is_none());
     assert_eq!(latest.objective, "Migrate inline plan without copying it");
 
     let plan_path = crate::work_item_plan::plan_path(runtime.agent_home().as_path(), &legacy.id);
@@ -1373,12 +1386,10 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
     let mut legacy_with_artifact =
         WorkItemRecord::new("default", "Keep existing artifact", WorkItemState::Open);
     legacy_with_artifact.id = "legacy-plan-item-with-artifact".into();
-    legacy_with_artifact.plan = Some("Stale inline plan body.".into());
-    runtime
-        .inner
-        .storage
-        .append_work_item(&legacy_with_artifact)
-        .unwrap();
+    legacy_with_artifact.legacy_inline_plan = Some("Stale inline plan body.".into());
+    let mut legacy_with_artifact_json = serde_json::to_value(&legacy_with_artifact).unwrap();
+    legacy_with_artifact_json["plan"] = serde_json::json!("Stale inline plan body.");
+    writeln!(work_items_file, "{}", legacy_with_artifact_json).unwrap();
     let existing_plan_path =
         crate::work_item_plan::plan_path(runtime.agent_home().as_path(), &legacy_with_artifact.id);
     std::fs::create_dir_all(existing_plan_path.parent().unwrap()).unwrap();
@@ -1396,7 +1407,7 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
         .await
         .unwrap();
 
-    assert!(updated_with_artifact.plan.is_none());
+    assert!(updated_with_artifact.legacy_inline_plan.is_none());
     assert_eq!(
         std::fs::read_to_string(&existing_plan_path).unwrap(),
         "Existing artifact body."

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -3152,6 +3152,25 @@ fn truncated_mutation_recovery_hint(tool_name: &str) -> &'static str {
 mod tests {
     use super::*;
 
+    fn fixture_plan_artifact(
+        work_item: &WorkItemRecord,
+        preview: impl Into<String>,
+    ) -> crate::types::WorkItemPlanArtifact {
+        let preview = preview.into();
+        crate::types::WorkItemPlanArtifact {
+            owner_agent_id: work_item.agent_id.clone(),
+            workspace_id: crate::types::agent_home_workspace_id(&work_item.agent_id),
+            workspace_alias: Some(crate::types::AGENT_HOME_WORKSPACE_ID.into()),
+            relative_path: crate::work_item_plan::plan_relative_path(&work_item.id),
+            path: std::path::PathBuf::from(format!("/tmp/{}/plan.md", work_item.id)),
+            hash: "sha256:test".into(),
+            bytes: preview.len() as u64,
+            updated_at: chrono::Utc::now(),
+            preview,
+            preview_complete: true,
+        }
+    }
+
     #[test]
     fn truncated_mutation_recovery_hint_is_tool_specific() {
         let apply_patch = truncated_mutation_recovery_hint("ApplyPatch");
@@ -3376,7 +3395,10 @@ mod tests {
         );
         work_item.id = "work_reminder".into();
         work_item.plan_status = WorkItemPlanStatus::Ready;
-        work_item.legacy_inline_plan = Some("Patch runtime reminder.\nRun focused tests.".into());
+        work_item.plan_artifact = Some(fixture_plan_artifact(
+            &work_item,
+            "Patch runtime reminder.\nRun focused tests.",
+        ));
         work_item.todo_list = vec![
             crate::types::TodoItem {
                 text: "Patch runtime reminder".into(),
@@ -3450,12 +3472,13 @@ mod tests {
         );
         work_item.id = "work_large_reminder".into();
         work_item.plan_status = WorkItemPlanStatus::Ready;
-        work_item.legacy_inline_plan = Some(
+        work_item.plan_artifact = Some(fixture_plan_artifact(
+            &work_item,
             (0..80)
                 .map(|idx| format!("step {idx}: {}", "inspect and verify ".repeat(40)))
                 .collect::<Vec<_>>()
                 .join("\n"),
-        );
+        ));
         work_item.todo_list = (0..80)
             .map(|idx| crate::types::TodoItem {
                 text: format!("todo {idx}: {}", "finish bounded work ".repeat(30)),

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -853,7 +853,12 @@ fn build_work_item_stale_reminder(
             work_item_plan_status_label(work_item.plan_status)
         ),
     ];
-    if let Some(plan) = work_item.plan.as_deref() {
+    if let Some(plan) = work_item
+        .plan_artifact
+        .as_ref()
+        .map(|artifact| artifact.preview.as_str())
+        .filter(|preview| !preview.trim().is_empty())
+    {
         lines.push("- Plan:".to_string());
         let mut plan_chars = 0usize;
         for line in plan.lines().take(WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT) {
@@ -3371,7 +3376,7 @@ mod tests {
         );
         work_item.id = "work_reminder".into();
         work_item.plan_status = WorkItemPlanStatus::Ready;
-        work_item.plan = Some("Patch runtime reminder.\nRun focused tests.".into());
+        work_item.legacy_inline_plan = Some("Patch runtime reminder.\nRun focused tests.".into());
         work_item.todo_list = vec![
             crate::types::TodoItem {
                 text: "Patch runtime reminder".into(),
@@ -3445,7 +3450,7 @@ mod tests {
         );
         work_item.id = "work_large_reminder".into();
         work_item.plan_status = WorkItemPlanStatus::Ready;
-        work_item.plan = Some(
+        work_item.legacy_inline_plan = Some(
             (0..80)
                 .map(|idx| format!("step {idx}: {}", "inspect and verify ".repeat(40)))
                 .collect::<Vec<_>>()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3342,7 +3342,14 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
         let mut work_item = WorkItemRecord::new("default", "fix issue #223", WorkItemState::Open);
-        work_item.legacy_inline_plan = Some("Implement the new WorkItem model.".into());
+        work_item.plan_artifact = Some(
+            crate::work_item_plan::ensure_plan_artifact(
+                dir.path(),
+                &work_item,
+                Some("Implement the new WorkItem model."),
+            )
+            .unwrap(),
+        );
         work_item.todo_list = vec![TodoItem {
             text: "persist work item store".into(),
             state: TodoItemState::InProgress,
@@ -3354,7 +3361,10 @@ mod tests {
         assert_eq!(snapshot.work_items.len(), 1);
         assert_eq!(snapshot.work_items[0].id, work_item.id);
         assert_eq!(
-            snapshot.work_items[0].legacy_inline_plan.as_deref(),
+            snapshot.work_items[0]
+                .plan_artifact
+                .as_ref()
+                .map(|artifact| artifact.preview.as_str()),
             Some("Implement the new WorkItem model.")
         );
         assert_eq!(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3342,7 +3342,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
         let mut work_item = WorkItemRecord::new("default", "fix issue #223", WorkItemState::Open);
-        work_item.plan = Some("Implement the new WorkItem model.".into());
+        work_item.legacy_inline_plan = Some("Implement the new WorkItem model.".into());
         work_item.todo_list = vec![TodoItem {
             text: "persist work item store".into(),
             state: TodoItemState::InProgress,
@@ -3354,7 +3354,7 @@ mod tests {
         assert_eq!(snapshot.work_items.len(), 1);
         assert_eq!(snapshot.work_items[0].id, work_item.id);
         assert_eq!(
-            snapshot.work_items[0].plan.as_deref(),
+            snapshot.work_items[0].legacy_inline_plan.as_deref(),
             Some("Implement the new WorkItem model.")
         );
         assert_eq!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -3067,8 +3067,8 @@ pub struct WorkItemRecord {
     pub objective: String,
     pub state: WorkItemState,
     pub plan_status: WorkItemPlanStatus,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub plan: Option<String>,
+    #[serde(default, alias = "plan", skip_serializing)]
+    pub legacy_inline_plan: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_artifact: Option<WorkItemPlanArtifact>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -3101,7 +3101,7 @@ impl WorkItemRecord {
             objective: objective.into(),
             state,
             plan_status: WorkItemPlanStatus::Draft,
-            plan: None,
+            legacy_inline_plan: None,
             plan_artifact: None,
             todo_list: Vec::new(),
             blocked_by: None,
@@ -4273,6 +4273,37 @@ mod tests {
         work_item.as_object_mut().unwrap().remove("workspace_id");
         let work_item: WorkItemRecord = serde_json::from_value(work_item).unwrap();
         assert_eq!(work_item.workspace_id, AGENT_HOME_WORKSPACE_ID);
+
+        let mut legacy_inline_plan =
+            WorkItemRecord::new("default", "migrate inline plan", WorkItemState::Open);
+        legacy_inline_plan.legacy_inline_plan = Some("legacy body".into());
+        let serialized_legacy_inline_plan = serde_json::to_value(&legacy_inline_plan).unwrap();
+        assert!(
+            serialized_legacy_inline_plan.get("plan").is_none(),
+            "WorkItemRecord must not serialize inline plan body state"
+        );
+        assert!(
+            serialized_legacy_inline_plan
+                .get("legacy_inline_plan")
+                .is_none(),
+            "legacy inline plan migration state must stay internal"
+        );
+
+        let legacy_inline_plan: WorkItemRecord = serde_json::from_value(serde_json::json!({
+            "id": "work_legacy_inline_plan",
+            "agent_id": "default",
+            "objective": "ship",
+            "state": "open",
+            "plan_status": "ready",
+            "plan": "legacy body",
+            "created_at": "2026-04-20T00:00:00Z",
+            "updated_at": "2026-04-20T00:00:00Z"
+        }))
+        .unwrap();
+        assert_eq!(
+            legacy_inline_plan.legacy_inline_plan.as_deref(),
+            Some("legacy body")
+        );
 
         let legacy_work_item = serde_json::json!({
             "id": "work_legacy",

--- a/src/work_item_plan.rs
+++ b/src/work_item_plan.rs
@@ -41,7 +41,7 @@ pub(crate) fn ensure_plan_artifact(
                 .with_context(|| format!("failed to create {}", parent.display()))?;
         }
         let body = initial_plan
-            .or(record.plan.as_deref())
+            .or(record.legacy_inline_plan.as_deref())
             .unwrap_or_default()
             .as_bytes();
         fs::write(&path, body).with_context(|| format!("failed to write {}", path.display()))?;
@@ -54,9 +54,9 @@ pub(crate) fn refresh_plan_artifact_metadata(
     record: &mut WorkItemRecord,
 ) -> Result<bool> {
     let previous = record.plan_artifact.clone();
-    let had_inline_plan = record.plan.is_some();
+    let had_inline_plan = record.legacy_inline_plan.is_some();
     let path = plan_path(agent_home, &record.id);
-    if !path.exists() && record.plan.is_none() && record.plan_artifact.is_some() {
+    if !path.exists() && record.legacy_inline_plan.is_none() && record.plan_artifact.is_some() {
         anyhow::bail!(
             "missing plan artifact {} for work item {}",
             path.display(),
@@ -64,7 +64,7 @@ pub(crate) fn refresh_plan_artifact_metadata(
         );
     }
     let artifact = ensure_plan_artifact(agent_home, record, None)?;
-    record.plan = None;
+    record.legacy_inline_plan = None;
     record.plan_artifact = Some(artifact);
     Ok(had_inline_plan || record.plan_artifact != previous)
 }


### PR DESCRIPTION
Fixes #1379.

## Summary
- remove inline WorkItem plan body from the serialized `WorkItemRecord` contract while preserving legacy `plan` JSON migration into the AgentHome plan artifact
- switch WorkItem memory/projection helpers to use `plan_artifact.preview` instead of inline plan state
- document blocked WorkItem `recheck_at` / `recheck_consumed_at` semantics in the WorkItem RFC/spec and remove the now-fixed known-gap note

## Validation
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test work_items`
