### PR TITLE
feat: add provider-first model projection

### DIFF
--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -4,10 +4,13 @@ use serde_json::{json, Value};
 
 use crate::{
     auth::{load_codex_cli_credential, load_codex_oauth_profile_credential},
-    config::{AppConfig, CredentialSource, ModelRef, RuntimeModelCatalog},
+    config::{AppConfig, CredentialSource, ModelRef, ProviderId, RuntimeModelCatalog},
     context::ContextConfig,
     onboarding::{onboarding_report, search_diagnostics},
-    types::ResolvedModelAvailability,
+    types::{
+        ModelProviderAvailability, ModelProviderEntry, ProviderModelEntry,
+        ResolvedModelAvailability,
+    },
 };
 
 use super::{build_candidate, classify_provider_error, retry::provider_retry_policy_json};
@@ -49,6 +52,16 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
             &availability,
         ));
     }
+    let model_providers = resolved_model_providers(config);
+    let models_by_provider = model_providers
+        .iter()
+        .map(|provider| {
+            (
+                provider.id.clone(),
+                resolved_provider_models(config, &provider.id),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
 
     json!({
         "default_model": config.default_model.as_string(),
@@ -59,6 +72,8 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
         "onboarding": onboarding_report(config),
         "search": search_diagnostics(config),
         "model_availability": model_availability,
+        "model_providers": model_providers,
+        "models_by_provider": models_by_provider,
         "providers": providers,
     })
 }
@@ -89,6 +104,112 @@ pub fn resolved_model_availability(config: &AppConfig) -> Vec<ResolvedModelAvail
         .collect()
 }
 
+pub fn resolved_model_providers(config: &AppConfig) -> Vec<ModelProviderEntry> {
+    let models = resolved_model_availability(config);
+    let mut providers = BTreeMap::<String, Vec<&ResolvedModelAvailability>>::new();
+    for model in &models {
+        providers
+            .entry(model.provider.clone())
+            .or_default()
+            .push(model);
+    }
+    for provider_id in config.providers.keys() {
+        providers
+            .entry(provider_id.as_str().to_string())
+            .or_default();
+    }
+
+    providers
+        .into_iter()
+        .map(|(provider_id, models)| {
+            let parsed_provider_id = ProviderId::parse(&provider_id).ok();
+            let provider = parsed_provider_id
+                .as_ref()
+                .and_then(|provider_id| config.providers.get(provider_id));
+            let first_model = models.first().copied();
+            let available_count = models.iter().filter(|model| model.available).count();
+            let model_count = models.len();
+            let availability = if model_count == 0 || available_count == 0 {
+                ModelProviderAvailability::Unavailable
+            } else if available_count == model_count {
+                ModelProviderAvailability::Available
+            } else {
+                ModelProviderAvailability::Degraded
+            };
+            let provider_configured = provider.is_some()
+                || first_model
+                    .map(|model| model.provider_configured)
+                    .unwrap_or(false);
+            let provider_source = first_model
+                .and_then(|model| model.provider_source.clone())
+                .or_else(|| {
+                    if provider.is_some() {
+                        parsed_provider_id
+                            .as_ref()
+                            .map(|provider_id| provider_source_for_config(config, provider_id))
+                    } else {
+                        None
+                    }
+                });
+            let credential_configured = models.iter().any(|model| model.credential_configured)
+                || provider
+                    .map(provider_static_credential_configured)
+                    .unwrap_or(false);
+
+            ModelProviderEntry {
+                id: provider_id.clone(),
+                display_name: Some(provider_id.clone()),
+                availability,
+                provider_configured,
+                provider_source,
+                transport: first_model
+                    .and_then(|model| model.transport.clone())
+                    .or_else(|| provider.map(|provider| provider.transport.as_str().to_string())),
+                credential_source: first_model
+                    .and_then(|model| model.credential_source.clone())
+                    .or_else(|| provider.map(|provider| provider.auth.source.as_str().to_string())),
+                credential_kind: first_model
+                    .and_then(|model| model.credential_kind.clone())
+                    .or_else(|| provider.map(|provider| provider.auth.kind.as_str().to_string())),
+                credential_configured,
+                default_model: default_model_for_provider(config, &provider_id),
+                model_count,
+                discovered_model_count: models
+                    .iter()
+                    .filter(|model| model.metadata_source == "remote_discovered")
+                    .count(),
+                policy_notes: Vec::new(),
+            }
+        })
+        .collect()
+}
+
+pub fn resolved_provider_models(config: &AppConfig, provider: &str) -> Vec<ProviderModelEntry> {
+    resolved_model_availability(config)
+        .into_iter()
+        .filter(|model| model.provider == provider)
+        .map(|model| {
+            let model_id = model.policy.model_ref.model.clone();
+            ProviderModelEntry {
+                provider: model.provider,
+                id: model_id,
+                model_ref: model.model,
+                display_name: model.display_name,
+                availability: if model.available {
+                    ModelProviderAvailability::Available
+                } else {
+                    ModelProviderAvailability::Unavailable
+                },
+                selectable: model.available,
+                unavailable_reason: model.unavailable_reason,
+                metadata_source: model.metadata_source,
+                policy: model.policy,
+                policy_notes: Vec::new(),
+            }
+        })
+        .collect()
+}
+
 fn resolved_model_availability_entry(
     config: &AppConfig,
     catalog: &RuntimeModelCatalog,
@@ -107,17 +228,7 @@ fn resolved_model_availability_entry(
     };
     let provider = config.providers.get(&model_ref.provider);
     let provider_configured = provider.is_some();
-    let provider_source = provider.map(|_| {
-        if config
-            .stored_config
-            .providers
-            .contains_key(&model_ref.provider)
-        {
-            "config".to_string()
-        } else {
-            "built_in".to_string()
-        }
-    });
+    let provider_source = provider.map(|_| provider_source_for_config(config, &model_ref.provider));
     let credential_configured = provider
         .map(provider_static_credential_configured)
         .unwrap_or(false);
@@ -155,6 +266,25 @@ fn resolved_model_availability_entry(
         unavailable_reason,
         policy,
     }
+}
+
+fn provider_source_for_config(config: &AppConfig, provider_id: &ProviderId) -> String {
+    if config.stored_config.providers.contains_key(provider_id) {
+        "config".to_string()
+    } else {
+        "built_in".to_string()
+    }
+}
+
+fn default_model_for_provider(config: &AppConfig, provider_id: &str) -> Option<String> {
+    if config.default_model.provider.as_str() == provider_id {
+        return Some(config.default_model.model.clone());
+    }
+    config
+        .fallback_models
+        .iter()
+        .find(|model| model.provider.as_str() == provider_id)
+        .map(|model| model.model.clone())
 }
 
 fn provider_static_credential_configured(provider: &crate::config::ProviderRuntimeConfig) -> bool {
@@ -259,7 +389,10 @@ mod tests {
         model_catalog::{ModelMetadataSource, ModelRuntimeOverride},
     };
 
-    use super::{provider_doctor, resolved_model_availability};
+    use super::{
+        provider_doctor, resolved_model_availability, resolved_model_providers,
+        resolved_provider_models,
+    };
 
     struct TestConfigFixture {
         _home_dir: tempfile::TempDir,
@@ -407,6 +540,43 @@ mod tests {
         assert_eq!(custom.metadata_source, "config_override");
         assert!(custom.available);
         assert_eq!(custom.policy.runtime_max_output_tokens, 1024);
+    }
+
+    #[test]
+    fn resolved_model_providers_groups_models_by_provider() {
+        let fixture = test_config(Some("openai-key"));
+        let providers = resolved_model_providers(&fixture.config);
+        let openai = providers
+            .iter()
+            .find(|entry| entry.id == "openai")
+            .expect("openai provider entry");
+
+        assert!(openai.provider_configured);
+        assert!(openai.credential_configured);
+        assert_eq!(openai.default_model.as_deref(), Some("gpt-5.4"));
+        assert!(openai.model_count > 0);
+        assert_eq!(
+            openai.availability,
+            crate::types::ModelProviderAvailability::Available
+        );
+    }
+
+    #[test]
+    fn resolved_provider_models_returns_models_for_one_provider() {
+        let fixture = test_config(Some("openai-key"));
+        let models = resolved_provider_models(&fixture.config, "openai");
+        let openai = models
+            .iter()
+            .find(|entry| entry.model_ref == "openai/gpt-5.4")
+            .expect("openai model entry");
+
+        assert_eq!(openai.provider, "openai");
+        assert_eq!(openai.id, "gpt-5.4");
+        assert!(openai.selectable);
+        assert_eq!(
+            openai.availability,
+            crate::types::ModelProviderAvailability::Available
+        );
     }
 
     #[test]

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -8,7 +8,7 @@ use crate::{
     context::ContextConfig,
     onboarding::{onboarding_report, search_diagnostics},
     types::{
-        ModelProviderAvailability, ModelProviderEntry, ProviderModelEntry,
+        ModelAvailability, ModelProviderAvailability, ModelProviderEntry, ProviderModelEntry,
         ResolvedModelAvailability,
     },
 };
@@ -52,13 +52,15 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
             &availability,
         ));
     }
