### PR TITLE
fix: downgrade cross-workitem TaskResult delivery to background notification (#1467)

### DIFF
--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -77,7 +77,8 @@ impl ContinuationTrigger {
                     })
                     .unwrap_or(false),
                 wake_hint_source: None,
-                task_work_item_id: task.and_then(|t| t.effective_work_item_id().map(ToString::to_string)),
+                task_work_item_id: task
+                    .and_then(|t| t.effective_work_item_id().map(ToString::to_string)),
             }),
             MessageKind::TaskStatus
             | MessageKind::Control
@@ -242,7 +243,10 @@ fn resolve_waiting(
         };
     }
 
-    if trigger.kind == ContinuationTriggerKind::TaskResult && trigger.task_terminal && same_work_item {
+    if trigger.kind == ContinuationTriggerKind::TaskResult
+        && trigger.task_terminal
+        && same_work_item
+    {
         // Terminal task state is persisted before TaskResult enqueue, so
         // resuming here cannot reopen the stale active-task wait that just ended.
         evidence.push("terminal_task_result".to_string());
@@ -327,7 +331,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::ResumeExpectedWait);
         assert!(resolution.model_reentry);
     }
@@ -343,7 +348,8 @@ mod tests {
                 wake_hint_source: Some("callback".into()),
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);
     }
@@ -359,7 +365,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::ResumeOverride);
         assert!(resolution.model_reentry);
     }
@@ -381,7 +388,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);
     }
@@ -403,7 +411,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
         assert!(resolution.model_reentry);
     }
@@ -425,7 +434,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
         assert!(resolution.model_reentry);
     }
@@ -441,7 +451,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::ResumeOverride);
         assert!(resolution.model_reentry);
     }
@@ -457,7 +468,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);
         assert!(resolution.matched_waiting_reason);
@@ -474,7 +486,8 @@ mod tests {
                 wake_hint_source: None,
                 task_work_item_id: None,
             },
-        None);
+            None,
+        );
 
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -10,6 +10,7 @@ pub(super) struct ContinuationTrigger {
     pub(super) contentful: bool,
     pub(super) task_terminal: bool,
     pub(super) wake_hint_source: Option<String>,
+    pub(super) task_work_item_id: Option<String>,
 }
 
 impl ContinuationTrigger {
@@ -23,6 +24,7 @@ impl ContinuationTrigger {
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
                 wake_hint_source: None,
+                task_work_item_id: None,
             }),
             MessageKind::WebhookEvent | MessageKind::CallbackEvent | MessageKind::ChannelEvent => {
                 Some(Self {
@@ -30,6 +32,7 @@ impl ContinuationTrigger {
                     contentful: body_is_contentful(&message.body),
                     task_terminal: false,
                     wake_hint_source: None,
+                    task_work_item_id: None,
                 })
             }
             MessageKind::TimerTick => Some(Self {
@@ -37,11 +40,13 @@ impl ContinuationTrigger {
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
                 wake_hint_source: None,
+                task_work_item_id: None,
             }),
             MessageKind::InternalFollowup => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
                 contentful: body_is_contentful(&message.body),
                 task_terminal: false,
+                task_work_item_id: None,
                 wake_hint_source: None,
             }),
             MessageKind::SystemTick => Some(Self {
@@ -55,6 +60,7 @@ impl ContinuationTrigger {
                     .and_then(|value| value.get("source"))
                     .and_then(serde_json::Value::as_str)
                     .map(ToString::to_string),
+                task_work_item_id: None,
             }),
             MessageKind::TaskResult => Some(Self {
                 kind: admission_trigger_kind_for_message_kind(&message.kind),
@@ -71,6 +77,7 @@ impl ContinuationTrigger {
                     })
                     .unwrap_or(false),
                 wake_hint_source: None,
+                task_work_item_id: task.and_then(|t| t.effective_work_item_id().map(ToString::to_string)),
             }),
             MessageKind::TaskStatus
             | MessageKind::Control
