### PR TITLE
fix: align id and sequence RFC polish

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -27,6 +27,7 @@ use crate::{
     config::{AppConfig, RuntimeModelCatalog},
     context::ContextConfig,
     host_registry::RuntimeRegistry,
+    ids,
     provider::{build_provider_from_config, AgentProvider},
     runtime::{InitialWorkspaceBinding, RuntimeHandle},
     storage::AppStorage,
@@ -487,11 +488,8 @@ impl RuntimeHost {
         category: &str,
     ) -> Result<(String, RuntimeHandle, JoinHandle<()>)> {
         let agent_id = match category {
-            "run" => format!("{TEMP_RUN_AGENT_PREFIX}{}", uuid::Uuid::new_v4().simple()),
-            other => format!(
-                "{TEMP_AGENT_PREFIX}{other}_{}",
-                uuid::Uuid::new_v4().simple()
-            ),
+            "run" => ids::runtime_id(TEMP_RUN_AGENT_PREFIX.trim_end_matches('_')),
+            other => ids::runtime_id(&format!("{TEMP_AGENT_PREFIX}{other}")),
         };
         self.validate_agent_id(&agent_id)?;
         let (runtime, runtime_task) = self.spawn_runtime(&agent_id)?;
@@ -771,7 +769,7 @@ impl RuntimeHost {
         template: Option<&str>,
         catalog_agent_home: &Path,
     ) -> Result<AgentIdentityRecord> {
-        let child_agent_id = format!("{TEMP_CHILD_AGENT_PREFIX}{}", uuid::Uuid::new_v4().simple());
+        let child_agent_id = ids::runtime_id(TEMP_CHILD_AGENT_PREFIX.trim_end_matches('_'));
         self.validate_agent_id(&child_agent_id)?;
         if let Some(template) = template {
             initialize_agent_home_from_template_with_catalog(

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 
 use crate::{
     config::AppConfig,
+    ids,
     storage::AppStorage,
     system::WorkspaceAccessMode,
     types::{AgentIdentityRecord, WorkspaceEntry, WorkspaceOccupancyRecord},
@@ -142,7 +143,7 @@ impl RuntimeRegistry {
             ));
         }
         let record = WorkspaceOccupancyRecord {
-            occupancy_id: format!("occ-{}", uuid::Uuid::new_v4().simple()),
+            occupancy_id: ids::workspace_occupancy_id(),
             execution_root_id: execution_root_id.to_string(),
             workspace_id: workspace_id.to_string(),
             holder_agent_id: holder_agent_id.to_string(),

--- a/src/http.rs
+++ b/src/http.rs
@@ -25,7 +25,6 @@ use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
 use tower_http::compression::CompressionLayer;
 use tracing::{error, warn};
-use uuid::Uuid;
 
 #[cfg(unix)]
 use axum::body::Body;
@@ -3250,7 +3249,7 @@ fn require_non_empty(value: String, field: &str) -> Result<String, (StatusCode, 
 fn non_empty_or_generated(value: Option<String>, prefix: &str) -> String {
     value
         .and_then(non_empty_opt)
-        .unwrap_or_else(|| format!("{prefix}_{}", Uuid::new_v4().simple()))
+        .unwrap_or_else(|| crate::ids::runtime_id(prefix))
 }
 
 fn non_empty_opt(value: String) -> Option<String> {

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -14,7 +14,7 @@ fn short_random_hex() -> String {
         .collect()
 }
 
-fn runtime_id(prefix: &str) -> String {
+pub(crate) fn runtime_id(prefix: &str) -> String {
     format!("{prefix}_{}", short_random_hex())
 }
 
@@ -47,7 +47,7 @@ pub fn brief_id() -> String {
 }
 
 pub fn transcript_entry_id() -> String {
-    runtime_id("transcript")
+    runtime_id("tr")
 }
 
 pub fn episode_id() -> String {
@@ -63,7 +63,7 @@ pub fn timer_id() -> String {
 }
 
 pub fn delivery_summary_id() -> String {
-    runtime_id("delivery")
+    runtime_id("deliv")
 }
 
 pub fn external_trigger_id() -> String {
@@ -76,6 +76,18 @@ pub fn operator_notification_id() -> String {
 
 pub fn operator_delivery_intent_id() -> String {
     runtime_id("odi")
+}
+
+pub fn workspace_occupancy_id() -> String {
+    runtime_id("occ")
+}
+
+pub fn audit_event_id() -> String {
+    runtime_id("event")
+}
+
+pub fn work_item_delegation_id() -> String {
+    runtime_id("delegation")
 }
 
 pub fn capability_id(prefix: &str) -> String {
@@ -107,14 +119,17 @@ mod tests {
             (workspace_id(), "ws"),
             (work_item_id(), "work"),
             (brief_id(), "brief"),
-            (transcript_entry_id(), "transcript"),
+            (transcript_entry_id(), "tr"),
             (episode_id(), "ep"),
             (wait_condition_id(), "wait"),
             (timer_id(), "timer"),
-            (delivery_summary_id(), "delivery"),
+            (delivery_summary_id(), "deliv"),
             (external_trigger_id(), "trigger"),
             (operator_notification_id(), "notify"),
             (operator_delivery_intent_id(), "odi"),
+            (workspace_occupancy_id(), "occ"),
+            (audit_event_id(), "event"),
+            (work_item_delegation_id(), "delegation"),
         ] {
             assert_runtime_id(&id, prefix);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1274,7 +1274,7 @@ mod tests {
                 .with_timezone(&chrono::Utc)
         };
         let event = |kind: &str, created_at, data| AuditEvent {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: holon::ids::audit_event_id(),
             event_seq: 0,
             created_at,
             kind: kind.into(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1563,13 +1563,11 @@ impl AppStorage {
                 | crate::types::QueueEntryStatus::Dropped => None,
             })
             .collect::<Vec<_>>();
-        replay_messages.sort_by(|left, right| {
-            left.created_at.cmp(&right.created_at).then_with(|| {
-                match (left.message_seq, right.message_seq) {
-                    (Some(left_seq), Some(right_seq)) => left_seq.cmp(&right_seq),
-                    _ => std::cmp::Ordering::Equal,
-                }
-            })
+        replay_messages.sort_by(|left, right| match (left.message_seq, right.message_seq) {
+            (Some(left_seq), Some(right_seq)) => left_seq
+                .cmp(&right_seq)
+                .then_with(|| left.created_at.cmp(&right.created_at)),
+            _ => left.created_at.cmp(&right.created_at),
         });
 
         let active_tasks = self.latest_active_task_records(usize::MAX)?;
@@ -3710,7 +3708,7 @@ mod tests {
     }
 
     #[test]
-    fn recovery_snapshot_orders_message_replay_by_timestamp_before_sequence() {
+    fn recovery_snapshot_orders_message_replay_by_sequence_before_timestamp() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
         let created_at = Utc::now();
@@ -3765,7 +3763,7 @@ mod tests {
                 .iter()
                 .map(|message| message.id.as_str())
                 .collect::<Vec<_>>(),
-            vec![earlier.id.as_str(), later.id.as_str()]
+            vec![later.id.as_str(), earlier.id.as_str()]
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3289,7 +3289,7 @@ impl WorkItemDelegationRecord {
     ) -> Self {
         let now = Utc::now();
         Self {
-            delegation_id: ids::capability_id("delegation"),
+            delegation_id: ids::work_item_delegation_id(),
             parent_agent_id: parent_agent_id.into(),
             parent_work_item_id: parent_work_item_id.into(),
             child_agent_id: child_agent_id.into(),
@@ -3612,7 +3612,7 @@ pub struct AuditEvent {
 impl AuditEvent {
     pub fn new(kind: impl Into<String>, data: Value) -> Self {
         Self {
-            id: ids::capability_id("event"),
+            id: ids::audit_event_id(),
             event_seq: 0,
             created_at: Utc::now(),
             kind: kind.into(),


### PR DESCRIPTION
## Summary

- make recovery replay prefer `message_seq` append order when available
- move remaining runtime-object IDs for audit events, delegation records, workspace occupancy, temporary runtime agents, and generated HTTP bindings through `ids.rs`
- align small runtime ID prefixes with the RFC (`tr`, `deliv`, `occ`) and update focused tests

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo test ids::tests`
- `cargo test recovery_snapshot_orders_message_replay_by_sequence`
