### PR TITLE
docs: refresh API/CLI contract inventories

### DIFF
--- a/docs/website/reference/README.md
+++ b/docs/website/reference/README.md
@@ -19,7 +19,7 @@ behavior changes.
 <!-- INDEX:START -->
 
 - [CLI reference](./cli.md)
-  Holon's current command-line interface — verified against holon --help (v0.14.0).
+  Holon's current command-line interface — verified against holon --help.
   <!-- mdorigin:index kind=article -->
 
 - [CLI contract inventory](./cli-contract-inventory.md)
@@ -47,7 +47,7 @@ behavior changes.
   <!-- mdorigin:index kind=article -->
 
 - [API contract inventory](./api-contract-inventory.md)
-  First-pass stability inventory for Holon's HTTP control-plane API parameters, responses, and follow-up contract work.
+  Post-baseline stability inventory for Holon's HTTP control-plane API parameters, responses, and Phase 2 contract work.
   <!-- mdorigin:index kind=article -->
 
 - [Model tool schema inventory](./model-tool-schema-inventory.md)

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -1,18 +1,18 @@
 ---
 title: API contract inventory
-summary: First-pass stability inventory for Holon's HTTP control-plane API parameters, responses, and follow-up contract work.
+summary: Post-baseline stability inventory for Holon's HTTP control-plane API parameters, responses, and Phase 2 contract work.
 order: 25
 ---
 
 # API contract inventory
 
-This page is the first-pass inventory for Holon's **HTTP control-plane API**.
+This page is the post-baseline inventory for Holon's **HTTP control-plane API**.
 It complements the [HTTP control plane](./http-control-plane.md) reference by
 recording the route list, request parameters, response shapes, and contract
-gaps that need stabilization before scripts and integrations can rely on the
-API long term.
+gaps that still need stabilization before scripts and integrations can rely on
+the API long term.
 
-- **Last reviewed against:** `holon` v0.14.1, `main` at `77fe575`.
+- **Last reviewed against:** `holon` v0.14.1, `main` at `bff2293`.
 - **Primary source:** `src/http.rs` Axum router and request/response structs.
 - **Generated schema:** [`openapi.json`](./openapi.json), produced by
   `holon::openapi::generate_openapi_json()` and checked by
@@ -22,7 +22,8 @@ API long term.
   `cargo test --test http_route_snapshot`.
 - **Client source:** `src/client.rs` for the subset consumed by the TUI/CLI.
 - **Current status:** pre-1.0 baseline. Treat shapes below as observed
-  behavior, not a final compatibility promise.
+  behavior, not a final compatibility promise. Milestone 8 established the
+  first checked baseline; the remaining gaps are Phase 2 stabilization work.
 
 ## Stability levels
 
@@ -163,7 +164,9 @@ response directly.
 | `GET` | `/agents/:agent_id/status` | Path `agent_id`; auth header when bearer mode is active. | `AgentSummary` | Candidate stable | Main read model for one agent. |
 | `GET` | `/agents/:agent_id/state` | Path `agent_id`; auth header when bearer mode is active. | `AgentStateSnapshot` | Experimental | Broad bootstrap snapshot; includes agent, session, tasks, timers, work items, waiting intents, external triggers, notifications, workspace, execution. |
 | `GET` | `/agents/:agent_id/briefs` | Path `agent_id`; query `limit?`. | `BriefRecord[]` | Candidate stable | Defaults to `20`. |
-| `GET` | `/agents/:agent_id/tasks` | Path `agent_id`; query `limit?`. | `TaskRecord[]` | Candidate stable for list; Gap for task detail APIs | Defaults to `50`; only active/recent task listing, no status/output/input/stop route yet. |
+| `GET` | `/agents/:agent_id/tasks` | Path `agent_id`; query `limit?`. | `TaskRecord[]` | Candidate stable for list; DTO schema still broad | Defaults to `50`; active/recent task listing. |
+| `GET` | `/agents/:agent_id/tasks/:task_id` | Path `agent_id`, `task_id`. | `TaskStatusSnapshot` | Candidate stable route; DTO schema still broad | Returns a single task lifecycle snapshot. |
+| `GET` | `/agents/:agent_id/tasks/:task_id/output` | Path `agent_id`, `task_id`; query `block?`, `timeout_ms?`. | `TaskOutputResult` | Candidate stable route; DTO schema still broad | Reads bounded task output and can optionally wait for readiness. |
 | `GET` | `/agents/:agent_id/timers` | Path `agent_id`; query `limit?`. | `TimerRecord[]` | Candidate stable | Defaults to `50`. |
 | `GET` | `/agents/:agent_id/transcript` | Path `agent_id`; query `limit?`. | `TranscriptEntry[]` | Experimental | Transcript data can include provider/tool internals. |
 | `GET` | `/agents/:agent_id/worktree-summary` | Path `agent_id`. | `{ agent_id, summary }` | Experimental | Summary shape follows managed worktree internals. |
@@ -245,20 +248,23 @@ Projection contract:
 |--------|------|--------------|------------------|-----------|-------|
 | `POST` | `/control/agents/:agent_id/prompt` | `{ text }` | `{ ok, agent_id, message_id }` | Candidate stable | Enqueues a trusted operator prompt with `interject` priority. |
 | `POST` | `/control/agents/:agent_id/wake` | `{ reason, source?, correlation_id?, causation_id? }` | `{ ok, agent_id, disposition }` | Candidate stable | Empty `reason` is rejected. Does not start a stopped agent. |
-| `POST` | `/control/agents/:agent_id/control` | `{ action, trust? }`; `action` is `start` or `stop`. | `{ ok }` | Candidate stable | `trust` is currently audit metadata only. |
-| `POST` | `/control/agents/:agent_id/current-run/abort` | `{ run_id?, mode?, trust? }` | `{ ok, aborted, agent_id, run_id, mode, admission_context, provided_trust }` | Candidate stable | `mode` defaults to `stop_after_abort`; deprecated alias `pause_after_abort` is accepted. |
-| `POST` | `/control/agents/:agent_id/create` | `{ template?, trust? }` | `AgentSummary` | Experimental | Path id names the created agent. |
-| `POST` | `/control/agents/:agent_id/debug-prompt` | `{ text, trust? }` | `{ ok, agent_id, dump }` | Internal/debug | Dumps prompt rendering and should not be a stable automation API. |
+| `POST` | `/control/agents/:agent_id/control` | `{ action, authority_class? }`; `action` is `start` or `stop`. | `{ ok }` | Candidate stable | `authority_class` is currently audit/provenance metadata only. |
+| `POST` | `/control/agents/:agent_id/current-run/abort` | `{ run_id?, mode?, authority_class? }` | `{ ok, aborted, agent_id, run_id, mode, admission_context, provided_trust }` | Candidate stable | `mode` defaults to `stop_after_abort`; deprecated alias `pause_after_abort` is accepted. |
+| `POST` | `/control/agents/:agent_id/create` | `{ template?, authority_class? }` | `AgentSummary` | Experimental | Path id names the created agent. |
+| `POST` | `/control/agents/:agent_id/debug-prompt` | `{ text, authority_class? }` | `{ ok, agent_id, dump }` | Internal/debug | Dumps prompt rendering and should not be a stable automation API. |
 
 ### Tasks, work items, and timers
 
 | Method | Path | Request body | Success response | Stability | Notes |
 |--------|------|--------------|------------------|-----------|-------|
-| `POST` | `/control/agents/:agent_id/tasks` | `CreateCommandTaskRequest` | `TaskRecord` | Candidate stable for creation; Gap for lifecycle management | `serde(deny_unknown_fields)` rejects legacy fields. |
+| `POST` | `/control/agents/:agent_id/tasks` | `CreateCommandTaskRequest` | `TaskRecord` | Candidate stable for creation; DTO schema still broad | `serde(deny_unknown_fields)` rejects legacy fields. |
+| `POST` | `/control/agents/:agent_id/tasks/:task_id/input` | `{ text, authority_class? }` | `TaskInputResult` | Candidate stable route; DTO schema still broad | Delivers operator-authority text to an interactive command task or supervised child-agent task. |
+| `POST` | `/control/agents/:agent_id/tasks/:task_id/stop` | `{ authority_class? }` | `TaskStopResult` | Candidate stable route; DTO schema still broad | Requests managed-task cancellation. |
 | `GET` | `/agents/:agent_id/work-items` | none | `WorkItemRecord[]` | Experimental read model; CLI schema owner | Query parameter: `limit`; used by `holon work-item list`. |
 | `GET` | `/agents/:agent_id/work-items/:work_item_id` | none | `WorkItemRecord` | Experimental read model; CLI schema owner | Used by `holon work-item get`; returns 404 when the id is not found for the target agent. |
-| `POST` | `/control/agents/:agent_id/work-items` | `{ objective, trust? }` | `WorkItemRecord` | Experimental | Only creates/enqueues work items; update/pick/complete APIs remain deferred. |
-| `POST` | `/control/agents/:agent_id/timers` | `{ duration_ms, interval_ms?, summary?, trust? }` | `TimerRecord` | Candidate stable for creation; Gap for cancellation/list detail | `duration_ms` is required; `interval_ms` makes a repeating timer. |
+| `POST` | `/control/agents/:agent_id/work-items` | `{ objective, authority_class? }` | `WorkItemRecord` | Experimental | Creates/enqueues work items; update/pick/complete APIs remain Phase 2 work. |
+| `GET` | `/agents/:agent_id/timers/:timer_id` | Path `agent_id`, `timer_id`. | `TimerRecord` | Candidate stable route; DTO schema still broad | Returns 404 when the timer id is not found for the target agent. |
+| `POST` | `/control/agents/:agent_id/timers` | `{ duration_ms, interval_ms?, summary?, authority_class? }` | `TimerRecord` | Candidate stable for creation; cancellation remains Phase 2 work | `duration_ms` is required; `interval_ms` makes a repeating timer. |
 
 `CreateCommandTaskRequest` fields:
 
@@ -273,17 +279,17 @@ Projection contract:
 | `yield_time_ms` | integer | No | Defaults to `10000`. |
 | `max_output_tokens` | integer or null | No | Bounded output preview budget. |
 | `accepts_input` | bool | No | Defaults to `false`. |
-| `trust` | `TrustLevel` or null | No | Defaults to `trusted_operator`; recorded in audit. |
+| `authority_class` | `AuthorityClass` or null | No | Defaults to operator authority for admitted control-plane requests; recorded in provenance/audit. |
 
 ### Workspace and model controls
 
 | Method | Path | Request body | Success response | Stability | Notes |
 |--------|------|--------------|------------------|-----------|-------|
-| `POST` | `/control/agents/:agent_id/workspace/attach` | `{ path, trust? }` | `{ ok, agent_id, workspace_id, workspace_anchor }` | Candidate stable | `path` is converted into a workspace entry. |
-| `POST` | `/control/agents/:agent_id/workspace/exit` | `{ trust? }` | `{ ok, agent_id }` | Candidate stable | Returns agent to default workspace behavior. |
-| `POST` | `/control/agents/:agent_id/workspace/detach` | `{ workspace_id, trust? }` | `{ ok, agent_id, workspace_id }` | Candidate stable | `workspace_id` is trimmed before use. |
-| `POST` | `/control/agents/:agent_id/model` | `{ model, reasoning_effort?, trust? }` | `{ ok, agent_id, model }` | Experimental | `reasoning_effort` must be `low`, `medium`, `high`, or `xhigh`. |
-| `POST` | `/control/agents/:agent_id/model/clear` | `{ trust? }` | `{ ok, agent_id, model }` | Experimental | Clears the agent-level model override. |
+| `POST` | `/control/agents/:agent_id/workspace/attach` | `{ path, authority_class? }` | `{ ok, agent_id, workspace_id, workspace_anchor }` | Candidate stable | `path` is converted into a workspace entry. |
+| `POST` | `/control/agents/:agent_id/workspace/exit` | `{ authority_class? }` | `{ ok, agent_id }` | Candidate stable | Returns agent to default workspace behavior. |
+| `POST` | `/control/agents/:agent_id/workspace/detach` | `{ workspace_id, authority_class? }` | `{ ok, agent_id, workspace_id }` | Candidate stable | `workspace_id` is trimmed before use. |
+| `POST` | `/control/agents/:agent_id/model` | `{ model, reasoning_effort?, authority_class? }` | `{ ok, agent_id, model }` | Experimental | `reasoning_effort` must be `low`, `medium`, `high`, or `xhigh`. |
+| `POST` | `/control/agents/:agent_id/model/clear` | `{ authority_class? }` | `{ ok, agent_id, model }` | Experimental | Clears the agent-level model override. |
 
 ### Operator transport integration
 
