### PR TITLE
fix: keep turns running after CompleteWorkItem

### DIFF
--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -737,15 +737,31 @@ async fn build_response(
         None
     };
     let raw_final_text = raw_final_text(&final_state, baseline, final_status);
-    let delivery_summary_text = runtime
+    let new_delivery_summaries = runtime
         .storage()
         .read_recent_delivery_summaries(usize::MAX)?
         .into_iter()
         .filter(|summary| !baseline.delivery_summary_ids.contains(&summary.id))
+        .collect::<Vec<_>>();
+    let new_delivery_summary_by_id = new_delivery_summaries
+        .iter()
+        .map(|summary| (summary.id.as_str(), summary))
+        .collect::<HashMap<_, _>>();
+    let promoted_completion_report_text = view
+        .new_events
+        .iter()
+        .filter(|event| event.kind == "work_item_completion_report_promoted")
+        .filter_map(|event| event.data["delivery_summary_id"].as_str())
+        .filter_map(|id| new_delivery_summary_by_id.get(id))
         .last()
-        .map(|summary| summary.text)
-        .map(|text| text.trim().to_string())
+        .map(|summary| summary.text.trim().to_string())
         .filter(|text| !text.is_empty());
+    let delivery_summary_text = promoted_completion_report_text.or_else(|| {
+        new_delivery_summaries
+            .last()
+            .map(|summary| summary.text.trim().to_string())
+            .filter(|text| !text.is_empty())
+    });
     let final_text = delivery_summary_text
         .or_else(|| raw_final_text.clone())
         .unwrap_or_default();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -96,7 +96,7 @@ use command_task::ManagedTaskHandle;
 use continuation::{resolve_continuation, ContinuationTrigger};
 #[cfg(test)]
 use subagent::sanitize_subagent_result;
