### PR TITLE
feat: discover OpenRouter models

### DIFF
--- a/docs/rfcs/extensible-model-provider-configuration.md
+++ b/docs/rfcs/extensible-model-provider-configuration.md
@@ -745,11 +745,12 @@ The first implementation should deliver:
   `~/.holon/credentials.json` owner-only fallback
 - built-in provider auth defaults and strict custom-provider auth validation
 - resolved model/provider runtime status
+- OpenRouter model discovery cache refresh via
+  `holon config models refresh --provider openrouter`
 - tests for config parsing, fallback chain resolution, and provider construction
 
 It should not deliver:
 
-- dynamic network catalog refresh
 - provider plugin loading
 - multi-credential profile rotation
 - provider OAuth refresh flows
@@ -757,6 +758,14 @@ It should not deliver:
 - per-agent provider profiles
 
 Those can be added later without changing the core split defined here.
+
+OpenRouter discovery is intentionally a model metadata surface, not a runtime
+selection surface. Refresh writes a local discovery cache under `HOLON_HOME`;
+resolved model availability merges `models.catalog` overrides first, cached
+remote-discovered entries second, the curated built-in catalog third, and
+`model.unknown_fallback` only for otherwise unknown explicit refs. Discovery
+does not mutate `model.default` or `model.fallbacks`, and remote capabilities
+are displayed as hints because OpenRouter routing/provider metadata can change.
 
 ## Open Questions
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -354,6 +354,10 @@ pub enum ConfigCredentialCommands {
 #[derive(Debug, Subcommand)]
 pub enum ConfigModelCommands {
     List,
+    Refresh {
+        #[arg(long)]
+        provider: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -877,9 +877,8 @@ impl RuntimeModelCatalog {
     pub fn available_models(&self) -> Vec<BuiltInModelMetadata> {
         let mut models = self.built_in_catalog.list();
         for discovered in self.discovered_models.values() {
-            if !self.model_overrides.contains_key(&discovered.model_ref)
-                && self.built_in_catalog.get(&discovered.model_ref).is_none()
-            {
+            if !self.model_overrides.contains_key(&discovered.model_ref) {
+                models.retain(|model| model.model_ref != discovered.model_ref);
                 models.push(discovered.clone());
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use crate::{
     model_catalog::{
         BuiltInModelCatalog, BuiltInModelMetadata, ModelRuntimeOverride, ResolvedRuntimeModelPolicy,
     },
+    model_discovery::{discovery_cache_path, load_discovery_cache_at, ModelDiscoveryCacheFile},
     provider::ProviderNativeWebSearchKind,
     web::{WebProviderKind, WebSearchMode},
 };
@@ -90,6 +91,7 @@ pub struct RuntimeModelCatalog {
     pub fallback_models: Vec<ModelRef>,
     pub disable_provider_fallback: bool,
     pub built_in_catalog: BuiltInModelCatalog,
+    pub discovered_models: HashMap<ModelRef, BuiltInModelMetadata>,
     pub model_overrides: HashMap<ModelRef, ModelRuntimeOverride>,
     pub unknown_model_fallback: Option<ModelRuntimeOverride>,
     pub configured_runtime_max_output_tokens: u32,
@@ -127,6 +129,7 @@ pub struct AppConfig {
     pub tui_alternate_screen: AltScreenMode,
     pub validated_model_overrides: HashMap<ModelRef, ModelRuntimeOverride>,
     pub validated_unknown_model_fallback: Option<ModelRuntimeOverride>,
+    pub model_discovery_cache: ModelDiscoveryCacheFile,
     pub providers: ProviderRegistry,
 }
 
@@ -646,6 +649,11 @@ impl AppConfig {
         let validated_model_overrides = resolve_model_catalog(&stored_config)?;
         let validated_unknown_model_fallback =
             validate_optional_model_runtime_override(stored_config.model.unknown_fallback.clone())?;
+        let model_discovery_cache = load_discovery_cache_at(&discovery_cache_path(&home_dir))
+            .unwrap_or_else(|error| {
+                tracing::warn!(error = %error, "ignoring invalid model discovery cache");
+                ModelDiscoveryCacheFile::default()
+            });
         let mut providers =
             resolve_provider_registry(&stored_config, &settings_env, &credential_store)?;
         for provider in providers.values_mut() {
@@ -708,6 +716,7 @@ impl AppConfig {
             tui_alternate_screen,
             validated_model_overrides,
             validated_unknown_model_fallback,
+            model_discovery_cache,
             providers,
         })
     }
@@ -782,6 +791,11 @@ impl RuntimeModelCatalog {
             fallback_models: config.fallback_models.clone(),
             disable_provider_fallback: config.provider_fallback_disabled(),
             built_in_catalog: BuiltInModelCatalog::default(),
+            discovered_models: config
+                .model_discovery_cache
+                .models()
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
             model_overrides: config.validated_model_overrides.clone(),
             unknown_model_fallback: config.validated_unknown_model_fallback.clone(),
             configured_runtime_max_output_tokens: config.runtime_max_output_tokens,
@@ -836,6 +850,7 @@ impl RuntimeModelCatalog {
         self.built_in_catalog.resolve_policy(
             &model_ref,
             &self.model_overrides,
+            &self.discovered_models,
             self.unknown_model_fallback.as_ref(),
             base_context_config,
             self.configured_runtime_max_output_tokens,
@@ -851,6 +866,7 @@ impl RuntimeModelCatalog {
             .apply_policy(
                 &self.effective_model(model_override),
                 &self.model_overrides,
+                &self.discovered_models,
                 self.unknown_model_fallback.as_ref(),
                 base_context_config,
                 self.configured_runtime_max_output_tokens,
@@ -859,7 +875,66 @@ impl RuntimeModelCatalog {
     }
 
     pub fn available_models(&self) -> Vec<BuiltInModelMetadata> {
-        self.built_in_catalog.list()
+        let mut models = self.built_in_catalog.list();
+        for discovered in self.discovered_models.values() {
+            if !self.model_overrides.contains_key(&discovered.model_ref)
+                && self.built_in_catalog.get(&discovered.model_ref).is_none()
+            {
+                models.push(discovered.clone());
+            }
+        }
+        for (model_ref, override_config) in &self.model_overrides {
+            let base = self
+                .discovered_models
+                .get(model_ref)
+                .or_else(|| self.built_in_catalog.get(model_ref));
+            models.retain(|model| &model.model_ref != model_ref);
+            models.push(BuiltInModelMetadata {
+                model_ref: model_ref.clone(),
+                display_name: override_config
+                    .display_name
+                    .clone()
+                    .or_else(|| base.map(|model| model.display_name.clone()))
+                    .unwrap_or_else(|| model_ref.as_string()),
+                description: override_config
+                    .description
+                    .clone()
+                    .or_else(|| base.map(|model| model.description.clone()))
+                    .unwrap_or_else(|| "User-configured model metadata override.".to_string()),
+                context_window_tokens: override_config
+                    .context_window_tokens
+                    .or_else(|| base.and_then(|model| model.context_window_tokens)),
+                effective_context_window_percent: override_config
+                    .effective_context_window_percent
+                    .unwrap_or_else(|| {
+                        base.map(|model| model.effective_context_window_percent)
+                            .unwrap_or(95)
+                    }),
+                auto_compact_token_limit: override_config
+                    .auto_compact_token_limit
+                    .or_else(|| base.and_then(|model| model.auto_compact_token_limit)),
+                default_max_output_tokens: override_config
+                    .runtime_max_output_tokens
+                    .or_else(|| base.and_then(|model| model.default_max_output_tokens)),
+                max_output_tokens_upper_limit: base
+                    .and_then(|model| model.max_output_tokens_upper_limit),
+                tool_output_truncation_estimated_tokens: override_config
+                    .tool_output_truncation_estimated_tokens
+                    .or_else(|| {
+                        base.and_then(|model| model.tool_output_truncation_estimated_tokens)
+                    }),
+                capabilities: base
+                    .map(|model| model.capabilities.clone())
+                    .unwrap_or_default(),
+                source: crate::model_catalog::ModelMetadataSource::ConfigOverride,
+            });
+        }
+        models.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        models
     }
 }
 
@@ -870,6 +945,7 @@ impl Default for RuntimeModelCatalog {
             fallback_models: Vec::new(),
             disable_provider_fallback: false,
             built_in_catalog: BuiltInModelCatalog::default(),
+            discovered_models: HashMap::new(),
             model_overrides: HashMap::new(),
             unknown_model_fallback: None,
             configured_runtime_max_output_tokens: 8192,
@@ -4102,7 +4178,8 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::context::ContextConfig;
-    use crate::model_catalog::ModelRuntimeOverride;
+    use crate::model_catalog::{BuiltInModelMetadata, ModelMetadataSource, ModelRuntimeOverride};
+    use crate::model_discovery::{ModelDiscoveryCacheFile, ProviderModelDiscoveryCache};
     use crate::provider::ProviderNativeWebSearchKind;
 
     use super::{
@@ -4251,6 +4328,7 @@ mod tests {
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: HashMap::new(),
             validated_unknown_model_fallback: None,
+            model_discovery_cache: ModelDiscoveryCacheFile::default(),
             providers: provider_registry_for_tests(
                 Some("openai-key"),
                 Some("anthropic-token"),
@@ -6183,6 +6261,88 @@ mod tests {
             unknown.source,
             crate::model_catalog::ModelMetadataSource::UnknownFallback
         );
+    }
+
+    #[test]
+    fn runtime_model_catalog_uses_discovery_cache_between_overrides_and_builtins() {
+        let mut fixture = test_app_config("openrouter/anthropic/claude-3.5-sonnet", &[]);
+        let remote_model_ref = ModelRef::parse("openrouter/anthropic/claude-3.5-sonnet").unwrap();
+        fixture.config.model_discovery_cache.providers.insert(
+            ProviderId::parse("openrouter").unwrap(),
+            ProviderModelDiscoveryCache {
+                provider: ProviderId::parse("openrouter").unwrap(),
+                fetched_at: chrono::Utc::now(),
+                source_url: Some("https://openrouter.ai/api/v1/models".into()),
+                response_hash: Some("sha256:test".into()),
+                models: vec![BuiltInModelMetadata {
+                    model_ref: remote_model_ref.clone(),
+                    display_name: "Remote Claude".into(),
+                    description: "Remote discovered model.".into(),
+                    context_window_tokens: Some(123_456),
+                    effective_context_window_percent: 95,
+                    auto_compact_token_limit: None,
+                    default_max_output_tokens: Some(7_777),
+                    max_output_tokens_upper_limit: Some(7_777),
+                    tool_output_truncation_estimated_tokens: None,
+                    capabilities: Default::default(),
+                    source: ModelMetadataSource::RemoteDiscovered,
+                }],
+            },
+        );
+        let unknown_fallback = ModelRuntimeOverride {
+            prompt_budget_estimated_tokens: Some(12_000),
+            ..ModelRuntimeOverride::default()
+        };
+        fixture.config.stored_config.model.unknown_fallback = Some(unknown_fallback.clone());
+        fixture.config.validated_unknown_model_fallback = Some(unknown_fallback);
+
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+        let base_context = ContextConfig {
+            recent_messages: fixture.config.context_window_messages,
+            recent_briefs: fixture.config.context_window_briefs,
+            compaction_trigger_messages: fixture.config.compaction_trigger_messages,
+            compaction_keep_recent_messages: fixture.config.compaction_keep_recent_messages,
+            prompt_budget_estimated_tokens: fixture.config.prompt_budget_estimated_tokens,
+            compaction_trigger_estimated_tokens: fixture.config.compaction_trigger_estimated_tokens,
+            compaction_keep_recent_estimated_tokens: fixture
+                .config
+                .compaction_keep_recent_estimated_tokens,
+            recent_episode_candidates: fixture.config.recent_episode_candidates,
+            max_relevant_episodes: fixture.config.max_relevant_episodes,
+        };
+
+        let remote = catalog.resolved_model_policy(&base_context, None);
+        assert_eq!(remote.source, ModelMetadataSource::RemoteDiscovered);
+        assert_eq!(remote.prompt_budget_estimated_tokens, 117_283);
+        assert_eq!(remote.runtime_max_output_tokens, 7_777);
+
+        let available = catalog.available_models();
+        let listed = available
+            .iter()
+            .find(|model| model.model_ref == remote_model_ref)
+            .expect("remote model should be listed");
+        assert_eq!(listed.source, ModelMetadataSource::RemoteDiscovered);
+
+        let override_config = ModelRuntimeOverride {
+            display_name: Some("Configured Claude".into()),
+            prompt_budget_estimated_tokens: Some(42_000),
+            ..ModelRuntimeOverride::default()
+        };
+        fixture
+            .config
+            .validated_model_overrides
+            .insert(remote_model_ref.clone(), override_config.clone());
+        fixture
+            .config
+            .stored_config
+            .models
+            .catalog
+            .insert(remote_model_ref.as_string(), override_config);
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+        let overridden = catalog.resolved_model_policy(&base_context, None);
+        assert_eq!(overridden.source, ModelMetadataSource::ConfigOverride);
+        assert_eq!(overridden.display_name, "Configured Claude");
+        assert_eq!(overridden.prompt_budget_estimated_tokens, 42_000);
     }
 
     #[test]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -58,6 +58,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: crate::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: provider_registry_for_tests(None, Some("dummy"), home.path().join(".codex")),
         web_config: crate::web::WebConfig::default(),
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -1625,6 +1625,7 @@ mod tests {
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: std::collections::HashMap::new(),
             validated_unknown_model_fallback: None,
+            model_discovery_cache: Default::default(),
             providers: provider_registry_for_tests(
                 None,
                 anthropic_token,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod http;
 pub mod ingress;
 pub mod memory;
 pub mod model_catalog;
+pub mod model_discovery;
 pub mod onboarding;
 pub mod onboarding_tui;
 pub mod openapi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use holon::{
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
     http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
+    model_discovery::{discovery_cache_path, refresh_provider_models},
     onboarding::onboarding_report,
     onboarding_tui::run_onboarding_tui,
     provider::{provider_doctor, resolved_model_availability},
@@ -781,6 +782,7 @@ mod tests {
             tui_alternate_screen: AltScreenMode::Auto,
             validated_model_overrides: Default::default(),
             validated_unknown_model_fallback: None,
+            model_discovery_cache: Default::default(),
             providers: provider_registry_for_tests(None, Some("dummy"), home.join(".codex")),
             web_config: holon::web::WebConfig::default(),
         }
@@ -2407,6 +2409,19 @@ async fn handle_config_models_command(command: ConfigModelCommands) -> Result<()
         ConfigModelCommands::List => {
             let config = AppConfig::load_for_config_inspection()?;
             print_json(&serde_json::to_value(resolved_model_availability(&config))?)
+        }
+        ConfigModelCommands::Refresh { provider } => {
+            let provider_id = ProviderId::parse(&provider)?;
+            let config = AppConfig::load_for_config_inspection()?;
+            let provider = config.providers.get(&provider_id).with_context(|| {
+                format!(
+                    "provider {} is not configured or built in",
+                    provider_id.as_str()
+                )
+            })?;
+            let report =
+                refresh_provider_models(provider, &discovery_cache_path(&config.home_dir)).await?;
+            print_json(&serde_json::to_value(report)?)
         }
     }
 }

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -16,6 +16,7 @@ pub enum ModelMetadataSource {
     BuiltInCatalog,
     ConservativeBuiltin,
     ConfigOverride,
+    RemoteDiscovered,
     UnknownFallback,
 }
 
@@ -183,11 +184,13 @@ impl BuiltInModelCatalog {
         &self,
         model_ref: &ModelRef,
         overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+        discovered_models: &HashMap<ModelRef, BuiltInModelMetadata>,
         unknown_fallback: Option<&ModelRuntimeOverride>,
         base_context_config: &ContextConfig,
         configured_runtime_max_output_tokens: u32,
     ) -> ResolvedRuntimeModelPolicy {
-        let built_in = self.get(model_ref);
+        let discovered = discovered_models.get(model_ref);
+        let built_in = discovered.or_else(|| self.get(model_ref));
         let override_config = overrides.get(model_ref);
         let fallback_override = if built_in.is_none() {
             unknown_fallback
@@ -304,6 +307,7 @@ impl BuiltInModelCatalog {
         &self,
         model_ref: &ModelRef,
         overrides: &HashMap<ModelRef, ModelRuntimeOverride>,
+        discovered_models: &HashMap<ModelRef, BuiltInModelMetadata>,
         unknown_fallback: Option<&ModelRuntimeOverride>,
         base_context_config: &ContextConfig,
         configured_runtime_max_output_tokens: u32,
@@ -311,6 +315,7 @@ impl BuiltInModelCatalog {
         let policy = self.resolve_policy(
             model_ref,
             overrides,
+            discovered_models,
             unknown_fallback,
             base_context_config,
             configured_runtime_max_output_tokens,
@@ -1854,6 +1859,7 @@ mod tests {
         let policy = catalog.resolve_policy(
             &ModelRef::new(ProviderId::openai_codex(), "gpt-5.4"),
             &HashMap::new(),
+            &HashMap::new(),
             None,
             &base_context(),
             8192,
@@ -1869,6 +1875,7 @@ mod tests {
         let catalog = BuiltInModelCatalog::new();
         let policy = catalog.resolve_policy(
             &ModelRef::new(ProviderId::openai_codex(), "gpt-5.3-codex-spark"),
+            &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
@@ -1887,6 +1894,7 @@ mod tests {
         let policy = catalog.resolve_policy(
             &ModelRef::new(ProviderId::openai_codex(), "gpt-5.3-codex"),
             &HashMap::new(),
+            &HashMap::new(),
             None,
             &base_context(),
             8192,
@@ -1904,6 +1912,7 @@ mod tests {
         let policy = catalog.resolve_policy(
             &ModelRef::parse("deepseek/deepseek-v4-flash").unwrap(),
             &HashMap::new(),
+            &HashMap::new(),
             None,
             &base_context(),
             8192,
@@ -1918,6 +1927,7 @@ mod tests {
 
         let nearai = catalog.resolve_policy(
             &ModelRef::parse("nearai/zai-org/GLM-5.1-FP8").unwrap(),
+            &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
@@ -1937,6 +1947,7 @@ mod tests {
         let deepseek = catalog.resolve_policy(
             &ModelRef::parse("deepseek-anthropic/deepseek-v4-flash").unwrap(),
             &HashMap::new(),
+            &HashMap::new(),
             None,
             &base_context(),
             8192,
@@ -1949,6 +1960,7 @@ mod tests {
         let deepseek_openai = catalog.resolve_policy(
             &ModelRef::parse("deepseek-openai/deepseek-v4-flash").unwrap(),
             &HashMap::new(),
+            &HashMap::new(),
             None,
             &base_context(),
             8192,
@@ -1958,6 +1970,7 @@ mod tests {
 
         let xiaomi = catalog.resolve_policy(
             &ModelRef::parse("xiaomi-token-plan-openai/mimo-v2-pro").unwrap(),
+            &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
@@ -1972,6 +1985,7 @@ mod tests {
         let zai = catalog.resolve_policy(
             &ModelRef::parse("zai-anthropic/glm-4.7").unwrap(),
             &HashMap::new(),
+            &HashMap::new(),
             None,
             &base_context(),
             8192,
@@ -1981,6 +1995,7 @@ mod tests {
 
         let bigmodel = catalog.resolve_policy(
             &ModelRef::parse("bigmodel-openai/glm-4.7").unwrap(),
+            &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
@@ -1995,6 +2010,7 @@ mod tests {
         let catalog = BuiltInModelCatalog::new();
         let policy = catalog.resolve_policy(
             &ModelRef::new(ProviderId::openai(), "custom-model"),
+            &HashMap::new(),
             &HashMap::new(),
             Some(&ModelRuntimeOverride {
                 prompt_budget_estimated_tokens: Some(64_000),
@@ -2026,6 +2042,7 @@ mod tests {
         let policy = catalog.resolve_policy(
             &ModelRef::new(ProviderId::anthropic(), "claude-sonnet-4-6"),
             &overrides,
+            &HashMap::new(),
             None,
             &base_context(),
             8192,

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -1,0 +1,284 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::{ModelRef, ProviderId, ProviderRuntimeConfig},
+    model_catalog::{BuiltInModelMetadata, ModelCapabilityFlags, ModelMetadataSource},
+};
+
+const OPENROUTER_MODELS_PATH: &str = "/models";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ModelDiscoveryCacheFile {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub providers: BTreeMap<ProviderId, ProviderModelDiscoveryCache>,
+}
+
+impl ModelDiscoveryCacheFile {
+    pub fn models(&self) -> HashMap<ModelRef, BuiltInModelMetadata> {
+        self.providers
+            .values()
+            .flat_map(|provider| provider.models.iter().cloned())
+            .map(|model| (model.model_ref.clone(), model))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderModelDiscoveryCache {
+    pub provider: ProviderId,
+    pub fetched_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_hash: Option<String>,
+    #[serde(default)]
+    pub models: Vec<BuiltInModelMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelDiscoveryRefreshReport {
+    pub provider: ProviderId,
+    pub fetched_at: DateTime<Utc>,
+    pub model_count: usize,
+    pub cache_path: PathBuf,
+}
+
+pub fn discovery_cache_path(home_dir: &Path) -> PathBuf {
+    home_dir.join("model-discovery-cache.json")
+}
+
+pub fn load_discovery_cache_at(path: &Path) -> Result<ModelDiscoveryCacheFile> {
+    if !path.exists() {
+        return Ok(ModelDiscoveryCacheFile::default());
+    }
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read model discovery cache {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .with_context(|| format!("failed to parse model discovery cache {}", path.display()))
+}
+
+pub fn save_discovery_cache_at(path: &Path, cache: &ModelDiscoveryCacheFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create model discovery cache dir {}",
+                parent.display()
+            )
+        })?;
+    }
+    let bytes =
+        serde_json::to_vec_pretty(cache).context("failed to serialize model discovery cache")?;
+    fs::write(path, bytes)
+        .with_context(|| format!("failed to write model discovery cache {}", path.display()))
+}
+
+pub async fn refresh_provider_models(
+    provider: &ProviderRuntimeConfig,
+    cache_path: &Path,
+) -> Result<ModelDiscoveryRefreshReport> {
+    if provider.id.as_str() != "openrouter" {
+        return Err(anyhow!(
+            "provider {} does not support model discovery yet",
+            provider.id.as_str()
+        ));
+    }
+
+    let source_url = openrouter_models_url(&provider.base_url)?;
+    let request = reqwest::Client::builder()
+        .user_agent("holon-model-discovery")
+        .build()
+        .context("failed to build model discovery HTTP client")?
+        .get(&source_url);
+    let request = if let Some(credential) = provider.credential.as_deref() {
+        request.bearer_auth(credential)
+    } else {
+        request
+    };
+    let response = request
+        .send()
+        .await
+        .context("OpenRouter model discovery request failed")?
+        .error_for_status()
+        .context("OpenRouter model discovery returned an error status")?;
+    let raw = response
+        .bytes()
+        .await
+        .context("failed to read OpenRouter model discovery response")?;
+    let response_hash = format!("sha256:{}", sha256_hex(&raw));
+    let payload: OpenRouterModelsResponse = serde_json::from_slice(&raw)
+        .context("failed to parse OpenRouter model discovery response")?;
+    let fetched_at = Utc::now();
+    let models = payload.into_model_metadata(&provider.id);
+
+    let mut cache = load_discovery_cache_at(cache_path)?;
+    cache.providers.insert(
+        provider.id.clone(),
+        ProviderModelDiscoveryCache {
+            provider: provider.id.clone(),
+            fetched_at,
+            source_url: Some(source_url),
+            response_hash: Some(response_hash),
+            models: models.clone(),
+        },
+    );
+    save_discovery_cache_at(cache_path, &cache)?;
+
+    Ok(ModelDiscoveryRefreshReport {
+        provider: provider.id.clone(),
+        fetched_at,
+        model_count: models.len(),
+        cache_path: cache_path.to_path_buf(),
+    })
+}
+
+fn openrouter_models_url(base_url: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(base_url)
+        .with_context(|| format!("invalid OpenRouter base_url {base_url:?}"))?;
+    let path = url.path().trim_end_matches('/');
+    url.set_path(&format!("{path}{OPENROUTER_MODELS_PATH}"));
+    Ok(url.to_string())
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterModelsResponse {
+    #[serde(default)]
+    data: Vec<OpenRouterModel>,
+}
+
+impl OpenRouterModelsResponse {
+    fn into_model_metadata(self, provider: &ProviderId) -> Vec<BuiltInModelMetadata> {
+        let mut models = self
+            .data
+            .into_iter()
+            .filter_map(|model| model.into_model_metadata(provider))
+            .collect::<Vec<_>>();
+        models.sort_by(|left, right| {
+            left.display_name
+                .cmp(&right.display_name)
+                .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
+        });
+        models
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterModel {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    context_length: Option<usize>,
+    #[serde(default)]
+    architecture: Option<OpenRouterArchitecture>,
+    #[serde(default)]
+    top_provider: Option<OpenRouterTopProvider>,
+}
+
+impl OpenRouterModel {
+    fn into_model_metadata(self, provider: &ProviderId) -> Option<BuiltInModelMetadata> {
+        let id = self.id.trim();
+        if id.is_empty() {
+            return None;
+        }
+        let display_name = self
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(id)
+            .to_string();
+        let description = self
+            .description
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("Remote discovered OpenRouter model metadata.")
+            .to_string();
+        let max_output_tokens_upper_limit = self
+            .top_provider
+            .as_ref()
+            .and_then(|provider| provider.max_completion_tokens);
+        let image_input = self
+            .architecture
+            .as_ref()
+            .map(|architecture| {
+                architecture
+                    .input_modalities
+                    .iter()
+                    .any(|value| value.eq_ignore_ascii_case("image"))
+            })
+            .unwrap_or(false);
+        Some(BuiltInModelMetadata {
+            model_ref: ModelRef::new(provider.clone(), id.to_string()),
+            display_name,
+            description,
+            context_window_tokens: self.context_length,
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: max_output_tokens_upper_limit,
+            max_output_tokens_upper_limit,
+            tool_output_truncation_estimated_tokens: None,
+            capabilities: ModelCapabilityFlags {
+                image_input,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::RemoteDiscovered,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterArchitecture {
+    #[serde(default)]
+    input_modalities: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterTopProvider {
+    #[serde(default)]
+    max_completion_tokens: Option<u32>,
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_openrouter_models_to_remote_metadata() {
+        let payload: OpenRouterModelsResponse = serde_json::from_str(
+            r#"{"data":[{"id":"anthropic/claude-3.5-sonnet","name":"Claude 3.5 Sonnet","description":"test","context_length":200000,"architecture":{"input_modalities":["text","image"]},"top_provider":{"max_completion_tokens":8192}}]}"#,
+        )
+        .unwrap();
+
+        let models = payload.into_model_metadata(&ProviderId::parse("openrouter").unwrap());
+
+        assert_eq!(models.len(), 1);
+        let model = &models[0];
+        assert_eq!(
+            model.model_ref.as_string(),
+            "openrouter/anthropic/claude-3.5-sonnet"
+        );
+        assert_eq!(model.display_name, "Claude 3.5 Sonnet");
+        assert_eq!(model.context_window_tokens, Some(200_000));
+        assert_eq!(model.max_output_tokens_upper_limit, Some(8192));
+        assert!(model.capabilities.image_input);
+        assert_eq!(model.source, ModelMetadataSource::RemoteDiscovered);
+    }
+}

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -225,7 +225,7 @@ impl OpenRouterModel {
             context_window_tokens: self.context_length,
             effective_context_window_percent: 95,
             auto_compact_token_limit: None,
-            default_max_output_tokens: max_output_tokens_upper_limit,
+            default_max_output_tokens: None,
             max_output_tokens_upper_limit,
             tool_output_truncation_estimated_tokens: None,
             capabilities: ModelCapabilityFlags {

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -914,6 +914,7 @@ mod tests {
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: HashMap::new(),
             validated_unknown_model_fallback: None,
+            model_discovery_cache: Default::default(),
             providers: provider_registry_for_tests(openai_key, None, PathBuf::new()),
             web_config: crate::web::WebConfig::default(),
         }

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -147,6 +147,7 @@ fn resolved_model_policy_for_candidate(
     BuiltInModelCatalog::default().resolve_policy(
         model_ref,
         &config.validated_model_overrides,
+        &config.model_discovery_cache.models(),
         config.validated_unknown_model_fallback.as_ref(),
         &base_context_config,
         config.runtime_max_output_tokens,

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -301,6 +301,7 @@ mod tests {
             tui_alternate_screen: crate::config::AltScreenMode::Auto,
             validated_model_overrides: HashMap::new(),
             validated_unknown_model_fallback: None,
+            model_discovery_cache: Default::default(),
             providers: provider_registry_for_tests(
                 openai_key,
                 Some("anthropic-token"),

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -302,6 +302,7 @@ pub fn test_config(
         tui_alternate_screen: crate::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: provider_registry_for_tests(openai_key, anthropic_token, codex_home),
         web_config: crate::web::WebConfig::default(),
     };

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -576,6 +576,7 @@ fn openai_compaction_policy_from_config(
     let policy = BuiltInModelCatalog::default().resolve_policy(
         &ModelRef::new(provider, model),
         &config.validated_model_overrides,
+        &config.model_discovery_cache.models(),
         config.validated_unknown_model_fallback.as_ref(),
         &base_context_config,
         config.runtime_max_output_tokens,
@@ -592,6 +593,7 @@ fn openai_compaction_policy_for_model(
 ) -> OpenAiCompactionPolicy {
     let policy = BuiltInModelCatalog::default().resolve_policy(
         &ModelRef::new(provider, model),
+        &Default::default(),
         &Default::default(),
         None,
         &ContextConfig::default(),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -73,6 +73,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: crate::config::provider_registry_for_tests(
             None,
             Some("dummy"),

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -46,6 +46,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: holon::config::provider_registry_for_tests(
             None,
             Some("dummy"),

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -242,6 +242,20 @@
     "aliases": []
   },
   {
+    "path": "config.models.refresh",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "provider",
+        "short": null,
+        "default_value": null,
+        "possible_values": null,
+        "required": true
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "config.providers",
     "positionals": [],
     "flags": [],

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -168,6 +168,7 @@ impl TestConfigBuilder {
             tui_alternate_screen: holon::config::AltScreenMode::Auto,
             validated_model_overrides: std::collections::HashMap::new(),
             validated_unknown_model_fallback: None,
+            model_discovery_cache: Default::default(),
             providers: holon::config::provider_registry_for_tests(
                 None,
                 Some("dummy"),

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -48,6 +48,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: holon::config::provider_registry_for_tests(
             None,
             Some("dummy"),

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -47,6 +47,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: holon::config::provider_registry_for_tests(
             None,
             Some("dummy"),

--- a/tests/wt203_task_owned_worktree_cleanup.rs
+++ b/tests/wt203_task_owned_worktree_cleanup.rs
@@ -46,6 +46,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: holon::config::provider_registry_for_tests(
             None,
             Some("dummy"),

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -47,6 +47,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: holon::config::provider_registry_for_tests(
             None,
             Some("dummy"),

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -47,6 +47,7 @@ fn test_config() -> AppConfig {
         tui_alternate_screen: holon::config::AltScreenMode::Auto,
         validated_model_overrides: std::collections::HashMap::new(),
         validated_unknown_model_fallback: None,
+        model_discovery_cache: Default::default(),
         providers: holon::config::provider_registry_for_tests(
             None,
             Some("dummy"),


### PR DESCRIPTION
## Summary

Fixes #1562.

Adds a provider model discovery path for OpenRouter without changing runtime model selection semantics:

- adds `holon config models refresh --provider openrouter`
- fetches OpenRouter `/models` and writes a local discovery cache under `HOLON_HOME`
- maps remote metadata into Holon model metadata with `remote_discovered` source
- merges availability with precedence: config override, remote discovery cache, built-in catalog, then unknown fallback for otherwise unknown explicit refs
- keeps `model.default` and `model.fallbacks` unchanged by discovery
- documents the curated-vs-discovered catalog boundary

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p holon model_discovery --lib`
- `cargo test -p holon runtime_model_catalog_uses_discovery_cache_between_overrides_and_builtins --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
