### PR TITLE
fix: preserve runtime ID entropy

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,12 +1,15 @@
 use uuid::Uuid;
 
-const SHORT_RANDOM_HEX_LEN: usize = 15; // 60 bits
+const SHORT_RANDOM_HEX_LEN: usize = 15; // 15 random hex nibbles ~= 60 bits
+const UUID_VERSION_NIBBLE_INDEX: usize = 12;
 
 fn short_random_hex() -> String {
     Uuid::new_v4()
         .simple()
         .to_string()
         .chars()
+        .enumerate()
+        .filter_map(|(index, ch)| (index != UUID_VERSION_NIBBLE_INDEX).then_some(ch))
         .take(SHORT_RANDOM_HEX_LEN)
         .collect()
 }


### PR DESCRIPTION
Follow-up to PR #1506 review comment: https://github.com/holon-run/holon/pull/1506#discussion_r3322538293\n\n## Summary\n- skip the fixed UUID v4 version nibble when deriving compact runtime IDs\n- keep the existing 15-hex-character runtime ID suffix shape\n\n## Verification\n- cargo fmt --all -- --check\n- cargo test ids::tests\n- RUSTFLAGS="-D warnings" cargo check --all-targets