### PR TITLE
fix: prefer authority_class over legacy trust alias in MessageEnvelope deserialization

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -4008,7 +4008,7 @@ mod tests {
 
         assert_eq!(message.authority_class, AuthorityClass::RuntimeInstruction);
     }
- 
+
     #[test]
     fn message_with_both_trust_and_authority_class_deserializes_authority_class_first() {
         // When both "trust" and "authority_class" exist, the explicit
@@ -4030,7 +4030,7 @@ mod tests {
                 "text": "hello"
             }
         });
- 
+
         let message: MessageEnvelope = serde_json::from_value(dual).unwrap();
         assert_eq!(message.authority_class, AuthorityClass::OperatorInstruction);
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,8 +32,10 @@ impl<'de> Deserialize<'de> for MessageEnvelope {
             created_at: DateTime<Utc>,
             kind: MessageKind,
             origin: MessageOrigin,
-            #[serde(default, alias = "trust")]
+            #[serde(default)]
             authority_class: Option<AuthorityClass>,
+            #[serde(default, alias = "trust")]
+            legacy_trust: Option<AuthorityClass>,
             priority: Priority,
             #[serde(default)]
             trigger_kind: Option<ContinuationTriggerKind>,
@@ -56,6 +58,7 @@ impl<'de> Deserialize<'de> for MessageEnvelope {
         let compat = MessageEnvelopeCompat::deserialize(deserializer)?;
         let authority_class = compat
             .authority_class
+            .or(compat.legacy_trust)
             .ok_or_else(|| serde::de::Error::missing_field("authority_class"))?;
         Ok(Self {
             id: compat.id,
@@ -4004,6 +4007,32 @@ mod tests {
         let message: MessageEnvelope = serde_json::from_value(legacy).unwrap();
 
         assert_eq!(message.authority_class, AuthorityClass::RuntimeInstruction);
+    }
+ 
+    #[test]
+    fn message_with_both_trust_and_authority_class_deserializes_authority_class_first() {
+        // When both "trust" and "authority_class" exist, the explicit
+        // authority_class field takes precedence.
+        let dual = serde_json::json!({
+            "id": "msg-dual",
+            "agent_id": "default",
+            "created_at": "2026-05-27T11:11:59Z",
+            "kind": "operator_prompt",
+            "origin": {
+                "kind": "operator",
+                "actor_id": "control"
+            },
+            "trust": "trusted_operator",
+            "authority_class": "operator_instruction",
+            "priority": "interject",
+            "body": {
+                "type": "text",
+                "text": "hello"
+            }
+        });
+ 
+        let message: MessageEnvelope = serde_json::from_value(dual).unwrap();
+        assert_eq!(message.authority_class, AuthorityClass::OperatorInstruction);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix `MessageEnvelope` deserialization to prefer the explicit `authority_class` field over the legacy `trust` alias when both are present.

## Problem

When a message contains both `trust` (legacy alias) and `authority_class` (the canonical field), serde's alias behavior means the last-deserialized value wins. This can cause the legacy alias to shadow the canonical field, producing incorrect authority classification.

## Fix

Split the deserialization helper struct so that:
- `authority_class` captures the canonical field (without alias)
- `legacy_trust` captures only the `trust` alias

Then combine them with `authority_class.or(legacy_trust)`, ensuring the canonical field takes precedence when both are present.

## Changes

- `src/types.rs`: Restructure `MessageEnvelopeCompat` deserialization and add a test for the dual-field case

## Verification

- `cargo check --all-targets` passes
- New test `message_with_both_trust_and_authority_class_deserializes_authority_class_first` added
