### PR TITLE
feat: add SpawnAgent model selection

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -196,6 +196,51 @@
               "null"
             ]
           },
+          "model": {
+            "properties": {
+              "allow_fallback": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "max_output_tokens": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "model": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "reasoning_effort": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "temperature": {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "provider",
+              "model"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "preset": {
             "enum": [
               "private_child",
@@ -394,6 +439,77 @@
         "error_result": "ToolError",
         "model_rendering": "canonical_json_envelope",
         "success_result": "TaskStopResult"
+      },
+      "stability": "stable"
+    },
+    {
+      "description": "List configured/discovered model providers. By default unavailable providers are omitted; set include_unavailable=true to inspect blocked options.",
+      "family": "core_agent",
+      "freeform_grammar": null,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "include_unavailable": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "ListModelProviders",
+      "related_surfaces": [],
+      "result_envelope": {
+        "canonical": "ToolResultEnvelope",
+        "error_result": "ToolError",
+        "model_rendering": "canonical_json_envelope",
+        "success_result": "ListModelProvidersResult"
+      },
+      "stability": "stable"
+    },
+    {
+      "description": "List models for a provider. Use provider from ListModelProviders; cursor is a model_ref returned by a previous page.",
+      "family": "core_agent",
+      "freeform_grammar": null,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "include_unavailable": {
+            "default": false,
+            "type": "boolean"
+          },
+          "limit": {
+            "default": null,
+            "format": "uint",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "provider": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider"
+        ],
+        "type": "object"
+      },
+      "name": "ListProviderModels",
+      "related_surfaces": [],
+      "result_envelope": {
+        "canonical": "ToolResultEnvelope",
+        "error_result": "ToolError",
+        "model_rendering": "canonical_json_envelope",
+        "success_result": "ListProviderModelsResult"
       },
       "stability": "stable"
     },

--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -197,6 +197,7 @@
             ]
           },
           "model": {
+            "additionalProperties": false,
             "properties": {
               "allow_fallback": {
                 "type": [

--- a/src/host.rs
+++ b/src/host.rs
@@ -37,8 +37,9 @@ use crate::{
         AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus,
         AgentSummary, AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome,
         ExternalTriggerRecord, ExternalTriggerStatus, OperatorNotificationRecord,
-        RuntimeFailureSummary, TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind,
-        WorkspaceEntry, WorkspaceOccupancyRecord,
+        RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
+        TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -123,6 +124,27 @@ pub(crate) struct ChildTaskTerminalResult {
     pub status: TaskStatus,
     pub text: String,
     pub task_detail: Option<Value>,
+}
+
+async fn apply_spawn_model_resolution(
+    runtime: &RuntimeHandle,
+    resolution: &SpawnAgentModelResolution,
+) -> Result<()> {
+    if resolution.resolution_status == SpawnAgentModelResolutionStatus::Inherited {
+        return Ok(());
+    }
+    let provider = crate::config::ProviderId::parse(&resolution.resolved_provider)?;
+    let model_ref = crate::config::ModelRef::new(provider, resolution.resolved_model.clone());
+    let reasoning_effort = resolution
+        .resolved_parameters
+        .as_ref()
+        .and_then(|parameters| parameters.get("reasoning_effort"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    runtime
+        .set_model_override(model_ref, reasoning_effort)
+        .await?;
+    Ok(())
 }
 
 impl RuntimeHost {
@@ -905,6 +927,7 @@ impl RuntimeHost {
         authority_class: AuthorityClass,
         worktree: bool,
         template: Option<String>,
+        model_resolution: SpawnAgentModelResolution,
     ) -> Result<ChildTaskSpawn> {
         let parent_state = parent_runtime.agent_state().await?;
         let parent_agent_home = self.agent_data_dir(&parent_state.id);
@@ -920,6 +943,7 @@ impl RuntimeHost {
         child_runtime
             .inherit_from_parent_state(&parent_state)
             .await?;
+        apply_spawn_model_resolution(&child_runtime, &model_resolution).await?;
         let child_turn_baseline = child_runtime.agent_state().await?.turn_index;
 
         let mut task_detail = json!({
@@ -931,6 +955,7 @@ impl RuntimeHost {
             "child_profile_preset": AgentProfilePreset::PrivateChild,
             "wait_policy": task.wait_policy(),
             "workspace_mode": if worktree { "worktree" } else { "inherit" },
+            "model_resolution": model_resolution,
         });
 
         if worktree {
@@ -1003,6 +1028,7 @@ impl RuntimeHost {
         initial_message: Option<String>,
         authority_class: AuthorityClass,
         template: Option<String>,
+        model_resolution: SpawnAgentModelResolution,
     ) -> Result<String> {
         let parent_state = parent_runtime.agent_state().await?;
         let parent_agent_home = self.agent_data_dir(&parent_state.id);
@@ -1020,6 +1046,7 @@ impl RuntimeHost {
                 .inherit_attached_workspaces_from_parent_state(&parent_state)
                 .await?;
         }
+        apply_spawn_model_resolution(&named_runtime, &model_resolution).await?;
 
         let Some(initial_message) = initial_message else {
             return Ok(named_identity.agent_id);
@@ -1347,6 +1374,7 @@ impl RuntimeHostBridge {
         authority_class: AuthorityClass,
         worktree: bool,
         template: Option<String>,
+        model_resolution: SpawnAgentModelResolution,
     ) -> Result<ChildTaskSpawn> {
         self.host()?
             .spawn_child_task(
@@ -1356,6 +1384,7 @@ impl RuntimeHostBridge {
                 authority_class,
                 worktree,
                 template,
+                model_resolution,
             )
             .await
     }
@@ -1367,6 +1396,7 @@ impl RuntimeHostBridge {
         initial_message: Option<String>,
         authority_class: AuthorityClass,
         template: Option<String>,
+        model_resolution: SpawnAgentModelResolution,
     ) -> Result<String> {
         self.host()?
             .spawn_public_named_agent(
@@ -1375,6 +1405,7 @@ impl RuntimeHostBridge {
                 initial_message,
                 authority_class,
                 template,
+                model_resolution,
             )
             .await
     }
@@ -1566,6 +1597,17 @@ mod tests {
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
+    }
+
+    fn inherited_model_resolution(provider: &str, model: &str) -> SpawnAgentModelResolution {
+        SpawnAgentModelResolution {
+            requested: None,
+            resolved_provider: provider.to_string(),
+            resolved_model: model.to_string(),
+            resolved_parameters: None,
+            resolution_status: SpawnAgentModelResolutionStatus::Inherited,
+            policy_notes: Vec::new(),
+        }
     }
 
     struct BlockingProvider {
@@ -1821,6 +1863,7 @@ mod tests {
             Some("continue release work".into()),
             AuthorityClass::OperatorInstruction,
             None,
+            inherited_model_resolution("anthropic", "claude-sonnet-4-6"),
         )
         .await
         .unwrap();
@@ -1843,6 +1886,7 @@ mod tests {
             Some("coordinate release work".into()),
             AuthorityClass::OperatorInstruction,
             None,
+            inherited_model_resolution("anthropic", "claude-sonnet-4-6"),
         )
         .await
         .unwrap();
@@ -1884,6 +1928,7 @@ mod tests {
                 AgentProfilePreset::PrivateChild,
                 None,
                 false,
+                None,
                 None,
             )
             .await
@@ -1938,6 +1983,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn private_child_spawn_accepts_explicit_model_selection() {
+        let fixture = provider_test_config(Some("dummy-token"));
+        let host = RuntimeHost::new(fixture.config).unwrap();
+        let parent = host.default_runtime().await.unwrap();
+
+        let spawned = parent
+            .spawn_agent(
+                Some("compare implementation".into()),
+                AuthorityClass::OperatorInstruction,
+                AgentProfilePreset::PrivateChild,
+                None,
+                false,
+                None,
+                Some(crate::types::SpawnAgentModelRequest {
+                    provider: "anthropic".into(),
+                    model: "claude-haiku-4-5".into(),
+                    reasoning_effort: Some("high".into()),
+                    temperature: None,
+                    max_output_tokens: None,
+                    allow_fallback: Some(false),
+                }),
+            )
+            .await
+            .unwrap();
+
+        let resolution = spawned
+            .model_resolution
+            .as_ref()
+            .expect("spawn should return model resolution");
+        assert_eq!(
+            resolution.resolution_status,
+            SpawnAgentModelResolutionStatus::Accepted
+        );
+        assert_eq!(resolution.resolved_provider, "anthropic");
+        assert_eq!(resolution.resolved_model, "claude-haiku-4-5");
+
+        let child = host.get_or_create_agent(&spawned.agent_id).await.unwrap();
+        let child_summary = child.agent_summary().await.unwrap();
+        assert_eq!(
+            child_summary.model.override_model.unwrap().as_string(),
+            "anthropic/claude-haiku-4-5"
+        );
+        assert_eq!(
+            child_summary.model.override_reasoning_effort.as_deref(),
+            Some("high")
+        );
+    }
+
+    #[tokio::test]
+    async fn private_child_spawn_rejects_unavailable_explicit_model_without_fallback() {
+        let fixture = provider_test_config(Some("dummy-token"));
+        let host = RuntimeHost::new(fixture.config).unwrap();
+        let parent = host.default_runtime().await.unwrap();
+
+        let error = parent
+            .spawn_agent(
+                Some("compare implementation".into()),
+                AuthorityClass::OperatorInstruction,
+                AgentProfilePreset::PrivateChild,
+                None,
+                false,
+                None,
+                Some(crate::types::SpawnAgentModelRequest {
+                    provider: "openai".into(),
+                    model: "gpt-5.4".into(),
+                    reasoning_effort: None,
+                    temperature: None,
+                    max_output_tokens: None,
+                    allow_fallback: Some(false),
+                }),
+            )
+            .await
+            .expect_err("unavailable explicit model should be rejected before child creation");
+
+        assert!(error.to_string().contains("requested model"));
+        assert!(error.to_string().contains("unavailable"));
+    }
+
+    #[tokio::test]
     async fn private_child_runtime_spawn_rejects_blank_initial_message() {
         let (_home, host) = test_host();
         let parent = host.default_runtime().await.unwrap();
@@ -1949,6 +2073,7 @@ mod tests {
                 AgentProfilePreset::PrivateChild,
                 None,
                 false,
+                None,
                 None,
             )
             .await
@@ -1997,6 +2122,7 @@ mod tests {
             None,
             AuthorityClass::OperatorInstruction,
             None,
+            inherited_model_resolution("anthropic", "claude-sonnet-4-6"),
         )
         .await
         .unwrap();
@@ -2026,6 +2152,7 @@ mod tests {
             Some("bootstrap release lane".into()),
             AuthorityClass::OperatorInstruction,
             None,
+            inherited_model_resolution("anthropic", "claude-sonnet-4-6"),
         )
         .await
         .unwrap();
@@ -2085,6 +2212,7 @@ mod tests {
             None,
             AuthorityClass::OperatorInstruction,
             Some("worker".into()),
+            inherited_model_resolution("anthropic", "claude-sonnet-4-6"),
         )
         .await
         .unwrap();

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -60,7 +60,10 @@ pub fn provider_doctor(config: &AppConfig) -> Value {
         .map(|provider| {
             (
                 provider.id.clone(),
-                provider_models_from_availability(&provider_model_availability, &provider.id),
+                provider_models_from_availability_for_runtime(
+                    &provider_model_availability,
+                    &provider.id,
+                ),
             )
         })
         .collect::<BTreeMap<_, _>>();
@@ -115,6 +118,13 @@ fn resolved_model_providers_from_availability(
     config: &AppConfig,
     models: &[ResolvedModelAvailability],
 ) -> Vec<ModelProviderEntry> {
+    resolved_model_providers_from_availability_for_runtime(Some(config), models)
+}
+
+pub(crate) fn resolved_model_providers_from_availability_for_runtime(
+    config: Option<&AppConfig>,
+    models: &[ResolvedModelAvailability],
+) -> Vec<ModelProviderEntry> {
     let mut providers = BTreeMap::<String, Vec<&ResolvedModelAvailability>>::new();
     for model in models {
         providers
@@ -122,19 +132,25 @@ fn resolved_model_providers_from_availability(
             .or_default()
             .push(model);
     }
-    for provider_id in config.providers.keys() {
-        providers
-            .entry(provider_id.as_str().to_string())
-            .or_default();
+    if let Some(config) = config {
+        for provider_id in config.providers.keys() {
+            providers
+                .entry(provider_id.as_str().to_string())
+                .or_default();
+        }
     }
 
     providers
         .into_iter()
         .map(|(provider_id, models)| {
             let parsed_provider_id = ProviderId::parse(&provider_id).ok();
-            let provider = parsed_provider_id
-                .as_ref()
-                .and_then(|provider_id| config.providers.get(provider_id));
+            let provider = config
+                .and_then(|config| {
+                    parsed_provider_id
+                        .as_ref()
+                        .map(|provider_id| (config, provider_id))
+                })
+                .and_then(|(config, provider_id)| config.providers.get(provider_id));
             let first_model = models.first().copied();
             let available_count = models.iter().filter(|model| model.available).count();
             let model_count = models.len();
@@ -153,9 +169,11 @@ fn resolved_model_providers_from_availability(
                 .and_then(|model| model.provider_source.clone())
                 .or_else(|| {
                     if provider.is_some() {
-                        parsed_provider_id
-                            .as_ref()
-                            .map(|provider_id| provider_source_for_config(config, provider_id))
+                        config.and_then(|config| {
+                            parsed_provider_id
+                                .as_ref()
+                                .map(|provider_id| provider_source_for_config(config, provider_id))
+                        })
                     } else {
                         None
                     }
@@ -181,7 +199,8 @@ fn resolved_model_providers_from_availability(
                     .and_then(|model| model.credential_kind.clone())
                     .or_else(|| provider.map(|provider| provider.auth.kind.as_str().to_string())),
                 credential_configured,
-                default_model: default_model_for_provider(config, &provider_id),
+                default_model: config
+                    .and_then(|config| default_model_for_provider(config, &provider_id)),
                 model_count,
                 discovered_model_count: models
                     .iter()
@@ -195,10 +214,10 @@ fn resolved_model_providers_from_availability(
 
 pub fn resolved_provider_models(config: &AppConfig, provider: &str) -> Vec<ProviderModelEntry> {
     let models = resolved_model_availability(config);
-    provider_models_from_availability(&models, provider)
+    provider_models_from_availability_for_runtime(&models, provider)
 }
 
-fn provider_models_from_availability(
+pub(crate) fn provider_models_from_availability_for_runtime(
     models: &[ResolvedModelAvailability],
     provider: &str,
 ) -> Vec<ProviderModelEntry> {
@@ -209,6 +228,7 @@ fn provider_models_from_availability(
         .into_iter()
         .map(|model| {
             let model_id = model.policy.model_ref.model.clone();
+            let supported_parameters = supported_model_parameters(&model);
             ProviderModelEntry {
                 provider: model.provider,
                 id: model_id,
@@ -222,11 +242,22 @@ fn provider_models_from_availability(
                 selectable: model.available,
                 unavailable_reason: model.unavailable_reason,
                 metadata_source: model.metadata_source,
+                supported_parameters,
                 policy: model.policy,
                 policy_notes: Vec::new(),
             }
         })
         .collect()
+}
+
+fn supported_model_parameters(model: &ResolvedModelAvailability) -> Vec<String> {
+    let mut parameters = vec!["reasoning_effort".to_string()];
+    if model.policy.max_output_tokens_upper_limit.is_some()
+        || model.policy.runtime_max_output_tokens > 0
+    {
+        parameters.push("max_output_tokens".to_string());
+    }
+    parameters
 }
 
 fn resolved_model_availability_entry(
@@ -596,6 +627,14 @@ mod tests {
             openai.availability,
             crate::types::ModelAvailability::Available
         );
+        assert!(openai
+            .supported_parameters
+            .iter()
+            .any(|parameter| parameter == "reasoning_effort"));
+        assert!(openai
+            .supported_parameters
+            .iter()
+            .any(|parameter| parameter == "max_output_tokens"));
     }
 
     #[test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -20,6 +20,10 @@ pub use diagnostics::{
     provider_doctor, resolved_model_availability, resolved_model_providers,
     resolved_provider_models,
 };
+pub(crate) use diagnostics::{
+    provider_models_from_availability_for_runtime,
+    resolved_model_providers_from_availability_for_runtime,
+};
 pub use http_trace::ProviderHttpTraceDiagnostics;
 pub(crate) use retry::sanitize_transport_url;
 pub use transports::{

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -466,4 +466,30 @@ impl RuntimeHandle {
         }
         Ok(self.inner.model_availability.clone())
     }
+
+    pub(crate) async fn model_providers(&self) -> Result<Vec<crate::types::ModelProviderEntry>> {
+        let models = self.model_availability().await?;
+        let config = self.provider_config_for_projection().await;
+        Ok(
+            crate::provider::resolved_model_providers_from_availability_for_runtime(
+                config.as_ref(),
+                &models,
+            ),
+        )
+    }
+
+    pub(crate) async fn provider_models(
+        &self,
+        provider: &str,
+    ) -> Result<Vec<crate::types::ProviderModelEntry>> {
+        let models = self.model_availability().await?;
+        Ok(crate::provider::provider_models_from_availability_for_runtime(&models, provider))
+    }
+
+    async fn provider_config_for_projection(&self) -> Option<AppConfig> {
+        self.inner
+            .provider_reconfig
+            .as_ref()
+            .map(|reconfig| reconfig.config.clone())
+    }
 }

--- a/src/runtime/task_supervisor.rs
+++ b/src/runtime/task_supervisor.rs
@@ -47,6 +47,7 @@ impl ManagedTaskSupervisor<'_> {
         agent_id: Option<String>,
         worktree: bool,
         template: Option<String>,
+        model_request: Option<crate::types::SpawnAgentModelRequest>,
     ) -> Result<SpawnAgentResult> {
         self.runtime
             .spawn_agent(
@@ -56,6 +57,7 @@ impl ManagedTaskSupervisor<'_> {
                 agent_id,
                 worktree,
                 template,
+                model_request,
             )
             .await
     }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1,10 +1,12 @@
 use super::message_dispatch::message_text;
 use super::{task_state_reducer, *};
+use crate::config::{ModelRef, ProviderId};
 use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
     AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot,
-    DeliverySummaryRecord, FailureArtifact, FailureArtifactCategory, SpawnAgentResult, TaskHandle,
+    DeliverySummaryRecord, FailureArtifact, FailureArtifactCategory, SpawnAgentModelRequest,
+    SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle,
     TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus,
     TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef, WorkItemDelegationRecord,
     WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
@@ -69,6 +71,29 @@ fn spawn_agent_task_label(initial_message: &str) -> String {
         collapsed
     };
     crate::tool::helpers::truncate_text(&label, SPAWN_AGENT_TASK_LABEL_CHAR_BUDGET)
+}
+
+fn inherited_model_parameters(
+    model: &crate::types::AgentModelState,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let mut parameters = serde_json::Map::new();
+    if let Some(reasoning_effort) = model.override_reasoning_effort.clone() {
+        parameters.insert("reasoning_effort".into(), reasoning_effort.into());
+    }
+    (!parameters.is_empty()).then_some(parameters)
+}
+
+fn inherited_spawn_model_resolution(
+    model: &crate::types::AgentModelState,
+) -> SpawnAgentModelResolution {
+    SpawnAgentModelResolution {
+        requested: None,
+        resolved_provider: model.effective_model.provider.as_str().to_string(),
+        resolved_model: model.effective_model.model.clone(),
+        resolved_parameters: inherited_model_parameters(model),
+        resolution_status: SpawnAgentModelResolutionStatus::Inherited,
+        policy_notes: Vec::new(),
+    }
 }
 
 fn task_status_label(status: &TaskStatus) -> &'static str {
@@ -306,6 +331,7 @@ impl RuntimeHandle {
         agent_id: Option<String>,
         worktree: bool,
         template: Option<String>,
+        model_request: Option<SpawnAgentModelRequest>,
     ) -> Result<SpawnAgentResult> {
         if !self.supports_child_agent_spawning() {
             return Err(anyhow::Error::from(
@@ -322,6 +348,9 @@ impl RuntimeHandle {
                 ),
             ));
         }
+        let model_resolution = self
+            .resolve_spawn_agent_model_request(model_request)
+            .await?;
         let bridge = self
             .inner
             .host_bridge
@@ -355,6 +384,7 @@ impl RuntimeHandle {
                         authority_class.clone(),
                         worktree,
                         template.clone(),
+                        model_resolution.clone(),
                     )
                     .await
                 {
@@ -423,6 +453,7 @@ impl RuntimeHandle {
                     delegation_id: None,
                     parent_work_item_id: None,
                     child_work_item_id: None,
+                    model_resolution: Some(model_resolution),
                 })
             }
             AgentProfilePreset::PublicNamed => {
@@ -441,6 +472,7 @@ impl RuntimeHandle {
                         initial_message,
                         authority_class,
                         template,
+                        model_resolution.clone(),
                     )
                     .await?;
 
@@ -457,9 +489,122 @@ impl RuntimeHandle {
                     delegation_id: None,
                     parent_work_item_id: None,
                     child_work_item_id: None,
+                    model_resolution: Some(model_resolution),
                 })
             }
         }
+    }
+
+    async fn resolve_spawn_agent_model_request(
+        &self,
+        request: Option<SpawnAgentModelRequest>,
+    ) -> Result<SpawnAgentModelResolution> {
+        let Some(request) = request else {
+            let inherited = self.model_state_for(&self.agent_state().await?);
+            return Ok(inherited_spawn_model_resolution(&inherited));
+        };
+
+        let provider = ProviderId::parse(&request.provider).map_err(|error| {
+            ToolError::new(
+                "invalid_tool_input",
+                format!("SpawnAgent model.provider is invalid: {error}"),
+            )
+            .with_details(serde_json::json!({
+                "field": "model.provider",
+                "validation_error": error.to_string(),
+            }))
+            .with_recovery_hint("provide a lowercase provider id from ListModelProviders")
+        })?;
+        let requested_model = request.model.trim();
+        if requested_model.is_empty() {
+            return Err(anyhow::Error::from(
+                ToolError::new(
+                    "invalid_tool_input",
+                    "SpawnAgent model.model must not be empty",
+                )
+                .with_details(serde_json::json!({
+                    "field": "model.model",
+                    "validation_error": "must not be empty",
+                }))
+                .with_recovery_hint("provide a model id from ListProviderModels"),
+            ));
+        }
+        let model_ref = ModelRef::new(provider, requested_model.to_string());
+        let model_ref_string = model_ref.as_string();
+        let availability =
+            self.model_availability().await?.into_iter().find(|entry| {
+                entry.policy.model_ref == model_ref || entry.model == model_ref_string
+            });
+        let Some(availability) = availability else {
+            return Err(anyhow::Error::from(
+                ToolError::new(
+                    "model_request_rejected",
+                    format!("requested model {model_ref_string} is not in the model catalog"),
+                )
+                .with_details(serde_json::json!({
+                    "requested_model": model_ref_string,
+                    "resolution_status": "rejected",
+                }))
+                .with_recovery_hint(
+                    "call ListModelProviders and ListProviderModels before requesting a model",
+                ),
+            ));
+        };
+
+        if !availability.available {
+            let allow_fallback = request.allow_fallback.unwrap_or(true);
+            let reason = availability
+                .unavailable_reason
+                .clone()
+                .unwrap_or_else(|| "model_unavailable".to_string());
+            let recovery_hint = if allow_fallback {
+                "request an available/selectable model; fallback for explicit unavailable SpawnAgent requests is not used before child creation"
+            } else {
+                "request an available/selectable model, or omit model to inherit the parent model"
+            };
+            return Err(anyhow::Error::from(
+                ToolError::new(
+                    "model_request_rejected",
+                    format!("requested model {model_ref_string} is unavailable: {reason}"),
+                )
+                .with_details(serde_json::json!({
+                    "requested_model": model_ref_string,
+                    "unavailable_reason": reason,
+                    "allow_fallback": allow_fallback,
+                    "resolution_status": "rejected",
+                }))
+                .with_recovery_hint(recovery_hint),
+            ));
+        }
+
+        let mut resolved_parameters = serde_json::Map::new();
+        let mut policy_notes = Vec::new();
+        if let Some(reasoning_effort) = request.reasoning_effort.clone() {
+            resolved_parameters.insert("reasoning_effort".into(), reasoning_effort.into());
+        }
+        if let Some(temperature) = request.temperature {
+            resolved_parameters.insert("temperature".into(), temperature.into());
+            policy_notes.push(
+                "temperature is accepted for audit output; provider support is transport-specific"
+                    .to_string(),
+            );
+        }
+        if let Some(max_output_tokens) = request.max_output_tokens {
+            resolved_parameters.insert("max_output_tokens".into(), max_output_tokens.into());
+            policy_notes.push(
+                "max_output_tokens is accepted for audit output; runtime policy may cap effective output"
+                    .to_string(),
+            );
+        }
+
+        Ok(SpawnAgentModelResolution {
+            requested: Some(request),
+            resolved_provider: availability.policy.model_ref.provider.as_str().to_string(),
+            resolved_model: availability.policy.model_ref.model,
+            resolved_parameters: (!resolved_parameters.is_empty()).then_some(resolved_parameters),
+            resolution_status: SpawnAgentModelResolutionStatus::Accepted,
+            policy_notes,
+        })
     }
 
     async fn schedule_worktree_child_agent_task(
@@ -668,6 +813,8 @@ impl RuntimeHandle {
 
         let existing_detail = task_record.detail.clone();
         let existing_child_id = detail_string(&existing_detail, "child_agent_id");
+        let inherited_model_resolution =
+            inherited_spawn_model_resolution(&self.model_state_for(&self.agent_state().await?));
         let runtime = self.clone();
         let task_id = task_record.id.clone();
         let task_id_for_cleanup = task_id.clone();
@@ -697,6 +844,7 @@ impl RuntimeHandle {
                                 authority_class.clone(),
                                 worktree,
                                 None,
+                                inherited_model_resolution.clone(),
                             )
                             .await?;
                         Ok((
@@ -714,6 +862,7 @@ impl RuntimeHandle {
                             authority_class.clone(),
                             worktree,
                             None,
+                            inherited_model_resolution.clone(),
                         )
                         .await?;
                     Ok((

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -415,6 +415,22 @@ mod tests {
             .get("objective")
             .is_some());
 
+        let list_model_providers = specs
+            .iter()
+            .find(|spec| spec.name == "ListModelProviders")
+            .expect("ListModelProviders should be present");
+        assert!(list_model_providers.input_schema["properties"]
+            .get("include_unavailable")
+            .is_some());
+
+        let list_provider_models = specs
+            .iter()
+            .find(|spec| spec.name == "ListProviderModels")
+            .expect("ListProviderModels should be present");
+        assert!(list_provider_models.input_schema["properties"]
+            .get("provider")
+            .is_some());
+
         let spawn_agent = specs
             .iter()
             .find(|spec| spec.name == "SpawnAgent")
@@ -431,6 +447,12 @@ mod tests {
         assert!(spawn_agent.input_schema["properties"]
             .get("template")
             .is_some());
+        assert!(spawn_agent.input_schema["properties"]
+            .get("model")
+            .is_some());
+        assert!(spawn_agent.input_schema["properties"]["model"]
+            .to_string()
+            .contains("allow_fallback"));
         assert!(spawn_agent.input_schema["properties"]["preset"]
             .to_string()
             .contains("public_named"));

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -83,7 +83,7 @@ fn tool_stability_level(name: &str) -> &'static str {
         | "TaskStatus" | "TaskInput" | "TaskOutput" | "TaskStop" | "CreateWorkItem"
         | "PickWorkItem" | "GetWorkItem" | "ListWorkItems" | "UpdateWorkItem"
         | "CompleteWorkItem" | "UseWorkspace" | "AgentGet" | "Enqueue" | "SpawnAgent"
-        | "MemorySearch" | "MemoryGet" => "stable",
+        | "ListModelProviders" | "ListProviderModels" | "MemorySearch" | "MemoryGet" => "stable",
         _ => "experimental",
     }
 }
@@ -97,6 +97,8 @@ fn tool_success_result_contract(name: &str) -> &'static str {
         "ExecCommand" => "ExecCommandResult",
         "ExecCommandBatch" => "ExecCommandBatchResult",
         "GetWorkItem" => "GetWorkItemResult",
+        "ListModelProviders" => "ListModelProvidersResult",
+        "ListProviderModels" => "ListProviderModelsResult",
         "ListWorkItems" => "ListWorkItemsResult",
         "MemoryGet" => "MemoryGetResponse",
         "MemorySearch" => "MemorySearchResponse",

--- a/src/tool/tools/list_model_providers.rs
+++ b/src/tool/tools/list_model_providers.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    runtime::RuntimeHandle,
+    tool::spec::typed_spec,
+    types::{AuthorityClass, ModelProviderAvailability, ModelProviderEntry, ToolCapabilityFamily},
+};
+
+use super::{serialize_success, BuiltinToolDefinition};
+use crate::tool::helpers::parse_tool_args;
+
+pub(crate) const NAME: &str = "ListModelProviders";
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ListModelProvidersArgs {
+    #[serde(default)]
+    pub(crate) include_unavailable: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ListModelProvidersResult {
+    pub(crate) include_unavailable: bool,
+    pub(crate) providers: Vec<ModelProviderEntry>,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::CoreAgent,
+        spec: typed_spec::<ListModelProvidersArgs>(
+            NAME,
+            "List configured/discovered model providers. By default unavailable providers are omitted; set include_unavailable=true to inspect blocked options.",
+        )?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    _agent_id: &str,
+    _authority_class: &AuthorityClass,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: ListModelProvidersArgs = parse_tool_args(NAME, input)?;
+    let mut providers = runtime.model_providers().await?;
+    if !args.include_unavailable {
+        providers
+            .retain(|provider| provider.availability != ModelProviderAvailability::Unavailable);
+    }
+    serialize_success(
+        NAME,
+        &ListModelProvidersResult {
+            include_unavailable: args.include_unavailable,
+            providers,
+        },
+    )
+}

--- a/src/tool/tools/list_provider_models.rs
+++ b/src/tool/tools/list_provider_models.rs
@@ -72,25 +72,7 @@ pub(crate) async fn execute(
     if !args.include_unavailable {
         models.retain(|model| model.availability != ModelAvailability::Unavailable);
     }
-    let start = cursor
-        .as_deref()
-        .and_then(|cursor| {
-            models
-                .iter()
-                .position(|model| model.model_ref == cursor)
-                .map(|index| index + 1)
-        })
-        .unwrap_or(0);
-    let mut page = models
-        .into_iter()
-        .skip(start)
-        .take(limit + 1)
-        .collect::<Vec<_>>();
-    let next_cursor = if page.len() > limit {
-        page.pop().map(|model| model.model_ref)
-    } else {
-        None
-    };
+    let (page, next_cursor) = page_provider_models(models, cursor.as_deref(), limit);
     let returned = page.len();
     serialize_success(
         NAME,
@@ -103,4 +85,89 @@ pub(crate) async fn execute(
             models: page,
         },
     )
+}
+
+fn page_provider_models(
+    models: Vec<ProviderModelEntry>,
+    cursor: Option<&str>,
+    limit: usize,
+) -> (Vec<ProviderModelEntry>, Option<String>) {
+    let start = cursor
+        .and_then(|cursor| {
+            models
+                .iter()
+                .position(|model| model.model_ref == cursor)
+                .map(|index| index + 1)
+        })
+        .unwrap_or(0);
+    let mut page = models
+        .into_iter()
+        .skip(start)
+        .take(limit + 1)
+        .collect::<Vec<_>>();
+    if page.len() <= limit {
+        return (page, None);
+    }
+
+    page.truncate(limit);
+    let next_cursor = page.last().map(|model| model.model_ref.clone());
+    (page, next_cursor)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::ModelRef;
+    use crate::types::{ModelAvailability, ProviderModelEntry};
+
+    use super::page_provider_models;
+
+    fn model(model_ref: &str) -> ProviderModelEntry {
+        let policy = crate::model_catalog::ResolvedRuntimeModelPolicy {
+            model_ref: ModelRef::parse(model_ref).unwrap(),
+            ..crate::model_catalog::ResolvedRuntimeModelPolicy::default()
+        };
+        ProviderModelEntry {
+            provider: "test".to_string(),
+            id: model_ref.trim_start_matches("test/").to_string(),
+            model_ref: model_ref.to_string(),
+            display_name: model_ref.to_string(),
+            availability: ModelAvailability::Available,
+            selectable: true,
+            unavailable_reason: None,
+            metadata_source: "test".to_string(),
+            policy,
+            supported_parameters: Vec::new(),
+            policy_notes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn pagination_cursor_resumes_after_last_returned_model() {
+        let models = vec![
+            model("test/a"),
+            model("test/b"),
+            model("test/c"),
+            model("test/d"),
+        ];
+
+        let (first_page, next_cursor) = page_provider_models(models.clone(), None, 2);
+        assert_eq!(
+            first_page
+                .iter()
+                .map(|entry| entry.model_ref.as_str())
+                .collect::<Vec<_>>(),
+            vec!["test/a", "test/b"]
+        );
+        assert_eq!(next_cursor.as_deref(), Some("test/b"));
+
+        let (second_page, next_cursor) = page_provider_models(models, next_cursor.as_deref(), 2);
+        assert_eq!(
+            second_page
+                .iter()
+                .map(|entry| entry.model_ref.as_str())
+                .collect::<Vec<_>>(),
+            vec!["test/c", "test/d"]
+        );
+        assert_eq!(next_cursor, None);
+    }
 }

--- a/src/tool/tools/list_provider_models.rs
+++ b/src/tool/tools/list_provider_models.rs
@@ -1,0 +1,106 @@
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    runtime::RuntimeHandle,
+    tool::spec::typed_spec,
+    types::{AuthorityClass, ModelAvailability, ProviderModelEntry, ToolCapabilityFamily},
+};
+
+use super::{serialize_success, BuiltinToolDefinition};
+use crate::tool::helpers::{invalid_tool_input, normalize_optional_non_empty, parse_tool_args};
+
+pub(crate) const NAME: &str = "ListProviderModels";
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 500;
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ListProviderModelsArgs {
+    pub(crate) provider: String,
+    #[serde(default)]
+    pub(crate) cursor: Option<String>,
+    #[serde(default)]
+    pub(crate) limit: Option<usize>,
+    #[serde(default)]
+    pub(crate) include_unavailable: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ListProviderModelsResult {
+    pub(crate) provider: String,
+    pub(crate) include_unavailable: bool,
+    pub(crate) limit: usize,
+    pub(crate) returned: usize,
+    pub(crate) next_cursor: Option<String>,
+    pub(crate) models: Vec<ProviderModelEntry>,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::CoreAgent,
+        spec: typed_spec::<ListProviderModelsArgs>(
+            NAME,
+            "List models for a provider. Use provider from ListModelProviders; cursor is a model_ref returned by a previous page.",
+        )?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    _agent_id: &str,
+    _authority_class: &AuthorityClass,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: ListProviderModelsArgs = parse_tool_args(NAME, input)?;
+    let provider = normalize_optional_non_empty(Some(args.provider)).ok_or_else(|| {
+        invalid_tool_input(
+            NAME,
+            "ListProviderModels requires a non-empty provider",
+            serde_json::json!({
+                "field": "provider",
+                "validation_error": "must not be empty",
+            }),
+            "call ListModelProviders first and pass one returned provider id",
+        )
+    })?;
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let cursor = normalize_optional_non_empty(args.cursor);
+    let mut models = runtime.provider_models(&provider).await?;
+    if !args.include_unavailable {
+        models.retain(|model| model.availability != ModelAvailability::Unavailable);
+    }
+    let start = cursor
+        .as_deref()
+        .and_then(|cursor| {
+            models
+                .iter()
+                .position(|model| model.model_ref == cursor)
+                .map(|index| index + 1)
+        })
+        .unwrap_or(0);
+    let mut page = models
+        .into_iter()
+        .skip(start)
+        .take(limit + 1)
+        .collect::<Vec<_>>();
+    let next_cursor = if page.len() > limit {
+        page.pop().map(|model| model.model_ref)
+    } else {
+        None
+    };
+    let returned = page.len();
+    serialize_success(
+        NAME,
+        &ListProviderModelsResult {
+            provider,
+            include_unavailable: args.include_unavailable,
+            limit,
+            returned,
+            next_cursor,
+            models: page,
+        },
+    )
+}

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod enqueue;
 pub(crate) mod exec_command;
 pub(crate) mod exec_command_batch;
 pub(crate) mod get_work_item;
+pub(crate) mod list_model_providers;
+pub(crate) mod list_provider_models;
 pub(crate) mod list_work_items;
 pub(crate) mod memory_get;
 pub(crate) mod memory_search;
@@ -54,6 +56,8 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         task_input::definition()?,
         task_output::definition()?,
         task_stop::definition()?,
+        list_model_providers::definition()?,
+        list_provider_models::definition()?,
         create_work_item::definition()?,
         pick_work_item::definition()?,
         get_work_item::definition()?,
@@ -116,6 +120,12 @@ pub(crate) async fn execute_builtin_tool(
         }
         task_stop::NAME => {
             task_stop::execute(runtime, agent_id, authority_class, &call.input).await
+        }
+        list_model_providers::NAME => {
+            list_model_providers::execute(runtime, agent_id, authority_class, &call.input).await
+        }
+        list_provider_models::NAME => {
+            list_provider_models::execute(runtime, agent_id, authority_class, &call.input).await
         }
         create_work_item::NAME => {
             create_work_item::execute(runtime, agent_id, authority_class, &call.input).await

--- a/src/tool/tools/spawn_agent.rs
+++ b/src/tool/tools/spawn_agent.rs
@@ -153,3 +153,30 @@ pub(crate) async fn execute(
         .await?;
     serialize_success(NAME, &result)
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::tool::helpers::parse_tool_args;
+
+    use super::{SpawnAgentArgs, NAME};
+
+    #[test]
+    fn spawn_agent_rejects_unknown_nested_model_fields() {
+        let result = parse_tool_args::<SpawnAgentArgs>(
+            NAME,
+            &json!({
+                "initial_message": "compare implementation",
+                "model": {
+                    "provider": "anthropic",
+                    "model": "claude-haiku-4-5",
+                    "max_output_token": 1000
+                }
+            }),
+        );
+        let error = result.err().expect("nested model typos should be rejected");
+
+        assert!(error.to_string().contains("max_output_token"));
+    }
+}

--- a/src/tool/tools/spawn_agent.rs
+++ b/src/tool/tools/spawn_agent.rs
@@ -7,7 +7,7 @@ use crate::{
     host_registry::validate_agent_id_format,
     runtime::RuntimeHandle,
     tool::spec::typed_spec,
-    types::{AgentProfilePreset, AuthorityClass, ToolCapabilityFamily},
+    types::{AgentProfilePreset, AuthorityClass, SpawnAgentModelRequest, ToolCapabilityFamily},
 };
 
 use super::{serialize_success, BuiltinToolDefinition};
@@ -39,6 +39,7 @@ pub(crate) struct SpawnAgentArgs {
     pub(crate) agent_id: Option<String>,
     pub(crate) template: Option<String>,
     pub(crate) workspace_mode: Option<SpawnAgentWorkspaceMode>,
+    pub(crate) model: Option<SpawnAgentModelRequest>,
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
@@ -147,6 +148,7 @@ pub(crate) async fn execute(
             agent_id,
             worktree,
             template,
+            args.model,
         )
         .await?;
     serialize_success(NAME, &result)

--- a/src/types.rs
+++ b/src/types.rs
@@ -3007,6 +3007,7 @@ pub struct SpawnAgentResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct SpawnAgentModelRequest {
     pub provider: String,
     pub model: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3002,6 +3002,45 @@ pub struct SpawnAgentResult {
     pub parent_work_item_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_resolution: Option<SpawnAgentModelResolution>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct SpawnAgentModelRequest {
+    pub provider: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_fallback: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SpawnAgentModelResolutionStatus {
+    Inherited,
+    Accepted,
+    Normalized,
+    FallbackUsed,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SpawnAgentModelResolution {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested: Option<SpawnAgentModelRequest>,
+    pub resolved_provider: String,
+    pub resolved_model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_parameters: Option<serde_json::Map<String, serde_json::Value>>,
+    pub resolution_status: SpawnAgentModelResolutionStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub policy_notes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -3921,6 +3960,8 @@ pub struct ProviderModelEntry {
     pub unavailable_reason: Option<String>,
     pub metadata_source: String,
     pub policy: ResolvedRuntimeModelPolicy,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_parameters: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub policy_notes: Vec<String>,
 }

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -597,6 +597,7 @@ pub async fn notify_operator_records_default_public_and_private_child_targets() 
             None,
             false,
             None,
+            None,
         )
         .await?;
     let child_runtime = host.get_or_create_agent(&spawned.agent_id).await?;


### PR DESCRIPTION
## Summary\n\n- adds optional SpawnAgent model requests with provider/model/parameter fields and model_resolution audit output\n- applies accepted explicit model requests to spawned child/public agents via model override while preserving inherited behavior when omitted\n- adds ListModelProviders and ListProviderModels tools backed by provider-first model projection\n\nCloses #1580.\n\n## Verification\n\n- cargo test resolved_provider_models_returns_models_for_one_provider --lib\n- cargo test private_child_spawn_accepts_explicit_model_selection --lib\n- cargo test private_child_spawn_rejects_unavailable_explicit_model_without_fallback --lib\n- cargo test stable_tool_specs_expose_canonical_coding_tools --lib\n- cargo fmt --all -- --check\n- RUSTFLAGS="-D warnings" cargo check --all-targets