### PR TITLE
feat: add TUI onboarding wizard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod ingress;
 pub mod memory;
 pub mod model_catalog;
 pub mod onboarding;
+pub mod onboarding_tui;
 pub mod openapi;
 pub mod operator_event;
 pub mod policy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,10 +29,8 @@ use holon::{
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
     http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
-    onboarding::{
-        credential_repair_plan, onboarding_report, OnboardingCredentialRepair, OnboardingReport,
-        OnboardingStatus,
-    },
+    onboarding::onboarding_report,
+    onboarding_tui::run_onboarding_tui,
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
     solve::{run_solve, SolveRequest},
@@ -134,7 +132,16 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         if *json || !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
             return print_json(&serde_json::to_value(report)?);
         }
-        return run_interactive_onboarding(config, report);
+        let summary = run_onboarding_tui(config)?;
+        println!("Holon onboarding configured.");
+        println!("- provider: {}", summary.provider);
+        println!("- credential profile: {}", summary.credential_profile);
+        println!("- default model: {}", summary.default_model);
+        println!("- search: {}", summary.search);
+        if summary.credential_written {
+            println!("Credential material was stored locally and was not printed.");
+        }
+        return Ok(());
     }
 
     if let Commands::Tui {
@@ -245,181 +252,6 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         Commands::Debug { command } => handle_debug_command(config, command).await,
         Commands::Onboard { .. } => unreachable!("onboard command is handled before runtime load"),
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
-    }
-}
-
-fn print_onboarding_report(report: &OnboardingReport) {
-    println!("Holon onboarding");
-    println!("Status: {}", onboarding_status_label(report.status));
-    println!();
-
-    for section in &report.sections {
-        println!(
-            "- {} [{}]: {}",
-            section.title,
-            onboarding_status_label(section.status),
-            section.summary
-        );
-        for action in &section.actions {
-            println!("  next: {}", action.title);
-            if let Some(command) = &action.command {
-                println!("       {}", command.join(" "));
-            }
-        }
-    }
-
-    if report.next_actions.is_empty() {
-        println!();
-        println!("Setup looks ready. Try `holon daemon start` or `holon run \"hello\"`.");
-    } else {
-        println!();
-        println!("Recommended next steps:");
-        for action in &report.next_actions {
-            println!("- {}", action.title);
-            if let Some(command) = &action.command {
-                println!("  {}", command.join(" "));
-            }
-        }
-        println!();
-        println!("Run `holon onboard --json` for the full secret-safe diagnostic report.");
-    }
-}
-
-fn run_interactive_onboarding(config: AppConfig, report: OnboardingReport) -> Result<()> {
-    print_onboarding_report(&report);
-    println!();
-    println!("Interactive setup");
-
-    let Some(plan) = credential_repair_plan(&config) else {
-        println!("No repair actions are needed.");
-        return Ok(());
-    };
-
-    println!("- {}", plan.summary);
-    println!("  provider: {}", plan.provider);
-    println!("  credential profile: {}", plan.credential_profile);
-    if !plan.provider_configured {
-        println!(
-            "Provider {} is not configured. Configure it first with `holon config providers set {}`.",
-            plan.provider, plan.provider
-        );
-        return Ok(());
-    }
-    if plan.requires_confirmation
-        && !confirm(
-            "This will update the existing provider auth configuration. Continue?",
-            false,
-        )?
-    {
-        println!("No changes written.");
-        return Ok(());
-    }
-    if !confirm("Configure this credential now?", true)? {
-        println!("No changes written.");
-        return Ok(());
-    }
-
-    let prompt = format!(
-        "Enter {} credential for profile {}: ",
-        plan.credential_kind, plan.credential_profile
-    );
-    let mut material = rpassword::prompt_password(prompt)
-        .context("failed to read credential material without echo")?;
-    trim_trailing_newlines(&mut material);
-    if material.trim().is_empty() {
-        anyhow::bail!("credential material must not be empty");
-    }
-
-    apply_onboarding_credential_repair(&config, &plan, material)?;
-    println!(
-        "Configured provider {} with credential profile {}.",
-        plan.provider, plan.credential_profile
-    );
-    println!("Credential material was stored locally and was not printed.");
-    Ok(())
-}
-
-fn apply_onboarding_credential_repair(
-    config: &AppConfig,
-    plan: &OnboardingCredentialRepair,
-    material: String,
-) -> Result<()> {
-    let provider_id = ProviderId::parse(&plan.provider)?;
-    let credential_kind = CredentialKind::parse(&plan.credential_kind)?;
-
-    let mut persisted = load_persisted_config_at(&config.config_file_path)?;
-    let mut provider_config =
-        if let Some(provider_config) = persisted.providers.remove(&provider_id) {
-            provider_config
-        } else {
-            let provider = config.providers.get(&provider_id).with_context(|| {
-                format!(
-                "provider {} is not configured; configure it with `holon config providers set {}`",
-                provider_id.as_str(),
-                provider_id.as_str()
-            )
-            })?;
-            ProviderConfigFile {
-                transport: provider.transport,
-                base_url: provider.base_url.clone(),
-                auth: provider.auth.clone(),
-                reasoning_effort: provider.reasoning_effort.clone(),
-                builtin_web_search: provider.builtin_web_search.clone(),
-            }
-        };
-    let credential_external = config
-        .providers
-        .get(&provider_id)
-        .and_then(|provider| provider.auth.external.clone());
-    provider_config.auth = ProviderAuthConfig {
-        source: CredentialSource::AuthProfile,
-        kind: credential_kind,
-        env: None,
-        profile: Some(plan.credential_profile.clone()),
-        external: credential_external,
-    };
-    validate_provider_config(&provider_id, &provider_config)?;
-
-    set_credential_profile_at(
-        &credential_store_path(&config.home_dir),
-        &plan.credential_profile,
-        credential_kind,
-        material,
-    )?;
-    persisted.providers.insert(provider_id, provider_config);
-    save_persisted_config_at(&config.config_file_path, &persisted)?;
-    Ok(())
-}
-
-fn confirm(prompt: &str, default: bool) -> Result<bool> {
-    let suffix = if default { "[Y/n]" } else { "[y/N]" };
-    print!("{prompt} {suffix} ");
-    std::io::stdout()
-        .flush()
-        .context("failed to flush confirmation prompt")?;
-    let mut answer = String::new();
-    std::io::stdin()
-        .read_line(&mut answer)
-        .context("failed to read confirmation")?;
-    let answer = answer.trim().to_ascii_lowercase();
-    if answer.is_empty() {
-        return Ok(default);
-    }
-    match answer.as_str() {
-        "y" | "yes" => Ok(true),
-        "n" | "no" => Ok(false),
-        _ => Err(anyhow!("expected yes or no")),
-    }
-}
-
-fn onboarding_status_label(status: OnboardingStatus) -> &'static str {
-    match status {
-        OnboardingStatus::Configured => "configured",
-        OnboardingStatus::Missing => "missing",
-        OnboardingStatus::Unavailable => "unavailable",
-        OnboardingStatus::Restricted => "restricted",
-        OnboardingStatus::Skipped => "skipped",
-        OnboardingStatus::Failed => "failed",
     }
 }
 

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -8,11 +8,14 @@ use crate::{
     config::{
         built_in_provider_default_config, credential_store_path, load_persisted_config_at,
         save_persisted_config_at, set_credential_profile_at, validate_provider_config, AppConfig,
-        CredentialKind, CredentialSource, ModelRef, ProviderAuthConfig, ProviderId,
+        CredentialKind, CredentialSource, ModelRef, ProviderAuthConfig, ProviderConfigFile,
+        ProviderId, ProviderRuntimeConfig,
     },
     model_catalog::BuiltInModelCatalog,
     web::{WebProviderAuthClass, WebProviderSupportStatus},
 };
