### PR TITLE
fix: add drain timeout to collect_remaining_output to prevent infinite blocking

### DIFF
--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -36,6 +36,8 @@ const INPUT_CHANNEL_CAPACITY: usize = 16;
 const STREAM_TAIL_CHAR_LIMIT: usize = 128_000;
 const COMBINED_TAIL_CHAR_LIMIT: usize = 256_000;
 const PROCESS_STATUS_POLL_INTERVAL: Duration = Duration::from_millis(25);
+// After the main process exits, cap output drain so background pipe-holders cannot block forever.
+const COLLECT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub(super) enum ManagedTaskHandle {
     Async(JoinHandle<()>),
@@ -1194,9 +1196,14 @@ where
 }
 
 async fn collect_remaining_output(running: &mut RunningCommand, captured: &mut CapturedOutput) {
-    while let Some(chunk) = running.output_rx.recv().await {
-        captured.push(chunk);
-    }
+    let drain = async {
+        while let Some(chunk) = running.output_rx.recv().await {
+            captured.push(chunk);
+        }
+    };
+    // After the main process exits, background children may hold pipe write-ends
+    // open indefinitely.  Cap the drain so the agent cannot block forever.
+    let _ = tokio::time::timeout(COLLECT_OUTPUT_DRAIN_TIMEOUT, drain).await;
     for handle in running.reader_handles.drain(..) {
         let _ = handle.await;
     }
@@ -1207,10 +1214,17 @@ async fn collect_remaining_output_into_file(
     captured: &mut CapturedOutput,
     file: &mut tokio::fs::File,
 ) -> Result<()> {
-    while let Some(chunk) = running.output_rx.recv().await {
-        file.write_all(chunk.text.as_bytes()).await?;
-        captured.push(chunk);
-    }
+    let drain = async {
+        while let Some(chunk) = running.output_rx.recv().await {
+            if file.write_all(chunk.text.as_bytes()).await.is_err() {
+                break;
+            }
+            captured.push(chunk);
+        }
+    };
+    // After the main process exits, background children may hold pipe write-ends
+    // open indefinitely.  Cap the drain so the agent cannot block forever.
+    let _ = tokio::time::timeout(COLLECT_OUTPUT_DRAIN_TIMEOUT, drain).await;
     for handle in running.reader_handles.drain(..) {
         let _ = handle.await;
     }


### PR DESCRIPTION
## Problem

`collect_remaining_output` blocks indefinitely when a shell script launches a background subprocess with `&`. The child inherits the shell's stdout pipe — after the shell exits, the background process keeps the write-end open, so the `output_rx` channel never closes and the agent gets stuck in `awake_running` forever.

See [#1478](https://github.com/holon-run/holon/issues/1478) for full details and timeline.

## Fix

Wrap both `collect_remaining_output` and `collect_remaining_output_into_file` in a 2-second `tokio::time::timeout`. After the main process exits, remaining output drains within the window; anything still held open by background children is truncated rather than blocking the agent indefinitely.

The timeout is independent of `yield_time_ms` — `yield_time_ms` controls how long to wait for the process to complete during execution, while `COLLECT_OUTPUT_DRAIN_TIMEOUT` caps the post-exit cleanup phase.

## Changes

- Added `COLLECT_OUTPUT_DRAIN_TIMEOUT` constant (2 seconds)
- `collect_remaining_output`: drain loop wrapped in timeout
- `collect_remaining_output_into_file`: drain loop wrapped in timeout, with early break on write failure

## Verification

- `cargo check --all-targets` — clean
- `cargo test --lib command_task` — 11/11 passed
- `cargo fmt --all -- --check` — clean