### PR TITLE
feat: add in-memory turn context projection

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1603,7 +1603,7 @@ fn render_recent_turns_with_budget(
         .filter(|message| {
             briefs
                 .iter()
-                .any(|brief| brief.related_message_id.as_deref() == Some(message.id.as_str()))
+                .any(|brief| brief_matches_message(brief, message))
                 || tools.iter().any(|tool| {
                     tool.turn_index != 0 && message.message_seq == Some(tool.turn_index)
                 })
@@ -1616,6 +1616,7 @@ fn render_recent_turns_with_budget(
             current_message,
             operator,
             briefs,
+            tools,
             current_work_item,
         ));
     }
@@ -1668,7 +1669,7 @@ fn render_turn_projection(
 
     let related_briefs = briefs
         .iter()
-        .filter(|brief| brief.related_message_id.as_deref() == Some(message.id.as_str()))
+        .filter(|brief| brief_matches_message(brief, message))
         .map(|brief| {
             format!(
                 "    - {:?}: {}",
@@ -1699,9 +1700,10 @@ fn render_current_continuation_turn_projection(
     current_message: &MessageEnvelope,
     operator: &MessageEnvelope,
     briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
     current_work_item: Option<&WorkItemRecord>,
 ) -> String {
-    let mut rendered = render_turn_projection(operator, briefs, &[], Some(current_message));
+    let mut rendered = render_turn_projection(operator, briefs, tools, Some(current_message));
     let mut lines = vec![
         format!(
             "  - current relation: {}",
@@ -1715,12 +1717,20 @@ fn render_current_continuation_turn_projection(
     if let Some(work_item) = current_work_item {
         lines.push(format!(
             "  - current work item: {} :: {}",
-            work_item.id, work_item.objective
+            sanitize_inline(&work_item.id),
+            sanitize_inline(&truncate_text(&work_item.objective, 160))
         ));
     }
     rendered.push('\n');
     rendered.push_str(&lines.join("\n"));
     rendered
+}
+
+fn brief_matches_message(brief: &BriefRecord, message: &MessageEnvelope) -> bool {
+    brief.related_message_id.as_deref() == Some(message.id.as_str())
+        || brief
+            .turn_index
+            .is_some_and(|turn_index| message.message_seq == Some(turn_index))
 }
 
 fn turn_trigger_label(message: &MessageEnvelope) -> &'static str {

--- a/src/context.rs
+++ b/src/context.rs
@@ -324,6 +324,21 @@ pub fn build_context(
         );
     }
 
+    if let Some(content) = render_recent_turns_with_budget(
+        &messages,
+        &briefs,
+        &tools,
+        current_message,
+        current_work_item,
+        remaining_budget,
+    ) {
+        push_budgeted_section(
+            &mut sections,
+            &mut remaining_budget,
+            turn_section("recent_turns", content),
+        );
+    }
+
     if let Some(content) = render_recent_messages_with_budget(&messages, remaining_budget) {
         push_budgeted_section(
             &mut sections,
@@ -1565,6 +1580,158 @@ fn render_recent_briefs_with_budget(briefs: &[BriefRecord], budget: usize) -> Op
         briefs.iter().map(render_brief).collect(),
         budget,
     )
+}
+
+fn render_recent_turns_with_budget(
+    messages: &[MessageEnvelope],
+    briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
+    current_message: &MessageEnvelope,
+    current_work_item: Option<&WorkItemRecord>,
+    budget: usize,
+) -> Option<String> {
+    let latest_operator_for_continuation = (!is_trusted_operator_input(current_message))
+        .then(|| latest_trusted_operator_input(messages, current_message))
+        .flatten();
+    let mut rendered_turns = messages
+        .iter()
+        .filter(|message| include_in_prompt_context(message))
+        .filter(|message| {
+            latest_operator_for_continuation
+                .is_none_or(|operator| !same_message_identity(message, operator))
+        })
+        .filter(|message| {
+            briefs
+                .iter()
+                .any(|brief| brief.related_message_id.as_deref() == Some(message.id.as_str()))
+                || tools.iter().any(|tool| {
+                    tool.turn_index != 0 && message.message_seq == Some(tool.turn_index)
+                })
+        })
+        .map(|message| render_turn_projection(message, briefs, tools, None))
+        .collect::<Vec<_>>();
+
+    if let Some(operator) = latest_operator_for_continuation {
+        rendered_turns.push(render_current_continuation_turn_projection(
+            current_message,
+            operator,
+            briefs,
+            current_work_item,
+        ));
+    }
+
+    if rendered_turns.is_empty() {
+        return None;
+    }
+
+    render_budgeted_lines("Recent turns:", rendered_turns, budget)
+}
+
+fn render_turn_projection(
+    message: &MessageEnvelope,
+    briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
+    continuation: Option<&MessageEnvelope>,
+) -> String {
+    let mut lines = vec![format!(
+        "- Turn {}:",
+        message
+            .message_seq
+            .map(|seq| format!("message_seq {seq}"))
+            .unwrap_or_else(|| message.id.clone())
+    )];
+    lines.push(format!("  - trigger: {}", turn_trigger_label(message)));
+    if let Some(continuation) = continuation {
+        lines.push(format!(
+            "  - continues input: {}",
+            message
+                .message_seq
+                .map(|seq| format!("message_seq {seq}"))
+                .unwrap_or_else(|| message.id.clone())
+        ));
+        lines.push(format!(
+            "  - continuation trigger: {}",
+            turn_trigger_label(continuation)
+        ));
+    }
+    if is_trusted_operator_input(message) {
+        lines.push(format!(
+            "  - operator asked: {}",
+            sanitize_inline(&body_preview(&message.body))
+        ));
+    } else {
+        lines.push(format!(
+            "  - input: {}",
+            sanitize_inline(&body_preview(&message.body))
+        ));
+    }
+
+    let related_briefs = briefs
+        .iter()
+        .filter(|brief| brief.related_message_id.as_deref() == Some(message.id.as_str()))
+        .map(|brief| {
+            format!(
+                "    - {:?}: {}",
+                brief.kind,
+                sanitize_inline(&truncate_text(&brief.text, 160))
+            )
+        })
+        .collect::<Vec<_>>();
+    if !related_briefs.is_empty() {
+        lines.push("  - produced briefs:".to_string());
+        lines.extend(related_briefs);
+    }
+
+    let related_tools = tools
+        .iter()
+        .filter(|tool| tool.turn_index != 0 && message.message_seq == Some(tool.turn_index))
+        .map(render_recent_tool_execution)
+        .collect::<Vec<_>>();
+    if !related_tools.is_empty() {
+        lines.push("  - tool executions:".to_string());
+        lines.extend(related_tools.into_iter().map(|tool| format!("    {tool}")));
+    }
+
+    lines.join("\n")
+}
+
+fn render_current_continuation_turn_projection(
+    current_message: &MessageEnvelope,
+    operator: &MessageEnvelope,
+    briefs: &[BriefRecord],
+    current_work_item: Option<&WorkItemRecord>,
+) -> String {
+    let mut rendered = render_turn_projection(operator, briefs, &[], Some(current_message));
+    let mut lines = vec![
+        format!(
+            "  - current relation: {}",
+            runtime_continuation_label(current_message)
+        ),
+        format!(
+            "  - current input: {}",
+            sanitize_inline(&body_preview(&current_message.body))
+        ),
+    ];
+    if let Some(work_item) = current_work_item {
+        lines.push(format!(
+            "  - current work item: {} :: {}",
+            work_item.id, work_item.objective
+        ));
+    }
+    rendered.push('\n');
+    rendered.push_str(&lines.join("\n"));
+    rendered
+}
+
+fn turn_trigger_label(message: &MessageEnvelope) -> &'static str {
+    if is_trusted_operator_input(message) {
+        return "trusted operator input";
+    }
+    runtime_continuation_label(message)
+}
+
+fn sanitize_inline(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn render_recent_tools_with_budget(tools: &[ToolExecutionRecord], budget: usize) -> Option<String> {

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -12,8 +12,8 @@ use holon::{
         AgentRegistryStatus, AgentState, AgentVisibility, AuthorityClass, BriefKind, BriefRecord,
         ContinuationClass, ContinuationResolution, ContinuationTriggerKind, LoadedAgentsMd,
         MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
-        SkillsRuntimeView, TodoItem, TodoItemState, WaitingReason, WorkItemRecord, WorkItemState,
-        WorkingMemoryDelta, WorkingMemorySnapshot,
+        SkillsRuntimeView, TodoItem, TodoItemState, ToolExecutionRecord, ToolExecutionStatus,
+        WaitingReason, WorkItemRecord, WorkItemState, WorkingMemoryDelta, WorkingMemorySnapshot,
     },
 };
 use serde_json::json;
@@ -261,6 +261,35 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
         Some(operator_message.id.clone()),
         Some("task_exec_1".into()),
     ))?;
+    let mut turn_index_brief = BriefRecord::new(
+        "default",
+        BriefKind::Result,
+        "Captured completion report promotion.",
+        None,
+        None,
+    );
+    turn_index_brief.turn_index = Some(1);
+    storage.append_brief(&turn_index_brief)?;
+    storage.append_tool_execution(&ToolExecutionRecord {
+        id: "tool_exec_1".into(),
+        agent_id: "default".into(),
+        work_item_id: None,
+        turn_index: 1,
+        tool_name: "ExecCommand".into(),
+        created_at: Utc::now(),
+        completed_at: Some(Utc::now()),
+        duration_ms: 42,
+        authority_class: AuthorityClass::RuntimeInstruction,
+        status: ToolExecutionStatus::Success,
+        input: json!({ "fixture": true }),
+        output: json!({ "exit": 0 }),
+        summary: "Run command: cargo test runtime_flow".into(),
+        invocation_surface: Some("commentary".into()),
+    })?;
+
+    let mut work_item = WorkItemRecord::new("default", "Track\nruntime flow", WorkItemState::Open);
+    work_item.id = "work_runtime_flow".into();
+    storage.append_work_item(&work_item)?;
 
     let task_result = MessageEnvelope::new(
         "default",
@@ -291,7 +320,11 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
 
     let rendered = render_context_snapshot(
         &storage,
-        &AgentState::new("default"),
+        &{
+            let mut session = AgentState::new("default");
+            session.current_work_item_id = Some(work_item.id.clone());
+            session
+        },
         &task_result,
         Some(&continuation),
     )?;
@@ -302,13 +335,23 @@ Agent id: default
 ## execution_environment
 {EXECUTION_ENVIRONMENT}
 
+## current_work_item
+Current work item:
+- Id: work_runtime_flow
+- State: Open
+- Readiness: Runnable
+- Objective: Track
+runtime flow
+- Plan status: draft
+- Plan artifact: $AGENT_HOME/work-items/work_runtime_flow/plan.md
+- Plan preview complete: true
+
 ## context_contract
 {CONTEXT_CONTRACT}
 
 ## continuation_anchor
 Continuation anchor:
-Latest trusted operator input:
-Run cargo test runtime_flow and report back.
+Latest trusted operator input: message_seq 1.
 Current input relation: current_input is a task-result continuation, not a new operator request. Continue the latest trusted operator input above unless the current WorkItem projection is more specific.
 
 ## recent_turns
@@ -320,16 +363,28 @@ Recent turns:
   - operator asked: Run cargo test runtime_flow and report back.
   - produced briefs:
     - Ack: Started cargo test runtime_flow.
+    - Result: Captured completion report promotion.
+  - tool executions:
+    - [trusted_system][Success] Run command: cargo test runtime_flow
   - current relation: a task-result continuation
   - current input: Command task completed successfully: cargo test runtime_flow
+  - current work item: work_runtime_flow :: Track runtime flow
 
 ## recent_messages
 Recent messages:
 - [operator][cli_prompt][local_process][operator_instruction][OperatorPrompt] Run cargo test runtime_flow and report back.
 
+## latest_result
+Latest completed result:
+Captured completion report promotion.
+
 ## recent_briefs
 Recent briefs:
 - [Ack] Started cargo test runtime_flow.
+
+## recent_tool_executions
+Recent tool executions:
+- [trusted_system][Success] Run command: cargo test runtime_flow
 
 ## continuation_context
 Continuation context:

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -9,9 +9,9 @@ use holon::{
     system::{ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
         AdmissionContext, AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset,
-        AgentRegistryStatus, AgentState, AgentVisibility, AuthorityClass, ContinuationClass,
-        ContinuationResolution, ContinuationTriggerKind, LoadedAgentsMd, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+        AgentRegistryStatus, AgentState, AgentVisibility, AuthorityClass, BriefKind, BriefRecord,
+        ContinuationClass, ContinuationResolution, ContinuationTriggerKind, LoadedAgentsMd,
+        MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
         SkillsRuntimeView, TodoItem, TodoItemState, WaitingReason, WorkItemRecord, WorkItemState,
         WorkingMemoryDelta, WorkingMemorySnapshot,
     },
@@ -136,6 +136,215 @@ fn append_work_item_todo(
     work_item.todo_list = todo_list;
     work_item.updated_at = Utc::now();
     storage.append_work_item(&work_item)?;
+    Ok(())
+}
+
+#[test]
+fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
+    let dir = tempdir()?;
+    let storage = AppStorage::new(dir.path())?;
+
+    let previous_operator = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator:jolestar".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "Run the focused prompt projection test.".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
+    );
+    storage.append_message(&previous_operator)?;
+    storage.append_brief(&BriefRecord::new(
+        "default",
+        BriefKind::Result,
+        "Focused prompt projection test passed.",
+        Some(previous_operator.id.clone()),
+        None,
+    ))?;
+
+    let current_message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator:jolestar".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "Continue with the next prompt projection case.".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
+    );
+
+    let rendered = render_context_snapshot(
+        &storage,
+        &AgentState::new("default"),
+        &current_message,
+        None,
+    )?;
+    let expected = format!(
+        r#"## agent
+Agent id: default
+
+## execution_environment
+{EXECUTION_ENVIRONMENT}
+
+## context_contract
+{CONTEXT_CONTRACT}
+
+## continuation_anchor
+Continuation anchor:
+Latest trusted operator input: current_input.
+Current input relation: current_input is the latest trusted operator input.
+
+## recent_turns
+Recent turns:
+- Turn message_seq 1:
+  - trigger: trusted operator input
+  - operator asked: Run the focused prompt projection test.
+  - produced briefs:
+    - Result: Focused prompt projection test passed.
+
+## recent_messages
+Recent messages:
+- [operator][cli_prompt][local_process][operator_instruction][OperatorPrompt] Run the focused prompt projection test.
+
+## latest_result
+Latest completed result:
+Focused prompt projection test passed.
+
+## current_input
+Current input:
+- [operator][cli_prompt][local_process][operator_instruction][OperatorPrompt]
+  Continue with the next prompt projection case."#
+    );
+    assert_snapshot(&rendered, &expected);
+    Ok(())
+}
+
+#[test]
+fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Result<()> {
+    let dir = tempdir()?;
+    let storage = AppStorage::new(dir.path())?;
+
+    let operator_message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator:jolestar".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "Run cargo test runtime_flow and report back.".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::CliPrompt,
+        AdmissionContext::LocalProcess,
+    );
+    storage.append_message(&operator_message)?;
+    storage.append_brief(&BriefRecord::new(
+        "default",
+        BriefKind::Ack,
+        "Started cargo test runtime_flow.",
+        Some(operator_message.id.clone()),
+        Some("task_exec_1".into()),
+    ))?;
+
+    let task_result = MessageEnvelope::new(
+        "default",
+        MessageKind::TaskResult,
+        MessageOrigin::Task {
+            task_id: "task_exec_1".into(),
+        },
+        AuthorityClass::RuntimeInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "Command task completed successfully: cargo test runtime_flow".into(),
+        },
+    )
+    .with_admission(
+        MessageDeliverySurface::TaskRejoin,
+        AdmissionContext::RuntimeOwned,
+    );
+
+    let continuation = ContinuationResolution {
+        trigger_kind: ContinuationTriggerKind::TaskResult,
+        class: ContinuationClass::ResumeExpectedWait,
+        model_reentry: true,
+        prior_closure_outcome: holon::types::ClosureOutcome::Waiting,
+        prior_waiting_reason: Some(WaitingReason::AwaitingTaskResult),
+        matched_waiting_reason: true,
+        evidence: vec![],
+    };
+
+    let rendered = render_context_snapshot(
+        &storage,
+        &AgentState::new("default"),
+        &task_result,
+        Some(&continuation),
+    )?;
+    let expected = format!(
+        r#"## agent
+Agent id: default
+
+## execution_environment
+{EXECUTION_ENVIRONMENT}
+
+## context_contract
+{CONTEXT_CONTRACT}
+
+## continuation_anchor
+Continuation anchor:
+Latest trusted operator input:
+Run cargo test runtime_flow and report back.
+Current input relation: current_input is a task-result continuation, not a new operator request. Continue the latest trusted operator input above unless the current WorkItem projection is more specific.
+
+## recent_turns
+Recent turns:
+- Turn message_seq 1:
+  - trigger: trusted operator input
+  - continues input: message_seq 1
+  - continuation trigger: a task-result continuation
+  - operator asked: Run cargo test runtime_flow and report back.
+  - produced briefs:
+    - Ack: Started cargo test runtime_flow.
+  - current relation: a task-result continuation
+  - current input: Command task completed successfully: cargo test runtime_flow
+
+## recent_messages
+Recent messages:
+- [operator][cli_prompt][local_process][operator_instruction][OperatorPrompt] Run cargo test runtime_flow and report back.
+
+## recent_briefs
+Recent briefs:
+- [Ack] Started cargo test runtime_flow.
+
+## continuation_context
+Continuation context:
+ - Trigger kind: task_result
+ - Continuation class: resume_expected_wait
+ - Prior closure outcome: waiting
+ - Prior waiting reason: awaiting_task_result
+ - Waiting reason matched: true
+
+## current_input
+Current input:
+- [task][task_rejoin][runtime_owned][runtime_instruction][TaskResult]
+  Command task completed successfully: cargo test runtime_flow"#
+    );
+    assert_snapshot(&rendered, &expected);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1524.

## Summary
- Adds an in-memory `recent_turns` prompt section built from existing message, brief, tool execution, and WorkItem state.
- Links recoverable operator input turns to result/ack briefs and tool executions while preserving existing `recent_messages` / `recent_briefs` fallback sections.
- Makes task-result continuations explicitly reference the originating trusted operator input and current relation in model-visible context.

## Verification
- `cargo test -p holon --test prompt_context_snapshots recent_turns_snapshot -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