@@ -333,7 +339,7 @@ treated as schema surfaces, not incidental Rust structs:
 | `AgentListEntry` | `/agents/list` | Keep lightweight; avoid reintroducing heavy runtime/model payloads. |
 | `TaskRecord` | `/agents/:id/tasks`, task creation, state snapshot, events | Task kind/status enums, detail truncation, recovery metadata, output references. |
 | `WorkItemRecord` | work-item creation, state snapshot, events | State, plan status, plan artifact, todo list, blockers/recheck timestamps. |
-| `TimerRecord` | `/agents/:id/timers`, timer creation, state snapshot | Repeating timer fields and status enum. |
+| `TimerRecord` | `/agents/:id/timers`, `/agents/:id/timers/:timer_id`, timer creation, state snapshot | Repeating timer fields and status enum. |
 | `BriefRecord` | `/agents/:id/briefs` | User-facing delivery vs internal traces. |
 | `TranscriptEntry` | `/agents/:id/transcript` | Potential provider/tool internals and truncation policy. |
 | `StreamEventEnvelope` | events page and SSE stream | Projection/redaction, provenance, payload versioning. |
@@ -342,50 +348,55 @@ treated as schema surfaces, not incidental Rust structs:
 
 ## Detected contract gaps
 
-1. **No generated route/schema inventory.** The current route list is hand
-   extracted from `src/http.rs`. Add a test or generator that snapshots method,
-   path, handler, request type, query type, and response contract.
-2. **Event projection allowlist needs more real-world coverage.** `operator`
+1. **OpenAPI route/type metadata is still only partially colocated with
+   implementation.** Route coverage and schema snapshots now exist, but the
+   generated baseline still depends on a conservative OpenAPI table. Phase 2
+   moves operation metadata closer to Axum route/type definitions.
+2. **Stable DTO schemas need tightening.** Several task, work-item, timer,
+   agent, event, and envelope responses are still represented broadly in the
+   OpenAPI baseline and should become first-class typed components where they
+   are stable client contracts.
+3. **Event projection allowlist needs more real-world coverage.** `operator`
    now has a redaction contract, but additional runtime event kinds may need
    explicit allowlist additions as TUI/client consumption broadens.
-3. **Task lifecycle APIs are incomplete.** HTTP can create and list tasks, but
-   lacks task status/output/input/stop routes that correspond to runtime tool
-   operations.
 4. **WorkItem mutation APIs are incomplete.** HTTP can list/get/create/enqueue
    work items and include them in state snapshots, but update/pick/complete
    routes remain deferred.
-5. **Timer lifecycle APIs are incomplete.** HTTP can create and list timers, but
-   lacks cancellation or detail routes.
+5. **Timer lifecycle APIs are incomplete.** HTTP can create/list/get timers,
+   but lacks cancellation semantics and endpoint coverage.
 6. **Deployment guidance still needs hardening.** The HTTP ingress trust/auth
    table is documented, but production-facing guidance should still describe
    when to use bearer mode, local mode, callback capabilities, and dedicated
    operator adapters.
 7. **Tool schema is a separate API surface.** Built-in tool input/result schemas
-   are not covered by this HTTP inventory and need their own stability
-   inventory.
+   now have their own checked inventory; this HTTP inventory should link to it
+   rather than duplicate it.
 
 ## Tracking issues
 
