### PR TITLE
fix: tighten task lifecycle OpenAPI schemas

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -143,9 +143,1160 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "TaskInputResult": {
+        "properties": {
+          "accepted_input": {
+            "type": "boolean"
+          },
+          "bytes_written": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "input_target": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary_text": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "task": {
+            "properties": {
+              "child_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "child_observability": {
+                "properties": {
+                  "blocked_reason": {
+                    "enum": [
+                      "managed_task_queued",
+                      "managed_task_running",
+                      "managed_task_cancelling",
+                      "awaiting_managed_task",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "current_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "last_progress_brief": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "last_result_brief": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "phase": {
+                    "enum": [
+                      "running",
+                      "blocked",
+                      "waiting",
+                      "terminal"
+                    ],
+                    "type": "string"
+                  },
+                  "waiting_reason": {
+                    "enum": [
+                      "awaiting_operator_input",
+                      "awaiting_external_change",
+                      "awaiting_task_result",
+                      "awaiting_timer",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "work_summary": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "phase"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "child_supervision": {
+                "properties": {
+                  "child_agent_id": {
+                    "type": "string"
+                  },
+                  "child_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cleanup_owner": {
+                    "type": "string"
+                  },
+                  "cleanup_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "delegation_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "followup_target": {
+                    "type": "string"
+                  },
+                  "parent_agent_id": {
+                    "type": "string"
+                  },
+                  "parent_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "supervision_task_id": {
+                    "type": "string"
+                  },
+                  "workspace_mode": {
+                    "enum": [
+                      "inherit",
+                      "worktree",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "worktree": true
+                },
+                "required": [
+                  "parent_agent_id",
+                  "child_agent_id",
+                  "supervision_task_id",
+                  "cleanup_owner",
+                  "followup_target"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "command": {
+                "properties": {
+                  "accepts_input": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "cmd": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cmd_digest": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "exit_status": {
+                    "format": "int32",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "input_target": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "login": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "output_path": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "promoted_from_exec_command": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "result_summary": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "shell": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "terminal_reentry": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "tty": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "workdir": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "parent_message_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "enum": [
+                  "queued",
+                  "running",
+                  "cancelling",
+                  "completed",
+                  "failed",
+                  "cancelled",
+                  "interrupted"
+                ],
+                "type": "string"
+              },
+              "summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "task_id": {
+                "type": "string"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "wait_policy": {
+                "enum": [
+                  "background"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "task_id",
+              "kind",
+              "status",
+              "created_at",
+              "updated_at",
+              "wait_policy"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "task",
+          "accepted_input"
+        ],
+        "title": "TaskInputResult",
+        "type": "object"
+      },
+      "TaskOutputResult": {
+        "properties": {
+          "retrieval_status": {
+            "enum": [
+              "success",
+              "timeout",
+              "not_ready"
+            ],
+            "type": "string"
+          },
+          "task": {
+            "properties": {
+              "artifacts": {
+                "items": {
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "child_supervision": {
+                "properties": {
+                  "child_agent_id": {
+                    "type": "string"
+                  },
+                  "child_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cleanup_owner": {
+                    "type": "string"
+                  },
+                  "cleanup_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "delegation_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "followup_target": {
+                    "type": "string"
+                  },
+                  "parent_agent_id": {
+                    "type": "string"
+                  },
+                  "parent_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "supervision_task_id": {
+                    "type": "string"
+                  },
+                  "workspace_mode": {
+                    "enum": [
+                      "inherit",
+                      "worktree",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "worktree": true
+                },
+                "required": [
+                  "parent_agent_id",
+                  "child_agent_id",
+                  "supervision_task_id",
+                  "cleanup_owner",
+                  "followup_target"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "exit_status": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "failure_artifact": {
+                "properties": {
+                  "category": {
+                    "enum": [
+                      "transport",
+                      "protocol",
+                      "runtime",
+                      "task",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "exit_status": {
+                    "format": "int32",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "model_ref": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "provider": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_chain": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "status": {
+                    "format": "uint16",
+                    "maximum": 65535,
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "summary": {
+                    "type": "string"
+                  },
+                  "task_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "category",
+                  "kind",
+                  "summary"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "kind": {
+                "type": "string"
+              },
+              "output_artifact": {
+                "format": "uint",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "output_preview": {
+                "type": "string"
+              },
+              "output_truncated": {
+                "type": "boolean"
+              },
+              "result_summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "enum": [
+                  "queued",
+                  "running",
+                  "cancelling",
+                  "completed",
+                  "failed",
+                  "cancelled",
+                  "interrupted"
+                ],
+                "type": "string"
+              },
+              "summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "task_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "task_id",
+              "kind",
+              "status",
+              "output_preview",
+              "output_truncated"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "retrieval_status",
+          "task"
+        ],
+        "title": "TaskOutputResult",
+        "type": "object"
+      },
+      "TaskStatusSnapshot": {
+        "properties": {
+          "child_agent_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "child_observability": {
+            "properties": {
+              "blocked_reason": {
+                "enum": [
+                  "managed_task_queued",
+                  "managed_task_running",
+                  "managed_task_cancelling",
+                  "awaiting_managed_task",
+                  null
+                ],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "current_work_item_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "last_progress_brief": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "last_result_brief": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "phase": {
+                "enum": [
+                  "running",
+                  "blocked",
+                  "waiting",
+                  "terminal"
+                ],
+                "type": "string"
+              },
+              "waiting_reason": {
+                "enum": [
+                  "awaiting_operator_input",
+                  "awaiting_external_change",
+                  "awaiting_task_result",
+                  "awaiting_timer",
+                  null
+                ],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "work_summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "phase"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "child_supervision": {
+            "properties": {
+              "child_agent_id": {
+                "type": "string"
+              },
+              "child_work_item_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "cleanup_owner": {
+                "type": "string"
+              },
+              "cleanup_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "delegation_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "followup_target": {
+                "type": "string"
+              },
+              "parent_agent_id": {
+                "type": "string"
+              },
+              "parent_work_item_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "supervision_task_id": {
+                "type": "string"
+              },
+              "workspace_mode": {
+                "enum": [
+                  "inherit",
+                  "worktree",
+                  null
+                ],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "worktree": true
+            },
+            "required": [
+              "parent_agent_id",
+              "child_agent_id",
+              "supervision_task_id",
+              "cleanup_owner",
+              "followup_target"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "command": {
+            "properties": {
+              "accepts_input": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "cmd": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "cmd_digest": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "exit_status": {
+                "format": "int32",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "input_target": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "login": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "output_path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "promoted_from_exec_command": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "result_summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "shell": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "terminal_reentry": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "tty": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "workdir": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "parent_message_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "queued",
+              "running",
+              "cancelling",
+              "completed",
+              "failed",
+              "cancelled",
+              "interrupted"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "task_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "wait_policy": {
+            "enum": [
+              "background"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "task_id",
+          "kind",
+          "status",
+          "created_at",
+          "updated_at",
+          "wait_policy"
+        ],
+        "title": "TaskStatusSnapshot",
+        "type": "object"
+      },
       "TaskStopRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "TaskStopResult": {
+        "properties": {
+          "force_stop_requested": {
+            "type": "boolean"
+          },
+          "stop_requested": {
+            "type": "boolean"
+          },
+          "summary_text": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "task": {
+            "properties": {
+              "child_agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "child_observability": {
+                "properties": {
+                  "blocked_reason": {
+                    "enum": [
+                      "managed_task_queued",
+                      "managed_task_running",
+                      "managed_task_cancelling",
+                      "awaiting_managed_task",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "current_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "last_progress_brief": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "last_result_brief": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "phase": {
+                    "enum": [
+                      "running",
+                      "blocked",
+                      "waiting",
+                      "terminal"
+                    ],
+                    "type": "string"
+                  },
+                  "waiting_reason": {
+                    "enum": [
+                      "awaiting_operator_input",
+                      "awaiting_external_change",
+                      "awaiting_task_result",
+                      "awaiting_timer",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "work_summary": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "phase"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "child_supervision": {
+                "properties": {
+                  "child_agent_id": {
+                    "type": "string"
+                  },
+                  "child_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cleanup_owner": {
+                    "type": "string"
+                  },
+                  "cleanup_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "delegation_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "followup_target": {
+                    "type": "string"
+                  },
+                  "parent_agent_id": {
+                    "type": "string"
+                  },
+                  "parent_work_item_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "supervision_task_id": {
+                    "type": "string"
+                  },
+                  "workspace_mode": {
+                    "enum": [
+                      "inherit",
+                      "worktree",
+                      null
+                    ],
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "worktree": true
+                },
+                "required": [
+                  "parent_agent_id",
+                  "child_agent_id",
+                  "supervision_task_id",
+                  "cleanup_owner",
+                  "followup_target"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "command": {
+                "properties": {
+                  "accepts_input": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "cmd": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cmd_digest": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "exit_status": {
+                    "format": "int32",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "input_target": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "login": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "output_path": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "promoted_from_exec_command": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "result_summary": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "shell": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "terminal_reentry": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "tty": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "workdir": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "parent_message_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "enum": [
+                  "queued",
+                  "running",
+                  "cancelling",
+                  "completed",
+                  "failed",
+                  "cancelled",
+                  "interrupted"
+                ],
+                "type": "string"
+              },
+              "summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "task_id": {
+                "type": "string"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "wait_policy": {
+                "enum": [
+                  "background"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "task_id",
+              "kind",
+              "status",
+              "created_at",
+              "updated_at",
+              "wait_policy"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "task",
+          "stop_requested",
+          "force_stop_requested"
+        ],
+        "title": "TaskStopResult",
         "type": "object"
       },
       "UninstallSkillRequest": {
@@ -769,11 +1920,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/TaskStatusSnapshot"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {
@@ -836,11 +1987,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/TaskOutputResult"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {
@@ -2283,11 +3434,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/TaskInputResult"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {
@@ -2360,11 +3511,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/TaskStopResult"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -298,7 +298,98 @@
                       "null"
                     ]
                   },
-                  "worktree": true
+                  "worktree": {
+                    "properties": {
+                      "actual_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "auto_cleaned_up": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "branch_cleanup_error": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "branch_cleanup_status": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "changed_files": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "cleanup_error": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cleanup_reason": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cleanup_status": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "original_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "original_cwd": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "projection_kind": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "retained_for_review": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "worktree_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "worktree_path": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  }
                 },
                 "required": [
                   "parent_agent_id",
@@ -540,7 +631,98 @@
                       "null"
                     ]
                   },
-                  "worktree": true
+                  "worktree": {
+                    "properties": {
+                      "actual_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "auto_cleaned_up": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "branch_cleanup_error": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "branch_cleanup_status": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "changed_files": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "cleanup_error": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cleanup_reason": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cleanup_status": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "original_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "original_cwd": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "projection_kind": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "retained_for_review": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "worktree_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "worktree_path": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  }
                 },
                 "required": [
                   "parent_agent_id",
@@ -828,7 +1010,98 @@
                   "null"
                 ]
               },
-              "worktree": true
+              "worktree": {
+                "properties": {
+                  "actual_branch": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "auto_cleaned_up": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "branch_cleanup_error": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "branch_cleanup_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "changed_files": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "cleanup_error": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cleanup_reason": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cleanup_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "original_branch": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "original_cwd": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "projection_kind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "retained_for_review": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "worktree_branch": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "worktree_path": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
             },
             "required": [
               "parent_agent_id",
@@ -1134,7 +1407,98 @@
                       "null"
                     ]
                   },
-                  "worktree": true
+                  "worktree": {
+                    "properties": {
+                      "actual_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "auto_cleaned_up": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "branch_cleanup_error": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "branch_cleanup_status": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "changed_files": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "cleanup_error": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cleanup_reason": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cleanup_status": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "original_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "original_cwd": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "projection_kind": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "retained_for_review": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "worktree_branch": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "worktree_path": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  }
                 },
                 "required": [
                   "parent_agent_id",

--- a/src/http.rs
+++ b/src/http.rs
@@ -61,8 +61,9 @@ use crate::{
         MessageOrigin, OperatorNotificationRecord, OperatorTransportBinding,
         OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskRecord,
-        TaskStatus, TaskStopResult, TimerRecord, TurnTerminalRecord, WaitingIntentRecord,
-        WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord, WorktreeSession,
+        TaskStatus, TaskStatusSnapshot, TaskStopResult, TimerRecord, TurnTerminalRecord,
+        WaitingIntentRecord, WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord,
+        WorktreeSession,
     },
 };
 
@@ -1925,13 +1926,14 @@ pub async fn task_stop(
         .and_then(|detail| detail.get("force_stop_requested"))
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let snapshot = TaskStatusSnapshot::from_task_record(&task);
     let result = TaskStopResult {
         summary_text: Some(match task.status {
             TaskStatus::Cancelling => format!("stop requested for task {}", task.id),
             TaskStatus::Cancelled => format!("cancelled task {}", task.id),
             _ => format!("updated task {}", task.id),
         }),
-        task,
+        task: snapshot,
         stop_requested: true,
         force_stop_requested,
     };

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -2,7 +2,10 @@ use aide::{
     axum::{routing::ApiMethodDocs, ApiRouter},
     openapi::{OpenApi, Operation},
 };
+use schemars::{generate::SchemaSettings, JsonSchema};
 use serde_json::{json, Value};
+
+use crate::types::{TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult};
 
 const API_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -15,6 +18,7 @@ struct RouteSpec {
     summary: &'static str,
     description: &'static str,
     request_schema: Option<&'static str>,
+    response_schema: Option<&'static str>,
     response_kind: ResponseKind,
     auth: AuthKind,
     metadata_source: MetadataSource,
@@ -57,10 +61,10 @@ const ROUTES: &[RouteSpec] = &[
     event_stream_route("get", "/agents/{agent_id}/events/stream", "agentEventsStream", "events", "Agent event stream", "Return Server-Sent Events carrying StreamEventEnvelope JSON data. Query parameters: after_seq, limit, projection. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens.", None, AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/transcript", "agentTranscript", "agents", "Recent transcript", "Return recent transcript entries. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/tasks", "agentTasks", "tasks", "List active tasks", "Return active task records. Query parameter: limit.", None, AuthKind::RemoteAccess),
-    route("get", "/agents/{agent_id}/tasks/{task_id}", "agentTaskStatus", "tasks", "Task status", "Return a task lifecycle snapshot by id.", None, AuthKind::RemoteAccess),
-    route("get", "/agents/{agent_id}/tasks/{task_id}/output", "agentTaskOutput", "tasks", "Task output", "Return a task output snapshot. Query parameters: block, timeout_ms.", None, AuthKind::RemoteAccess),
-    route("post", "/control/agents/{agent_id}/tasks/{task_id}/input", "taskInput", "control", "Task input", "Deliver text input to a managed task.", Some("TaskInputRequest"), AuthKind::Control),
-    route("post", "/control/agents/{agent_id}/tasks/{task_id}/stop", "taskStop", "control", "Task stop", "Request cancellation for a managed task.", Some("TaskStopRequest"), AuthKind::Control),
+    route_with_response("get", "/agents/{agent_id}/tasks/{task_id}", "agentTaskStatus", "tasks", "Task status", "Return a task lifecycle snapshot by id.", None, "TaskStatusSnapshot", AuthKind::RemoteAccess),
+    route_with_response("get", "/agents/{agent_id}/tasks/{task_id}/output", "agentTaskOutput", "tasks", "Task output", "Return a task output snapshot. Query parameters: block, timeout_ms.", None, "TaskOutputResult", AuthKind::RemoteAccess),
+    route_with_response("post", "/control/agents/{agent_id}/tasks/{task_id}/input", "taskInput", "control", "Task input", "Deliver text input to a managed task.", Some("TaskInputRequest"), "TaskInputResult", AuthKind::Control),
+    route_with_response("post", "/control/agents/{agent_id}/tasks/{task_id}/stop", "taskStop", "control", "Task stop", "Request cancellation for a managed task.", Some("TaskStopRequest"), "TaskStopResult", AuthKind::Control),
     route("get", "/agents/{agent_id}/work-items", "agentWorkItems", "work-items", "List work items", "Return latest work item records for the agent. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/work-items/{work_item_id}", "agentWorkItem", "work-items", "Work item detail", "Return a work item record by id.", None, AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/worktree-summary", "agentWorktreeSummary", "agents", "Worktree summary", "Return managed worktree summary for an agent.", None, AuthKind::RemoteAccess),
@@ -118,6 +122,33 @@ const fn route(
         summary,
         description,
         request_schema,
+        response_schema: None,
+        response_kind: ResponseKind::Json,
+        auth,
+        metadata_source: MetadataSource::Manual,
+    }
+}
+
+const fn route_with_response(
+    method: &'static str,
+    path: &'static str,
+    operation_id: &'static str,
+    tag: &'static str,
+    summary: &'static str,
+    description: &'static str,
+    request_schema: Option<&'static str>,
+    response_schema: &'static str,
+    auth: AuthKind,
+) -> RouteSpec {
+    RouteSpec {
+        method,
+        path,
+        operation_id,
+        tag,
+        summary,
+        description,
+        request_schema,
+        response_schema: Some(response_schema),
         response_kind: ResponseKind::Json,
         auth,
         metadata_source: MetadataSource::Manual,
@@ -142,6 +173,7 @@ const fn aide_route(
         summary,
         description,
         request_schema,
+        response_schema: None,
         response_kind: ResponseKind::Json,
         auth,
         metadata_source: MetadataSource::Aide,
@@ -166,6 +198,7 @@ const fn event_stream_route(
         summary,
         description,
         request_schema,
+        response_schema: None,
         response_kind: ResponseKind::EventStream,
         auth,
         metadata_source: MetadataSource::Manual,
@@ -285,7 +318,7 @@ fn operation(spec: &RouteSpec) -> Value {
         "summary": spec.summary,
         "description": spec.description,
         "parameters": path_parameters(spec.path),
-        "responses": responses(spec.response_kind),
+        "responses": responses(spec.response_kind, spec.response_schema),
     });
     if let Some(schema) = spec.request_schema {
         op["requestBody"] = json!({
@@ -340,22 +373,33 @@ fn path_param(name: &str, description: &str) -> Value {
     })
 }
 
-fn responses(kind: ResponseKind) -> Value {
+fn responses(kind: ResponseKind, response_schema: Option<&str>) -> Value {
     match kind {
-        ResponseKind::Json => json!({
-            "200": {
-                "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized.",
-                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JsonValue" } } }
-            },
-            "4XX": {
-                "description": "Client error JSON response.",
-                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
-            },
-            "5XX": {
-                "description": "Server error JSON response.",
-                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
-            }
-        }),
+        ResponseKind::Json => {
+            let success_description = if response_schema.is_some() {
+                "Successful JSON response using a stable DTO schema."
+            } else {
+                "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            };
+            let success_schema = response_schema
+                .map(|schema| json!({ "$ref": format!("#/components/schemas/{schema}") }))
+                .unwrap_or_else(|| json!({ "$ref": "#/components/schemas/JsonValue" }));
+
+            json!({
+                "200": {
+                    "description": success_description,
+                    "content": { "application/json": { "schema": success_schema } }
+                },
+                "4XX": {
+                    "description": "Client error JSON response.",
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+                },
+                "5XX": {
+                    "description": "Server error JSON response.",
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+                }
+            })
+        }
         ResponseKind::EventStream => json!({
             "200": {
                 "description": "Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object.",
@@ -403,6 +447,22 @@ fn component_schemas() -> Value {
     schemas.insert("CallbackBody".into(), json!({
         "description": "Raw callback request body. JSON and text bodies are parsed; other content types are represented internally as base64 JSON."
     }));
+    schemas.insert(
+        "TaskStatusSnapshot".into(),
+        component_schema::<TaskStatusSnapshot>(),
+    );
+    schemas.insert(
+        "TaskOutputResult".into(),
+        component_schema::<TaskOutputResult>(),
+    );
+    schemas.insert(
+        "TaskInputResult".into(),
+        component_schema::<TaskInputResult>(),
+    );
+    schemas.insert(
+        "TaskStopResult".into(),
+        component_schema::<TaskStopResult>(),
+    );
     for name in [
         "EnqueueRequest",
         "IncomingOrigin",
@@ -430,6 +490,20 @@ fn component_schemas() -> Value {
         schemas.insert(name.into(), request_schema.clone());
     }
     Value::Object(schemas)
+}
+
+fn component_schema<T: JsonSchema>() -> Value {
+    let schema = SchemaSettings::draft07()
+        .with(|settings| {
+            settings.inline_subschemas = true;
+        })
+        .into_generator()
+        .into_root_schema_for::<T>();
+    let mut value = serde_json::to_value(schema).expect("serialize OpenAPI component schema");
+    if let Some(object) = value.as_object_mut() {
+        object.remove("$schema");
+    }
+    value
 }
 
 #[cfg(test)]

--- a/src/tool/tools/task_stop.rs
+++ b/src/tool/tools/task_stop.rs
@@ -48,6 +48,7 @@ pub(crate) async fn execute(
         .and_then(|detail| detail.get("force_stop_requested"))
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let snapshot = crate::types::TaskStatusSnapshot::from_task_record(&task);
     serialize_success(
         NAME,
         &TaskStopResult {
@@ -56,7 +57,7 @@ pub(crate) async fn execute(
                 TaskStatus::Cancelled => format!("cancelled task {}", task.id),
                 _ => format!("updated task {}", task.id),
             }),
-            task,
+            task: snapshot,
             stop_requested: true,
             force_stop_requested,
         },

--- a/src/types.rs
+++ b/src/types.rs
@@ -2495,11 +2495,71 @@ pub struct ChildSupervisionProjection {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_mode: Option<ChildAgentWorkspaceMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub worktree: Option<Value>,
+    pub worktree: Option<ChildSupervisionWorktreeProjection>,
     pub cleanup_owner: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cleanup_status: Option<String>,
     pub followup_target: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
+pub struct ChildSupervisionWorktreeProjection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_cleaned_up: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retained_for_review: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_cleanup_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_cleanup_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual_branch: Option<String>,
+}
+
+impl ChildSupervisionWorktreeProjection {
+    fn from_value(value: &Value) -> Self {
+        Self {
+            worktree_path: value_string(value, "worktree_path"),
+            worktree_branch: value_string(value, "worktree_branch"),
+            projection_kind: value_string(value, "projection_kind"),
+            original_cwd: value_string(value, "original_cwd"),
+            original_branch: value_string(value, "original_branch"),
+            changed_files: value
+                .get("changed_files")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect(),
+            cleanup_status: value_string(value, "cleanup_status"),
+            cleanup_reason: value_string(value, "cleanup_reason"),
+            cleanup_error: value_string(value, "cleanup_error"),
+            auto_cleaned_up: value.get("auto_cleaned_up").and_then(Value::as_bool),
+            retained_for_review: value.get("retained_for_review").and_then(Value::as_bool),
+            branch_cleanup_status: value_string(value, "branch_cleanup_status"),
+            branch_cleanup_error: value_string(value, "branch_cleanup_error"),
+            actual_branch: value_string(value, "actual_branch"),
+        }
+    }
 }
 
 impl ChildSupervisionProjection {
@@ -2523,7 +2583,9 @@ impl ChildSupervisionProjection {
             child_work_item_id: None,
             delegation_id: None,
             workspace_mode: task.child_agent_workspace_mode(),
-            worktree,
+            worktree: worktree
+                .as_ref()
+                .map(ChildSupervisionWorktreeProjection::from_value),
             cleanup_owner: "supervision_task".into(),
             cleanup_status,
             followup_target: "parent_supervisor".into(),
@@ -2909,6 +2971,13 @@ fn task_detail_i32(detail: &Option<Value>, key: &str) -> Option<i32> {
 
 fn task_detail_value<'a>(detail: &'a Option<Value>, key: &str) -> Option<&'a Value> {
     detail.as_ref().and_then(|detail| detail.get(key))
+}
+
+fn value_string(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
 }
 
 impl TaskRecoverySpec {

--- a/src/types.rs
+++ b/src/types.rs
@@ -675,7 +675,7 @@ pub struct WorkReactivationSignal {
     pub reactivation_mode: WorkReactivationMode,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WaitingReason {
     AwaitingOperatorInput,
@@ -738,7 +738,7 @@ pub struct ClosureDecision {
     pub evidence: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskWaitPolicy {
     Background,
@@ -748,7 +748,7 @@ pub const CHILD_AGENT_TASK_KIND: &str = "child_agent_task";
 pub const LEGACY_SUBAGENT_TASK_KIND: &str = "subagent_task";
 pub const LEGACY_WORKTREE_SUBAGENT_TASK_KIND: &str = "worktree_subagent_task";
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskKind {
     CommandTask,
@@ -787,7 +787,7 @@ impl std::fmt::Display for TaskKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ChildAgentWorkspaceMode {
     Inherit,
@@ -1207,7 +1207,7 @@ pub enum RuntimeFailurePhase {
     RuntimeTurn,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum FailureArtifactCategory {
     Transport,
@@ -1217,7 +1217,7 @@ pub enum FailureArtifactCategory {
     Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct FailureArtifact {
     pub category: FailureArtifactCategory,
     pub kind: String,
@@ -2194,7 +2194,7 @@ pub struct OperatorDeliveryRecord {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
     Queued,
@@ -2206,7 +2206,7 @@ pub enum TaskStatus {
     Interrupted,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct TaskHandle {
     pub task_id: String,
     pub task_kind: String,
@@ -2240,7 +2240,7 @@ impl TaskHandle {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ChildAgentPhase {
     Running,
@@ -2249,7 +2249,7 @@ pub enum ChildAgentPhase {
     Terminal,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ChildAgentBlockedReason {
     ManagedTaskQueued,
@@ -2258,7 +2258,7 @@ pub enum ChildAgentBlockedReason {
     AwaitingManagedTask,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct ChildAgentObservabilitySnapshot {
     pub phase: ChildAgentPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2362,19 +2362,20 @@ impl TaskRecord {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TaskListEntry {
     pub id: String,
     pub kind: String,
     pub status: TaskStatus,
     pub summary: Option<String>,
+    #[schemars(schema_with = "datetime_schema")]
     pub updated_at: DateTime<Utc>,
     pub wait_policy: TaskWaitPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<CommandTaskStatusSnapshot>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct CommandTaskStatusSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cmd: Option<String>,
@@ -2480,7 +2481,7 @@ impl CommandTaskStatusSnapshot {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct ChildSupervisionProjection {
     pub parent_agent_id: String,
     pub child_agent_id: String,
@@ -2537,14 +2538,16 @@ impl ChildSupervisionProjection {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TaskStatusSnapshot {
     pub task_id: String,
     pub kind: String,
     pub status: TaskStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+    #[schemars(schema_with = "datetime_schema")]
     pub created_at: DateTime<Utc>,
+    #[schemars(schema_with = "datetime_schema")]
     pub updated_at: DateTime<Utc>,
     pub wait_policy: TaskWaitPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2584,7 +2587,7 @@ impl TaskStatusSnapshot {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskOutputRetrievalStatus {
     Success,
@@ -2592,7 +2595,7 @@ pub enum TaskOutputRetrievalStatus {
     NotReady,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TaskOutputSnapshot {
     pub task_id: String,
     pub kind: String,
@@ -2612,7 +2615,7 @@ pub struct TaskOutputSnapshot {
     pub child_supervision: Option<ChildSupervisionProjection>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TaskOutputResult {
     pub retrieval_status: TaskOutputRetrievalStatus,
     pub task: TaskOutputSnapshot,
@@ -2720,19 +2723,19 @@ pub struct ExecCommandBatchResult {
     pub summary_text: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct ToolArtifactRef {
     pub path: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TaskStatusResult {
     pub task: TaskStatusSnapshot,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_text: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TaskInputResult {
     pub task: TaskStatusSnapshot,
     pub accepted_input: bool,
@@ -2838,13 +2841,20 @@ pub struct UseWorkspaceResult {
     pub summary_text: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct TaskStopResult {
-    pub task: TaskRecord,
+    pub task: TaskStatusSnapshot,
     pub stop_requested: bool,
     pub force_stop_requested: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_text: Option<String>,
+}
+
+fn datetime_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "string",
+        "format": "date-time"
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -441,7 +441,7 @@ pub async fn task_input_and_stop_routes_manage_task_lifecycle() -> Result<()> {
         .await?
         .json()
         .await?;
-    assert_eq!(stop["task"]["id"], stop_task_id);
+    assert_eq!(stop["task"]["task_id"], stop_task_id);
     assert_eq!(stop["stop_requested"], true);
 
     let missing = client


### PR DESCRIPTION
## Summary
- add typed OpenAPI response schemas for task status/output/input/stop lifecycle DTOs
- derive JsonSchema for task lifecycle read models and supporting enums/projections
- return TaskStatusSnapshot from task stop results to keep the stable client contract free of full internal TaskRecord shape
- refresh the checked-in OpenAPI snapshot

Closes #1439

## Verification
- cargo fmt --all -- --check
- cargo test --test openapi_snapshot
- cargo test --test http_tasks
- RUSTFLAGS="-D warnings" cargo check --all-targets
