### PR TITLE
feat: add WorkItem mutation HTTP endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "indexmap",
  "ref-cast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = "0.12", features = ["gzip", "json", "rustls-tls"], default
 rusqlite = { version = "0.31", features = ["bundled"] }
 pulldown-cmark = "0.13"
 portable-pty = "0.9"
-schemars = "0.9"
+schemars = { version = "0.9", features = ["chrono04"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/docs/website/guides/integration.md
+++ b/docs/website/guides/integration.md
@@ -52,6 +52,9 @@ Access modes: `local`, `tunnel`, `lan`, `tailnet`.
 |--------|------|-------------|
 | `POST` | `/control/agents/:agent_id/tasks` | Create a command task |
 | `POST` | `/control/agents/:agent_id/work-items` | Create a work item |
+| `POST` | `/control/agents/:agent_id/work-items/:work_item_id/pick` | Pick the current work item |
+| `PATCH` | `/control/agents/:agent_id/work-items/:work_item_id` | Update a work item |
+| `POST` | `/control/agents/:agent_id/work-items/:work_item_id/complete` | Complete a work item |
 | `GET` | `/agents/:agent_id/tasks` | List agent tasks |
 | `GET` | `/agents/:agent_id/briefs` | Get recent briefs/context |
 | `GET` | `/agents/:agent_id/transcript` | Get agent transcript |
@@ -127,6 +130,25 @@ curl http://localhost:8787/agents/my-agent/status
 curl -X POST http://localhost:8787/control/agents/my-agent/work-items \
   -H "Content-Type: application/json" \
   -d '{"objective": "Review and fix all clippy warnings"}'
+```
+
+### Update and complete a work item
+
+```bash
+curl -X PATCH http://localhost:8787/control/agents/my-agent/work-items/work_123 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "plan_status": "ready",
+    "todo_list": [
+      { "text": "Run cargo check", "state": "completed" }
+    ],
+    "blocked_by": "waiting for CI",
+    "recheck_after": 600000
+  }'
+
+curl -X POST http://localhost:8787/control/agents/my-agent/work-items/work_123/complete \
+  -H "Content-Type: application/json" \
+  -d '{}'
 ```
 
 ### Wake a sleeping agent

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -262,7 +262,10 @@ Projection contract:
 | `POST` | `/control/agents/:agent_id/tasks/:task_id/stop` | `{ authority_class? }` | `TaskStopResult` | Candidate stable route; DTO schema still broad | Requests managed-task cancellation. |
 | `GET` | `/agents/:agent_id/work-items` | none | `WorkItemRecord[]` | Experimental read model; CLI schema owner | Query parameter: `limit`; used by `holon work-item list`. |
 | `GET` | `/agents/:agent_id/work-items/:work_item_id` | none | `WorkItemRecord` | Experimental read model; CLI schema owner | Used by `holon work-item get`; returns 404 when the id is not found for the target agent. |
-| `POST` | `/control/agents/:agent_id/work-items` | `{ objective, authority_class? }` | `WorkItemRecord` | Experimental | Creates/enqueues work items; update/pick/complete APIs remain Phase 2 work. |
+| `POST` | `/control/agents/:agent_id/work-items` | `{ objective, authority_class? }` | `WorkItemRecord` | Experimental | Creates/enqueues work items. |
+| `POST` | `/control/agents/:agent_id/work-items/:work_item_id/pick` | `{ reason?, authority_class? }` | `PickWorkItemResponse` | Experimental | Sets the current WorkItem focus to an existing open WorkItem and returns the previous/current focus transition. |
+| `PATCH` | `/control/agents/:agent_id/work-items/:work_item_id` | `UpdateWorkItemRequest` | `WorkItemRecord` | Experimental | Mutates objective, plan status, todo list, and blocker/recheck fields. Empty mutations are rejected. |
+| `POST` | `/control/agents/:agent_id/work-items/:work_item_id/complete` | `{ authority_class? }` | `WorkItemRecord` | Experimental | Marks an open WorkItem completed; cancel/delete remains out of scope. |
 | `GET` | `/agents/:agent_id/timers/:timer_id` | Path `agent_id`, `timer_id`. | `TimerRecord` | Candidate stable route; DTO schema still broad | Returns 404 when the timer id is not found for the target agent. |
 | `POST` | `/control/agents/:agent_id/timers` | `{ duration_ms, interval_ms?, summary?, authority_class? }` | `TimerRecord` | Candidate stable for creation; cancellation remains Phase 2 work | `duration_ms` is required; `interval_ms` makes a repeating timer. |
 
@@ -359,9 +362,10 @@ treated as schema surfaces, not incidental Rust structs:
 3. **Event projection allowlist needs more real-world coverage.** `operator`
    now has a redaction contract, but additional runtime event kinds may need
    explicit allowlist additions as TUI/client consumption broadens.
-4. **WorkItem mutation APIs are incomplete.** HTTP can list/get/create/enqueue
-   work items and include them in state snapshots, but update/pick/complete
-   routes remain deferred.
+4. **WorkItem mutation APIs now cover focus/update/complete.** HTTP can
+   list/get/create/enqueue, pick focus, update objective/planning/blocker
+   fields, and complete work items. Cancel/delete remains intentionally out of
+   scope until a distinct lifecycle contract is needed.
 5. **Timer lifecycle APIs are incomplete.** HTTP can create/list/get timers,
    but lacks cancellation semantics and endpoint coverage.
 6. **Deployment guidance still needs hardening.** The HTTP ingress trust/auth
@@ -384,7 +388,6 @@ milestone and tracked by
 |-------|-------|
 | [#1438](https://github.com/holon-run/holon/issues/1438) `api: migrate OpenAPI baseline to aide route/type metadata` | Move OpenAPI operation metadata closer to route and DTO definitions. |
 | [#1439](https://github.com/holon-run/holon/issues/1439) `api: tighten OpenAPI DTO schemas for stable read models` | Replace selected generic JSON schemas with typed stable DTO schemas. |
-| [#1440](https://github.com/holon-run/holon/issues/1440) `api: add WorkItem mutation HTTP lifecycle endpoints` | Add or explicitly scope update/pick/complete mutation endpoints. |
 | [#1441](https://github.com/holon-run/holon/issues/1441) `api: add Timer cancellation lifecycle endpoint` | Define timer cancellation semantics and HTTP endpoint behavior. |
 | [#1443](https://github.com/holon-run/holon/issues/1443) `events: define stable operator-facing event payload subset` | Version/document stable event fields and projection/redaction boundaries. |
 
@@ -394,9 +397,7 @@ milestone and tracked by
    ([#1438](https://github.com/holon-run/holon/issues/1438)).
 2. Tighten DTO schemas for stable read models and control-plane results
    ([#1439](https://github.com/holon-run/holon/issues/1439)).
-3. Add WorkItem mutation endpoints or explicitly define the non-goals
-   ([#1440](https://github.com/holon-run/holon/issues/1440)).
-4. Add timer cancellation semantics and endpoint coverage
+3. Add timer cancellation semantics and endpoint coverage
    ([#1441](https://github.com/holon-run/holon/issues/1441)).
-5. Define the stable operator-facing event payload subset
+4. Define the stable operator-facing event payload subset
    ([#1443](https://github.com/holon-run/holon/issues/1443)).

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -356,6 +356,44 @@ Creates a durable work item for the agent.
 }
 ```
 
+**`POST /control/agents/:id/work-items/:work_item_id/pick`** — Pick work item
+
+Makes an existing open work item the current focus for the agent. The response
+returns the previous focus, current focus, current work item id, and the
+recorded focus transition.
+
+```json
+{ "reason": "external scheduler selected next work", "authority_class": "integration_signal" }
+```
+
+**`PATCH /control/agents/:id/work-items/:work_item_id`** — Update work item
+
+Mutates one or more WorkItem fields. Empty updates are rejected. `blocked_by`
+uses a nested optional shape: a string sets the blocker, `null` clears it, and
+omitting the field leaves it unchanged. `recheck_after` is milliseconds and
+requires a non-empty blocker.
+
+```json
+{
+  "objective": "Fix the build and update docs",
+  "plan_status": "ready",
+  "todo_list": [{ "text": "Run cargo check", "state": "completed" }],
+  "blocked_by": "waiting for CI",
+  "recheck_after": 600000,
+  "authority_class": "operator_instruction"
+}
+```
+
+**`POST /control/agents/:id/work-items/:work_item_id/complete`** — Complete work item
+
+Marks an open work item completed and returns the updated `WorkItemRecord`.
+Cancel, close-without-completion, and delete are intentionally out of scope for
+this lifecycle surface.
+
+```json
+{ "authority_class": "operator_instruction" }
+```
+
 **`POST /control/agents/:id/timers`** — Create timer
 
 Creates a timer that will deliver a `TimerTick` to the agent.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -19,6 +19,26 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "CompleteWorkItemRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "authority_class": {
+            "enum": [
+              "operator_instruction",
+              "runtime_instruction",
+              "integration_signal",
+              "external_evidence",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "CompleteWorkItemRequest",
+        "type": "object"
+      },
       "ControlPromptRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -131,6 +151,455 @@
       "OperatorTransportBindingRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "PickWorkItemRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "authority_class": {
+            "enum": [
+              "operator_instruction",
+              "runtime_instruction",
+              "integration_signal",
+              "external_evidence",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "PickWorkItemRequest",
+        "type": "object"
+      },
+      "PickWorkItemResponse": {
+        "properties": {
+          "current_work_item": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "blocked_by": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "legacy_inline_plan": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "writeOnly": true
+              },
+              "objective": {
+                "type": "string"
+              },
+              "plan_artifact": {
+                "properties": {
+                  "bytes": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "hash": {
+                    "type": "string"
+                  },
+                  "owner_agent_id": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "preview": {
+                    "type": "string"
+                  },
+                  "preview_complete": {
+                    "type": "boolean"
+                  },
+                  "relative_path": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "updated_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "workspace_alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "workspace_id": {
+                    "default": "agent_home",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "hash",
+                  "bytes",
+                  "updated_at",
+                  "preview",
+                  "preview_complete"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "plan_status": {
+                "enum": [
+                  "draft",
+                  "ready",
+                  "needs_input"
+                ],
+                "type": "string"
+              },
+              "recheck_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "recheck_consumed_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "result_summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "revision": {
+                "default": 1,
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "state": {
+                "enum": [
+                  "open",
+                  "completed"
+                ],
+                "type": "string"
+              },
+              "todo_list": {
+                "items": {
+                  "properties": {
+                    "state": {
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed"
+                      ],
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "state"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "workspace_id": {
+                "default": "agent_home",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "agent_id",
+              "objective",
+              "state",
+              "plan_status",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "object"
+          },
+          "current_work_item_id": {
+            "type": "string"
+          },
+          "previous_work_item": {
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "blocked_by": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "legacy_inline_plan": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "writeOnly": true
+              },
+              "objective": {
+                "type": "string"
+              },
+              "plan_artifact": {
+                "properties": {
+                  "bytes": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "hash": {
+                    "type": "string"
+                  },
+                  "owner_agent_id": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "preview": {
+                    "type": "string"
+                  },
+                  "preview_complete": {
+                    "type": "boolean"
+                  },
+                  "relative_path": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "updated_at": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "workspace_alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "workspace_id": {
+                    "default": "agent_home",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "hash",
+                  "bytes",
+                  "updated_at",
+                  "preview",
+                  "preview_complete"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "plan_status": {
+                "enum": [
+                  "draft",
+                  "ready",
+                  "needs_input"
+                ],
+                "type": "string"
+              },
+              "recheck_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "recheck_consumed_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "result_summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "revision": {
+                "default": 1,
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "state": {
+                "enum": [
+                  "open",
+                  "completed"
+                ],
+                "type": "string"
+              },
+              "todo_list": {
+                "items": {
+                  "properties": {
+                    "state": {
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed"
+                      ],
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "state"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "workspace_id": {
+                "default": "agent_home",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "agent_id",
+              "objective",
+              "state",
+              "plan_status",
+              "created_at",
+              "updated_at"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "transition": {
+            "properties": {
+              "current_focus_mode": {
+                "type": "string"
+              },
+              "current_readiness": {
+                "enum": [
+                  "runnable",
+                  "waiting_for_operator",
+                  "blocked",
+                  "completed"
+                ],
+                "type": "string"
+              },
+              "current_work_item_id": {
+                "type": "string"
+              },
+              "previous_readiness": {
+                "enum": [
+                  "runnable",
+                  "waiting_for_operator",
+                  "blocked",
+                  "completed",
+                  null
+                ],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "previous_work_item_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "switch_kind": {
+                "type": "string"
+              },
+              "warnings": {
+                "items": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "current_work_item_id",
+              "current_readiness",
+              "switch_kind",
+              "current_focus_mode"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "current_work_item",
+          "current_work_item_id",
+          "transition"
+        ],
+        "title": "PickWorkItemResponse",
         "type": "object"
       },
       "SetAgentModelRequest": {
@@ -1666,6 +2135,247 @@
       "UninstallSkillRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "UpdateWorkItemRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "authority_class": {
+            "enum": [
+              "operator_instruction",
+              "runtime_instruction",
+              "integration_signal",
+              "external_evidence",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "blocked_by": true,
+          "objective": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "plan_status": {
+            "enum": [
+              "draft",
+              "ready",
+              "needs_input",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "recheck_after": {
+            "format": "uint64",
+            "minimum": 1,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "todo_list": {
+            "items": {
+              "properties": {
+                "state": {
+                  "enum": [
+                    "pending",
+                    "in_progress",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "text",
+                "state"
+              ],
+              "type": "object"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "title": "UpdateWorkItemRequest",
+        "type": "object"
+      },
+      "WorkItemRecord": {
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "blocked_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "legacy_inline_plan": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "writeOnly": true
+          },
+          "objective": {
+            "type": "string"
+          },
+          "plan_artifact": {
+            "properties": {
+              "bytes": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "hash": {
+                "type": "string"
+              },
+              "owner_agent_id": {
+                "default": "",
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "preview": {
+                "type": "string"
+              },
+              "preview_complete": {
+                "type": "boolean"
+              },
+              "relative_path": {
+                "default": "",
+                "type": "string"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "workspace_alias": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "workspace_id": {
+                "default": "agent_home",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path",
+              "hash",
+              "bytes",
+              "updated_at",
+              "preview",
+              "preview_complete"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "plan_status": {
+            "enum": [
+              "draft",
+              "ready",
+              "needs_input"
+            ],
+            "type": "string"
+          },
+          "recheck_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "recheck_consumed_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "result_summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "revision": {
+            "default": 1,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "completed"
+            ],
+            "type": "string"
+          },
+          "todo_list": {
+            "items": {
+              "properties": {
+                "state": {
+                  "enum": [
+                    "pending",
+                    "in_progress",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "text",
+                "state"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "workspace_id": {
+            "default": "agent_home",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "objective",
+          "state",
+          "plan_status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "WorkItemRecord",
         "type": "object"
       }
     },
@@ -4079,11 +4789,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/WorkItemRecord"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {
@@ -4112,6 +4822,237 @@
           }
         ],
         "summary": "Create work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/work-items/{work_item_id}": {
+      "patch": {
+        "description": "Mutate work item objective, plan status, todo list, or blocker fields.",
+        "operationId": "updateWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Work item id.",
+            "in": "path",
+            "name": "work_item_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkItemRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/work-items/{work_item_id}/complete": {
+      "post": {
+        "description": "Mark an open work item completed.",
+        "operationId": "completeWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Work item id.",
+            "in": "path",
+            "name": "work_item_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkItemRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Complete work item",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/work-items/{work_item_id}/pick": {
+      "post": {
+        "description": "Make an existing open work item the current focus for the agent.",
+        "operationId": "pickWorkItem",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Work item id.",
+            "in": "path",
+            "name": "work_item_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PickWorkItemRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PickWorkItemResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Pick work item",
         "tags": [
           "control"
         ]

--- a/src/http.rs
+++ b/src/http.rs
@@ -13,11 +13,12 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse,
     },
-    routing::{get, post},
+    routing::{get, patch, post},
     Json, Router,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use chrono::Utc;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use tokio::time::{sleep, Duration};
@@ -61,9 +62,9 @@ use crate::{
         MessageOrigin, OperatorNotificationRecord, OperatorTransportBinding,
         OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskRecord,
-        TaskStatus, TaskStatusSnapshot, TaskStopResult, TimerRecord, TurnTerminalRecord,
-        WaitingIntentRecord, WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord,
-        WorktreeSession,
+        TaskStatus, TaskStatusSnapshot, TaskStopResult, TimerRecord, TodoItem, TurnTerminalRecord,
+        WaitingIntentRecord, WorkItemPlanStatus, WorkItemRecord, WorkItemState,
+        WorkspaceOccupancyRecord, WorktreeSession,
     },
 };
 
@@ -211,6 +212,18 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/control/agents/{agent_id}/work-items",
             post(create_work_item),
+        )
+        .route(
+            "/control/agents/{agent_id}/work-items/{work_item_id}/pick",
+            post(pick_work_item),
+        )
+        .route(
+            "/control/agents/{agent_id}/work-items/{work_item_id}",
+            patch(update_work_item),
+        )
+        .route(
+            "/control/agents/{agent_id}/work-items/{work_item_id}/complete",
+            post(complete_work_item),
         )
         .route("/control/agents/{agent_id}/timers", post(create_timer))
         .route("/control/agents/{agent_id}/create", post(create_agent))
@@ -565,10 +578,43 @@ pub struct CreateCommandTaskRequest {
     pub authority_class: Option<AuthorityClass>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct CreateWorkItemRequest {
     pub objective: String,
     pub authority_class: Option<AuthorityClass>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PickWorkItemRequest {
+    pub reason: Option<String>,
+    pub authority_class: Option<AuthorityClass>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateWorkItemRequest {
+    pub objective: Option<String>,
+    pub plan_status: Option<WorkItemPlanStatus>,
+    pub todo_list: Option<Vec<TodoItem>>,
+    pub blocked_by: Option<Value>,
+    #[schemars(range(min = 1))]
+    pub recheck_after: Option<u64>,
+    pub authority_class: Option<AuthorityClass>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CompleteWorkItemRequest {
+    pub authority_class: Option<AuthorityClass>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PickWorkItemResponse {
+    pub previous_work_item: Option<WorkItemRecord>,
+    pub current_work_item: WorkItemRecord,
+    pub current_work_item_id: String,
+    pub transition: crate::runtime::WorkItemFocusTransition,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2031,6 +2077,160 @@ pub async fn create_work_item(
     Ok(Json(record))
 }
 
+pub async fn pick_work_item(
+    Path((agent_id, work_item_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<PickWorkItemRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let admission_context = control_admission_context(&state);
+    let provided_trust = request.authority_class;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let boundary = current_boundary_metadata(&runtime)
+        .await
+        .map_err(error_response)?;
+    let picked = runtime
+        .pick_work_item_with_reason(work_item_id, normalize_optional_non_empty(request.reason))
+        .await
+        .map_err(work_item_lifecycle_error)?;
+    runtime
+        .append_audit_event(
+            "work_item_pick_requested",
+            json!({
+                "work_item_id": picked.current_work_item.id.clone(),
+                "target_agent_id": agent_id,
+                "admission_context": admission_context,
+                "provided_trust": provided_trust,
+                "boundary": boundary,
+            }),
+        )
+        .map_err(error_response)?;
+    let current_work_item_id = picked.current_work_item.id.clone();
+    Ok(Json(PickWorkItemResponse {
+        previous_work_item: picked.previous_work_item,
+        current_work_item: picked.current_work_item,
+        current_work_item_id,
+        transition: picked.transition,
+    }))
+}
+
+pub async fn update_work_item(
+    Path((agent_id, work_item_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<UpdateWorkItemRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let admission_context = control_admission_context(&state);
+    let provided_trust = request.authority_class;
+    let objective = request
+        .objective
+        .map(|value| {
+            let trimmed = value.trim().to_string();
+            if trimmed.is_empty() {
+                Err(bad_request("objective must not be empty"))
+            } else {
+                Ok(trimmed)
+            }
+        })
+        .transpose()?;
+    let blocked_by = request
+        .blocked_by
+        .map(parse_blocked_by_mutation)
+        .transpose()?;
+    if request.recheck_after == Some(0) {
+        return Err(bad_request("recheck_after must be greater than 0"));
+    }
+    if request.recheck_after.is_some() && blocked_by.as_ref().is_none_or(Option::is_none) {
+        return Err(bad_request(
+            "recheck_after requires a non-empty blocked_by value",
+        ));
+    }
+    if objective.is_none()
+        && request.plan_status.is_none()
+        && request.todo_list.is_none()
+        && blocked_by.is_none()
+    {
+        return Err(bad_request(
+            "request must include at least one mutation field",
+        ));
+    }
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let boundary = current_boundary_metadata(&runtime)
+        .await
+        .map_err(error_response)?;
+    let record = runtime
+        .update_work_item_fields_with_recheck(
+            work_item_id,
+            objective,
+            request.plan_status,
+            None,
+            request.todo_list,
+            blocked_by,
+            request.recheck_after,
+        )
+        .await
+        .map_err(work_item_lifecycle_error)?;
+    runtime
+        .append_audit_event(
+            "work_item_update_requested",
+            json!({
+                "work_item_id": record.id.clone(),
+                "target_agent_id": agent_id,
+                "admission_context": admission_context,
+                "provided_trust": provided_trust,
+                "boundary": boundary,
+            }),
+        )
+        .map_err(error_response)?;
+    Ok(Json(record))
+}
+
+pub async fn complete_work_item(
+    Path((agent_id, work_item_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<CompleteWorkItemRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let admission_context = control_admission_context(&state);
+    let provided_trust = request.authority_class;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let boundary = current_boundary_metadata(&runtime)
+        .await
+        .map_err(error_response)?;
+    let record = runtime
+        .complete_work_item(work_item_id, Vec::new())
+        .await
+        .map_err(work_item_lifecycle_error)?;
+    runtime
+        .append_audit_event(
+            "work_item_complete_requested",
+            json!({
+                "work_item_id": record.id.clone(),
+                "target_agent_id": agent_id,
+                "admission_context": admission_context,
+                "provided_trust": provided_trust,
+                "boundary": boundary,
+            }),
+        )
+        .map_err(error_response)?;
+    Ok(Json(record))
+}
+
 pub async fn work_items(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -3162,6 +3362,38 @@ fn task_lifecycle_error(error: anyhow::Error) -> (StatusCode, Json<Value>) {
         not_found(message)
     } else {
         error_response(error)
+    }
+}
+
+fn work_item_lifecycle_error(error: anyhow::Error) -> (StatusCode, Json<Value>) {
+    let message = error.to_string();
+    let lower = message.to_ascii_lowercase();
+    if (lower.contains("work item") && lower.ends_with("not found"))
+        || lower.starts_with("unknown work item ")
+    {
+        not_found(message)
+    } else if message.starts_with("cannot ") {
+        bad_request(message)
+    } else {
+        error_response(error)
+    }
+}
+
+fn normalize_optional_non_empty(value: Option<String>) -> Option<String> {
+    value.and_then(|inner| {
+        let trimmed = inner.trim().to_string();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+fn parse_blocked_by_mutation(value: Value) -> Result<Option<String>, (StatusCode, Json<Value>)> {
+    match value {
+        Value::Null => Ok(None),
+        Value::String(inner) => {
+            let trimmed = inner.trim().to_string();
+            Ok((!trimmed.is_empty()).then_some(trimmed))
+        }
+        _ => Err(bad_request("blocked_by must be a string or null")),
     }
 }
 

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -5,7 +5,14 @@ use aide::{
 use schemars::{generate::SchemaSettings, JsonSchema};
 use serde_json::{json, Value};
 
-use crate::types::{TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult};
+use crate::{
+    http::{
+        CompleteWorkItemRequest, PickWorkItemRequest, PickWorkItemResponse, UpdateWorkItemRequest,
+    },
+    types::{
+        TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult, WorkItemRecord,
+    },
+};
 
 const API_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -75,7 +82,10 @@ const ROUTES: &[RouteSpec] = &[
     route("post", "/agents/{agent_id}/enqueue", "enqueueAgent", "ingress", "Enqueue agent message", "Enqueue a public channel/webhook message for the named agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
     route("post", "/webhooks/generic/{agent_id}", "genericWebhook", "ingress", "Generic webhook", "Convert an arbitrary JSON webhook body into a trusted integration message.", Some("GenericJsonPayload"), AuthKind::None),
     route("post", "/control/agents/{agent_id}/tasks", "createCommandTask", "control", "Create command task", "Schedule a command task for an agent.", Some("CreateCommandTaskRequest"), AuthKind::Control),
-    route("post", "/control/agents/{agent_id}/work-items", "createWorkItem", "control", "Create work item", "Create or enqueue a public work item objective.", Some("CreateWorkItemRequest"), AuthKind::Control),
+    route_with_response("post", "/control/agents/{agent_id}/work-items", "createWorkItem", "control", "Create work item", "Create or enqueue a public work item objective.", Some("CreateWorkItemRequest"), "WorkItemRecord", AuthKind::Control),
+    route_with_response("post", "/control/agents/{agent_id}/work-items/{work_item_id}/pick", "pickWorkItem", "control", "Pick work item", "Make an existing open work item the current focus for the agent.", Some("PickWorkItemRequest"), "PickWorkItemResponse", AuthKind::Control),
+    route_with_response("patch", "/control/agents/{agent_id}/work-items/{work_item_id}", "updateWorkItem", "control", "Update work item", "Mutate work item objective, plan status, todo list, or blocker fields.", Some("UpdateWorkItemRequest"), "WorkItemRecord", AuthKind::Control),
+    route_with_response("post", "/control/agents/{agent_id}/work-items/{work_item_id}/complete", "completeWorkItem", "control", "Complete work item", "Mark an open work item completed.", Some("CompleteWorkItemRequest"), "WorkItemRecord", AuthKind::Control),
     route("post", "/control/agents/{agent_id}/timers", "createTimer", "control", "Create timer", "Schedule a timer for an agent.", Some("CreateTimerRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/create", "createAgent", "control", "Create named agent", "Create a public named agent, optionally from a template.", Some("CreateAgentRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/workspace/attach", "attachWorkspace", "control", "Attach workspace", "Attach a workspace path to an agent.", Some("AttachWorkspaceRequest"), AuthKind::Control),
@@ -462,6 +472,26 @@ fn component_schemas() -> Value {
     schemas.insert(
         "TaskStopResult".into(),
         component_schema::<TaskStopResult>(),
+    );
+    schemas.insert(
+        "WorkItemRecord".into(),
+        component_schema::<WorkItemRecord>(),
+    );
+    schemas.insert(
+        "PickWorkItemResponse".into(),
+        component_schema::<PickWorkItemResponse>(),
+    );
+    schemas.insert(
+        "PickWorkItemRequest".into(),
+        component_schema::<PickWorkItemRequest>(),
+    );
+    schemas.insert(
+        "UpdateWorkItemRequest".into(),
+        component_schema::<UpdateWorkItemRequest>(),
+    );
+    schemas.insert(
+        "CompleteWorkItemRequest".into(),
+        component_schema::<CompleteWorkItemRequest>(),
     );
     for name in [
         "EnqueueRequest",

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -10,6 +10,7 @@ use crate::types::{
     WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
     CHILD_AGENT_TASK_KIND,
 };
+use schemars::JsonSchema;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
@@ -24,13 +25,13 @@ struct TaskMessageSnapshot {
     text: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct WorkItemFocusTransitionWarning {
     pub code: String,
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct WorkItemFocusTransition {
     pub previous_work_item_id: Option<String>,
     pub current_work_item_id: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -980,7 +980,7 @@ pub struct BriefAttachment {
     pub value: Option<Value>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthorityClass {
     #[serde(alias = "trusted_operator")]
@@ -3037,14 +3037,14 @@ pub struct CommandTaskSpec {
     pub terminal_reentry: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemState {
     Open,
     Completed,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemPlanStatus {
     Draft,
@@ -3052,7 +3052,7 @@ pub enum WorkItemPlanStatus {
     NeedsInput,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemReadiness {
     Runnable,
@@ -3116,7 +3116,7 @@ impl Default for AgentPostureProjection {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct WorkItemPlanArtifact {
     #[serde(default)]
     pub owner_agent_id: String,
@@ -3134,7 +3134,7 @@ pub struct WorkItemPlanArtifact {
     pub preview_complete: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct WorkItemRecord {
     pub id: String,
     #[serde(alias = "session_id")]
@@ -3310,13 +3310,13 @@ impl DeliverySummaryRecord {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct TodoItem {
     pub text: String,
     pub state: TodoItemState,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TodoItemState {
     Pending,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 52, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 55, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();
@@ -136,7 +136,7 @@ fn balanced_call_end(source: &str, start: usize) -> Option<usize> {
 fn parse_route_call(call: &str) -> HttpRoute {
     let (path, after_path) = parse_first_string(call);
     let call_tail = after_path.trim_start_matches(|ch: char| ch == ',' || ch.is_whitespace());
-    for method in ["get", "post"] {
+    for method in ["get", "post", "patch"] {
         let prefix = format!("{method}(");
         if let Some(handler_start) = call_tail.find(&prefix) {
             let handler_start = handler_start + prefix.len();

--- a/tests/http_tasks.rs
+++ b/tests/http_tasks.rs
@@ -24,5 +24,7 @@ http_async_tests!(
     work_item_routes_list_and_return_work_item_detail,
     create_work_item_route_does_not_replace_existing_active_item,
     create_work_item_route_rejects_empty_objective_with_bad_request,
+    work_item_mutation_routes_pick_update_and_complete,
+    work_item_mutation_routes_validate_bad_requests,
     timer_detail_route_returns_latest_timer_record,
 );

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -527,6 +527,33 @@
     ]
   },
   {
+    "method": "patch",
+    "path": "/control/agents/{agent_id}/work-items/{work_item_id}",
+    "handler": "update_work_item",
+    "operation_id": "updateWorkItem",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "work_item_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "UpdateWorkItemRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
     "method": "post",
     "path": "/agents/{agent_id}/enqueue",
     "handler": "enqueue",
@@ -969,6 +996,60 @@
     ],
     "request_schema": "CreateWorkItemRequest",
     "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/control/agents/{agent_id}/work-items/{work_item_id}/complete",
+    "handler": "complete_work_item",
+    "operation_id": "completeWorkItem",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "work_item_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CompleteWorkItemRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/control/agents/{agent_id}/work-items/{work_item_id}/pick",
+    "handler": "pick_work_item",
+    "operation_id": "pickWorkItem",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "work_item_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "PickWorkItemRequest",
+    "request_strict": true,
     "response_content_types": [
       "application/json"
     ],

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -568,6 +568,159 @@ pub async fn create_work_item_route_rejects_empty_objective_with_bad_request() -
     Ok(())
 }
 
+pub async fn work_item_mutation_routes_pick_update_and_complete() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let client = reqwest::Client::new();
+    let runtime = host.default_runtime().await?;
+
+    let first = runtime
+        .create_work_item("first queued item".into(), None, None, Vec::new())
+        .await?;
+    let second = runtime
+        .create_work_item("second queued item".into(), None, None, Vec::new())
+        .await?;
+    runtime.pick_work_item(first.id.clone()).await?;
+
+    let pick: serde_json::Value = client
+        .post(format!(
+            "{base}/control/agents/default/work-items/{second_id}/pick",
+            second_id = second.id
+        ))
+        .json(&serde_json::json!({
+            "reason": "HTTP client selected next work",
+            "authority_class": "integration_signal"
+        }))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(pick["current_work_item_id"], second.id);
+    assert_eq!(pick["previous_work_item"]["id"], first.id);
+    assert_eq!(
+        pick["transition"]["reason"],
+        "HTTP client selected next work"
+    );
+
+    let update: serde_json::Value = client
+        .patch(format!(
+            "{base}/control/agents/default/work-items/{second_id}",
+            second_id = second.id
+        ))
+        .json(&serde_json::json!({
+            "objective": "refined via HTTP",
+            "plan_status": "ready",
+            "todo_list": [
+                {"text": "wire HTTP endpoint", "state": "completed"},
+                {"text": "verify behavior", "state": "in_progress"}
+            ],
+            "blocked_by": "waiting on review",
+            "recheck_after": 60000,
+            "authority_class": "integration_signal"
+        }))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(update["id"], second.id);
+    assert_eq!(update["objective"], "refined via HTTP");
+    assert_eq!(update["plan_status"], "ready");
+    assert_eq!(update["blocked_by"], "waiting on review");
+    assert!(update["recheck_at"].is_string());
+    assert_eq!(update["todo_list"].as_array().expect("todo array").len(), 2);
+
+    let complete: serde_json::Value = client
+        .post(format!(
+            "{base}/control/agents/default/work-items/{second_id}/complete",
+            second_id = second.id
+        ))
+        .json(&serde_json::json!({
+            "authority_class": "integration_signal"
+        }))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(complete["id"], second.id);
+    assert_eq!(complete["state"], "completed");
+    assert!(complete.get("blocked_by").is_none());
+
+    wait_until(|| {
+        let events = runtime.storage().read_recent_events(200)?;
+        Ok([
+            "work_item_pick_requested",
+            "work_item_update_requested",
+            "work_item_complete_requested",
+        ]
+        .into_iter()
+        .all(|kind| {
+            events.iter().any(|event| {
+                event.kind == kind && event.data["provided_trust"] == "integration_signal"
+            })
+        }))
+    })
+    .await?;
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn work_item_mutation_routes_validate_bad_requests() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let client = reqwest::Client::new();
+    let runtime = host.default_runtime().await?;
+    let work = runtime
+        .create_work_item(
+            "validate HTTP work item mutation".into(),
+            None,
+            None,
+            Vec::new(),
+        )
+        .await?;
+
+    let empty_update = client
+        .patch(format!(
+            "{base}/control/agents/default/work-items/{}",
+            work.id
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(empty_update.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = empty_update.json().await?;
+    assert_eq!(
+        body["error"],
+        "request must include at least one mutation field"
+    );
+
+    let recheck_without_blocker = client
+        .patch(format!(
+            "{base}/control/agents/default/work-items/{}",
+            work.id
+        ))
+        .json(&serde_json::json!({
+            "blocked_by": null,
+            "recheck_after": 1000
+        }))
+        .send()
+        .await?;
+    assert_eq!(
+        recheck_without_blocker.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+
+    let missing = client
+        .post(format!(
+            "{base}/control/agents/default/work-items/missing-work/complete"
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn timer_detail_route_returns_latest_timer_record() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let runtime = host.default_runtime().await?;


### PR DESCRIPTION
## Summary

Closes #1440.

Adds stable HTTP control-plane WorkItem mutation endpoints for the lifecycle operations that already exist in the runtime tool surface:

- `POST /control/agents/:agent_id/work-items/:work_item_id/pick`
- `PATCH /control/agents/:agent_id/work-items/:work_item_id`
- `POST /control/agents/:agent_id/work-items/:work_item_id/complete`

The implementation preserves control-plane auth/provenance auditing, returns typed WorkItem responses, and keeps cancel/delete out of scope for this lifecycle surface.

## Changes

- Wired Axum routes and request/response DTOs for pick, update, and complete.
- Added validation for empty updates, empty objectives, invalid blocker payloads, and `recheck_after` without a blocker.
- Added typed OpenAPI schemas for WorkItem records and mutation DTOs, including refreshed `openapi.json`.
- Documented the new endpoints in the HTTP control-plane reference, integration guide, and API contract inventory.
- Added HTTP behavior tests for successful mutation and representative validation/not-found cases.

## Verification

- `cargo test --test http_tasks`
- `cargo test --test openapi_snapshot`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