+
+const DUCKDUCKGO_SEARCH_PROVIDER_ID: &str = "duckduckgo";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OnboardingReport {
@@ -297,6 +300,12 @@ pub fn apply_onboarding_wizard_draft(
         .providers
         .remove(&draft.provider)
         .or_else(|| {
+            config
+                .providers
+                .get(&draft.provider)
+                .map(provider_config_file_from_runtime)
+        })
+        .or_else(|| {
             built_in_provider_default_config(&draft.provider)
                 .ok()
                 .flatten()
@@ -307,18 +316,16 @@ pub fn apply_onboarding_wizard_draft(
                 draft.provider.as_str()
             )
         })?;
-    provider_config.auth = ProviderAuthConfig {
-        source: CredentialSource::AuthProfile,
-        kind: draft.credential_kind,
-        env: None,
-        profile: Some(draft.credential_profile.clone()),
-        external: provider_config.auth.external.clone(),
-    };
-    validate_provider_config(&draft.provider, &provider_config)?;
-
     let credential_written = credential_material
         .map(|mut material| {
             trim_trailing_newlines(&mut material);
+            provider_config.auth = ProviderAuthConfig {
+                source: CredentialSource::AuthProfile,
+                kind: draft.credential_kind,
+                env: None,
+                profile: Some(draft.credential_profile.clone()),
+                external: provider_config.auth.external.clone(),
+            };
             set_credential_profile_at(
                 &credential_store_path(&config.home_dir),
                 &draft.credential_profile,
@@ -329,6 +336,7 @@ pub fn apply_onboarding_wizard_draft(
         })
         .transpose()?
         .unwrap_or(false);
+    validate_provider_config(&draft.provider, &provider_config)?;
 
     persisted.model.default = Some(draft.default_model.as_string());
     persisted
@@ -342,12 +350,13 @@ pub fn apply_onboarding_wizard_draft(
             persisted.web.search.enabled = Some(true);
             persisted.web.search.builtin_provider.enabled = Some(true);
             persisted.web.search.provider = Some("auto".into());
+            persisted.web.search.providers.clear();
         }
         OnboardingSearchSelection::DuckDuckGo => {
             persisted.web.search.enabled = Some(true);
             persisted.web.search.builtin_provider.enabled = Some(false);
-            persisted.web.search.provider = Some("duck_duck_go".into());
-            persisted.web.search.providers = vec!["duck_duck_go".into()];
+            persisted.web.search.provider = Some(DUCKDUCKGO_SEARCH_PROVIDER_ID.into());
+            persisted.web.search.providers = vec![DUCKDUCKGO_SEARCH_PROVIDER_ID.into()];
         }
     }
     save_persisted_config_at(&config.config_file_path, &persisted)?;
@@ -360,6 +369,16 @@ pub fn apply_onboarding_wizard_draft(
         search: draft.search.label().into(),
         credential_written,
     })
+}
+
+fn provider_config_file_from_runtime(provider: &ProviderRuntimeConfig) -> ProviderConfigFile {
+    ProviderConfigFile {
+        transport: provider.transport,
+        base_url: provider.base_url.clone(),
+        auth: provider.auth.clone(),
+        reasoning_effort: provider.reasoning_effort.clone(),
+        builtin_web_search: provider.builtin_web_search.clone(),
+    }
 }
 
 fn trim_trailing_newlines(value: &mut String) {
@@ -496,7 +515,7 @@ pub fn search_diagnostics(config: &AppConfig) -> SearchDiagnostics {
                 "config".into(),
                 "set".into(),
                 "web.search.provider".into(),
-                "duck_duck_go".into(),
+                DUCKDUCKGO_SEARCH_PROVIDER_ID.into(),
             ]),
         }]
     };
@@ -662,7 +681,7 @@ fn managed_search_provider_diagnostic(
     config: &AppConfig,
     provider_id: &str,
 ) -> SearchManagedProviderDiagnostic {
-    if provider_id == "duck_duck_go" {
+    if provider_id == DUCKDUCKGO_SEARCH_PROVIDER_ID {
         let capabilities = crate::web::WebProviderKind::DuckDuckGo.capabilities();
         return SearchManagedProviderDiagnostic {
             id: provider_id.into(),
@@ -1056,11 +1075,8 @@ mod tests {
         assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-5.4"));
         assert_eq!(persisted.web.search.enabled, Some(true));
         assert_eq!(persisted.web.search.builtin_provider.enabled, Some(false));
-        assert_eq!(
-            persisted.web.search.provider.as_deref(),
-            Some("duck_duck_go")
-        );
-        assert_eq!(persisted.web.search.providers, vec!["duck_duck_go"]);
+        assert_eq!(persisted.web.search.provider.as_deref(), Some("duckduckgo"));
+        assert_eq!(persisted.web.search.providers, vec!["duckduckgo"]);
         assert_eq!(
             persisted
                 .providers
@@ -1079,6 +1095,31 @@ mod tests {
                 .map(|profile| profile.material.as_str()),
             Some("test-secret")
         );
+    }
+
+    #[test]
+    fn onboarding_wizard_apply_preserves_existing_auth_without_new_secret() {
+        let config = test_config(Some("openai-key"));
+        let draft = OnboardingWizardDraft {
+            provider: ProviderId::openai(),
+            credential_profile: "openai".into(),
+            credential_kind: CredentialKind::ApiKey,
+            default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
+            search: OnboardingSearchSelection::BuiltInProvider,
+        };
+
+        let summary = apply_onboarding_wizard_draft(&config, &draft, None).unwrap();
+        let persisted = load_persisted_config_at(&config.config_file_path).unwrap();
+        let openai = persisted.providers.get(&ProviderId::openai()).unwrap();
+        let store = load_credential_store_at(&credential_store_path(&config.home_dir)).unwrap();
+
+        assert!(!summary.credential_written);
+        assert_eq!(openai.auth.source, CredentialSource::Env);
+        assert_eq!(openai.auth.env.as_deref(), Some("OPENAI_API_KEY"));
+        assert_eq!(openai.auth.profile, None);
+        assert!(store.profiles.is_empty());
+        assert_eq!(persisted.web.search.provider.as_deref(), Some("auto"));
+        assert!(persisted.web.search.providers.is_empty());
     }
 
     #[test]
@@ -1141,7 +1182,7 @@ mod tests {
         let mut config = test_config(Some("openai-key"));
         config.web_config.search.enabled = true;
         config.web_config.search.builtin_provider_enabled = false;
-        config.web_config.search.provider = "duck_duck_go".into();
+        config.web_config.search.provider = "duckduckgo".into();
         config.web_config.search.mode = WebSearchMode::Single;
 
         let report = onboarding_report(&config);
@@ -1152,7 +1193,7 @@ mod tests {
             .expect("search section");
 
         assert_eq!(search.status, OnboardingStatus::Configured);
-        assert_eq!(search.details["provider"], "duck_duck_go");
+        assert_eq!(search.details["provider"], "duckduckgo");
         assert_eq!(search.details["mode"], "single");
         assert_eq!(
             search.details["managed_providers"][0]["kind"],

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1,10 +1,16 @@
 use std::collections::BTreeMap;
 
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    config::{AppConfig, CredentialKind, CredentialSource, ProviderId},
+    config::{
+        built_in_provider_default_config, credential_store_path, load_persisted_config_at,
+        save_persisted_config_at, set_credential_profile_at, validate_provider_config, AppConfig,
+        CredentialKind, CredentialSource, ModelRef, ProviderAuthConfig, ProviderId,
+    },
+    model_catalog::BuiltInModelCatalog,
     web::{WebProviderAuthClass, WebProviderSupportStatus},
 };
 
@@ -97,6 +103,269 @@ pub struct OnboardingCredentialRepair {
     pub credential_configured: bool,
     pub requires_confirmation: bool,
     pub summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnboardingWizardDraft {
+    pub provider: ProviderId,
+    pub credential_profile: String,
+    pub credential_kind: CredentialKind,
+    pub default_model: ModelRef,
+    pub search: OnboardingSearchSelection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnboardingSearchSelection {
+    Disabled,
+    BuiltInProvider,
+    DuckDuckGo,
+}
+
+impl OnboardingSearchSelection {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Disabled => "Disable WebSearch",
+            Self::BuiltInProvider => "Use model provider built-in search",
+            Self::DuckDuckGo => "Use DuckDuckGo managed search",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnboardingProviderChoice {
+    pub id: ProviderId,
+    pub title: String,
+    pub detail: String,
+    pub credential_kind: CredentialKind,
+    pub credential_profile: String,
+    pub credential_configured: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnboardingModelChoice {
+    pub model: ModelRef,
+    pub title: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnboardingSearchChoice {
+    pub selection: OnboardingSearchSelection,
+    pub title: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnboardingApplySummary {
+    pub provider: String,
+    pub credential_profile: String,
+    pub credential_kind: String,
+    pub default_model: String,
+    pub search: String,
+    pub credential_written: bool,
+}
+
+pub fn onboarding_provider_choices(config: &AppConfig) -> Vec<OnboardingProviderChoice> {
+    [
+        ProviderId::openai_codex(),
+        ProviderId::openai(),
+        ProviderId::anthropic(),
+        ProviderId::gemini(),
+    ]
+    .into_iter()
+    .filter_map(|id| {
+        config.providers.get(&id).map(|provider| {
+            let title = match id.as_str() {
+                ProviderId::OPENAI_CODEX => "OpenAI Codex".to_string(),
+                ProviderId::OPENAI => "OpenAI".to_string(),
+                ProviderId::ANTHROPIC => "Anthropic".to_string(),
+                ProviderId::GEMINI => "Gemini".to_string(),
+                other => other.to_string(),
+            };
+            let auth = match provider.auth.kind {
+                CredentialKind::OAuth => "OAuth login/profile",
+                CredentialKind::ApiKey => "API key",
+                CredentialKind::None => "no credential",
+                _ => provider.auth.kind.as_str(),
+            };
+            OnboardingProviderChoice {
+                id: id.clone(),
+                title,
+                detail: format!("{} · {}", provider.transport.as_str(), auth),
+                credential_kind: provider.auth.kind,
+                credential_profile: provider
+                    .auth
+                    .profile
+                    .clone()
+                    .unwrap_or_else(|| id.as_str().to_string()),
+                credential_configured: provider.has_configured_credential()
+                    || provider.auth.source == CredentialSource::None,
+            }
+        })
+    })
+    .collect()
+}
+
+pub fn onboarding_model_choices(
+    config: &AppConfig,
+    provider: &ProviderId,
+) -> Vec<OnboardingModelChoice> {
+    let mut models = RuntimeModelCatalogShim::choices(config, provider);
+    if models.is_empty() {
+        models.push(OnboardingModelChoice {
+            model: ModelRef::new(provider.clone(), "unknown"),
+            title: format!("{}/unknown", provider.as_str()),
+            detail: "custom provider model placeholder".into(),
+        });
+    }
+    models
+}
+
+struct RuntimeModelCatalogShim;
+
+impl RuntimeModelCatalogShim {
+    fn choices(config: &AppConfig, provider: &ProviderId) -> Vec<OnboardingModelChoice> {
+        let preferred = BuiltInModelCatalog::default().preferred_model_for_provider(provider);
+        let mut entries = crate::config::RuntimeModelCatalog::from_config(config)
+            .available_models()
+            .into_iter()
+            .filter(|entry| &entry.model_ref.provider == provider)
+            .collect::<Vec<_>>();
+        entries.sort_by(|left, right| {
+            let left_preferred = preferred.as_ref() == Some(&left.model_ref);
+            let right_preferred = preferred.as_ref() == Some(&right.model_ref);
+            right_preferred
+                .cmp(&left_preferred)
+                .then_with(|| left.display_name.cmp(&right.display_name))
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        entries
+            .into_iter()
+            .map(|entry| {
+                let preferred_suffix = if preferred.as_ref() == Some(&entry.model_ref) {
+                    " · recommended"
+                } else {
+                    ""
+                };
+                OnboardingModelChoice {
+                    title: format!("{}{}", entry.display_name, preferred_suffix),
+                    detail: entry.model_ref.as_string(),
+                    model: entry.model_ref,
+                }
+            })
+            .collect()
+    }
+}
+
+pub fn onboarding_search_choices(config: &AppConfig) -> Vec<OnboardingSearchChoice> {
+    let builtin_detail = if config
+        .providers
+        .get(&config.default_model.provider)
+        .and_then(|provider| provider.builtin_web_search.as_ref())
+        .is_some()
+    {
+        "provider-declared native search when supported by the selected model"
+    } else {
+        "enable provider-declared search for providers that support it"
+    };
+    vec![
+        OnboardingSearchChoice {
+            selection: OnboardingSearchSelection::BuiltInProvider,
+            title: OnboardingSearchSelection::BuiltInProvider.label().into(),
+            detail: builtin_detail.into(),
+        },
+        OnboardingSearchChoice {
+            selection: OnboardingSearchSelection::DuckDuckGo,
+            title: OnboardingSearchSelection::DuckDuckGo.label().into(),
+            detail: "free managed provider; no API key required".into(),
+        },
+        OnboardingSearchChoice {
+            selection: OnboardingSearchSelection::Disabled,
+            title: OnboardingSearchSelection::Disabled.label().into(),
+            detail: "keep WebSearch off; WebFetch can still fetch explicit URLs".into(),
+        },
+    ]
+}
+
+pub fn apply_onboarding_wizard_draft(
+    config: &AppConfig,
+    draft: &OnboardingWizardDraft,
+    credential_material: Option<String>,
+) -> Result<OnboardingApplySummary> {
+    let mut persisted = load_persisted_config_at(&config.config_file_path)?;
+    let mut provider_config = persisted
+        .providers
+        .remove(&draft.provider)
+        .or_else(|| {
+            built_in_provider_default_config(&draft.provider)
+                .ok()
+                .flatten()
+        })
+        .with_context(|| {
+            format!(
+                "provider {} is not configured and has no built-in default",
+                draft.provider.as_str()
+            )
+        })?;
+    provider_config.auth = ProviderAuthConfig {
+        source: CredentialSource::AuthProfile,
+        kind: draft.credential_kind,
+        env: None,
+        profile: Some(draft.credential_profile.clone()),
+        external: provider_config.auth.external.clone(),
+    };
+    validate_provider_config(&draft.provider, &provider_config)?;
+
+    let credential_written = credential_material
+        .map(|mut material| {
+            trim_trailing_newlines(&mut material);
+            set_credential_profile_at(
+                &credential_store_path(&config.home_dir),
+                &draft.credential_profile,
+                draft.credential_kind,
+                material,
+            )
+            .map(|_| true)
+        })
+        .transpose()?
+        .unwrap_or(false);
+
+    persisted.model.default = Some(draft.default_model.as_string());
+    persisted
+        .providers
+        .insert(draft.provider.clone(), provider_config);
+    match draft.search {
+        OnboardingSearchSelection::Disabled => {
+            persisted.web.search.enabled = Some(false);
+        }
+        OnboardingSearchSelection::BuiltInProvider => {
+            persisted.web.search.enabled = Some(true);
+            persisted.web.search.builtin_provider.enabled = Some(true);
+            persisted.web.search.provider = Some("auto".into());
+        }
+        OnboardingSearchSelection::DuckDuckGo => {
+            persisted.web.search.enabled = Some(true);
+            persisted.web.search.builtin_provider.enabled = Some(false);
+            persisted.web.search.provider = Some("duck_duck_go".into());
+            persisted.web.search.providers = vec!["duck_duck_go".into()];
+        }
+    }
+    save_persisted_config_at(&config.config_file_path, &persisted)?;
+
+    Ok(OnboardingApplySummary {
+        provider: draft.provider.as_str().into(),
+        credential_profile: draft.credential_profile.clone(),
+        credential_kind: draft.credential_kind.as_str().into(),
+        default_model: draft.default_model.as_string(),
+        search: draft.search.label().into(),
+        credential_written,
+    })
+}
+
+fn trim_trailing_newlines(value: &mut String) {
+    while value.ends_with('\n') || value.ends_with('\r') {
+        value.pop();
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -580,12 +849,15 @@ mod tests {
 
     use crate::{
         config::{
+            credential_store_path, load_credential_store_at, load_persisted_config_at,
             provider_registry_for_tests, AppConfig, ControlAuthMode, CredentialKind,
             CredentialSource, ModelRef, ProviderAuthConfig, ProviderConfigFile, ProviderId,
             ProviderTransportKind,
         },
         onboarding::{
-            credential_repair_plan, onboarding_report, search_diagnostics, OnboardingStatus,
+            apply_onboarding_wizard_draft, credential_repair_plan, onboarding_model_choices,
+            onboarding_provider_choices, onboarding_report, search_diagnostics,
+            OnboardingSearchSelection, OnboardingStatus, OnboardingWizardDraft,
         },
         web::{WebProviderConfig, WebProviderKind, WebProviderLimitsConfig, WebSearchMode},
     };
@@ -732,6 +1004,81 @@ mod tests {
         let config = test_config(Some("openai-key"));
 
         assert_eq!(credential_repair_plan(&config), None);
+    }
+
+    #[test]
+    fn onboarding_wizard_choices_include_provider_auth_and_models() {
+        let config = test_config(None);
+
+        let providers = onboarding_provider_choices(&config);
+        let openai = providers
+            .iter()
+            .find(|provider| provider.id == ProviderId::openai())
+            .expect("openai provider choice");
+        let codex = providers
+            .iter()
+            .find(|provider| provider.id == ProviderId::openai_codex())
+            .expect("openai-codex provider choice");
+
+        assert_eq!(openai.credential_kind, CredentialKind::ApiKey);
+        assert_eq!(openai.credential_profile, "openai");
+        assert_eq!(codex.credential_kind, CredentialKind::OAuth);
+        assert_eq!(codex.credential_profile, "openai-codex");
+
+        let models = onboarding_model_choices(&config, &ProviderId::openai());
+        assert!(models
+            .iter()
+            .any(|choice| choice.model.as_string() == "openai/gpt-5.4"));
+    }
+
+    #[test]
+    fn onboarding_wizard_apply_writes_config_without_printing_secret() {
+        let config = test_config(None);
+        let draft = OnboardingWizardDraft {
+            provider: ProviderId::openai(),
+            credential_profile: "openai".into(),
+            credential_kind: CredentialKind::ApiKey,
+            default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
+            search: OnboardingSearchSelection::DuckDuckGo,
+        };
+
+        let summary =
+            apply_onboarding_wizard_draft(&config, &draft, Some("test-secret\n".into())).unwrap();
+        let persisted = load_persisted_config_at(&config.config_file_path).unwrap();
+        let store = load_credential_store_at(&credential_store_path(&config.home_dir)).unwrap();
+
+        assert_eq!(summary.provider, "openai");
+        assert_eq!(summary.default_model, "openai/gpt-5.4");
+        assert_eq!(summary.search, "Use DuckDuckGo managed search");
+        assert!(summary.credential_written);
+        assert!(!format!("{summary:?}").contains("test-secret"));
+
+        assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-5.4"));
+        assert_eq!(persisted.web.search.enabled, Some(true));
+        assert_eq!(persisted.web.search.builtin_provider.enabled, Some(false));
+        assert_eq!(
+            persisted.web.search.provider.as_deref(),
+            Some("duck_duck_go")
+        );
+        assert_eq!(persisted.web.search.providers, vec!["duck_duck_go"]);
+        assert_eq!(
+            persisted
+                .providers
+                .get(&ProviderId::openai())
+                .and_then(|provider| provider.auth.profile.as_deref()),
+            Some("openai")
+        );
+        assert_eq!(
+            store.profiles.get("openai").map(|profile| profile.kind),
+            Some(CredentialKind::ApiKey)
+        );
+        assert_eq!(
+            store
+                .profiles
+                .get("openai")
+                .map(|profile| profile.material.as_str()),
+            Some("test-secret")
+        );
     }
 
     #[test]

--- a/src/onboarding_tui.rs
+++ b/src/onboarding_tui.rs
@@ -1,0 +1,477 @@
+use std::{
+    collections::BTreeMap,
+    io::{self, Stdout},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+    Frame, Terminal,
+};
+
+use crate::{
+    config::{AppConfig, CredentialKind, ProviderId},
+    onboarding::{
+        apply_onboarding_wizard_draft, onboarding_model_choices, onboarding_provider_choices,
+        onboarding_search_choices, OnboardingApplySummary, OnboardingModelChoice,
+        OnboardingProviderChoice, OnboardingSearchChoice, OnboardingSearchSelection,
+        OnboardingWizardDraft,
+    },
+};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+pub fn run_onboarding_tui(config: AppConfig) -> Result<OnboardingApplySummary> {
+    let mut app = OnboardingTuiApp::new(&config);
+    let mut guard = TerminalGuard::new();
+    enable_raw_mode()?;
+    guard.raw_mode_enabled = true;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    guard.alternate_screen_enabled = true;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    loop {
+        terminal.draw(|frame| draw(frame, &app))?;
+        if app.should_quit {
+            anyhow::bail!("onboarding cancelled");
+        }
+        if let Some(draft) = app.completed_draft.clone() {
+            terminal.show_cursor()?;
+            drop(guard);
+            let summary =
+                apply_onboarding_wizard_draft(&config, &draft, app.credential_material.clone())?;
+            return Ok(summary);
+        }
+        if event::poll(POLL_INTERVAL)? {
+            if let Event::Key(key) = event::read()? {
+                if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+                    app.handle_key(key.code)?;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct OnboardingTuiApp {
+    providers: Vec<OnboardingProviderChoice>,
+    models_by_provider: BTreeMap<ProviderId, Vec<OnboardingModelChoice>>,
+    models: Vec<OnboardingModelChoice>,
+    search_choices: Vec<OnboardingSearchChoice>,
+    step: Step,
+    provider_index: usize,
+    model_index: usize,
+    search_index: usize,
+    selected_provider: Option<OnboardingProviderChoice>,
+    selected_model: Option<OnboardingModelChoice>,
+    selected_search: OnboardingSearchSelection,
+    credential_input: String,
+    credential_material: Option<String>,
+    completed_draft: Option<OnboardingWizardDraft>,
+    should_quit: bool,
+    status: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Step {
+    Provider,
+    Auth,
+    Model,
+    Search,
+    Confirm,
+}
+
+impl OnboardingTuiApp {
+    fn new(config: &AppConfig) -> Self {
+        let providers = onboarding_provider_choices(config);
+        let models_by_provider = providers
+            .iter()
+            .map(|provider| {
+                (
+                    provider.id.clone(),
+                    onboarding_model_choices(config, &provider.id),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let provider_index = providers
+            .iter()
+            .position(|provider| provider.id == config.default_model.provider)
+            .unwrap_or(0);
+        let selected_provider = providers.get(provider_index).cloned();
+        let models = selected_provider
+            .as_ref()
+            .and_then(|provider| models_by_provider.get(&provider.id).cloned())
+            .unwrap_or_default();
+        let model_index = models
+            .iter()
+            .position(|model| model.model == config.default_model)
+            .unwrap_or(0);
+        let search_choices = onboarding_search_choices(config);
+        let selected_search = if !config.web_config.search.enabled {
+            OnboardingSearchSelection::Disabled
+        } else if config.web_config.search.provider == "duck_duck_go" {
+            OnboardingSearchSelection::DuckDuckGo
+        } else {
+            OnboardingSearchSelection::BuiltInProvider
+        };
+        let search_index = search_choices
+            .iter()
+            .position(|choice| choice.selection == selected_search)
+            .unwrap_or(0);
+        Self {
+            providers,
+            models_by_provider,
+            models,
+            search_choices,
+            step: Step::Provider,
+            provider_index,
+            model_index,
+            search_index,
+            selected_provider,
+            selected_model: None,
+            selected_search,
+            credential_input: String::new(),
+            credential_material: None,
+            completed_draft: None,
+            should_quit: false,
+            status: "Use ↑/↓ to move, Enter to select, Esc to cancel.".into(),
+        }
+    }
+
+    fn handle_key(&mut self, code: KeyCode) -> Result<()> {
+        match code {
+            KeyCode::Esc => self.should_quit = true,
+            KeyCode::Backspace if self.step == Step::Auth => {
+                self.credential_input.pop();
+            }
+            KeyCode::Char(ch) if self.step == Step::Auth => self.credential_input.push(ch),
+            KeyCode::Up => self.move_selection(-1),
+            KeyCode::Down => self.move_selection(1),
+            KeyCode::Enter => self.advance()?,
+            KeyCode::Left => self.back(),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        let (index, len) = match self.step {
+            Step::Provider => (&mut self.provider_index, self.providers.len()),
+            Step::Model => (&mut self.model_index, self.models.len()),
+            Step::Search => (&mut self.search_index, self.search_choices.len()),
+            _ => return,
+        };
+        if len == 0 {
+            *index = 0;
+            return;
+        }
+        *index = (*index as isize + delta).rem_euclid(len as isize) as usize;
+    }
+
+    fn back(&mut self) {
+        self.step = match self.step {
+            Step::Provider => Step::Provider,
+            Step::Auth => Step::Provider,
+            Step::Model => Step::Auth,
+            Step::Search => Step::Model,
+            Step::Confirm => Step::Search,
+        };
+    }
+
+    fn advance(&mut self) -> Result<()> {
+        match self.step {
+            Step::Provider => {
+                let provider = self
+                    .providers
+                    .get(self.provider_index)
+                    .cloned()
+                    .context("no model provider choices are available")?;
+                self.models = self
+                    .models_by_provider
+                    .get(&provider.id)
+                    .cloned()
+                    .unwrap_or_default();
+                self.model_index = 0;
+                self.selected_provider = Some(provider);
+                self.step = Step::Auth;
+            }
+            Step::Auth => {
+                let provider = self
+                    .selected_provider
+                    .as_ref()
+                    .context("provider not selected")?;
+                if provider.credential_kind == CredentialKind::OAuth {
+                    if !provider.credential_configured {
+                        self.status = "OAuth login initiation is not available yet; import a Holon OAuth profile or run codex login, then rerun onboard.".into();
+                        return Ok(());
+                    }
+                    self.credential_material = None;
+                } else {
+                    if !provider.credential_configured && self.credential_input.trim().is_empty() {
+                        self.status = "Enter a credential value before continuing.".into();
+                        return Ok(());
+                    }
+                    if !self.credential_input.trim().is_empty() {
+                        self.credential_material = Some(self.credential_input.clone());
+                    }
+                }
+                self.step = Step::Model;
+            }
+            Step::Model => {
+                self.selected_model = self.models.get(self.model_index).cloned();
+                self.step = Step::Search;
+            }
+            Step::Search => {
+                self.selected_search = self
+                    .search_choices
+                    .get(self.search_index)
+                    .map(|choice| choice.selection)
+                    .unwrap_or(OnboardingSearchSelection::BuiltInProvider);
+                self.step = Step::Confirm;
+            }
+            Step::Confirm => {
+                let provider = self
+                    .selected_provider
+                    .as_ref()
+                    .context("provider not selected")?;
+                let model = self.selected_model.as_ref().context("model not selected")?;
+                self.completed_draft = Some(OnboardingWizardDraft {
+                    provider: provider.id.clone(),
+                    credential_profile: provider.credential_profile.clone(),
+                    credential_kind: provider.credential_kind,
+                    default_model: model.model.clone(),
+                    search: self.selected_search,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn draw(frame: &mut Frame<'_>, app: &OnboardingTuiApp) {
+    let area = centered(frame.area(), 90, 80);
+    frame.render_widget(Clear, area);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(8),
+            Constraint::Length(4),
+        ])
+        .split(area);
+    let title = Paragraph::new(Text::from(vec![
+        Line::from(vec![Span::styled(
+            "Holon onboarding",
+            Style::default().add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(step_label(app.step)),
+    ]))
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(title, chunks[0]);
+    match app.step {
+        Step::Provider => draw_list(
+            frame,
+            chunks[1],
+            "Choose model provider",
+            app.providers
+                .iter()
+                .map(|v| (&v.title, &v.detail))
+                .collect(),
+            app.provider_index,
+        ),
+        Step::Auth => draw_auth(frame, chunks[1], app),
+        Step::Model => draw_list(
+            frame,
+            chunks[1],
+            "Choose default model",
+            app.models.iter().map(|v| (&v.title, &v.detail)).collect(),
+            app.model_index,
+        ),
+        Step::Search => draw_list(
+            frame,
+            chunks[1],
+            "Configure search",
+            app.search_choices
+                .iter()
+                .map(|v| (&v.title, &v.detail))
+                .collect(),
+            app.search_index,
+        ),
+        Step::Confirm => draw_confirm(frame, chunks[1], app),
+    }
+    frame.render_widget(
+        Paragraph::new(format!("{}  ·  ← back", app.status))
+            .wrap(Wrap { trim: true })
+            .block(Block::default().borders(Borders::ALL).title("Help")),
+        chunks[2],
+    );
+}
+
+fn draw_list(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    title: &str,
+    rows: Vec<(&String, &String)>,
+    selected: usize,
+) {
+    let items = rows
+        .into_iter()
+        .map(|(title, detail)| {
+            ListItem::new(vec![Line::from(title.clone()), Line::from(detail.clone())])
+        })
+        .collect::<Vec<_>>();
+    let mut state = ListState::default();
+    if !items.is_empty() {
+        state.select(Some(selected.min(items.len() - 1)));
+    }
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_symbol("> ")
+        .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_auth(frame: &mut Frame<'_>, area: Rect, app: &OnboardingTuiApp) {
+    let provider = app.selected_provider.as_ref();
+    let title = provider
+        .map(|provider| format!("Authenticate {}", provider.title))
+        .unwrap_or_else(|| "Authenticate provider".into());
+    let body = provider
+        .map(|provider| {
+            let masked = "*".repeat(app.credential_input.chars().count());
+            let instruction = match provider.credential_kind {
+                CredentialKind::OAuth => "Use the existing Holon-owned OAuth profile or external Codex fallback. If it is missing, import credentials with `holon config credentials set --kind oauth --stdin openai-codex` or run `codex login`, then rerun onboard.",
+                CredentialKind::ApiKey => {
+                    "Enter API key. The value is masked and stored in the local Holon credential store."
+                }
+                _ => "Enter credential material if required.",
+            };
+            Text::from(vec![
+                Line::from(format!("profile: {}", provider.credential_profile)),
+                Line::from(format!("kind: {}", provider.credential_kind.as_str())),
+                Line::from(format!(
+                    "configured: {}",
+                    if provider.credential_configured { "yes" } else { "no" }
+                )),
+                Line::from(""),
+                Line::from(instruction),
+                Line::from(""),
+                if provider.credential_kind == CredentialKind::OAuth {
+                    Line::from("credential input: handled by OAuth profile; nothing is echoed here")
+                } else {
+                    Line::from(format!("credential: {masked}"))
+                },
+            ])
+        })
+        .unwrap_or_else(|| Text::from("No provider selected."));
+    frame.render_widget(
+        Paragraph::new(body)
+            .wrap(Wrap { trim: true })
+            .block(Block::default().borders(Borders::ALL).title(title)),
+        area,
+    );
+}
+
+fn draw_confirm(frame: &mut Frame<'_>, area: Rect, app: &OnboardingTuiApp) {
+    let provider = app.selected_provider.as_ref();
+    let model = app.selected_model.as_ref();
+    let text = Text::from(vec![
+        Line::from("Review changes. Press Enter to write config, ← to go back, Esc to cancel."),
+        Line::from(""),
+        Line::from(format!(
+            "provider: {}",
+            provider
+                .map(|provider| provider.id.as_str().to_string())
+                .unwrap_or_else(|| "-".into())
+        )),
+        Line::from(format!(
+            "credential profile: {}",
+            provider
+                .map(|provider| provider.credential_profile.clone())
+                .unwrap_or_else(|| "-".into())
+        )),
+        Line::from(format!(
+            "default model: {}",
+            model
+                .map(|model| model.model.as_string())
+                .unwrap_or_else(|| "-".into())
+        )),
+        Line::from(format!("search: {}", app.selected_search.label())),
+        Line::from(""),
+        Line::from("Secret material is never printed in this summary."),
+    ]);
+    frame.render_widget(
+        Paragraph::new(text)
+            .wrap(Wrap { trim: true })
+            .block(Block::default().borders(Borders::ALL).title("Confirm")),
+        area,
+    );
+}
+
+fn step_label(step: Step) -> &'static str {
+    match step {
+        Step::Provider => "Step 1/5 · model provider",
+        Step::Auth => "Step 2/5 · authentication",
+        Step::Model => "Step 3/5 · default model",
+        Step::Search => "Step 4/5 · search",
+        Step::Confirm => "Step 5/5 · confirm",
+    }
+}
+
+fn centered(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+struct TerminalGuard {
+    raw_mode_enabled: bool,
+    alternate_screen_enabled: bool,
+}
+
+impl TerminalGuard {
+    fn new() -> Self {
+        Self {
+            raw_mode_enabled: false,
+            alternate_screen_enabled: false,
+        }
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        if self.raw_mode_enabled {
+            let _ = disable_raw_mode();
+        }
+        if self.alternate_screen_enabled {
+            let mut stdout: Stdout = io::stdout();
+            let _ = execute!(stdout, LeaveAlternateScreen);
+        }
+    }
+}

--- a/src/onboarding_tui.rs
+++ b/src/onboarding_tui.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const DUCKDUCKGO_SEARCH_PROVIDER_ID: &str = "duckduckgo";
 
 pub fn run_onboarding_tui(config: AppConfig) -> Result<OnboardingApplySummary> {
     let mut app = OnboardingTuiApp::new(&config);
@@ -122,7 +123,7 @@ impl OnboardingTuiApp {
         let search_choices = onboarding_search_choices(config);
         let selected_search = if !config.web_config.search.enabled {
             OnboardingSearchSelection::Disabled
-        } else if config.web_config.search.provider == "duck_duck_go" {
+        } else if config.web_config.search.provider == DUCKDUCKGO_SEARCH_PROVIDER_ID {
             OnboardingSearchSelection::DuckDuckGo
         } else {
             OnboardingSearchSelection::BuiltInProvider
@@ -199,6 +200,14 @@ impl OnboardingTuiApp {
                     .get(self.provider_index)
                     .cloned()
                     .context("no model provider choices are available")?;
+                if self
+                    .selected_provider
+                    .as_ref()
+                    .is_some_and(|selected| selected.id != provider.id)
+                {
+                    self.credential_input.clear();
+                    self.credential_material = None;
+                }
                 self.models = self
                     .models_by_provider
                     .get(&provider.id)


### PR DESCRIPTION
## Summary

- replace the old `holon onboard` line-prompt repair flow with a full-screen selectable TUI wizard when stdin/stdout are TTYs
- add shared onboarding wizard data/apply helpers for provider, default model, search, and credential-profile configuration
- keep `holon onboard --json` and non-TTY behavior on the existing secret-safe JSON diagnostic path
- add focused tests for wizard choices and secret-safe config/credential writes

## OAuth note

The current repository has Holon-owned `openai-codex` OAuth credential storage/refresh, but no initial OAuth login initiation command in this branch. The TUI therefore treats OAuth as an existing Holon profile/external fallback step and does not ask users to paste OAuth secrets; if the profile is missing, it tells users to import credentials or run the external fallback before rerunning onboard.

## Verification

- `cargo fmt --all -- --check`
- `cargo test onboarding_wizard --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