-use turn::{LoopControlOptions, TurnTerminalDelivery};
+use turn::LoopControlOptions;
 
 #[derive(Debug, Clone)]
 pub(super) struct WorkItemCompletionReportPromotion {

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -105,27 +105,23 @@ impl RuntimeHandle {
             brief.turn_index = Some(outcome.turn_index);
             self.persist_brief(&brief).await?;
         } else {
-            match outcome.terminal_delivery {
-                TurnTerminalDelivery::NormalBrief => {
-                    let mut brief =
-                        brief::make_result(&message.agent_id, message, outcome.final_text.clone());
-                    brief.turn_index = Some(outcome.turn_index);
-                    self.persist_brief(&brief).await?;
-                }
-                TurnTerminalDelivery::WorkItemCompletionReportPromoted {
-                    work_item_id,
-                    delivery_summary_id,
-                    brief_id,
-                } => {
+            if !outcome.terminal_delivery.suppress_normal_brief {
+                let mut brief =
+                    brief::make_result(&message.agent_id, message, outcome.final_text.clone());
+                brief.turn_index = Some(outcome.turn_index);
+                self.persist_brief(&brief).await?;
+            }
+            for promotion in &outcome.terminal_delivery.promoted_completion_reports {
+                if outcome.terminal_delivery.suppress_normal_brief {
                     self.inner.storage.append_event(&AuditEvent::new(
                         "turn_terminal_brief_suppressed",
                         serde_json::json!({
                             "agent_id": message.agent_id.clone(),
                             "message_id": message.id.clone(),
                             "reason": "work_item_completion_report_promoted",
-                            "work_item_id": work_item_id,
-                            "delivery_summary_id": delivery_summary_id,
-                            "brief_id": brief_id,
+                            "work_item_id": &promotion.work_item_id,
+                            "delivery_summary_id": &promotion.delivery_summary_id,
+                            "brief_id": &promotion.brief_id,
                         }),
                     ))?;
                 }

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -28,6 +28,14 @@ fn legacy_blocking_payload_task_for_work_item(
     }
 }
 
+fn continuation_context_config() -> ContextConfig {
+    ContextConfig {
+        prompt_budget_estimated_tokens: 16384,
+        compaction_keep_recent_estimated_tokens: 2048,
+        ..context_config()
+    }
+}
+
 struct CompleteWorkItemReportProvider {
     work_item_id: String,
     report_text: Option<String>,
@@ -70,9 +78,103 @@ impl AgentProvider for CompleteWorkItemReportProvider {
     }
 }
 
+struct CompleteThenExecProvider {
+    work_item_id: String,
+    calls: Mutex<usize>,
+}
+
+#[async_trait]
+impl AgentProvider for CompleteThenExecProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        let blocks = if *calls == 1 {
+            vec![
+                ModelBlock::Text {
+                    text: "Finished the tracked work.".into(),
+                },
+                ModelBlock::ToolUse {
+                    id: "complete-work".into(),
+                    name: "CompleteWorkItem".into(),
+                    input: serde_json::json!({
+                        "work_item_id": self.work_item_id.clone(),
+                    }),
+                },
+                ModelBlock::ToolUse {
+                    id: "verify".into(),
+                    name: "ExecCommand".into(),
+                    input: serde_json::json!({
+                        "cmd": "printf 'verified'",
+                        "shell": "sh",
+                    }),
+                },
+            ]
+        } else {
+            vec![ModelBlock::Text {
+                text: "Verified after completion.".into(),
+            }]
+        };
+        Ok(ProviderTurnResponse {
+            blocks,
+            stop_reason: None,
+            input_tokens: 10,
+            output_tokens: 10,
+            cache_usage: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
+struct StaleTextThenCompleteProvider {
+    work_item_id: String,
+    calls: Mutex<usize>,
+}
+
+#[async_trait]
+impl AgentProvider for StaleTextThenCompleteProvider {
+    async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        let blocks = if *calls == 1 {
+            vec![
+                ModelBlock::Text {
+                    text: "This text belongs to the ExecCommand tool call.".into(),
+                },
+                ModelBlock::ToolUse {
+                    id: "inspect".into(),
+                    name: "ExecCommand".into(),
+                    input: serde_json::json!({
+                        "cmd": "printf 'inspected'",
+                        "shell": "sh",
+                    }),
+                },
+                ModelBlock::ToolUse {
+                    id: "complete-work".into(),
+                    name: "CompleteWorkItem".into(),
+                    input: serde_json::json!({
+                        "work_item_id": self.work_item_id.clone(),
+                    }),
+                },
+            ]
+        } else {
+            vec![ModelBlock::Text {
+                text: "No completion report was provided.".into(),
+            }]
+        };
+        Ok(ProviderTurnResponse {
+            blocks,
+            stop_reason: None,
+            input_tokens: 10,
+            output_tokens: 10,
+            cache_usage: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
 struct MultiCompleteWorkItemReportProvider {
     work_item_ids: Vec<String>,
-    report_text: String,
+    report_texts: Vec<String>,
     calls: Mutex<usize>,
 }
 
@@ -82,10 +184,13 @@ impl AgentProvider for MultiCompleteWorkItemReportProvider {
         let mut calls = self.calls.lock().await;
         *calls += 1;
         let blocks = if *calls == 1 {
-            let mut blocks = vec![ModelBlock::Text {
-                text: self.report_text.clone(),
-            }];
+            let mut blocks = Vec::new();
             for (index, work_item_id) in self.work_item_ids.iter().enumerate() {
+                if let Some(report_text) = self.report_texts.get(index) {
+                    blocks.push(ModelBlock::Text {
+                        text: report_text.clone(),
+                    });
+                }
                 blocks.push(ModelBlock::ToolUse {
                     id: format!("complete-work-{index}"),
                     name: "CompleteWorkItem".into(),
@@ -1838,7 +1943,7 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         "http://127.0.0.1:7878".into(),
         provider.clone(),
         "default".into(),
-        context_config(),
+        continuation_context_config(),
     )
     .unwrap();
     let message = MessageEnvelope::new(
@@ -1864,8 +1969,8 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         .unwrap();
     assert_eq!(
         *provider.calls.lock().await,
-        1,
-        "promoted completion report should end the provider loop"
+        2,
+        "promoted completion report should not hard-stop the provider loop"
     );
 
     let completed = runtime
@@ -1937,6 +2042,169 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
             && event.data["reason"].as_str() == Some("work_item_completion_report_promoted")
             && event.data["work_item_id"].as_str() == Some(work_item.id.as_str())
     }));
+}
+
+#[tokio::test]
+async fn complete_work_item_followed_by_same_round_tool_keeps_terminal_brief() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = seed_runtime
+        .create_work_item("complete then verify".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(work_item.id.clone())
+        .await
+        .unwrap();
+
+    let provider = Arc::new(CompleteThenExecProvider {
+        work_item_id: work_item.id.clone(),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        continuation_context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "complete and verify".into(),
+        },
+    );
+
+    runtime
+        .process_interactive_message(
+            &message,
+            None,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(*provider.calls.lock().await, 2);
+    let briefs = runtime.recent_briefs(10).await.unwrap();
+    assert!(briefs.iter().any(|brief| {
+        brief.kind == BriefKind::Result && brief.text == "Finished the tracked work."
+    }));
+    assert!(briefs.iter().any(|brief| {
+        brief.kind == BriefKind::Result && brief.text == "Verified after completion."
+    }));
+    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    assert!(!events
+        .iter()
+        .any(|event| event.kind == "turn_terminal_brief_suppressed"));
+}
+
+#[tokio::test]
+async fn complete_work_item_does_not_promote_text_before_other_tool() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let seed_runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let work_item = seed_runtime
+        .create_work_item("complete after another tool".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    seed_runtime
+        .pick_work_item(work_item.id.clone())
+        .await
+        .unwrap();
+
+    let provider = Arc::new(StaleTextThenCompleteProvider {
+        work_item_id: work_item.id.clone(),
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider,
+        "default".into(),
+        continuation_context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "inspect then complete".into(),
+        },
+    );
+
+    runtime
+        .process_interactive_message(
+            &message,
+            None,
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let completed = runtime
+        .latest_work_item(&work_item.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completed.state, WorkItemState::Completed);
+    assert_eq!(completed.result_summary, None);
+    assert!(runtime
+        .storage()
+        .latest_delivery_summary(&work_item.id)
+        .unwrap()
+        .is_none());
+    let transcript = runtime.storage().read_recent_transcript(10).unwrap();
+    let tool_results = transcript
+        .iter()
+        .find(|entry| entry.kind == crate::types::TranscriptEntryKind::ToolResults)
+        .expect("tool results should be recorded");
+    let completion_result = tool_results.data["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|result| result["tool_use_id"].as_str() == Some("complete-work"))
+        .expect("completion result should be recorded");
+    let content: serde_json::Value =
+        serde_json::from_str(completion_result["content"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        content["result"]["completion_report_promoted"].as_bool(),
+        None
+    );
 }
 
 #[tokio::test]
@@ -2136,7 +2404,10 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
 
     let provider = Arc::new(MultiCompleteWorkItemReportProvider {
         work_item_ids: vec![first.id.clone(), second.id.clone()],
-        report_text: "Finished two work items in one report.".into(),
+        report_texts: vec![
+            "Finished the first work item.".into(),
+            "Finished the second work item.".into(),
+        ],
         calls: Mutex::new(0),
     });
     let runtime = RuntimeHandle::new(
@@ -2146,7 +2417,7 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
         "http://127.0.0.1:7878".into(),
         provider.clone(),
         "default".into(),
-        context_config(),
+        continuation_context_config(),
     )
     .unwrap();
     let message = MessageEnvelope::new(
@@ -2171,20 +2442,49 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
         .await
         .unwrap();
 
-    for work_item_id in [&first.id, &second.id] {
+    for (work_item_id, report_text) in [
+        (&first.id, "Finished the first work item."),
+        (&second.id, "Finished the second work item."),
+    ] {
         let completed = runtime
             .latest_work_item(work_item_id)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(completed.state, WorkItemState::Completed);
-        assert_eq!(completed.result_summary, None);
-        assert!(runtime
-            .storage()
-            .latest_delivery_summary(work_item_id)
-            .unwrap()
-            .is_none());
+        assert_eq!(completed.result_summary.as_deref(), Some(report_text));
+        assert_eq!(
+            runtime
+                .storage()
+                .latest_delivery_summary(work_item_id)
+                .unwrap()
+                .expect("completion report should persist delivery summary")
+                .text,
+            report_text
+        );
     }
+    assert_eq!(
+        *provider.calls.lock().await,
+        2,
+        "multiple completion reports should not hard-stop the provider loop"
+    );
+    let briefs = runtime.recent_briefs(10).await.unwrap();
+    assert_eq!(
+        briefs
+            .iter()
+            .filter(|brief| brief.kind == BriefKind::Result
+                && brief.work_item_id.as_deref() == Some(first.id.as_str()))
+            .count(),
+        1
+    );
+    assert_eq!(
+        briefs
+            .iter()
+            .filter(|brief| brief.kind == BriefKind::Result
+                && brief.work_item_id.as_deref() == Some(second.id.as_str()))
+            .count(),
+        1
+    );
     let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
     assert_eq!(
         events
@@ -2195,11 +2495,15 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
                         == Some("completion_report_not_promoted_multiple_completions")
             })
             .count(),
+        0
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.kind == "turn_terminal_brief_suppressed")
+            .count(),
         2
     );
-    assert!(!events
-        .iter()
-        .any(|event| event.kind == "turn_terminal_brief_suppressed"));
 }
 
 #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -50,18 +50,38 @@ pub(super) struct AgentLoopOutcome {
 }
 
 #[derive(Debug, Clone)]
-pub(super) enum TurnTerminalDelivery {
-    /// The turn should emit the normal terminal result brief from its final
-    /// assistant text.
-    NormalBrief,
-    /// The turn already promoted a same-round WorkItem completion report into
-    /// a result brief, so the operator-dispatch path must suppress its
-    /// otherwise duplicate terminal brief.
-    WorkItemCompletionReportPromoted {
-        work_item_id: String,
-        delivery_summary_id: String,
-        brief_id: String,
-    },
+pub(super) struct TurnTerminalDelivery {
+    /// Completion reports already promoted during this turn.
+    pub(super) promoted_completion_reports: Vec<TurnPromotedCompletionReport>,
+    /// Whether the terminal result brief should be suppressed because it would
+    /// only duplicate a promoted completion report.
+    pub(super) suppress_normal_brief: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct TurnPromotedCompletionReport {
+    pub(super) work_item_id: String,
+    pub(super) delivery_summary_id: String,
+    pub(super) brief_id: String,
+}
+
+impl TurnTerminalDelivery {
+    fn normal() -> Self {
+        Self {
+            promoted_completion_reports: Vec::new(),
+            suppress_normal_brief: false,
+        }
+    }
+
+    fn completion_reports(
+        promoted_completion_reports: Vec<TurnPromotedCompletionReport>,
+        suppress_normal_brief: bool,
+    ) -> Self {
+        Self {
+            promoted_completion_reports,
+            suppress_normal_brief,
+        }
+    }
 }
 
 pub(super) struct LoopControlOptions {
@@ -1395,7 +1415,7 @@ impl RuntimeHandle {
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
             terminal_kind: TurnTerminalKind::Aborted,
-            terminal_delivery: TurnTerminalDelivery::NormalBrief,
+            terminal_delivery: TurnTerminalDelivery::normal(),
         }))
     }
 
@@ -1553,7 +1573,7 @@ impl RuntimeHandle {
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
             terminal_kind,
-            terminal_delivery: TurnTerminalDelivery::NormalBrief,
+            terminal_delivery: TurnTerminalDelivery::normal(),
         }))
     }
 
@@ -1813,8 +1833,10 @@ impl TurnExecution<'_> {
         } = self;
         let mut completed_rounds = Vec::<TurnRoundRecord>::new();
         let turn_started_at = Instant::now();
-        let mut should_sleep = false;
         let mut sleep_duration_ms = None;
+        let mut promoted_completion_reports = Vec::<TurnPromotedCompletionReport>::new();
+        let mut post_completion_continuation_action = false;
+        let mut completed_work_item_this_turn = false;
         let mut round = 0usize;
         let mut truncated_text_history = Vec::new();
         let mut last_assistant_message: Option<String> = None;
@@ -1896,7 +1918,7 @@ impl TurnExecution<'_> {
                         sleep_duration_ms: None,
                         allow_sleep_runnable_work_override: false,
                         terminal_kind: TurnTerminalKind::Aborted,
-                        terminal_delivery: TurnTerminalDelivery::NormalBrief,
+                        terminal_delivery: TurnTerminalDelivery::normal(),
                     });
                 }
             }
@@ -2127,7 +2149,7 @@ impl TurnExecution<'_> {
                             sleep_duration_ms: None,
                             allow_sleep_runnable_work_override: false,
                             terminal_kind: TurnTerminalKind::BaselineOverBudget,
-                            terminal_delivery: TurnTerminalDelivery::NormalBrief,
+                            terminal_delivery: TurnTerminalDelivery::normal(),
                         });
                     }
                 };
