### PR TITLE
fix: remove top-level status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Start the long-running local runtime:
 
 ```bash
 holon daemon start
-holon status
+holon agent status
 ```
 
 Open the local operator console:
@@ -180,8 +180,8 @@ holon daemon stop
 Inspect local state:
 
 ```bash
-holon status
 holon agent list
+holon agent status
 holon transcript --limit 50
 ```
 

--- a/docs/local-operator-troubleshooting.md
+++ b/docs/local-operator-troubleshooting.md
@@ -4,7 +4,7 @@ This document defines the recommended local troubleshooting workflow for
 `Holon`.
 
 The goal is to give operators one repeatable path instead of guessing between
-`run`, `serve`, `daemon`, `status`, and `tui`.
+`run`, `serve`, `daemon`, `agent status`, and `tui`.
 
 ## First Principle
 
@@ -27,7 +27,7 @@ For a long-lived local runtime, inspect in this order:
 
 1. `holon daemon status`
 2. `holon daemon logs`
-3. `holon status`, `holon tail`, or `holon transcript`
+3. `holon agent status`, `holon tail`, or `holon transcript`
 4. `holon tui`
 5. `holon daemon restart` or a foreground `holon serve`
 
@@ -221,7 +221,7 @@ If the long-lived runtime seems unhealthy:
 
 If the runtime is healthy but work seems stuck:
 
-1. run `holon status`
+1. run `holon agent status`
 2. run `holon transcript --limit 50`
 3. open `holon tui`
 

--- a/docs/project-goals.md
+++ b/docs/project-goals.md
@@ -46,7 +46,7 @@ framework magic:
   into logs
 - explicit local daemon log inspection path for startup/shutdown debugging
 - one documented local troubleshooting order across `run`, `daemon status`,
-  `daemon logs`, `status` / `transcript`, `tui`, and foreground `serve`
+  `daemon logs`, `agent status` / `transcript`, `tui`, and foreground `serve`
 - explicit provider-attempt timeline diagnostics for retry, fail-fast, and
   fallback behavior on operator-facing runtime surfaces
 - explicit operator-facing token usage summaries for run/status plus per-turn

--- a/docs/website/guides/durable-agent-workflow.md
+++ b/docs/website/guides/durable-agent-workflow.md
@@ -80,9 +80,6 @@ Reconnect later or from another terminal:
 
 ```bash
 # Quick status check (no TUI needed)
-holon status
-
-# See what the agent is doing
 holon agent status builder
 
 # Reconnect the TUI to interact

--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -106,7 +106,6 @@ These commands require a reachable local control plane unless noted otherwise.
 | Command | Args | Options | Output | Initial stability | Notes |
 |---|---|---|---|---:|---|
 | `holon prompt` | `<TEXT>` | `--agent <AGENT>` | JSON control prompt response | `experimental` | Lightweight prompt path; response shape belongs to control-plane API inventory. |
-| `holon status` | none | `--agent <AGENT>` | JSON agent status | `stable` candidate | Agent summary is a key operator/API surface. |
 | `holon tail` | none | `--limit <LIMIT>` default `20`; `--agent <AGENT>` | JSON recent briefs/log tail | `stable` candidate | Result shape should align with brief/output contract. |
 | `holon transcript` | none | `--limit <LIMIT>` default `50`; `--agent <AGENT>` | JSON transcript entries | `stable` candidate | Transcript entry stability needs API inventory. |
 | `holon task run` | `<SUMMARY>` | required `--cmd <CMD>`; `--workdir <WORKDIR>`; `--shell <SHELL>`; `--login <true\|false>`; `--tty`; `--yield-time-ms <MS>`; `--max-output-tokens <N>`; `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Creates command tasks through the control plane. |

--- a/docs/website/reference/cli-exit-codes.md
+++ b/docs/website/reference/cli-exit-codes.md
@@ -42,7 +42,7 @@ Commands that need the local or remote control plane exit with code `1` when
 transport fails:
 
 ```bash
-HOLON_HTTP_ADDR=127.0.0.1:9 holon status
+HOLON_HTTP_ADDR=127.0.0.1:9 holon agent status
 echo $? # 1
 ```
 

--- a/docs/website/reference/cli-stability-policy.md
+++ b/docs/website/reference/cli-stability-policy.md
@@ -52,7 +52,7 @@ Current script-facing candidates include:
 - `holon daemon status`, `holon daemon logs`, and the daemon lifecycle commands.
 - `holon config get|set|unset|schema` and credential/provider management
   commands that print JSON.
-- `holon status`, `holon agent list`, and `holon agent status`.
+- `holon agent list` and `holon agent status`.
 - `holon workspace attach|exit|detach`, subject to workspace identity contract
   stability.
 - `holon run --json` and `holon solve --json` only for the documented response

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -44,7 +44,6 @@ holon (v0.14.1)
 │   ├── schema   Show all config keys with types and defaults
 │   └── doctor   Full system health check
 ├── prompt       Send a prompt to an agent (lightweight)
-├── status       Show agent status
 ├── tail         Show recent log tail
 ├── transcript   Show conversation transcript
 ├── events       Read stable runtime event envelopes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,10 +53,6 @@ pub enum Commands {
         #[arg(long)]
         agent: Option<String>,
     },
-    Status {
-        #[arg(long)]
-        agent: Option<String>,
-    },
     Tail {
         #[arg(long, default_value_t = 20)]
         limit: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,11 +149,6 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
             let response = client.control_prompt(&agent, text).await?;
             print_json(&serde_json::to_value(response)?)
         }
-        Commands::Status { agent } => {
-            let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
-            let client = LocalClient::new(config)?;
-            print_json(&serde_json::to_value(client.agent_status(&agent).await?)?)
-        }
         Commands::Tail { limit, agent } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
             let client = LocalClient::new(config)?;

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -191,6 +191,7 @@ fn unreachable_control_plane_exits_nonzero_without_machine_stdout() {
     let (mut command, _home) = isolated_holon_command();
     let output = command
         .env("HOLON_HTTP_ADDR", "127.0.0.1:9")
+        .arg("agent")
         .arg("status")
         .output()
         .expect("run holon");

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -1167,20 +1167,6 @@
     "aliases": []
   },
   {
-    "path": "status",
-    "positionals": [],
-    "flags": [
-      {
-        "long": "agent",
-        "short": null,
-        "default_value": null,
-        "possible_values": null,
-        "required": false
-      }
-    ],
-    "aliases": []
-  },
-  {
     "path": "tail",
     "positionals": [],
     "flags": [


### PR DESCRIPTION
## Summary
- remove the top-level `holon status` command from the CLI dispatch
- update docs and examples to use `holon agent status`
- keep the control-plane unreachable exit-code coverage on `holon agent status`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test cli_exit_codes`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`