### PR TITLE
fix: improve tui turn layout

### DIFF
--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::presentation::{PresentationItem, PresentationReducer, Renderable};
 use crate::tui::projection::{is_presentation_reducer_event, ProjectionEventRecord};
 use crossterm::event::KeyCode;
+use unicode_width::UnicodeWidthChar;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ChatScrollState {
@@ -130,6 +131,7 @@ pub(super) enum ConversationCell {
         body: String,
         display_kind: ConversationDisplayKind,
         group_id: Option<String>,
+        header_hint: Option<String>,
     },
 }
 
@@ -168,10 +170,23 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
         let mut reducer = PresentationReducer::new();
         let mut timed_items = reducer.reduce(events.as_slice());
         timed_items.extend(reducer.flush());
+        let mut pending_agent_header_hint: Option<String> = None;
 
         for timed in &timed_items {
             if timed.item.is_visible_at(level) {
+                if let Some(hint) = resume_header_hint(&timed.item) {
+                    pending_agent_header_hint = Some(hint);
+                    continue;
+                }
                 let display_kind = conversation_display_kind(&timed.item);
+                let group_id = timed
+                    .turn_index
+                    .map(|turn_index| format!("agent:{agent_speaker}:turn:{turn_index}"));
+                let header_hint = if group_id.is_some() {
+                    pending_agent_header_hint.take()
+                } else {
+                    None
+                };
                 for rendered in timed.item.render(level) {
                     push_projected_conversation_cell(
                         &mut cells,
@@ -184,9 +199,8 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
                             timed.event_seq,
                             agent_speaker,
                             display_kind,
-                            timed.turn_index.map(|turn_index| {
-                                format!("agent:{agent_speaker}:turn:{turn_index}")
-                            }),
+                            group_id.clone(),
+                            header_hint.clone(),
                         ),
                     );
                 }
@@ -269,11 +283,12 @@ fn push_projected_conversation_cell(
 
 fn projected_conversation_cell_key(source_key: &str, cell: &ConversationCell) -> String {
     format!(
-        "{}|{:?}|{:?}|{}|{}",
+        "{}|{:?}|{:?}|{}|{}|{}",
         source_key,
         cell.role(),
         cell.display_kind(),
         cell.sort_speaker(),
+        cell.header_hint().unwrap_or(""),
         normalized_operator_message_body_key(cell.sort_body())
     )
 }
@@ -328,6 +343,13 @@ impl ConversationCell {
         }
     }
 
+    fn header_hint(&self) -> Option<&str> {
+        match self {
+            Self::SystemNotice { header_hint, .. } => header_hint.as_deref(),
+            Self::UserMessage { .. } | Self::ActiveActivity { .. } => None,
+        }
+    }
+
     fn groups_with_previous(&self, previous: &Self) -> bool {
         match (previous, self) {
             (
@@ -348,6 +370,13 @@ impl ConversationCell {
         }
     }
 
+    fn needs_section_break_after(&self, next: &Self) -> bool {
+        next.groups_with_previous(self)
+            && self.display_kind() != next.display_kind()
+            && self.display_kind() != ConversationDisplayKind::Operator
+            && next.display_kind() != ConversationDisplayKind::Operator
+    }
+
     fn render_lines(&self, width: u16, include_header: bool) -> Vec<Line<'static>> {
         match self {
             Self::UserMessage {
@@ -363,6 +392,7 @@ impl ConversationCell {
                 speaker,
                 body,
                 display_kind,
+                header_hint,
                 ..
             } => render_message_block_lines(
                 *created_at,
@@ -370,6 +400,7 @@ impl ConversationCell {
                 speaker,
                 body,
                 *display_kind,
+                header_hint.as_deref(),
                 width,
                 false,
                 include_header,
@@ -410,7 +441,9 @@ pub(super) fn build_chat_text_for_width(items: &[ConversationCell], width: u16) 
             .extend(item.render_lines(width, !grouped_with_previous));
         if index + 1 < items.len() {
             let groups_with_next = items[index + 1].groups_with_previous(item);
-            if !groups_with_next {
+            if item.needs_section_break_after(&items[index + 1]) {
+                text.lines.push(Line::default());
+            } else if !groups_with_next {
                 text.lines.push(Line::default());
             }
         }
@@ -452,6 +485,7 @@ fn render_message_block_lines(
     speaker: &str,
     body: &str,
     display_kind: ConversationDisplayKind,
+    header_hint: Option<&str>,
     width: u16,
     spaced_markdown: bool,
     include_header: bool,
@@ -463,7 +497,12 @@ fn render_message_block_lines(
     };
     let body_lines = body.lines;
     let mut lines = if include_header {
-        vec![Line::from(chat_header_spans(created_at, role, speaker))]
+        vec![Line::from(chat_header_spans(
+            created_at,
+            role,
+            speaker,
+            header_hint,
+        ))]
     } else {
         Vec::new()
     };
@@ -474,12 +513,58 @@ fn render_message_block_lines(
             continue;
         }
 
-        let mut spans = Vec::with_capacity(line.spans.len() + 1);
-        spans.push(Span::raw(message_body_indent(display_kind)));
-        spans.extend(line.spans.clone());
-        lines.push(Line::from(spans).style(line.style));
+        lines.extend(wrap_body_line(
+            &line,
+            message_body_indent(display_kind),
+            width,
+        ));
     }
     lines
+}
+
+fn wrap_body_line(line: &Line<'static>, indent: &'static str, width: u16) -> Vec<Line<'static>> {
+    let width = usize::from(width);
+    if width == usize::from(u16::MAX) || width == 0 {
+        let mut spans = Vec::with_capacity(line.spans.len() + 1);
+        spans.push(Span::raw(indent));
+        spans.extend(line.spans.clone());
+        return vec![Line::from(spans).style(line.style)];
+    }
+
+    let indent_width = display_width(indent);
+    let max_width = width.max(indent_width + 8);
+    let mut lines = Vec::new();
+    let mut spans = vec![Span::raw(indent)];
+    let mut current_width = indent_width;
+
+    for span in &line.spans {
+        let mut chunk = String::new();
+        for ch in span.content.chars() {
+            let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if current_width + ch_width > max_width && current_width > indent_width {
+                if !chunk.is_empty() {
+                    spans.push(Span::styled(std::mem::take(&mut chunk), span.style));
+                }
+                lines.push(Line::from(spans).style(line.style));
+                spans = vec![Span::raw(indent)];
+                current_width = indent_width;
+            }
+            chunk.push(ch);
+            current_width += ch_width;
+        }
+        if !chunk.is_empty() {
+            spans.push(Span::styled(chunk, span.style));
+        }
+    }
+
+    lines.push(Line::from(spans).style(line.style));
+    lines
+}
+
+fn display_width(text: &str) -> usize {
+    text.chars()
+        .map(|ch| UnicodeWidthChar::width(ch).unwrap_or(0))
+        .sum()
 }
 
 fn message_body_indent(display_kind: ConversationDisplayKind) -> &'static str {
@@ -501,6 +586,7 @@ fn render_operator_message_lines(
         "operator",
         body,
         ConversationDisplayKind::Operator,
+        None,
         width,
         false,
         true,
@@ -578,6 +664,7 @@ fn chat_header_spans(
     created_at: DateTime<chrono::Utc>,
     role: ChatBlockRole,
     speaker: &str,
+    header_hint: Option<&str>,
 ) -> Vec<Span<'static>> {
     let (marker, marker_style) = match role {
         ChatBlockRole::Operator => ("> ", Style::default().add_modifier(Modifier::BOLD)),
@@ -589,7 +676,7 @@ fn chat_header_spans(
         ),
     };
 
-    vec![
+    let mut spans = vec![
         Span::styled(marker, marker_style),
         Span::styled(
             speaker.to_string(),
@@ -600,7 +687,15 @@ fn chat_header_spans(
             chat_timestamp(created_at),
             Style::default().add_modifier(Modifier::DIM),
         ),
-    ]
+    ];
+    if let Some(hint) = header_hint.filter(|hint| !hint.trim().is_empty()) {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            hint.trim().to_string(),
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+    }
+    spans
 }
 
 fn chat_timestamp(created_at: DateTime<chrono::Utc>) -> String {
@@ -631,6 +726,34 @@ fn conversation_display_kind(item: &PresentationItem) -> ConversationDisplayKind
         | PresentationItem::ContinuationDetail { .. }
         | PresentationItem::GenericEvent { .. } => ConversationDisplayKind::Activity,
     }
+}
+
+fn resume_header_hint(item: &PresentationItem) -> Option<String> {
+    let PresentationItem::ResumeNotice { reason, .. } = item else {
+        return None;
+    };
+    let reason = reason.trim();
+    if let Some(trigger) = reason
+        .strip_prefix("Continuation triggered by ")
+        .and_then(|tail| tail.split(';').next())
+    {
+        return Some(match trigger.trim() {
+            "operator_input" => "operator input".to_string(),
+            "task_result" => "task result".to_string(),
+            "system_tick" => "system tick".to_string(),
+            "timer" => "timer".to_string(),
+            "external_trigger" => "external trigger".to_string(),
+            other if !other.is_empty() => other.replace('_', " "),
+            _ => "resumed".to_string(),
+        });
+    }
+    if reason.starts_with("Timer fired") {
+        return Some("timer".to_string());
+    }
+    if reason.starts_with("External event") {
+        return Some("external trigger".to_string());
+    }
+    Some("resumed".to_string())
 }
 
 fn active_activity_status_label(speaker: &str) -> Option<&'static str> {
@@ -1281,6 +1404,7 @@ pub(super) fn rendered_to_conversation_cell(
     agent_speaker: &str,
     display_kind: ConversationDisplayKind,
     group_id: Option<String>,
+    header_hint: Option<String>,
 ) -> ConversationCell {
     if cell.is_live {
         ConversationCell::ActiveActivity {
@@ -1302,6 +1426,7 @@ pub(super) fn rendered_to_conversation_cell(
             body: cell.body.clone(),
             display_kind,
             group_id,
+            header_hint,
         }
     }
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,9 +1,9 @@
 use super::{
     app::TuiApp,
     chat::{
-        build_chat_text, chat_text, collect_chat_items, is_operator_origin_value,
-        paragraph_max_scroll, paragraph_max_scroll_unframed, ChatScrollState, ConversationCell,
-        ConversationDisplayKind,
+        build_chat_text, build_chat_text_for_width, chat_text, collect_chat_items,
+        is_operator_origin_value, paragraph_max_scroll, paragraph_max_scroll_unframed,
+        ChatScrollState, ConversationCell, ConversationDisplayKind,
     },
     composer::ComposerState,
     determine_alt_screen_mode_for_terminal,
@@ -756,6 +756,7 @@ fn build_chat_text_groups_activity_by_kind_not_minute() {
             body: "first activity".into(),
             display_kind: ConversationDisplayKind::Activity,
             group_id: Some("agent:holon-pm:turn:1".into()),
+            header_hint: None,
         },
         ConversationCell::SystemNotice {
             created_at: second_created_at,
@@ -764,6 +765,7 @@ fn build_chat_text_groups_activity_by_kind_not_minute() {
             body: "second activity".into(),
             display_kind: ConversationDisplayKind::Activity,
             group_id: Some("agent:holon-pm:turn:1".into()),
+            header_hint: None,
         },
         ConversationCell::SystemNotice {
             created_at: second_created_at,
@@ -772,6 +774,7 @@ fn build_chat_text_groups_activity_by_kind_not_minute() {
             body: "narrative line".into(),
             display_kind: ConversationDisplayKind::Narrative,
             group_id: Some("agent:holon-pm:turn:2".into()),
+            header_hint: None,
         },
     ];
 
@@ -806,10 +809,28 @@ fn build_chat_text_groups_agent_cells_by_turn_index() {
     app.display_mode = OperatorDisplayMode::Verbose;
     let ts = Utc::now();
     let mut projection = TuiProjection::from_snapshot(sample_snapshot("holon-pm", "evt-0"));
+    let resume_event = pipeline_event_envelope(
+        "evt-resume",
+        1,
+        "holon-pm",
+        "continuation_trigger_received",
+        json!({
+            "agent_id": "holon-pm",
+            "trigger_kind": "operator_input"
+        }),
+    );
+    projection.apply_event(
+        AgentStreamEvent {
+            id: resume_event.id.clone(),
+            event: resume_event.event_type.clone(),
+            data: StreamEventEnvelope { ts, ..resume_event },
+        },
+        &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
     for event in [
         pipeline_event_envelope(
             "evt-progress",
-            1,
+            2,
             "holon-pm",
             "assistant_round_recorded",
             json!({
@@ -823,7 +844,7 @@ fn build_chat_text_groups_agent_cells_by_turn_index() {
         ),
         pipeline_event_envelope(
             "evt-tool",
-            2,
+            3,
             "holon-pm",
             "tool_executed",
             json!({
@@ -861,7 +882,7 @@ fn build_chat_text_groups_agent_cells_by_turn_index() {
     };
     let brief_event = StreamEventEnvelope {
         id: "evt-brief".into(),
-        event_seq: 3,
+        event_seq: 4,
         ts,
         agent_id: "holon-pm".into(),
         event_type: "brief_created".into(),
@@ -888,9 +909,44 @@ fn build_chat_text_groups_agent_cells_by_turn_index() {
         .filter(|line| line.contains("• holon-pm "))
         .count();
     assert_eq!(header_count, 1);
+    assert!(lines
+        .iter()
+        .any(|line| line.contains("• holon-pm ") && line.contains("operator input")));
+    assert!(!lines
+        .iter()
+        .any(|line| line.contains("Continuation triggered")));
     assert!(lines.iter().any(|line| line.contains("I will inspect")));
     assert!(lines.iter().any(|line| line.contains("gh pr view 1497")));
     assert!(lines.iter().any(|line| line.contains("PR is merged.")));
+}
+
+#[test]
+fn build_chat_text_wraps_body_lines_with_indent() {
+    let ts = Utc::now();
+    let items = vec![ConversationCell::SystemNotice {
+        created_at: ts,
+        event_seq: 1,
+        speaker: "holon-pm".into(),
+        body: "abcdefghij klmnopqrst uvwxyz".into(),
+        display_kind: ConversationDisplayKind::Activity,
+        group_id: Some("agent:holon-pm:turn:1".into()),
+        header_hint: None,
+    }];
+
+    let lines: Vec<String> = build_chat_text_for_width(&items, 18)
+        .lines
+        .into_iter()
+        .map(|line| line.spans.into_iter().map(|span| span.content).collect())
+        .collect();
+    assert!(lines.iter().any(|line| line.starts_with("    abc")));
+    assert!(
+        lines
+            .iter()
+            .skip(1)
+            .filter(|line| !line.trim().is_empty())
+            .all(|line| line.starts_with("    ")),
+        "wrapped body lines should keep activity indentation: {lines:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- attach resume notices to the agent turn header instead of rendering them as separate body rows
- add one intra-turn spacer when the conversation switches between activity and narrative content
- pre-wrap conversation body lines at TUI width while preserving indentation, so long commands do not continue at column 0

## Verification
- cargo fmt --all -- --check
- cargo test tui::tests --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets
