### PR TITLE
fix: tolerate dual trust fields in legacy messages

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -32,8 +32,10 @@ impl<'de> Deserialize<'de> for MessageEnvelope {
             created_at: DateTime<Utc>,
             kind: MessageKind,
             origin: MessageOrigin,
-            #[serde(default, alias = "trust")]
+            #[serde(default)]
             authority_class: Option<AuthorityClass>,
+            #[serde(default)]
+            trust: Option<AuthorityClass>,
             priority: Priority,
             #[serde(default)]
             trigger_kind: Option<ContinuationTriggerKind>,
@@ -56,6 +58,7 @@ impl<'de> Deserialize<'de> for MessageEnvelope {
         let compat = MessageEnvelopeCompat::deserialize(deserializer)?;
         let authority_class = compat
             .authority_class
+            .or(compat.trust)
             .ok_or_else(|| serde::de::Error::missing_field("authority_class"))?;
         Ok(Self {
             id: compat.id,
@@ -4004,6 +4007,31 @@ mod tests {
         let message: MessageEnvelope = serde_json::from_value(legacy).unwrap();
 
         assert_eq!(message.authority_class, AuthorityClass::RuntimeInstruction);
+    }
+
+    #[test]
+    fn legacy_messages_with_trust_and_authority_class_prefer_authority_class() {
+        let legacy = serde_json::json!({
+            "id": "msg-dual-field",
+            "agent_id": "default",
+            "created_at": "2026-04-22T00:00:00Z",
+            "kind": "operator_prompt",
+            "origin": {
+                "kind": "operator",
+                "actor_id": "control"
+            },
+            "trust": "trusted_system",
+            "authority_class": "operator_instruction",
+            "priority": "normal",
+            "body": {
+                "type": "text",
+                "text": "resume"
+            }
+        });
+
+        let message: MessageEnvelope = serde_json::from_value(legacy).unwrap();
+
+        assert_eq!(message.authority_class, AuthorityClass::OperatorInstruction);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PR #1481 fixed legacy records that only had the old `trust` field, but older `messages.jsonl` rows can contain both top-level fields:

- `trust`: old trust/provenance field name
- `authority_class`: newer authority field name

`MessageEnvelope` used `#[serde(alias = "trust")]` on `authority_class`, so serde treated both JSON keys as the same field and failed with:

```text
duplicate field `authority_class`
```

This still blocks startup when loading legacy message ledgers.

## Fix

- Deserialize `MessageEnvelope` with separate optional `authority_class` and `trust` fields.
- Prefer `authority_class` when both are present.
- Fall back to `trust` for older rows that do not have `authority_class`.
- Keep missing-field behavior when neither field exists.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/holon-dual-trust-target cargo test -q types::tests --lib`
- `CARGO_TARGET_DIR=/tmp/holon-dual-trust-target RUSTFLAGS="-D warnings" cargo check --all-targets`
