### PR TITLE
feat(onboard): add interactive credential repair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "reqwest",
+ "rpassword",
  "rusqlite",
  "schemars",
  "serde",
@@ -1735,6 +1736,27 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2802,6 +2824,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper-util = { version = "0.1", features = ["server-auto", "tokio", "service", "
 libc = "0.2"
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 reqwest = { version = "0.12", features = ["gzip", "json", "rustls-tls"], default-features = false }
+rpassword = "7.3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 pulldown-cmark = "0.13"
 portable-pty = "0.9"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,17 @@ setup paths:
   `codex login` session and supports Codex subscriptions. You can also connect
   custom providers with compatible protocols.
 
-The recommended local setup is to save the API key first, then point the
+For an interactive first run or repair flow, use:
+
+```bash
+holon onboard
+```
+
+In a TTY this guides you through the default provider credential setup without
+echoing the credential material. In scripts, use `holon onboard --json` for the
+secret-safe diagnostic report.
+
+The equivalent manual setup is to save the API key first, then point the
 provider at the corresponding credential profile:
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
-    #[command(about = "Inspect initial setup and print secret-safe onboarding guidance")]
+    #[command(about = "Interactively set up Holon or print secret-safe onboarding diagnostics")]
     Onboard {
         #[arg(long)]
         json: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,6 +298,13 @@ fn run_interactive_onboarding(config: AppConfig, report: OnboardingReport) -> Re
     println!("- {}", plan.summary);
     println!("  provider: {}", plan.provider);
     println!("  credential profile: {}", plan.credential_profile);
+    if !plan.provider_configured {
+        println!(
+            "Provider {} is not configured. Configure it first with `holon config providers set {}`.",
+            plan.provider, plan.provider
+        );
+        return Ok(());
+    }
     if plan.requires_confirmation
         && !confirm(
             "This will update the existing provider auth configuration. Continue?",
@@ -341,24 +348,35 @@ fn apply_onboarding_credential_repair(
     let credential_kind = CredentialKind::parse(&plan.credential_kind)?;
 
     let mut persisted = load_persisted_config_at(&config.config_file_path)?;
-    let mut provider_config = if let Some(provider_config) =
-        persisted.providers.remove(&provider_id)
-    {
-        provider_config
-    } else {
-        built_in_provider_default_config(&provider_id)?.with_context(|| {
-            format!(
-                "provider {} has no built-in defaults; configure it with `holon config providers set`",
+    let mut provider_config =
+        if let Some(provider_config) = persisted.providers.remove(&provider_id) {
+            provider_config
+        } else {
+            let provider = config.providers.get(&provider_id).with_context(|| {
+                format!(
+                "provider {} is not configured; configure it with `holon config providers set {}`",
+                provider_id.as_str(),
                 provider_id.as_str()
             )
-        })?
-    };
+            })?;
+            ProviderConfigFile {
+                transport: provider.transport,
+                base_url: provider.base_url.clone(),
+                auth: provider.auth.clone(),
+                reasoning_effort: provider.reasoning_effort.clone(),
+                builtin_web_search: provider.builtin_web_search.clone(),
+            }
+        };
+    let credential_external = config
+        .providers
+        .get(&provider_id)
+        .and_then(|provider| provider.auth.external.clone());
     provider_config.auth = ProviderAuthConfig {
         source: CredentialSource::AuthProfile,
         kind: credential_kind,
         env: None,
         profile: Some(plan.credential_profile.clone()),
-        external: None,
+        external: credential_external,
     };
     validate_provider_config(&provider_id, &provider_config)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     ffi::OsString,
     fs,
-    io::Write,
+    io::{IsTerminal, Write},
     net::SocketAddr,
     path::{Path, PathBuf},
 };
@@ -29,7 +29,10 @@ use holon::{
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
     http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
-    onboarding::{onboarding_report, OnboardingReport, OnboardingStatus},
+    onboarding::{
+        credential_repair_plan, onboarding_report, OnboardingCredentialRepair, OnboardingReport,
+        OnboardingStatus,
+    },
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
     solve::{run_solve, SolveRequest},
@@ -128,11 +131,10 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
     if let Commands::Onboard { json } = &command {
         let config = AppConfig::load_for_config_inspection()?;
         let report = onboarding_report(&config);
-        if *json {
+        if *json || !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
             return print_json(&serde_json::to_value(report)?);
         }
-        print_onboarding_report(&report);
-        return Ok(());
+        return run_interactive_onboarding(config, report);
     }
 
     if let Commands::Tui {
@@ -280,6 +282,115 @@ fn print_onboarding_report(report: &OnboardingReport) {
         }
         println!();
         println!("Run `holon onboard --json` for the full secret-safe diagnostic report.");
+    }
+}
+
+fn run_interactive_onboarding(config: AppConfig, report: OnboardingReport) -> Result<()> {
+    print_onboarding_report(&report);
+    println!();
+    println!("Interactive setup");
+
+    let Some(plan) = credential_repair_plan(&config) else {
+        println!("No repair actions are needed.");
+        return Ok(());
+    };
+
+    println!("- {}", plan.summary);
+    println!("  provider: {}", plan.provider);
+    println!("  credential profile: {}", plan.credential_profile);
+    if plan.requires_confirmation
+        && !confirm(
+            "This will update the existing provider auth configuration. Continue?",
+            false,
+        )?
+    {
+        println!("No changes written.");
+        return Ok(());
+    }
+    if !confirm("Configure this credential now?", true)? {
+        println!("No changes written.");
+        return Ok(());
+    }
+
+    let prompt = format!(
+        "Enter {} credential for profile {}: ",
+        plan.credential_kind, plan.credential_profile
+    );
+    let mut material = rpassword::prompt_password(prompt)
+        .context("failed to read credential material without echo")?;
+    trim_trailing_newlines(&mut material);
+    if material.trim().is_empty() {
+        anyhow::bail!("credential material must not be empty");
+    }
+
+    apply_onboarding_credential_repair(&config, &plan, material)?;
+    println!(
+        "Configured provider {} with credential profile {}.",
+        plan.provider, plan.credential_profile
+    );
+    println!("Credential material was stored locally and was not printed.");
+    Ok(())
+}
+
+fn apply_onboarding_credential_repair(
+    config: &AppConfig,
+    plan: &OnboardingCredentialRepair,
+    material: String,
+) -> Result<()> {
+    let provider_id = ProviderId::parse(&plan.provider)?;
+    let credential_kind = CredentialKind::parse(&plan.credential_kind)?;
+
+    let mut persisted = load_persisted_config_at(&config.config_file_path)?;
+    let mut provider_config = if let Some(provider_config) =
+        persisted.providers.remove(&provider_id)
+    {
+        provider_config
+    } else {
+        built_in_provider_default_config(&provider_id)?.with_context(|| {
+            format!(
+                "provider {} has no built-in defaults; configure it with `holon config providers set`",
+                provider_id.as_str()
+            )
+        })?
+    };
+    provider_config.auth = ProviderAuthConfig {
+        source: CredentialSource::AuthProfile,
+        kind: credential_kind,
+        env: None,
+        profile: Some(plan.credential_profile.clone()),
+        external: None,
+    };
+    validate_provider_config(&provider_id, &provider_config)?;
+
+    set_credential_profile_at(
+        &credential_store_path(&config.home_dir),
+        &plan.credential_profile,
+        credential_kind,
+        material,
+    )?;
+    persisted.providers.insert(provider_id, provider_config);
+    save_persisted_config_at(&config.config_file_path, &persisted)?;
+    Ok(())
+}
+
+fn confirm(prompt: &str, default: bool) -> Result<bool> {
+    let suffix = if default { "[Y/n]" } else { "[y/N]" };
+    print!("{prompt} {suffix} ");
+    std::io::stdout()
+        .flush()
+        .context("failed to flush confirmation prompt")?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("failed to read confirmation")?;
+    let answer = answer.trim().to_ascii_lowercase();
+    if answer.is_empty() {
+        return Ok(default);
+    }
+    match answer.as_str() {
+        "y" | "yes" => Ok(true),
+        "n" | "no" => Ok(false),
+        _ => Err(anyhow!("expected yes or no")),
     }
 }
 

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    config::{AppConfig, CredentialSource, ProviderId},
+    config::{AppConfig, CredentialKind, CredentialSource, ProviderId},
     web::{WebProviderAuthClass, WebProviderSupportStatus},
 };
 
@@ -21,6 +21,7 @@ pub fn credential_repair_plan(config: &AppConfig) -> Option<OnboardingCredential
     let provider_id = &config.default_model.provider;
     let provider = config.providers.get(provider_id);
     let provider_configured = provider.is_some();
+    let persisted_provider_configured = config.stored_config.providers.contains_key(provider_id);
     let credential_configured = provider
         .map(|provider| {
             provider.has_configured_credential() || provider.auth.source == CredentialSource::None
@@ -33,12 +34,18 @@ pub fn credential_repair_plan(config: &AppConfig) -> Option<OnboardingCredential
 
     Some(OnboardingCredentialRepair {
         provider: provider_id.as_str().to_string(),
-        credential_profile: default_credential_profile(provider_id),
-        credential_kind: "api_key".into(),
+        credential_profile: provider
+            .and_then(|provider| provider.auth.profile.clone())
+            .unwrap_or_else(|| default_credential_profile(provider_id)),
+        credential_kind: provider
+            .map(|provider| provider.auth.kind)
+            .unwrap_or(CredentialKind::ApiKey)
+            .as_str()
+            .into(),
         provider_configured,
         credential_configured,
-        requires_confirmation: provider_configured,
-        summary: if provider_configured {
+        requires_confirmation: persisted_provider_configured,
+        summary: if persisted_provider_configured {
             "Update the default model provider to use a stored credential profile.".into()
         } else {
             "Configure the default model provider with a stored credential profile.".into()
@@ -572,7 +579,11 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::{
-        config::{provider_registry_for_tests, AppConfig, ControlAuthMode, ModelRef},
+        config::{
+            provider_registry_for_tests, AppConfig, ControlAuthMode, CredentialKind,
+            CredentialSource, ModelRef, ProviderAuthConfig, ProviderConfigFile, ProviderId,
+            ProviderTransportKind,
+        },
         onboarding::{
             credential_repair_plan, onboarding_report, search_diagnostics, OnboardingStatus,
         },
@@ -654,8 +665,66 @@ mod tests {
         assert_eq!(plan.credential_profile, "openai");
         assert_eq!(plan.credential_kind, "api_key");
         assert!(plan.provider_configured);
-        assert!(plan.requires_confirmation);
+        assert!(!plan.requires_confirmation);
         assert!(!json.contains("openai-key"));
+    }
+
+    #[test]
+    fn credential_repair_plan_requires_confirmation_for_persisted_provider_config() {
+        let mut config = test_config(None);
+        config.stored_config.providers.insert(
+            ProviderId::openai(),
+            ProviderConfigFile {
+                transport: ProviderTransportKind::OpenAiResponses,
+                base_url: "https://api.openai.com/v1".into(),
+                auth: ProviderAuthConfig {
+                    source: CredentialSource::Env,
+                    kind: CredentialKind::ApiKey,
+                    env: Some("OPENAI_API_KEY".into()),
+                    profile: None,
+                    external: None,
+                },
+                reasoning_effort: None,
+                builtin_web_search: None,
+            },
+        );
+
+        let plan = credential_repair_plan(&config).expect("repair plan");
+
+        assert!(plan.provider_configured);
+        assert!(plan.requires_confirmation);
+        assert_eq!(
+            plan.summary,
+            "Update the default model provider to use a stored credential profile."
+        );
+    }
+
+    #[test]
+    fn credential_repair_plan_preserves_provider_auth_contract() {
+        let mut config = test_config(None);
+        config.default_model = ModelRef::parse("openai-codex/gpt-5.4").unwrap();
+
+        let plan = credential_repair_plan(&config).expect("repair plan");
+
+        assert_eq!(plan.provider, "openai-codex");
+        assert_eq!(plan.credential_profile, "openai-codex");
+        assert_eq!(plan.credential_kind, "oauth");
+        assert!(plan.provider_configured);
+        assert!(!plan.requires_confirmation);
+    }
+
+    #[test]
+    fn credential_repair_plan_marks_unknown_default_provider_unconfigured() {
+        let mut config = test_config(None);
+        config.default_model = ModelRef::parse("custom/gpt-5.4").unwrap();
+
+        let plan = credential_repair_plan(&config).expect("repair plan");
+
+        assert_eq!(plan.provider, "custom");
+        assert_eq!(plan.credential_profile, "custom");
+        assert_eq!(plan.credential_kind, "api_key");
+        assert!(!plan.provider_configured);
+        assert!(!plan.requires_confirmation);
     }
 
     #[test]

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    config::{AppConfig, CredentialSource},
+    config::{AppConfig, CredentialSource, ProviderId},
     web::{WebProviderAuthClass, WebProviderSupportStatus},
 };
 
@@ -15,6 +15,39 @@ pub struct OnboardingReport {
     pub sections: Vec<OnboardingSection>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<OnboardingAction>,
+}
+
+pub fn credential_repair_plan(config: &AppConfig) -> Option<OnboardingCredentialRepair> {
+    let provider_id = &config.default_model.provider;
+    let provider = config.providers.get(provider_id);
+    let provider_configured = provider.is_some();
+    let credential_configured = provider
+        .map(|provider| {
+            provider.has_configured_credential() || provider.auth.source == CredentialSource::None
+        })
+        .unwrap_or(false);
+
+    if credential_configured {
+        return None;
+    }
+
+    Some(OnboardingCredentialRepair {
+        provider: provider_id.as_str().to_string(),
+        credential_profile: default_credential_profile(provider_id),
+        credential_kind: "api_key".into(),
+        provider_configured,
+        credential_configured,
+        requires_confirmation: provider_configured,
+        summary: if provider_configured {
+            "Update the default model provider to use a stored credential profile.".into()
+        } else {
+            "Configure the default model provider with a stored credential profile.".into()
+        },
+    })
+}
+
+fn default_credential_profile(provider_id: &ProviderId) -> String {
+    provider_id.as_str().to_string()
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -46,6 +79,17 @@ pub struct OnboardingAction {
     pub title: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingCredentialRepair {
+    pub provider: String,
+    pub credential_profile: String,
+    pub credential_kind: String,
+    pub provider_configured: bool,
+    pub credential_configured: bool,
+    pub requires_confirmation: bool,
+    pub summary: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -529,7 +573,9 @@ mod tests {
 
     use crate::{
         config::{provider_registry_for_tests, AppConfig, ControlAuthMode, ModelRef},
-        onboarding::{onboarding_report, search_diagnostics, OnboardingStatus},
+        onboarding::{
+            credential_repair_plan, onboarding_report, search_diagnostics, OnboardingStatus,
+        },
         web::{WebProviderConfig, WebProviderKind, WebProviderLimitsConfig, WebSearchMode},
     };
 
@@ -596,6 +642,27 @@ mod tests {
         assert_eq!(report.status, OnboardingStatus::Missing);
         assert_eq!(model.status, OnboardingStatus::Missing);
         assert_eq!(report.next_actions.len(), 1);
+    }
+
+    #[test]
+    fn credential_repair_plan_targets_default_provider_without_secret_material() {
+        let config = test_config(None);
+        let plan = credential_repair_plan(&config).expect("repair plan");
+        let json = serde_json::to_string(&plan).unwrap();
+
+        assert_eq!(plan.provider, "openai");
+        assert_eq!(plan.credential_profile, "openai");
+        assert_eq!(plan.credential_kind, "api_key");
+        assert!(plan.provider_configured);
+        assert!(plan.requires_confirmation);
+        assert!(!json.contains("openai-key"));
+    }
+
+    #[test]
+    fn credential_repair_plan_is_absent_when_default_provider_has_credential() {
+        let config = test_config(Some("openai-key"));
+
+        assert_eq!(credential_repair_plan(&config), None);
     }
 
     #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -264,3 +264,16 @@ fn onboard_json_contract_is_secret_safe_and_actionable() {
         "onboard JSON must not expose credential material"
     );
 }
+
+#[test]
+fn onboard_defaults_to_scriptable_json_when_not_a_tty() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+
+    let value = run_json(&home, &["onboard"]);
+
+    assert_eq!(value["schema_version"], json!(1));
+    assert!(
+        value["sections"].as_array().is_some(),
+        "non-TTY onboard output should remain scriptable JSON: {value}"
+    );
+}


### PR DESCRIPTION
## Summary

- make `holon onboard` run an interactive setup/repair path on TTYs while keeping non-TTY and `--json` scriptable diagnostics
- add shared onboarding credential repair planning for the default model provider
- store credential material with hidden input and require confirmation before updating existing provider auth
- document the interactive onboarding path and cover non-TTY/scriptable behavior

Closes #1554

## Verification

- `cargo fmt --all -- --check`
- `cargo test --test cli_snapshot test_cli_snapshot_matches`
- `cargo test --test cli_json_contract onboard`
- `cargo test onboarding::tests::credential_repair_plan --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
