### PR TITLE
api: add Timer cancellation lifecycle endpoint

### DIFF
--- a/docs/website/guides/integration.md
+++ b/docs/website/guides/integration.md
@@ -151,6 +151,18 @@ curl -X POST http://localhost:8787/control/agents/my-agent/work-items/work_123/c
   -d '{}'
 ```
 
+### Create and cancel a timer
+
+```bash
+curl -X POST http://localhost:8787/control/agents/my-agent/timers \
+  -H "Content-Type: application/json" \
+  -d '{"duration_ms": 60000, "summary": "reminder"}'
+
+curl -X POST http://localhost:8787/control/agents/my-agent/timers/timer_123/cancel \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
 ### Wake a sleeping agent
 
 ```bash

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -267,7 +267,8 @@ Projection contract:
 | `PATCH` | `/control/agents/:agent_id/work-items/:work_item_id` | `UpdateWorkItemRequest` | `WorkItemRecord` | Experimental | Mutates objective, plan status, todo list, and blocker/recheck fields. Empty mutations are rejected. |
 | `POST` | `/control/agents/:agent_id/work-items/:work_item_id/complete` | `{ authority_class? }` | `WorkItemRecord` | Experimental | Marks an open WorkItem completed; cancel/delete remains out of scope. |
 | `GET` | `/agents/:agent_id/timers/:timer_id` | Path `agent_id`, `timer_id`. | `TimerRecord` | Candidate stable route; DTO schema still broad | Returns 404 when the timer id is not found for the target agent. |
-| `POST` | `/control/agents/:agent_id/timers` | `{ duration_ms, interval_ms?, summary?, authority_class? }` | `TimerRecord` | Candidate stable for creation; cancellation remains Phase 2 work | `duration_ms` is required; `interval_ms` makes a repeating timer. |
+| `POST` | `/control/agents/:agent_id/timers` | `{ duration_ms, interval_ms?, summary?, authority_class? }` | `TimerRecord` | Candidate stable | `duration_ms` is required; `interval_ms` makes a repeating timer. |
+| `POST` | `/control/agents/:agent_id/timers/:timer_id/cancel` | `{ authority_class? }` | `TimerRecord` | Candidate stable | Idempotent for already-cancelled timers. Missing timers return 404; completed timers return 400 because they already fired. |
 
 `CreateCommandTaskRequest` fields:
 
@@ -366,8 +367,8 @@ treated as schema surfaces, not incidental Rust structs:
    list/get/create/enqueue, pick focus, update objective/planning/blocker
    fields, and complete work items. Cancel/delete remains intentionally out of
    scope until a distinct lifecycle contract is needed.
-5. **Timer lifecycle APIs are incomplete.** HTTP can create/list/get timers,
-   but lacks cancellation semantics and endpoint coverage.
+5. **Timer lifecycle APIs now cover cancellation.** HTTP can create/list/get
+   timers and cancel active timers. Delete/purge remains out of scope.
 6. **Deployment guidance still needs hardening.** The HTTP ingress trust/auth
    table is documented, but production-facing guidance should still describe
    when to use bearer mode, local mode, callback capabilities, and dedicated
@@ -388,7 +389,6 @@ milestone and tracked by
 |-------|-------|
 | [#1438](https://github.com/holon-run/holon/issues/1438) `api: migrate OpenAPI baseline to aide route/type metadata` | Move OpenAPI operation metadata closer to route and DTO definitions. |
 | [#1439](https://github.com/holon-run/holon/issues/1439) `api: tighten OpenAPI DTO schemas for stable read models` | Replace selected generic JSON schemas with typed stable DTO schemas. |
-| [#1441](https://github.com/holon-run/holon/issues/1441) `api: add Timer cancellation lifecycle endpoint` | Define timer cancellation semantics and HTTP endpoint behavior. |
 | [#1443](https://github.com/holon-run/holon/issues/1443) `events: define stable operator-facing event payload subset` | Version/document stable event fields and projection/redaction boundaries. |
 
 ## Suggested next work
@@ -397,7 +397,5 @@ milestone and tracked by
    ([#1438](https://github.com/holon-run/holon/issues/1438)).
 2. Tighten DTO schemas for stable read models and control-plane results
    ([#1439](https://github.com/holon-run/holon/issues/1439)).
-3. Add timer cancellation semantics and endpoint coverage
-   ([#1441](https://github.com/holon-run/holon/issues/1441)).
-4. Define the stable operator-facing event payload subset
+3. Define the stable operator-facing event payload subset
    ([#1443](https://github.com/holon-run/holon/issues/1443)).

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -407,6 +407,18 @@ Creates a timer that will deliver a `TimerTick` to the agent.
 }
 ```
 
+**`POST /control/agents/:id/timers/:timer_id/cancel`** — Cancel timer
+
+Cancels an active timer and returns the updated `TimerRecord`. Cancellation is
+idempotent for an already-cancelled timer. A missing timer returns a shared
+404 error envelope; a completed timer returns a shared 400 lifecycle error
+because it already fired. Cancellation immediately updates timer list/detail
+projections and emits `timer_cancelled`.
+
+```json
+{ "authority_class": "operator_instruction" }
+```
+
 **`POST /control/agents/:id/debug-prompt`** — Debug prompt
 
 Sends a debug-mode prompt (runtime-internal classification). Request body:

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -14,6 +14,26 @@
       "CallbackBody": {
         "description": "Raw callback request body. JSON and text bodies are parsed; other content types are represented internally as base64 JSON."
       },
+      "CancelTimerRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "authority_class": {
+            "enum": [
+              "operator_instruction",
+              "runtime_instruction",
+              "integration_signal",
+              "external_evidence",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "CancelTimerRequest",
+        "type": "object"
+      },
       "ClearAgentModelRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -65,8 +85,45 @@
         "type": "object"
       },
       "CreateTimerRequest": {
-        "additionalProperties": true,
-        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "additionalProperties": false,
+        "properties": {
+          "authority_class": {
+            "enum": [
+              "operator_instruction",
+              "runtime_instruction",
+              "integration_signal",
+              "external_evidence",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "duration_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "interval_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "duration_ms"
+        ],
+        "title": "CreateTimerRequest",
         "type": "object"
       },
       "CreateWorkItemRequest": {
@@ -2130,6 +2187,82 @@
           "force_stop_requested"
         ],
         "title": "TaskStopResult",
+        "type": "object"
+      },
+      "TimerRecord": {
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "duration_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "fire_count": {
+            "default": 0,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "interval_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "last_fired_at": {
+            "default": null,
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "next_fire_at": {
+            "default": null,
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "repeat": {
+            "type": "boolean"
+          },
+          "status": {
+            "default": "active",
+            "enum": [
+              "active",
+              "completed",
+              "cancelled"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "created_at",
+          "duration_ms",
+          "repeat"
+        ],
+        "title": "TimerRecord",
         "type": "object"
       },
       "UninstallSkillRequest": {
@@ -4653,11 +4786,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonValue"
+                  "$ref": "#/components/schemas/TimerRecord"
                 }
               }
             },
-            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+            "description": "Successful JSON response using a stable DTO schema."
           },
           "4XX": {
             "content": {
@@ -4686,6 +4819,83 @@
           }
         ],
         "summary": "Create timer",
+        "tags": [
+          "control"
+        ]
+      }
+    },
+    "/control/agents/{agent_id}/timers/{timer_id}/cancel": {
+      "post": {
+        "description": "Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.",
+        "operationId": "cancelTimer",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Timer id.",
+            "in": "path",
+            "name": "timer_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelTimerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimerRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Cancel timer",
         "tags": [
           "control"
         ]

--- a/src/http.rs
+++ b/src/http.rs
@@ -226,6 +226,10 @@ pub fn router(state: AppState) -> Router {
             post(complete_work_item),
         )
         .route("/control/agents/{agent_id}/timers", post(create_timer))
+        .route(
+            "/control/agents/{agent_id}/timers/{timer_id}/cancel",
+            post(cancel_timer),
+        )
         .route("/control/agents/{agent_id}/create", post(create_agent))
         .route(
             "/control/agents/{agent_id}/workspace/attach",
@@ -617,11 +621,18 @@ pub struct PickWorkItemResponse {
     pub transition: crate::runtime::WorkItemFocusTransition,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct CreateTimerRequest {
     pub duration_ms: u64,
     pub interval_ms: Option<u64>,
     pub summary: Option<String>,
+    pub authority_class: Option<AuthorityClass>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CancelTimerRequest {
     pub authority_class: Option<AuthorityClass>,
 }
 
@@ -2349,6 +2360,53 @@ pub async fn create_timer(
         )
         .map_err(error_response)?;
     Ok(Json(timer))
+}
+
+pub async fn cancel_timer(
+    Path((agent_id, timer_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<CancelTimerRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let admission_context = control_admission_context(&state);
+    let provided_trust = request.authority_class;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let boundary = current_boundary_metadata(&runtime)
+        .await
+        .map_err(error_response)?;
+    let timer = runtime
+        .cancel_timer(&timer_id)
+        .await
+        .map_err(timer_lifecycle_error)?;
+    runtime
+        .append_audit_event(
+            "timer_cancel_requested",
+            json!({
+                "timer_id": timer.id,
+                "target_agent_id": agent_id,
+                "admission_context": admission_context,
+                "provided_trust": provided_trust,
+                "boundary": boundary,
+            }),
+        )
+        .map_err(error_response)?;
+    Ok(Json(timer))
+}
+
+fn timer_lifecycle_error(err: anyhow::Error) -> (StatusCode, Json<Value>) {
+    let message = err.to_string();
+    if message.starts_with("timer ") && message.ends_with(" not found") {
+        not_found(message)
+    } else if message.starts_with("cannot ") {
+        bad_request(message)
+    } else {
+        error_response(err)
+    }
 }
 
 pub async fn list_skills(

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -7,10 +7,12 @@ use serde_json::{json, Value};
 
 use crate::{
     http::{
-        CompleteWorkItemRequest, PickWorkItemRequest, PickWorkItemResponse, UpdateWorkItemRequest,
+        CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest, PickWorkItemRequest,
+        PickWorkItemResponse, UpdateWorkItemRequest,
     },
     types::{
-        TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult, WorkItemRecord,
+        TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult, TimerRecord,
+        WorkItemRecord,
     },
 };
 
@@ -86,7 +88,8 @@ const ROUTES: &[RouteSpec] = &[
     route_with_response("post", "/control/agents/{agent_id}/work-items/{work_item_id}/pick", "pickWorkItem", "control", "Pick work item", "Make an existing open work item the current focus for the agent.", Some("PickWorkItemRequest"), "PickWorkItemResponse", AuthKind::Control),
     route_with_response("patch", "/control/agents/{agent_id}/work-items/{work_item_id}", "updateWorkItem", "control", "Update work item", "Mutate work item objective, plan status, todo list, or blocker fields.", Some("UpdateWorkItemRequest"), "WorkItemRecord", AuthKind::Control),
     route_with_response("post", "/control/agents/{agent_id}/work-items/{work_item_id}/complete", "completeWorkItem", "control", "Complete work item", "Mark an open work item completed.", Some("CompleteWorkItemRequest"), "WorkItemRecord", AuthKind::Control),
-    route("post", "/control/agents/{agent_id}/timers", "createTimer", "control", "Create timer", "Schedule a timer for an agent.", Some("CreateTimerRequest"), AuthKind::Control),
+    route_with_response("post", "/control/agents/{agent_id}/timers", "createTimer", "control", "Create timer", "Schedule a timer for an agent.", Some("CreateTimerRequest"), "TimerRecord", AuthKind::Control),
+    route_with_response("post", "/control/agents/{agent_id}/timers/{timer_id}/cancel", "cancelTimer", "control", "Cancel timer", "Cancel an active timer. Cancellation is idempotent for already-cancelled timers; completed or missing timers return a shared error envelope.", Some("CancelTimerRequest"), "TimerRecord", AuthKind::Control),
     route("post", "/control/agents/{agent_id}/create", "createAgent", "control", "Create named agent", "Create a public named agent, optionally from a template.", Some("CreateAgentRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/workspace/attach", "attachWorkspace", "control", "Attach workspace", "Attach a workspace path to an agent.", Some("AttachWorkspaceRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/workspace/exit", "exitWorkspace", "control", "Exit workspace", "Return an agent to its default AgentHome workspace.", Some("ExitWorkspaceRequest"), AuthKind::Control),
@@ -477,6 +480,7 @@ fn component_schemas() -> Value {
         "WorkItemRecord".into(),
         component_schema::<WorkItemRecord>(),
     );
+    schemas.insert("TimerRecord".into(), component_schema::<TimerRecord>());
     schemas.insert(
         "PickWorkItemResponse".into(),
         component_schema::<PickWorkItemResponse>(),
@@ -493,6 +497,14 @@ fn component_schemas() -> Value {
         "CompleteWorkItemRequest".into(),
         component_schema::<CompleteWorkItemRequest>(),
     );
+    schemas.insert(
+        "CreateTimerRequest".into(),
+        component_schema::<CreateTimerRequest>(),
+    );
+    schemas.insert(
+        "CancelTimerRequest".into(),
+        component_schema::<CancelTimerRequest>(),
+    );
     for name in [
         "EnqueueRequest",
         "IncomingOrigin",
@@ -500,7 +512,6 @@ fn component_schemas() -> Value {
         "TaskInputRequest",
         "TaskStopRequest",
         "CreateWorkItemRequest",
-        "CreateTimerRequest",
         "CreateAgentRequest",
         "AttachWorkspaceRequest",
         "ExitWorkspaceRequest",

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -140,6 +140,38 @@ impl RuntimeHandle {
         Ok(timer)
     }
 
+    pub async fn cancel_timer(&self, timer_id: &str) -> Result<TimerRecord> {
+        let mut timer = self
+            .inner
+            .storage
+            .latest_timer_record(timer_id)?
+            .ok_or_else(|| anyhow!("timer {timer_id} not found"))?;
+        if timer.agent_id != self.agent_id().await? {
+            return Err(anyhow!("timer {timer_id} not found"));
+        }
+        match timer.status {
+            TimerStatus::Cancelled => return Ok(timer),
+            TimerStatus::Completed => {
+                return Err(anyhow!("cannot cancel completed timer {timer_id}"))
+            }
+            TimerStatus::Active => {}
+        }
+
+        timer.status = TimerStatus::Cancelled;
+        timer.next_fire_at = None;
+        self.inner.storage.append_timer(&timer)?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "timer_cancelled",
+            serde_json::json!({
+                "timer_id": timer.id,
+                "status": timer.status,
+                "fire_count": timer.fire_count,
+            }),
+        ))?;
+        self.inner.notify.notify_waiters();
+        Ok(timer)
+    }
+
     pub(crate) async fn recover_active_timers(&self, timers: Vec<TimerRecord>) -> Result<()> {
         for timer in timers {
             self.recover_timer(timer).await?;
@@ -198,6 +230,13 @@ impl RuntimeHandle {
     }
 
     async fn fire_timer_record(&self, timer: &mut TimerRecord) -> Result<()> {
+        if let Some(latest) = self.inner.storage.latest_timer_record(&timer.id)? {
+            if latest.status != TimerStatus::Active {
+                *timer = latest;
+                return Ok(());
+            }
+        }
+
         let message = MessageEnvelope {
             metadata: Some(serde_json::json!({ "timer_id": timer.id })),
             ..MessageEnvelope::new(

--- a/src/types.rs
+++ b/src/types.rs
@@ -3324,7 +3324,7 @@ pub enum TodoItemState {
     Completed,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct TimerRecord {
     pub id: String,
     #[serde(alias = "session_id")]
@@ -3344,7 +3344,7 @@ pub struct TimerRecord {
     pub fire_count: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TimerStatus {
     #[serde(alias = "scheduled")]

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 55, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 56, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/http_tasks.rs
+++ b/tests/http_tasks.rs
@@ -27,4 +27,5 @@ http_async_tests!(
     work_item_mutation_routes_pick_update_and_complete,
     work_item_mutation_routes_validate_bad_requests,
     timer_detail_route_returns_latest_timer_record,
+    timer_cancel_route_is_idempotent_and_updates_projection,
 );

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -951,7 +951,34 @@
       }
     ],
     "request_schema": "CreateTimerRequest",
-    "request_strict": false,
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/control/agents/{agent_id}/timers/{timer_id}/cancel",
+    "handler": "cancel_timer",
+    "operation_id": "cancelTimer",
+    "tag": "control",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "timer_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": "CancelTimerRequest",
+    "request_strict": true,
     "response_content_types": [
       "application/json"
     ],

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -29,7 +29,6 @@ use holon::{
 use reqwest::Client;
 use tokio::net::TcpListener;
 use tokio::sync::watch;
-use tokio::time::{sleep, Duration, Instant};
 #[cfg(unix)]
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -37,9 +36,10 @@ use tokio::{
 };
 
 use super::{
-    attach_default_workspace, connect_addr, git, init_git_repo, read_next_sse_event, spawn_server,
-    spawn_server_for_host, spawn_server_with_config, spawn_server_with_runtime_config, tempdir,
-    test_config, test_config_with_paths, test_work_item, wait_until, ParsedSseEvent,
+    attach_default_workspace, connect_addr, eventually_async, git, init_git_repo,
+    read_next_sse_event, spawn_server, spawn_server_for_host, spawn_server_with_config,
+    spawn_server_with_runtime_config, tempdir, test_config, test_config_with_paths, test_work_item,
+    wait_until, ParsedSseEvent,
 };
 
 pub async fn create_command_task_route_rejects_legacy_kind_field() -> Result<()> {
@@ -806,7 +806,26 @@ pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result
     let completed = runtime
         .schedule_timer(1, None, Some("already completed timer".into()))
         .await?;
-    sleep(Duration::from_millis(50)).await;
+    eventually_async({
+        let client = client.clone();
+        let base = base.clone();
+        let completed_id = completed.id.clone();
+        move || {
+            let client = client.clone();
+            let base = base.clone();
+            let completed_id = completed_id.clone();
+            async move {
+                let detail: serde_json::Value = client
+                    .get(format!("{base}/agents/default/timers/{completed_id}"))
+                    .send()
+                    .await?
+                    .json()
+                    .await?;
+                Ok(detail["status"] == "completed")
+            }
+        }
+    })
+    .await?;
     let completed_cancel = client
         .post(format!(
             "{base}/control/agents/default/timers/{}/cancel",

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -749,3 +749,84 @@ pub async fn timer_detail_route_returns_latest_timer_record() -> Result<()> {
     server.abort();
     Ok(())
 }
+
+pub async fn timer_cancel_route_is_idempotent_and_updates_projection() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    let timer = runtime
+        .schedule_timer(5_000, None, Some("cancel lifecycle timer".into()))
+        .await?;
+
+    let cancelled_response = client
+        .post(format!(
+            "{base}/control/agents/default/timers/{}/cancel",
+            timer.id
+        ))
+        .json(&serde_json::json!({"authority_class": "integration_signal"}))
+        .send()
+        .await?;
+    assert_eq!(cancelled_response.status(), reqwest::StatusCode::OK);
+    let cancelled_body = cancelled_response.text().await?;
+    let cancelled: serde_json::Value = serde_json::from_str(&cancelled_body)?;
+    assert_eq!(cancelled["id"], timer.id);
+    assert_eq!(cancelled["status"], "cancelled");
+    assert!(cancelled["next_fire_at"].is_null());
+
+    let idempotent: serde_json::Value = client
+        .post(format!(
+            "{base}/control/agents/default/timers/{}/cancel",
+            timer.id
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(idempotent["status"], "cancelled");
+
+    let detail: serde_json::Value = client
+        .get(format!("{base}/agents/default/timers/{}", timer.id))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(detail["status"], "cancelled");
+
+    let missing = client
+        .post(format!(
+            "{base}/control/agents/default/timers/missing-timer/cancel"
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let completed = runtime
+        .schedule_timer(1, None, Some("already completed timer".into()))
+        .await?;
+    sleep(Duration::from_millis(50)).await;
+    let completed_cancel = client
+        .post(format!(
+            "{base}/control/agents/default/timers/{}/cancel",
+            completed.id
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(completed_cancel.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let events = runtime.all_events()?;
+    assert!(events
+        .iter()
+        .any(|event| { event.kind == "timer_cancelled" && event.data["timer_id"] == timer.id }));
+    assert!(events.iter().any(|event| {
+        event.kind == "timer_cancel_requested"
+            && event.data["timer_id"] == timer.id
+            && event.data["provided_trust"] == "integration_signal"
+    }));
+
+    server.abort();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add `POST /control/agents/{agent_id}/timers/{timer_id}/cancel` with idempotent cancellation for already-cancelled timers
- persist cancellation immediately, suppress future timer delivery after cancellation, and emit audit events for requested/performed cancellation
- add OpenAPI schema/operation coverage, HTTP integration coverage, and reference docs for timer lifecycle semantics

Fixes #1441

## Verification

- `cargo test --test http_tasks timer_cancel_route_is_idempotent_and_updates_projection -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`