### PR TITLE
fix: refresh discovered OpenRouter models in picker

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -12,6 +12,7 @@ use crate::{
     context::ContextConfig,
     host::RuntimeHostBridge,
     model_catalog::BuiltInModelMetadata,
+    model_discovery::{discovery_cache_path, load_discovery_cache_at},
     provider::{build_provider_from_model_chain, resolved_model_availability, AgentProvider},
     queue::RuntimeQueue,
     storage::AppStorage,
@@ -424,11 +425,27 @@ impl RuntimeHandle {
         self.inner.context_config.read().await.clone()
     }
 
+    fn model_config_with_fresh_discovery_cache(&self) -> Result<Option<AppConfig>> {
+        let Some(reconfig) = self.inner.provider_reconfig.as_ref() else {
+            return Ok(None);
+        };
+        let mut config = reconfig.config.clone();
+        config.model_discovery_cache =
+            load_discovery_cache_at(&discovery_cache_path(&config.home_dir))?;
+        Ok(Some(config))
+    }
+
     pub(crate) async fn available_models(&self) -> Result<Vec<BuiltInModelMetadata>> {
+        if let Some(config) = self.model_config_with_fresh_discovery_cache()? {
+            return Ok(RuntimeModelCatalog::from_config(&config).available_models());
+        }
         Ok(self.inner.model_catalog.available_models())
     }
 
     pub(crate) async fn model_availability(&self) -> Result<Vec<ResolvedModelAvailability>> {
+        if let Some(config) = self.model_config_with_fresh_discovery_cache()? {
+            return Ok(resolved_model_availability(&config));
+        }
         Ok(self.inner.model_availability.clone())
     }
 }

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -425,25 +425,43 @@ impl RuntimeHandle {
         self.inner.context_config.read().await.clone()
     }
 
-    fn model_config_with_fresh_discovery_cache(&self) -> Result<Option<AppConfig>> {
+    async fn model_config_with_fresh_discovery_cache(&self) -> Option<AppConfig> {
         let Some(reconfig) = self.inner.provider_reconfig.as_ref() else {
-            return Ok(None);
+            return None;
         };
         let mut config = reconfig.config.clone();
-        config.model_discovery_cache =
-            load_discovery_cache_at(&discovery_cache_path(&config.home_dir))?;
-        Ok(Some(config))
+        let cache_path = discovery_cache_path(&config.home_dir);
+        match tokio::task::spawn_blocking(move || load_discovery_cache_at(&cache_path)).await {
+            Ok(Ok(cache)) => {
+                config.model_discovery_cache = cache;
+                Some(config)
+            }
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    error = %err,
+                    "failed to refresh model discovery cache; using startup model catalog"
+                );
+                None
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "model discovery cache refresh task failed; using startup model catalog"
+                );
+                None
+            }
+        }
     }
 
     pub(crate) async fn available_models(&self) -> Result<Vec<BuiltInModelMetadata>> {
-        if let Some(config) = self.model_config_with_fresh_discovery_cache()? {
+        if let Some(config) = self.model_config_with_fresh_discovery_cache().await {
             return Ok(RuntimeModelCatalog::from_config(&config).available_models());
         }
         Ok(self.inner.model_catalog.available_models())
     }
 
     pub(crate) async fn model_availability(&self) -> Result<Vec<ResolvedModelAvailability>> {
-        if let Some(config) = self.model_config_with_fresh_discovery_cache()? {
+        if let Some(config) = self.model_config_with_fresh_discovery_cache().await {
             return Ok(resolved_model_availability(&config));
         }
         Ok(self.inner.model_availability.clone())

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -642,9 +642,7 @@ impl TuiApp {
                 self.status_line = "Opened raw events overlay".into();
             }
             SlashCommand::Model => {
-                if self.model_availability.is_empty() {
-                    self.begin_load_models();
-                }
+                self.begin_load_models();
                 self.overlay = OverlayState::ModelPicker {
                     filter: String::new(),
                     selected: 0,

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -263,6 +263,16 @@ mod tests {
     }
 
     #[test]
+    fn picker_rows_skip_unavailable_models() {
+        let agent = summary();
+        let availability = model_availability();
+        let rows = model_picker_rows(Some(&agent), &availability, "");
+        assert!(!rows
+            .iter()
+            .any(|row| row.title.contains("anthropic/claude-sonnet-4-6")));
+    }
+
+    #[test]
     fn picker_rows_filter_by_model_and_label() {
         let agent = summary();
         let availability = model_availability();


### PR DESCRIPTION
## Summary
- reload the model discovery cache when serving /models so refreshed OpenRouter models appear without restarting the daemon
- make the TUI /model command refresh model availability every time it opens the picker
- add coverage for filtering unavailable picker rows

## Verification
- cargo fmt --all -- --check
- cargo test tui::model_picker --all-targets
- cargo test resolved_model_availability_includes_config_catalog_models --all-targets
- RUSTFLAGS="-D warnings" cargo check --all-targets