### PR TITLE
fix: address PR #1493 review feedback — update cwd_rooting policy and add workdir test

### DIFF
--- a/docs/website/concepts/security-and-execution-boundaries.md
+++ b/docs/website/concepts/security-and-execution-boundaries.md
@@ -31,7 +31,7 @@ describes the current policy snapshot and what is enforced:
 
 | Boundary | Level | What it means |
 |----------|-------|---------------|
-| `cwd_rooting` | hard_enforced | Commands cannot escape the workspace root as their working directory |
+| `cwd_rooting` | runtime_shaped | The runtime allows workdir outside the workspace root when explicitly requested; sandboxing is the responsibility of the execution backend |
 | `projection_rooting` | hard_enforced | Filesystem views are constrained to the projected root |
 | `path_confinement` | not_enforced | The runtime does not prevent access outside the workspace by path |
 | `write_confinement` | not_enforced | Write operations are not restricted to the workspace |

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -1817,4 +1817,29 @@ mod tests {
             Some(resolved.output_path.to_string_lossy().as_ref())
         );
     }
+
+    #[tokio::test]
+    async fn resolve_command_task_accepts_workdir_outside_execution_root() {
+        let (_home, workspace, runtime) = test_runtime();
+        // Create a directory outside the workspace root
+        let outside_dir = workspace.path().parent().unwrap().join("outside_cwd");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+
+        let mut spec = command_spec(false, false);
+        spec.workdir = Some(outside_dir.to_string_lossy().into_owned());
+
+        let resolved = resolved_command(&runtime, &spec).await;
+        // The resolved workdir should point to the external directory, not the workspace root
+        let resolved_canonical = std::fs::canonicalize(&resolved.workdir).unwrap();
+        let outside_canonical = std::fs::canonicalize(&outside_dir).unwrap();
+        assert_eq!(
+            resolved_canonical, outside_canonical,
+            "workdir outside execution_root should be accepted and resolve to the requested directory"
+        );
+        assert_ne!(
+            resolved.workdir,
+            workspace.path(),
+            "workdir should not fall back to workspace root"
+        );
+    }
 }

--- a/src/system/types.rs
+++ b/src/system/types.rs
@@ -457,7 +457,7 @@ mod tests {
         );
         assert_eq!(
             snapshot.process_execution.cwd_rooting,
-            ExecutionGuaranteeLevel::HardEnforced
+            ExecutionGuaranteeLevel::RuntimeShaped
         );
         assert_eq!(
             snapshot.process_execution.path_confinement,

--- a/src/system/types.rs
+++ b/src/system/types.rs
@@ -46,7 +46,7 @@ impl ExecutionProfile {
                     process_execution: ExecutionGuaranteeLevel::RuntimeShaped,
                 },
                 process_execution: ProcessExecutionCapabilitySnapshot {
-                    cwd_rooting: ExecutionGuaranteeLevel::HardEnforced,
+                    cwd_rooting: ExecutionGuaranteeLevel::RuntimeShaped,
                     projection_rooting: ExecutionGuaranteeLevel::HardEnforced,
                     path_confinement: ExecutionGuaranteeLevel::NotEnforced,
                     write_confinement: ExecutionGuaranteeLevel::NotEnforced,

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -37,7 +37,7 @@ Resource authority:
   - workspace_projection: hard_enforced
   - process_execution: runtime_shaped
 Process execution guarantees:
-  - cwd_rooting: hard_enforced
+  - cwd_rooting: runtime_shaped
   - projection_rooting: hard_enforced
   - path_confinement: not_enforced
   - write_confinement: not_enforced


### PR DESCRIPTION
## Summary

Follow-up to #1493 (merged). Addresses copilot review comments that were left unaddressed before merge.

## Changes

1. **cwd_rooting policy update**: Changed `cwd_rooting` from `hard_enforced` to `runtime_shaped` in:
   - `src/system/types.rs` — `ExecutionProfile` process execution guarantees
   - `docs/website/concepts/security-and-execution-boundaries.md` — documentation table
   - `tests/prompt_context_snapshots.rs` — snapshot expectations

   Since #1493 removed the execution_root boundary enforcement for ExecCommand workdir, the policy should no longer claim hard enforcement.

2. **Unit test**: Added `resolve_command_task_accepts_workdir_outside_execution_root` in `src/runtime/command_task.rs` to document and regression-test that workdir paths outside the execution_root are accepted.

## Verification

- `cargo fmt -- --check` ✓
- `cargo test --lib resolve_command_task_accepts_workdir_outside_execution_root` ✓
- `cargo test --test prompt_context_snapshots` ✓
- `cargo check --all-targets` ✓