### PR TITLE
fix: remove guards that block direct worktree-to-worktree switching

### DIFF
--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -918,19 +918,6 @@ impl RuntimeHandle {
     ) -> Result<()> {
         let agent_id = self.agent_id().await?;
         let existing_state = self.agent_state().await?;
-        if projection_kind == WorkspaceProjectionKind::GitWorktreeRoot
-            && existing_state
-                .active_workspace_entry
-                .as_ref()
-                .is_some_and(|entry| {
-                    entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot
-                })
-        {
-            return Err(anyhow!(
-                "agent {} is already using an isolated execution root; use UseWorkspace with a direct workspace before creating another isolated root",
-                agent_id
-            ));
-        }
         if !existing_state
             .attached_workspaces
             .iter()
@@ -1084,16 +1071,6 @@ impl RuntimeHandle {
     ) -> Result<()> {
         let agent_id = self.agent_id().await?;
         let existing_state = self.agent_state().await?;
-        if existing_state
-            .active_workspace_entry
-            .as_ref()
-            .is_some_and(|entry| entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot)
-        {
-            return Err(anyhow!(
-                "agent {} is already using an isolated execution root; use UseWorkspace with a direct workspace before entering another git worktree root",
-                agent_id
-            ));
-        }
         if !existing_state
             .attached_workspaces
             .iter()


### PR DESCRIPTION
## Summary

Remove two guards in `enter_workspace` and `enter_existing_git_worktree` that rejected worktree-to-worktree transitions. The `agent_home` detour was a meaningless ceremony — the `attached_workspaces` check later in both functions is the real authorization boundary.

## Problem

When an agent is already inside a git worktree (`projection_kind=GitWorktreeRoot`), calling `UseWorkspace(path=<another worktree>)` fails with:

> agent X is already using an isolated execution root; use UseWorkspace with a direct workspace before entering another git worktree root

The model treats `UseWorkspace` as a directory switch and doesn't understand the internal `projection_kind` state machine. tuptup-dev hit this 21 times across 15 turns.

## Changes

- `src/runtime/lifecycle.rs`: Removed the `enter_workspace` guard that blocked worktree-to-worktree when requesting `mode=isolated`.
- `src/runtime/lifecycle.rs`: Removed the `enter_existing_git_worktree` guard that blocked worktree-to-worktree when the target path is detected as an existing worktree.

## Safety

- The `attached_workspaces` check in both functions is the actual authorization boundary — it confirms the target workspace is already bound to the agent.
- `enter_existing_git_worktree` correctly releases old occupancy (`worktree_session=None` on old entry).
- `enter_workspace` correctly replaces the old session.
- `worktree A → agent_home → worktree B` and `worktree A → worktree B` end in exactly the same state.

## Verification

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✓
- `cargo test --all-targets` — all tests pass (two pre-existing timeout failures unrelated to this change)

Fixes #1461
