### PR TITLE
fix: align agent lifecycle posture projection

### DIFF
--- a/docs/rfcs/agent-lifecycle-control-posture.md
+++ b/docs/rfcs/agent-lifecycle-control-posture.md
@@ -120,10 +120,16 @@ enum AgentStatus {
     Booting,
     AwakeIdle,
     AwakeRunning,
+    AwaitingTask,
     Asleep,
     Stopped,
 }
 ```
+
+`AwaitingTask` is retained as a transitional lifecycle label because the
+current runtime, TUI, daemon, and waiting paths project blocking task waits
+through it. It may be folded into `AwakeIdle` plus task-wait scheduling posture
+in a later migration, but this RFC treats it as current implementation contract.
 
 `Paused` should remain readable only for legacy persisted state during the
 migration window. New lifecycle control should not generate `Paused`; it should

--- a/docs/rfcs/agent-state-model.md
+++ b/docs/rfcs/agent-state-model.md
@@ -241,6 +241,7 @@ Initial shape:
 
 ```text
 AgentSchedulingPosture =
+  Unknown
   ActiveTurn
   HasQueuedInput
   HasRunnableWork
@@ -253,6 +254,8 @@ AgentSchedulingPosture =
 ```
 
 This posture is not manually written by the agent. It is derived.
+`Unknown` is the default value before a projection has been assembled; it is not
+part of the stable scheduling contract.
 
 Suggested precedence:
 
@@ -265,6 +268,14 @@ Suggested precedence:
 7. `WaitingForOperator` if open work requires operator input.
 8. `Blocked` if open work has only non-recoverable or unstructured blockers.
 9. `Idle` if no open work, queued input, active turn, or active wait remains.
+
+WorkItem-level waits are more specific than this reduced agent posture. In the
+current implementation, `WorkItemSchedulingState::WaitingTimer` and
+`WorkItemSchedulingState::WaitingSystem` are retained as distinct scheduler wait
+states, but project to `AgentSchedulingPosture::Blocked` at the agent summary
+level. Scheduler idle-boundary decisions still inspect the WorkItem scheduling
+state and emit the timer or system-tick action instead of treating those waits as
+plain idle.
 
 The exact precedence can evolve, but the important rule is that passive sleep
 posture must not hide higher-priority facts such as queued input or runnable

--- a/docs/website/spec/agent-state.md
+++ b/docs/website/spec/agent-state.md
@@ -76,7 +76,7 @@ task, and wait state, not from summary fields.
 | `Booting` | Agent is initializing; not yet handed to the scheduler |
 | `AwakeIdle` | Agent is awake but no model turn is in progress |
 | `AwakeRunning` | A model turn is currently executing |
-| `AwaitingTask` | Agent is awake but blocked on a non-terminal task result |
+| `AwaitingTask` | Transitional label for an awake agent blocked on a non-terminal task result |
 | `Asleep` | Agent called `Sleep` at end of turn; no model turn running |
 | `Stopped` | Agent lifecycle is stopped; scheduler will not start new turns |
 
@@ -89,9 +89,11 @@ task, and wait state, not from summary fields.
   input.
 - An `Asleep` agent can have runnable WorkItems. `Asleep` does **not** mean
   idle or empty.
-- `AwaitingTask` means a non-terminal task (command, child agent) blocks
-  further model reentry; the agent is still awake and the scheduler can wake
-  it when the task completes.
+- `AwaitingTask` is a transitional lifecycle label used by current runtime,
+  TUI, daemon, and waiting projections while a non-terminal task (command,
+  child agent) blocks further model reentry. It may later collapse into
+  `AwakeIdle` plus task-wait scheduling posture, but remains current contract
+  until that migration happens.
 - `Stopped` is a hard lifecycle boundary. The scheduler will not start new
   turns for a stopped agent. Stopped agents release runtime-owned execution
   resources.
@@ -112,7 +114,7 @@ The scheduler derives a scheduling posture from current state. This is a
 | `WaitingForTask` | An active non-terminal task is blocking |
 | `WaitingForExternal` | Agent is waiting on an external event |
 | `WaitingForOperator` | WorkItem `plan_status=needs_input` or active operator wait |
-| `Blocked` | WorkItem has `blocked_by` set or an active non-operator wait |
+| `Blocked` | WorkItem has `blocked_by` set or an active timer/system/non-operator wait |
 | `Idle` | No queued input, no runnable work, no blocking conditions |
 | `Unknown` | Default before first projection; not part of the stable contract |
 | `Archived` | Agent lifecycle is stopped (maps from `AgentStatus::Stopped`) |
@@ -122,6 +124,10 @@ The scheduler derives a scheduling posture from current state. This is a
 - Posture is derived from queue depth, WorkItem readiness, waiting state,
   task blocking state, and external triggers.
 - Posture is snapshot-derived; it is not persisted as durable state.
+- WorkItem-level `WaitingTimer` and `WaitingSystem` remain distinct scheduler
+  wait states, but the reduced agent-level posture currently reports them as
+  `Blocked`; scheduler idle-boundary decisions still inspect the WorkItem wait
+  state to emit the timer or system-tick action.
 - `AgentSummary.scheduling_posture` exposes this projection; consumers should
   not treat it as an authoritative scheduling input.
 
@@ -188,16 +194,16 @@ Agent lifecycle control is `Start` / `Stop`:
 - `AgentStatus` still includes transitionary states (`Booting`, `AwaitingTask`)
   that may collapse as the scheduler model matures. See follow-up if
   `AwaitingTask` becomes fully subsumed by `AwakeIdle` + task blocking.
-- `AgentLifecycleHint` is under-defined; its relationship to `AgentStatus` and
-  `AgentSchedulingPosture` is not yet a stable contract.
+- `AgentLifecycleHint` carries lifecycle delivery hints such as whether
+  external messages are accepted and optional operator guidance. Deprecated
+  Pause/Resume projection fields are not part of the contract.
 - `AgentSummary` includes some fields (`recent_operator_notifications`,
   `recent_brief_count`) whose contract is not yet hardened.
 - `AgentStatus::Asleep` remains a lifecycle/display projection, but scheduler
   idle-boundary decisions inspect wait and work facts before treating an
   already-asleep agent as idle.
-- `AgentStatus::AwaitingTask` exists in code but is not in the RFC's target
-  status set (`agent-lifecycle-control-posture.md`).
-- `AgentLifecycleHint` retains `resume_*` fields from the deprecated Pause/Resume
-  model. See [issue #1378](https://github.com/holon-run/holon/issues/1378).
+- `AgentStatus::AwaitingTask` remains a transitional status in code even though
+  it is not in the long-term target status set
+  (`agent-lifecycle-control-posture.md`).
 - `AgentSchedulingPosture::Archived` is used (for `Stopped` agents) contrary
   to the previous spec claim of "Not currently used".

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -763,6 +763,21 @@ fn idle_boundary_decision_inspects_wait_facts_while_asleep() {
 }
 
 #[test]
+fn idle_boundary_decision_does_not_treat_asleep_with_queued_input_as_idle() {
+    let dir = tempdir().unwrap();
+    let storage = AppStorage::new(dir.path()).unwrap();
+    let mut agent = AgentState::new("default");
+    agent.status = AgentStatus::Asleep;
+    agent.pending = 1;
+    storage.write_agent(&agent).unwrap();
+
+    let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
+    let decision = scheduler::idle_boundary_decision(&projection, "fixture");
+    assert_eq!(decision.kind, scheduler::SchedulerDecisionKind::Noop);
+    assert_eq!(decision.reason, "queue_not_empty");
+}
+
+#[test]
 fn idle_boundary_decision_reactivates_runnable_work_while_asleep() {
     let dir = tempdir().unwrap();
     let storage = AppStorage::new(dir.path()).unwrap();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3063,6 +3063,36 @@ mod tests {
         let posture_for = |storage: &AppStorage, agent: &AgentState| {
             storage.agent_posture_projection(agent).unwrap().posture
         };
+        let append_wait_condition =
+            |storage: &AppStorage, work_item_id: &str, kind: WaitConditionKind| {
+                let wait_kind = format!("{kind:?}");
+                let wake_sources = match kind {
+                    WaitConditionKind::Timer => vec![WakeSource::Timer {
+                        wake_at: Utc::now() + chrono::Duration::minutes(5),
+                    }],
+                    WaitConditionKind::System => vec![WakeSource::SystemTick],
+                    _ => unreachable!("helper is only used for timer/system waits"),
+                };
+                storage
+                    .append_wait_condition(&WaitConditionRecord {
+                        id: format!("{kind:?}-condition"),
+                        agent_id: "default".into(),
+                        work_item_id: Some(work_item_id.into()),
+                        status: WaitConditionStatus::Active,
+                        kind,
+                        source: None,
+                        subject_ref: None,
+                        waiting_for: wait_kind,
+                        wake_sources,
+                        continuation: None,
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                        expires_at: None,
+                        resolved_at: None,
+                        cancelled_at: None,
+                    })
+                    .unwrap();
+            };
 
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
@@ -3155,6 +3185,30 @@ mod tests {
         let mut blocked = WorkItemRecord::new("default", "blocked", WorkItemState::Open);
         blocked.blocked_by = Some("unstructured blocker".into());
         storage.append_work_item(&blocked).unwrap();
+        assert_eq!(
+            posture_for(&storage, &agent),
+            AgentSchedulingPosture::Blocked
+        );
+
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let mut agent = AgentState::new("default");
+        agent.status = AgentStatus::Asleep;
+        let timer_wait = WorkItemRecord::new("default", "timer wait", WorkItemState::Open);
+        storage.append_work_item(&timer_wait).unwrap();
+        append_wait_condition(&storage, &timer_wait.id, WaitConditionKind::Timer);
+        assert_eq!(
+            posture_for(&storage, &agent),
+            AgentSchedulingPosture::Blocked
+        );
+
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let mut agent = AgentState::new("default");
+        agent.status = AgentStatus::Asleep;
+        let system_wait = WorkItemRecord::new("default", "system wait", WorkItemState::Open);
+        storage.append_work_item(&system_wait).unwrap();
+        append_wait_condition(&storage, &system_wait.id, WaitConditionKind::System);
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::Blocked

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -923,7 +923,6 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
             agent.identity.ownership.cleanup_summary()
         ),
         format!("Status: {:?}", agent.agent.status),
-        format!("Resume required: {}", agent.lifecycle.resume_required),
         format!(
             "Model: {} ({:?})",
             agent.model.effective_model.as_string(),
@@ -944,9 +943,6 @@ pub(super) fn render_summary(agent: &AgentSummary) -> String {
     }
     if let Some(hint) = agent.lifecycle.operator_hint.as_deref() {
         lines.push(format!("Lifecycle hint: {}", hint));
-    }
-    if let Some(resume_cli_hint) = agent.lifecycle.resume_cli_hint.as_deref() {
-        lines.push(format!("Resume: {}", resume_cli_hint));
     }
     lines.push(format!(
         "Runtime default: {}",

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -432,7 +432,7 @@ fn header_view_model_shows_agent_status_without_contract() {
 }
 
 #[test]
-fn header_view_model_prefers_operator_waiting_label_and_resume_hint() {
+fn header_view_model_prefers_operator_waiting_label() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(
         client,
@@ -442,16 +442,12 @@ fn header_view_model_prefers_operator_waiting_label_and_resume_hint() {
     snapshot.agent.agent.status = AgentStatus::AwakeIdle;
     snapshot.agent.closure.waiting_reason =
         Some(crate::types::WaitingReason::AwaitingOperatorInput);
-    snapshot.agent.lifecycle.resume_required = true;
     app.agents = vec![snapshot.agent.clone()];
     app.projection = Some(TuiProjection::from_snapshot(snapshot));
 
     let view_model = HeaderViewModel::from_app(&app);
 
-    assert_eq!(
-        view_model.line,
-        "holon-dev  waiting for you · resume required"
-    );
+    assert_eq!(view_model.line, "holon-dev  waiting for you");
 }
 
 #[test]

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -39,11 +39,7 @@ impl StatusbarViewModel {
 }
 
 pub(super) fn render_header_line(agent: &AgentSummary) -> String {
-    let mut line = format!("{}  {}", agent.identity.agent_id, agent_status_label(agent));
-    if agent.lifecycle.resume_required {
-        line.push_str(" · resume required");
-    }
-    line
+    format!("{}  {}", agent.identity.agent_id, agent_status_label(agent))
 }
 
 fn agent_status_label(agent: &AgentSummary) -> &'static str {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3672,7 +3672,8 @@ impl Default for AgentLifecycleHint {
 }
 
 impl AgentLifecycleHint {
-    pub fn from_status(_agent_id: &str, status: AgentStatus) -> Self {
+    #[allow(unused_variables)]
+    pub fn from_status(agent_id: &str, status: AgentStatus) -> Self {
         if status == AgentStatus::Stopped {
             return Self {
                 accepts_external_messages: false,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3657,42 +3657,28 @@ pub struct ResolvedModelAvailability {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentLifecycleHint {
-    pub resume_required: bool,
     pub accepts_external_messages: bool,
-    pub wake_requires_resume: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub operator_hint: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resume_cli_hint: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resume_control_path: Option<String>,
 }
 
 impl Default for AgentLifecycleHint {
     fn default() -> Self {
         Self {
-            resume_required: false,
             accepts_external_messages: true,
-            wake_requires_resume: false,
             operator_hint: None,
-            resume_cli_hint: None,
-            resume_control_path: None,
         }
     }
 }
 
 impl AgentLifecycleHint {
-    pub fn from_status(agent_id: &str, status: AgentStatus) -> Self {
+    pub fn from_status(_agent_id: &str, status: AgentStatus) -> Self {
         if status == AgentStatus::Stopped {
             return Self {
-                resume_required: true,
                 accepts_external_messages: false,
-                wake_requires_resume: true,
                 operator_hint: Some(
                     "agent is administratively stopped; start before new prompts or wakes".into(),
                 ),
-                resume_cli_hint: Some(format!("holon agent start {agent_id}")),
-                resume_control_path: Some(format!("/control/agents/{agent_id}/control")),
             };
         }
         Self::default()

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -781,7 +781,9 @@ pub async fn stopped_status_includes_lifecycle_start_guidance() -> Result<()> {
         .await?;
     assert_eq!(payload["agent"]["status"], "stopped");
     assert_eq!(payload["lifecycle"]["accepts_external_messages"], false);
-    let lifecycle = payload["lifecycle"].as_object().unwrap();
+    let lifecycle = payload["lifecycle"]
+        .as_object()
+        .expect("lifecycle must be a JSON object");
     for removed_field in [
         "resume_required",
         "wake_requires_resume",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -780,17 +780,16 @@ pub async fn stopped_status_includes_lifecycle_start_guidance() -> Result<()> {
         .json()
         .await?;
     assert_eq!(payload["agent"]["status"], "stopped");
-    assert_eq!(payload["lifecycle"]["resume_required"], true);
     assert_eq!(payload["lifecycle"]["accepts_external_messages"], false);
-    assert_eq!(payload["lifecycle"]["wake_requires_resume"], true);
-    assert_eq!(
-        payload["lifecycle"]["resume_cli_hint"],
-        "holon agent start default"
-    );
-    assert_eq!(
-        payload["lifecycle"]["resume_control_path"],
-        "/control/agents/default/control"
-    );
+    let lifecycle = payload["lifecycle"].as_object().unwrap();
+    for removed_field in [
+        "resume_required",
+        "wake_requires_resume",
+        "resume_cli_hint",
+        "resume_control_path",
+    ] {
+        assert!(!lifecycle.contains_key(removed_field));
+    }
     assert!(payload["lifecycle"]["operator_hint"]
         .as_str()
         .unwrap_or_default()


### PR DESCRIPTION
## Summary

- remove deprecated Pause/Resume lifecycle hint fields from the public `AgentLifecycleHint` projection and TUI rendering
- document the current `AwaitingTask`, `Unknown`, and timer/system wait projection contracts across RFC and website specs
- add regressions for asleep agents with queued input and timer/system WorkItem waits so scheduler/posture behavior stays explicit

Closes #1378.

## Rationale

The RFC-vs-code validation in #1367 found three lifecycle/model gaps: public summaries still exposed deprecated resume hints, `AwaitingTask` remained an implementation contract without matching docs, and reduced agent posture could hide more specific scheduler wait facts. This patch fixes the public projection at the contract boundary and records the remaining reduced-posture behavior without adding parallel mechanisms.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets -- --test-threads=1`