@@ -2642,12 +2664,22 @@ impl TurnExecution<'_> {
                     turn_index: terminal.turn_index,
                     should_sleep: true,
                     sleep_duration_ms,
-                    allow_sleep_runnable_work_override: false,
+                    allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
-                    terminal_delivery: TurnTerminalDelivery::NormalBrief,
+                    terminal_delivery: if !promoted_completion_reports.is_empty() {
+                        TurnTerminalDelivery::completion_reports(
+                            promoted_completion_reports,
+                            !post_completion_continuation_action,
+                        )
+                    } else {
+                        TurnTerminalDelivery::normal()
+                    },
                 });
             }
 
+            if !promoted_completion_reports.is_empty() && !tool_calls.is_empty() {
+                post_completion_continuation_action = true;
+            }
             let round_tool_calls = tool_calls.clone();
             let mut tool_results = Vec::new();
             let mut tool_result_envelopes = Vec::new();
@@ -2805,7 +2837,6 @@ impl TurnExecution<'_> {
                         }
 
                         if result.should_sleep {
-                            should_sleep = true;
                             sleep_duration_ms = result.sleep_duration_ms;
                         }
                         runtime.inner.storage.append_tool_execution(&record)?;
@@ -2905,16 +2936,29 @@ impl TurnExecution<'_> {
                     }
                 }
             }
