### PR TITLE
fix: move TUI composer cursor with Up/Down

### DIFF
--- a/src/tui/composer.rs
+++ b/src/tui/composer.rs
@@ -52,6 +52,39 @@ impl ComposerState {
         }
     }
 
+    pub(super) fn move_up(&mut self) {
+        let line_start = self.current_line_start();
+        if line_start == 0 {
+            return;
+        }
+
+        let previous_line_end = line_start - 1;
+        let previous_line_start = self.text[..previous_line_end]
+            .rfind('\n')
+            .map(|index| index + 1)
+            .unwrap_or(0);
+        self.cursor = self.line_index_at_column(
+            previous_line_start,
+            previous_line_end,
+            self.current_line_column(),
+        );
+    }
+
+    pub(super) fn move_down(&mut self) {
+        let line_end = self.current_line_end();
+        if line_end == self.text.len() {
+            return;
+        }
+
+        let next_line_start = line_end + 1;
+        let next_line_end = self.text[next_line_start..]
+            .find('\n')
+            .map(|index| next_line_start + index)
+            .unwrap_or(self.text.len());
+        self.cursor =
+            self.line_index_at_column(next_line_start, next_line_end, self.current_line_column());
+    }
+
     pub(super) fn move_home(&mut self) {
         self.cursor = self.current_line_start();
     }
@@ -151,6 +184,23 @@ impl ComposerState {
             .map(|index| self.cursor + index)
             .unwrap_or(self.text.len())
     }
