### PR TITLE
fix: clear stale pending_fallback_model when agent has no further fallback

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1148,6 +1148,18 @@ impl RuntimeHandle {
                 let failed_state = {
                     let mut guard = self.inner.agent.lock().await;
                     if !matches!(guard.state.status, AgentStatus::Stopped) {
+                        // Defense-in-depth: clear a stale pending_fallback_model when
+                        // the current error has no further fallback to delegate to.
+                        // This prevents the agent from becoming permanently stuck on
+                        // a fallback model that is unsupported or unavailable.
+                        if guard.state.pending_fallback_model.is_some() {
+                            let has_fallback = provider_attempt_timeline(&err)
+                                .and_then(|t| t.pending_fallback_model_ref.as_deref())
+                                .is_some();
+                            if !has_fallback {
+                                guard.state.pending_fallback_model = None;
+                            }
+                        }
                         scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
                     }
                     guard.current_run_abort = None;

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1979,6 +1979,13 @@ impl TurnExecution<'_> {
                         {
                             return Ok(outcome);
                         }
+                        {
+                            let mut guard = runtime.inner.agent.lock().await;
+                            if guard.state.pending_fallback_model.is_some() {
+                                guard.state.pending_fallback_model = None;
+                                runtime.inner.storage.write_agent(&guard.state)?;
+                            }
+                        }
                         runtime
                             .persist_turn_terminal_record(
                                 TurnTerminalKind::Aborted,
@@ -2227,6 +2234,13 @@ impl TurnExecution<'_> {
                             .await?
                         {
                             return Ok(outcome);
+                        }
+                        {
+                            let mut guard = runtime.inner.agent.lock().await;
+                            if guard.state.pending_fallback_model.is_some() {
+                                guard.state.pending_fallback_model = None;
+                                runtime.inner.storage.write_agent(&guard.state)?;
+                            }
                         }
                         runtime
                             .persist_turn_terminal_record(


### PR DESCRIPTION
## Root Cause

When an external model provider returns an error for a fallback model (retry exhausted), the agent would be permanently stuck because `pending_fallback_model` was never cleared. On every subsequent turn, `provider_chain_for_turn` would skip the primary model and use the fallback, which would fail again with the same error, creating an unbreakable loop.

## Fix

Adds defense-in-depth cleanup of `pending_fallback_model` in three error-handling paths:

1. **`src/runtime.rs`** — When the error has no further fallback model in its `provider_attempt_timeline`, clear the stale `pending_fallback_model` before persisting agent state.

2. **`src/runtime/turn.rs`** — On `TurnTerminalKind::Aborted` (turn exhausted all fallbacks), clear `pending_fallback_model` so the next turn starts with the primary model.

## Verification

- `cargo check` passes
- All 39 fallback-related tests (`cargo test --lib fallback`) pass