-    let model_providers = resolved_model_providers(config);
+    let provider_model_availability = resolved_model_availability(config);
+    let model_providers =
+        resolved_model_providers_from_availability(config, &provider_model_availability);
     let models_by_provider = model_providers
         .iter()
         .map(|provider| {
             (
                 provider.id.clone(),
-                resolved_provider_models(config, &provider.id),
+                provider_models_from_availability(&provider_model_availability, &provider.id),
             )
         })
         .collect::<BTreeMap<_, _>>();
@@ -106,8 +108,15 @@ pub fn resolved_model_availability(config: &AppConfig) -> Vec<ResolvedModelAvail
 
 pub fn resolved_model_providers(config: &AppConfig) -> Vec<ModelProviderEntry> {
     let models = resolved_model_availability(config);
+    resolved_model_providers_from_availability(config, &models)
+}
+
+fn resolved_model_providers_from_availability(
+    config: &AppConfig,
+    models: &[ResolvedModelAvailability],
+) -> Vec<ModelProviderEntry> {
     let mut providers = BTreeMap::<String, Vec<&ResolvedModelAvailability>>::new();
-    for model in &models {
+    for model in models {
         providers
             .entry(model.provider.clone())
             .or_default()
@@ -185,9 +194,19 @@ pub fn resolved_model_providers(config: &AppConfig) -> Vec<ModelProviderEntry> {
 }
 
 pub fn resolved_provider_models(config: &AppConfig, provider: &str) -> Vec<ProviderModelEntry> {
-    resolved_model_availability(config)
-        .into_iter()
+    let models = resolved_model_availability(config);
+    provider_models_from_availability(&models, provider)
+}
+
+fn provider_models_from_availability(
+    models: &[ResolvedModelAvailability],
+    provider: &str,
+) -> Vec<ProviderModelEntry> {
+    models
+        .iter()
         .filter(|model| model.provider == provider)
+        .cloned()
+        .into_iter()
         .map(|model| {
             let model_id = model.policy.model_ref.model.clone();
             ProviderModelEntry {
@@ -196,9 +215,9 @@ pub fn resolved_provider_models(config: &AppConfig, provider: &str) -> Vec<Provi
                 model_ref: model.model,
                 display_name: model.display_name,
                 availability: if model.available {
-                    ModelProviderAvailability::Available
+                    ModelAvailability::Available
                 } else {
-                    ModelProviderAvailability::Unavailable
+                    ModelAvailability::Unavailable
                 },
                 selectable: model.available,
                 unavailable_reason: model.unavailable_reason,
@@ -575,7 +594,7 @@ mod tests {
         assert!(openai.selectable);
         assert_eq!(
             openai.availability,
-            crate::types::ModelProviderAvailability::Available
+            crate::types::ModelAvailability::Available
         );
     }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -16,7 +16,10 @@ mod tool_schema;
 mod transports;
 
 pub use catalog::{build_provider_from_config, build_provider_from_model_chain};
-pub use diagnostics::{provider_doctor, resolved_model_availability};
+pub use diagnostics::{
+    provider_doctor, resolved_model_availability, resolved_model_providers,
+    resolved_provider_models,
+};
 pub use http_trace::ProviderHttpTraceDiagnostics;
 pub(crate) use retry::sanitize_transport_url;
 pub use transports::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -3879,6 +3879,13 @@ pub enum ModelProviderAvailability {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelAvailability {
+    Available,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModelProviderEntry {
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3908,7 +3915,7 @@ pub struct ProviderModelEntry {
     pub id: String,
     pub model_ref: String,
     pub display_name: String,
-    pub availability: ModelProviderAvailability,
+    pub availability: ModelAvailability,
     pub selectable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unavailable_reason: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3871,6 +3871,54 @@ pub struct ResolvedModelAvailability {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelProviderAvailability {
+    Available,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelProviderEntry {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    pub availability: ModelProviderAvailability,
+    pub provider_configured: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_kind: Option<String>,
+    pub credential_configured: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_model: Option<String>,
+    pub model_count: usize,
+    pub discovered_model_count: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub policy_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderModelEntry {
+    pub provider: String,
+    pub id: String,
+    pub model_ref: String,
+    pub display_name: String,
+    pub availability: ModelProviderAvailability,
+    pub selectable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unavailable_reason: Option<String>,
+    pub metadata_source: String,
+    pub policy: ResolvedRuntimeModelPolicy,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub policy_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentLifecycleHint {
     pub accepts_external_messages: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- add provider-first model/provider DTOs for the shared model catalog projection
- expose provider-first projection in provider diagnostics as model_providers and models_by_provider
- add focused diagnostics tests for provider grouping and provider-scoped model listing

This is PR 1 for #1568/#1580 groundwork; it does not add SpawnAgent model selection or TUI picker changes yet.

## Verification
- cargo fmt --all -- --check
- cargo test provider::diagnostics --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets