### PR TITLE
feat: add onboarding command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ holon config set model.default "openai-codex/gpt-5.5"
 Inspect the configured state with:
 
 ```bash
+holon onboard
 holon config doctor
 holon config models list
 ```

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -149,6 +149,7 @@ holon daemon stop
 ```bash
 holon config list                # All current config
 holon config schema              # All keys with types and defaults
+holon onboard                    # Secret-safe setup guidance and next steps
 holon config doctor              # Full health check
 holon config providers list      # All registered providers
 holon config models list         # Available models with status

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,11 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
+    #[command(about = "Inspect initial setup and print secret-safe onboarding guidance")]
+    Onboard {
+        #[arg(long)]
+        json: bool,
+    },
     Serve {
         #[command(flatten)]
         options: ServeOptions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,10 +125,10 @@ async fn main() -> Result<()> {
 }
 
 async fn run_runtime_command(command: Commands) -> Result<()> {
-    if let Commands::Onboard { json } = command {
+    if let Commands::Onboard { json } = &command {
         let config = AppConfig::load_for_config_inspection()?;
         let report = onboarding_report(&config);
-        if json {
+        if *json {
             return print_json(&serde_json::to_value(report)?);
         }
         print_onboarding_report(&report);
@@ -141,13 +141,18 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         token,
         token_file,
         token_profile,
-    } = command
+    } = &command
     {
         let config = AppConfig::load_for_config_inspection()?;
-        let token = resolve_remote_token(&config, token, token_file, token_profile)?;
-        let client = LocalClient::remote(config.clone(), connect, token)?;
+        let token = resolve_remote_token(
+            &config,
+            token.clone(),
+            token_file.clone(),
+            token_profile.clone(),
+        )?;
+        let client = LocalClient::remote(config.clone(), connect.clone(), token)?;
         client.handshake().await?;
-        return run_tui(config, no_alt_screen, Some(client)).await;
+        return run_tui(config, *no_alt_screen, Some(client)).await;
     }
 
     let config = AppConfig::load()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use holon::{
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
     http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
+    onboarding::{onboarding_report, OnboardingReport, OnboardingStatus},
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
     solve::{run_solve, SolveRequest},
@@ -124,6 +125,16 @@ async fn main() -> Result<()> {
 }
 
 async fn run_runtime_command(command: Commands) -> Result<()> {
+    if let Commands::Onboard { json } = command {
+        let config = AppConfig::load_for_config_inspection()?;
+        let report = onboarding_report(&config);
+        if json {
+            return print_json(&serde_json::to_value(report)?);
+        }
+        print_onboarding_report(&report);
+        return Ok(());
+    }
+
     if let Commands::Tui {
         no_alt_screen,
         connect: Some(connect),
@@ -225,7 +236,56 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         Commands::Run { .. } => unreachable!("run command is handled separately"),
         Commands::Solve { .. } => unreachable!("solve command is handled separately"),
         Commands::Debug { command } => handle_debug_command(config, command).await,
+        Commands::Onboard { .. } => unreachable!("onboard command is handled before runtime load"),
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
+    }
+}
+
+fn print_onboarding_report(report: &OnboardingReport) {
+    println!("Holon onboarding");
+    println!("Status: {}", onboarding_status_label(report.status));
+    println!();
+
+    for section in &report.sections {
+        println!(
+            "- {} [{}]: {}",
+            section.title,
+            onboarding_status_label(section.status),
+            section.summary
+        );
+        for action in &section.actions {
+            println!("  next: {}", action.title);
+            if let Some(command) = &action.command {
+                println!("       {}", command.join(" "));
+            }
+        }
+    }
+
+    if report.next_actions.is_empty() {
+        println!();
+        println!("Setup looks ready. Try `holon daemon start` or `holon run \"hello\"`.");
+    } else {
+        println!();
+        println!("Recommended next steps:");
+        for action in &report.next_actions {
+            println!("- {}", action.title);
+            if let Some(command) = &action.command {
+                println!("  {}", command.join(" "));
+            }
+        }
+        println!();
+        println!("Run `holon onboard --json` for the full secret-safe diagnostic report.");
+    }
+}
+
+fn onboarding_status_label(status: OnboardingStatus) -> &'static str {
+    match status {
+        OnboardingStatus::Configured => "configured",
+        OnboardingStatus::Missing => "missing",
+        OnboardingStatus::Unavailable => "unavailable",
+        OnboardingStatus::Restricted => "restricted",
+        OnboardingStatus::Skipped => "skipped",
+        OnboardingStatus::Failed => "failed",
     }
 }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -248,10 +248,17 @@ fn onboard_json_contract_is_secret_safe_and_actionable() {
         }),
         "onboard report should include model provider diagnostics: {value}"
     );
-    assert!(
-        value["next_actions"].as_array().is_some(),
-        "onboard report should include actionable next-step array: {value}"
-    );
+    match value.get("next_actions") {
+        Some(next_actions) => assert!(
+            next_actions.as_array().is_some(),
+            "onboard report next_actions should be an array when present: {value}"
+        ),
+        None => assert_eq!(
+            value["status"],
+            json!("configured"),
+            "onboard report should omit next_actions only when fully configured: {value}"
+        ),
+    }
     assert!(
         !value.to_string().contains("super-secret"),
         "onboard JSON must not expose credential material"

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -220,3 +220,40 @@ fn config_credentials_json_contract_is_stable_and_redacted() {
     let empty_list = run_json(&home, &["config", "credentials", "list"]);
     assert_eq!(empty_list, json!([]));
 }
+
+#[test]
+fn onboard_json_contract_is_secret_safe_and_actionable() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+    let _set = run_json(
+        &home,
+        &[
+            "config",
+            "credentials",
+            "set",
+            "demo",
+            "--kind",
+            "api_key",
+            "--material",
+            "super-secret",
+        ],
+    );
+
+    let value = run_json(&home, &["onboard", "--json"]);
+    assert_eq!(value["schema_version"], json!(1));
+    assert!(
+        value["sections"].as_array().is_some_and(|sections| {
+            sections
+                .iter()
+                .any(|section| section["id"] == "model_provider")
+        }),
+        "onboard report should include model provider diagnostics: {value}"
+    );
+    assert!(
+        value["next_actions"].as_array().is_some(),
+        "onboard report should include actionable next-step array: {value}"
+    );
+    assert!(
+        !value.to_string().contains("super-secret"),
+        "onboard JSON must not expose credential material"
+    );
+}

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -754,6 +754,23 @@
     "aliases": []
   },
   {
+    "path": "onboard",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "prompt",
     "positionals": [
       {


### PR DESCRIPTION
## Summary
- add a top-level `holon onboard` command for initial setup guidance
- reuse the existing onboarding report for secret-safe JSON output via `--json`
- document the command and add JSON contract/snapshot coverage

Closes #1520

## Verification
- cargo test --test cli_snapshot refresh_cli_snapshot -- --ignored
- cargo test --test cli_json_contract
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets