### PR TITLE
fix: avoid duplicate WorkItem completion delivery

### DIFF
--- a/docs/rfcs/work-item-centered-agent-runtime.md
+++ b/docs/rfcs/work-item-centered-agent-runtime.md
@@ -502,6 +502,10 @@ runtime should persist:
   projection using the same text;
 - a WorkItem result report projection that context and compaction can read.
 
+That delivery projection is terminal for the current turn. Normal turn-final
+brief generation should not emit a second user-facing result for the same
+completion report.
+
 If a WorkItem is completed without same-round report text, completion may still
 succeed, but the runtime should not synthesize a generic result report from
 arbitrary runtime evidence. It should surface a structured warning so the agent

--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -579,6 +579,9 @@ When the same assistant round contains both operator-facing completion report
 text and a successful `CompleteWorkItem` call for the focused WorkItem, the
 runtime should promote that text into the WorkItem result summary, delivery
 summary, and completion brief.
+The promoted completion brief is the terminal user-facing delivery for that
+turn; runtime finalization should not emit a second result brief with the same
+completion.
 
 The promoted result summary is not a full progress log. Detailed evidence
 remains in transcript, tool records, briefs, verification output, PRs, issues,

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -1830,6 +1830,10 @@ operator-facing report text and exactly one successful focused
 `CompleteWorkItem` call. The tool call marks the work item completed; after that
 state transition succeeds, the runtime promotes the same-round assistant text
 into the WorkItem result summary, delivery summary, and result brief.
+That promoted result brief is the terminal user-facing delivery for the turn;
+the normal turn-final result brief is suppressed to avoid delivering the same
+completion twice. Other runnable WorkItems continue through the scheduler's
+work-queue `SystemTick` path.
 
 Completion reports are explicit-only in this release line. The turn-end and
 work-item lifecycle do not synthesize fallback summaries from runtime evidence.

--- a/docs/website/concepts/runtime-model.md
+++ b/docs/website/concepts/runtime-model.md
@@ -67,7 +67,9 @@ visible through `GetWorkItem` and `ListWorkItems`, and indexed by
 conclude on that issue?" without re-reading the full transcript.
 
 Completion reports replace free-form manual summaries. They are tied to the
