### PR TITLE
feat: add Holon-managed openai-codex OAuth profile foundation

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -54,6 +54,15 @@ pub fn load_codex_cli_credential(codex_home: &Path) -> Result<CodexCliCredential
     ))
 }
 
+pub fn load_codex_oauth_profile_credential(
+    material: &str,
+    profile: &str,
+) -> Result<CodexCliCredential> {
+    let auth: AuthDotJson = serde_json::from_str(material)
+        .with_context(|| format!("failed to parse Holon credential profile {profile}"))?;
+    auth_to_credential(auth, &format!("credential_profile:{profile}"))
+}
+
 pub fn codex_cli_auth_file_exists(codex_home: &Path) -> bool {
     auth_file_path(&canonical_or_original(codex_home)).is_file()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2357,12 +2357,6 @@ fn resolve_provider_registry(
     credential_store: &CredentialStoreFile,
 ) -> Result<ProviderRegistry> {
     let mut registry = built_in_provider_registry_with_settings(settings_env)?;
-    for provider in registry.values_mut() {
-        if provider.credential.is_none() {
-            provider.credential =
-                resolve_provider_credential(&provider.auth, settings_env, credential_store)?;
-        }
-    }
     for (id, provider_config) in &stored_config.providers {
         let built_in = registry.remove(id);
         let runtime = materialize_provider_config(
@@ -2373,6 +2367,12 @@ fn resolve_provider_registry(
             built_in,
         )?;
         registry.insert(id.clone(), runtime);
+    }
+    for provider in registry.values_mut() {
+        if provider.credential.is_none() {
+            provider.credential =
+                resolve_provider_credential(&provider.auth, settings_env, credential_store)?;
+        }
     }
     Ok(registry)
 }
@@ -4230,6 +4230,49 @@ mod tests {
             credential["tokens"]["access_token"],
             Value::String("token".into())
         );
+    }
+
+    #[test]
+    fn app_config_applies_provider_overrides_before_materializing_openai_codex_profile() {
+        let dir = tempdir().unwrap();
+        let _agent_guard = EnvVarGuard::unset("HOLON_AGENT_ID");
+        save_persisted_config_at(
+            &persisted_config_path(dir.path()),
+            &HolonConfigFile {
+                providers: BTreeMap::from([(
+                    ProviderId::openai_codex(),
+                    ProviderConfigFile {
+                        transport: ProviderTransportKind::OpenAiCodexResponses,
+                        base_url: "https://chatgpt.com/backend-api/codex".into(),
+                        auth: ProviderAuthConfig {
+                            source: CredentialSource::ExternalCli,
+                            kind: CredentialKind::SessionToken,
+                            env: None,
+                            profile: None,
+                            external: Some("codex_cli".into()),
+                        },
+                        reasoning_effort: None,
+                        builtin_web_search: None,
+                    },
+                )]),
+                ..HolonConfigFile::default()
+            },
+        )
+        .unwrap();
+        set_credential_profile_at(
+            &credential_store_path(dir.path()),
+            OPENAI_CODEX_CREDENTIAL_PROFILE,
+            CredentialKind::ApiKey,
+            "wrong-kind-token".into(),
+        )
+        .unwrap();
+
+        let config = AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap();
+        let openai_codex = config.providers.get(&ProviderId::openai_codex()).unwrap();
+
+        assert_eq!(openai_codex.auth.source, CredentialSource::ExternalCli);
+        assert_eq!(openai_codex.auth.kind, CredentialKind::SessionToken);
+        assert_eq!(openai_codex.credential, None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,6 +132,8 @@ pub const DEFAULT_LOCAL_AGENT_ID: &str = "main";
 
 pub type ProviderRegistry = BTreeMap<ProviderId, ProviderRuntimeConfig>;
 
+pub const OPENAI_CODEX_CREDENTIAL_PROFILE: &str = "openai-codex";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderRuntimeConfig {
     pub id: ProviderId,
@@ -547,11 +549,13 @@ impl AppConfig {
         });
         let config_file_path = persisted_config_path(&home_dir);
         let stored_config = load_persisted_config_at(&config_file_path)?;
-        let credential_store = if config_uses_credential_profiles(&stored_config) {
-            load_credential_store_at(&credential_store_path(&home_dir))?
-        } else {
-            CredentialStoreFile::default()
-        };
+        let credential_store_path = credential_store_path(&home_dir);
+        let credential_store =
+            if config_uses_credential_profiles(&stored_config) || credential_store_path.exists() {
+                load_credential_store_at(&credential_store_path)?
+            } else {
+                CredentialStoreFile::default()
+            };
         let http_addr = env::var("HOLON_HTTP_ADDR").unwrap_or_else(|_| "127.0.0.1:7878".into());
         let callback_base_url =
             env::var("HOLON_CALLBACK_BASE_URL").unwrap_or_else(|_| format!("http://{http_addr}"));
@@ -2353,6 +2357,12 @@ fn resolve_provider_registry(
     credential_store: &CredentialStoreFile,
 ) -> Result<ProviderRegistry> {
     let mut registry = built_in_provider_registry_with_settings(settings_env)?;
+    for provider in registry.values_mut() {
+        if provider.credential.is_none() {
+            provider.credential =
+                resolve_provider_credential(&provider.auth, settings_env, credential_store)?;
+        }
+    }
     for (id, provider_config) in &stored_config.providers {
         let built_in = registry.remove(id);
         let runtime = materialize_provider_config(
@@ -2386,10 +2396,10 @@ fn built_in_provider_registry_with_settings(
             base_url: env::var("HOLON_OPENAI_CODEX_BASE_URL")
                 .unwrap_or_else(|_| "https://chatgpt.com/backend-api/codex".to_string()),
             auth: ProviderAuthConfig {
-                source: CredentialSource::ExternalCli,
-                kind: CredentialKind::SessionToken,
+                source: CredentialSource::AuthProfile,
+                kind: CredentialKind::OAuth,
                 env: None,
-                profile: None,
+                profile: Some(OPENAI_CODEX_CREDENTIAL_PROFILE.into()),
                 external: Some("codex_cli".into()),
             },
             credential: None,
@@ -3196,10 +3206,10 @@ pub fn provider_registry_for_tests(
             transport: ProviderTransportKind::OpenAiCodexResponses,
             base_url: "https://chatgpt.com/backend-api/codex".into(),
             auth: ProviderAuthConfig {
-                source: CredentialSource::ExternalCli,
-                kind: CredentialKind::SessionToken,
+                source: CredentialSource::AuthProfile,
+                kind: CredentialKind::OAuth,
                 env: None,
-                profile: None,
+                profile: Some(OPENAI_CODEX_CREDENTIAL_PROFILE.into()),
                 external: Some("codex_cli".into()),
             },
             credential: None,
@@ -3371,8 +3381,19 @@ fn authenticated_model_candidates(
 
 fn provider_has_usable_auth(provider: &ProviderRuntimeConfig) -> bool {
     match provider.auth.source {
-        CredentialSource::Env | CredentialSource::AuthProfile => {
+        CredentialSource::Env => provider.has_configured_credential(),
+        CredentialSource::AuthProfile => {
             provider.has_configured_credential()
+                || (provider.id.is_openai_codex()
+                    && provider.auth.profile.as_deref() == Some(OPENAI_CODEX_CREDENTIAL_PROFILE)
+                    && provider
+                        .codex_home
+                        .as_deref()
+                        .map(|home| {
+                            codex_cli_auth_file_exists(home)
+                                && load_codex_cli_credential(home).is_ok()
+                        })
+                        .unwrap_or(false))
         }
         CredentialSource::ExternalCli => {
             provider.auth.external.as_deref() == Some("codex_cli")
@@ -3953,7 +3974,7 @@ mod tests {
         CredentialKind, CredentialSource, CredentialStoreFile, HolonConfigFile, ModelConfigFile,
         ModelRef, ProviderAuthConfig, ProviderBuiltinWebSearchConfig, ProviderConfigFile,
         ProviderId, ProviderRegistry, ProviderRuntimeConfig, ProviderTransportKind,
-        RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID,
+        RuntimeModelCatalog, DEFAULT_LOCAL_AGENT_ID, OPENAI_CODEX_CREDENTIAL_PROFILE,
     };
 
     struct EnvVarSnapshot {
@@ -4149,6 +4170,66 @@ mod tests {
 
         let value = get_config_value("ANTHROPIC_BASE_URL", None, &settings);
         assert_eq!(value.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn built_in_openai_codex_defaults_to_holon_oauth_profile() {
+        let settings_env = HashMap::new();
+        let registry = built_in_provider_registry_with_settings(&settings_env).unwrap();
+        let openai_codex = registry.get(&ProviderId::openai_codex()).unwrap();
+
+        assert_eq!(openai_codex.auth.source, CredentialSource::AuthProfile);
+        assert_eq!(openai_codex.auth.kind, CredentialKind::OAuth);
+        assert_eq!(
+            openai_codex.auth.profile.as_deref(),
+            Some(OPENAI_CODEX_CREDENTIAL_PROFILE)
+        );
+        assert_eq!(openai_codex.auth.external.as_deref(), Some("codex_cli"));
+        assert!(openai_codex.credential.is_none());
+    }
+
+    #[test]
+    fn app_config_load_materializes_openai_codex_profile_from_existing_store() {
+        let dir = tempdir().unwrap();
+        let _agent_guard = EnvVarGuard::unset("HOLON_AGENT_ID");
+        save_persisted_config_at(
+            &persisted_config_path(dir.path()),
+            &HolonConfigFile {
+                model: ModelConfigFile {
+                    default: Some("openai-codex/gpt-5.4".into()),
+                    ..ModelConfigFile::default()
+                },
+                ..HolonConfigFile::default()
+            },
+        )
+        .unwrap();
+        set_credential_profile_at(
+            &credential_store_path(dir.path()),
+            OPENAI_CODEX_CREDENTIAL_PROFILE,
+            CredentialKind::OAuth,
+            "{\"tokens\":{\"access_token\":\"token\",\"refresh_token\":\"refresh\",\"account_id\":\"acct\"}}"
+                .into(),
+        )
+        .unwrap();
+
+        let config = AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap();
+        let openai_codex = config.providers.get(&ProviderId::openai_codex()).unwrap();
+
+        assert_eq!(
+            openai_codex.auth.profile.as_deref(),
+            Some(OPENAI_CODEX_CREDENTIAL_PROFILE)
+        );
+        let credential: Value = serde_json::from_str(
+            openai_codex
+                .credential
+                .as_deref()
+                .expect("openai-codex credential material should be loaded"),
+        )
+        .unwrap();
+        assert_eq!(
+            credential["tokens"]["access_token"],
+            Value::String("token".into())
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2357,6 +2357,9 @@ fn resolve_provider_registry(
     credential_store: &CredentialStoreFile,
 ) -> Result<ProviderRegistry> {
     let mut registry = built_in_provider_registry_with_settings(settings_env)?;
+    for provider in registry.values_mut() {
+        provider.credential = None;
+    }
     for (id, provider_config) in &stored_config.providers {
         let built_in = registry.remove(id);
         let runtime = materialize_provider_config(
@@ -4239,6 +4242,10 @@ mod tests {
         save_persisted_config_at(
             &persisted_config_path(dir.path()),
             &HolonConfigFile {
+                model: ModelConfigFile {
+                    default: Some("openai-codex/gpt-5.4".into()),
+                    ..ModelConfigFile::default()
+                },
                 providers: BTreeMap::from([(
                     ProviderId::openai_codex(),
                     ProviderConfigFile {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4981,7 +4981,7 @@ mod tests {
     }
 
     #[test]
-    fn app_config_ignores_bad_credential_store_permissions_until_profile_auth_is_used() {
+    fn app_config_rejects_bad_credential_store_permissions_when_store_exists() {
         let dir = tempdir().unwrap();
         save_persisted_config_at(
             &persisted_config_path(dir.path()),
@@ -5002,6 +5002,12 @@ mod tests {
             fs::set_permissions(&store_path, fs::Permissions::from_mode(0o644)).unwrap();
         }
 
+        #[cfg(unix)]
+        {
+            let err = AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap_err();
+            assert!(err.to_string().contains("chmod 600"));
+        }
+        #[cfg(not(unix))]
         AppConfig::load_with_home(Some(dir.path().to_path_buf())).unwrap();
 
         let mut config = load_persisted_config_at(&persisted_config_path(dir.path())).unwrap();

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -131,7 +131,7 @@ fn resolved_model_availability_entry(
     } else if !provider_configured {
         Some("provider_not_configured".to_string())
     } else if provider
-        .map(|provider| credential_missing_should_be_static_reason(provider.auth.source))
+        .map(credential_missing_should_be_static_reason)
         .unwrap_or(false)
         && !credential_configured
     {
@@ -161,9 +161,14 @@ fn provider_static_credential_configured(provider: &crate::config::ProviderRunti
     provider.has_configured_credential() || matches!(provider.auth.source, CredentialSource::None)
 }
 
-fn credential_missing_should_be_static_reason(source: CredentialSource) -> bool {
+fn credential_missing_should_be_static_reason(
+    provider: &crate::config::ProviderRuntimeConfig,
+) -> bool {
+    if provider.id.is_openai_codex() && provider.auth.source == CredentialSource::AuthProfile {
+        return false;
+    }
     matches!(
-        source,
+        provider.auth.source,
         CredentialSource::Env | CredentialSource::AuthProfile
     )
 }

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde_json::{json, Value};
 
 use crate::{
-    auth::load_codex_cli_credential,
+    auth::{load_codex_cli_credential, load_codex_oauth_profile_credential},
     config::{AppConfig, CredentialSource, ModelRef, RuntimeModelCatalog},
     context::ContextConfig,
     onboarding::{onboarding_report, search_diagnostics},
@@ -204,13 +204,29 @@ fn provider_availability(config: &AppConfig, model_ref: &ModelRef) -> Value {
     };
 
     if let Some(provider) = config.providers.get(&model_ref.provider) {
-        if provider.auth.source != CredentialSource::ExternalCli {
+        if provider.auth.source != CredentialSource::ExternalCli
+            && !(provider.id.is_openai_codex()
+                && provider.auth.source == CredentialSource::AuthProfile)
+        {
             return availability;
         }
-        let Some(codex_home) = provider.codex_home.as_ref() else {
-            return availability;
-        };
-        let credential_result = load_codex_cli_credential(codex_home);
+        let credential_result = provider
+            .credential
+            .as_deref()
+            .filter(|material| !material.trim().is_empty())
+            .map(|material| {
+                load_codex_oauth_profile_credential(
+                    material,
+                    provider.auth.profile.as_deref().unwrap_or("openai-codex"),
+                )
+            })
+            .unwrap_or_else(|| {
+                provider
+                    .codex_home
+                    .as_ref()
+                    .map(|codex_home| load_codex_cli_credential(codex_home))
+                    .unwrap_or_else(|| Err(anyhow::anyhow!("missing codex_home")))
+            });
         if let Ok(credential) = credential_result.as_ref() {
             availability["credential"] = json!({
                 "source": credential.source,

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -133,9 +133,7 @@ async fn openai_codex_expired_cli_token_fails_fast_with_login_hint() {
         .await
         .expect_err("expired Codex CLI token should fail before send");
 
-    assert!(error
-        .to_string()
-        .contains("Codex CLI access token is expired"));
+    assert!(error.to_string().contains("OAuth access token is expired"));
     assert!(error.to_string().contains("codex login"));
     let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
     assert_eq!(timeline.attempts.len(), 1);

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -660,13 +660,13 @@ impl AgentProvider for OpenAiCodexProvider {
                     &model_ref,
                     vec![
                         format!(
-                            "Codex CLI access token is expired: credential from {} expired at {}",
+                            "OpenAI Codex OAuth access token is expired: credential source {} expired at {}",
                             credential.source,
                             expires_at.to_rfc3339()
                         ),
-                        "Run `holon config credentials set --kind oauth --stdin openai-codex` to configure Holon-managed OAuth, or run `codex login` to refresh external CLI credentials.".into(),
+                        "Run `holon config credentials set --kind oauth --stdin openai-codex` to configure or refresh Holon-managed OAuth, or run `codex login` if using external CLI credentials.".into(),
                     ],
-                    "OpenAI Codex authentication failed: Codex CLI access token is expired or the Holon-managed openai-codex OAuth access token is expired. Configure a Holon-managed openai-codex credential profile or run `codex login` to refresh Codex CLI credentials.",
+                    "OpenAI Codex authentication failed: OAuth access token is expired. Configure or refresh the Holon-managed openai-codex credential profile, or run `codex login` if using Codex CLI credentials.",
                 ));
             }
         }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use crate::{
-    auth::load_codex_cli_credential,
+    auth::{load_codex_cli_credential, load_codex_oauth_profile_credential, CodexCliCredential},
     config::{
         AppConfig, CredentialKind, CredentialSource, ModelRef, ProviderBuiltinWebSearchConfig,
         ProviderId, ProviderRuntimeConfig,
@@ -59,6 +59,8 @@ pub struct OpenAiCodexProvider {
     client: Client,
     provider_id: String,
     base_url: String,
+    credential_profile: Option<String>,
+    credential_material: Option<String>,
     codex_home: std::path::PathBuf,
     originator: String,
     model: String,
@@ -342,11 +344,13 @@ impl OpenAiCodexProvider {
             .codex_home
             .clone()
             .ok_or_else(|| anyhow::anyhow!("missing codex_home for OpenAI Codex provider"))?;
-        load_codex_cli_credential(&codex_home)?;
+        resolve_openai_codex_credential(provider_config, &codex_home)?;
         Ok(Self {
             client,
             provider_id: provider_config.id.as_str().to_string(),
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
+            credential_profile: provider_config.auth.profile.clone(),
+            credential_material: provider_config.credential.clone(),
             codex_home,
             originator: provider_config
                 .originator
@@ -361,6 +365,40 @@ impl OpenAiCodexProvider {
             continuation: Arc::new(Mutex::new(OpenAiContinuationState::default())),
         })
     }
+
+    fn resolve_credential(&self) -> Result<CodexCliCredential> {
+        self.credential_material
+            .as_deref()
+            .filter(|material| !material.trim().is_empty())
+            .map(|material| {
+                load_codex_oauth_profile_credential(
+                    material,
+                    self.credential_profile.as_deref().unwrap_or("openai-codex"),
+                )
+            })
+            .unwrap_or_else(|| load_codex_cli_credential(&self.codex_home))
+    }
+}
+
+fn resolve_openai_codex_credential(
+    provider_config: &ProviderRuntimeConfig,
+    codex_home: &Path,
+) -> Result<CodexCliCredential> {
+    provider_config
+        .credential
+        .as_deref()
+        .filter(|material| !material.trim().is_empty())
+        .map(|material| {
+            load_codex_oauth_profile_credential(
+                material,
+                provider_config
+                    .auth
+                    .profile
+                    .as_deref()
+                    .unwrap_or("openai-codex"),
+            )
+        })
+        .unwrap_or_else(|| load_codex_cli_credential(codex_home))
 }
 
 fn openai_compaction_policy_from_config(
@@ -603,16 +641,16 @@ impl AgentProvider for OpenAiProvider {
 impl AgentProvider for OpenAiCodexProvider {
     async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
         let model_ref = format!("{}/{}", self.provider_id, self.model);
-        let credential = load_codex_cli_credential(&self.codex_home).map_err(|error| {
+        let credential = self.resolve_credential().map_err(|error| {
             openai_codex_auth_error(
                 "credential_resolution",
                 &model_ref,
                 vec![
                     error.to_string(),
-                    "OpenAI Codex uses Codex CLI authentication; run `codex login`, then retry."
+                    "OpenAI Codex uses a Holon-managed openai-codex credential profile; run `holon config credentials set --kind oauth --stdin openai-codex` or `codex login`, then retry."
                         .into(),
                 ],
-                "OpenAI Codex authentication failed: Codex CLI credentials are unavailable. Run `codex login`, then retry.",
+                "OpenAI Codex authentication failed: no Holon openai-codex credential profile or usable Codex CLI credentials are available.",
             )
         })?;
         if let Some(expires_at) = credential.expires_at {
@@ -622,13 +660,13 @@ impl AgentProvider for OpenAiCodexProvider {
                     &model_ref,
                     vec![
                         format!(
-                            "Codex CLI credential from {} expired at {}",
+                            "Codex CLI access token is expired: credential from {} expired at {}",
                             credential.source,
                             expires_at.to_rfc3339()
                         ),
-                        "Run `codex login`, then retry.".into(),
+                        "Run `holon config credentials set --kind oauth --stdin openai-codex` to configure Holon-managed OAuth, or run `codex login` to refresh external CLI credentials.".into(),
                     ],
-                    "OpenAI Codex authentication failed: the Codex CLI access token is expired. Run `codex login`, then retry.",
+                    "OpenAI Codex authentication failed: Codex CLI access token is expired or the Holon-managed openai-codex OAuth access token is expired. Configure a Holon-managed openai-codex credential profile or run `codex login` to refresh Codex CLI credentials.",
                 ));
             }
         }
@@ -744,7 +782,7 @@ impl AgentProvider for OpenAiCodexProvider {
         &self,
         request: ProviderNativeWebSearchRequest,
     ) -> Result<()> {
-        let credential = load_codex_cli_credential(&self.codex_home)?;
+        let credential = self.resolve_credential()?;
         let probe_request = builtin_web_search_probe_turn_request(request);
         let body = build_openai_responses_request(
             &self.model,
@@ -4403,16 +4441,56 @@ mod tests {
         build_openai_responses_request, chat_completions_url, incremental_diagnostics,
         latest_openai_compaction_index, openai_compaction_trigger_for_request_plan,
         openai_compaction_trigger_for_window, openai_provider_window_compaction_candidate,
-        plan_openai_responses_request, OpenAiCompactionPolicy, OpenAiContinuationState,
-        OpenAiProviderWindow, OpenAiRequestPlan, OpenAiRequestShape,
+        plan_openai_responses_request, resolve_openai_codex_credential, OpenAiCompactionPolicy,
+        OpenAiContinuationState, OpenAiProviderWindow, OpenAiRequestPlan, OpenAiRequestShape,
         OpenAiResponsesTransportContract, ToolSchemaContract,
+    };
+    use crate::config::{
+        CredentialKind, CredentialSource, ProviderAuthConfig, ProviderId, ProviderRuntimeConfig,
+        ProviderTransportKind, OPENAI_CODEX_CREDENTIAL_PROFILE,
     };
     use crate::provider::{
         ConversationMessage, ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
         ProviderTurnRequest,
     };
+    use base64::Engine;
     use serde_json::json;
+    use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
+
+    fn encode_segment(value: serde_json::Value) -> String {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(value.to_string())
+    }
+
+    fn make_token(payload: serde_json::Value) -> String {
+        format!(
+            "{}.{}.{}",
+            encode_segment(json!({"alg": "none"})),
+            encode_segment(payload),
+            encode_segment(json!("sig"))
+        )
+    }
+
+    fn test_openai_codex_config(credential: Option<String>) -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::openai_codex(),
+            transport: ProviderTransportKind::OpenAiCodexResponses,
+            base_url: "https://chatgpt.com/backend-api/codex".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::AuthProfile,
+                kind: CredentialKind::OAuth,
+                env: None,
+                profile: Some(OPENAI_CODEX_CREDENTIAL_PROFILE.into()),
+                external: Some("codex_cli".into()),
+            },
+            credential,
+            codex_home: Some(PathBuf::from("/tmp/codex-home")),
+            originator: Some("codex_cli_rs".into()),
+            reasoning_effort: Some("low".into()),
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
 
     #[test]
     fn chat_completions_url_accepts_openai_compatible_base_urls() {
@@ -4439,6 +4517,34 @@ mod tests {
         assert_eq!(
             chat_completions_url("https://proxy.example/chat/completions"),
             "https://proxy.example/chat/completions"
+        );
+    }
+
+    #[test]
+    fn openai_codex_resolves_holon_oauth_profile_before_cli_files() {
+        let credential_material = json!({
+            "tokens": {
+                "access_token": make_token(json!({
+                    "exp": 1_900_000_000,
+                    "chatgpt_account_id": "acct_profile"
+                })),
+                "refresh_token": "refresh",
+                "account_id": "acct_profile"
+            }
+        })
+        .to_string();
+        let provider_config = test_openai_codex_config(Some(credential_material));
+
+        let credential = resolve_openai_codex_credential(
+            &provider_config,
+            provider_config.codex_home.as_ref().unwrap(),
+        )
+        .expect("Holon profile credential should resolve");
+
+        assert_eq!(credential.account_id, "acct_profile");
+        assert_eq!(
+            credential.source,
+            format!("credential_profile:{OPENAI_CODEX_CREDENTIAL_PROFILE}")
         );
     }
 

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2459,7 +2459,7 @@ async fn batch_command_reading_discovered_skill_marks_it_active() {
                     {
                         "cmd": "sed -n '1,8p' .agents/skills/demo/SKILL.md",
                         "workdir": ".",
-                        "yield_time_ms": 30000
+                        "yield_time_ms": 120000
                     }
                 ]
             }),


### PR DESCRIPTION
## Summary

Refs #1428 and #1426.

This PR adds the first Holon-managed `openai-codex` OAuth profile boundary while preserving the external Codex CLI fallback:

- defaults the built-in `openai-codex` provider to `credential_profile + oauth` with profile `openai-codex`
- materializes built-in provider credentials from Holon's credential store even when the persisted config does not explicitly reference credential profiles
- resolves OpenAI Codex credentials from the Holon profile before falling back to Codex CLI auth files
- keeps expired/unavailable Codex CLI credentials as explicit diagnostics instead of silently refreshing or rewriting external CLI credential files
- adds focused tests for profile defaults, materialization, and Codex profile precedence

This is intentionally a foundation PR, not the full OAuth login/refresh lifecycle from #1428. Follow-up work still needs Holon-owned login, refresh, rotation persistence, and refresh singleflight/locking.

## Verification

- `cargo test openai_codex --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
