### PR TITLE
docs: explain context layout and continuity

### DIFF
--- a/docs/website/concepts/README.md
+++ b/docs/website/concepts/README.md
@@ -52,6 +52,10 @@ out, and the state disappears. Holon is different because:
 The **memory system** page explains how Holon preserves continuity across
 turns through working memory, episode archives, and indexed search.
 
+The **context continuity** page explains how Holon assembles bounded prompt
+context from turns, work items, task results, briefs, and structured episodes
+without relying on raw transcript replay.
+
 The **runtime model** page expands the four-object mental model into precise
 lifecycle vocabulary: agent profiles, work-item states, task kinds, queue
 semantics, triggers, and workspace isolation.
@@ -73,6 +77,10 @@ These are maintainer-facing documents; you do not need them to use Holon.
 
 - [Runtime model](./runtime-model.md)
   Agents, tasks, work items, workspaces, and the execution loop that make up Holon's runtime.
+  <!-- mdorigin:index kind=article -->
+
+- [Context continuity](./context-continuity.md)
+  How Holon keeps long-lived agent context coherent without replaying every transcript turn.
   <!-- mdorigin:index kind=article -->
 
 - [Memory system](./memory.md)

--- a/docs/website/concepts/context-continuity.md
+++ b/docs/website/concepts/context-continuity.md
@@ -1,0 +1,130 @@
+---
+title: Context continuity
+summary: How Holon keeps long-lived agent context coherent without replaying every transcript turn.
+order: 12
+---
+
+# Context Continuity
+
+Holon agents are meant to continue work across many turns, wakeups, tasks, and
+model calls. Context continuity is the product contract that lets an agent keep
+the current objective, important results, and provenance visible without
+replaying the entire transcript.
+
+Holon does this by treating context as a runtime projection, not as a chat log.
+The durable record remains available for audit and recovery, while each model
+turn receives a bounded selection of the information that matters now.
+
+## What the Model Sees
+
+A Holon prompt is assembled from several sections with different jobs:
+
+| Section | Purpose |
+|---------|---------|
+| **Current input and continuation anchor** | The event that woke the agent and the trusted operator intent it continues. |
+| **Current work item** | The active objective, durable plan, todo list, and any waiting state. |
+| **Working memory** | A compact snapshot of current state and follow-ups derived from runtime records. |
+| **Relevant episode memory** | Archived completed work selected by relevance and budget. |
+| **Recent runtime evidence** | Recent messages, result briefs, task results, tool executions, and wakeups when they are directly useful. |
+| **Execution environment** | The current workspace, runtime capabilities, and scoped guidance. |
+
+These sections are not separate sources of truth competing with each other.
+They are projections of runtime evidence. The durable ledger remains the audit
+trail; the prompt is the budgeted view used for the next model decision.
+
+## Turns Are the Causal Unit
+
+Holon uses runtime turns as the main way to preserve continuity. A turn is one
+activation of an agent: an operator message, a task result, an external wake, a
+scheduler tick, or a provider recovery attempt.
+
+The important part is not only the trigger. A turn also links what happened:
+
+- the operator input or external event that caused the turn;
+- task results or tool executions observed during the turn;
+- result briefs produced for the operator;
+- work item updates, waits, and completion reports;
+- provenance and trust classification for the inputs involved.
+
+This keeps related facts together. For example, a CI wake can be shown as a
+continuation of the original "fix this issue" request instead of replacing
+that request as the newest intent. A completion report can stay linked to the
+work item it completed instead of becoming an unrelated summary.
+
+## Projection Is Not Transcript Truncation
+
+Simple truncation drops the oldest text once a context window fills. That is
+not enough for long-lived agents: old text may contain the operator's original
+intent, a completed decision, a task-result fact, or the reason an agent is
+waiting.
+
+Holon uses projection instead:
+
+1. **Pin what must remain authoritative**, such as trusted operator intent,
+   active work item state, waits, and lifecycle transitions.
+2. **Select useful recent turns** by continuation chain, retention priority,
+   and budget.
+3. **Fold low-value runtime noise**, such as duplicate wakeups, retries,
+   fallback attempts, no-op scheduler ticks, or repeated pending polls.
+4. **Render older completed work as structured episodes** with source refs and
+   authority boundaries.
+
+The result is a shorter prompt that still preserves why the agent is acting,
+what it has already done, and which evidence supports the current state.
+
+## Compaction Preserves Provenance
+
+Compaction is a way to keep context bounded; it is not permission to rewrite
+history.
+
+When older turn ranges age out of the hot prompt budget, Holon can archive them
+as structured episodes. An episode records the covered turn range, source turn
+IDs, source references, decisions, results, verification, unresolved items,
+operator intents, and model inferences.
+
+Model-generated summaries may help describe an episode, but they are evidence,
+not authority. They do not change the trust level of an input, overwrite
+operator intent, decide work item state, or determine what may be discarded.
+The source refs remain available for audit and recovery.
+
+## Work Items, Tasks, Briefs, and Final Answers
+
+Continuity depends on keeping runtime objects distinct:
+
+- **Work items** hold durable objectives, plans, todo lists, waits, and
+  completion status.
+- **Tasks** represent supervised commands or child agents. Their results can
+  wake an agent and continue an older operator request.
+- **Briefs** are user-facing or prompt-facing outputs produced by a turn. A
+  turn may produce more than one brief, including work item completion reports.
+- **Final answers** are what the operator sees for the current interaction.
+  They are delivery artifacts, not the only memory mechanism.
+
+Because these objects are linked through turns, the agent can answer questions
+such as "what did we do for that issue?" or "why are you waiting?" without
+searching an unstructured transcript.
+
+## What Is User-Facing Contract
+
+Users should be able to rely on these behaviors:
+
+- the current objective and trusted operator intent remain visible across
+  wakeups and task-result continuations;
+- active work item state is treated as authoritative runtime state;
+- compaction keeps provenance and does not silently flatten trust boundaries;
+- completed work can be recalled through episode memory and completion
+  reports;
+- prompt context is bounded, so old transcript text is not always replayed.
+
+The exact internal schemas, token budgets, and retention scores are
+implementation details. The visible contract is that Holon preserves continuity
+through typed runtime evidence rather than by treating the chat transcript as
+the only source of memory.
+
+## See Also
+
+- [Runtime Model](/concepts/runtime-model.md) — Agents, work items, tasks, and wakeups
+- [Memory System](/concepts/memory.md) — Working memory, episode memory, durable ledger, and search
+- [Trust Boundaries](/concepts/trust-boundaries.md) — Origin and trust classification
+- RFC: [Turn-Based Context Projection](https://github.com/holon-run/holon/blob/main/docs/rfcs/turn-based-context-projection.md)
+- RFC: [Long-Lived Context Memory](https://github.com/holon-run/holon/blob/main/docs/rfcs/long-lived-context-memory.md)

--- a/docs/website/concepts/context-continuity.md
+++ b/docs/website/concepts/context-continuity.md
@@ -71,6 +71,8 @@ Holon uses projection instead:
 
 The result is a shorter prompt that still preserves why the agent is acting,
 what it has already done, and which evidence supports the current state.
+This turn-based context projection is Holon's intended direction for preserving
+continuity without rendering an unbounded transcript.
 
 ## Compaction Preserves Provenance
 
@@ -104,7 +106,7 @@ Because these objects are linked through turns, the agent can answer questions
 such as "what did we do for that issue?" or "why are you waiting?" without
 searching an unstructured transcript.
 
-## What Is User-Facing Contract
+## What Is the User-Facing Contract
 
 Users should be able to rely on these behaviors:
 

--- a/docs/website/concepts/memory.md
+++ b/docs/website/concepts/memory.md
@@ -85,7 +85,7 @@ Each turn assembles a prompt from budgeted memory sections:
 
 - Hot turn context (current input, continuation, recent events)
 - Turn-based context projection (linked turns, result briefs, task results,
-  and WorkItem transitions)
+  and work item transitions)
 - Current work item and plan
 - Relevant episode memory
 - Working memory snapshot

--- a/docs/website/concepts/memory.md
+++ b/docs/website/concepts/memory.md
@@ -84,6 +84,8 @@ not rendered in full by default.
 Each turn assembles a prompt from budgeted memory sections:
 
 - Hot turn context (current input, continuation, recent events)
+- Turn-based context projection (linked turns, result briefs, task results,
+  and WorkItem transitions)
 - Current work item and plan
 - Relevant episode memory
 - Working memory snapshot
@@ -91,6 +93,8 @@ Each turn assembles a prompt from budgeted memory sections:
 
 This assembly keeps prompt size bounded while preserving continuity.
 Slow-changing memory sections keep provider cache identity stable.
+For a user-facing walkthrough of how these sections fit together, see
+[Context Continuity](/concepts/context-continuity.md).
 
 ## Memory vs Agent Home Files
 
@@ -149,6 +153,7 @@ surface and let shared workspaces accumulate knowledge across multiple agents.
 
 ## See Also
 
+- [Context Continuity](/concepts/context-continuity.md) — How Holon keeps context coherent without replaying the entire transcript
 - [Runtime Model](/concepts/runtime-model.md) — Agents, work items, and the execution loop
 - [Documentation Layers](/concepts/documentation-layers.md) — How memory fits into Holon's documentation architecture
 - [Agent Templates](/guides/agent-templates.md) — How templates initialize agent role contracts

--- a/docs/website/concepts/runtime-model.md
+++ b/docs/website/concepts/runtime-model.md
@@ -139,6 +139,12 @@ Holon separates **internal execution traces** from **user-facing delivery**:
 - **Task output** — Command stdout/stderr, available through task inspection
 - **Transcripts** — Full turn history for debugging
 
+Briefs and task results are linked back to the runtime turns that produced
+them. This lets Holon preserve continuity across wakeups and task-result
+continuations without treating the raw transcript as the only context source.
+See [Context Continuity](/concepts/context-continuity.md) for the
+user-facing model of prompt layout, projection, and compaction.
+
 ### Workspaces
 
 Every agent has exactly one active workspace. Workspaces define:
@@ -164,6 +170,7 @@ Each agent turn follows this pattern:
 
 ## See Also
 
+- [Context Continuity](/concepts/context-continuity.md) — How Holon preserves model-visible continuity across turns
 - [Memory System](/concepts/memory.md) — How Holon preserves continuity across turns
 - [Trust Boundaries](/concepts/trust-boundaries.md) — How Holon classifies and
   enforces trust


### PR DESCRIPTION
## Summary

Closes #1533.

This adds a user-facing concept page for context continuity and links it from the existing concept documentation.

## Changes

- Added `docs/website/concepts/context-continuity.md` explaining:
  - model-visible context layout;
  - turns as the causal unit for continuity;
  - projection vs transcript truncation;
  - structured episode compaction and provenance boundaries;
  - how WorkItems, tasks, briefs, and final answers relate.
- Linked the new page from the concepts index, memory system page, and runtime model page.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
