### PR TITLE
fix: ExecCommandBatch schema cleanup + MemoryGet cross-workspace lookup (#1451, #1454)

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -917,7 +917,7 @@
       "stability": "stable"
     },
     {
-      "description": "Run a bounded sequential batch of ExecCommand-like startup requests and return one grouped receipt. Each item supports cmd plus optional workdir, shell, login, yield_time_ms, and max_output_tokens. Per-item yield_time_ms defaults to 10_000 ms when omitted; set it only when intentionally changing that item's foreground wait window. Do not use tty, accepts_input, or non-command tools inside the batch.",
+      "description": "Run a bounded sequential batch of ExecCommand-like startup requests and return one grouped receipt. Each item supports cmd plus optional workdir, shell, login, yield_time_ms, and max_output_tokens. Per-item yield_time_ms defaults to 10_000 ms when omitted; set it only when intentionally changing that item's foreground wait window. Do not use non-command tools inside the batch.",
       "family": "local_environment",
       "freeform_grammar": null,
       "input_schema": {
@@ -927,12 +927,6 @@
             "items": {
               "additionalProperties": false,
               "properties": {
-                "accepts_input": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
                 "cmd": {
                   "type": "string"
                 },
@@ -953,12 +947,6 @@
                 "shell": {
                   "type": [
                     "string",
-                    "null"
-                  ]
-                },
-                "tty": {
-                  "type": [
-                    "boolean",
                     "null"
                   ]
                 },

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -384,12 +384,11 @@ impl MemoryIndex {
         &self,
         source_ref: &str,
         max_chars: Option<usize>,
-        active_workspace_id: Option<&str>,
+        _active_workspace_id: Option<&str>,
     ) -> Result<Option<MemoryGetResult>> {
         let max_chars = max_chars
             .unwrap_or(GET_CHARS_DEFAULT)
             .clamp(1, GET_CHARS_MAX);
-        let workspace_filter = active_workspace_id.map(ToString::to_string);
         self.connection
             .query_row(
                 r#"
@@ -397,9 +396,8 @@ impl MemoryIndex {
                        title, original_body, metadata_json, updated_at
                 FROM memory_documents
                 WHERE source_ref = ?1
-                  AND (scope_kind = 'agent' OR (?2 IS NOT NULL AND workspace_id = ?2))
                 "#,
-                params![source_ref, workspace_filter],
+                params![source_ref],
                 |row| {
                     let content: String = row.get(7)?;
                     let metadata_json: String = row.get(8)?;
@@ -1199,14 +1197,15 @@ mod tests {
         assert_eq!(memory.content, "runtime exact evidence body");
         assert!(!memory.truncated);
 
-        assert!(
-            get_memory(&storage, &other_brief_ref, None, Some("ws-holon"))
-                .unwrap()
-                .is_none()
-        );
+        // source_ref is globally unique; MemoryGet resolves it regardless of
+        // active workspace (fixes #1454).
+        let other = get_memory(&storage, &other_brief_ref, None, Some("ws-holon"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(other.content, "other workspace exact evidence");
         assert!(get_memory(&storage, &brief_ref, None, None)
             .unwrap()
-            .is_none());
+            .is_some());
     }
 
     #[test]

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -39,8 +39,6 @@ pub(crate) struct ExecCommandBatchItemArgs {
     pub(crate) login: Option<bool>,
     pub(crate) yield_time_ms: Option<u64>,
     pub(crate) max_output_tokens: Option<u64>,
-    pub(crate) tty: Option<bool>,
-    pub(crate) accepts_input: Option<bool>,
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
@@ -48,7 +46,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::LocalEnvironment,
         spec: crate::tool::spec::typed_spec::<ExecCommandBatchArgs>(
             NAME,
-            "Run a bounded sequential batch of ExecCommand-like startup requests and return one grouped receipt. Each item supports cmd plus optional workdir, shell, login, yield_time_ms, and max_output_tokens. Per-item yield_time_ms defaults to 10_000 ms when omitted; set it only when intentionally changing that item's foreground wait window. Do not use tty, accepts_input, or non-command tools inside the batch.",
+            "Run a bounded sequential batch of ExecCommand-like startup requests and return one grouped receipt. Each item supports cmd plus optional workdir, shell, login, yield_time_ms, and max_output_tokens. Per-item yield_time_ms defaults to 10_000 ms when omitted; set it only when intentionally changing that item's foreground wait window. Do not use non-command tools inside the batch.",
         )?,
     })
 }
@@ -163,18 +161,6 @@ async fn execute_batch_item(
 ) -> ExecCommandBatchItemResult {
     let started = Instant::now();
     let cmd = item.cmd.clone();
-    if let Some(error) = rejected_item_error(&item) {
-        return ExecCommandBatchItemResult {
-            index,
-            cmd,
-            status: ExecCommandBatchItemStatus::Rejected,
-            result: None,
-            error_kind: Some(error.kind),
-            error_message: Some(error.message),
-            duration_ms: Some(started.elapsed().as_millis() as u64),
-        };
-    }
-
     let spec = CommandTaskSpec {
         cmd: item.cmd,
         workdir: item.workdir,
@@ -224,31 +210,6 @@ async fn execute_batch_item(
             }
         }
     }
-}
-
-fn rejected_item_error(item: &ExecCommandBatchItemArgs) -> Option<ToolError> {
-    let field = if item.tty.is_some() {
-        Some("tty")
-    } else if item.accepts_input.is_some() {
-        Some("accepts_input")
-    } else {
-        None
-    }?;
-
-    Some(
-        ToolError::new(
-            "unsupported_batch_command_field",
-            format!("{NAME} items do not support `{field}`"),
-        )
-        .with_details(json!({
-            "field": field,
-            "reason": "batch command items cannot request interactive or command-task continuation semantics",
-        }))
-        .with_recovery_hint(format!(
-            "call ExecCommand directly when you need `{field}`"
-        ))
-        .with_retryable(false),
-    )
 }
 
 pub(crate) fn render_for_model(result: &ToolResult) -> Result<String> {
@@ -348,39 +309,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rejects_command_task_fields_in_items() {
-        let item = ExecCommandBatchItemArgs {
-            cmd: "python -i".into(),
-            workdir: None,
-            shell: None,
-            login: None,
-            yield_time_ms: None,
-            max_output_tokens: None,
-            tty: Some(true),
-            accepts_input: None,
+    fn rejects_unknown_fields_in_items() {
+        // tty is not a valid field on ExecCommandBatchItemArgs; serde deny_unknown_fields
+        // should reject it at parse time.
+        let input = serde_json::json!({
+            "items": [{
+                "cmd": "echo hello",
+                "tty": true
+            }]
+        });
+        let err = match serde_json::from_value::<ExecCommandBatchArgs>(input) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("tty should cause deserialization failure"),
         };
+        assert!(err.contains("tty"), "error should mention tty: {err}");
 
-        let error = rejected_item_error(&item).expect("tty should be rejected");
-        assert_eq!(error.kind, "unsupported_batch_command_field");
-        assert!(error.message.contains("tty"));
-
-        let item = ExecCommandBatchItemArgs {
-            cmd: "python -i".into(),
-            workdir: None,
-            shell: None,
-            login: None,
-            yield_time_ms: None,
-            max_output_tokens: None,
-            tty: None,
-            accepts_input: Some(true),
+        // Same for accepts_input
+        let input = serde_json::json!({
+            "items": [{
+                "cmd": "echo hello",
+                "accepts_input": true
+            }]
+        });
+        let err = match serde_json::from_value::<ExecCommandBatchArgs>(input) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("accepts_input should cause deserialization failure"),
         };
-        let error = rejected_item_error(&item).expect("accepts_input should be rejected");
-        assert_eq!(error.kind, "unsupported_batch_command_field");
-        assert!(error.message.contains("accepts_input"));
-        assert!(error
-            .recovery_hint
-            .as_deref()
-            .is_some_and(|hint| hint == "call ExecCommand directly when you need `accepts_input`"));
+        assert!(
+            err.contains("accepts_input"),
+            "error should mention accepts_input: {err}"
+        );
     }
 
     #[test]

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -633,10 +633,6 @@ pub async fn exec_command_batch_returns_grouped_item_results() -> Result<()> {
                             "login": false
                         },
                         {
-                            "cmd": "python -i",
-                            "tty": true
-                        },
-                        {
                             "cmd": format!("printf '{}'", long_stdout),
                             "login": false,
                             "max_output_tokens": 20
@@ -654,10 +650,10 @@ pub async fn exec_command_batch_returns_grouped_item_results() -> Result<()> {
     let envelope = parse_tool_result_value(&result)?;
     let value = &envelope["result"];
     assert_eq!(envelope["tool_name"], "ExecCommandBatch");
-    assert_eq!(value["item_count"], 4);
+    assert_eq!(value["item_count"], 3);
     assert_eq!(value["completed_count"], 2);
     assert_eq!(value["failed_count"], 1);
-    assert_eq!(value["rejected_count"], 1);
+    assert_eq!(value["rejected_count"], 0);
     assert_eq!(value["skipped_count"], 0);
     assert_eq!(value["items"][0]["status"], "completed");
     assert_eq!(value["items"][0]["result"]["exit_status"], 0);
@@ -667,17 +663,12 @@ pub async fn exec_command_batch_returns_grouped_item_results() -> Result<()> {
     );
     assert_eq!(value["items"][1]["status"], "failed");
     assert_eq!(value["items"][1]["result"]["exit_status"], 7);
-    assert_eq!(value["items"][2]["status"], "rejected");
-    assert_eq!(
-        value["items"][2]["error_kind"],
-        "unsupported_batch_command_field"
-    );
-    assert!(value["items"][3]["result"]["stdout_preview"]
+    assert!(value["items"][2]["result"]["stdout_preview"]
         .as_str()
         .expect("stdout preview")
         .contains("[output truncated"));
     assert_eq!(
-        value["items"][3]["result"]["command_diagnostics"]["effective_max_output_tokens"],
+        value["items"][2]["result"]["command_diagnostics"]["effective_max_output_tokens"],
         20
     );
     assert!(


### PR DESCRIPTION
Two fixes for milestone v0.15.0.

## #1451 ExecCommandBatch: remove tty/accepts_input from item struct

**Problem**: `ExecCommandBatchItemArgs` includes `tty` and `accepts_input` fields. The auto-generated JSON Schema exposes them as optional fields, causing models to use them even though the runtime rejects them. The prose warning in the tool description is a soft constraint that LLMs ignore when the structured schema says otherwise.

**Fix**: Remove `tty` and `accepts_input` from the struct. With `#[serde(deny_unknown_fields)]`, serde now rejects these fields at parse time with a clear "unknown field" error — the schema becomes the single source of truth.

- Remove `rejected_item_error` function (no longer needed)
- Update tool description to remove the soft prose warning
- Replace old runtime-rejection test with deserialization-rejection test

## #1454 MemoryGet: resolve source_ref regardless of active workspace

**Problem**: `MemorySearch` with `include_all_workspaces: true` returns cross-workspace results, but `MemoryGet` always filters by active workspace. Using a search result's `source_ref` from a different workspace causes `memory_source_not_found`.

**Fix**: Remove workspace filter from `MemoryIndex::get()` SQL query. Since `source_ref` is the primary key and globally unique, workspace filtering is unnecessary for point lookups.

- Update test to reflect new cross-workspace resolution behavior

## Verification
- `cargo fmt --all` ✓
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✓
- `cargo test -- rejects_unknown_fields_in_items` ✓
- `cargo test -- memory_get_returns_exact_markdown_and_runtime_source_content` ✓