-These follow-up issues are grouped under the
+Milestone 8 baseline issues are complete. Phase 2 follow-up issues are grouped
+under the same
 [`CLI/API Stability Contracts`](https://github.com/holon-run/holon/milestone/8)
-milestone.
+milestone and tracked by
+[#1444](https://github.com/holon-run/holon/issues/1444).
 
 | Issue | Scope |
 |-------|-------|
-| [#1396](https://github.com/holon-run/holon/issues/1396) `api: add HTTP route and schema snapshot tests` | Generate or snapshot the route/schema inventory so contract drift is visible in CI. |
-| [#1397](https://github.com/holon-run/holon/issues/1397) `api: define shared HTTP error envelope and status-code contract` | Normalize or document error JSON and HTTP status-code mapping. |
-| [#1398](https://github.com/holon-run/holon/issues/1398) `api: define success envelope policy for control-plane responses` | Decide which route classes return `{ ok, ... }` envelopes versus direct records. |
-| [#1399](https://github.com/holon-run/holon/issues/1399) `api: stabilize event replay and SSE projection contract` | Stabilize cursor behavior, SSE fields, projection, and redaction. |
-| [#1400](https://github.com/holon-run/holon/issues/1400) `api: add task, WorkItem, and timer lifecycle endpoints` | Add or explicitly defer task, work-item, and timer detail/control endpoints. |
-| [#1401](https://github.com/holon-run/holon/issues/1401) `api: document HTTP ingress trust and auth boundaries` | Publish a trust/auth table for public enqueue, webhooks, operator bindings, and callbacks. |
-| [#1402](https://github.com/holon-run/holon/issues/1402) `api: inventory and version model-facing tool schemas` | Produce the separate inventory for built-in model-facing tool schemas. |
+| [#1438](https://github.com/holon-run/holon/issues/1438) `api: migrate OpenAPI baseline to aide route/type metadata` | Move OpenAPI operation metadata closer to route and DTO definitions. |
+| [#1439](https://github.com/holon-run/holon/issues/1439) `api: tighten OpenAPI DTO schemas for stable read models` | Replace selected generic JSON schemas with typed stable DTO schemas. |
+| [#1440](https://github.com/holon-run/holon/issues/1440) `api: add WorkItem mutation HTTP lifecycle endpoints` | Add or explicitly scope update/pick/complete mutation endpoints. |
+| [#1441](https://github.com/holon-run/holon/issues/1441) `api: add Timer cancellation lifecycle endpoint` | Define timer cancellation semantics and HTTP endpoint behavior. |
+| [#1443](https://github.com/holon-run/holon/issues/1443) `events: define stable operator-facing event payload subset` | Version/document stable event fields and projection/redaction boundaries. |
 
 ## Suggested next work
 
-1. Add HTTP route/schema snapshot tests ([#1396](https://github.com/holon-run/holon/issues/1396)).
-2. Define and test the common error envelope ([#1397](https://github.com/holon-run/holon/issues/1397)).
-3. Decide per-route success envelope policy ([#1398](https://github.com/holon-run/holon/issues/1398)).
-4. Stabilize event replay/SSE projection and redaction ([#1399](https://github.com/holon-run/holon/issues/1399)).
-5. Add or explicitly defer task, work-item, and timer lifecycle endpoints ([#1400](https://github.com/holon-run/holon/issues/1400)).
-6. Document HTTP ingress trust/auth boundaries ([#1401](https://github.com/holon-run/holon/issues/1401)).
-7. Produce a separate tool-schema inventory for model-facing APIs ([#1402](https://github.com/holon-run/holon/issues/1402)).
+1. Migrate the OpenAPI baseline toward `aide` route/type metadata
+   ([#1438](https://github.com/holon-run/holon/issues/1438)).
+2. Tighten DTO schemas for stable read models and control-plane results
+   ([#1439](https://github.com/holon-run/holon/issues/1439)).
+3. Add WorkItem mutation endpoints or explicitly define the non-goals
+   ([#1440](https://github.com/holon-run/holon/issues/1440)).
+4. Add timer cancellation semantics and endpoint coverage
+   ([#1441](https://github.com/holon-run/holon/issues/1441)).
+5. Define the stable operator-facing event payload subset
+   ([#1443](https://github.com/holon-run/holon/issues/1443)).

--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -217,20 +217,21 @@ that visibly affect CLI behavior while invoking commands.
 
 ## Tracking issues
 
-The initial CLI/API stability follow-up work is tracked in the
+The initial Milestone 8 CLI/API stability follow-up work is complete. Phase 2
+work remains tracked in the
 [CLI/API Stability Contracts](https://github.com/holon-run/holon/milestone/8)
-milestone:
+milestone by
+[#1444](https://github.com/holon-run/holon/issues/1444):
 
 | Priority | Issue | Scope |
 |---:|---|---|
-| 0 | [#1388](https://github.com/holon-run/holon/issues/1388) | Normalize or explicitly document raw HTTP response output paths. |
-| 0 | [#1389](https://github.com/holon-run/holon/issues/1389) | Define and test baseline CLI exit-code behavior. |
-| 0 | [#1390](https://github.com/holon-run/holon/issues/1390) | Add normalized command tree snapshot tests. |
-| 0 | [#1391](https://github.com/holon-run/holon/issues/1391) | Publish CLI stability levels and support policy. |
-| 1 | [#1392](https://github.com/holon-run/holon/issues/1392) | Add task lifecycle management commands. |
-| 1 | [#1393](https://github.com/holon-run/holon/issues/1393) | Add WorkItem inspection commands. |
-| 1 | [#1394](https://github.com/holon-run/holon/issues/1394) | Clarify event-stream CLI surface versus `tail` and `transcript`. |
-| 2 | [#1395](https://github.com/holon-run/holon/issues/1395) | Track deferred automation convenience additions. |
+| 1 | [#1437](https://github.com/holon-run/holon/issues/1437) | Refresh API/CLI contract inventories after Milestone 8 completion. |
+| 1 | [#1442](https://github.com/holon-run/holon/issues/1442) | Add JSON output schema and golden tests for stable commands. |
+| 2 | [#1438](https://github.com/holon-run/holon/issues/1438) | Migrate OpenAPI baseline to `aide` route/type metadata. |
+| 2 | [#1439](https://github.com/holon-run/holon/issues/1439) | Tighten OpenAPI DTO schemas for stable read models. |
+| 2 | [#1440](https://github.com/holon-run/holon/issues/1440) | Add WorkItem mutation HTTP lifecycle endpoints. |
+| 2 | [#1441](https://github.com/holon-run/holon/issues/1441) | Add Timer cancellation lifecycle endpoint. |
+| 3 | [#1443](https://github.com/holon-run/holon/issues/1443) | Define stable operator-facing event payload subset. |
 
 ## Recommended next contract tests
 
@@ -248,7 +249,10 @@ milestone:
 
 After this CLI inventory is reviewed, continue in this order:
 
-1. Control-plane HTTP endpoints and response schemas used by the CLI.
-2. Runtime message/event/task/work-item envelopes.
-3. Public model-facing tool schemas and result envelopes.
+1. CLI JSON output schemas for stable-candidate commands
+   ([#1442](https://github.com/holon-run/holon/issues/1442)).
+2. Control-plane DTO schemas used by CLI task/work-item/timer commands
+   ([#1439](https://github.com/holon-run/holon/issues/1439)).
+3. Runtime event payload subset used by tail, transcript, replay, and SSE
+   ([#1443](https://github.com/holon-run/holon/issues/1443)).
 4. Rust crate public API, if it is intended to be consumed externally.

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-summary: Holon's current command-line interface — verified against holon --help (v0.14.0).
+summary: Holon's current command-line interface — verified against holon --help.
 order: 10
 ---
 <!-- maintenance: regenerate from `holon --help` output when commands change -->
@@ -16,7 +16,7 @@ For scripting guidance, stability levels, and support policy, see
 ## Command Tree
 
 ```
-holon (v0.14.0)
+holon (v0.14.1)
 ├── serve        Start HTTP control plane server
 ├── daemon       Background daemon lifecycle
 │   ├── start    Start the daemon
@@ -86,10 +86,10 @@ holon (v0.14.0)
 └── help         Print help
 ```
 
-> **Note:** This reference reflects the latest release. If you are running a
-> source build from `main`, some commands or flags may differ. Always run
-> `holon --help` and `holon <COMMAND> --help` for the live command reference
-> of your installed version.
+> **Note:** This reference is maintained from the checked CLI snapshot. If you
+> are running a source build from `main`, some commands or flags may differ.
+> Always run `holon --help` and `holon <COMMAND> --help` for the live command
+> reference of your installed version.
 
 ## Common Workflows
 

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -13,7 +13,7 @@ work items, tasks, queues, wakeups, and user-facing delivery.
 The current generated OpenAPI baseline is checked in at
 [`openapi.json`](./openapi.json). It is a conservative schema for the present
 route surface; some request and response schemas intentionally remain broad
-until the success/error envelope and DTO contracts are stabilized.
+until the Phase 2 route/type metadata and DTO contracts are stabilized.
 
 ## Authentication
 
@@ -113,9 +113,27 @@ Returns recent briefs (acknowledgements and results) for the agent.
 
 Returns active and recent tasks with status, kind, and timing metadata.
 
+**`GET /agents/:id/tasks/:task_id`** — Task status
+
+Returns the structured task lifecycle snapshot for one managed task.
+
+**`GET /agents/:id/tasks/:task_id/output`** — Task output
+
+Returns a bounded task output result. Query parameters:
+
+| Param | Description |
+|-------|-------------|
+| `block` | Whether to wait for output/completion before returning |
+| `timeout_ms` | Optional bounded wait duration when `block=true` |
+
 **`GET /agents/:id/timers`** — Recent timers
 
 Returns recent timer records.
+
+**`GET /agents/:id/timers/:timer_id`** — Timer detail
+
+Returns a single timer record by id, or a shared error envelope when the timer
+is not found for the target agent.
 
 **`GET /agents/:id/events`** — Event log
 
@@ -273,7 +291,7 @@ Response:
 Sends a control action. Request body:
 
 ```json
-{ "action": "stop", "trust": "trusted_operator" }
+{ "action": "stop", "authority_class": "operator_instruction" }
 ```
 
 **`POST /control/agents/:id/current-run/abort`** — Abort current run
@@ -291,7 +309,7 @@ a compatibility alias and is treated as `stop_after_abort`.
 Creates a new agent managed by the host. The agent id comes from the URL path.
 
 ```json
-{ "template": null, "trust": "trusted_operator" }
+{ "template": null, "authority_class": "operator_instruction" }
 ```
 
 **`POST /control/agents/:id/tasks`** — Create command task
@@ -315,7 +333,7 @@ tasks receive stdin or TTY text when they were created with interactive input
 enabled; supervised child-agent tasks receive a follow-up input.
 
 ```json
-{ "text": "continue\n" }
+{ "text": "continue\n", "authority_class": "operator_instruction" }
 ```
 
 **`POST /control/agents/:id/tasks/:task_id/stop`** — Stop task
@@ -324,17 +342,17 @@ Requests cancellation for a managed task and returns the structured task stop
 receipt.
 
 ```json
-{}
+{ "authority_class": "operator_instruction" }
 ```
 
 **`POST /control/agents/:id/work-items`** — Create work item
 
-Creates a durable work item for the agent. Only `objective` is accepted.
+Creates a durable work item for the agent.
 
 ```json
 {
   "objective": "Fix the build",
-  "trust": "trusted_operator"
+  "authority_class": "operator_instruction"
 }
 ```
 
@@ -347,7 +365,7 @@ Creates a timer that will deliver a `TimerTick` to the agent.
   "duration_ms": 60000,
   "interval_ms": null,
   "summary": "reminder",
-  "trust": "trusted_operator"
+  "authority_class": "operator_instruction"
 }
 ```
 
@@ -356,7 +374,7 @@ Creates a timer that will deliver a `TimerTick` to the agent.
 Sends a debug-mode prompt (runtime-internal classification). Request body:
 
 ```json
-{ "text": "debug instruction", "trust": "trusted_operator" }
+{ "text": "debug instruction", "authority_class": "operator_instruction" }
 ```
 
 **`POST /control/agents/:id/operator-bindings`** — Create operator transport binding
@@ -406,7 +424,7 @@ Request body:
 Returns to the agent home workspace. Accepts an optional body:
 
 ```json
-{ "trust": "trusted_operator" }
+{ "authority_class": "operator_instruction" }
 ```
 
 **`POST /control/agents/:id/workspace/detach`** — Detach workspace
@@ -414,7 +432,7 @@ Returns to the agent home workspace. Accepts an optional body:
 Removes a workspace registration without switching. Request body:
 
 ```json
-{ "workspace_id": "ws-abc123", "trust": "trusted_operator" }
+{ "workspace_id": "ws-abc123", "authority_class": "operator_instruction" }
 ```
 
 **`POST /control/agents/:id/model`** — Set agent model
@@ -428,7 +446,7 @@ Removes a workspace registration without switching. Request body:
 Reverts to the default model. Accepts an optional body:
 
 ```json
-{ "trust": "trusted_operator" }
+{ "authority_class": "operator_instruction" }
 ```
 
 ### Runtime management


### PR DESCRIPTION
## Summary
- refresh the API contract inventory after Milestone 8 baseline work
- update CLI contract tracking from the completed Milestone 8 set to Phase 2 follow-up issues
- document newly available task detail/output/input/stop and timer detail routes in the reference docs

Closes #1437

## Verification
- python3 docs/website/.tools/check-links.py
- cargo test --test openapi_snapshot --test http_route_snapshot --test cli_snapshot --test tool_schema_inventory_snapshot
- git diff --check