-            let completion_promotion = runtime
+            let completion_promotions = runtime
                 .promote_round_completion_report_if_present(
                     agent_id,
                     round,
                     turn_index,
-                    &combined_text,
+                    &completed_round_assistant_blocks,
                     &mut tool_results,
                     &mut tool_result_envelopes,
                 )
                 .await?;
+            if tool_result_envelopes
+                .iter()
+                .any(envelope_completes_work_item)
+            {
+                completed_work_item_this_turn = true;
+            }
+            if !completion_promotions.is_empty()
+                && round_has_post_completion_non_completion_tool_call(
+                    &completed_round_assistant_blocks,
+                )
+            {
+                post_completion_continuation_action = true;
+            }
             runtime
                 .inner
                 .storage
@@ -2933,6 +2977,11 @@ impl TurnExecution<'_> {
             let mut interjections = before_tool_execution_interjections;
             interjections.extend(after_tool_results_interjections);
             let has_operator_interjections = !interjections.is_empty();
+            if (!promoted_completion_reports.is_empty() || !completion_promotions.is_empty())
+                && has_operator_interjections
+            {
+                post_completion_continuation_action = true;
+            }
             let round_record = TurnRoundRecord {
                 round,
                 estimated_tokens: build_round_estimated_tokens(
@@ -2960,32 +3009,13 @@ impl TurnExecution<'_> {
             }
             completed_rounds.push(round_record);
 
-            if let Some(promotion) = completion_promotion {
-                if !has_operator_interjections {
-                    let final_text = last_assistant_message.clone().unwrap_or_default();
-                    let terminal = runtime
-                        .persist_turn_terminal_record(
-                            TurnTerminalKind::Completed,
-                            last_assistant_message.clone(),
-                            turn_started_at.elapsed().as_millis() as u64,
-                            Some(&checkpoint_state),
-                        )
-                        .await?;
-                    return Ok(AgentLoopOutcome {
-                        final_text,
-                        turn_index: terminal.turn_index,
-                        should_sleep,
-                        sleep_duration_ms,
-                        allow_sleep_runnable_work_override: should_sleep,
-                        terminal_kind: TurnTerminalKind::Completed,
-                        terminal_delivery: TurnTerminalDelivery::WorkItemCompletionReportPromoted {
-                            work_item_id: promotion.record.id,
-                            delivery_summary_id: promotion.delivery_summary_id,
-                            brief_id: promotion.brief_id,
-                        },
-                    });
-                }
-            }
+            promoted_completion_reports.extend(completion_promotions.into_iter().map(
+                |promotion| TurnPromotedCompletionReport {
+                    work_item_id: promotion.record.id,
+                    delivery_summary_id: promotion.delivery_summary_id,
+                    brief_id: promotion.brief_id,
+                },
+            ));
 
             if only_sleep_tools && !has_operator_interjections {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
@@ -3002,9 +3032,16 @@ impl TurnExecution<'_> {
                     turn_index: terminal.turn_index,
                     should_sleep: true,
                     sleep_duration_ms: sleep_duration_ms.or(legacy_sleep_duration_ms),
-                    allow_sleep_runnable_work_override: true,
+                    allow_sleep_runnable_work_override: completed_work_item_this_turn,
                     terminal_kind: TurnTerminalKind::Completed,
-                    terminal_delivery: TurnTerminalDelivery::NormalBrief,
+                    terminal_delivery: if !promoted_completion_reports.is_empty() {
+                        TurnTerminalDelivery::completion_reports(
+                            promoted_completion_reports,
+                            !post_completion_continuation_action,
+                        )
+                    } else {
+                        TurnTerminalDelivery::normal()
+                    },
                 });
             }
         }