-work item lifecycle, not to individual model turns.
+work item lifecycle, not to individual model turns. Once a completion report is
+promoted, it is the terminal user-facing delivery for that turn; the scheduler
+resumes any other runnable work in a later work-queue tick.
 ```
 
 ### Tasks

--- a/docs/website/spec/scheduler.md
+++ b/docs/website/spec/scheduler.md
@@ -133,6 +133,8 @@ WorkItems flow through scheduling states that the scheduler consumes:
   to do; this is distinct from `Sleep` (the initial transition).
 - `EmitSystemTick` injects an internal follow-up message to re-enter the model
   when a runnable WorkItem is found at an idle boundary.
+- When `CompleteWorkItem` promotion ends a turn, any remaining runnable
+  WorkItem is resumed by the same work-queue `SystemTick` path.
 - Wake hints are **liveness signals**: they tell the scheduler to re-evaluate
   but do not themselves carry content for the model.
 - Duplicate suppression uses idempotency keys to prevent redundant system

--- a/docs/website/spec/tools.md
+++ b/docs/website/spec/tools.md
@@ -52,7 +52,7 @@ Tools are grouped by capability family for authority gating:
 | `PickWorkItem` | Set current focus |
 | `GetWorkItem` | Read single WorkItem with plan preview |
 | `ListWorkItems` | Query with filters |
-| `CompleteWorkItem` | Mark complete; completion report promotion |
+| `CompleteWorkItem` | Mark complete; promote same-round assistant text as the terminal completion report |
 | `WaitFor` | Record task, external, or operator waiting state and yield |
 
 ### Task control plane

--- a/docs/website/spec/wake-and-continuation.md
+++ b/docs/website/spec/wake-and-continuation.md
@@ -40,6 +40,9 @@ and class:
 | `InternalFollowup` | The agent enqueued a self-follow-up via `Enqueue` |
 | `SystemTick` | The scheduler emitted a runtime-owned follow-up for a runnable WorkItem |
 
+`SystemTick` is also how Holon resumes other runnable WorkItems after a
+promoted `CompleteWorkItem` report ends the current turn.
+
 ### Continuation classes (`ContinuationClass`)
 
 | Class | Meaning |

--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -134,7 +134,7 @@ current WorkItem is the focus for the current turn:
 | `PickWorkItem` | Set current focus to an existing open WorkItem |
 | `GetWorkItem` | Read a single WorkItem with plan preview |
 | `ListWorkItems` | Query with filters: all, open, completed, current, queued, blocked, waiting_for_operator, runnable |
-| `CompleteWorkItem` | Mark complete; the next assistant-text block in the same round is promoted as the completion report |
+| `CompleteWorkItem` | Mark complete; same-round assistant text is promoted as the completion report |
 | `WaitFor` | Attach a task, external, or operator wait to the current WorkItem and yield |
 
 **Key contract:**
@@ -149,7 +149,14 @@ current WorkItem is the focus for the current turn:
   should wait.
 - `CompleteWorkItem` promotion: the operator-facing completion report must be
   written as assistant text **in the same round**. After the tool succeeds,
-  the runtime promotes that text as the canonical completion report.
+  the runtime promotes that text as the canonical completion report and
+  terminal user-facing delivery for the turn.
+- A promoted completion report writes exactly one result brief for that
+  WorkItem. The turn-final result brief is suppressed so the same completion is
+  not delivered twice.
+- Additional runnable WorkItems after completion resume through scheduler-owned
+  work-queue `SystemTick` messages, not through another provider round in the
+  completed WorkItem's turn.
 - Plan body changes go through direct file edits to `plan_artifact.path`, not
   through `UpdateWorkItem`.
 

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -742,7 +742,7 @@ async fn build_response(
         .read_recent_delivery_summaries(usize::MAX)?
         .into_iter()
         .filter(|summary| !baseline.delivery_summary_ids.contains(&summary.id))
-        .max_by(|left, right| left.created_at.cmp(&right.created_at))
+        .last()
         .map(|summary| summary.text)
         .map(|text| text.trim().to_string())
         .filter(|text| !text.is_empty());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -97,7 +97,33 @@ use command_task::ManagedTaskHandle;
 use continuation::{resolve_continuation, ContinuationTrigger};
 #[cfg(test)]
 use subagent::sanitize_subagent_result;
-use turn::LoopControlOptions;
+use turn::{LoopControlOptions, TurnTerminalDelivery};
+
+#[derive(Debug, Clone)]
+pub(super) struct WorkItemCompletionReportPromotion {
+    pub(super) record: crate::types::WorkItemRecord,
+    pub(super) delivery_summary_id: String,
+    pub(super) brief_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum WorkItemCompletionReportPromotionOutcome {
+    /// Completion changed the WorkItem state, but did not create a new
+    /// user-facing report for terminal delivery.
+    Unchanged(crate::types::WorkItemRecord),
+    /// Completion promoted the assistant's same-round report into the
+    /// WorkItem's delivery summary and result brief.
+    Promoted(WorkItemCompletionReportPromotion),
+}
+
+impl WorkItemCompletionReportPromotionOutcome {
+    pub(super) fn into_record(self) -> crate::types::WorkItemRecord {
+        match self {
+            Self::Unchanged(record) => record,
+            Self::Promoted(promotion) => promotion.record,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 struct WorktreeSubagentResult {

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -99,12 +99,35 @@ impl RuntimeHandle {
             )
             .await?;
 
-        let brief = if outcome.terminal_kind.is_failure() {
-            brief::make_failure(&message.agent_id, message, outcome.final_text.clone())
+        if outcome.terminal_kind.is_failure() {
+            let brief = brief::make_failure(&message.agent_id, message, outcome.final_text.clone());
+            self.persist_brief(&brief).await?;
         } else {
-            brief::make_result(&message.agent_id, message, outcome.final_text.clone())
-        };
-        self.persist_brief(&brief).await?;
+            match outcome.terminal_delivery {
+                TurnTerminalDelivery::NormalBrief => {
+                    let brief =
+                        brief::make_result(&message.agent_id, message, outcome.final_text.clone());
+                    self.persist_brief(&brief).await?;
+                }
+                TurnTerminalDelivery::WorkItemCompletionReportPromoted {
+                    work_item_id,
+                    delivery_summary_id,
+                    brief_id,
+                } => {
+                    self.inner.storage.append_event(&AuditEvent::new(
+                        "turn_terminal_brief_suppressed",
+                        serde_json::json!({
+                            "agent_id": message.agent_id.clone(),
+                            "message_id": message.id.clone(),
+                            "reason": "work_item_completion_report_promoted",
+                            "work_item_id": work_item_id,
+                            "delivery_summary_id": delivery_summary_id,
+                            "brief_id": brief_id,
+                        }),
+                    ))?;
+                }
+            }
+        }
         self.promote_turn_active_skills().await?;
 
         if outcome.should_sleep {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2302,6 +2302,26 @@ impl RuntimeHandle {
         source_round: Option<usize>,
         warnings: Vec<serde_json::Value>,
     ) -> Result<WorkItemRecord> {
+        Ok(self
+            .promote_work_item_completion_report_with_metadata(
+                work_item_id,
+                report_text,
+                source_turn_index,
+                source_round,
+                warnings,
+            )
+            .await?
+            .into_record())
+    }
+
+    pub(super) async fn promote_work_item_completion_report_with_metadata(
+        &self,
+        work_item_id: String,
+        report_text: String,
+        source_turn_index: Option<u64>,
+        source_round: Option<usize>,
+        warnings: Vec<serde_json::Value>,
+    ) -> Result<WorkItemCompletionReportPromotionOutcome> {
         let agent_id = self.agent_id().await?;
         let existing = self.validate_owned_work_item(&agent_id, &work_item_id)?;
         if existing.state != WorkItemState::Completed {
@@ -2312,10 +2332,14 @@ impl RuntimeHandle {
         }
         let report_text = report_text.trim();
         if report_text.is_empty() {
-            return Ok(existing);
+            return Ok(WorkItemCompletionReportPromotionOutcome::Unchanged(
+                existing,
+            ));
         }
         if existing.result_summary.as_deref() == Some(report_text) {
-            return Ok(existing);
+            return Ok(WorkItemCompletionReportPromotionOutcome::Unchanged(
+                existing,
+            ));
         }
         let record = WorkItemRecord {
             revision: existing.revision + 1,
@@ -2356,11 +2380,17 @@ impl RuntimeHandle {
                 "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
                 "warnings": warnings.clone(),
                 "warning_count": warnings.len(),
-                "delivery_summary_id": delivery_summary.id,
-                "brief_id": brief.id,
+                "delivery_summary_id": delivery_summary.id.clone(),
+                "brief_id": brief.id.clone(),
             }),
         ))?;
-        Ok(record)
+        Ok(WorkItemCompletionReportPromotionOutcome::Promoted(
+            WorkItemCompletionReportPromotion {
+                record,
+                delivery_summary_id: delivery_summary.id,
+                brief_id: brief.id,
+            },
+        ))
     }
 
     pub async fn record_work_item_completion_warning(

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -70,6 +70,47 @@ impl AgentProvider for CompleteWorkItemReportProvider {
     }
 }
 
+struct MultiCompleteWorkItemReportProvider {
+    work_item_ids: Vec<String>,
+    report_text: String,
+    calls: Mutex<usize>,
+}
+
+#[async_trait]
+impl AgentProvider for MultiCompleteWorkItemReportProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        let blocks = if *calls == 1 {
+            let mut blocks = vec![ModelBlock::Text {
+                text: self.report_text.clone(),
+            }];
+            for (index, work_item_id) in self.work_item_ids.iter().enumerate() {
+                blocks.push(ModelBlock::ToolUse {
+                    id: format!("complete-work-{index}"),
+                    name: "CompleteWorkItem".into(),
+                    input: serde_json::json!({
+                        "work_item_id": work_item_id,
+                    }),
+                });
+            }
+            blocks
+        } else {
+            vec![ModelBlock::Text {
+                text: "done".into(),
+            }]
+        };
+        Ok(ProviderTurnResponse {
+            blocks,
+            stop_reason: None,
+            input_tokens: 10,
+            output_tokens: 10,
+            cache_usage: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
 #[test]
 fn work_item_record_revision_defaults_for_old_records() {
     let value = serde_json::json!({
@@ -1753,16 +1794,17 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         .unwrap();
 
     let report_text = "Implemented completion report promotion and verified focused tests.";
+    let provider = Arc::new(CompleteWorkItemReportProvider {
+        work_item_id: work_item.id.clone(),
+        report_text: Some(report_text.into()),
+        calls: Mutex::new(0),
+    });
     let runtime = RuntimeHandle::new(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
         "http://127.0.0.1:7878".into(),
-        Arc::new(CompleteWorkItemReportProvider {
-            work_item_id: work_item.id.clone(),
-            report_text: Some(report_text.into()),
-            calls: Mutex::new(0),
-        }),
+        provider.clone(),
         "default".into(),
         context_config(),
     )
@@ -1788,6 +1830,11 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         )
         .await
         .unwrap();
+    assert_eq!(
+        *provider.calls.lock().await,
+        1,
+        "promoted completion report should end the provider loop"
+    );
 
     let completed = runtime
         .latest_work_item(&work_item.id)
@@ -1803,11 +1850,26 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         .expect("completion report should persist delivery summary");
     assert_eq!(summary.text, report_text);
     let briefs = runtime.recent_briefs(10).await.unwrap();
-    assert!(briefs.iter().any(|brief| {
-        brief.kind == BriefKind::Result
-            && brief.work_item_id.as_deref() == Some(work_item.id.as_str())
-            && brief.text == report_text
-    }));
+    let result_briefs = briefs
+        .iter()
+        .filter(|brief| brief.kind == BriefKind::Result && brief.text == report_text)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        result_briefs.len(),
+        1,
+        "completion report should produce exactly one user-facing result brief"
+    );
+    assert_eq!(
+        result_briefs[0].work_item_id.as_deref(),
+        Some(work_item.id.as_str())
+    );
+    assert!(
+        !briefs.iter().any(|brief| {
+            brief.kind == BriefKind::Result
+                && brief.related_message_id.as_deref() == Some(message.id.as_str())
+        }),
+        "normal terminal result brief should be suppressed after completion promotion"
+    );
     let tools = runtime.storage().read_recent_tool_executions(10).unwrap();
     let complete_tool = tools
         .iter()
@@ -1836,6 +1898,91 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         tool_result["result"]["completion_report_promoted"].as_bool(),
         Some(true)
     );
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "turn_terminal_brief_suppressed"
+            && event.data["reason"].as_str() == Some("work_item_completion_report_promoted")
+            && event.data["work_item_id"].as_str() == Some(work_item.id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn promoted_completion_report_resumes_next_queued_work_item_via_system_tick() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let active = seed_runtime
+        .create_work_item("finish active work".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(active.id.clone())
+        .await
+        .unwrap();
+    let queued = seed_runtime
+        .create_work_item("resume queued work".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+
+    let provider = Arc::new(CompleteWorkItemReportProvider {
+        work_item_id: active.id.clone(),
+        report_text: Some("Active work is complete.".into()),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "finish active work".into(),
+        },
+    );
+
+    runtime
+        .process_message(message, closure_decision(ClosureOutcome::Completed, None))
+        .await
+        .unwrap();
+
+    let messages = runtime.storage().read_recent_messages(10).unwrap();
+    let tick = messages
+        .iter()
+        .find(|message| {
+            matches!(
+                (&message.kind, &message.origin),
+                (MessageKind::SystemTick, MessageOrigin::System { subsystem }) if subsystem == "work_queue"
+            )
+        })
+        .expect("queued runnable work item should be resumed by work queue tick");
+    assert_eq!(tick.work_item_id.as_deref(), Some(queued.id.as_str()));
+    assert_eq!(
+        tick.metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("work_queue"))
+            .and_then(|metadata| metadata.get("reason"))
+            .and_then(|value| value.as_str()),
+        Some("queued_available")
+    );
 }
 
 #[tokio::test]
@@ -1861,16 +2008,17 @@ async fn complete_work_item_without_same_round_report_warns_without_summary() {
         .await
         .unwrap();
 
+    let provider = Arc::new(CompleteWorkItemReportProvider {
+        work_item_id: work_item.id.clone(),
+        report_text: None,
+        calls: Mutex::new(0),
+    });
     let runtime = RuntimeHandle::new(
         "default",
         dir.path().to_path_buf(),
         workspace.path().to_path_buf(),
         "http://127.0.0.1:7878".into(),
-        Arc::new(CompleteWorkItemReportProvider {
-            work_item_id: work_item.id.clone(),
-            report_text: None,
-            calls: Mutex::new(0),
-        }),
+        provider.clone(),
         "default".into(),
         context_config(),
     )
@@ -1896,7 +2044,6 @@ async fn complete_work_item_without_same_round_report_warns_without_summary() {
         )
         .await
         .unwrap();
-
     let completed = runtime
         .latest_work_item(&work_item.id)
         .await
@@ -1926,6 +2073,100 @@ async fn complete_work_item_without_same_round_report_warns_without_summary() {
             && event.data["kind"].as_str() == Some("missing_completion_report")
             && event.data["work_item_id"].as_str() == Some(work_item.id.as_str())
     }));
+    assert!(!events
+        .iter()
+        .any(|event| event.kind == "turn_terminal_brief_suppressed"));
+}
+
+#[tokio::test]
+async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circuit() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let first = seed_runtime
+        .create_work_item("first completion".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let second = seed_runtime
+        .create_work_item("second completion".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+
+    let provider = Arc::new(MultiCompleteWorkItemReportProvider {
+        work_item_ids: vec![first.id.clone(), second.id.clone()],
+        report_text: "Finished two work items in one report.".into(),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "finish both tracked items".into(),
+        },
+    );
+
+    runtime
+        .process_interactive_message(
+            &message,
+            None,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    for work_item_id in [&first.id, &second.id] {
+        let completed = runtime
+            .latest_work_item(work_item_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(completed.state, WorkItemState::Completed);
+        assert_eq!(completed.result_summary, None);
+        assert!(runtime
+            .storage()
+            .latest_delivery_summary(work_item_id)
+            .unwrap()
+            .is_none());
+    }
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| {
+                event.kind == "work_item_completion_warning"
+                    && event.data["kind"].as_str()
+                        == Some("completion_report_not_promoted_multiple_completions")
+            })
+            .count(),
+        2
+    );
+    assert!(!events
+        .iter()
+        .any(|event| event.kind == "turn_terminal_brief_suppressed"));
 }
 
 #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -34,7 +34,8 @@ use crate::{
 
 use super::{
     combine_text_history, is_max_output_stop_reason, message_dispatch::message_text, scheduler,
-    CurrentRunAborted, RuntimeHandle,
+    CurrentRunAborted, RuntimeHandle, WorkItemCompletionReportPromotion,
+    WorkItemCompletionReportPromotionOutcome,
 };
 
 pub(super) struct AgentLoopOutcome {
@@ -42,6 +43,22 @@ pub(super) struct AgentLoopOutcome {
     pub(super) should_sleep: bool,
     pub(super) sleep_duration_ms: Option<u64>,
     pub(super) terminal_kind: TurnTerminalKind,
+    pub(super) terminal_delivery: TurnTerminalDelivery,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum TurnTerminalDelivery {
+    /// The turn should emit the normal terminal result brief from its final
+    /// assistant text.
+    NormalBrief,
+    /// The turn already promoted a same-round WorkItem completion report into
+    /// a result brief, so the operator-dispatch path must suppress its
+    /// otherwise duplicate terminal brief.
+    WorkItemCompletionReportPromoted {
+        work_item_id: String,
+        delivery_summary_id: String,
+        brief_id: String,
+    },
 }
 
 pub(super) struct LoopControlOptions {
@@ -1372,6 +1389,7 @@ impl RuntimeHandle {
             should_sleep: false,
             sleep_duration_ms: None,
             terminal_kind: TurnTerminalKind::Aborted,
+            terminal_delivery: TurnTerminalDelivery::NormalBrief,
         }))
     }
 
@@ -1526,6 +1544,7 @@ impl RuntimeHandle {
             should_sleep: false,
             sleep_duration_ms: None,
             terminal_kind,
+            terminal_delivery: TurnTerminalDelivery::NormalBrief,
         }))
     }
 
@@ -1866,6 +1885,7 @@ impl TurnExecution<'_> {
                         should_sleep: false,
                         sleep_duration_ms: None,
                         terminal_kind: TurnTerminalKind::Aborted,
+                        terminal_delivery: TurnTerminalDelivery::NormalBrief,
                     });
                 }
             }
@@ -2087,6 +2107,7 @@ impl TurnExecution<'_> {
                             should_sleep: false,
                             sleep_duration_ms: None,
                             terminal_kind: TurnTerminalKind::BaselineOverBudget,
+                            terminal_delivery: TurnTerminalDelivery::NormalBrief,
                         });
                     }
                 };
@@ -2585,6 +2606,7 @@ impl TurnExecution<'_> {
                     should_sleep,
                     sleep_duration_ms,
                     terminal_kind: TurnTerminalKind::Completed,
+                    terminal_delivery: TurnTerminalDelivery::NormalBrief,
                 });
             }
 
@@ -2839,7 +2861,7 @@ impl TurnExecution<'_> {
                     }
                 }
             }
-            runtime
+            let completion_promotion = runtime
                 .promote_round_completion_report_if_present(
                     agent_id,
                     round,
@@ -2894,6 +2916,31 @@ impl TurnExecution<'_> {
             }
             completed_rounds.push(round_record);
 
+            if let Some(promotion) = completion_promotion {
+                if !has_operator_interjections {
+                    let final_text = last_assistant_message.clone().unwrap_or_default();
+                    runtime
+                        .persist_turn_terminal_record(
+                            TurnTerminalKind::Completed,
+                            last_assistant_message.clone(),
+                            turn_started_at.elapsed().as_millis() as u64,
+                            Some(&checkpoint_state),
+                        )
+                        .await?;
+                    return Ok(AgentLoopOutcome {
+                        final_text,
+                        should_sleep,
+                        sleep_duration_ms,
+                        terminal_kind: TurnTerminalKind::Completed,
+                        terminal_delivery: TurnTerminalDelivery::WorkItemCompletionReportPromoted {
+                            work_item_id: promotion.record.id,
+                            delivery_summary_id: promotion.delivery_summary_id,
+                            brief_id: promotion.brief_id,
+                        },
+                    });
+                }
+            }
+
             if only_sleep_tools && !has_operator_interjections {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
                 runtime
@@ -2909,6 +2956,7 @@ impl TurnExecution<'_> {
                     should_sleep: true,
                     sleep_duration_ms,
                     terminal_kind: TurnTerminalKind::Completed,
+                    terminal_delivery: TurnTerminalDelivery::NormalBrief,
                 });
             }
         }
@@ -2924,7 +2972,7 @@ impl RuntimeHandle {
         combined_text: &str,
         tool_results: &mut [ToolResultBlock],
         tool_result_envelopes: &mut [ToolResultEnvelope],
-    ) -> Result<()> {
+    ) -> Result<Option<WorkItemCompletionReportPromotion>> {
         let completion_indexes = tool_result_envelopes
             .iter()
             .enumerate()
@@ -2941,7 +2989,7 @@ impl RuntimeHandle {
             .filter_map(|(index, envelope)| result_work_item_id(envelope).map(|id| (index, id)))
             .collect::<Vec<_>>();
         if completion_indexes.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
         if completion_indexes.len() != 1 {
@@ -2965,7 +3013,7 @@ impl RuntimeHandle {
                 )
                 .await?;
             }
-            return Ok(());
+            return Ok(None);
         }
 
         let (index, work_item_id) = completion_indexes
@@ -2988,18 +3036,23 @@ impl RuntimeHandle {
                 Some(round),
             )
             .await?;
-            return Ok(());
+            return Ok(None);
         }
 
         let warnings = envelope_warnings(&tool_result_envelopes[index]);
-        self.promote_work_item_completion_report(
-            work_item_id.clone(),
-            report_text.to_string(),
-            Some(turn_index),
-            Some(round),
-            warnings,
-        )
-        .await?;
+        let promotion = match self
+            .promote_work_item_completion_report_with_metadata(
+                work_item_id.clone(),
+                report_text.to_string(),
+                Some(turn_index),
+                Some(round),
+                warnings,
+            )
+            .await?
+        {
+            WorkItemCompletionReportPromotionOutcome::Promoted(promotion) => promotion,
+            WorkItemCompletionReportPromotionOutcome::Unchanged(_) => return Ok(None),
+        };
         if let Some(result) = tool_result_envelopes[index].result.as_mut() {
             if let Some(object) = result.as_object_mut() {
                 object.insert("completion_report_promoted".into(), serde_json::json!(true));
@@ -3017,10 +3070,12 @@ impl RuntimeHandle {
                 "work_item_id": work_item_id,
                 "turn_index": turn_index,
                 "round": round,
+                "delivery_summary_id": promotion.delivery_summary_id.clone(),
+                "brief_id": promotion.brief_id.clone(),
                 "text_preview": truncate_preview(report_text, ROUND_TEXT_PREVIEW_LIMIT),
             }),
         ))?;
-        Ok(())
+        Ok(Some(promotion))
     }
 }
 

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -274,7 +274,7 @@ async fn run_once_prefers_completed_work_item_delivery_summary_over_latest_turn_
     );
     assert_eq!(
         second.raw_final_text.as_deref(),
-        Some("Fixed two test annotation issues.")
+        Some("Implemented broad prompt/context snapshot coverage")
     );
     let runtime = host
         .get_public_agent_for_external_ingress("default")


### PR DESCRIPTION
## Summary

- treat a promoted `CompleteWorkItem` completion report as the terminal user-facing delivery for the turn
- suppress the normal turn-final result brief when the completion report already wrote the canonical result brief
- preserve non-promoted completion warning paths and document continuation through work-queue `SystemTick`

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test -q complete_work_item --lib`
- `cargo test -q runtime::tests::work_items --lib`

Closes #1355
