### PR TITLE
feat: improve onboarding provider setup

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,10 @@
 use std::{
     fs,
+    io::{Read, Write},
+    net::TcpListener,
     path::{Path, PathBuf},
     process::Command,
+    time::Duration,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -16,6 +19,7 @@ pub struct CodexCliCredential {
     pub access_token: String,
     pub account_id: String,
     pub expires_at: Option<DateTime<Utc>>,
+    pub refreshed_at: Option<DateTime<Utc>>,
     pub source: String,
 }
 
@@ -41,6 +45,12 @@ struct TokenData {
 pub struct RefreshedCodexOAuthProfile {
     pub material: String,
     pub credential: CodexCliCredential,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexOAuthLoginResult {
+    pub material: String,
+    pub account_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,18 +80,24 @@ pub struct CodexOAuthRefreshFailure {
 
 pub fn load_codex_cli_credential(codex_home: &Path) -> Result<CodexCliCredential> {
     let home = canonical_or_original(codex_home);
+    let mut candidates = Vec::new();
     if let Ok(auth) = load_auth_from_file(&home) {
-        return auth_to_credential(auth, "file");
+        candidates.push(auth_to_credential(auth, "file")?);
     }
     if cfg!(target_os = "macos") {
         if let Ok(auth) = load_auth_from_macos_keychain(&home) {
-            return auth_to_credential(auth, "keychain");
+            candidates.push(auth_to_credential(auth, "keychain")?);
         }
     }
-    Err(anyhow!(
-        "no Codex CLI credentials found in {} or the local keychain; run `codex login` first",
-        home.display()
-    ))
+    candidates
+        .into_iter()
+        .max_by_key(codex_cli_credential_freshness_key)
+        .ok_or_else(|| {
+            anyhow!(
+                "no Holon OpenAI Codex OAuth credential or Codex CLI fallback credential found in {}; run Holon onboarding login for openai-codex, or run `codex login` to configure the external fallback",
+                home.display()
+            )
+        })
 }
 
 pub fn load_codex_oauth_profile_credential(
@@ -170,8 +186,86 @@ struct RefreshResponse {
 }
 
 const CODEX_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CODEX_OAUTH_ISSUER: &str = "https://auth.openai.com";
+const CODEX_OAUTH_ISSUER_OVERRIDE_ENV_VAR: &str = "CODEX_OAUTH_ISSUER_OVERRIDE";
 const CODEX_REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 const CODEX_REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
+const CODEX_OAUTH_CALLBACK_PORT: u16 = 1455;
+const CODEX_OAUTH_CALLBACK_FALLBACK_PORT: u16 = 1457;
+
+pub fn run_codex_oauth_login_profile_material() -> Result<CodexOAuthLoginResult> {
+    run_codex_oauth_login_profile_material_with_browser(true)
+}
+
+fn run_codex_oauth_login_profile_material_with_browser(
+    open_browser: bool,
+) -> Result<CodexOAuthLoginResult> {
+    let issuer = std::env::var(CODEX_OAUTH_ISSUER_OVERRIDE_ENV_VAR)
+        .unwrap_or_else(|_| CODEX_OAUTH_ISSUER.to_string());
+    let listener = bind_codex_oauth_callback_listener()?;
+    listener
+        .set_nonblocking(false)
+        .context("failed to configure Codex OAuth callback listener")?;
+    let port = listener
+        .local_addr()
+        .context("failed to read Codex OAuth callback listener address")?
+        .port();
+    let redirect_uri = format!("http://localhost:{port}/auth/callback");
+    let pkce = generate_codex_pkce();
+    let state = generate_oauth_random_string();
+    let auth_url = build_codex_oauth_authorize_url(&issuer, &redirect_uri, &pkce, &state);
+
+    if open_browser {
+        open_url_in_browser(&auth_url);
+    }
+    eprintln!(
+        "Starting Holon OpenAI Codex OAuth login on http://localhost:{port}.\nIf your browser did not open, navigate to this URL:\n\n{auth_url}\n"
+    );
+
+    loop {
+        let (mut stream, _) = listener
+            .accept()
+            .context("failed to receive Codex OAuth callback")?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(15)))
+            .context("failed to configure Codex OAuth callback read timeout")?;
+        let mut buffer = [0_u8; 8192];
+        let size = stream
+            .read(&mut buffer)
+            .context("failed to read Codex OAuth callback request")?;
+        let request = String::from_utf8_lossy(&buffer[..size]);
+        let Some(target) = parse_http_get_target(&request) else {
+            write_http_response(&mut stream, 400, "Bad Request", "Bad Request")?;
+            continue;
+        };
+
+        match handle_codex_oauth_callback(
+            target,
+            &issuer,
+            &redirect_uri,
+            &pkce.code_verifier,
+            &state,
+        ) {
+            Ok(Some(result)) => {
+                write_http_response(
+                    &mut stream,
+                    200,
+                    "OK",
+                    "Holon OpenAI Codex login complete. You can close this tab and return to Holon.",
+                )?;
+                return Ok(result);
+            }
+            Ok(None) => {
+                write_http_response(&mut stream, 404, "Not Found", "Not Found")?;
+            }
+            Err(error) => {
+                let body = format!("Holon OpenAI Codex login failed: {error}");
+                write_http_response(&mut stream, 400, "Bad Request", &body)?;
+                return Err(error);
+            }
+        }
+    }
+}
 
 async fn request_codex_oauth_refresh(
     client: &reqwest::Client,
@@ -207,16 +301,13 @@ async fn request_codex_oauth_refresh(
     let kind = classify_refresh_failure_kind(&body);
     let message = match kind {
         CodexOAuthRefreshFailureKind::Expired => {
-            "OpenAI Codex refresh token expired; run Holon-managed openai-codex login again."
-                .to_string()
+            "OpenAI Codex refresh token expired; run Holon onboarding login for openai-codex again.".to_string()
         }
         CodexOAuthRefreshFailureKind::Reused => {
-            "OpenAI Codex refresh token was reused; run Holon-managed openai-codex login again."
-                .to_string()
+            "OpenAI Codex refresh token was reused; run Holon onboarding login for openai-codex again.".to_string()
         }
         CodexOAuthRefreshFailureKind::Revoked => {
-            "OpenAI Codex refresh token was revoked; run Holon-managed openai-codex login again."
-                .to_string()
+            "OpenAI Codex refresh token was revoked; run Holon onboarding login for openai-codex again.".to_string()
         }
         CodexOAuthRefreshFailureKind::Other => {
             let hint = try_parse_refresh_error_message(&body).unwrap_or_else(|| body.clone());
@@ -226,8 +317,209 @@ async fn request_codex_oauth_refresh(
     Err(CodexOAuthRefreshFailure { kind, message })
 }
 
+#[derive(Debug, Clone)]
+struct CodexPkce {
+    code_verifier: String,
+    code_challenge: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LoginTokenResponse {
+    id_token: String,
+    access_token: String,
+    refresh_token: String,
+}
+
+fn bind_codex_oauth_callback_listener() -> Result<TcpListener> {
+    TcpListener::bind(("127.0.0.1", CODEX_OAUTH_CALLBACK_PORT))
+        .or_else(|_| TcpListener::bind(("127.0.0.1", CODEX_OAUTH_CALLBACK_FALLBACK_PORT)))
+        .context("failed to bind OpenAI Codex OAuth callback listener")
+}
+
+fn generate_codex_pkce() -> CodexPkce {
+    let code_verifier = generate_oauth_random_string();
+    let digest = Sha256::digest(code_verifier.as_bytes());
+    let code_challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+    CodexPkce {
+        code_verifier,
+        code_challenge,
+    }
+}
+
+fn generate_oauth_random_string() -> String {
+    let mut bytes = Vec::with_capacity(64);
+    for _ in 0..4 {
+        bytes.extend_from_slice(uuid::Uuid::new_v4().as_bytes());
+    }
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn build_codex_oauth_authorize_url(
+    issuer: &str,
+    redirect_uri: &str,
+    pkce: &CodexPkce,
+    state: &str,
+) -> String {
+    let query = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("response_type", "code")
+        .append_pair("client_id", CODEX_OAUTH_CLIENT_ID)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair(
+            "scope",
+            "openid profile email offline_access api.connectors.read api.connectors.invoke",
+        )
+        .append_pair("code_challenge", &pkce.code_challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("id_token_add_organizations", "true")
+        .append_pair("codex_cli_simplified_flow", "true")
+        .append_pair("state", state)
+        .append_pair("originator", "codex_cli_rs")
+        .finish();
+    format!("{}/oauth/authorize?{query}", issuer.trim_end_matches('/'))
+}
+
+fn open_url_in_browser(url: &str) {
+    #[cfg(target_os = "macos")]
+    let command = ("open", vec![url]);
+    #[cfg(target_os = "linux")]
+    let command = ("xdg-open", vec![url]);
+    #[cfg(target_os = "windows")]
+    let command = ("cmd", vec!["/C", "start", "", url]);
+
+    #[allow(unused_variables)]
+    let _ = Command::new(command.0).args(command.1).status();
+}
+
+fn parse_http_get_target(request: &str) -> Option<&str> {
+    let line = request.lines().next()?;
+    let mut parts = line.split_whitespace();
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some("GET"), Some(target), Some(_version)) => Some(target),
+        _ => None,
+    }
+}
+
+fn handle_codex_oauth_callback(
+    target: &str,
+    issuer: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+    state: &str,
+) -> Result<Option<CodexOAuthLoginResult>> {
+    let parsed = url::Url::parse(&format!("http://localhost{target}"))
+        .context("failed to parse OpenAI Codex OAuth callback URL")?;
+    if parsed.path() != "/auth/callback" {
+        return Ok(None);
+    }
+    let params = parsed
+        .query_pairs()
+        .into_owned()
+        .collect::<std::collections::BTreeMap<_, _>>();
+    if params.get("state").map(String::as_str) != Some(state) {
+        anyhow::bail!("OpenAI Codex OAuth callback state did not match");
+    }
+    if let Some(error) = params.get("error") {
+        let description = params
+            .get("error_description")
+            .map(String::as_str)
+            .unwrap_or("no description");
+        anyhow::bail!("OpenAI Codex OAuth callback returned {error}: {description}");
+    }
+    let code = params
+        .get("code")
+        .filter(|code| !code.trim().is_empty())
+        .context("OpenAI Codex OAuth callback did not include an authorization code")?;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to start OpenAI Codex OAuth token exchange runtime")?;
+    let tokens = runtime.block_on(exchange_codex_oauth_code_for_tokens(
+        issuer,
+        redirect_uri,
+        code_verifier,
+        code,
+    ))?;
+    Ok(Some(codex_oauth_tokens_to_login_result(tokens)?))
+}
+
+async fn exchange_codex_oauth_code_for_tokens(
+    issuer: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+    code: &str,
+) -> Result<LoginTokenResponse> {
+    let endpoint = format!("{}/oauth/token", issuer.trim_end_matches('/'));
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", "authorization_code")
+        .append_pair("code", code)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("client_id", CODEX_OAUTH_CLIENT_ID)
+        .append_pair("code_verifier", code_verifier)
+        .finish();
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .context("failed to exchange OpenAI Codex OAuth code for tokens")?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "OpenAI Codex OAuth token exchange failed with HTTP {status}: {}",
+            try_parse_refresh_error_message(&body).unwrap_or(body)
+        );
+    }
+    response
+        .json::<LoginTokenResponse>()
+        .await
+        .context("failed to parse OpenAI Codex OAuth token response")
+}
+
+fn codex_oauth_tokens_to_login_result(tokens: LoginTokenResponse) -> Result<CodexOAuthLoginResult> {
+    let account_id = extract_account_id_from_access_token(&tokens.access_token)
+        .or_else(|| extract_account_id_from_id_token(&Value::String(tokens.id_token.clone())));
+    let auth = AuthDotJson {
+        tokens: Some(TokenData {
+            access_token: tokens.access_token,
+            refresh_token: tokens.refresh_token,
+            account_id: account_id.clone(),
+            id_token: Some(Value::String(tokens.id_token)),
+        }),
+        last_refresh: Some(Utc::now()),
+    };
+    let material = serde_json::to_string(&auth)
+        .context("failed to serialize OpenAI Codex OAuth credential")?;
+    Ok(CodexOAuthLoginResult {
+        material,
+        account_id,
+    })
+}
+
+fn write_http_response(
+    stream: &mut std::net::TcpStream,
+    status: u16,
+    reason: &str,
+    body: &str,
+) -> Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .context("failed to write OpenAI Codex OAuth callback response")?;
+    stream
+        .flush()
+        .context("failed to flush OpenAI Codex OAuth callback response")
+}
+
 pub fn codex_cli_auth_file_exists(codex_home: &Path) -> bool {
-    auth_file_path(&canonical_or_original(codex_home)).is_file()
+    let home = canonical_or_original(codex_home);
+    auth_file_path(&home).is_file()
+        || (cfg!(target_os = "macos") && load_auth_from_macos_keychain(&home).is_ok())
 }
 
 fn load_auth_from_file(codex_home: &Path) -> Result<AuthDotJson> {
@@ -282,8 +574,20 @@ fn auth_to_credential(auth: AuthDotJson, source: &str) -> Result<CodexCliCredent
         access_token: tokens.access_token,
         account_id,
         expires_at,
+        refreshed_at: auth.last_refresh,
         source: source.to_string(),
     })
+}
+
+fn codex_cli_credential_freshness_key(
+    credential: &CodexCliCredential,
+) -> (Option<DateTime<Utc>>, Option<DateTime<Utc>>, u8) {
+    let source_rank = match credential.source.as_str() {
+        "keychain" => 2,
+        "file" => 1,
+        _ => 0,
+    };
+    (credential.expires_at, credential.refreshed_at, source_rank)
 }
 
 fn auth_file_path(codex_home: &Path) -> PathBuf {
@@ -474,6 +778,29 @@ mod tests {
 
         assert_eq!(credential.account_id, "acct_id_token");
         assert_eq!(credential.source, "file");
+    }
+
+    #[test]
+    fn codex_oauth_login_result_material_is_profile_compatible() {
+        let result = codex_oauth_tokens_to_login_result(LoginTokenResponse {
+            id_token: make_token(json!({
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": "acct_login"
+                }
+            })),
+            access_token: make_token(json!({
+                "exp": 1_900_000_000
+            })),
+            refresh_token: "refresh_login".to_string(),
+        })
+        .expect("login material should serialize");
+
+        let credential = load_codex_oauth_profile_credential(&result.material, "openai-codex")
+            .expect("login material should parse as a Holon OAuth profile");
+
+        assert_eq!(result.account_id.as_deref(), Some("acct_login"));
+        assert_eq!(credential.account_id, "acct_login");
+        assert_eq!(credential.source, "credential_profile:openai-codex");
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -94,7 +94,7 @@ pub fn load_codex_cli_credential(codex_home: &Path) -> Result<CodexCliCredential
         .max_by_key(codex_cli_credential_freshness_key)
         .ok_or_else(|| {
             anyhow!(
-                "no Holon OpenAI Codex OAuth credential or Codex CLI fallback credential found in {}; run Holon onboarding login for openai-codex, or run `codex login` to configure the external fallback",
+                "no Codex CLI credential found in {}; run `codex login` to configure the external fallback",
                 home.display()
             )
         })
@@ -430,16 +430,16 @@ fn handle_codex_oauth_callback(
         .filter(|code| !code.trim().is_empty())
         .context("OpenAI Codex OAuth callback did not include an authorization code")?;
 
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("failed to start OpenAI Codex OAuth token exchange runtime")?;
-    let tokens = runtime.block_on(exchange_codex_oauth_code_for_tokens(
-        issuer,
-        redirect_uri,
-        code_verifier,
-        code,
-    ))?;
+    let exchange = exchange_codex_oauth_code_for_tokens(issuer, redirect_uri, code_verifier, code);
+    let tokens = if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(|| handle.block_on(exchange))
+    } else {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to start OpenAI Codex OAuth token exchange runtime")?;
+        runtime.block_on(exchange)
+    }?;
     Ok(Some(codex_oauth_tokens_to_login_result(tokens)?))
 }
 

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
+    auth::load_codex_cli_credential,
     config::{
         built_in_provider_default_config, credential_store_path, load_persisted_config_at,
         save_persisted_config_at, set_credential_profile_at, validate_provider_config, AppConfig,
@@ -120,16 +121,16 @@ pub struct OnboardingWizardDraft {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OnboardingSearchSelection {
     Disabled,
-    BuiltInProvider,
-    DuckDuckGo,
+    Auto,
+    ManagedDuckDuckGo,
 }
 
 impl OnboardingSearchSelection {
     pub fn label(self) -> &'static str {
         match self {
             Self::Disabled => "Disable WebSearch",
-            Self::BuiltInProvider => "Use model provider built-in search",
-            Self::DuckDuckGo => "Use DuckDuckGo managed search",
+            Self::Auto => "Auto: prefer native search, fallback to managed WebSearch",
+            Self::ManagedDuckDuckGo => "Managed WebSearch: DuckDuckGo",
         }
     }
 }
@@ -142,6 +143,8 @@ pub struct OnboardingProviderChoice {
     pub credential_kind: CredentialKind,
     pub credential_profile: String,
     pub credential_configured: bool,
+    pub codex_home: Option<PathBuf>,
+    pub configured: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -149,6 +152,7 @@ pub struct OnboardingModelChoice {
     pub model: ModelRef,
     pub title: String,
     pub detail: String,
+    pub custom: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -169,22 +173,11 @@ pub struct OnboardingApplySummary {
 }
 
 pub fn onboarding_provider_choices(config: &AppConfig) -> Vec<OnboardingProviderChoice> {
-    [
-        ProviderId::openai_codex(),
-        ProviderId::openai(),
-        ProviderId::anthropic(),
-        ProviderId::gemini(),
-    ]
-    .into_iter()
-    .filter_map(|id| {
-        config.providers.get(&id).map(|provider| {
-            let title = match id.as_str() {
-                ProviderId::OPENAI_CODEX => "OpenAI Codex".to_string(),
-                ProviderId::OPENAI => "OpenAI".to_string(),
-                ProviderId::ANTHROPIC => "Anthropic".to_string(),
-                ProviderId::GEMINI => "Gemini".to_string(),
-                other => other.to_string(),
-            };
+    config
+        .providers
+        .values()
+        .filter(|provider| should_show_onboarding_provider(config, &provider.id))
+        .map(|provider| {
             let auth = match provider.auth.kind {
                 CredentialKind::OAuth => "OAuth login/profile",
                 CredentialKind::ApiKey => "API key",
@@ -192,36 +185,143 @@ pub fn onboarding_provider_choices(config: &AppConfig) -> Vec<OnboardingProvider
                 _ => provider.auth.kind.as_str(),
             };
             OnboardingProviderChoice {
-                id: id.clone(),
-                title,
+                id: provider.id.clone(),
+                title: provider_title(&provider.id),
                 detail: format!("{} · {}", provider.transport.as_str(), auth),
                 credential_kind: provider.auth.kind,
                 credential_profile: provider
                     .auth
                     .profile
                     .clone()
-                    .unwrap_or_else(|| id.as_str().to_string()),
-                credential_configured: provider.has_configured_credential()
-                    || provider.auth.source == CredentialSource::None,
+                    .unwrap_or_else(|| provider.id.as_str().to_string()),
+                credential_configured: provider_credential_configured(provider),
+                codex_home: provider.codex_home.clone(),
+                configured: config.stored_config.providers.contains_key(&provider.id),
             }
         })
-    })
-    .collect()
+        .collect()
+}
+
+fn should_show_onboarding_provider(config: &AppConfig, provider_id: &ProviderId) -> bool {
+    canonical_onboarding_provider_id(provider_id)
+        .map(|canonical_id| {
+            canonical_id == *provider_id || !config.providers.contains_key(&canonical_id)
+        })
+        .unwrap_or(true)
+}
+
+fn canonical_onboarding_provider_id(provider_id: &ProviderId) -> Option<ProviderId> {
+    let id = provider_id.as_str();
+    for suffix in ["-openai", "-anthropic"] {
+        if let Some(base) = id.strip_suffix(suffix) {
+            return ProviderId::parse(base).ok();
+        }
+    }
+    None
+}
+
+fn provider_title(provider_id: &ProviderId) -> String {
+    match provider_id.as_str() {
+        ProviderId::OPENAI_CODEX => "OpenAI Codex".to_string(),
+        ProviderId::OPENAI => "OpenAI".to_string(),
+        ProviderId::ANTHROPIC => "Anthropic".to_string(),
+        ProviderId::GEMINI => "Gemini".to_string(),
+        other => other
+            .split(['-', '_'])
+            .filter(|part| !part.is_empty())
+            .map(|part| {
+                let mut chars = part.chars();
+                chars
+                    .next()
+                    .map(|first| first.to_uppercase().chain(chars).collect::<String>())
+                    .unwrap_or_default()
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+    }
+}
+
+fn provider_credential_configured(provider: &ProviderRuntimeConfig) -> bool {
+    provider.has_configured_credential()
+        || provider.auth.source == CredentialSource::None
+        || (provider.id.is_openai_codex()
+            && provider.auth.external.as_deref() == Some("codex_cli")
+            && provider
+                .codex_home
+                .as_deref()
+                .map(|home| load_codex_cli_credential(home).is_ok())
+                .unwrap_or(false))
 }
 
 pub fn onboarding_model_choices(
     config: &AppConfig,
     provider: &ProviderId,
 ) -> Vec<OnboardingModelChoice> {
-    let mut models = RuntimeModelCatalogShim::choices(config, provider);
+    let mut models = configured_model_choices(config, provider);
+    for choice in RuntimeModelCatalogShim::choices(config, provider) {
+        if !models.iter().any(|existing| existing.model == choice.model) {
+            models.push(choice);
+        }
+    }
     if models.is_empty() {
         models.push(OnboardingModelChoice {
             model: ModelRef::new(provider.clone(), "unknown"),
             title: format!("{}/unknown", provider.as_str()),
             detail: "custom provider model placeholder".into(),
+            custom: false,
         });
     }
+    models.push(OnboardingModelChoice {
+        model: ModelRef::new(provider.clone(), "__custom__"),
+        title: "Custom model…".into(),
+        detail: format!("enter any {} model id", provider.as_str()),
+        custom: true,
+    });
     models
+}
+
+fn configured_model_choices(
+    config: &AppConfig,
+    provider: &ProviderId,
+) -> Vec<OnboardingModelChoice> {
+    let mut models = Vec::new();
+    push_configured_model_choice(
+        &mut models,
+        &config.default_model,
+        provider,
+        "current default model",
+    );
+    for model in &config.fallback_models {
+        push_configured_model_choice(&mut models, model, provider, "configured fallback model");
+    }
+    let mut override_models = config
+        .validated_model_overrides
+        .keys()
+        .filter(|model| &model.provider == provider)
+        .cloned()
+        .collect::<Vec<_>>();
+    override_models.sort_by_key(ModelRef::as_string);
+    for model in override_models {
+        push_configured_model_choice(&mut models, &model, provider, "configured model override");
+    }
+    models
+}
+
+fn push_configured_model_choice(
+    models: &mut Vec<OnboardingModelChoice>,
+    model: &ModelRef,
+    provider: &ProviderId,
+    detail: &str,
+) {
+    if &model.provider != provider || models.iter().any(|choice| choice.model == *model) {
+        return;
+    }
+    models.push(OnboardingModelChoice {
+        model: model.clone(),
+        title: model.as_string(),
+        detail: detail.into(),
+        custom: false,
+    });
 }
 
 struct RuntimeModelCatalogShim;
@@ -254,6 +354,7 @@ impl RuntimeModelCatalogShim {
                     title: format!("{}{}", entry.display_name, preferred_suffix),
                     detail: entry.model_ref.as_string(),
                     model: entry.model_ref,
+                    custom: false,
                 }
             })
             .collect()
@@ -261,26 +362,26 @@ impl RuntimeModelCatalogShim {
 }
 
 pub fn onboarding_search_choices(config: &AppConfig) -> Vec<OnboardingSearchChoice> {
-    let builtin_detail = if config
+    let native_detail = if config
         .providers
         .get(&config.default_model.provider)
         .and_then(|provider| provider.builtin_web_search.as_ref())
         .is_some()
     {
-        "provider-declared native search when supported by the selected model"
+        "current provider declares native search; runtime still probes the active model"
     } else {
-        "enable provider-declared search for providers that support it"
+        "current provider has no native search declaration; managed WebSearch remains available"
     };
     vec![
         OnboardingSearchChoice {
-            selection: OnboardingSearchSelection::BuiltInProvider,
-            title: OnboardingSearchSelection::BuiltInProvider.label().into(),
-            detail: builtin_detail.into(),
+            selection: OnboardingSearchSelection::Auto,
+            title: OnboardingSearchSelection::Auto.label().into(),
+            detail: format!("{native_detail}; DuckDuckGo is used as the default managed fallback"),
         },
         OnboardingSearchChoice {
-            selection: OnboardingSearchSelection::DuckDuckGo,
-            title: OnboardingSearchSelection::DuckDuckGo.label().into(),
-            detail: "free managed provider; no API key required".into(),
+            selection: OnboardingSearchSelection::ManagedDuckDuckGo,
+            title: OnboardingSearchSelection::ManagedDuckDuckGo.label().into(),
+            detail: "global agent WebSearch provider; no per-model native search".into(),
         },
         OnboardingSearchChoice {
             selection: OnboardingSearchSelection::Disabled,
@@ -346,13 +447,13 @@ pub fn apply_onboarding_wizard_draft(
         OnboardingSearchSelection::Disabled => {
             persisted.web.search.enabled = Some(false);
         }
-        OnboardingSearchSelection::BuiltInProvider => {
+        OnboardingSearchSelection::Auto => {
             persisted.web.search.enabled = Some(true);
             persisted.web.search.builtin_provider.enabled = Some(true);
             persisted.web.search.provider = Some("auto".into());
             persisted.web.search.providers.clear();
         }
-        OnboardingSearchSelection::DuckDuckGo => {
+        OnboardingSearchSelection::ManagedDuckDuckGo => {
             persisted.web.search.enabled = Some(true);
             persisted.web.search.builtin_provider.enabled = Some(false);
             persisted.web.search.provider = Some(DUCKDUCKGO_SEARCH_PROVIDER_ID.into());
@@ -871,8 +972,9 @@ mod tests {
             credential_store_path, load_credential_store_at, load_persisted_config_at,
             provider_registry_for_tests, AppConfig, ControlAuthMode, CredentialKind,
             CredentialSource, ModelRef, ProviderAuthConfig, ProviderConfigFile, ProviderId,
-            ProviderTransportKind,
+            ProviderRuntimeConfig, ProviderTransportKind,
         },
+        model_catalog::ModelRuntimeOverride,
         onboarding::{
             apply_onboarding_wizard_draft, credential_repair_plan, onboarding_model_choices,
             onboarding_provider_choices, onboarding_report, search_diagnostics,
@@ -1027,7 +1129,87 @@ mod tests {
 
     #[test]
     fn onboarding_wizard_choices_include_provider_auth_and_models() {
-        let config = test_config(None);
+        let mut config = test_config(None);
+        let custom_provider = ProviderId::parse("custom-openai").unwrap();
+        let custom_provider_config = ProviderRuntimeConfig {
+            id: custom_provider.clone(),
+            transport: ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://custom.example/v1".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::Env,
+                kind: CredentialKind::ApiKey,
+                env: Some("CUSTOM_OPENAI_API_KEY".into()),
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        };
+        config
+            .providers
+            .insert(custom_provider.clone(), custom_provider_config.clone());
+        config.stored_config.providers.insert(
+            custom_provider.clone(),
+            ProviderConfigFile {
+                transport: custom_provider_config.transport,
+                base_url: custom_provider_config.base_url.clone(),
+                auth: custom_provider_config.auth.clone(),
+                reasoning_effort: None,
+                builtin_web_search: None,
+            },
+        );
+        let deepseek = ProviderId::parse("deepseek").unwrap();
+        let deepseek_anthropic = ProviderId::parse("deepseek-anthropic").unwrap();
+        let deepseek_openai = ProviderId::parse("deepseek-openai").unwrap();
+        let deepseek_config = ProviderRuntimeConfig {
+            id: deepseek.clone(),
+            transport: ProviderTransportKind::AnthropicMessages,
+            base_url: "https://api.deepseek.com/anthropic".into(),
+            auth: ProviderAuthConfig {
+                source: CredentialSource::Env,
+                kind: CredentialKind::ApiKey,
+                env: Some("DEEPSEEK_API_KEY".into()),
+                profile: None,
+                external: None,
+            },
+            credential: None,
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        };
+        config
+            .providers
+            .insert(deepseek.clone(), deepseek_config.clone());
+        config.providers.insert(
+            deepseek_anthropic.clone(),
+            ProviderRuntimeConfig {
+                id: deepseek_anthropic.clone(),
+                ..deepseek_config.clone()
+            },
+        );
+        config.providers.insert(
+            deepseek_openai.clone(),
+            ProviderRuntimeConfig {
+                id: deepseek_openai.clone(),
+                transport: ProviderTransportKind::OpenAiChatCompletions,
+                base_url: "https://api.deepseek.com/v1".into(),
+                ..deepseek_config
+            },
+        );
+        config.default_model = ModelRef::parse("openai/custom-default").unwrap();
+        config.fallback_models = vec![ModelRef::parse("openai/custom-fallback").unwrap()];
+        config.validated_model_overrides.insert(
+            ModelRef::parse("openai/custom-override").unwrap(),
+            ModelRuntimeOverride::default(),
+        );
 
         let providers = onboarding_provider_choices(&config);
         let openai = providers
@@ -1038,16 +1220,36 @@ mod tests {
             .iter()
             .find(|provider| provider.id == ProviderId::openai_codex())
             .expect("openai-codex provider choice");
+        let custom = providers
+            .iter()
+            .find(|provider| provider.id == custom_provider)
+            .expect("custom provider choice");
 
         assert_eq!(openai.credential_kind, CredentialKind::ApiKey);
         assert_eq!(openai.credential_profile, "openai");
         assert_eq!(codex.credential_kind, CredentialKind::OAuth);
         assert_eq!(codex.credential_profile, "openai-codex");
+        assert_eq!(custom.credential_kind, CredentialKind::ApiKey);
+        assert_eq!(custom.credential_profile, "custom-openai");
+        assert!(custom.configured);
+        assert!(providers.iter().any(|provider| provider.id == deepseek));
+        assert!(!providers
+            .iter()
+            .any(|provider| provider.id == deepseek_anthropic));
+        assert!(!providers
+            .iter()
+            .any(|provider| provider.id == deepseek_openai));
 
         let models = onboarding_model_choices(&config, &ProviderId::openai());
+        assert_eq!(models[0].model.as_string(), "openai/custom-default");
+        assert_eq!(models[1].model.as_string(), "openai/custom-fallback");
+        assert_eq!(models[2].model.as_string(), "openai/custom-override");
         assert!(models
             .iter()
             .any(|choice| choice.model.as_string() == "openai/gpt-5.4"));
+        assert!(models
+            .iter()
+            .any(|choice| choice.custom && choice.title == "Custom model…"));
     }
 
     #[test]
@@ -1058,7 +1260,7 @@ mod tests {
             credential_profile: "openai".into(),
             credential_kind: CredentialKind::ApiKey,
             default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
-            search: OnboardingSearchSelection::DuckDuckGo,
+            search: OnboardingSearchSelection::ManagedDuckDuckGo,
         };
 
         let summary =
@@ -1068,7 +1270,7 @@ mod tests {
 
         assert_eq!(summary.provider, "openai");
         assert_eq!(summary.default_model, "openai/gpt-5.4");
-        assert_eq!(summary.search, "Use DuckDuckGo managed search");
+        assert_eq!(summary.search, "Managed WebSearch: DuckDuckGo");
         assert!(summary.credential_written);
         assert!(!format!("{summary:?}").contains("test-secret"));
 
@@ -1105,7 +1307,7 @@ mod tests {
             credential_profile: "openai".into(),
             credential_kind: CredentialKind::ApiKey,
             default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),
-            search: OnboardingSearchSelection::BuiltInProvider,
+            search: OnboardingSearchSelection::Auto,
         };
 
         let summary = apply_onboarding_wizard_draft(&config, &draft, None).unwrap();

--- a/src/onboarding_tui.rs
+++ b/src/onboarding_tui.rs
@@ -49,8 +49,7 @@ pub fn run_onboarding_tui(config: AppConfig) -> Result<OnboardingApplySummary> {
         terminal.draw(|frame| draw(frame, &app))?;
         if app.should_quit {
             drop(guard);
-            println!("\nOnboarding cancelled.");
-            std::process::exit(0);
+            anyhow::bail!("Onboarding cancelled.");
         }
         if let Some(draft) = app.completed_draft.clone() {
             terminal.show_cursor()?;
@@ -273,6 +272,7 @@ impl OnboardingTuiApp {
                     self.step = Step::CustomModel;
                 } else {
                     self.selected_model = Some(model);
+                    self.custom_model_input.clear();
                     self.step = Step::Search;
                 }
             }

--- a/src/onboarding_tui.rs
+++ b/src/onboarding_tui.rs
@@ -12,15 +12,16 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    layout::{Constraint, Direction, Layout, Position, Rect},
+    style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Frame, Terminal,
 };
 
 use crate::{
-    config::{AppConfig, CredentialKind, ProviderId},
+    auth::run_codex_oauth_login_profile_material,
+    config::{AppConfig, CredentialKind, ModelRef, ProviderId},
     onboarding::{
         apply_onboarding_wizard_draft, onboarding_model_choices, onboarding_provider_choices,
         onboarding_search_choices, OnboardingApplySummary, OnboardingModelChoice,
@@ -47,7 +48,9 @@ pub fn run_onboarding_tui(config: AppConfig) -> Result<OnboardingApplySummary> {
     loop {
         terminal.draw(|frame| draw(frame, &app))?;
         if app.should_quit {
-            anyhow::bail!("onboarding cancelled");
+            drop(guard);
+            println!("\nOnboarding cancelled.");
+            std::process::exit(0);
         }
         if let Some(draft) = app.completed_draft.clone() {
             terminal.show_cursor()?;
@@ -80,6 +83,7 @@ struct OnboardingTuiApp {
     selected_model: Option<OnboardingModelChoice>,
     selected_search: OnboardingSearchSelection,
     credential_input: String,
+    custom_model_input: String,
     credential_material: Option<String>,
     completed_draft: Option<OnboardingWizardDraft>,
     should_quit: bool,
@@ -91,6 +95,7 @@ enum Step {
     Provider,
     Auth,
     Model,
+    CustomModel,
     Search,
     Confirm,
 }
@@ -123,10 +128,12 @@ impl OnboardingTuiApp {
         let search_choices = onboarding_search_choices(config);
         let selected_search = if !config.web_config.search.enabled {
             OnboardingSearchSelection::Disabled
+        } else if config.web_config.search.builtin_provider_enabled {
+            OnboardingSearchSelection::Auto
         } else if config.web_config.search.provider == DUCKDUCKGO_SEARCH_PROVIDER_ID {
-            OnboardingSearchSelection::DuckDuckGo
+            OnboardingSearchSelection::ManagedDuckDuckGo
         } else {
-            OnboardingSearchSelection::BuiltInProvider
+            OnboardingSearchSelection::Auto
         };
         let search_index = search_choices
             .iter()
@@ -145,6 +152,7 @@ impl OnboardingTuiApp {
             selected_model: None,
             selected_search,
             credential_input: String::new(),
+            custom_model_input: String::new(),
             credential_material: None,
             completed_draft: None,
             should_quit: false,
@@ -158,7 +166,16 @@ impl OnboardingTuiApp {
             KeyCode::Backspace if self.step == Step::Auth => {
                 self.credential_input.pop();
             }
+            KeyCode::Backspace if self.step == Step::CustomModel => {
+                self.custom_model_input.pop();
+            }
+            KeyCode::Char('l') | KeyCode::Char('L') if self.can_run_codex_login() => {
+                self.run_codex_login_for_selected_provider()?;
+            }
             KeyCode::Char(ch) if self.step == Step::Auth => self.credential_input.push(ch),
+            KeyCode::Char(ch) if self.step == Step::CustomModel => {
+                self.custom_model_input.push(ch);
+            }
             KeyCode::Up => self.move_selection(-1),
             KeyCode::Down => self.move_selection(1),
             KeyCode::Enter => self.advance()?,
@@ -187,6 +204,8 @@ impl OnboardingTuiApp {
             Step::Provider => Step::Provider,
             Step::Auth => Step::Provider,
             Step::Model => Step::Auth,
+            Step::CustomModel => Step::Model,
+            Step::Search if !self.custom_model_input.trim().is_empty() => Step::CustomModel,
             Step::Search => Step::Model,
             Step::Confirm => Step::Search,
         };
@@ -224,7 +243,7 @@ impl OnboardingTuiApp {
                     .context("provider not selected")?;
                 if provider.credential_kind == CredentialKind::OAuth {
                     if !provider.credential_configured {
-                        self.status = "OAuth login initiation is not available yet; import a Holon OAuth profile or run codex login, then rerun onboard.".into();
+                        self.run_codex_login_for_selected_provider()?;
                         return Ok(());
                     }
                     self.credential_material = None;
@@ -240,7 +259,35 @@ impl OnboardingTuiApp {
                 self.step = Step::Model;
             }
             Step::Model => {
-                self.selected_model = self.models.get(self.model_index).cloned();
+                let model = self
+                    .models
+                    .get(self.model_index)
+                    .cloned()
+                    .context("no model choices are available")?;
+                if model.custom {
+                    self.selected_model = None;
+                    self.custom_model_input.clear();
+                    self.status =
+                        "Enter a model id. Use `provider/model` or a model name for this provider."
+                            .into();
+                    self.step = Step::CustomModel;
+                } else {
+                    self.selected_model = Some(model);
+                    self.step = Step::Search;
+                }
+            }
+            Step::CustomModel => {
+                let provider = self
+                    .selected_provider
+                    .as_ref()
+                    .context("provider not selected")?;
+                let model_ref = parse_custom_model_ref(provider, &self.custom_model_input)?;
+                self.selected_model = Some(OnboardingModelChoice {
+                    title: model_ref.as_string(),
+                    detail: "custom model".into(),
+                    model: model_ref,
+                    custom: false,
+                });
                 self.step = Step::Search;
             }
             Step::Search => {
@@ -248,7 +295,7 @@ impl OnboardingTuiApp {
                     .search_choices
                     .get(self.search_index)
                     .map(|choice| choice.selection)
-                    .unwrap_or(OnboardingSearchSelection::BuiltInProvider);
+                    .unwrap_or(OnboardingSearchSelection::Auto);
                 self.step = Step::Confirm;
             }
             Step::Confirm => {
@@ -268,17 +315,93 @@ impl OnboardingTuiApp {
         }
         Ok(())
     }
+
+    fn run_codex_login_for_selected_provider(&mut self) -> Result<()> {
+        let provider = self
+            .selected_provider
+            .as_mut()
+            .context("provider not selected")?;
+        if !provider.id.is_openai_codex() {
+            self.status =
+                "This OAuth provider does not have an onboard-managed login command yet.".into();
+            return Ok(());
+        }
+
+        disable_raw_mode()?;
+        execute!(io::stdout(), LeaveAlternateScreen)?;
+        println!("Starting Holon OpenAI Codex OAuth login. Complete the browser login, then return here.");
+        let login_result = run_codex_oauth_login_profile_material();
+        execute!(io::stdout(), EnterAlternateScreen)?;
+        enable_raw_mode()?;
+        let login = match login_result {
+            Ok(login) => login,
+            Err(error) => {
+                self.status = format!("Holon OpenAI Codex OAuth login failed: {error}");
+                return Ok(());
+            }
+        };
+        if login.material.trim().is_empty() {
+            self.status =
+                "Holon OpenAI Codex OAuth login did not return credential material.".into();
+            return Ok(());
+        }
+        provider.credential_configured = true;
+        self.credential_material = Some(login.material);
+        if provider.credential_configured {
+            self.status = login
+                .account_id
+                .map(|account| {
+                    format!(
+                        "Holon OpenAI Codex OAuth credential saved for account {account}; continuing to model selection."
+                    )
+                })
+                .unwrap_or_else(|| {
+                    "Holon OpenAI Codex OAuth credential saved; continuing to model selection."
+                        .into()
+                });
+            self.step = Step::Model;
+        }
+        Ok(())
+    }
+
+    fn can_run_codex_login(&self) -> bool {
+        self.step == Step::Auth
+            && self
+                .selected_provider
+                .as_ref()
+                .is_some_and(|provider| provider.id.is_openai_codex())
+    }
+}
+
+fn parse_custom_model_ref(provider: &OnboardingProviderChoice, input: &str) -> Result<ModelRef> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("enter a model id before continuing");
+    }
+    let model_ref = if trimmed.contains('/') {
+        ModelRef::parse(trimmed)?
+    } else {
+        ModelRef::new(provider.id.clone(), trimmed)
+    };
+    if model_ref.provider != provider.id {
+        anyhow::bail!(
+            "custom model provider {} does not match selected provider {}",
+            model_ref.provider.as_str(),
+            provider.id.as_str()
+        );
+    }
+    Ok(model_ref)
 }
 
 fn draw(frame: &mut Frame<'_>, app: &OnboardingTuiApp) {
-    let area = centered(frame.area(), 90, 80);
+    let area = centered(frame.area(), 92, 84);
     frame.render_widget(Clear, area);
-    let chunks = Layout::default()
+    let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(4),
             Constraint::Min(8),
-            Constraint::Length(4),
+            Constraint::Length(3),
         ])
         .split(area);
     let title = Paragraph::new(Text::from(vec![
@@ -289,57 +412,146 @@ fn draw(frame: &mut Frame<'_>, app: &OnboardingTuiApp) {
         Line::from(step_label(app.step)),
     ]))
     .block(Block::default().borders(Borders::ALL));
-    frame.render_widget(title, chunks[0]);
+    frame.render_widget(title, outer[0]);
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(28), Constraint::Min(48)])
+        .split(outer[1]);
+    draw_sidebar(frame, body[0], app);
     match app.step {
         Step::Provider => draw_list(
             frame,
-            chunks[1],
+            body[1],
             "Choose model provider",
             app.providers
                 .iter()
-                .map(|v| (&v.title, &v.detail))
+                .map(|v| (v.title.clone(), provider_detail(v)))
                 .collect(),
             app.provider_index,
         ),
-        Step::Auth => draw_auth(frame, chunks[1], app),
+        Step::Auth => draw_auth(frame, body[1], app),
         Step::Model => draw_list(
             frame,
-            chunks[1],
+            body[1],
             "Choose default model",
-            app.models.iter().map(|v| (&v.title, &v.detail)).collect(),
+            app.models
+                .iter()
+                .map(|v| (v.title.clone(), v.detail.clone()))
+                .collect(),
             app.model_index,
         ),
+        Step::CustomModel => draw_custom_model(frame, body[1], app),
         Step::Search => draw_list(
             frame,
-            chunks[1],
+            body[1],
             "Configure search",
             app.search_choices
                 .iter()
-                .map(|v| (&v.title, &v.detail))
+                .map(|v| (v.title.clone(), v.detail.clone()))
                 .collect(),
             app.search_index,
         ),
-        Step::Confirm => draw_confirm(frame, chunks[1], app),
+        Step::Confirm => draw_confirm(frame, body[1], app),
     }
     frame.render_widget(
-        Paragraph::new(format!("{}  ·  ← back", app.status))
-            .wrap(Wrap { trim: true })
-            .block(Block::default().borders(Borders::ALL).title("Help")),
-        chunks[2],
+        Paragraph::new(format!(
+            "{}  ·  ↑/↓ move · Enter select/continue · ← back · Esc cancel",
+            app.status
+        ))
+        .wrap(Wrap { trim: true })
+        .block(Block::default().borders(Borders::ALL).title("Help")),
+        outer[2],
     );
+}
+
+fn draw_sidebar(frame: &mut Frame<'_>, area: Rect, app: &OnboardingTuiApp) {
+    let steps = [
+        (Step::Provider, "Provider"),
+        (Step::Auth, "Auth"),
+        (Step::Model, "Model"),
+        (Step::Search, "Search"),
+        (Step::Confirm, "Confirm"),
+    ];
+    let mut lines = steps
+        .iter()
+        .map(|(step, label)| {
+            let marker =
+                if *step == app.step || (app.step == Step::CustomModel && *step == Step::Model) {
+                    "●"
+                } else {
+                    "○"
+                };
+            let style =
+                if *step == app.step || (app.step == Step::CustomModel && *step == Step::Model) {
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::DarkGray)
+                };
+            Line::from(vec![
+                Span::styled(marker, style),
+                Span::raw(" "),
+                Span::styled(*label, style),
+            ])
+        })
+        .collect::<Vec<_>>();
+    lines.push(Line::from(""));
+    lines.push(Line::from("Current"));
+    lines.push(Line::from(format!(
+        "provider: {}",
+        app.selected_provider
+            .as_ref()
+            .map(|provider| provider.id.as_str())
+            .unwrap_or("-")
+    )));
+    lines.push(Line::from(format!(
+        "model: {}",
+        app.selected_model
+            .as_ref()
+            .map(|model| model.model.as_string())
+            .unwrap_or_else(|| "-".into())
+    )));
+    lines.push(Line::from(format!(
+        "search: {}",
+        app.selected_search.label()
+    )));
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
+            .wrap(Wrap { trim: true })
+            .block(Block::default().borders(Borders::ALL).title("Progress")),
+        area,
+    );
+}
+
+fn provider_detail(provider: &OnboardingProviderChoice) -> String {
+    let origin = if provider.configured {
+        "configured"
+    } else {
+        "built-in"
+    };
+    let auth = if provider.credential_configured {
+        "credential ready"
+    } else {
+        "needs credential"
+    };
+    format!("{} · {} · {}", provider.detail, origin, auth)
 }
 
 fn draw_list(
     frame: &mut Frame<'_>,
     area: Rect,
     title: &str,
-    rows: Vec<(&String, &String)>,
+    rows: Vec<(String, String)>,
     selected: usize,
 ) {
     let items = rows
         .into_iter()
         .map(|(title, detail)| {
-            ListItem::new(vec![Line::from(title.clone()), Line::from(detail.clone())])
+            ListItem::new(vec![
+                Line::from(title),
+                Line::from(Span::styled(detail, Style::default().fg(Color::DarkGray))),
+            ])
         })
         .collect::<Vec<_>>();
     let mut state = ListState::default();
@@ -348,8 +560,12 @@ fn draw_list(
     }
     let list = List::new(items)
         .block(Block::default().borders(Borders::ALL).title(title))
-        .highlight_symbol("> ")
-        .highlight_style(Style::default().add_modifier(Modifier::BOLD));
+        .highlight_symbol("› ")
+        .highlight_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
     frame.render_stateful_widget(list, area, &mut state);
 }
 
@@ -358,38 +574,89 @@ fn draw_auth(frame: &mut Frame<'_>, area: Rect, app: &OnboardingTuiApp) {
     let title = provider
         .map(|provider| format!("Authenticate {}", provider.title))
         .unwrap_or_else(|| "Authenticate provider".into());
-    let body = provider
-        .map(|provider| {
-            let masked = "*".repeat(app.credential_input.chars().count());
-            let instruction = match provider.credential_kind {
-                CredentialKind::OAuth => "Use the existing Holon-owned OAuth profile or external Codex fallback. If it is missing, import credentials with `holon config credentials set --kind oauth --stdin openai-codex` or run `codex login`, then rerun onboard.",
+    let block = Block::default().borders(Borders::ALL).title(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let Some(provider) = provider else {
+        frame.render_widget(Paragraph::new("No provider selected."), inner);
+        return;
+    };
+
+    let input_area = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+    let masked = "*".repeat(app.credential_input.chars().count());
+    let input_prefix = if provider.credential_kind == CredentialKind::OAuth {
+        "credential input: handled by OAuth profile; nothing is echoed here"
+    } else {
+        "credential: "
+    };
+    let input_line = if provider.credential_kind == CredentialKind::OAuth {
+        Line::from(input_prefix)
+    } else {
+        Line::from(format!("{input_prefix}{masked}"))
+    };
+    let body = {
+        let instruction = match provider.credential_kind {
+                CredentialKind::OAuth if provider.id.is_openai_codex() => "Press Enter to continue when credential is ready. If missing, Enter starts Holon's built-in Codex OAuth login; press `l` anytime to run/refresh it.",
+                CredentialKind::OAuth => "Use an existing Holon-owned OAuth profile. Onboard-managed login is currently available for OpenAI Codex only.",
                 CredentialKind::ApiKey => {
                     "Enter API key. The value is masked and stored in the local Holon credential store."
                 }
                 _ => "Enter credential material if required.",
             };
-            Text::from(vec![
-                Line::from(format!("profile: {}", provider.credential_profile)),
-                Line::from(format!("kind: {}", provider.credential_kind.as_str())),
-                Line::from(format!(
-                    "configured: {}",
-                    if provider.credential_configured { "yes" } else { "no" }
-                )),
-                Line::from(""),
-                Line::from(instruction),
-                Line::from(""),
-                if provider.credential_kind == CredentialKind::OAuth {
-                    Line::from("credential input: handled by OAuth profile; nothing is echoed here")
+        Text::from(vec![
+            Line::from(format!("profile: {}", provider.credential_profile)),
+            Line::from(format!("kind: {}", provider.credential_kind.as_str())),
+            Line::from(format!(
+                "configured: {}",
+                if provider.credential_configured {
+                    "yes"
                 } else {
-                    Line::from(format!("credential: {masked}"))
-                },
-            ])
-        })
-        .unwrap_or_else(|| Text::from("No provider selected."));
+                    "no"
+                }
+            )),
+            Line::from(""),
+            Line::from(instruction),
+            Line::from(""),
+        ])
+    };
     frame.render_widget(
-        Paragraph::new(body)
+        Paragraph::new(body).wrap(Wrap { trim: true }),
+        input_area[0],
+    );
+    frame.render_widget(Paragraph::new(input_line), input_area[1]);
+    if provider.credential_kind != CredentialKind::OAuth {
+        frame.set_cursor_position(Position {
+            x: input_area[1]
+                .x
+                .saturating_add((input_prefix.len() + app.credential_input.chars().count()) as u16),
+            y: input_area[1].y,
+        });
+    }
+}
+
+fn draw_custom_model(frame: &mut Frame<'_>, area: Rect, app: &OnboardingTuiApp) {
+    let provider = app.selected_provider.as_ref();
+    let text = Text::from(vec![
+        Line::from("Enter a custom model id, then press Enter."),
+        Line::from(""),
+        Line::from(format!(
+            "selected provider: {}",
+            provider
+                .map(|provider| provider.id.as_str().to_string())
+                .unwrap_or_else(|| "-".into())
+        )),
+        Line::from("accepted forms: provider/model or model-name"),
+        Line::from(""),
+        Line::from(format!("model: {}", app.custom_model_input)),
+    ]);
+    frame.render_widget(
+        Paragraph::new(text)
             .wrap(Wrap { trim: true })
-            .block(Block::default().borders(Borders::ALL).title(title)),
+            .block(Block::default().borders(Borders::ALL).title("Custom model")),
         area,
     );
 }
@@ -435,6 +702,7 @@ fn step_label(step: Step) -> &'static str {
         Step::Provider => "Step 1/5 · model provider",
         Step::Auth => "Step 2/5 · authentication",
         Step::Model => "Step 3/5 · default model",
+        Step::CustomModel => "Step 3/5 · custom model",
         Step::Search => "Step 4/5 · search",
         Step::Confirm => "Step 5/5 · confirm",
     }

--- a/src/provider/tests/routing_auth_doctor.rs
+++ b/src/provider/tests/routing_auth_doctor.rs
@@ -114,7 +114,7 @@ fn build_candidate_reports_missing_auth_for_each_provider() {
     .expect("missing Codex auth should fail codex candidate");
     assert!(codex_err
         .to_string()
-        .contains("no Codex CLI credentials found"));
+        .contains("no Holon openai-codex credential profile or usable Codex CLI credentials"));
 
     let gemini = test_config("gemini/gemini-3-pro", &[], None, None, false);
     let gemini_err = build_candidate(
@@ -291,7 +291,9 @@ async fn openai_codex_unauthorized_status_includes_login_hint_and_diagnostics() 
         .expect_err("401 should fail fast");
 
     assert_eq!(attempts.load(Ordering::SeqCst), 1);
-    assert!(error.to_string().contains("Codex CLI token may be expired"));
+    assert!(error
+        .to_string()
+        .contains("OpenAI Codex authentication failed"));
     assert!(error.to_string().contains("codex login"));
     let timeline = provider_attempt_timeline(&error).expect("missing attempt timeline");
     assert_eq!(
@@ -376,10 +378,9 @@ fn provider_doctor_reports_success_and_failure_paths() {
         .as_str()
         .unwrap()
         .contains("missing OPENAI_API_KEY"));
-    assert!(providers[2]["availability"]["error"]
-        .as_str()
-        .unwrap()
-        .contains("no Codex CLI credentials found"));
+    let codex_error = providers[2]["availability"]["error"].as_str().unwrap();
+    assert!(codex_error.contains("Codex"));
+    assert!(codex_error.contains("credential"));
 }
 
 #[test]
@@ -1815,7 +1816,9 @@ fn build_candidate_fails_when_codex_external_cli_auth_missing() {
     )
     .err()
     .expect("missing external CLI auth should fail");
-    assert!(err.to_string().contains("no Codex CLI credentials found"));
+    assert!(err
+        .to_string()
+        .contains("no Holon openai-codex credential profile or usable Codex CLI credentials"));
 }
 
 #[test]
@@ -1899,10 +1902,9 @@ fn provider_doctor_reports_missing_codex_external_cli_auth() {
         codex_provider["availability"]["available"],
         Value::Bool(false)
     );
-    assert!(codex_provider["availability"]["error"]
-        .as_str()
-        .unwrap()
-        .contains("no Codex CLI credentials found"));
+    let codex_error = codex_provider["availability"]["error"].as_str().unwrap();
+    assert!(codex_error.contains("Codex"));
+    assert!(codex_error.contains("credential"));
 }
 
 #[test]

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -65,6 +65,7 @@ pub struct OpenAiCodexProvider {
     base_url: String,
     credential_profile: Option<String>,
     credential_material: Option<String>,
+    credential_external: Option<String>,
     credential_store_path: Option<PathBuf>,
     codex_home: std::path::PathBuf,
     originator: String,
@@ -356,6 +357,7 @@ impl OpenAiCodexProvider {
             base_url: provider_config.base_url.trim_end_matches('/').to_string(),
             credential_profile: provider_config.auth.profile.clone(),
             credential_material: provider_config.credential.clone(),
+            credential_external: provider_config.auth.external.clone(),
             credential_store_path: provider_config.credential_store_path.clone(),
             codex_home,
             originator: provider_config
@@ -373,7 +375,8 @@ impl OpenAiCodexProvider {
     }
 
     fn resolve_credential(&self) -> Result<CodexCliCredential> {
-        self.credential_material
+        let profile = self
+            .credential_material
             .as_deref()
             .filter(|material| !material.trim().is_empty())
             .map(|material| {
@@ -382,7 +385,17 @@ impl OpenAiCodexProvider {
                     self.credential_profile.as_deref().unwrap_or("openai-codex"),
                 )
             })
-            .unwrap_or_else(|| load_codex_cli_credential(&self.codex_home))
+            .transpose()?;
+        let cli = if self.credential_external.as_deref() == Some("codex_cli") || profile.is_none() {
+            load_codex_cli_credential(&self.codex_home).ok()
+        } else {
+            None
+        };
+        choose_openai_codex_credential(profile, cli).ok_or_else(|| {
+            anyhow::anyhow!(
+                "no Holon openai-codex credential profile or usable Codex CLI credentials are available"
+            )
+        })
     }
 
     async fn resolve_fresh_credential(&self) -> Result<CodexCliCredential> {
@@ -393,10 +406,10 @@ impl OpenAiCodexProvider {
         if !credential_needs_refresh(&credential) {
             return Ok(credential);
         }
-        self.refresh_holon_oauth_profile().await
+        self.refresh_holon_oauth_profile(false).await
     }
 
-    async fn refresh_holon_oauth_profile(&self) -> Result<CodexCliCredential> {
+    async fn refresh_holon_oauth_profile(&self, force: bool) -> Result<CodexCliCredential> {
         let profile = self.credential_profile.as_deref().unwrap_or("openai-codex");
         let store_path = self.credential_store_path.as_ref().ok_or_else(|| {
             anyhow::anyhow!(
@@ -416,7 +429,7 @@ impl OpenAiCodexProvider {
             );
         }
         let current = load_codex_oauth_profile_credential(&entry.material, profile)?;
-        if !credential_needs_refresh(&current) {
+        if !force && !credential_needs_refresh(&current) {
             return Ok(current);
         }
         let refreshed =
@@ -432,6 +445,16 @@ impl OpenAiCodexProvider {
         );
         save_credential_store_at(store_path, &store)?;
         Ok(refreshed.credential)
+    }
+
+    async fn refresh_after_auth_failure(
+        &self,
+        credential: &CodexCliCredential,
+    ) -> Result<Option<CodexCliCredential>> {
+        if !credential.source.starts_with("credential_profile:") {
+            return Ok(None);
+        }
+        self.refresh_holon_oauth_profile(true).await.map(Some)
     }
 }
 
@@ -528,6 +551,66 @@ fn credential_needs_refresh(credential: &CodexCliCredential) -> bool {
         .unwrap_or(false)
 }
 
+fn choose_openai_codex_credential(
+    profile: Option<CodexCliCredential>,
+    cli: Option<CodexCliCredential>,
+) -> Option<CodexCliCredential> {
+    match (profile, cli) {
+        (Some(profile), Some(cli)) => Some(
+            [profile, cli]
+                .into_iter()
+                .max_by_key(openai_codex_credential_freshness_key)
+                .expect("credential candidate array is non-empty"),
+        ),
+        (Some(profile), None) => Some(profile),
+        (None, Some(cli)) => Some(cli),
+        (None, None) => None,
+    }
+}
+
+fn openai_codex_credential_freshness_key(
+    credential: &CodexCliCredential,
+) -> (
+    Option<chrono::DateTime<Utc>>,
+    Option<chrono::DateTime<Utc>>,
+    u8,
+) {
+    let source_rank = if credential.source == "keychain" {
+        3
+    } else if credential.source == "file" {
+        2
+    } else if credential.source.starts_with("credential_profile:") {
+        1
+    } else {
+        0
+    };
+    (credential.expires_at, credential.refreshed_at, source_rank)
+}
+
+fn openai_codex_headers(
+    credential: &CodexCliCredential,
+    originator: &str,
+) -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "authorization",
+            format!("Bearer {}", credential.access_token),
+        ),
+        ("chatgpt-account-id", credential.account_id.clone()),
+        ("OpenAI-Beta", "responses=experimental".to_string()),
+        ("originator", originator.to_string()),
+    ]
+}
+
+fn is_openai_codex_auth_status_error(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<ProviderTransportError>()
+        .is_some_and(|error| {
+            error.classification.kind == ProviderFailureKind::AuthError
+                && matches!(error.status, Some(401 | 403))
+        })
+}
+
 fn codex_refresh_error(profile: &str, failure: CodexOAuthRefreshFailure) -> anyhow::Error {
     anyhow::anyhow!(
         "OpenAI Codex OAuth refresh failed for Holon credential profile {profile}: {} ({})",
@@ -540,7 +623,7 @@ fn resolve_openai_codex_credential(
     provider_config: &ProviderRuntimeConfig,
     codex_home: &Path,
 ) -> Result<CodexCliCredential> {
-    provider_config
+    let profile = provider_config
         .credential
         .as_deref()
         .filter(|material| !material.trim().is_empty())
@@ -554,7 +637,18 @@ fn resolve_openai_codex_credential(
                     .unwrap_or("openai-codex"),
             )
         })
-        .unwrap_or_else(|| load_codex_cli_credential(codex_home))
+        .transpose()?;
+    let cli = if provider_config.auth.external.as_deref() == Some("codex_cli") || profile.is_none()
+    {
+        load_codex_cli_credential(codex_home).ok()
+    } else {
+        None
+    };
+    choose_openai_codex_credential(profile, cli).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no Holon openai-codex credential profile or usable Codex CLI credentials are available"
+        )
+    })
 }
 
 fn openai_compaction_policy_from_config(
@@ -803,7 +897,7 @@ impl AgentProvider for OpenAiCodexProvider {
                 &model_ref,
                 vec![
                     error.to_string(),
-                    "OpenAI Codex uses a Holon-managed openai-codex credential profile; refresh token failures require re-running Holon-managed openai-codex login or re-importing credentials. External Codex CLI credentials are not silently refreshed or overwritten."
+                    "OpenAI Codex can use a Holon-managed openai-codex credential profile or the external Codex CLI credential store. Holon may refresh its own profile, but only reads Codex CLI credentials and never overwrites them."
                         .into(),
                 ],
                 "OpenAI Codex authentication failed: no Holon openai-codex credential profile or usable Codex CLI credentials are available.",
@@ -820,9 +914,9 @@ impl AgentProvider for OpenAiCodexProvider {
                             credential.source,
                             expires_at.to_rfc3339()
                         ),
-                        "Run `holon config credentials set --kind oauth --stdin openai-codex` to configure or refresh Holon-managed OAuth, or run `codex login` if using external CLI credentials.".into(),
+                        "Run Holon onboarding login for openai-codex to configure or refresh Holon-managed OAuth, or run `codex login` if intentionally using external CLI credentials.".into(),
                     ],
-                    "OpenAI Codex authentication failed: OAuth access token is expired. Configure or refresh the Holon-managed openai-codex credential profile, or run `codex login` if using Codex CLI credentials.",
+                    "OpenAI Codex authentication failed: OAuth access token is expired. Run Holon onboarding login for openai-codex again, or run `codex login` if intentionally using external CLI credentials.",
                 ));
             }
         }
@@ -838,15 +932,8 @@ impl AgentProvider for OpenAiCodexProvider {
         let mut sent_diagnostics = plan.diagnostics.clone();
         let plan_scope = plan.scope.clone();
         let plan_request_shape = plan.request_shape.clone();
-        let headers = vec![
-            (
-                "authorization",
-                format!("Bearer {}", credential.access_token),
-            ),
-            ("chatgpt-account-id", credential.account_id.clone()),
-            ("OpenAI-Beta", "responses=experimental".to_string()),
-            ("originator", self.originator.clone()),
-        ];
+        let mut credential = credential;
+        let mut headers = openai_codex_headers(&credential, &self.originator);
         let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
         if let Some(remote_compaction) = maybe_compact_openai_request_plan(
             &self.continuation,
@@ -866,7 +953,7 @@ impl AgentProvider for OpenAiCodexProvider {
         let parsed = match send_openai_responses_streaming_request(
             &self.client,
             openai_codex_responses_url(&self.base_url),
-            plan.body,
+            plan.body.clone(),
             headers.clone(),
             trace.as_ref(),
             request_agent_id(&request),
@@ -875,8 +962,50 @@ impl AgentProvider for OpenAiCodexProvider {
         {
             Ok(parsed) => parsed,
             Err(error) => {
-                invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
-                return Err(error);
+                if is_openai_codex_auth_status_error(&error) {
+                    if let Some(refreshed) =
+                        self.refresh_after_auth_failure(&credential).await.map_err(|refresh_error| {
+                            openai_codex_auth_error(
+                                "credential_refresh_after_auth_failure",
+                                &model_ref,
+                                vec![
+                                    error.to_string(),
+                                    refresh_error.to_string(),
+                                    "OpenAI Codex returned an auth error; Holon attempted to refresh the Holon-managed profile before retrying.".into(),
+                                ],
+                                "OpenAI Codex authentication failed and Holon-managed OAuth refresh did not recover it.",
+                            )
+                        })?
+                    {
+                        credential = refreshed;
+                        headers = openai_codex_headers(&credential, &self.originator);
+                        match send_openai_responses_streaming_request(
+                            &self.client,
+                            openai_codex_responses_url(&self.base_url),
+                            plan.body.clone(),
+                            headers.clone(),
+                            trace.as_ref(),
+                            request_agent_id(&request),
+                        )
+                        .await
+                        {
+                            Ok(parsed) => parsed,
+                            Err(retry_error) => {
+                                invalidate_openai_continuation(
+                                    &self.continuation,
+                                    plan.scope.as_ref(),
+                                );
+                                return Err(retry_error);
+                            }
+                        }
+                    } else {
+                        invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
+                        return Err(error);
+                    }
+                } else {
+                    invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
+                    return Err(error);
+                }
             }
         };
         update_openai_continuation(
@@ -948,15 +1077,7 @@ impl AgentProvider for OpenAiCodexProvider {
             ToolSchemaContract::Relaxed,
             self.reasoning_effort.as_deref(),
         )?;
-        let headers = vec![
-            (
-                "authorization",
-                format!("Bearer {}", credential.access_token),
-            ),
-            ("chatgpt-account-id", credential.account_id.clone()),
-            ("OpenAI-Beta", "responses=experimental".to_string()),
-            ("originator", self.originator.clone()),
-        ];
+        let headers = openai_codex_headers(&credential, &self.originator);
         let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
         send_openai_responses_streaming_request(
             &self.client,
@@ -4044,7 +4165,7 @@ fn openai_codex_status_error_context(status: reqwest::StatusCode) -> &'static st
         status,
         reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
     ) {
-        "OpenAI Codex authentication failed; the Codex CLI token may be expired. Run `codex login`, then retry."
+        "OpenAI Codex authentication failed; run Holon onboarding login for openai-codex again, or run `codex login` if intentionally using external CLI credentials."
     } else {
         "OpenAI-style streaming request failed"
     }
@@ -4594,14 +4715,15 @@ fn unsupported_streaming_transport_error(provider_name: &str) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_openai_responses_request, chat_completions_url, incremental_diagnostics,
-        latest_openai_compaction_index, openai_compaction_trigger_for_request_plan,
-        openai_compaction_trigger_for_window, openai_provider_window_compaction_candidate,
-        plan_openai_responses_request, resolve_openai_codex_credential, CredentialStoreRefreshLock,
-        OpenAiCodexProvider, OpenAiCompactionPolicy, OpenAiContinuationState, OpenAiProviderWindow,
-        OpenAiRequestPlan, OpenAiRequestShape, OpenAiResponsesTransportContract,
-        ToolSchemaContract,
+        build_openai_responses_request, chat_completions_url, choose_openai_codex_credential,
+        incremental_diagnostics, latest_openai_compaction_index,
+        openai_compaction_trigger_for_request_plan, openai_compaction_trigger_for_window,
+        openai_provider_window_compaction_candidate, plan_openai_responses_request,
+        resolve_openai_codex_credential, CredentialStoreRefreshLock, OpenAiCodexProvider,
+        OpenAiCompactionPolicy, OpenAiContinuationState, OpenAiProviderWindow, OpenAiRequestPlan,
+        OpenAiRequestShape, OpenAiResponsesTransportContract, ToolSchemaContract,
     };
+    use crate::auth::CodexCliCredential;
     use crate::config::{
         load_credential_store_at, save_credential_store_at, CredentialKind, CredentialProfileFile,
         CredentialSource, CredentialStoreFile, ProviderAuthConfig, ProviderId,
@@ -4735,6 +4857,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn openai_codex_prefers_fresher_cli_credential_over_stale_profile() {
+        let profile = CodexCliCredential {
+            access_token: "profile-access".into(),
+            account_id: "acct_profile".into(),
+            expires_at: chrono::DateTime::from_timestamp(1_900_000_000, 0),
+            refreshed_at: chrono::DateTime::from_timestamp(1_800_000_000, 0),
+            source: format!("credential_profile:{OPENAI_CODEX_CREDENTIAL_PROFILE}"),
+        };
+        let cli = CodexCliCredential {
+            access_token: "cli-access".into(),
+            account_id: "acct_cli".into(),
+            expires_at: chrono::DateTime::from_timestamp(1_910_000_000, 0),
+            refreshed_at: chrono::DateTime::from_timestamp(1_810_000_000, 0),
+            source: "keychain".into(),
+        };
+
+        let credential = choose_openai_codex_credential(Some(profile), Some(cli))
+            .expect("credential should resolve");
+
+        assert_eq!(credential.access_token, "cli-access");
+        assert_eq!(credential.source, "keychain");
+    }
+
     #[tokio::test]
     async fn openai_codex_refreshes_and_persists_holon_oauth_profile() {
         let server = axum::Router::new().route(
@@ -4797,6 +4943,82 @@ mod tests {
         let credential = provider.resolve_fresh_credential().await.unwrap();
         assert_eq!(credential.account_id, "acct_profile");
 
+        let store = load_credential_store_at(&credential_store_path).unwrap();
+        let material = &store.profiles[OPENAI_CODEX_CREDENTIAL_PROFILE].material;
+        assert!(material.contains("rotated-refresh"));
+        assert!(!material.contains("old-refresh"));
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn openai_codex_auth_failure_forces_profile_refresh_even_when_jwt_is_not_expiring() {
+        let server = axum::Router::new().route(
+            "/oauth/token",
+            axum::routing::post(|| async {
+                axum::Json(json!({
+                    "access_token": make_token(json!({
+                        "exp": Utc::now().timestamp() + 3600,
+                        "chatgpt_account_id": "acct_profile"
+                    })),
+                    "refresh_token": "rotated-refresh"
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, server).await.unwrap();
+        });
+        let _env_lock = CODEX_REFRESH_ENV_LOCK.lock().unwrap();
+        let _env = EnvVarGuard::set(
+            "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
+            format!("http://{addr}/oauth/token"),
+        );
+
+        let home = tempfile::tempdir().unwrap();
+        let credential_store_path = home.path().join("credentials.json");
+        let valid_but_invalidated_material = json!({
+            "tokens": {
+                "access_token": make_token(json!({
+                    "exp": Utc::now().timestamp() + 3600,
+                    "chatgpt_account_id": "acct_profile"
+                })),
+                "refresh_token": "old-refresh",
+                "account_id": "acct_profile"
+            }
+        })
+        .to_string();
+        let mut profiles = BTreeMap::new();
+        profiles.insert(
+            OPENAI_CODEX_CREDENTIAL_PROFILE.to_string(),
+            CredentialProfileFile {
+                kind: CredentialKind::OAuth,
+                material: valid_but_invalidated_material.clone(),
+            },
+        );
+        save_credential_store_at(&credential_store_path, &CredentialStoreFile { profiles })
+            .unwrap();
+
+        let mut provider_config = test_openai_codex_config(Some(valid_but_invalidated_material));
+        provider_config.credential_store_path = Some(credential_store_path.clone());
+        let provider = OpenAiCodexProvider::from_runtime_config(
+            &provider_config,
+            "gpt-codex-test",
+            1024,
+            home.path(),
+        )
+        .unwrap();
+
+        let old_credential = provider.resolve_fresh_credential().await.unwrap();
+        assert!(old_credential.source.starts_with("credential_profile:"));
+
+        let refreshed = provider
+            .refresh_after_auth_failure(&old_credential)
+            .await
+            .unwrap()
+            .expect("profile auth failure should force refresh");
+
+        assert_eq!(refreshed.account_id, "acct_profile");
         let store = load_credential_store_at(&credential_store_path).unwrap();
         let material = &store.profiles[OPENAI_CODEX_CREDENTIAL_PROFILE].material;
         assert!(material.contains("rotated-refresh"));

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -965,6 +965,7 @@ impl AgentProvider for OpenAiCodexProvider {
                 if is_openai_codex_auth_status_error(&error) {
                     if let Some(refreshed) =
                         self.refresh_after_auth_failure(&credential).await.map_err(|refresh_error| {
+                            invalidate_openai_continuation(&self.continuation, plan.scope.as_ref());
                             openai_codex_auth_error(
                                 "credential_refresh_after_auth_failure",
                                 &model_ref,


### PR DESCRIPTION
## Summary
- expand onboarding provider/model/search choices to include configured providers, custom models, and an auto search policy
- add onboard-managed OpenAI Codex OAuth login and credential freshness handling while preserving Codex CLI fallback reads
- improve onboarding TUI flow, including OAuth login prompts, progress details, custom model input, and visible API key input cursor

## Verification
- cargo fmt --all -- --check
- cargo test --lib onboarding::tests
- RUSTFLAGS="-D warnings" cargo check --all-targets
