### PR TITLE
test: define stable operator event payload subset

### DIFF
--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -216,11 +216,10 @@ transport-local response sequence numbers.
 
 Runtime events should have clear, standard payload schemas that first-party
 clients and integrations can consume directly. The default replay projection is
-the operator projection, and it includes the raw standard event payload. UI
-noise and density are handled by client-side presentation policy, not by
-mutating or clipping the stream payload. A local debug projection remains
-available for explicitly authorized debug clients, but the canonical event
-contract should not depend on a separate redacted operator shape.
+the operator projection, and it exposes only the stable operator-facing payload
+subset. Raw/debug runtime payloads remain available through the explicitly
+authorized local debug projection, but they are not part of the public replay
+compatibility contract.
 
 ## Event Envelope
 
@@ -237,8 +236,8 @@ Every stream event should use one canonical envelope.
   "type": "task_status_updated",
   "projection": {
     "name": "operator",
-    "raw_payload_included": true,
-    "redactions": []
+    "raw_payload_included": false,
+    "redactions": ["raw_output"]
   },
   "provenance": {
     "origin": {"kind": "operator"},
@@ -265,8 +264,10 @@ Every stream event should use one canonical envelope.
   - raw runtime event kind
 - `projection`
   - the replay projection applied to this envelope
-  - `raw_payload_included=true` means the payload is the canonical event
-    payload for the selected authorized replay surface
+  - `raw_payload_included=false` on the `operator` projection means raw/debug
+    fields were omitted and any omitted payload keys are listed in `redactions`
+  - `raw_payload_included=true` is reserved for explicitly authorized debug
+    projections that include the raw event payload
 - `provenance`
   - provenance fields duplicated for client recovery and indexing
 - `payload`
@@ -417,7 +418,9 @@ audit events.
 
 ## Event Payload Strategy
 
-The stream payload should remain raw and explicit.
+The stream envelope should remain raw and explicit about provenance, cursor,
+and projection. The default operator payload is a documented stable subset; the
+full raw runtime payload is available only through the local debug projection.
 
 That means:
 

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -186,8 +186,8 @@ Default-agent aliases:
 
 | Method | Path | Inputs | Success response | Stability | Notes |
 |--------|------|--------|------------------|-----------|-------|
-| `GET` | `/agents/:agent_id/events` | Path `agent_id`; query `before_seq?`, `after_seq?`, `limit?`, `order?`, `projection?`. | `EventsPageResponse` | Candidate stable route; experimental payload | `limit` defaults to the event window and is clamped. `order` is `asc` or `desc`. `projection` is `operator` or `local_debug`. |
-| `GET` | `/agents/:agent_id/events/stream` | Path `agent_id`; query `after_seq?`, `limit?`, `projection?`; `Accept: text/event-stream` recommended. | SSE frames with JSON `StreamEventEnvelope` data. | Candidate stable route; experimental payload | SSE `id` is `event_seq`; SSE `event` is the raw audit event kind. |
+| `GET` | `/agents/:agent_id/events` | Path `agent_id`; query `before_seq?`, `after_seq?`, `limit?`, `order?`, `projection?`. | `EventsPageResponse` | Candidate stable route and envelope; operator payload v1 subset | `limit` defaults to the event window and is clamped. `order` is `asc` or `desc`. `projection` is `operator` or `local_debug`. |
+| `GET` | `/agents/:agent_id/events/stream` | Path `agent_id`; query `after_seq?`, `limit?`, `projection?`; `Accept: text/event-stream` recommended. | SSE frames with JSON `StreamEventEnvelope` data. | Candidate stable route and envelope; operator payload v1 subset | SSE `id` is `event_seq`; SSE `event` is the raw audit event kind. |
 
 Event page cursors are exclusive: `after_seq` returns records with higher
 `event_seq`, `before_seq` returns records with lower `event_seq`, and combining
@@ -213,12 +213,39 @@ Stable `StreamEventEnvelope` fields:
 
 Projection contract:
 
-- `operator` is the default public projection. It preserves only
-  operator-facing summary/status/identity/cursor/provenance fields in
-  `payload`, sets `raw_payload_included: false`, and lists omitted raw/debug
-  fields in `redactions`.
+- `operator` is the default public projection. It preserves only the
+  operator-facing v1 field subset in `payload`, sets
+  `raw_payload_included: false`, and lists omitted raw/debug fields in
+  `redactions`. The v1 subset is intentionally shared by events page and SSE
+  stream output.
 - `local_debug` requires control auth and preserves the raw event payload with
   `raw_payload_included: true` and an empty `redactions` list.
+
+Stable operator payload v1 fields:
+
+| Field family | Stable fields | Notes |
+|--------------|---------------|-------|
+| Identity and correlation | `agent_id`, `message_id`, `task_id`, `work_item_id`, `run_id`, `correlation_id`, `causation_id` | IDs are stable handles for joining the event with read-model routes. |
+| Provenance and admission | `origin`, `authority_class`, `delivery_surface`, `priority` | Enough to preserve operator/system/external trust boundaries without exposing the full ingress body. |
+| State and outcome | `status`, `exit_status`, `duration_ms`, `stop_reason`, `summary` | Used by task, turn, brief, and lifecycle events for operator-visible state transitions. |
+| Turn/model summary | `turn_index`, `round`, `has_text`, `has_tool_calls`, `text_block_count`, `text_char_count`, `text_preview`, `tool_call_count`, `tool_name`, `tool_names` | Summary-only fields; provider/raw message bodies remain debug-only. |
+| Workspace projection | `workspace_id`, `workspace_label`, `projection_kind` | Stable workspace identity/projection facts; host paths and access-mode internals remain debug-only unless separately stabilized. |
+| Cursor/detail summaries | `event_seq` | Included only when an event payload already carries a related cursor; the envelope `event_seq` remains the replay cursor. |
+
+Selected high-value event kinds with checked operator payload behavior:
+
+| Event kind | Stable operator fields currently asserted | Debug-only examples redacted from operator projection |
+|------------|-------------------------------------------|------------------------------------------------------|
+| `message_admitted` | `agent_id`, `message_id`, `origin`, `authority_class`, `delivery_surface`, `priority`, `summary`, `text_preview` | Raw prompt text or transport bodies such as `raw_text`. |
+| `brief_created` | `agent_id`, `run_id`, `work_item_id`, `status`, `summary`, `text_preview` | Full/raw brief payload objects such as `raw_brief`. |
+| `task_status_updated` | `agent_id`, `task_id`, `status`, `duration_ms`, `exit_status`, `summary` | Raw stdout/stderr or command-output bodies. |
+| `assistant_round_recorded` | `agent_id`, `run_id`, `turn_index`, `round`, `stop_reason`, text/tool counts, `text_preview`, `tool_names` | Full assistant text and provider traces. |
+| `tool_executed` | `agent_id`, `task_id`, `tool_name`, `status`, `duration_ms`, `exit_status`, `summary` when present | Command strings, local paths, artifact/debug refs, raw output. |
+
+Unknown or newly added raw payload fields are treated as debug-only until they
+are added to the operator v1 subset and covered by tests/docs. This keeps
+runtime-internal event detail available through `local_debug` without making it
+an accidental public compatibility contract.
 
 ### Public ingress
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1718,6 +1718,9 @@ fn operator_replay_payload(payload: &Value) -> Value {
     Value::Object(projected)
 }
 
+// Stable operator replay payload v1 field subset. Unknown raw event payload
+// fields stay available through the authorized local-debug projection but are
+// redacted from the default operator replay contract until documented here.
 const OPERATOR_REPLAY_PAYLOAD_FIELDS: &[&str] = &[
     "agent_id",
     "authority_class",

--- a/tests/http_events.rs
+++ b/tests/http_events.rs
@@ -16,6 +16,7 @@ http_async_tests!(
     events_route_supports_cursor_replay,
     events_stream_supports_cursor_and_rfc3339_ts,
     events_route_preserves_replay_provenance,
+    events_route_operator_projection_keeps_stable_high_value_payload_fields,
     events_route_operator_projection_redacts_tool_payload,
     events_route_operator_projection_redacts_assistant_round_payload,
     events_route_local_debug_projection_preserves_raw_payload_with_control_auth,

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -304,6 +304,136 @@ pub async fn events_route_preserves_replay_provenance() -> Result<()> {
     Ok(())
 }
 
+pub async fn events_route_operator_projection_keeps_stable_high_value_payload_fields() -> Result<()>
+{
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    client
+        .post(format!("{base}/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": "stable operator event bootstrap" }))
+        .send()
+        .await?;
+    wait_until(|| Ok(runtime.storage().read_recent_events(1)?.first().is_some())).await?;
+
+    let after_seq = newest_event_seq(&base, &client, None).await?;
+
+    runtime.storage().append_event(&AuditEvent::new(
+        "message_admitted",
+        serde_json::json!({
+            "agent_id": "default",
+            "message_id": "msg-stable",
+            "origin": { "kind": "operator" },
+            "authority_class": "operator_instruction",
+            "delivery_surface": "http_control_prompt",
+            "priority": "interject",
+            "summary": "operator prompt admitted",
+            "text_preview": "inspect status",
+            "raw_text": "debug-only prompt body",
+        }),
+    ))?;
+    runtime.storage().append_event(&AuditEvent::new(
+        "brief_created",
+        serde_json::json!({
+            "agent_id": "default",
+            "run_id": "run-stable",
+            "work_item_id": "work-stable",
+            "status": "completed",
+            "summary": "work finished",
+            "text_preview": "final summary",
+            "raw_brief": { "debug": true },
+        }),
+    ))?;
+    runtime.storage().append_event(&AuditEvent::new(
+        "task_status_updated",
+        serde_json::json!({
+            "agent_id": "default",
+            "task_id": "task-stable",
+            "status": "completed",
+            "duration_ms": 123,
+            "exit_status": 0,
+            "summary": "cargo check passed",
+            "stdout": "debug-only output",
+        }),
+    ))?;
+
+    let page: serde_json::Value = client
+        .get(format!(
+            "{base}/agents/default/events?after_seq={after_seq}&limit=10&order=asc&projection=operator"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let events = page["events"].as_array().expect("events");
+
+    let admitted = events
+        .iter()
+        .find(|event| event["type"] == "message_admitted")
+        .expect("message_admitted projection");
+    assert_eq!(
+        admitted["payload"],
+        serde_json::json!({
+            "agent_id": "default",
+            "authority_class": "operator_instruction",
+            "delivery_surface": "http_control_prompt",
+            "message_id": "msg-stable",
+            "origin": { "kind": "operator" },
+            "priority": "interject",
+            "summary": "operator prompt admitted",
+            "text_preview": "inspect status",
+        })
+    );
+    assert_eq!(
+        admitted["projection"]["redactions"],
+        serde_json::json!(["raw_text"])
+    );
+
+    let brief = events
+        .iter()
+        .find(|event| event["type"] == "brief_created")
+        .expect("brief_created projection");
+    assert_eq!(
+        brief["payload"],
+        serde_json::json!({
+            "agent_id": "default",
+            "run_id": "run-stable",
+            "status": "completed",
+            "summary": "work finished",
+            "text_preview": "final summary",
+            "work_item_id": "work-stable",
+        })
+    );
+    assert_eq!(
+        brief["projection"]["redactions"],
+        serde_json::json!(["raw_brief"])
+    );
+
+    let task = events
+        .iter()
+        .find(|event| event["type"] == "task_status_updated")
+        .expect("task_status_updated projection");
+    assert_eq!(
+        task["payload"],
+        serde_json::json!({
+            "agent_id": "default",
+            "duration_ms": 123,
+            "exit_status": 0,
+            "status": "completed",
+            "summary": "cargo check passed",
+            "task_id": "task-stable",
+        })
+    );
+    assert_eq!(
+        task["projection"]["redactions"],
+        serde_json::json!(["stdout"])
+    );
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn events_route_operator_projection_redacts_tool_payload() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let runtime = host.default_runtime().await?;


### PR DESCRIPTION
Closes #1443

## Summary
- document the operator event replay payload v1 subset in the API contract inventory
- align the event-stream RFC with operator projection redaction semantics
- add regression coverage for high-value operator event payload fields and debug-only redactions

## Verification
- cargo test --test http_events events_route_operator_projection_keeps_stable_high_value_payload_fields
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets