### PR TITLE
fix: suppress duplicate work item tool display

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -791,6 +791,10 @@ impl PresentationReducer {
                         i += 1;
                         continue;
                     }
+                    if is_successful_work_item_tool_event(event) {
+                        i += 1;
+                        continue;
+                    }
                     if is_apply_patch_tool_event(event) {
                         for item in apply_patch_items(event) {
                             items.push(TimedItem::from_event(item, event));
@@ -1440,6 +1444,16 @@ fn is_exec_command_tool_event(event: &ProjectionEventRecord) -> bool {
 
 fn is_apply_patch_tool_event(event: &ProjectionEventRecord) -> bool {
     event.payload.get("tool_name").and_then(Value::as_str) == Some("ApplyPatch")
+}
+
+fn is_successful_work_item_tool_event(event: &ProjectionEventRecord) -> bool {
+    if event.kind != "tool_executed" {
+        return false;
+    }
+    matches!(
+        event.payload.get("tool_name").and_then(Value::as_str),
+        Some("CreateWorkItem" | "UpdateWorkItem" | "CompleteWorkItem")
+    )
 }
 
 fn apply_patch_items(event: &ProjectionEventRecord) -> Vec<PresentationItem> {
@@ -2428,7 +2442,7 @@ mod tests {
     }
 
     #[test]
-    fn reducer_does_not_render_non_exec_tool_as_command() {
+    fn reducer_suppresses_successful_work_item_tool_bookkeeping() {
         let event = make_event(
             "tool_executed",
             "Updated work item: UpdateWorkItem",
@@ -2441,11 +2455,30 @@ mod tests {
         let mut reducer = PresentationReducer::new();
         let items = reducer.reduce(&[event]);
 
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn reducer_keeps_failed_work_item_tool_bookkeeping() {
+        let event = make_event(
+            "tool_execution_failed",
+            "Update work item failed: missing work item",
+            json!({
+                "tool_name": "UpdateWorkItem",
+                "error": "missing work item"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[event]);
+
         assert_eq!(items.len(), 1);
-        assert!(!matches!(
-            items[0].item,
-            PresentationItem::CommandExecuted { .. }
-        ));
+        match &items[0].item {
+            PresentationItem::ToolAction { summary } => {
+                assert!(summary.contains("Update work item failed"));
+            }
+            other => panic!("expected ToolAction, got {:?}", other),
+        }
     }
 
     #[test]
@@ -2680,6 +2713,51 @@ mod tests {
                 }
                 other => panic!("expected WorkItemBookkeeping, got {:?}", other),
             }
+        }
+    }
+
+    #[test]
+    fn reducer_suppresses_duplicate_update_work_item_tool_event() {
+        let updated = make_event(
+            "work_item_written",
+            "work item updated",
+            json!({
+                "action": "updated",
+                "record": {
+                    "id": "wi-1",
+                    "agent_id": "default",
+                    "workspace_id": "agent_home",
+                    "objective": "deduplicate work item update display",
+                    "state": "open",
+                    "plan_status": "ready",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:01Z"
+                }
+            }),
+        );
+        let tool_event = make_event(
+            "tool_executed",
+            "Updated work item: UpdateWorkItem",
+            json!({
+                "tool_name": "UpdateWorkItem",
+                "summary": "updated work item"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[updated, tool_event]);
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::WorkItemBookkeeping {
+                transition,
+                summary,
+                ..
+            } => {
+                assert_eq!(*transition, WorkItemTransition::Updated);
+                assert_eq!(summary, "deduplicate work item update display");
+            }
+            other => panic!("expected WorkItemBookkeeping, got {:?}", other),
         }
     }
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1450,6 +1450,9 @@ fn is_successful_work_item_tool_event(event: &ProjectionEventRecord) -> bool {
     if event.kind != "tool_executed" {
         return false;
     }
+    if event.payload.get("status").and_then(Value::as_str) != Some("success") {
+        return false;
+    }
     matches!(
         event.payload.get("tool_name").and_then(Value::as_str),
         Some("CreateWorkItem" | "UpdateWorkItem" | "CompleteWorkItem")
@@ -2448,6 +2451,7 @@ mod tests {
             "Updated work item: UpdateWorkItem",
             json!({
                 "tool_name": "UpdateWorkItem",
+                "status": "success",
                 "summary": "updated work item"
             }),
         );
@@ -2456,6 +2460,28 @@ mod tests {
         let items = reducer.reduce(&[event]);
 
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn reducer_keeps_error_status_work_item_tool_bookkeeping() {
+        let event = make_event(
+            "tool_executed",
+            "UpdateWorkItem error validation_failed: missing work item",
+            json!({
+                "tool_name": "UpdateWorkItem",
+                "status": "error",
+                "error": "missing work item"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[event]);
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::ToolAction { .. } => {}
+            other => panic!("expected ToolAction, got {:?}", other),
+        }
     }
 
     #[test]
@@ -2740,6 +2766,7 @@ mod tests {
             "Updated work item: UpdateWorkItem",
             json!({
                 "tool_name": "UpdateWorkItem",
+                "status": "success",
                 "summary": "updated work item"
             }),
         );

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -1587,8 +1587,8 @@ mod tests {
             sample_event(
                 "tool_executed",
                 json!({
-                    "tool_name": "UpdateWorkItem",
-                    "summary": "updated work item"
+                    "tool_name": "TaskStatus",
+                    "summary": "inspected task status"
                 }),
             ),
             &writer,


### PR DESCRIPTION
## Summary
- suppress successful CreateWorkItem/UpdateWorkItem/CompleteWorkItem tool_executed records from normal presentation output
- keep rich work_item_written lifecycle events as the visible work item bookkeeping source
- keep failed work item tool executions visible and add regression coverage for the duplicate UpdateWorkItem case

Fixes #1557

## Verification
- cargo test -p holon presentation
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
