### PR TITLE
fix: stop daemon via recorded runtime address

### DIFF
--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -305,7 +305,8 @@ pub async fn daemon_start(
 
 pub async fn daemon_stop(config: &AppConfig) -> Result<DaemonLifecycleResult> {
     let before = daemon_status(config).await?;
-    match probe_runtime(config).await {
+    let stop_probe = probe_runtime(config).await;
+    match &stop_probe {
         ProbeRuntime::Stopped {
             occupied_socket: true,
         } => {
@@ -355,7 +356,11 @@ Probe error: {details}",
         });
     }
 
-    let client = LocalClient::new(config.clone())?;
+    let shutdown_config = match &stop_probe {
+        ProbeRuntime::Running(status) => config_for_runtime_status(config, status),
+        _ => config.clone(),
+    };
+    let client = LocalClient::new(shutdown_config)?;
     let graceful = client.runtime_shutdown().await;
     if graceful.is_ok() && wait_for_shutdown(config, STOP_TIMEOUT).await.is_ok() {
         clear_persisted_daemon_lifecycle_failures(config)?;
@@ -412,6 +417,14 @@ Probe error: {details}",
         action: DaemonLifecycleAction::Stop,
         status: stopped_status(config)?,
     })
+}
+
+fn config_for_runtime_status(config: &AppConfig, status: &RuntimeStatusResponse) -> AppConfig {
+    let mut runtime_config = config.clone();
+    runtime_config.home_dir = status.home_dir.clone();
+    runtime_config.socket_path = status.socket_path.clone();
+    runtime_config.http_addr = status.http_addr.clone();
+    runtime_config
 }
 
 fn stopped_status(config: &AppConfig) -> Result<DaemonStatusView> {

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -600,6 +600,63 @@ async fn daemon_stop_treats_missing_pid_process_as_stale_state() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn daemon_stop_uses_recorded_runtime_http_addr_when_socket_is_missing() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut config = test_config();
+    config.http_addr = "127.0.0.1:9".into();
+    let paths = daemon_paths(&config);
+    fs::create_dir_all(config.run_dir()).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let metadata_http = listener.local_addr().unwrap().to_string();
+    let mut child = Command::new("sleep").arg("30").spawn().unwrap();
+    let pid = child.id();
+    let metadata = RuntimeServiceMetadata {
+        pid,
+        home_dir: config.home_dir.clone(),
+        socket_path: config.socket_path.clone(),
+        http_addr: metadata_http.clone(),
+        started_at: Utc::now(),
+        config_fingerprint: config_fingerprint(&config).unwrap(),
+    };
+    fs::write(&paths.metadata_path, serde_json::to_vec(&metadata).unwrap()).unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 2048];
+        let read = stream.read(&mut request).await.unwrap();
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("POST /control/runtime/shutdown "));
+        child.kill().unwrap();
+        child.wait().unwrap();
+        let body = serde_json::json!({
+            "ok": true,
+            "pid": pid,
+            "home_dir": metadata.home_dir,
+            "shutdown_requested": true
+        })
+        .to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+    });
+
+    let stopped = daemon_stop(&config).await.unwrap();
+    server.await.unwrap();
+
+    assert_eq!(stopped.action, crate::daemon::DaemonLifecycleAction::Stop);
+    assert_eq!(stopped.status.state, DaemonLifecycleState::Stopped);
+    assert!(!paths.metadata_path.exists());
+    assert!(!paths.pid_path.exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn daemon_stop_surfaces_incompatible_status_probe_guidance() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 


### PR DESCRIPTION
## Summary
- stop daemon using the http address recorded in daemon metadata/status instead of always using the default local address
- preserves the stopped-status fallback as local/default for post-shutdown status reporting
- adds coverage for stopping a daemon that listens on a non-local/Tailscale-style address

## Context
Follow-up to merged PR #1511. User verification showed stop still failed when the running holon daemon listened on a Tailscale network address.

## Verification
- cargo test daemon::tests
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets