### PR TITLE
fix: support WaitFor recheck fallback and optional external resource

### DIFF
--- a/docs/rfcs/scheduler-wait-state.md
+++ b/docs/rfcs/scheduler-wait-state.md
@@ -228,6 +228,7 @@ WaitFor {
   reason: String
   wake: operator_input | task_result | external
   resource: Option<String>
+  recheck_after_ms: Option<u64>
 }
 ```
 
@@ -235,23 +236,34 @@ Rules:
 
 - `reason` is required and must be non-empty.
 - `wake=task_result` requires `resource=<task_id>`.
-- `wake=external` requires `resource=<stable external object>`, such as a URL
-  or `github:holon-run/holon#1435`.
+- `wake=external` may include `resource=<stable external object>`, such as a
+  URL or `github:holon-run/holon#1435`; omitting `resource` means any external
+  ingress can wake the wait.
 - `wake=operator_input` may omit `resource`.
+- `recheck_after_ms` is optional. When present, it records a fallback recheck
+  deadline at `now + recheck_after_ms`; when omitted, the wait has no fallback
+  recheck deadline.
 - if a current open WorkItem exists, the wait is WorkItem-scoped;
 - if no current open WorkItem exists, the wait is agent-scoped;
 - to wait on another WorkItem, the agent must pick it first.
 
 WorkItem-scoped `WaitFor` replaces active waits on that WorkItem, writes
-`blocked_by=reason` for display, clears legacy recheck fields, and releases the
-current focus so scheduler projection no longer treats the item as runnable.
+`blocked_by=reason` for display, writes `recheck_at` only when
+`recheck_after_ms` is present, clears `recheck_at` otherwise, clears
+`recheck_consumed_at`, and releases the current focus so scheduler projection no
+longer treats the item as runnable.
+
+Agent-scoped `WaitFor` has no WorkItem record to mutate. When
+`recheck_after_ms` is present, the wait condition continuation records both the
+relative delay and absolute `recheck_at` so scheduler diagnostics can classify
+the external wait as recoverable.
 
 Mapping:
 
 | `wake` | `WaitCondition.kind` | `subject_ref` | `wake_sources` |
 |--------|----------------------|---------------|----------------|
 | `task_result` | `Task` | `resource` | `TaskResult { task_id: resource }` |
-| `external` | `External` | `resource` | `ExternalIngress { external_trigger_id: None }` |
+| `external` | `External` | `resource` when present | `ExternalIngress { external_trigger_id: None }` |
 | `operator_input` | `Operator` | `resource` when present | `OperatorInput` |
 
 Terminal task results resolve matching task wait conditions and clear the
