### PR TITLE
feat: persist lightweight turn records

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1745,10 +1745,19 @@ fn render_current_continuation_turn_projection(
 }
 
 fn brief_matches_message(brief: &BriefRecord, message: &MessageEnvelope) -> bool {
-    brief.related_message_id.as_deref() == Some(message.id.as_str())
-        || brief
-            .turn_index
-            .is_some_and(|turn_index| message.message_seq == Some(turn_index))
+    match (&brief.turn_id, &message.turn_id) {
+        (Some(brief_turn_id), Some(message_turn_id))
+            if !brief_turn_id.trim().is_empty() && !message_turn_id.trim().is_empty() =>
+        {
+            brief_turn_id == message_turn_id
+        }
+        _ => {
+            brief.related_message_id.as_deref() == Some(message.id.as_str())
+                || brief
+                    .turn_index
+                    .is_some_and(|turn_index| message.message_seq == Some(turn_index))
+        }
+    }
 }
 
 fn tool_execution_matches_message(tool: &ToolExecutionRecord, message: &MessageEnvelope) -> bool {
@@ -4992,6 +5001,42 @@ mod tests {
         tool.turn_id = None;
         message.turn_id = None;
         assert!(tool_execution_matches_message(&tool, &message));
+    }
+
+    #[test]
+    fn brief_matches_message_uses_turn_id_then_legacy_refs() {
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "finish work".into(),
+            },
+        );
+        message.id = "msg-1".into();
+        message.message_seq = Some(4);
+        message.turn_id = Some("turn-current".into());
+
+        let mut brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "done",
+            Some("msg-1".into()),
+            None,
+        );
+        brief.turn_index = Some(4);
+        brief.turn_id = Some("turn-current".into());
+
+        assert!(brief_matches_message(&brief, &message));
+
+        brief.turn_id = Some("turn-other".into());
+        assert!(!brief_matches_message(&brief, &message));
+
+        brief.turn_id = None;
+        message.turn_id = None;
+        assert!(brief_matches_message(&brief, &message));
     }
 
     fn execution_snapshot_for(session: &AgentState) -> ExecutionSnapshot {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1749,7 +1749,7 @@ fn brief_matches_message(brief: &BriefRecord, message: &MessageEnvelope) -> bool
         (Some(brief_turn_id), Some(message_turn_id))
             if !brief_turn_id.trim().is_empty() && !message_turn_id.trim().is_empty() =>
         {
-            brief_turn_id == message_turn_id
+            brief_turn_id.trim() == message_turn_id.trim()
         }
         _ => {
             brief.related_message_id.as_deref() == Some(message.id.as_str())
@@ -1765,7 +1765,7 @@ fn tool_execution_matches_message(tool: &ToolExecutionRecord, message: &MessageE
         (Some(tool_turn_id), Some(message_turn_id))
             if !tool_turn_id.trim().is_empty() && !message_turn_id.trim().is_empty() =>
         {
-            tool_turn_id == message_turn_id
+            tool_turn_id.trim() == message_turn_id.trim()
         }
         _ => tool.turn_index != 0 && message.message_seq == Some(tool.turn_index),
     }
@@ -4993,6 +4993,7 @@ mod tests {
             invocation_surface: None,
         };
 
+        tool.turn_id = Some(" turn-current ".into());
         assert!(tool_execution_matches_message(&tool, &message));
 
         tool.turn_id = Some("turn-other".into());
@@ -5029,6 +5030,7 @@ mod tests {
         brief.turn_index = Some(4);
         brief.turn_id = Some("turn-current".into());
 
+        brief.turn_id = Some(" turn-current ".into());
         assert!(brief_matches_message(&brief, &message));
 
         brief.turn_id = Some("turn-other".into());

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -291,6 +291,13 @@ impl RuntimeHandle {
             .collect::<Vec<_>>();
         let brief = brief::make_failure(&message.agent_id, message, failure_text.clone());
         self.persist_brief(&brief).await?;
+        let terminal = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.last_turn_terminal.clone()
+        };
+        if let Some(terminal) = terminal {
+            self.persist_turn_record(&terminal).await?;
+        }
         self.inner
             .storage
             .append_transcript_entry(&TranscriptEntry::new(

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -127,6 +127,7 @@ impl RuntimeHandle {
                 }
             }
         }
+        self.persist_turn_record(&outcome.terminal).await?;
         self.promote_turn_active_skills().await?;
 
         if outcome.should_sleep {

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -1201,3 +1201,76 @@ async fn runtime_failure_artifacts_preserve_provider_attempt_timeline() {
     assert!(failure.data["provider_attempt_timeline"]["winning_model_ref"].is_null());
     assert!(!failure.data["error_chain"].as_array().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn runtime_failure_artifacts_append_turn_record_after_failure_brief() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(FailingTimelineProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "trigger runtime failure".into(),
+        },
+    );
+    let error = match runtime
+        .run_agent_loop(
+            "default",
+            AuthorityClass::OperatorInstruction,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+    {
+        Ok(_) => panic!("provider failure should abort the turn"),
+        Err(error) => error,
+    };
+    let terminal = runtime
+        .agent_state()
+        .await
+        .unwrap()
+        .last_turn_terminal
+        .expect("missing aborted turn terminal");
+    assert_eq!(terminal.kind, TurnTerminalKind::Aborted);
+
+    runtime
+        .persist_runtime_failure_artifacts(&message, &error)
+        .await
+        .unwrap();
+
+    let briefs = runtime.storage().read_recent_briefs(10).unwrap();
+    let failure_brief = briefs
+        .iter()
+        .find(|brief| brief.kind == BriefKind::Failure)
+        .expect("missing runtime failure brief");
+    assert_eq!(
+        failure_brief.turn_id.as_deref(),
+        Some(terminal.turn_id.as_str())
+    );
+
+    let turns = runtime.storage().read_recent_turns(10).unwrap();
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0].turn_id, terminal.turn_id);
+    assert_eq!(turns[0].turn_index, terminal.turn_index);
+    assert_eq!(
+        turns[0].terminal.as_ref().map(|terminal| terminal.kind),
+        Some(TurnTerminalKind::Aborted)
+    );
+    assert_eq!(turns[0].produced_brief_ids, vec![failure_brief.id.clone()]);
+}

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -30,7 +30,7 @@ fn legacy_blocking_payload_task_for_work_item(
 
 fn continuation_context_config() -> ContextConfig {
     ContextConfig {
-        prompt_budget_estimated_tokens: 16384,
+        prompt_budget_estimated_tokens: 32768,
         turn_projection_budget_ratio: 1.0,
         compaction_keep_recent_estimated_tokens: 2048,
         ..context_config()

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -42,6 +42,7 @@ use super::{
 pub(super) struct AgentLoopOutcome {
     pub(super) final_text: String,
     pub(super) turn_index: u64,
+    pub(super) terminal: TurnTerminalRecord,
     pub(super) should_sleep: bool,
     pub(super) sleep_duration_ms: Option<u64>,
     pub(super) allow_sleep_runnable_work_override: bool,
@@ -99,6 +100,7 @@ const WORK_ITEM_STALE_REMINDER_MAX_TOKENS: usize = 512;
 const WORK_ITEM_STALE_REMINDER_PLAN_LINE_LIMIT: usize = 8;
 const WORK_ITEM_STALE_REMINDER_PLAN_CHAR_LIMIT: usize = 1_200;
 const WORK_ITEM_STALE_REMINDER_TODO_LIMIT: usize = 8;
+const TURN_RECORD_SCAN_LIMIT: usize = 4096;
 const OPERATOR_INTERJECTION_HEADER: &str =
     "[Operator message received while this turn was in progress]";
 const COMPACTION_BOUNDARY_FULL_PROGRESS_CHECKPOINT_PROMPT: &str = "\
@@ -231,7 +233,10 @@ fn terminal_checkpoint_from_state(
 }
 
 fn turn_optional_id_matches(candidate: Option<&str>, turn_id: &str) -> bool {
-    candidate.is_some_and(|candidate| !candidate.trim().is_empty() && candidate == turn_id)
+    candidate.is_some_and(|candidate| {
+        let candidate = candidate.trim();
+        !candidate.is_empty() && candidate == turn_id
+    })
 }
 
 fn build_checkpoint_resume_round(
@@ -1423,6 +1428,7 @@ impl RuntimeHandle {
         Ok(Some(AgentLoopOutcome {
             final_text,
             turn_index: terminal.turn_index,
+            terminal,
             should_sleep: false,
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
@@ -1467,7 +1473,6 @@ impl RuntimeHandle {
             self.inner.storage.write_agent(&guard.state)?;
             record
         };
-        self.persist_turn_record(&record).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "turn_terminal",
             serde_json::to_value(&record)?,
@@ -1475,7 +1480,7 @@ impl RuntimeHandle {
         Ok(record)
     }
 
-    async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
+    pub(super) async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
         let (agent_id, run_id, current_work_item_id) = {
             let guard = self.inner.agent.lock().await;
             (
@@ -1494,13 +1499,22 @@ impl RuntimeHandle {
         }
 
         let messages = self.inner.storage.read_all_messages()?;
-        let briefs = self.inner.storage.read_recent_briefs(usize::MAX)?;
-        let tools = self.inner.storage.read_recent_tool_executions(usize::MAX)?;
+        let briefs = self
+            .inner
+            .storage
+            .read_recent_briefs(TURN_RECORD_SCAN_LIMIT)?;
+        let tools = self
+            .inner
+            .storage
+            .read_recent_tool_executions(TURN_RECORD_SCAN_LIMIT)?;
         let delivery_summaries = self
             .inner
             .storage
-            .read_recent_delivery_summaries(usize::MAX)?;
-        let wait_conditions = self.inner.storage.read_recent_wait_conditions(usize::MAX)?;
+            .read_recent_delivery_summaries(TURN_RECORD_SCAN_LIMIT)?;
+        let wait_conditions = self
+            .inner
+            .storage
+            .read_recent_wait_conditions(TURN_RECORD_SCAN_LIMIT)?;
 
         let input_messages = messages
             .iter()
@@ -1510,7 +1524,7 @@ impl RuntimeHandle {
             })
             .collect::<Vec<_>>();
 
-        let mut record = TurnRecord::new(agent_id, terminal.turn_id.clone(), terminal.turn_index);
+        let mut record = TurnRecord::new(agent_id, turn_id, terminal.turn_index);
         record.run_id = run_id;
         record.current_work_item_id = current_work_item_id;
         record.trigger = input_messages
@@ -1683,6 +1697,7 @@ impl RuntimeHandle {
         Ok(Some(AgentLoopOutcome {
             final_text,
             turn_index: terminal.turn_index,
+            terminal,
             should_sleep: false,
             sleep_duration_ms: None,
             allow_sleep_runnable_work_override: false,
@@ -2037,6 +2052,7 @@ impl TurnExecution<'_> {
                     return Ok(AgentLoopOutcome {
                         final_text,
                         turn_index: terminal.turn_index,
+                        terminal,
                         should_sleep: false,
                         sleep_duration_ms: None,
                         allow_sleep_runnable_work_override: false,
@@ -2269,6 +2285,7 @@ impl TurnExecution<'_> {
                         return Ok(AgentLoopOutcome {
                             final_text,
                             turn_index: terminal.turn_index,
+                            terminal,
                             should_sleep: false,
                             sleep_duration_ms: None,
                             allow_sleep_runnable_work_override: false,
@@ -2786,6 +2803,7 @@ impl TurnExecution<'_> {
                 return Ok(AgentLoopOutcome {
                     final_text,
                     turn_index: terminal.turn_index,
+                    terminal,
                     should_sleep: true,
                     sleep_duration_ms,
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,
@@ -3156,6 +3174,7 @@ impl TurnExecution<'_> {
                 return Ok(AgentLoopOutcome {
                     final_text,
                     turn_index: terminal.turn_index,
+                    terminal,
                     should_sleep: true,
                     sleep_duration_ms: sleep_duration_ms.or(legacy_sleep_duration_ms),
                     allow_sleep_runnable_work_override: completed_work_item_this_turn,

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1480,25 +1480,6 @@ impl RuntimeHandle {
         Ok(record)
     }
 
-    async fn persist_turn_terminal_and_record(
-        &self,
-        kind: TurnTerminalKind,
-        last_assistant_message: Option<String>,
-        duration_ms: u64,
-        checkpoint_state: Option<&TurnLocalCheckpointState>,
-    ) -> Result<TurnTerminalRecord> {
-        let terminal = self
-            .persist_turn_terminal_record(
-                kind,
-                last_assistant_message,
-                duration_ms,
-                checkpoint_state,
-            )
-            .await?;
-        self.persist_turn_record(&terminal).await?;
-        Ok(terminal)
-    }
-
     pub(super) async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
         let (agent_id, run_id, current_work_item_id) = {
             let guard = self.inner.agent.lock().await;
@@ -2167,7 +2148,7 @@ impl TurnExecution<'_> {
                             }
                         }
                         runtime
-                            .persist_turn_terminal_and_record(
+                            .persist_turn_terminal_record(
                                 TurnTerminalKind::Aborted,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
@@ -2425,7 +2406,7 @@ impl TurnExecution<'_> {
                             }
                         }
                         runtime
-                            .persist_turn_terminal_and_record(
+                            .persist_turn_terminal_record(
                                 TurnTerminalKind::Aborted,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1480,6 +1480,25 @@ impl RuntimeHandle {
         Ok(record)
     }
 
+    async fn persist_turn_terminal_and_record(
+        &self,
+        kind: TurnTerminalKind,
+        last_assistant_message: Option<String>,
+        duration_ms: u64,
+        checkpoint_state: Option<&TurnLocalCheckpointState>,
+    ) -> Result<TurnTerminalRecord> {
+        let terminal = self
+            .persist_turn_terminal_record(
+                kind,
+                last_assistant_message,
+                duration_ms,
+                checkpoint_state,
+            )
+            .await?;
+        self.persist_turn_record(&terminal).await?;
+        Ok(terminal)
+    }
+
     pub(super) async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
         let (agent_id, run_id, current_work_item_id) = {
             let guard = self.inner.agent.lock().await;
@@ -2148,7 +2167,7 @@ impl TurnExecution<'_> {
                             }
                         }
                         runtime
-                            .persist_turn_terminal_record(
+                            .persist_turn_terminal_and_record(
                                 TurnTerminalKind::Aborted,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,
@@ -2406,7 +2425,7 @@ impl TurnExecution<'_> {
                             }
                         }
                         runtime
-                            .persist_turn_terminal_record(
+                            .persist_turn_terminal_and_record(
                                 TurnTerminalKind::Aborted,
                                 last_assistant_message.clone(),
                                 turn_started_at.elapsed().as_millis() as u64,

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -27,9 +27,9 @@ use crate::{
     types::{
         AdmissionContext, AuditEvent, AuthorityClass, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
-        TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind,
-        TurnTerminalCheckpointRecord, TurnTerminalKind, TurnTerminalRecord, WorkItemPlanStatus,
-        WorkItemRecord,
+        TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TurnRecord,
+        TurnTerminalCheckpointRecord, TurnTerminalKind, TurnTerminalRecord, TurnTerminalSummary,
+        TurnTriggerSummary, WorkItemPlanStatus, WorkItemRecord,
     },
 };
 
@@ -228,6 +228,10 @@ fn terminal_checkpoint_from_state(
         checkpoint_anchor_generation: latest.anchor_generation,
         current_anchor_generation: checkpoint_state.anchor_generation,
     })
+}
+
+fn turn_optional_id_matches(candidate: Option<&str>, turn_id: &str) -> bool {
+    candidate.is_some_and(|candidate| !candidate.trim().is_empty() && candidate == turn_id)
 }
 
 fn build_checkpoint_resume_round(
@@ -1463,11 +1467,105 @@ impl RuntimeHandle {
             self.inner.storage.write_agent(&guard.state)?;
             record
         };
+        self.persist_turn_record(&record).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "turn_terminal",
             serde_json::to_value(&record)?,
         ))?;
         Ok(record)
+    }
+
+    async fn persist_turn_record(&self, terminal: &TurnTerminalRecord) -> Result<()> {
+        let (agent_id, run_id, current_work_item_id) = {
+            let guard = self.inner.agent.lock().await;
+            (
+                guard.state.id.clone(),
+                guard.state.current_run_id.clone(),
+                guard
+                    .state
+                    .current_turn_work_item_id
+                    .clone()
+                    .or_else(|| guard.state.current_work_item_id.clone()),
+            )
+        };
+        let turn_id = terminal.turn_id.trim();
+        if turn_id.is_empty() {
+            return Ok(());
+        }
+
+        let messages = self.inner.storage.read_all_messages()?;
+        let briefs = self.inner.storage.read_recent_briefs(usize::MAX)?;
+        let tools = self.inner.storage.read_recent_tool_executions(usize::MAX)?;
+        let delivery_summaries = self
+            .inner
+            .storage
+            .read_recent_delivery_summaries(usize::MAX)?;
+        let wait_conditions = self.inner.storage.read_recent_wait_conditions(usize::MAX)?;
+
+        let input_messages = messages
+            .iter()
+            .filter(|message| {
+                turn_optional_id_matches(message.turn_id.as_deref(), turn_id)
+                    || message.message_seq == Some(terminal.turn_index)
+            })
+            .collect::<Vec<_>>();
+
+        let mut record = TurnRecord::new(agent_id, terminal.turn_id.clone(), terminal.turn_index);
+        record.run_id = run_id;
+        record.current_work_item_id = current_work_item_id;
+        record.trigger = input_messages
+            .first()
+            .map(|message| TurnTriggerSummary::from_message(message));
+        record.input_message_ids = input_messages
+            .iter()
+            .map(|message| message.id.clone())
+            .collect();
+        record.tool_execution_ids = tools
+            .iter()
+            .filter(|tool| {
+                turn_optional_id_matches(tool.turn_id.as_deref(), turn_id)
+                    || tool.turn_index == terminal.turn_index
+            })
+            .map(|tool| tool.id.clone())
+            .collect();
+        record.produced_brief_ids = briefs
+            .iter()
+            .filter(|brief| {
+                turn_optional_id_matches(brief.turn_id.as_deref(), turn_id)
+                    || brief.turn_index == Some(terminal.turn_index)
+            })
+            .map(|brief| brief.id.clone())
+            .collect();
+        let turn_delivery_summaries = delivery_summaries
+            .iter()
+            .filter(|summary| {
+                turn_optional_id_matches(summary.turn_id.as_deref(), turn_id)
+                    || summary.source_turn_index == Some(terminal.turn_index)
+            })
+            .collect::<Vec<_>>();
+        record.delivery_summary_ids = turn_delivery_summaries
+            .iter()
+            .map(|summary| summary.id.clone())
+            .collect();
+        record.completed_work_item_ids = turn_delivery_summaries
+            .iter()
+            .map(|summary| summary.work_item_id.clone())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        record.waiting_condition_ids = wait_conditions
+            .iter()
+            .filter(|condition| turn_optional_id_matches(condition.turn_id.as_deref(), turn_id))
+            .map(|condition| condition.id.clone())
+            .collect();
+        record.terminal = Some(TurnTerminalSummary::from_terminal(terminal));
+
+        self.inner.storage.append_turn(&record)?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "turn_record",
+            serde_json::to_value(&record)?,
+        ))?;
+        Ok(())
     }
 
     async fn maybe_defer_provider_lineage_failure(
@@ -1623,6 +1721,7 @@ impl RuntimeHandle {
             self.inner.storage.write_agent(&guard.state)?;
             record
         };
+        self.persist_turn_record(&record).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "turn_terminal",
             serde_json::to_value(&record)?,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,7 +18,7 @@ use crate::types::{
     ExternalWaitRecoverability, MessageEnvelope, OperatorDeliveryRecord,
     OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord, QueueEntryStatus,
     TaskRecord, TaskStatus, TimerRecord, TodoItem, TodoItemState, ToolExecutionRecord,
-    TranscriptEntry, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
+    TranscriptEntry, TurnRecord, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
     WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus, WakeSource,
     WorkItemDelegationRecord, WorkItemDelegationState, WorkItemReadiness, WorkItemRecord,
     WorkItemSchedulingState, WorkItemState, WorkingMemoryDelta, WorkspaceEntry,
@@ -171,6 +171,7 @@ pub struct AppStorage {
     work_item_delegations_path: PathBuf,
     timers_path: PathBuf,
     tools_path: PathBuf,
+    turns_path: PathBuf,
     transcript_path: PathBuf,
     queue_entries_path: PathBuf,
     waiting_intents_path: PathBuf,
@@ -242,6 +243,7 @@ impl AppStorage {
             work_item_delegations_path: ledger_dir.join("work_item_delegations.jsonl"),
             timers_path: ledger_dir.join("timers.jsonl"),
             tools_path: ledger_dir.join("tools.jsonl"),
+            turns_path: ledger_dir.join("turns.jsonl"),
             transcript_path,
             queue_entries_path: ledger_dir.join("queue_entries.jsonl"),
             waiting_intents_path: ledger_dir.join("waiting_intents.jsonl"),
@@ -374,6 +376,10 @@ impl AppStorage {
             self.mark_memory_index_dirty()?;
         }
         Ok(())
+    }
+
+    pub fn append_turn(&self, record: &TurnRecord) -> Result<()> {
+        self.append_jsonl(&self.turns_path, record)
     }
 
     pub fn append_transcript_entry(&self, entry: &TranscriptEntry) -> Result<()> {
@@ -670,6 +676,10 @@ impl AppStorage {
 
     pub fn read_recent_tool_executions(&self, limit: usize) -> Result<Vec<ToolExecutionRecord>> {
         read_recent_jsonl(&self.tools_path, limit)
+    }
+
+    pub fn read_recent_turns(&self, limit: usize) -> Result<Vec<TurnRecord>> {
+        read_recent_jsonl(&self.turns_path, limit)
     }
 
     pub fn read_recent_transcript(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
@@ -2147,6 +2157,39 @@ mod tests {
             .unwrap();
         let events = reopened.read_recent_events(10).unwrap();
         assert_eq!(events.last().map(|event| event.event_seq), Some(3));
+    }
+
+    #[test]
+    fn append_turn_persists_lightweight_turn_record() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let mut record = TurnRecord::new("default", "turn-1", 7);
+        record.input_message_ids = vec!["msg-1".into()];
+        record.tool_execution_ids = vec!["tool-1".into()];
+        record.produced_brief_ids = vec!["brief-1".into()];
+        record.delivery_summary_ids = vec!["delivery-1".into()];
+        record.completed_work_item_ids = vec!["work-1".into()];
+        record.terminal = Some(crate::types::TurnTerminalSummary {
+            kind: crate::types::TurnTerminalKind::Completed,
+            reason: None,
+            completed_at: Utc::now(),
+            duration_ms: 42,
+        });
+
+        storage.append_turn(&record).unwrap();
+
+        let turns = storage.read_recent_turns(10).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].turn_id, "turn-1");
+        assert_eq!(turns[0].input_message_ids, vec!["msg-1"]);
+        assert_eq!(turns[0].tool_execution_ids, vec!["tool-1"]);
+        assert_eq!(turns[0].produced_brief_ids, vec!["brief-1"]);
+        assert_eq!(turns[0].delivery_summary_ids, vec!["delivery-1"]);
+        assert_eq!(turns[0].completed_work_item_ids, vec!["work-1"]);
+        assert_eq!(
+            turns[0].terminal.as_ref().map(|terminal| terminal.kind),
+            Some(crate::types::TurnTerminalKind::Completed)
+        );
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2163,7 +2163,7 @@ mod tests {
     fn append_turn_persists_lightweight_turn_record() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
-        let mut record = TurnRecord::new("default", "turn-1", 7);
+        let mut record = TurnRecord::new("default", " turn-1 ", 7);
         record.input_message_ids = vec!["msg-1".into()];
         record.tool_execution_ids = vec!["tool-1".into()];
         record.produced_brief_ids = vec!["brief-1".into()];

--- a/src/types.rs
+++ b/src/types.rs
@@ -1294,6 +1294,103 @@ pub struct TurnTerminalRecord {
     pub duration_ms: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TurnTriggerSummary {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    pub kind: MessageKind,
+    pub origin: MessageOrigin,
+    pub authority_class: AuthorityClass,
+    pub priority: Priority,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_kind: Option<ContinuationTriggerKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+}
+
+impl TurnTriggerSummary {
+    pub fn from_message(message: &MessageEnvelope) -> Self {
+        Self {
+            message_id: Some(message.id.clone()),
+            kind: message.kind.clone(),
+            origin: message.origin.clone(),
+            authority_class: message.authority_class,
+            priority: message.priority.clone(),
+            trigger_kind: message.trigger_kind,
+            task_id: message.task_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TurnTerminalSummary {
+    pub kind: TurnTerminalKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    pub completed_at: DateTime<Utc>,
+    pub duration_ms: u64,
+}
+
+impl TurnTerminalSummary {
+    pub fn from_terminal(record: &TurnTerminalRecord) -> Self {
+        Self {
+            kind: record.kind,
+            reason: record.reason.clone(),
+            completed_at: record.completed_at,
+            duration_ms: record.duration_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TurnRecord {
+    pub turn_id: String,
+    pub turn_index: u64,
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<TurnTriggerSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_message_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_execution_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub produced_brief_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub delivery_summary_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completed_work_item_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub waiting_condition_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<TurnTerminalSummary>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl TurnRecord {
+    pub fn new(agent_id: impl Into<String>, turn_id: impl Into<String>, turn_index: u64) -> Self {
+        Self {
+            turn_id: turn_id.into(),
+            turn_index,
+            agent_id: agent_id.into(),
+            run_id: None,
+            current_work_item_id: None,
+            trigger: None,
+            input_message_ids: Vec::new(),
+            tool_execution_ids: Vec::new(),
+            produced_brief_ids: Vec::new(),
+            delivery_summary_ids: Vec::new(),
+            completed_work_item_ids: Vec::new(),
+            waiting_condition_ids: Vec::new(),
+            terminal: None,
+            created_at: Utc::now(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TurnTerminalCheckpointRecord {
     pub request_id: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1373,7 +1373,7 @@ pub struct TurnRecord {
 impl TurnRecord {
     pub fn new(agent_id: impl Into<String>, turn_id: impl Into<String>, turn_index: u64) -> Self {
         Self {
-            turn_id: turn_id.into(),
+            turn_id: turn_id.into().trim().to_string(),
             turn_index,
             agent_id: agent_id.into(),
             run_id: None,


### PR DESCRIPTION
## Summary
- add lightweight `TurnRecord` metadata for turn-level causal indexing without duplicating payloads
- persist turn records at terminal boundaries with refs to messages, tools, briefs, delivery summaries, waits, and terminal summary
- update `brief_matches_message` to prefer `turn_id` matching before legacy message/turn-index fallback

## Verification
- `cargo test --lib append_turn_persists_lightweight_turn_record`
- `cargo test --lib brief_matches_message_uses_turn_id_then_legacy_refs`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
