### PR TITLE
fix: centralize runtime ID generation policy

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,10 +1,8 @@
-use sha2::{Digest, Sha256};
-use uuid::Uuid;
-
 use crate::types::CallbackDeliveryMode;
+use sha2::{Digest, Sha256};
 
 pub(crate) fn generate_callback_token() -> String {
-    format!("cb_{}", Uuid::new_v4().simple())
+    crate::ids::capability_id("cb")
 }
 
 pub(crate) fn hash_callback_token(token: &str) -> String {

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -188,11 +188,7 @@ impl RuntimeRegistry {
             .file_name()
             .and_then(|name| name.to_str())
             .map(ToString::to_string);
-        let entry = WorkspaceEntry::new(
-            format!("ws-{}", uuid::Uuid::new_v4().simple()),
-            workspace_anchor,
-            repo_name,
-        );
+        let entry = WorkspaceEntry::new(crate::ids::workspace_id(), workspace_anchor, repo_name);
         self.inner.host_storage.append_workspace_entry(&entry)?;
         Ok(entry)
     }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,0 +1,128 @@
+use uuid::Uuid;
+
+const SHORT_RANDOM_HEX_LEN: usize = 15; // 60 bits
+
+fn short_random_hex() -> String {
+    Uuid::new_v4()
+        .simple()
+        .to_string()
+        .chars()
+        .take(SHORT_RANDOM_HEX_LEN)
+        .collect()
+}
+
+fn runtime_id(prefix: &str) -> String {
+    format!("{prefix}_{}", short_random_hex())
+}
+
+pub fn message_id() -> String {
+    runtime_id("msg")
+}
+
+pub fn task_id() -> String {
+    runtime_id("task")
+}
+
+pub fn run_id() -> String {
+    runtime_id("run")
+}
+
+pub fn tool_execution_id() -> String {
+    runtime_id("tool")
+}
+
+pub fn workspace_id() -> String {
+    runtime_id("ws")
+}
+
+pub fn work_item_id() -> String {
+    runtime_id("work")
+}
+
+pub fn brief_id() -> String {
+    runtime_id("brief")
+}
+
+pub fn transcript_entry_id() -> String {
+    runtime_id("transcript")
+}
+
+pub fn episode_id() -> String {
+    runtime_id("ep")
+}
+
+pub fn wait_condition_id() -> String {
+    runtime_id("wait")
+}
+
+pub fn timer_id() -> String {
+    runtime_id("timer")
+}
+
+pub fn delivery_summary_id() -> String {
+    runtime_id("delivery")
+}
+
+pub fn external_trigger_id() -> String {
+    runtime_id("trigger")
+}
+
+pub fn operator_notification_id() -> String {
+    runtime_id("notify")
+}
+
+pub fn operator_delivery_intent_id() -> String {
+    runtime_id("odi")
+}
+
+pub fn capability_id(prefix: &str) -> String {
+    format!(
+        "{prefix}_{}{}",
+        Uuid::new_v4().simple(),
+        Uuid::new_v4().simple()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_runtime_id(value: &str, prefix: &str) {
+        let (actual_prefix, random) = value.split_once('_').expect("id should contain prefix");
+        assert_eq!(actual_prefix, prefix);
+        assert_eq!(random.len(), SHORT_RANDOM_HEX_LEN);
+        assert!(random.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn ordinary_runtime_ids_use_compact_prefixed_shape() {
+        for (id, prefix) in [
+            (message_id(), "msg"),
+            (task_id(), "task"),
+            (run_id(), "run"),
+            (tool_execution_id(), "tool"),
+            (workspace_id(), "ws"),
+            (work_item_id(), "work"),
+            (brief_id(), "brief"),
+            (transcript_entry_id(), "transcript"),
+            (episode_id(), "ep"),
+            (wait_condition_id(), "wait"),
+            (timer_id(), "timer"),
+            (delivery_summary_id(), "delivery"),
+            (external_trigger_id(), "trigger"),
+            (operator_notification_id(), "notify"),
+            (operator_delivery_intent_id(), "odi"),
+        ] {
+            assert_runtime_id(&id, prefix);
+        }
+    }
+
+    #[test]
+    fn capability_ids_are_not_shortened_to_runtime_id_entropy() {
+        let id = capability_id("cb");
+        let (prefix, random) = id.split_once('_').expect("id should contain prefix");
+        assert_eq!(prefix, "cb");
+        assert!(random.len() >= 64);
+        assert!(random.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent_template;
 pub mod agents_md;
 mod auth;
 mod callbacks;
+pub mod ids;
 
 pub mod brief;
 pub mod cli;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -46,7 +46,6 @@ use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
-use uuid::Uuid;
 
 #[cfg(test)]
 use crate::provider::{ConversationMessage, ProviderTurnRequest};

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -27,7 +27,6 @@ use super::{
     scheduler_executor, workspace, InitialWorkspaceBinding, RuntimeAgent, RuntimeHandle,
     RuntimeInner,
 };
-use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub(super) struct ProviderReconfigurator {
@@ -159,7 +158,7 @@ impl RuntimeHandle {
         let initial_workspace_entry = match &initial_workspace {
             InitialWorkspaceBinding::Entry(entry) => Some(entry.clone()),
             InitialWorkspaceBinding::Anchor(anchor) => Some(crate::types::WorkspaceEntry::new(
-                format!("ws-{}", Uuid::new_v4().simple()),
+                crate::ids::workspace_id(),
                 anchor.clone(),
                 anchor
                     .file_name()

--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -56,7 +56,7 @@ impl RuntimeHandle {
             return capability_from_record(&descriptor);
         }
 
-        let external_trigger_id = Uuid::new_v4().to_string();
+        let external_trigger_id = crate::ids::external_trigger_id();
         let token = generate_callback_token();
         let trigger_url = build_callback_url(&self.inner.callback_base_url, &delivery_mode, &token);
         let descriptor = ExternalTriggerRecord {

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -517,7 +517,7 @@ impl RuntimeHandle {
         initial_capture: CapturedOutput,
     ) -> Result<TaskRecord> {
         let agent_id = self.agent_id().await?;
-        let task_id = uuid::Uuid::new_v4().to_string();
+        let task_id = crate::ids::task_id();
         resolved.output_path = self.command_task_output_path(&task_id)?;
         let (input_tx, input_rx) = mpsc::channel(INPUT_CHANNEL_CAPACITY);
         let detail = command_task_detail(

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -771,7 +771,7 @@ impl RuntimeHandle {
             return Ok(existing);
         }
         let workspace = WorkspaceEntry::new(
-            format!("ws-{}", Uuid::new_v4().simple()),
+            crate::ids::workspace_id(),
             normalized_anchor.clone(),
             normalized_anchor
                 .file_name()

--- a/src/runtime/operator.rs
+++ b/src/runtime/operator.rs
@@ -34,7 +34,7 @@ impl RuntimeHandle {
                     .map(|item| item.id)
             });
         let record = OperatorNotificationRecord {
-            notification_id: Uuid::new_v4().to_string(),
+            notification_id: crate::ids::operator_notification_id(),
             agent_id: target_parent_agent_id
                 .clone()
                 .unwrap_or_else(|| requested_by_agent_id.clone()),
@@ -195,7 +195,7 @@ impl RuntimeHandle {
         } else {
             binding.default_route_id.clone()
         };
-        let delivery_intent_id = format!("odi_{}", Uuid::new_v4().simple());
+        let delivery_intent_id = crate::ids::operator_delivery_intent_id();
         let now = Utc::now();
         let mut record = OperatorDeliveryRecord {
             delivery_intent_id: delivery_intent_id.clone(),

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -364,7 +364,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 .queue
                 .pop_if_next(&candidate.message.id)
                 .expect("queue head was just checked");
-            let run_id = Uuid::new_v4().to_string();
+            let run_id = crate::ids::run_id();
             let abort_token = CancellationToken::new();
             guard.state.pending = guard.queue.len();
             scheduler::apply_running_projection(&mut guard.state, run_id.clone());

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -176,7 +176,7 @@ impl RuntimeHandle {
             workspace_mode,
         };
         let task = TaskRecord {
-            id: Uuid::new_v4().to_string(),
+            id: crate::ids::task_id(),
             agent_id: agent_id.clone(),
             kind: TaskKind::ChildAgentTask,
             status: TaskStatus::Queued,
@@ -500,7 +500,7 @@ impl RuntimeHandle {
             workspace_mode,
         };
         let task = TaskRecord {
-            id: Uuid::new_v4().to_string(),
+            id: crate::ids::task_id(),
             agent_id: agent_id.clone(),
             kind: TaskKind::ChildAgentTask,
             status: TaskStatus::Queued,
@@ -852,7 +852,7 @@ impl RuntimeHandle {
             workspace_mode,
         };
         let task = TaskRecord {
-            id: Uuid::new_v4().to_string(),
+            id: crate::ids::task_id(),
             agent_id,
             kind: TaskKind::ChildAgentTask,
             status: TaskStatus::Queued,

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -387,7 +387,7 @@ async fn recovered_agent_with_none_workspace_initializes_active_entry() {
     );
     let entry = state.active_workspace_entry.as_ref().unwrap();
     assert!(
-        entry.workspace_id.starts_with("ws-"),
+        entry.workspace_id.starts_with("ws_"),
         "workspace_id should be generated for initial workspace"
     );
     assert_eq!(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -74,7 +74,7 @@ impl RuntimeHandle {
         }
 
         let condition = WaitConditionRecord {
-            id: format!("wait_{}", Uuid::new_v4().simple()),
+            id: crate::ids::wait_condition_id(),
             agent_id: agent_id.to_string(),
             work_item_id: work_item_id.clone(),
             status: WaitConditionStatus::Active,
@@ -411,7 +411,7 @@ impl RuntimeHandle {
     ) -> Result<TimerRecord> {
         let created_at = Utc::now();
         let timer = TimerRecord {
-            id: Uuid::new_v4().to_string(),
+            id: crate::ids::timer_id(),
             agent_id: self.agent_id().await?,
             created_at,
             duration_ms,

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -5,7 +5,6 @@ use serde_json::json;
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::LazyLock;
-use uuid::Uuid;
 
 use crate::{
     runtime::RuntimeHandle,
@@ -169,7 +168,7 @@ impl ToolRegistry {
             .num_milliseconds()
             .max(0) as u64;
         let record = ToolExecutionRecord {
-            id: Uuid::new_v4().to_string(),
+            id: crate::ids::tool_execution_id(),
             agent_id: agent_id.to_string(),
             work_item_id: None,
             turn_index: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,9 +5,9 @@ use serde::{de, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use uuid::Uuid;
 
 use crate::config::ModelRef;
+use crate::ids;
 use crate::model_catalog::ResolvedRuntimeModelPolicy;
 use crate::system::{
     ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind,
@@ -1036,7 +1036,7 @@ impl MessageEnvelope {
         body: MessageBody,
     ) -> Self {
         Self {
-            id: Uuid::new_v4().to_string(),
+            id: ids::message_id(),
             agent_id: agent_id.into(),
             created_at: Utc::now(),
             kind,
@@ -1423,7 +1423,7 @@ impl ActiveEpisodeBuilder {
     ) -> Self {
         let now = Utc::now();
         Self {
-            id: format!("ep_{}", Uuid::new_v4().simple()),
+            id: ids::episode_id(),
             started_at: now,
             start_turn_index,
             latest_turn_index: start_turn_index,
@@ -3193,7 +3193,7 @@ impl WorkItemRecord {
         let now = Utc::now();
         let agent_id = agent_id.into();
         Self {
-            id: format!("work_{}", Uuid::new_v4().simple()),
+            id: ids::work_item_id(),
             workspace_id: agent_home_workspace_id(&agent_id),
             agent_id,
             revision: 1,
@@ -3283,7 +3283,7 @@ impl WorkItemDelegationRecord {
     ) -> Self {
         let now = Utc::now();
         Self {
-            delegation_id: format!("delegation_{}", Uuid::new_v4().simple()),
+            delegation_id: ids::capability_id("delegation"),
             parent_agent_id: parent_agent_id.into(),
             parent_work_item_id: parent_work_item_id.into(),
             child_agent_id: child_agent_id.into(),
@@ -3319,7 +3319,7 @@ impl DeliverySummaryRecord {
         evidence: Option<Value>,
     ) -> Self {
         Self {
-            id: Uuid::new_v4().to_string(),
+            id: ids::delivery_summary_id(),
             agent_id: agent_id.into(),
             work_item_id: work_item_id.into(),
             created_at: Utc::now(),
@@ -3510,7 +3510,7 @@ impl TranscriptEntry {
         data: Value,
     ) -> Self {
         Self {
-            id: Uuid::new_v4().to_string(),
+            id: ids::transcript_entry_id(),
             agent_id: agent_id.into(),
             created_at: Utc::now(),
             kind,
@@ -3575,7 +3575,7 @@ impl BriefRecord {
     ) -> Self {
         let agent_id = agent_id.into();
         Self {
-            id: Uuid::new_v4().to_string(),
+            id: ids::brief_id(),
             workspace_id: agent_home_workspace_id(&agent_id),
             agent_id,
             work_item_id: None,
@@ -3603,7 +3603,7 @@ pub struct AuditEvent {
 impl AuditEvent {
     pub fn new(kind: impl Into<String>, data: Value) -> Self {
         Self {
-            id: Uuid::new_v4().to_string(),
+            id: ids::capability_id("event"),
             event_seq: 0,
             created_at: Utc::now(),
             kind: kind.into(),


### PR DESCRIPTION
## Summary
- add a centralized runtime ID policy module for ordinary object IDs
- route runtime/message/task/workspace/work item ID creation through the policy
- keep callback capability IDs on higher-entropy capability-grade generation
- update tests away from concrete UUID formatting assumptions

Closes #1500

## Verification
- cargo test --lib ids::tests
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
