### PR TITLE
docs: add holon onboard documentation

### DIFF
--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -218,11 +218,11 @@ In a terminal, this launches an interactive TUI that walks you through:
 
 1. **Provider selection** — choose from built-in providers (Anthropic, OpenAI,
    DeepSeek, Codex, etc.) or a custom provider
-2. **Model selection** — pick your default model
-3. **Search configuration** — enable DuckDuckGo managed search, model-native
+2. **Credential entry** — for OpenAI Codex: browser-based OAuth login; for other
+   providers: enter your API key (input is never echoed or stored in logs)
+3. **Model selection** — pick your default model, or enter a custom model id
+4. **Search configuration** — enable DuckDuckGo managed search, model-native
    search, or keep search disabled
-4. **Credential entry** — enter your API key (input is never echoed or stored
-   in logs)
 
 `holon onboard` writes the config, stores credentials securely, and prints a
 summary. It's the recommended path for first-time setup.

--- a/docs/website/getting-started/first-agent.md
+++ b/docs/website/getting-started/first-agent.md
@@ -206,6 +206,29 @@ In the TUI, you can switch between agents using the agent list view.
 
 ## Step 5: Configure models
 
+### Recommended: Quick setup with `holon onboard`
+
+The fastest way to configure Holon is the interactive onboarding wizard:
+
+```bash
+holon onboard
+```
+
+In a terminal, this launches an interactive TUI that walks you through:
+
+1. **Provider selection** — choose from built-in providers (Anthropic, OpenAI,
+   DeepSeek, Codex, etc.) or a custom provider
+2. **Model selection** — pick your default model
+3. **Search configuration** — enable DuckDuckGo managed search, model-native
+   search, or keep search disabled
+4. **Credential entry** — enter your API key (input is never echoed or stored
+   in logs)
+
+`holon onboard` writes the config, stores credentials securely, and prints a
+summary. It's the recommended path for first-time setup.
+
+### Manual setup (alternative)
+
 Holon requires model configuration to work with providers like Anthropic or OpenAI.
 
 ### Configuration layers

--- a/docs/website/guides/troubleshooting.md
+++ b/docs/website/guides/troubleshooting.md
@@ -50,6 +50,12 @@ Common causes:
 
 ### "No available model" or credential errors
 
+For the fastest repair, run the interactive onboarding wizard:
+
+```bash
+holon onboard
+```
+
 Run the diagnostic tool:
 
 ```bash

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -18,6 +18,7 @@ For scripting guidance, stability levels, and support policy, see
 ```
 holon (v0.14.1)
 ├── serve        Start HTTP control plane server
+├── onboard      Interactive setup wizard or secret-safe diagnostics
 ├── daemon       Background daemon lifecycle
 │   ├── start    Start the daemon
 │   ├── stop     Stop the daemon
@@ -144,12 +145,39 @@ holon daemon restart
 holon daemon stop
 ```
 
+### Onboarding
+
+`holon onboard` is the fastest way to configure Holon for the first time or
+repair a broken provider/model configuration. It has two modes:
+
+- **Interactive TUI** (default on a terminal): walks you through provider
+  selection, model choice, search settings, and credential input — without
+  echoing secret material to the screen.
+- **JSON diagnostics** (`--json` or non-TTY): prints a secret-safe diagnostic
+  report with actionable next steps, suitable for scripts and CI.
+
+```bash
+holon onboard                    # Interactive setup wizard (TTY)
+holon onboard --json             # Secret-safe diagnostic report (JSON)
+```
+
+The TUI flow guides you through:
+
+1. **Provider** — select from built-in and custom providers
+2. **Model** — pick a default model for your provider
+3. **Search** — enable DuckDuckGo managed search, model-native search, or disable
+4. **Credential** — enter your API key (input never echoed or stored in logs)
+- **Apply** — writes config, stores credentials, and prints a summary
+
+The JSON report includes `status`, `sections` (home, agent, model_provider,
+search, credentials), and `next_actions`. It is secret-safe by design: no
+credential material ever appears in the report.
+
 ### Configuration inspection
 
 ```bash
 holon config list                # All current config
 holon config schema              # All keys with types and defaults
-holon onboard                    # Secret-safe setup guidance and next steps
 holon config doctor              # Full health check
 holon config providers list      # All registered providers
 holon config models list         # Available models with status

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-summary: Holon's current command-line interface — verified against holon --help (v0.14.1).
+summary: Holon's current command-line interface — verified against holon --help (v0.16.0).
 order: 10
 ---
 <!-- maintenance: regenerate from `holon --help` output when commands change -->
@@ -16,7 +16,7 @@ For scripting guidance, stability levels, and support policy, see
 ## Command Tree
 
 ```
-holon (v0.15.1)
+holon (v0.16.0)
 ├── serve        Start HTTP control plane server
 ├── onboard      Interactive setup wizard or secret-safe diagnostics
 ├── daemon       Background daemon lifecycle

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -16,7 +16,7 @@ For scripting guidance, stability levels, and support policy, see
 ## Command Tree
 
 ```
-holon (v0.14.1)
+holon (v0.15.1)
 ├── serve        Start HTTP control plane server
 ├── onboard      Interactive setup wizard or secret-safe diagnostics
 ├── daemon       Background daemon lifecycle
@@ -164,10 +164,11 @@ holon onboard --json             # Secret-safe diagnostic report (JSON)
 The TUI flow guides you through:
 
 1. **Provider** — select from built-in and custom providers
-2. **Model** — pick a default model for your provider
-3. **Search** — enable DuckDuckGo managed search, model-native search, or disable
-4. **Credential** — enter your API key (input never echoed or stored in logs)
-- **Apply** — writes config, stores credentials, and prints a summary
+2. **Credential** — for OpenAI Codex: browser-based OAuth login; for other
+   providers: enter your API key (input never echoed or stored in logs)
+3. **Model** — pick a default model for your provider, or enter a custom model id
+4. **Search** — enable DuckDuckGo managed search, model-native search, or disable
+5. **Apply** — writes config, stores credentials, and prints a summary
 
 The JSON report includes `status`, `sections` (home, agent, model_provider,
 search, credentials), and `next_actions`. It is secret-safe by design: no


### PR DESCRIPTION
## Summary

Add `holon onboard` documentation across three docs pages.

### Changes

- **CLI Reference** (`docs/website/reference/cli.md`): Added `onboard` to the command tree (updated to v0.15.1) and a dedicated Onboarding section covering interactive TUI mode in the correct order (Provider → Credential/Auth → Model → Search → Apply) and JSON diagnostic mode (`--json` / non-TTY), including auth-path details (OpenAI Codex OAuth login vs API-key entry for other providers) and secret-safe design notes.

- **Getting Started** (`docs/website/getting-started/first-agent.md`): Added "Recommended: Quick setup with `holon onboard`" as the preferred path in Step 5, with the original manual steps kept under "Manual setup (alternative)", and generalized credential setup wording to cover API-key entry or OAuth login depending on provider.

- **Troubleshooting** (`docs/website/guides/troubleshooting.md`): Added a tip to run `holon onboard` first for interactive fixes before `holon config doctor` diagnostics in the "No available model or credential errors" section.