### PR TITLE
test: lock initial CLI JSON contracts

### DIFF
--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -77,7 +77,7 @@ than requiring a running daemon.
 | `holon config set` | `<KEY> <VALUE>` | none | JSON value after write | `stable` candidate | Value parsing is key-specific. |
 | `holon config unset` | `<KEY>` | none | JSON `{ "key": ..., "status": "unset" }` | `stable` candidate | Status string should be locked if scripts depend on it. |
 | `holon config list` | none | none | full persisted config JSON | `experimental` | Exposes broad config file shape; align with config reference before declaring stable. |
-| `holon config schema` | none | none | JSON config schema/metadata | `stable` candidate | Good machine-readable contract candidate. |
+| `holon config schema` | none | none | JSON config schema/metadata | `stable` JSON | Locked by `tests/cli_json_contract.rs`; entry objects expose `key`, `kind`, `description`, `default`, and optional `allowed_values`. |
 | `holon config doctor` | none | none | JSON provider/system diagnostics | `experimental` | Diagnostic shape may evolve as providers change. |
 | `holon config models list` | none | none | JSON model availability list | `experimental` | Provider catalog and availability details are still evolving. |
 
@@ -88,16 +88,16 @@ than requiring a running daemon.
 | `holon config providers set` | `<PROVIDER>` | `--transport <TRANSPORT>`; `--base-url <BASE_URL>`; `--credential-source <SOURCE>` default `none`; `--credential-kind <KIND>` default `none`; `--credential-env <ENV>`; `--credential-profile <PROFILE>`; `--credential-external <COMMAND>` | JSON `{ "applied_via": "offline_store", "provider": ... }` | `stable` candidate for command shape; `experimental` for provider object | Built-in providers may reject incompatible transport overrides. |
 | `holon config providers get` | `<PROVIDER>` | none | JSON provider view | `experimental` | Output uses runtime provider view. |
 | `holon config providers list` | none | none | JSON array/object of provider views | `experimental` | Output shape should be reconciled with API/config inventory. |
-| `holon config providers remove` | `<PROVIDER>` | none | JSON `{ "applied_via": "offline_store", "provider": ..., "status": "removed\|not_configured" }` | `stable` candidate | Status strings are script-facing. |
+| `holon config providers remove` | `<PROVIDER>` | none | JSON `{ "applied_via": "offline_store", "provider": ..., "status": "removed\|not_configured" }` | `stable` JSON | Locked by `tests/cli_json_contract.rs`; status strings are script-facing. |
 | `holon config providers doctor` | `<PROVIDER>` | none | JSON provider view plus model-chain diagnostics | `experimental` | Diagnostic details may evolve. |
 
 ### Credential configuration
 
 | Command | Args | Options | Output | Initial stability | Notes |
 |---|---|---|---|---:|---|
-| `holon config credentials set` | `<PROFILE>` | required `--kind <KIND>`; one of `--stdin` or `--material <MATERIAL>` | JSON `{ "applied_via": "offline_store", "credential": ... }` | `stable` candidate | `--stdin` prompt goes to stderr; raw `--material` is intentionally discouraged for secrets. |
-| `holon config credentials list` | none | none | JSON credential profile list | `stable` candidate | Must not expose credential material. |
-| `holon config credentials remove` | `<PROFILE>` | none | JSON `{ "applied_via": "offline_store", "credential": ... }` | `stable` candidate | Credential status shape needs explicit contract tests. |
+| `holon config credentials set` | `<PROFILE>` | required `--kind <KIND>`; one of `--stdin` or `--material <MATERIAL>` | JSON `{ "applied_via": "offline_store", "credential": { "profile": ..., "kind": ..., "configured": true } }` | `stable` JSON | Locked by `tests/cli_json_contract.rs`; `--stdin` prompt goes to stderr; raw `--material` is intentionally discouraged for secrets. |
+| `holon config credentials list` | none | none | JSON credential profile list with `profile`, `kind`, and `configured`; credential material is never included | `stable` JSON | Locked by `tests/cli_json_contract.rs`; must not expose credential material. |
+| `holon config credentials remove` | `<PROFILE>` | none | JSON `{ "applied_via": "offline_store", "credential": { "profile": ..., "kind": ..., "configured": false } }` | `stable` JSON | Locked by `tests/cli_json_contract.rs`; missing profiles return `kind: "unknown"` and `configured: false`. |
 
 ### Agent interaction and inspection
 

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -156,6 +156,12 @@ holon config models list         # Available models with status
 holon config credentials list    # Stored credential profiles
 ```
 
+Stable script-facing JSON contracts currently cover `holon config schema`,
+`holon config providers remove`, and `holon config credentials set/list/remove`.
+Other configuration inspection commands emit JSON too, but remain experimental
+until their provider/runtime DTO ownership is fully stabilized. Human-readable
+help and prose output are separate from these JSON contracts.
+
 ### Credential setup
 
 ```bash

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -1,0 +1,222 @@
+//! CLI JSON output contract tests.
+//!
+//! These tests lock the initial stable-candidate script-facing JSON surfaces.
+//! They intentionally exercise the compiled binary so stdout/stderr routing,
+//! pretty-printing, and persisted config paths are covered together.
+
+use std::{
+    collections::BTreeSet,
+    path::PathBuf,
+    process::{Command, Output},
+};
+
+use serde_json::{json, Value};
+
+fn holon_bin() -> PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_holon")
+        .map(PathBuf::from)
+        .or_else(|| option_env!("CARGO_BIN_EXE_holon").map(PathBuf::from))
+        .expect("CARGO_BIN_EXE_holon should be set for integration tests")
+}
+
+fn isolated_holon_command(home: &tempfile::TempDir) -> Command {
+    let mut command = Command::new(holon_bin());
+    command
+        .env("HOLON_HOME", home.path())
+        .env("HOLON_AGENT_ID", "main")
+        .env("HOLON_MODEL", "openai/gpt-5.4")
+        .env(
+            "HOLON_SOCKET_PATH",
+            home.path().join("run").join("missing.sock"),
+        )
+        .env_remove("HOLON_CONTROL_TOKEN")
+        .env_remove("HOLON_CONTROL_AUTH_MODE")
+        .env_remove("RUST_LOG");
+    command
+}
+
+fn run_json(home: &tempfile::TempDir, args: &[&str]) -> Value {
+    let output = isolated_holon_command(home)
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("run holon {args:?}: {error}"));
+    assert_success(output, args)
+}
+
+fn assert_success(output: Output, args: &[&str]) -> Value {
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "holon {args:?} failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stderr.is_empty(), "stderr should stay empty: {stderr}");
+    serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("stdout should be JSON for {args:?}: {error}\n{stdout}"))
+}
+
+#[test]
+fn config_schema_json_entries_keep_stable_shape() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+    let value = run_json(&home, &["config", "schema"]);
+    let entries = value.as_array().expect("schema output should be an array");
+    assert!(
+        entries.len() >= 40,
+        "schema should expose the known config surface, got {} entries",
+        entries.len()
+    );
+
+    let allowed_entry_keys =
+        BTreeSet::from(["allowed_values", "default", "description", "key", "kind"]);
+    let mut keys = BTreeSet::new();
+    for entry in entries {
+        let object = entry.as_object().expect("schema entry should be an object");
+        for key in object.keys() {
+            assert!(
+                allowed_entry_keys.contains(key.as_str()),
+                "unexpected config schema field {key:?} in {entry}"
+            );
+        }
+        assert!(
+            object
+                .get("key")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty()),
+            "schema entry should include a non-empty key: {entry}"
+        );
+        assert!(
+            object
+                .get("kind")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty()),
+            "schema entry should include a non-empty kind: {entry}"
+        );
+        assert!(
+            object
+                .get("description")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty()),
+            "schema entry should include a non-empty description: {entry}"
+        );
+        assert!(
+            object.contains_key("default"),
+            "schema entry should include default: {entry}"
+        );
+        keys.insert(object["key"].as_str().unwrap().to_string());
+    }
+
+    for expected in [
+        "model.default",
+        "model.fallbacks",
+        "runtime.max_output_tokens",
+        "tui.alternate_screen",
+        "web.fetch.enabled",
+        "web.search.provider",
+    ] {
+        assert!(
+            keys.contains(expected),
+            "schema output should include stable config key {expected}"
+        );
+    }
+}
+
+#[test]
+fn config_provider_remove_json_contract_is_stable() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+
+    let missing = run_json(&home, &["config", "providers", "remove", "script-test"]);
+    assert_eq!(
+        missing,
+        json!({
+            "applied_via": "offline_store",
+            "provider": "script-test",
+            "status": "not_configured"
+        })
+    );
+
+    let _set = run_json(
+        &home,
+        &[
+            "config",
+            "providers",
+            "set",
+            "script-test",
+            "--transport",
+            "anthropic_messages",
+            "--base-url",
+            "https://example.invalid",
+        ],
+    );
+    let removed = run_json(&home, &["config", "providers", "remove", "script-test"]);
+    assert_eq!(
+        removed,
+        json!({
+            "applied_via": "offline_store",
+            "provider": "script-test",
+            "status": "removed"
+        })
+    );
+}
+
+#[test]
+fn config_credentials_json_contract_is_stable_and_redacted() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+
+    let set = run_json(
+        &home,
+        &[
+            "config",
+            "credentials",
+            "set",
+            "demo",
+            "--kind",
+            "api_key",
+            "--material",
+            "super-secret",
+        ],
+    );
+    assert_eq!(
+        set,
+        json!({
+            "applied_via": "offline_store",
+            "credential": {
+                "configured": true,
+                "kind": "api_key",
+                "profile": "demo"
+            }
+        })
+    );
+
+    let list = run_json(&home, &["config", "credentials", "list"]);
+    assert_eq!(
+        list,
+        json!([
+            {
+                "configured": true,
+                "kind": "api_key",
+                "profile": "demo"
+            }
+        ])
+    );
+    assert!(
+        !list.to_string().contains("super-secret"),
+        "credential list JSON must not expose credential material"
+    );
+
+    let removed = run_json(&home, &["config", "credentials", "remove", "demo"]);
+    assert_eq!(
+        removed,
+        json!({
+            "applied_via": "offline_store",
+            "credential": {
+                "configured": false,
+                "kind": "api_key",
+                "profile": "demo"
+            }
+        })
+    );
+
+    let empty_list = run_json(&home, &["config", "credentials", "list"]);
+    assert_eq!(empty_list, json!([]));
+}


### PR DESCRIPTION
## Summary

Closes #1442.

This PR adds the first deterministic CLI JSON contract coverage for stable-candidate script-facing commands:

- `holon config schema`
- `holon config providers remove`
- `holon config credentials set/list/remove`

It keeps the initial scope on offline config commands so the golden/schema checks do not depend on daemon state, provider availability, or mutable runtime read models.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --test cli_json_contract`
- `cargo test --test cli_snapshot`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