@@ -83,7 +90,13 @@ impl ContinuationTrigger {
 pub(super) fn resolve_continuation(
     prior: &ClosureDecision,
     trigger: &ContinuationTrigger,
+    agent_work_item_id: Option<&str>,
 ) -> ContinuationResolution {
+    let same_work_item = match (trigger.task_work_item_id.as_deref(), agent_work_item_id) {
+        (Some(_), None) | (None, Some(_)) => false,
+        (None, None) => true,
+        (Some(t), Some(a)) => t == a,
+    };
     let mut evidence = Vec::new();
     evidence.push(format!("trigger_kind={}", enum_label(trigger.kind)));
     if trigger.contentful {
@@ -106,12 +119,14 @@ pub(super) fn resolve_continuation(
             prior_waiting_reason,
             prior_closure_outcome,
             trigger,
+            same_work_item,
             evidence,
         );
     }
 
-    let terminal_task_result =
-        trigger.kind == ContinuationTriggerKind::TaskResult && trigger.task_terminal;
+    let terminal_task_result = trigger.kind == ContinuationTriggerKind::TaskResult
+        && trigger.task_terminal
+        && same_work_item;
     let model_reentry = terminal_task_result
         || matches!(
             trigger.kind,
@@ -149,6 +164,7 @@ fn resolve_waiting(
     prior_waiting_reason: Option<WaitingReason>,
     prior_closure_outcome: ClosureOutcome,
     trigger: &ContinuationTrigger,
+    same_work_item: bool,
     mut evidence: Vec<String>,
 ) -> ContinuationResolution {
     let reason = prior_waiting_reason;
@@ -174,7 +190,7 @@ fn resolve_waiting(
     let override_allowed = trigger.kind == ContinuationTriggerKind::OperatorInput;
     if expected {
         let model_reentry = match trigger.kind {
-            ContinuationTriggerKind::TaskResult => trigger.task_terminal,
+            ContinuationTriggerKind::TaskResult => trigger.task_terminal && same_work_item,
             ContinuationTriggerKind::ExternalEvent => trigger.contentful,
             ContinuationTriggerKind::SystemTick => trigger.contentful,
             _ => true,
@@ -226,7 +242,7 @@ fn resolve_waiting(
         };
     }
 
-    if trigger.kind == ContinuationTriggerKind::TaskResult && trigger.task_terminal {
+    if trigger.kind == ContinuationTriggerKind::TaskResult && trigger.task_terminal && same_work_item {
         // Terminal task state is persisted before TaskResult enqueue, so
         // resuming here cannot reopen the stale active-task wait that just ended.
         evidence.push("terminal_task_result".to_string());
@@ -309,8 +325,9 @@ mod tests {
                 contentful: true,
                 task_terminal: true,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::ResumeExpectedWait);
         assert!(resolution.model_reentry);
     }
@@ -324,8 +341,9 @@ mod tests {
                 contentful: false,
                 task_terminal: false,
                 wake_hint_source: Some("callback".into()),
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);
     }
@@ -339,8 +357,9 @@ mod tests {
                 contentful: true,
                 task_terminal: false,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::ResumeOverride);
         assert!(resolution.model_reentry);
     }
@@ -360,8 +379,9 @@ mod tests {
                 contentful: false,
                 task_terminal: false,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);
     }
@@ -381,8 +401,9 @@ mod tests {
                 contentful: true,
                 task_terminal: true,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
         assert!(resolution.model_reentry);
     }
@@ -402,8 +423,9 @@ mod tests {
                 contentful: true,
                 task_terminal: true,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::LocalContinuation);
         assert!(resolution.model_reentry);
     }
@@ -417,8 +439,9 @@ mod tests {
                 contentful: true,
                 task_terminal: true,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::ResumeOverride);
         assert!(resolution.model_reentry);
     }
@@ -432,8 +455,9 @@ mod tests {
                 contentful: false,
                 task_terminal: false,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);
         assert!(resolution.matched_waiting_reason);
@@ -448,8 +472,9 @@ mod tests {
                 contentful: true,
                 task_terminal: false,
                 wake_hint_source: None,
+                task_work_item_id: None,
             },
-        );
+        None);
 
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -25,7 +25,7 @@ impl RuntimeHandle {
             ContinuationTrigger::from_message(message, task.as_ref().ok().and_then(Option::as_ref));
         let continuation_resolution = continuation_trigger
             .as_ref()
-            .map(|trigger| resolve_continuation(&prior_closure, trigger));
+            .map(|trigger| resolve_continuation(&prior_closure, trigger, scheduler_state.current_work_item_id.as_deref()));
         let model_turn_allowed = !matches!(scheduler_state.status, AgentStatus::Stopped);
         Ok(MessageDispatchPlan {
             prior_closure,

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -23,9 +23,13 @@ impl RuntimeHandle {
         };
         let continuation_trigger =
             ContinuationTrigger::from_message(message, task.as_ref().ok().and_then(Option::as_ref));
-        let continuation_resolution = continuation_trigger
-            .as_ref()
-            .map(|trigger| resolve_continuation(&prior_closure, trigger, scheduler_state.current_work_item_id.as_deref()));
+        let continuation_resolution = continuation_trigger.as_ref().map(|trigger| {
+            resolve_continuation(
+                &prior_closure,
+                trigger,
+                scheduler_state.current_work_item_id.as_deref(),
+            )
+        });
         let model_turn_allowed = !matches!(scheduler_state.status, AgentStatus::Stopped);
         Ok(MessageDispatchPlan {
             prior_closure,

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -191,7 +191,7 @@ impl RuntimeHandle {
         let _ = maybe_compact_agent(&self.inner.storage, &mut agent, &context_config)?;
         let prior_closure = self.current_closure_decision().await?;
         let continuation = ContinuationTrigger::from_message(&message, None)
-            .map(|trigger| resolve_continuation(&prior_closure, &trigger));
+            .map(|trigger| resolve_continuation(&prior_closure, &trigger, None));
         let identity = self.agent_identity_view().await?;
         self.ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
             .await?;
@@ -275,6 +275,7 @@ impl RuntimeHandle {
                     evidence: vec!["synthetic_subagent_prompt_preview".into()],
                 },
                 &trigger,
+                None,
             )
         });
         let context_config = self.current_context_config().await;


### PR DESCRIPTION
## Summary

Fixes #1467: When a terminal TaskResult arrives for a task belonging to a different WorkItem than the agent's current WorkItem, treat it as a liveness-only wake instead of triggering model re-entry. This prevents agents from being interrupted by task completions from unrelated work.

## Changes

### 
- Add `task_work_item_id: Option<String>` to `ContinuationTrigger`
- Populate it from `task.effective_work_item_id()` when constructing TaskResult triggers
- Add `agent_work_item_id: Option<&str>` parameter to `resolve_continuation()`  
- Compute `same_work_item` match between trigger task work item id and agent's current work item id
- Gate `terminal_task_result` model re-entry on `same_work_item` — only same-WorkItem terminal results trigger full re-entry
- Cross-workitem terminal results fall through as liveness-only wakes
- Update all 9 continuation unit tests for the new signature

### 
- Pass `scheduler_state.current_work_item_id` as `agent_work_item_id` to `resolve_continuation()`

### 
- Pass `None` for `agent_work_item_id` in operator-initiated dispatch paths (no current work item context)

## Verification

- `cargo check --all-targets` — passes with no warnings
- `cargo test -p holon --lib` — all 1383 tests pass (0 failures, 1 ignored)
- All 9 continuation unit tests pass