### PR TITLE
docs: update Workspace root prose to match cwd_rooting runtime_shaped policy

### DIFF
--- a/docs/website/concepts/security-and-execution-boundaries.md
+++ b/docs/website/concepts/security-and-execution-boundaries.md
@@ -47,8 +47,8 @@ Boundaries marked `not_enforced` rely on the operator's host configuration
 Holon provides workspace binding that constrains where the agent operates:
 
 - **Workspace root** — the agent's default working directory. The runtime
-  enforces that commands start inside this root, but the agent or its commands
-  can navigate elsewhere by path.
+  defaults commands to start inside this root, but an explicit workdir may
+  point outside the workspace when the execution backend allows it.
 - **Projection root** — constrains the filesystem view presented to the agent.
   When enforced, the agent only sees files under the projection root.
 - **ApplyPatch targets** — file mutation tools resolve relative paths against


### PR DESCRIPTION
## Summary

Follow-up to #1495. Updates the "Workspace root" prose in the security boundaries documentation to reflect the current `cwd_rooting: runtime_shaped` policy.

## Change

The prose previously said the runtime "enforces that commands start inside this root." Since #1493 removed the execution_root boundary enforcement for ExecCommand workdir and #1495 updated the policy to `runtime_shaped`, the prose now reads: "defaults commands to start inside this root, but an explicit workdir may point outside the workspace when the execution backend allows it."

This was noted as a non-blocking suggestion in the #1495 review.