@@ -274,9 +286,11 @@ WorkItem {
 ```
 
 `UpdateWorkItem` previously supported a small `recheck_after` input when the
-agent set or refreshed `blocked_by`. That path is now superseded by `WaitFor`
-for new waits. Historical fields remain in storage and read models for older
-records.
+agent set or refreshed `blocked_by`. That public entry point is removed:
+`UpdateWorkItem` updates WorkItem content and plan state only, while `WaitFor`
+is the authoritative entry point for wait state and fallback rechecks.
+Historical `recheck_at` and `recheck_consumed_at` fields remain in storage and
+read models for older records and for `WaitFor`-managed fallback rechecks.
 
 Rules:
 

--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -12,7 +12,7 @@
   },
   "tools": [
     {
-      "description": "Record an explicit wait condition and yield the current turn. Use wake=task_result with resource=<task_id> when waiting for a background task, wake=external with resource=<external object such as a URL or github:owner/repo#id> when waiting for outside state, or wake=operator_input when waiting for the operator. If there is a current open work item, WaitFor attaches to it and marks it waiting; otherwise it records an agent-level wait.",
+      "description": "Record an explicit wait condition and yield the current turn. Use wake=task_result with resource=<task_id> when waiting for a background task, wake=external with optional resource=<external object such as a URL or github:owner/repo#id> when waiting for outside state, or wake=operator_input when waiting for the operator. Optional recheck_after_ms records a fallback recheck deadline. If there is a current open work item, WaitFor attaches to it and marks it waiting; otherwise it records an agent-level wait.",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {
@@ -20,6 +20,15 @@
         "properties": {
           "reason": {
             "type": "string"
+          },
+          "recheck_after_ms": {
+            "default": null,
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "resource": {
             "default": null,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -587,6 +587,7 @@ async fn wait_for_task_result_marks_work_item_waiting_and_allows_sleep() {
             WaitForWakeKind::TaskResult,
             Some("task-1".into()),
             "waiting for task-1".into(),
+            None,
         )
         .await
         .unwrap();
@@ -642,6 +643,7 @@ async fn register_wait_for_validates_required_runtime_resources() {
             WaitForWakeKind::TaskResult,
             None,
             "waiting for task".into(),
+            None,
         )
         .await
         .unwrap_err();
@@ -656,12 +658,18 @@ async fn register_wait_for_validates_required_runtime_resources() {
             WaitForWakeKind::External,
             Some(" ".into()),
             "waiting for external state".into(),
+            None,
         )
         .await
-        .unwrap_err();
-    assert!(external_empty
-        .to_string()
-        .contains("requires non-empty resource"));
+        .unwrap();
+    assert_eq!(external_empty.condition.kind, WaitConditionKind::External);
+    assert_eq!(external_empty.condition.subject_ref, None);
+    assert_eq!(
+        external_empty.condition.wake_sources,
+        vec![WakeSource::ExternalIngress {
+            external_trigger_id: None
+        }]
+    );
 
     let operator_wait = runtime
         .register_wait_for(
@@ -670,11 +678,67 @@ async fn register_wait_for_validates_required_runtime_resources() {
             WaitForWakeKind::OperatorInput,
             None,
             "waiting for operator".into(),
+            None,
         )
         .await
         .unwrap();
     assert_eq!(operator_wait.condition.kind, WaitConditionKind::Operator);
     assert_eq!(operator_wait.condition.subject_ref, None);
+}
+
+#[tokio::test]
+async fn register_wait_for_external_recheck_sets_recoverable_work_item_deadline() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work = runtime
+        .create_work_item("wait for external".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+
+    let before = Utc::now();
+    let registration = runtime
+        .register_wait_for(
+            "default",
+            Some(work.id.clone()),
+            WaitForWakeKind::External,
+            None,
+            "waiting for any external event".into(),
+            Some(60_000),
+        )
+        .await
+        .unwrap();
+    let after = Utc::now();
+
+    let latest = runtime.latest_work_item(&work.id).await.unwrap().unwrap();
+    let recheck_at = latest
+        .recheck_at
+        .expect("work item wait should store fallback recheck");
+    assert_eq!(
+        latest.blocked_by.as_deref(),
+        Some("waiting for any external event")
+    );
+    assert_eq!(registration.recheck_after_ms, Some(60_000));
+    assert_eq!(registration.recheck_at, Some(recheck_at));
+    assert!(recheck_at >= before + chrono::Duration::milliseconds(60_000));
+    assert!(recheck_at <= after + chrono::Duration::milliseconds(60_000));
+    assert_eq!(registration.condition.subject_ref, None);
+    assert_eq!(
+        registration.condition.external_recoverability(),
+        Some(crate::types::ExternalWaitRecoverability::Recoverable)
+    );
 }
 
 #[tokio::test]
@@ -705,6 +769,7 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
             WaitForWakeKind::TaskResult,
             Some("task-1".into()),
             "waiting for task-1".into(),
+            None,
         )
         .await
         .unwrap();

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -5,6 +5,7 @@ use crate::types::{
     WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WaitConditionSummary,
     WaitingIntentScope, WaitingReason, WakeSource, WorkItemRecord, WorkItemState,
 };
+use chrono::{DateTime, Utc};
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
@@ -27,6 +28,10 @@ pub(crate) struct WaitForRegistration {
     pub(crate) scope: WaitForScope,
     pub(crate) condition: WaitConditionRecord,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) recheck_after_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) recheck_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) work_item: Option<WorkItemRecord>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) cancelled_wait_condition_ids: Vec<String>,
@@ -40,6 +45,7 @@ impl RuntimeHandle {
         wake: WaitForWakeKind,
         resource: Option<String>,
         reason: String,
+        recheck_after_ms: Option<u64>,
     ) -> Result<WaitForRegistration> {
         let runtime_agent_id = self.agent_id().await?;
         if agent_id != runtime_agent_id {
@@ -48,6 +54,7 @@ impl RuntimeHandle {
 
         let now = Utc::now();
         let (kind, subject_ref, wake_sources) = wait_condition_parts(wake, resource.clone())?;
+        let recheck_at = recheck_after_ms.map(|delay| recheck_at_from(now, delay));
         let mut work_item = None;
         let mut cancelled_wait_condition_ids = Vec::new();
         if let Some(work_item_id) = work_item_id.as_deref() {
@@ -66,7 +73,7 @@ impl RuntimeHandle {
                 )
                 .await?;
             let updated = self
-                .write_wait_for_work_item_blocker(existing, &reason)
+                .write_wait_for_work_item_blocker(existing, &reason, recheck_at)
                 .await?;
             self.release_current_work_item_if_matches(agent_id, &updated, "work_item_waiting")
                 .await?;
@@ -87,6 +94,12 @@ impl RuntimeHandle {
                 "created_by": "WaitFor",
                 "wake": wake,
                 "resource": resource,
+                "recheck_after_ms": recheck_after_ms,
+                "recheck_at": recheck_at,
+                "recovery": recheck_at.map(|_| serde_json::json!({
+                    "kind": "recoverable",
+                    "recheck_source": "WaitFor",
+                })),
                 "clear_blocker_on_task_result": wake == WaitForWakeKind::TaskResult,
             })),
             created_at: now,
@@ -119,6 +132,8 @@ impl RuntimeHandle {
                 WaitForScope::Agent
             },
             condition,
+            recheck_after_ms,
+            recheck_at,
             work_item,
             cancelled_wait_condition_ids,
         })
@@ -209,9 +224,10 @@ impl RuntimeHandle {
         &self,
         existing: WorkItemRecord,
         reason: &str,
+        recheck_at: Option<DateTime<Utc>>,
     ) -> Result<WorkItemRecord> {
         if existing.blocked_by.as_deref() == Some(reason)
-            && existing.recheck_at.is_none()
+            && existing.recheck_at == recheck_at
             && existing.recheck_consumed_at.is_none()
         {
             return Ok(existing);
@@ -219,7 +235,7 @@ impl RuntimeHandle {
         let mut record = WorkItemRecord {
             revision: existing.revision + 1,
             blocked_by: Some(reason.to_string()),
-            recheck_at: None,
+            recheck_at,
             recheck_consumed_at: None,
             updated_at: Utc::now(),
             ..existing
@@ -894,7 +910,7 @@ fn wait_condition_parts(
         }
         WaitForWakeKind::External => Ok((
             WaitConditionKind::External,
-            Some(wait_resource_required(wake, resource)?),
+            optional_wait_resource(resource),
             vec![WakeSource::ExternalIngress {
                 external_trigger_id: None,
             }],
@@ -902,11 +918,23 @@ fn wait_condition_parts(
     }
 }
 
-fn wait_resource_required(wake: WaitForWakeKind, resource: Option<String>) -> Result<String> {
+fn optional_wait_resource(resource: Option<String>) -> Option<String> {
     resource
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn wait_resource_required(wake: WaitForWakeKind, resource: Option<String>) -> Result<String> {
+    optional_wait_resource(resource)
         .ok_or_else(|| anyhow!("wait_for {:?} requires non-empty resource", wake))
+}
+
+fn recheck_at_from(now: DateTime<Utc>, recheck_after_ms: u64) -> DateTime<Utc> {
+    let recheck_after_ms = i64::try_from(recheck_after_ms).unwrap_or(i64::MAX);
+    let recheck_after =
+        chrono::Duration::try_milliseconds(recheck_after_ms).unwrap_or(chrono::Duration::MAX);
+    now.checked_add_signed(recheck_after)
+        .unwrap_or(DateTime::<Utc>::MAX_UTC)
 }
 
 fn reconciliation_signal_for_condition(

--- a/src/tool/tools/wait_for.rs
+++ b/src/tool/tools/wait_for.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -35,6 +36,8 @@ pub(crate) struct WaitForArgs {
     pub(crate) wake: WaitForWakeArg,
     #[serde(default)]
     pub(crate) resource: Option<String>,
+    #[serde(default)]
+    pub(crate) recheck_after_ms: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -46,6 +49,10 @@ pub(crate) struct WaitForResult {
     pub(crate) resource: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) recheck_after_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) recheck_at: Option<DateTime<Utc>>,
     pub(crate) wait_condition: WaitConditionSummary,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) work_item: Option<WorkItemView>,
@@ -58,7 +65,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<WaitForArgs>(
             NAME,
-            "Record an explicit wait condition and yield the current turn. Use wake=task_result with resource=<task_id> when waiting for a background task, wake=external with resource=<external object such as a URL or github:owner/repo#id> when waiting for outside state, or wake=operator_input when waiting for the operator. If there is a current open work item, WaitFor attaches to it and marks it waiting; otherwise it records an agent-level wait.",
+            "Record an explicit wait condition and yield the current turn. Use wake=task_result with resource=<task_id> when waiting for a background task, wake=external with optional resource=<external object such as a URL or github:owner/repo#id> when waiting for outside state, or wake=operator_input when waiting for the operator. Optional recheck_after_ms records a fallback recheck deadline. If there is a current open work item, WaitFor attaches to it and marks it waiting; otherwise it records an agent-level wait.",
         )?,
     })
 }
@@ -71,10 +78,7 @@ pub(crate) async fn execute(
 ) -> Result<ToolResult> {
     let args = parse_wait_for_args(input)?;
     let reason = validate_non_empty(args.reason, NAME, "reason")?;
-    let resource = args
-        .resource
-        .map(|value| validate_non_empty(value, NAME, "resource"))
-        .transpose()?;
+    let resource = optional_resource(args.resource);
     validate_resource_for_wake(args.wake, resource.as_deref())?;
 
     let context = query_context(runtime).await?;
@@ -86,6 +90,7 @@ pub(crate) async fn execute(
             args.wake.into(),
             resource.clone(),
             reason.clone(),
+            args.recheck_after_ms,
         )
         .await?;
     let updated_context = query_context(runtime).await?;
@@ -101,6 +106,8 @@ pub(crate) async fn execute(
         wake: args.wake,
         resource,
         work_item_id,
+        recheck_after_ms: registration.recheck_after_ms,
+        recheck_at: registration.recheck_at,
         wait_condition: WaitConditionSummary::from(registration.condition),
         work_item,
         cancelled_wait_condition_ids: registration.cancelled_wait_condition_ids,
@@ -121,20 +128,27 @@ fn parse_wait_for_args(input: &Value) -> Result<WaitForArgs> {
     parse_tool_args(NAME, input)
 }
 
+fn optional_resource(resource: Option<String>) -> Option<String> {
+    resource
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 fn validate_resource_for_wake(wake: WaitForWakeArg, resource: Option<&str>) -> Result<()> {
     match wake {
-        WaitForWakeArg::TaskResult | WaitForWakeArg::External if resource.is_none() => Err(
-            invalid_tool_input(
-                NAME,
-                format!("WaitFor wake `{}` requires non-empty `resource`", wake.as_str()),
-                json!({
-                    "field": "resource",
-                    "wake": wake,
-                    "validation_error": "required",
-                }),
-                "provide `resource` for task_result and external waits; use the task id for task_result and a stable external resource identifier for external waits",
+        WaitForWakeArg::TaskResult if resource.is_none() => Err(invalid_tool_input(
+            NAME,
+            format!(
+                "WaitFor wake `{}` requires non-empty `resource`",
+                wake.as_str()
             ),
-        ),
+            json!({
+                "field": "resource",
+                "wake": wake,
+                "validation_error": "required",
+            }),
+            "provide `resource` for task_result waits; use the task id as the resource",
+        )),
         _ => Ok(()),
     }
 }
@@ -186,23 +200,43 @@ mod tests {
 
     #[test]
     fn wait_for_requires_resource_for_task_and_external_waits() {
-        for wake in [WaitForWakeArg::TaskResult, WaitForWakeArg::External] {
-            let error = validate_resource_for_wake(wake, None).unwrap_err();
-            let tool_error = ToolError::from_anyhow(&error);
-            assert_eq!(tool_error.kind, "invalid_tool_input");
-            assert_eq!(
-                tool_error
-                    .details
-                    .as_ref()
-                    .and_then(|value| value.get("field"))
-                    .and_then(|value| value.as_str()),
-                Some("resource")
-            );
-        }
+        let error = validate_resource_for_wake(WaitForWakeArg::TaskResult, None).unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "invalid_tool_input");
+        assert_eq!(
+            tool_error
+                .details
+                .as_ref()
+                .and_then(|value| value.get("field"))
+                .and_then(|value| value.as_str()),
+            Some("resource")
+        );
     }
 
     #[test]
-    fn wait_for_allows_operator_input_without_resource() {
+    fn wait_for_allows_operator_and_external_without_resource() {
         validate_resource_for_wake(WaitForWakeArg::OperatorInput, None).unwrap();
+        validate_resource_for_wake(WaitForWakeArg::External, None).unwrap();
+    }
+
+    #[test]
+    fn wait_for_treats_empty_resource_as_absent() {
+        assert_eq!(optional_resource(Some("  ".into())), None);
+        assert_eq!(
+            optional_resource(Some("  github:repo#1  ".into())),
+            Some("github:repo#1".into())
+        );
+    }
+
+    #[test]
+    fn wait_for_parses_recheck_after_ms() {
+        let args = parse_wait_for_args(&json!({
+            "reason": "wait",
+            "wake": "external",
+            "recheck_after_ms": 300000,
+        }))
+        .unwrap();
+
+        assert_eq!(args.recheck_after_ms, Some(300000));
     }
 }


### PR DESCRIPTION
## Summary

- add `WaitFor.recheck_after_ms` and persist recoverable fallback metadata for WorkItem-scoped waits
- allow `WaitFor(wake="external")` without a resource to represent a broad external ingress wait
- update the scheduler wait-state RFC and focused tests for the new wait contract

Closes #1540.
Closes #1541.

## Verification

- `cargo test wait_for --all-targets`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
