### PR TITLE
fix: remove execution_root restriction from ExecCommand workdir

### DIFF
--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -11,9 +11,9 @@ use uuid::Uuid;
 
 use crate::{
     system::{
-        CaptureSpec, ExecutionScopeKind, ExecutionSnapshot,
-        ProcessHost, ProcessPurpose, ProcessRequest, ProgramInvocation, RunningProcess,
-        RunningProcessExitStatus, StdioSpec, StopSignal,
+        CaptureSpec, ExecutionScopeKind, ExecutionSnapshot, ProcessHost, ProcessPurpose,
+        ProcessRequest, ProgramInvocation, RunningProcess, RunningProcessExitStatus, StdioSpec,
+        StopSignal,
     },
     tool::helpers::{
         command_cost_diagnostics, command_digest, command_preview, effective_tool_output_tokens,

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::{
     system::{
-        workspace::WorkspacePathError, CaptureSpec, ExecutionScopeKind, ExecutionSnapshot,
+        CaptureSpec, ExecutionScopeKind, ExecutionSnapshot,
         ProcessHost, ProcessPurpose, ProcessRequest, ProgramInvocation, RunningProcess,
         RunningProcessExitStatus, StdioSpec, StopSignal,
     },
@@ -491,33 +491,7 @@ impl RuntimeHandle {
         let workdir = spec
             .workdir
             .as_deref()
-            .map(|value| view.resolve_path(value))
-            .map(|result| {
-                result.map_err(|error| {
-                    if error
-                        .downcast_ref::<WorkspacePathError>()
-                        .is_some_and(|workspace_error| {
-                            workspace_error.kind()
-                                == crate::system::workspace::WorkspacePathErrorKind::ExecutionRootViolation
-                        })
-                    {
-                        ToolError::new(
-                            "execution_root_violation",
-                            "requested working directory is outside the current execution root",
-                        )
-                        .with_details(json!({
-                            "attempted_workdir": spec.workdir.clone(),
-                            "execution_root": view.execution_root(),
-                            "cwd": view.cwd(),
-                        }))
-                        .with_recovery_hint("omit `workdir` to use the current workspace cwd, or provide a relative path inside the workspace")
-                        .with_retryable(false)
-                        .into()
-                    } else {
-                        error
-                    }
-                })
-            })
+            .map(|value| view.resolve_read_path(value))
             .transpose()?
             .unwrap_or_else(|| view.cwd().to_path_buf());
 

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -26,7 +26,6 @@ runtime_async_tests!(
     exec_command_reports_nonzero_exit_and_truncates_output,
     exec_command_batch_returns_grouped_item_results,
     exec_command_batch_stop_on_error_skips_later_items,
-    exec_command_workdir_violation_returns_structured_error,
     exec_command_spawn_failure_returns_shell_recovery_hint,
     tool_schema_and_dispatch_errors_are_recorded_without_corrupting_runtime_state,
     runtime_provider_failure_surfaces_failure_brief_and_transcript_entry,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -719,50 +719,6 @@ pub async fn exec_command_batch_stop_on_error_skips_later_items() -> Result<()> 
     Ok(())
 }
 
-pub async fn exec_command_workdir_violation_returns_structured_error() -> Result<()> {
-    let host =
-        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
-    attach_default_workspace(&host).await?;
-    let runtime = host.default_runtime().await?;
-    let registry = ToolRegistry::new(runtime.workspace_root());
-
-    let error = registry
-        .execute(
-            &runtime,
-            "default",
-            &AuthorityClass::OperatorInstruction,
-            &ToolCall {
-                id: "tool-exec-invalid-workdir".into(),
-                name: "ExecCommand".into(),
-                input: json!({
-                    "cmd": "pwd",
-                    "workdir": "../outside"
-                }),
-            },
-        )
-        .await
-        .unwrap_err();
-    let tool_error = ToolError::from_anyhow(&error);
-
-    assert_eq!(tool_error.kind, "execution_root_violation");
-    assert_eq!(
-        tool_error.message,
-        "requested working directory is outside the current execution root"
-    );
-    assert_eq!(
-        tool_error
-            .details
-            .as_ref()
-            .and_then(|value| value.get("attempted_workdir")),
-        Some(&json!("../outside"))
-    );
-    assert!(tool_error
-        .recovery_hint
-        .as_deref()
-        .is_some_and(|hint| hint.contains("omit `workdir`")));
-    Ok(())
-}
-
 pub async fn exec_command_spawn_failure_returns_shell_recovery_hint() -> Result<()> {
     let host =
         RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;


### PR DESCRIPTION
## Summary

Fixes #1492.

Change `ExecCommand` `workdir` path resolution from `resolve_path` (which enforces `execution_root` boundary) to `resolve_read_path` (which only normalizes the path without boundary checks).

## Rationale

- **`workdir` is just a process startup directory** — it does not control write capabilities. Restricting it provides no real security benefit.
- **Security belongs in the sandbox layer**, not in path checks. With `host_local` backend, path checks only give a false sense of safety.
- **Legitimate use cases are blocked** — agents need to run tools from agent_home directories or global tools from arbitrary directories.

## Change

One call site in `command_task.rs`: `resolve_path` → `resolve_read_path`, plus removing the now-dead `WorkspacePathError` import and the `execution_root_violation` error branch.

## Verification

- `cargo check --lib` passes cleanly.