+
+    fn current_line_column(&self) -> usize {
+        self.text[self.current_line_start()..self.cursor]
+            .chars()
+            .count()
+    }
+
+    fn line_index_at_column(&self, line_start: usize, line_end: usize, column: usize) -> usize {
+        let mut index = line_start;
+        for (count, (offset, ch)) in self.text[line_start..line_end].char_indices().enumerate() {
+            if count == column {
+                return line_start + offset;
+            }
+            index = line_start + offset + ch.len_utf8();
+        }
+        index
+    }
 }
 
 impl From<&str> for ComposerState {
@@ -217,6 +267,51 @@ mod tests {
         assert_eq!(composer.cursor(), "first\n".len());
         composer.move_end();
         assert_eq!(composer.cursor(), "first\nsecond".len());
+    }
+
+    #[test]
+    fn up_and_down_move_between_lines_at_matching_columns() {
+        let mut composer = ComposerState::from("alpha\nbeta\ncharlie");
+        composer.move_to_start();
+        for _ in 0..8 {
+            composer.move_right();
+        }
+
+        composer.move_up();
+        assert_eq!(composer.cursor(), 2);
+        composer.move_down();
+        assert_eq!(composer.cursor(), "alpha\nbe".len());
+        composer.move_down();
+        assert_eq!(composer.cursor(), "alpha\nbeta\nch".len());
+    }
+
+    #[test]
+    fn up_and_down_clamp_to_shorter_lines_and_noop_at_edges() {
+        let mut composer = ComposerState::from("long\nx\nwide");
+        composer.move_to_start();
+        for _ in 0..3 {
+            composer.move_right();
+        }
+        composer.move_up();
+        assert_eq!(composer.cursor(), 3);
+
+        composer.move_down();
+        assert_eq!(composer.cursor(), "long\nx".len());
+        composer.move_down();
+        assert_eq!(composer.cursor(), "long\nx\nw".len());
+        composer.move_down();
+        assert_eq!(composer.cursor(), "long\nx\nw".len());
+    }
+
+    #[test]
+    fn up_and_down_respect_utf8_columns() {
+        let mut composer = ComposerState::from("你好\n世界");
+        composer.move_to_start();
+        composer.move_right();
+        composer.move_down();
+        assert_eq!(composer.cursor(), "你好\n世".len());
+        composer.move_up();
+        assert_eq!(composer.cursor(), "你".len());
     }
 }
 

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1154,9 +1154,12 @@ impl TuiApp {
                 self.maybe_begin_load_older_events();
             }
             TuiKeyAction::HistoryPrevious | TuiKeyAction::HistoryNext => {
-                self.chat_scroll
-                    .scroll_with_key(key.code, self.chat_max_scroll);
-                self.maybe_begin_load_older_events();
+                let action = match key.code {
+                    KeyCode::Up => TuiKeyAction::Composer(ComposerAction::MoveUp),
+                    KeyCode::Down => TuiKeyAction::Composer(ComposerAction::MoveDown),
+                    _ => TuiKeyAction::Ignore,
+                };
+                apply_composer_key_action(action, &mut self.composer);
             }
             action => {
                 let before = self.composer.as_str().to_string();
@@ -1474,6 +1477,8 @@ fn apply_composer_key_action(
         TuiKeyAction::Composer(ComposerAction::Delete) => composer.delete(),
         TuiKeyAction::Composer(ComposerAction::MoveLeft) => composer.move_left(),
         TuiKeyAction::Composer(ComposerAction::MoveRight) => composer.move_right(),
+        TuiKeyAction::Composer(ComposerAction::MoveUp) => composer.move_up(),
+        TuiKeyAction::Composer(ComposerAction::MoveDown) => composer.move_down(),
         TuiKeyAction::Composer(ComposerAction::MoveHome) => composer.move_home(),
         TuiKeyAction::Composer(ComposerAction::MoveEnd) => composer.move_end(),
         TuiKeyAction::Composer(ComposerAction::InsertTab) => composer.insert_char('\t'),

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -64,6 +64,8 @@ pub(super) enum ComposerAction {
     Delete,
     MoveLeft,
     MoveRight,
+    MoveUp,
+    MoveDown,
     MoveHome,
     MoveEnd,
     InsertTab,
@@ -118,7 +120,7 @@ pub(super) const DEFAULT_BINDING_HINTS: &[DefaultBindingHint] = &[
     },
     DefaultBindingHint {
         context: KeyContext::Main,
-        action: "scroll chat when composer has content",
+        action: "move cursor when composer has content",
         keys: "Up/Down",
     },
     DefaultBindingHint {
@@ -244,6 +246,8 @@ fn resolve_composer_key(key: KeyEvent) -> TuiKeyAction {
         KeyCode::Delete => TuiKeyAction::Composer(ComposerAction::Delete),
         KeyCode::Left => TuiKeyAction::Composer(ComposerAction::MoveLeft),
         KeyCode::Right => TuiKeyAction::Composer(ComposerAction::MoveRight),
+        KeyCode::Up => TuiKeyAction::Composer(ComposerAction::MoveUp),
+        KeyCode::Down => TuiKeyAction::Composer(ComposerAction::MoveDown),
         KeyCode::Home => TuiKeyAction::Composer(ComposerAction::MoveHome),
         KeyCode::End => TuiKeyAction::Composer(ComposerAction::MoveEnd),
         KeyCode::Tab => TuiKeyAction::Composer(ComposerAction::InsertTab),
@@ -379,6 +383,14 @@ mod tests {
                 KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT)
             ),
             TuiKeyAction::Composer(ComposerAction::InsertNewline)
+        );
+        assert_eq!(
+            resolve_key(KeyContext::Composer, key(KeyCode::Up)),
+            TuiKeyAction::Composer(ComposerAction::MoveUp)
+        );
+        assert_eq!(
+            resolve_key(KeyContext::Composer, key(KeyCode::Down)),
+            TuiKeyAction::Composer(ComposerAction::MoveDown)
         );
     }
 

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -447,6 +447,7 @@ fn draw_help_overlay(frame: &mut Frame<'_>, scroll: u16) {
         "  Down browse newer input history",
         "",
         "Editing Shortcuts (work when composer has content)",
+        "  Up/Down move cursor between composer lines",
         "  Ctrl+A move cursor to start",
         "  Ctrl+E move cursor to end",
         "  Ctrl+B move cursor left",

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1189,6 +1189,94 @@ async fn enter_submits_instead_of_inserting_new_line() {
 }
 
 #[tokio::test]
+async fn empty_composer_up_and_down_navigate_input_history() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.input_history = vec!["first".into(), "second".into()];
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    assert_eq!(app.composer.as_str(), "second");
+    assert_eq!(app.history_index, Some(1));
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    assert!(app.composer.is_empty());
+    assert_eq!(app.history_index, None);
+}
+
+#[tokio::test]
+async fn non_empty_single_line_composer_up_down_do_not_scroll_chat() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.chat_max_scroll = 12;
+    app.composer = ComposerState::from("draft");
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(app.composer.as_str(), "draft");
+    assert_eq!(app.composer.cursor(), "draft".len());
+    assert!(app.chat_scroll.is_following_tail());
+}
+
+#[tokio::test]
+async fn multiline_composer_up_down_move_cursor_between_lines() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.composer = ComposerState::from("alpha\nbeta\ncharlie");
+    app.chat_max_scroll = 12;
+    app.composer.move_to_start();
+    for _ in 0..8 {
+        app.composer.move_right();
+    }
+
+    app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    assert_eq!(app.composer.cursor(), 2);
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .await
+        .unwrap();
+    assert_eq!(app.composer.cursor(), "alpha\nbe".len());
+    assert!(app.chat_scroll.is_following_tail());
+}
+
+#[tokio::test]
+async fn page_keys_still_scroll_chat_when_composer_has_content() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.chat_max_scroll = 12;
+    app.composer = ComposerState::from("draft");
+
+    app.handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(app.chat_scroll.effective_scroll(12), 2);
+    assert!(!app.chat_scroll.is_following_tail());
+}
+
+#[tokio::test]
 async fn agent_overlay_stays_open_while_navigating() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(


### PR DESCRIPTION
Fixes #1537.

## Summary
- Add Up/Down composer cursor movement across logical lines, preserving UTF-8 boundaries and clamping to shorter lines.
- Route Up/Down to composer movement when the composer has content, while keeping empty-composer input history navigation intact.
- Update TUI help text and keymap coverage for the new behavior.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p holon tui::composer`
- `cargo test -p holon tui::keymap`
- `cargo test -p holon empty_composer_up_and_down_navigate_input_history`
- `cargo test -p holon non_empty_single_line_composer_up_down_do_not_scroll_chat`
- `cargo test -p holon multiline_composer_up_down_move_cursor_between_lines`
- `cargo test -p holon page_keys_still_scroll_chat_when_composer_has_content`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