@@ -3017,10 +3054,10 @@ impl RuntimeHandle {
         agent_id: &str,
         round: usize,
         turn_index: u64,
-        combined_text: &str,
+        assistant_blocks: &[ModelBlock],
         tool_results: &mut [ToolResultBlock],
         tool_result_envelopes: &mut [ToolResultEnvelope],
-    ) -> Result<Option<WorkItemCompletionReportPromotion>> {
+    ) -> Result<Vec<WorkItemCompletionReportPromotion>> {
         let completion_indexes = tool_result_envelopes
             .iter()
             .enumerate()
@@ -3037,14 +3074,21 @@ impl RuntimeHandle {
             .filter_map(|(index, envelope)| result_work_item_id(envelope).map(|id| (index, id)))
             .collect::<Vec<_>>();
         if completion_indexes.is_empty() {
-            return Ok(None);
+            return Ok(Vec::new());
         }
 
-        if completion_indexes.len() != 1 {
-            for (index, work_item_id) in completion_indexes {
+        let report_texts_by_tool_id = completion_report_texts_by_tool_id(assistant_blocks);
+        let mut promotions = Vec::new();
+        for (index, work_item_id) in completion_indexes {
+            let tool_use_id = tool_results[index].tool_use_id.as_str();
+            let report_text = report_texts_by_tool_id
+                .iter()
+                .find_map(|(id, text)| (id == tool_use_id).then_some(text.trim()))
+                .unwrap_or_default();
+            if report_text.is_empty() {
                 let warning = completion_report_warning(
-                    "completion_report_not_promoted_multiple_completions",
-                    "Completion report was not promoted because this round completed multiple work items.",
+                    "missing_completion_report",
+                    "CompleteWorkItem succeeded without nearby preceding same-round operator-facing report text; no canonical completion report was promoted.",
                 );
                 append_completion_warning(&mut tool_result_envelopes[index], warning.clone());
                 update_tool_result_block_content(
@@ -3054,77 +3098,98 @@ impl RuntimeHandle {
                 )?;
                 self.record_work_item_completion_warning(
                     work_item_id,
-                    "completion_report_not_promoted_multiple_completions",
-                    "Completion report was not promoted because this round completed multiple work items.",
+                    "missing_completion_report",
+                    "CompleteWorkItem succeeded without nearby preceding same-round operator-facing report text; no canonical completion report was promoted.",
                     Some(turn_index),
                     Some(round),
                 )
                 .await?;
+                continue;
             }
-            return Ok(None);
-        }
 
-        let (index, work_item_id) = completion_indexes
-            .into_iter()
-            .next()
-            .expect("checked non-empty");
-        let report_text = combined_text.trim();
-        if report_text.is_empty() {
-            let warning = completion_report_warning(
-                "missing_completion_report",
-                "CompleteWorkItem succeeded without same-round operator-facing report text; no canonical completion report was promoted.",
-            );
-            append_completion_warning(&mut tool_result_envelopes[index], warning.clone());
+            let warnings = envelope_warnings(&tool_result_envelopes[index]);
+            let promotion = match self
+                .promote_work_item_completion_report_with_metadata(
+                    work_item_id.clone(),
+                    report_text.to_string(),
+                    Some(turn_index),
+                    Some(round),
+                    warnings,
+                )
+                .await?
+            {
+                WorkItemCompletionReportPromotionOutcome::Promoted(promotion) => promotion,
+                WorkItemCompletionReportPromotionOutcome::Unchanged(_) => continue,
+            };
+            if let Some(result) = tool_result_envelopes[index].result.as_mut() {
+                if let Some(object) = result.as_object_mut() {
+                    object.insert("completion_report_promoted".into(), serde_json::json!(true));
+                    object.insert(
+                        "completion_report_source".into(),
+                        serde_json::json!("same_assistant_round_preceding_text"),
+                    );
+                }
+            }
             update_tool_result_block_content(index, tool_results, &tool_result_envelopes[index])?;
-            self.record_work_item_completion_warning(
-                work_item_id,
-                "missing_completion_report",
-                "CompleteWorkItem succeeded without same-round operator-facing report text; no canonical completion report was promoted.",
-                Some(turn_index),
-                Some(round),
-            )
-            .await?;
-            return Ok(None);
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_completion_report_candidate_promoted",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "work_item_id": work_item_id,
+                    "turn_index": turn_index,
+                    "round": round,
+                    "delivery_summary_id": promotion.delivery_summary_id.clone(),
+                    "brief_id": promotion.brief_id.clone(),
+                    "text_preview": truncate_preview(report_text, ROUND_TEXT_PREVIEW_LIMIT),
+                }),
+            ))?;
+            promotions.push(promotion);
         }
+        Ok(promotions)
+    }
+}
 
-        let warnings = envelope_warnings(&tool_result_envelopes[index]);
-        let promotion = match self
-            .promote_work_item_completion_report_with_metadata(
-                work_item_id.clone(),
-                report_text.to_string(),
-                Some(turn_index),
-                Some(round),
-                warnings,
-            )
-            .await?
-        {
-            WorkItemCompletionReportPromotionOutcome::Promoted(promotion) => promotion,
-            WorkItemCompletionReportPromotionOutcome::Unchanged(_) => return Ok(None),
-        };
-        if let Some(result) = tool_result_envelopes[index].result.as_mut() {
-            if let Some(object) = result.as_object_mut() {
-                object.insert("completion_report_promoted".into(), serde_json::json!(true));
-                object.insert(
-                    "completion_report_source".into(),
-                    serde_json::json!("same_assistant_round"),
-                );
+fn completion_report_texts_by_tool_id(assistant_blocks: &[ModelBlock]) -> Vec<(String, String)> {
+    let mut pending_text = Vec::<String>::new();
+    let mut reports = Vec::<(String, String)>::new();
+    for block in assistant_blocks {
+        match block {
+            ModelBlock::Text { text } => {
+                if !text.trim().is_empty() {
+                    pending_text.push(text.clone());
+                }
+            }
+            ModelBlock::ToolUse { id, name, .. } => {
+                if name == "CompleteWorkItem" {
+                    let report_text = pending_text
+                        .iter()
+                        .map(|text| text.trim())
+                        .filter(|text| !text.is_empty())
+                        .collect::<Vec<_>>()
+                        .join("\n\n");
+                    reports.push((id.clone(), report_text));
+                }
+                pending_text.clear();
+            }
+            ModelBlock::Thinking { .. } | ModelBlock::RedactedThinking { .. } => {}
+        }
+    }
+    reports
+}
+
+fn round_has_post_completion_non_completion_tool_call(assistant_blocks: &[ModelBlock]) -> bool {
+    let mut saw_completion = false;
+    for block in assistant_blocks {
+        if let ModelBlock::ToolUse { name, .. } = block {
+            if saw_completion && name != "CompleteWorkItem" {
+                return true;
+            }
+            if name == "CompleteWorkItem" {
+                saw_completion = true;
             }
         }
-        update_tool_result_block_content(index, tool_results, &tool_result_envelopes[index])?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_completion_report_candidate_promoted",
-            serde_json::json!({
-                "agent_id": agent_id,
-                "work_item_id": work_item_id,
-                "turn_index": turn_index,
-                "round": round,
-                "delivery_summary_id": promotion.delivery_summary_id.clone(),
-                "brief_id": promotion.brief_id.clone(),
-                "text_preview": truncate_preview(report_text, ROUND_TEXT_PREVIEW_LIMIT),
-            }),
-        ))?;
-        Ok(Some(promotion))
     }
+    false
 }
 
 fn result_work_item_id(envelope: &ToolResultEnvelope) -> Option<String> {
@@ -3135,6 +3200,17 @@ fn result_work_item_id(envelope: &ToolResultEnvelope) -> Option<String> {
         .get("id")?
         .as_str()
         .map(ToString::to_string)
+}
+
+fn envelope_completes_work_item(envelope: &ToolResultEnvelope) -> bool {
+    envelope.tool_name == "CompleteWorkItem"
+        && envelope.status == ToolResultStatus::Success
+        && envelope
+            .result
+            .as_ref()
+            .and_then(|result| result.get("completed_transition"))
+            .and_then(Value::as_bool)
+            == Some(true)
 }
 
 fn envelope_warnings(envelope: &ToolResultEnvelope) -> Vec<Value> {

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -274,7 +274,7 @@ async fn run_once_prefers_completed_work_item_delivery_summary_over_latest_turn_
     );
     assert_eq!(
         second.raw_final_text.as_deref(),
-        Some("Implemented broad prompt/context snapshot coverage")
+        Some("Fixed two test annotation issues.")
     );
     let runtime = host
         .get_public_agent_for_external_ingress("default")


### PR DESCRIPTION
Fixes #1567.

## Summary
- Treat CompleteWorkItem as a WorkItem lifecycle boundary instead of a hard provider-loop terminator.
- Allow a turn to promote multiple completion reports, each bound to the same assistant response text immediately preceding its CompleteWorkItem call.
- Suppress the normal terminal brief only when it would duplicate promoted completion reports; keep it when there is explicit post-completion follow-up work.

## Verification
- cargo test -p holon complete_work_item --all-targets
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets