### PR TITLE
fix: harden WaitFor follow-up contracts

### DIFF
--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -112,8 +112,9 @@ active wait state:
   input blocks the current WorkItem.
 - Older blocked WorkItems with `recheck_at` carry a fallback deadline; the
   scheduler may re-evaluate them after that time.
-- Focus (current/queued) is separate from readiness. A blocked WorkItem can
-  still be the current focus for inspection.
+- Current focus is separate from readiness. A blocked WorkItem can still be the
+  current focus for inspection, while queued and blocked list filters are
+  derived views over focus plus scheduler readiness.
 
 ## Focus and current work
 

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -98,7 +98,7 @@ pub fn tool_sections(available_tools: &[ToolSpec]) -> Vec<PromptSection> {
         sections.push(section(
             "tool_work_item_read",
             PromptStability::Stable,
-            "Use ListWorkItems with filter=current to inspect the current work-item focus before relying on memory briefs. Use GetWorkItem when you already know the id and need its open/completed state, focus flag, readiness, plan_artifact descriptor with bounded preview, and optional todo_list. Read or edit plan_artifact.path directly when the preview is incomplete or the plan body needs changes. Use ListWorkItems for queue inspection with filters such as open, completed, current, queued, blocked, waiting_for_operator, and runnable. Treat current_work_item_id as focus, not lifecycle; open/completed describes completion, current/queued/blocked describes focus, and readiness describes scheduler eligibility. Read the work-item surface before switching, completing, or expanding cross-turn work so the next action is anchored to the right objective.".to_string(),
+            "Use ListWorkItems with filter=current to inspect the current work-item focus before relying on memory briefs. Use GetWorkItem when you already know the id and need its open/completed state, focus flag, readiness, plan_artifact descriptor with bounded preview, and optional todo_list. Read or edit plan_artifact.path directly when the preview is incomplete or the plan body needs changes. Use ListWorkItems for queue inspection with filters such as open, completed, current, queued, blocked, waiting_for_operator, and runnable. Treat current_work_item_id as focus, not lifecycle; open/completed describes completion, current describes focus, and queued/blocked/waiting_for_operator/runnable are derived from scheduler readiness plus current focus. Read the work-item surface before switching, completing, or expanding cross-turn work so the next action is anchored to the right objective.".to_string(),
         ));
     }
     if names.contains(&"TaskList")
@@ -444,7 +444,7 @@ mod tests {
         assert!(section.content.contains("runnable"));
         assert!(section
             .content
-            .contains("readiness describes scheduler eligibility"));
+            .contains("derived from scheduler readiness plus current focus"));
         assert!(section.content.contains("before relying on memory briefs"));
     }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -618,6 +618,66 @@ async fn wait_for_task_result_marks_work_item_waiting_and_allows_sleep() {
 }
 
 #[tokio::test]
+async fn register_wait_for_validates_required_runtime_resources() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let task_missing = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::TaskResult,
+            None,
+            "waiting for task".into(),
+        )
+        .await
+        .unwrap_err();
+    assert!(task_missing
+        .to_string()
+        .contains("requires non-empty resource"));
+
+    let external_empty = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::External,
+            Some(" ".into()),
+            "waiting for external state".into(),
+        )
+        .await
+        .unwrap_err();
+    assert!(external_empty
+        .to_string()
+        .contains("requires non-empty resource"));
+
+    let operator_wait = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "waiting for operator".into(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(operator_wait.condition.kind, WaitConditionKind::Operator);
+    assert_eq!(operator_wait.condition.subject_ref, None);
+}
+
+#[tokio::test]
 async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocker() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -792,6 +792,33 @@ async fn work_item_query_tools_return_readiness_views() {
         )
         .await
         .unwrap();
+    let wait_condition_blocked = runtime
+        .create_work_item("wait condition blocked".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let now = Utc::now();
+    runtime
+        .storage()
+        .append_wait_condition(&WaitConditionRecord {
+            id: "wait-external-only".into(),
+            agent_id: "default".into(),
+            work_item_id: Some(wait_condition_blocked.id.clone()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("test".into()),
+            subject_ref: Some("github:holon-run/holon#1459".into()),
+            waiting_for: "waiting for follow-up review".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: None,
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+        })
+        .unwrap();
 
     let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
     let list = |filter: &'static str| {
@@ -842,7 +869,7 @@ async fn work_item_query_tools_return_readiness_views() {
     );
 
     let queued_payload = list("queued").await;
-    assert_eq!(queued_payload["total_matching"].as_u64(), Some(2));
+    assert_eq!(queued_payload["total_matching"].as_u64(), Some(1));
     let queued_ids = queued_payload["work_items"]
         .as_array()
         .unwrap()
@@ -850,18 +877,23 @@ async fn work_item_query_tools_return_readiness_views() {
         .filter_map(|item| item["id"].as_str())
         .collect::<Vec<_>>();
     assert!(queued_ids.contains(&runnable.id.as_str()));
-    assert!(queued_ids.contains(&waiting.id.as_str()));
+    assert!(!queued_ids.contains(&waiting.id.as_str()));
+    assert!(!queued_ids.contains(&wait_condition_blocked.id.as_str()));
 
     let blocked_payload = list("blocked").await;
-    assert_eq!(blocked_payload["total_matching"].as_u64(), Some(1));
-    assert_eq!(
-        blocked_payload["work_items"][0]["id"].as_str(),
-        Some(blocked.id.as_str())
-    );
-    assert_eq!(
-        blocked_payload["work_items"][0]["readiness"].as_str(),
-        Some("blocked")
-    );
+    assert_eq!(blocked_payload["total_matching"].as_u64(), Some(2));
+    let blocked_items = blocked_payload["work_items"].as_array().unwrap();
+    let blocked_ids = blocked_items
+        .iter()
+        .filter_map(|item| item["id"].as_str())
+        .collect::<Vec<_>>();
+    assert!(blocked_ids.contains(&blocked.id.as_str()));
+    assert!(blocked_ids.contains(&wait_condition_blocked.id.as_str()));
+    let wait_condition_view = blocked_items
+        .iter()
+        .find(|item| item["id"].as_str() == Some(wait_condition_blocked.id.as_str()))
+        .expect("wait condition blocked item should be listed");
+    assert_eq!(wait_condition_view["readiness"].as_str(), Some("blocked"));
 }
 
 #[tokio::test]

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -47,7 +47,7 @@ impl RuntimeHandle {
         }
 
         let now = Utc::now();
-        let (kind, subject_ref, wake_sources) = wait_condition_parts(wake, resource.clone());
+        let (kind, subject_ref, wake_sources) = wait_condition_parts(wake, resource.clone())?;
         let mut work_item = None;
         let mut cancelled_wait_condition_ids = Vec::new();
         if let Some(work_item_id) = work_item_id.as_deref() {
@@ -876,29 +876,36 @@ fn reconciliation_signals_for_message(
 fn wait_condition_parts(
     wake: WaitForWakeKind,
     resource: Option<String>,
-) -> (WaitConditionKind, Option<String>, Vec<WakeSource>) {
+) -> Result<(WaitConditionKind, Option<String>, Vec<WakeSource>)> {
     match wake {
-        WaitForWakeKind::OperatorInput => (
+        WaitForWakeKind::OperatorInput => Ok((
             WaitConditionKind::Operator,
             resource,
             vec![WakeSource::OperatorInput],
-        ),
+        )),
         WaitForWakeKind::TaskResult => {
-            let task_id = resource.expect("WaitFor task_result resource is validated by tool");
-            (
+            let task_id = wait_resource_required(wake, resource)?;
+            Ok((
                 WaitConditionKind::Task,
                 Some(task_id.clone()),
                 vec![WakeSource::TaskResult { task_id }],
-            )
+            ))
         }
-        WaitForWakeKind::External => (
+        WaitForWakeKind::External => Ok((
             WaitConditionKind::External,
-            resource,
+            Some(wait_resource_required(wake, resource)?),
             vec![WakeSource::ExternalIngress {
                 external_trigger_id: None,
             }],
-        ),
+        )),
     }
+}
+
+fn wait_resource_required(wake: WaitForWakeKind, resource: Option<String>) -> Result<String> {
+    resource
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("wait_for {:?} requires non-empty resource", wake))
 }
 
 fn reconciliation_signal_for_condition(

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -16,8 +16,8 @@ use super::{
     serialize_success,
     work_item_query::{
         active_wait_conditions_by_work_item, latest_delivery_summaries_by_work_item,
-        lifecycle_view, query_context, readiness_for_view, view_for_record, WorkItemFocusView,
-        WorkItemLifecycleView, WorkItemQueryContext, WorkItemView,
+        lifecycle_view, query_context, readiness_for_view, view_for_record, WorkItemLifecycleView,
+        WorkItemQueryContext, WorkItemView,
     },
     BuiltinToolDefinition,
 };
@@ -141,6 +141,7 @@ fn matches_filter(
 ) -> bool {
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
+    let readiness = readiness_for_view(record, active_wait_conditions);
     match filter {
         ListWorkItemsFilter::All => true,
         ListWorkItemsFilter::Open => lifecycle_view(&record.state) == WorkItemLifecycleView::Open,
@@ -150,20 +151,13 @@ fn matches_filter(
         ListWorkItemsFilter::Current => is_current,
         ListWorkItemsFilter::Queued => {
             !is_current
-                && super::work_item_query::focus_view(record, is_current)
-                    == WorkItemFocusView::Queued
+                && record.state == WorkItemState::Open
+                && readiness == WorkItemReadiness::Runnable
         }
-        ListWorkItemsFilter::Blocked => {
-            !is_current
-                && super::work_item_query::focus_view(record, is_current)
-                    == WorkItemFocusView::Blocked
-        }
+        ListWorkItemsFilter::Blocked => !is_current && readiness == WorkItemReadiness::Blocked,
         ListWorkItemsFilter::WaitingForOperator => {
-            readiness_for_view(record, active_wait_conditions)
-                == WorkItemReadiness::WaitingForOperator
+            readiness == WorkItemReadiness::WaitingForOperator
         }
-        ListWorkItemsFilter::Runnable => {
-            readiness_for_view(record, active_wait_conditions) == WorkItemReadiness::Runnable
-        }
+        ListWorkItemsFilter::Runnable => readiness == WorkItemReadiness::Runnable,
     }
 }


### PR DESCRIPTION
## Summary

- harden `register_wait_for` so runtime callers get errors instead of panics when task/external waits omit `resource`
- align `ListWorkItems` queued/blocked filters with derived readiness from active wait conditions
- update prompt/spec wording and regression coverage for the #1459 Copilot review follow-up

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -q register_wait_for_validates_required_runtime_resources --lib`
- `cargo test -q work_item_query_tools_return_readiness_views --lib`
- `cargo test -q prompt::tools --lib`
- `cargo test -q wait_for --all-targets`
- `cargo test -q runtime::tests::runtime_state --lib`
- `cargo test -q runtime::tests::work_items --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Refs #1459
Refs #1416