### PR TITLE
fix: group TUI conversation by turn

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -152,6 +152,8 @@ pub enum ItemState {
 pub struct TimedItem {
     pub item: PresentationItem,
     pub ts: DateTime<Utc>,
+    pub event_seq: u64,
+    pub turn_index: Option<u64>,
     pub dedupe_key: String,
 }
 
@@ -160,6 +162,8 @@ impl TimedItem {
         Self {
             item,
             ts: event.ts,
+            event_seq: event.event_seq,
+            turn_index: event.payload.get("turn_index").and_then(Value::as_u64),
             dedupe_key: event_dedupe_key(event),
         }
     }
@@ -172,6 +176,22 @@ impl TimedItem {
         Self {
             item,
             ts,
+            event_seq: 0,
+            turn_index: None,
+            dedupe_key: dedupe_key.into(),
+        }
+    }
+
+    pub(crate) fn with_event_key(
+        item: PresentationItem,
+        event: &ProjectionEventRecord,
+        dedupe_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            item,
+            ts: event.ts,
+            event_seq: event.event_seq,
+            turn_index: event.payload.get("turn_index").and_then(Value::as_u64),
             dedupe_key: dedupe_key.into(),
         }
     }
@@ -783,12 +803,12 @@ impl PresentationReducer {
                     };
                     if let Some(key) = command_presentation_key(event, &cmd_preview) {
                         if let Some(index) = local_open_command_items.remove(&key) {
-                            items[index] = TimedItem::with_key(item, event.ts, key);
+                            items[index] = TimedItem::with_event_key(item, event, key);
                             self.open_command_keys.remove(&items[index].dedupe_key);
                         } else if self.open_command_keys.remove(&key) {
-                            items.push(TimedItem::with_key(item, event.ts, key));
+                            items.push(TimedItem::with_event_key(item, event, key));
                         } else {
-                            items.push(TimedItem::with_key(item, event.ts, key));
+                            items.push(TimedItem::with_event_key(item, event, key));
                         }
                     } else {
                         items.push(TimedItem::from_event(item, event));

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -100,13 +100,16 @@ impl RuntimeHandle {
             .await?;
 
         if outcome.terminal_kind.is_failure() {
-            let brief = brief::make_failure(&message.agent_id, message, outcome.final_text.clone());
+            let mut brief =
+                brief::make_failure(&message.agent_id, message, outcome.final_text.clone());
+            brief.turn_index = Some(outcome.turn_index);
             self.persist_brief(&brief).await?;
         } else {
             match outcome.terminal_delivery {
                 TurnTerminalDelivery::NormalBrief => {
-                    let brief =
+                    let mut brief =
                         brief::make_result(&message.agent_id, message, outcome.final_text.clone());
+                    brief.turn_index = Some(outcome.turn_index);
                     self.persist_brief(&brief).await?;
                 }
                 TurnTerminalDelivery::WorkItemCompletionReportPromoted {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2368,6 +2368,7 @@ impl RuntimeHandle {
             BriefRecord::new(agent_id.clone(), BriefKind::Result, report_text, None, None);
         brief.work_item_id = Some(record.id.clone());
         brief.workspace_id = record.workspace_id.clone();
+        brief.turn_index = source_turn_index;
         self.persist_brief(&brief).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_completion_report_promoted",

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -802,6 +802,7 @@ async fn context_length_exceeded_turn_fails_fast_without_runtime_error() {
         .find(|brief| brief.kind == BriefKind::Failure)
         .expect("failure brief should exist");
     assert!(failure.text.contains("context_length_exceeded"));
+    assert_eq!(failure.turn_index, Some(1));
 
     let events = runtime.storage().read_recent_events(20).unwrap();
     assert!(events

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1895,6 +1895,7 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         result_briefs[0].work_item_id.as_deref(),
         Some(work_item.id.as_str())
     );
+    assert_eq!(result_briefs[0].turn_index, Some(1));
     assert!(
         !briefs.iter().any(|brief| {
             brief.kind == BriefKind::Result

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -41,6 +41,7 @@ use super::{
 
 pub(super) struct AgentLoopOutcome {
     pub(super) final_text: String,
+    pub(super) turn_index: u64,
     pub(super) should_sleep: bool,
     pub(super) sleep_duration_ms: Option<u64>,
     pub(super) allow_sleep_runnable_work_override: bool,
@@ -1379,15 +1380,17 @@ impl RuntimeHandle {
             }),
         ))?;
         let final_text = "Turn stopped because the provider rejected the request with context_length_exceeded. This usually means the configured model context window or prompt budget is too large for the current provider path.".to_string();
-        self.persist_turn_terminal_record(
-            TurnTerminalKind::Aborted,
-            Some(final_text.clone()),
-            duration_ms,
-            None,
-        )
-        .await?;
+        let terminal = self
+            .persist_turn_terminal_record(
+                TurnTerminalKind::Aborted,
+                Some(final_text.clone()),
+                duration_ms,
+                None,
+            )
+            .await?;
         Ok(Some(AgentLoopOutcome {
             final_text,
+            turn_index: terminal.turn_index,
             should_sleep: false,
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
@@ -1481,15 +1484,16 @@ impl RuntimeHandle {
             }),
         ))?;
         let final_text = operator_message.clone();
-        self.persist_turn_terminal_record(
-            terminal_kind,
-            last_assistant_message
-                .clone()
-                .or_else(|| Some(final_text.clone())),
-            duration_ms,
-            None,
-        )
-        .await?;
+        let terminal = self
+            .persist_turn_terminal_record(
+                terminal_kind,
+                last_assistant_message
+                    .clone()
+                    .or_else(|| Some(final_text.clone())),
+                duration_ms,
+                None,
+            )
+            .await?;
         let event_kind = if side_effect_boundary_crossed {
             "provider_failed_needs_recovery"
         } else {
@@ -1544,6 +1548,7 @@ impl RuntimeHandle {
         ))?;
         Ok(Some(AgentLoopOutcome {
             final_text,
+            turn_index: terminal.turn_index,
             should_sleep: false,
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
@@ -1876,7 +1881,7 @@ impl TurnExecution<'_> {
                     let final_text = format!(
                         "Stopped after reaching the maximum tool loop depth ({max_tool_rounds})."
                     );
-                    runtime
+                    let terminal = runtime
                         .persist_turn_terminal_record(
                             TurnTerminalKind::Aborted,
                             Some(final_text.clone()),
@@ -1886,6 +1891,7 @@ impl TurnExecution<'_> {
                         .await?;
                     return Ok(AgentLoopOutcome {
                         final_text,
+                        turn_index: terminal.turn_index,
                         should_sleep: false,
                         sleep_duration_ms: None,
                         allow_sleep_runnable_work_override: false,
@@ -2099,7 +2105,7 @@ impl TurnExecution<'_> {
                             diagnostics.effective_budget_estimated_tokens,
                             diagnostics.tool_overhead_estimated_tokens,
                         );
-                        runtime
+                        let terminal = runtime
                             .persist_turn_terminal_record(
                                 TurnTerminalKind::BaselineOverBudget,
                                 Some(final_text.clone()),
@@ -2109,6 +2115,7 @@ impl TurnExecution<'_> {
                             .await?;
                         return Ok(AgentLoopOutcome {
                             final_text,
+                            turn_index: terminal.turn_index,
                             should_sleep: false,
                             sleep_duration_ms: None,
                             allow_sleep_runnable_work_override: false,
@@ -2608,7 +2615,7 @@ impl TurnExecution<'_> {
 
             if tool_calls.is_empty() {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
-                runtime
+                let terminal = runtime
                     .persist_turn_terminal_record(
                         TurnTerminalKind::Completed,
                         last_assistant_message.clone(),
@@ -2618,6 +2625,7 @@ impl TurnExecution<'_> {
                     .await?;
                 return Ok(AgentLoopOutcome {
                     final_text,
+                    turn_index: terminal.turn_index,
                     should_sleep: true,
                     sleep_duration_ms,
                     allow_sleep_runnable_work_override: false,
@@ -2940,7 +2948,7 @@ impl TurnExecution<'_> {
             if let Some(promotion) = completion_promotion {
                 if !has_operator_interjections {
                     let final_text = last_assistant_message.clone().unwrap_or_default();
-                    runtime
+                    let terminal = runtime
                         .persist_turn_terminal_record(
                             TurnTerminalKind::Completed,
                             last_assistant_message.clone(),
@@ -2950,6 +2958,7 @@ impl TurnExecution<'_> {
                         .await?;
                     return Ok(AgentLoopOutcome {
                         final_text,
+                        turn_index: terminal.turn_index,
                         should_sleep,
                         sleep_duration_ms,
                         allow_sleep_runnable_work_override: should_sleep,
@@ -2965,7 +2974,7 @@ impl TurnExecution<'_> {
 
             if only_sleep_tools && !has_operator_interjections {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
-                runtime
+                let terminal = runtime
                     .persist_turn_terminal_record(
                         TurnTerminalKind::Completed,
                         last_assistant_message.clone(),
@@ -2975,6 +2984,7 @@ impl TurnExecution<'_> {
                     .await?;
                 return Ok(AgentLoopOutcome {
                     final_text,
+                    turn_index: terminal.turn_index,
                     should_sleep: true,
                     sleep_duration_ms: sleep_duration_ms.or(legacy_sleep_duration_ms),
                     allow_sleep_runnable_work_override: true,

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -125,9 +125,11 @@ pub(super) enum ConversationCell {
     },
     SystemNotice {
         created_at: DateTime<chrono::Utc>,
+        event_seq: u64,
         speaker: String,
         body: String,
         display_kind: ConversationDisplayKind,
+        group_id: Option<String>,
     },
 }
 
@@ -179,8 +181,12 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
                         rendered_to_conversation_cell(
                             &rendered,
                             timed.ts,
+                            timed.event_seq,
                             agent_speaker,
                             display_kind,
+                            timed.turn_index.map(|turn_index| {
+                                format!("agent:{agent_speaker}:turn:{turn_index}")
+                            }),
                         ),
                     );
                 }
@@ -206,6 +212,7 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
     cells.sort_by(|left, right| {
         left.created_at()
             .cmp(&right.created_at())
+            .then_with(|| left.event_seq().cmp(&right.event_seq()))
             .then_with(|| chat_role_rank(left.role()).cmp(&chat_role_rank(right.role())))
             .then_with(|| left.sort_speaker().cmp(right.sort_speaker()))
             .then_with(|| left.sort_body().cmp(right.sort_body()))
@@ -284,6 +291,13 @@ impl ConversationCell {
         }
     }
 
+    fn event_seq(&self) -> u64 {
+        match self {
+            Self::SystemNotice { event_seq, .. } => *event_seq,
+            Self::UserMessage { .. } | Self::ActiveActivity { .. } => 0,
+        }
+    }
+
     fn display_kind(&self) -> ConversationDisplayKind {
         match self {
             Self::UserMessage { .. } => ConversationDisplayKind::Operator,
@@ -319,18 +333,16 @@ impl ConversationCell {
             (
                 Self::SystemNotice {
                     speaker: previous_speaker,
-                    display_kind: previous_kind,
+                    group_id: previous_group_id,
                     ..
                 },
                 Self::SystemNotice {
-                    speaker,
-                    display_kind,
-                    ..
+                    speaker, group_id, ..
                 },
             ) => {
-                *previous_kind == ConversationDisplayKind::Activity
-                    && *display_kind == ConversationDisplayKind::Activity
+                previous_group_id.is_some()
                     && previous_speaker == speaker
+                    && previous_group_id == group_id
             }
             _ => false,
         }
@@ -351,6 +363,7 @@ impl ConversationCell {
                 speaker,
                 body,
                 display_kind,
+                ..
             } => render_message_block_lines(
                 *created_at,
                 ChatBlockRole::Agent,
@@ -1264,8 +1277,10 @@ mod tests {
 pub(super) fn rendered_to_conversation_cell(
     cell: &crate::presentation::RenderedCell,
     ts: chrono::DateTime<chrono::Utc>,
+    event_seq: u64,
     agent_speaker: &str,
     display_kind: ConversationDisplayKind,
+    group_id: Option<String>,
 ) -> ConversationCell {
     if cell.is_live {
         ConversationCell::ActiveActivity {
@@ -1282,9 +1297,11 @@ pub(super) fn rendered_to_conversation_cell(
     } else {
         ConversationCell::SystemNotice {
             created_at: ts,
+            event_seq,
             speaker: agent_speaker.to_string(),
             body: cell.body.clone(),
             display_kind,
+            group_id,
         }
     }
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -685,6 +685,7 @@ fn build_chat_text_includes_structured_operator_messages() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: "I started a worktree task.".into(),
@@ -721,6 +722,7 @@ fn build_chat_text_renders_message_block_header_above_body() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: "First line\nSecond line".into(),
@@ -749,21 +751,27 @@ fn build_chat_text_groups_activity_by_kind_not_minute() {
     let items = vec![
         ConversationCell::SystemNotice {
             created_at: first_created_at,
+            event_seq: 1,
             speaker: "holon-pm".into(),
             body: "first activity".into(),
             display_kind: ConversationDisplayKind::Activity,
+            group_id: Some("agent:holon-pm:turn:1".into()),
         },
         ConversationCell::SystemNotice {
             created_at: second_created_at,
+            event_seq: 2,
             speaker: "holon-pm".into(),
             body: "second activity".into(),
             display_kind: ConversationDisplayKind::Activity,
+            group_id: Some("agent:holon-pm:turn:1".into()),
         },
         ConversationCell::SystemNotice {
             created_at: second_created_at,
+            event_seq: 3,
             speaker: "holon-pm".into(),
             body: "narrative line".into(),
             display_kind: ConversationDisplayKind::Narrative,
+            group_id: Some("agent:holon-pm:turn:2".into()),
         },
     ];
 
@@ -786,6 +794,103 @@ fn build_chat_text_groups_activity_by_kind_not_minute() {
     assert!(lines
         .iter()
         .any(|line| line.starts_with("  narrative line")));
+}
+
+#[test]
+fn build_chat_text_groups_agent_cells_by_turn_index() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.display_mode = OperatorDisplayMode::Verbose;
+    let ts = Utc::now();
+    let mut projection = TuiProjection::from_snapshot(sample_snapshot("holon-pm", "evt-0"));
+    for event in [
+        pipeline_event_envelope(
+            "evt-progress",
+            1,
+            "holon-pm",
+            "assistant_round_recorded",
+            json!({
+                "agent_id": "holon-pm",
+                "turn_index": 7,
+                "round": 1,
+                "text_preview": "I will inspect the PR.",
+                "has_text": true,
+                "has_tool_calls": false
+            }),
+        ),
+        pipeline_event_envelope(
+            "evt-tool",
+            2,
+            "holon-pm",
+            "tool_executed",
+            json!({
+                "agent_id": "holon-pm",
+                "turn_index": 7,
+                "tool_name": "ExecCommand",
+                "exec_command_cmd": "gh pr view 1497",
+                "duration_ms": 100,
+                "status": "success",
+                "summary": "gh pr view 1497"
+            }),
+        ),
+    ] {
+        projection.apply_event(
+            AgentStreamEvent {
+                id: event.id.clone(),
+                event: event.event_type.clone(),
+                data: StreamEventEnvelope { ts, ..event },
+            },
+            &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        );
+    }
+    let brief = BriefRecord {
+        id: "brief-1".into(),
+        agent_id: "holon-pm".into(),
+        workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
+        work_item_id: None,
+        turn_index: Some(7),
+        kind: BriefKind::Result,
+        created_at: ts,
+        text: "PR is merged.".into(),
+        attachments: None,
+        related_message_id: None,
+        related_task_id: None,
+    };
+    let brief_event = StreamEventEnvelope {
+        id: "evt-brief".into(),
+        event_seq: 3,
+        ts,
+        agent_id: "holon-pm".into(),
+        event_type: "brief_created".into(),
+        provenance: None,
+        payload: serde_json::to_value(brief).unwrap(),
+    };
+    projection.apply_event(
+        AgentStreamEvent {
+            id: brief_event.id.clone(),
+            event: brief_event.event_type.clone(),
+            data: brief_event,
+        },
+        &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.projection = Some(projection);
+
+    let lines: Vec<String> = build_chat_text(&collect_chat_items(&app))
+        .lines
+        .into_iter()
+        .map(|line| line.spans.into_iter().map(|span| span.content).collect())
+        .collect();
+    let header_count = lines
+        .iter()
+        .filter(|line| line.contains("• holon-pm "))
+        .count();
+    assert_eq!(header_count, 1);
+    assert!(lines.iter().any(|line| line.contains("I will inspect")));
+    assert!(lines.iter().any(|line| line.contains("gh pr view 1497")));
+    assert!(lines.iter().any(|line| line.contains("PR is merged.")));
 }
 
 #[test]
@@ -1570,6 +1675,7 @@ fn chat_text_renders_markdown_body() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: "**Done**\n- first\n- second".into(),
@@ -1603,6 +1709,7 @@ fn chat_text_renders_brief_events_from_projection() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: "### Title\n\nBody".into(),
@@ -1648,6 +1755,7 @@ fn chat_text_filters_operator_queue_ack_but_keeps_result_brief_events() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: "Real response".into(),
@@ -1680,6 +1788,7 @@ fn chat_text_summarizes_task_brief_output() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: "Task task-1 completed: line one\nline two\nline three".into(),
@@ -2233,6 +2342,7 @@ fn active_activity_timestamp_does_not_sort_before_tail_history() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: ts + chrono::Duration::seconds(10),
             text: "Latest durable response".into(),
@@ -2417,6 +2527,7 @@ fn collect_chat_items_orders_equal_timestamps_deterministically() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: ts,
             text: "same instant".into(),
@@ -3034,6 +3145,7 @@ fn chat_text_renders_full_long_brief_events() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: long_text,
@@ -3067,6 +3179,7 @@ fn chat_text_cache_reuses_unchanged_content_and_replaces_stale_entries() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: first_created_at,
             text: "**Done**".into(),
@@ -3097,6 +3210,7 @@ fn chat_text_cache_reuses_unchanged_content_and_replaces_stale_entries() {
             agent_id: "default".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Failure,
             created_at: first_created_at,
             text: "**Failed**".into(),
@@ -3378,6 +3492,7 @@ fn apply_agent_list_clears_stale_projection_when_selected_agent_disappears() {
             agent_id: "beta".into(),
             workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
             work_item_id: None,
+            turn_index: None,
             kind: BriefKind::Result,
             created_at: Utc::now(),
             text: "stale brief".into(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3555,6 +3555,8 @@ pub struct BriefRecord {
     pub workspace_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_index: Option<u64>,
     pub kind: BriefKind,
     pub created_at: DateTime<Utc>,
     pub text: String,
@@ -3577,6 +3579,7 @@ impl BriefRecord {
             workspace_id: agent_home_workspace_id(&agent_id),
             agent_id,
             work_item_id: None,
+            turn_index: None,
             kind,
             created_at: Utc::now(),
             text: text.into(),
@@ -4446,6 +4449,7 @@ mod tests {
         brief.as_object_mut().unwrap().remove("workspace_id");
         let brief: BriefRecord = serde_json::from_value(brief).unwrap();
         assert_eq!(brief.workspace_id, AGENT_HOME_WORKSPACE_ID);
+        assert_eq!(brief.turn_index, None);
 
         let mut work_item =
             serde_json::to_value(WorkItemRecord::new("default", "ship", WorkItemState::Open))


### PR DESCRIPTION
## Summary

- Add optional `turn_index` to `BriefRecord` and bind model-turn result/failure briefs to their terminal turn.
- Carry `turn_index`/`event_seq` through presentation items into TUI conversation cells.
- Group TUI agent conversation blocks by turn so narrative, tool activity, and final briefs share one agent header.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`
