### PR TITLE
feat: add provider-first TUI model picker

### DIFF
--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -517,11 +517,16 @@ impl TuiApp {
                 self.reset_composer_key_burst();
                 self.sync_slash_menu_after_edit(before != self.composer.as_str());
             }
-            OverlayState::ModelPicker { filter, selected } => {
+            OverlayState::ModelPicker {
+                provider,
+                filter,
+                selected,
+            } => {
                 filter.push_str(&paste_inline_text(text));
                 *selected = crate::tui::model_picker::clamp_model_picker_selection(
                     selected_agent.as_ref(),
                     &model_availability,
+                    provider.as_deref(),
                     filter,
                     *selected,
                 );
@@ -644,6 +649,7 @@ impl TuiApp {
             SlashCommand::Model => {
                 self.begin_load_models();
                 self.overlay = OverlayState::ModelPicker {
+                    provider: None,
                     filter: String::new(),
                     selected: 0,
                 };
@@ -957,50 +963,85 @@ impl TuiApp {
                 Ok(())
             }
             OverlayState::ModelPicker {
+                provider,
                 mut filter,
                 mut selected,
             } => {
                 match resolve_key(KeyContext::ModelPicker, key) {
-                    TuiKeyAction::OverlayClose => {}
+                    TuiKeyAction::OverlayClose => {
+                        if provider.is_some() {
+                            self.overlay = OverlayState::ModelPicker {
+                                provider: None,
+                                filter: String::new(),
+                                selected: 0,
+                            };
+                        }
+                    }
                     TuiKeyAction::OverlayAccept => {
-                        self.apply_model_picker_selection(&filter, selected).await?;
+                        self.apply_model_picker_selection(provider.as_deref(), &filter, selected)
+                            .await?;
                     }
                     TuiKeyAction::OverlayMoveUp => {
                         selected = selected.saturating_sub(1);
-                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                        self.overlay = OverlayState::ModelPicker {
+                            provider,
+                            filter,
+                            selected,
+                        };
                     }
                     TuiKeyAction::OverlayMoveDown => {
                         let max = crate::tui::model_picker::model_picker_rows(
                             self.selected_agent_summary(),
                             &self.model_availability,
+                            provider.as_deref(),
                             &filter,
                         )
                         .len()
                         .saturating_sub(1);
                         selected = (selected + 1).min(max);
-                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                        self.overlay = OverlayState::ModelPicker {
+                            provider,
+                            filter,
+                            selected,
+                        };
                     }
                     TuiKeyAction::ModelFilterBackspace => {
                         filter.pop();
                         selected = crate::tui::model_picker::clamp_model_picker_selection(
                             self.selected_agent_summary(),
                             &self.model_availability,
+                            provider.as_deref(),
                             &filter,
                             selected,
                         );
-                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                        self.overlay = OverlayState::ModelPicker {
+                            provider,
+                            filter,
+                            selected,
+                        };
                     }
                     TuiKeyAction::InsertChar(ch) => {
                         filter.push(ch);
                         selected = crate::tui::model_picker::clamp_model_picker_selection(
                             self.selected_agent_summary(),
                             &self.model_availability,
+                            provider.as_deref(),
                             &filter,
                             selected,
                         );
-                        self.overlay = OverlayState::ModelPicker { filter, selected };
+                        self.overlay = OverlayState::ModelPicker {
+                            provider,
+                            filter,
+                            selected,
+                        };
                     }
-                    _ => self.overlay = OverlayState::ModelPicker { filter, selected },
+                    _ => {
+                        self.overlay = OverlayState::ModelPicker {
+                            provider,
+                            filter,
+                            selected,
+                        }
+                    }
                 }
                 Ok(())
             }
@@ -1013,6 +1054,7 @@ impl TuiApp {
                 match resolve_key(KeyContext::ModelEffortPicker, key) {
                     TuiKeyAction::OverlayClose => {
                         self.overlay = OverlayState::ModelPicker {
+                            provider: None,
                             filter: return_filter,
                             selected: return_selected,
                         };
@@ -1323,7 +1365,12 @@ impl TuiApp {
         }
     }
 
-    async fn apply_model_picker_selection(&mut self, filter: &str, selected: usize) -> Result<()> {
+    async fn apply_model_picker_selection(
+        &mut self,
+        provider: Option<&str>,
+        filter: &str,
+        selected: usize,
+    ) -> Result<()> {
         let agent_id = self
             .selected_agent_id()
             .ok_or_else(|| anyhow!("no agent selected"))?
@@ -1331,6 +1378,7 @@ impl TuiApp {
         let choice = crate::tui::model_picker::selected_model_choice(
             self.selected_agent_summary(),
             &self.model_availability,
+            provider,
             filter,
             selected,
         )
@@ -1344,13 +1392,27 @@ impl TuiApp {
                 self.overlay = OverlayState::None;
                 self.begin_bootstrap_selected_agent();
             }
-            crate::tui::model_picker::ModelPickerChoice::Model { model } => {
-                self.overlay = OverlayState::ModelEffortPicker {
-                    model,
+            crate::tui::model_picker::ModelPickerChoice::Provider { provider } => {
+                self.overlay = OverlayState::ModelPicker {
+                    provider: Some(provider),
+                    filter: String::new(),
                     selected: 0,
-                    return_filter: filter.to_string(),
-                    return_selected: selected,
                 };
+            }
+            crate::tui::model_picker::ModelPickerChoice::Model {
+                model,
+                supports_reasoning_effort,
+            } => {
+                if supports_reasoning_effort {
+                    self.overlay = OverlayState::ModelEffortPicker {
+                        model,
+                        selected: 0,
+                        return_filter: filter.to_string(),
+                        return_selected: selected,
+                    };
+                } else {
+                    self.set_model_override(&agent_id, &model, None).await?;
+                }
             }
         }
         Ok(())
@@ -1374,8 +1436,19 @@ impl TuiApp {
         } else {
             Some(reasoning_effort.to_string())
         };
+        self.set_model_override(&agent_id, model, reasoning_effort)
+            .await?;
+        Ok(())
+    }
+
+    async fn set_model_override(
+        &mut self,
+        agent_id: &str,
+        model: &str,
+        reasoning_effort: Option<String>,
+    ) -> Result<()> {
         self.client
-            .set_agent_model_override(&agent_id, model.to_string(), reasoning_effort.clone())
+            .set_agent_model_override(agent_id, model.to_string(), reasoning_effort.clone())
             .await?;
         let suffix = reasoning_effort
             .as_deref()

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1053,8 +1053,11 @@ impl TuiApp {
             } => {
                 match resolve_key(KeyContext::ModelEffortPicker, key) {
                     TuiKeyAction::OverlayClose => {
+                        let provider = model
+                            .split_once('/')
+                            .map(|(provider, _)| provider.to_string());
                         self.overlay = OverlayState::ModelPicker {
-                            provider: None,
+                            provider,
                             filter: return_filter,
                             selected: return_selected,
                         };
@@ -1375,7 +1378,7 @@ impl TuiApp {
             .selected_agent_id()
             .ok_or_else(|| anyhow!("no agent selected"))?
             .to_string();
-        let choice = crate::tui::model_picker::selected_model_choice(
+        let row = crate::tui::model_picker::selected_model_picker_row(
             self.selected_agent_summary(),
             &self.model_availability,
             provider,
@@ -1383,8 +1386,17 @@ impl TuiApp {
             selected,
         )
         .ok_or_else(|| anyhow!("no model selection available"))?;
+        if !row.available {
+            self.status_line = format!("Model unavailable: {}; {}", row.title, row.detail);
+            self.overlay = OverlayState::ModelPicker {
+                provider: provider.map(str::to_string),
+                filter: filter.to_string(),
+                selected,
+            };
+            return Ok(());
+        }
 
-        match choice {
+        match row.choice {
             crate::tui::model_picker::ModelPickerChoice::InheritDefault => {
                 self.client.clear_agent_model_override(&agent_id).await?;
                 self.status_line =

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -3,7 +3,13 @@ use crate::types::{AgentSummary, ResolvedModelAvailability};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ModelPickerChoice {
     InheritDefault,
-    Model { model: String },
+    Provider {
+        provider: String,
+    },
+    Model {
+        model: String,
+        supports_reasoning_effort: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,6 +24,7 @@ pub(super) struct ModelPickerRow {
 pub(super) fn model_picker_rows(
     agent: Option<&AgentSummary>,
     model_availability: &[ResolvedModelAvailability],
+    provider: Option<&str>,
     filter: &str,
 ) -> Vec<ModelPickerRow> {
     let Some(agent) = agent else {
@@ -25,40 +32,46 @@ pub(super) fn model_picker_rows(
     };
     let inherit_row = inherit_default_row(agent);
     let query = filter.trim().to_ascii_lowercase();
-    let model_rows = model_availability
-        .iter()
-        .filter(|entry| entry.available)
-        .map(model_availability_row);
+    let choice_rows = match provider {
+        Some(provider) => provider_model_rows(model_availability, provider),
+        None => provider_rows(model_availability),
+    };
     if query.is_empty() {
         let mut rows = vec![inherit_row];
-        rows.extend(model_rows);
+        rows.extend(choice_rows);
         return rows;
     }
 
     let mut rows = vec![inherit_row];
-    rows.extend(model_rows.filter(|row| row.searchable.contains(&query)));
+    rows.extend(
+        choice_rows
+            .into_iter()
+            .filter(|row| row.searchable.contains(&query)),
+    );
     rows
 }
 
 pub(super) fn selected_model_choice(
     agent: Option<&AgentSummary>,
     model_availability: &[ResolvedModelAvailability],
+    provider: Option<&str>,
     filter: &str,
     selected: usize,
 ) -> Option<ModelPickerChoice> {
-    model_picker_rows(agent, model_availability, filter)
+    model_picker_rows(agent, model_availability, provider, filter)
         .into_iter()
         .nth(selected)
-        .map(|row| row.choice)
+        .and_then(|row| row.available.then_some(row.choice))
 }
 
 pub(super) fn clamp_model_picker_selection(
     agent: Option<&AgentSummary>,
     model_availability: &[ResolvedModelAvailability],
+    provider: Option<&str>,
     filter: &str,
     selected: usize,
 ) -> usize {
-    let len = model_picker_rows(agent, model_availability, filter).len();
+    let len = model_picker_rows(agent, model_availability, provider, filter).len();
     if len == 0 {
         0
     } else {
@@ -83,6 +96,81 @@ fn inherit_default_row(agent: &AgentSummary) -> ModelPickerRow {
     }
 }
 
+fn provider_rows(model_availability: &[ResolvedModelAvailability]) -> Vec<ModelPickerRow> {
+    let mut providers =
+        std::collections::BTreeMap::<String, Vec<&ResolvedModelAvailability>>::new();
+    for entry in model_availability {
+        providers
+            .entry(entry.provider.clone())
+            .or_default()
+            .push(entry);
+    }
+
+    providers
+        .into_iter()
+        .map(|(provider, models)| provider_row(provider, models))
+        .collect()
+}
+
+fn provider_row(provider: String, models: Vec<&ResolvedModelAvailability>) -> ModelPickerRow {
+    let available_count = models.iter().filter(|entry| entry.available).count();
+    let discovered_count = models
+        .iter()
+        .filter(|entry| entry.metadata_source == "remote_discovered")
+        .count();
+    let first = models.first().copied();
+    let transport = first
+        .and_then(|entry| entry.transport.as_deref())
+        .map(|transport| format!(" transport:{transport}"))
+        .unwrap_or_default();
+    let source = first
+        .and_then(|entry| entry.provider_source.as_deref())
+        .map(|source| format!(" provider:{source}"))
+        .unwrap_or_default();
+    let credential = first
+        .and_then(|entry| entry.credential_source.as_deref())
+        .map(|source| format!(" credential:{source}"))
+        .unwrap_or_default();
+    let status = if available_count > 0 {
+        format!(
+            "ready: {available_count}/{} models selectable",
+            models.len()
+        )
+    } else {
+        let reason = models
+            .iter()
+            .find_map(|entry| entry.unavailable_reason.as_deref())
+            .unwrap_or("provider unavailable");
+        format!("unavailable: {reason}")
+    };
+    let discovery = if discovered_count > 0 {
+        format!(" remote-discovered:{discovered_count}")
+    } else {
+        String::new()
+    };
+    ModelPickerRow {
+        choice: ModelPickerChoice::Provider {
+            provider: provider.clone(),
+        },
+        title: provider.clone(),
+        detail: format!("{status}{transport}{source}{credential}{discovery}"),
+        searchable: format!("{provider} {status}{transport}{source}{credential}{discovery}")
+            .to_ascii_lowercase(),
+        available: true,
+    }
+}
+
+fn provider_model_rows(
+    model_availability: &[ResolvedModelAvailability],
+    provider: &str,
+) -> Vec<ModelPickerRow> {
+    model_availability
+        .iter()
+        .filter(|entry| entry.provider == provider)
+        .map(model_availability_row)
+        .collect()
+}
+
 fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
     let status = if entry.available {
         "ready".to_string()
@@ -94,6 +182,11 @@ fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
                 .as_deref()
                 .unwrap_or("provider unavailable")
         )
+    };
+    let reasoning = if supports_reasoning_effort(entry) {
+        " reasoning:configurable"
+    } else {
+        " reasoning:skipped"
     };
     let provider = entry
         .provider_source
@@ -108,19 +201,29 @@ fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
     ModelPickerRow {
         choice: ModelPickerChoice::Model {
             model: entry.model.clone(),
+            supports_reasoning_effort: supports_reasoning_effort(entry),
         },
         title: format!("{}  {}", entry.model, entry.display_name),
         detail: format!(
-            "{status}  {provider}{transport}  source:{}",
+            "{status}  {provider}{transport}{reasoning}  source:{}",
             entry.metadata_source
         ),
         searchable: format!(
-            "{} {} {} {} {}",
-            entry.model, entry.display_name, entry.provider, entry.metadata_source, status
+            "{} {} {} {} {} {}",
+            entry.model,
+            entry.display_name,
+            entry.provider,
+            entry.metadata_source,
+            status,
+            reasoning
         )
         .to_ascii_lowercase(),
         available: entry.available,
     }
+}
+
+fn supports_reasoning_effort(entry: &ResolvedModelAvailability) -> bool {
+    entry.policy.capabilities.reasoning_summaries
 }
 
 #[cfg(test)]
@@ -139,7 +242,7 @@ mod tests {
         },
     };
 
-    fn policy(model: &str, display_name: &str) -> ResolvedRuntimeModelPolicy {
+    fn policy(model: &str, display_name: &str, reasoning: bool) -> ResolvedRuntimeModelPolicy {
         ResolvedRuntimeModelPolicy {
             model_ref: ModelRef::parse(model).unwrap(),
             display_name: display_name.into(),
@@ -152,12 +255,20 @@ mod tests {
             runtime_max_output_tokens: 32_000,
             tool_output_truncation_estimated_tokens: 2_500,
             max_output_tokens_upper_limit: Some(128_000),
-            capabilities: ModelCapabilityFlags::default(),
+            capabilities: ModelCapabilityFlags {
+                reasoning_summaries: reasoning,
+                ..ModelCapabilityFlags::default()
+            },
             source: ModelMetadataSource::BuiltInCatalog,
         }
     }
 
-    fn availability(model: &str, display_name: &str, available: bool) -> ResolvedModelAvailability {
+    fn availability(
+        model: &str,
+        display_name: &str,
+        available: bool,
+        reasoning: bool,
+    ) -> ResolvedModelAvailability {
         let model_ref = ModelRef::parse(model).unwrap();
         ResolvedModelAvailability {
             model: model.into(),
@@ -172,14 +283,20 @@ mod tests {
             credential_configured: available,
             available,
             unavailable_reason: (!available).then_some("credential_missing".into()),
-            policy: policy(model, display_name),
+            policy: policy(model, display_name, reasoning),
         }
     }
 
     fn model_availability() -> Vec<ResolvedModelAvailability> {
         vec![
-            availability("openai/gpt-5.4", "GPT-5.4", true),
-            availability("anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6", false),
+            availability("openai/gpt-5.4", "GPT-5.4", true, true),
+            availability(
+                "anthropic/claude-sonnet-4-6",
+                "Claude Sonnet 4.6",
+                false,
+                false,
+            ),
+            availability("openrouter/deepseek-v3", "DeepSeek V3", true, false),
         ]
     }
 
@@ -211,7 +328,7 @@ mod tests {
                 effective_fallback_models: Vec::new(),
                 override_model: None,
                 override_reasoning_effort: None,
-                resolved_policy: policy("openai/gpt-5.4", "GPT-5.4"),
+                resolved_policy: policy("openai/gpt-5.4", "GPT-5.4", true),
             },
             token_usage: AgentTokenUsageSummary {
                 total: TokenUsage::new(0, 0),
@@ -252,33 +369,51 @@ mod tests {
     }
 
     #[test]
-    fn picker_rows_include_inherit_and_runtime_availability() {
+    fn picker_rows_start_with_provider_choices() {
         let agent = summary();
         let availability = model_availability();
-        let rows = model_picker_rows(Some(&agent), &availability, "");
+        let rows = model_picker_rows(Some(&agent), &availability, None, "");
+        assert_eq!(rows.len(), 4);
+        assert!(rows[0].title.contains("inherit runtime default"));
+        assert!(rows.iter().any(|row| row.title == "openai"));
+        assert!(rows.iter().any(|row| row.title == "openrouter"));
+    }
+
+    #[test]
+    fn provider_model_page_shows_provider_specific_models() {
+        let agent = summary();
+        let availability = model_availability();
+        let rows = model_picker_rows(Some(&agent), &availability, Some("openrouter"), "");
         assert_eq!(rows.len(), 2);
         assert!(rows[0].title.contains("inherit runtime default"));
-        assert!(rows[1].title.contains("openai/gpt-5.4"));
+        assert!(rows[1].title.contains("openrouter/deepseek-v3"));
         assert!(rows[1].available);
+        assert!(rows[1].detail.contains("reasoning:skipped"));
     }
 
     #[test]
-    fn picker_rows_skip_unavailable_models() {
+    fn provider_model_page_surfaces_unavailable_models() {
         let agent = summary();
         let availability = model_availability();
-        let rows = model_picker_rows(Some(&agent), &availability, "");
-        assert!(!rows
+        let rows = model_picker_rows(Some(&agent), &availability, Some("anthropic"), "");
+        assert!(rows
             .iter()
             .any(|row| row.title.contains("anthropic/claude-sonnet-4-6")));
+        assert!(!rows[1].available);
+        assert!(rows[1].detail.contains("credential_missing"));
     }
 
     #[test]
-    fn picker_rows_filter_by_model_and_label() {
+    fn picker_rows_filter_by_provider_or_model_context() {
         let agent = summary();
         let availability = model_availability();
-        let rows = model_picker_rows(Some(&agent), &availability, "sonnet");
-        assert_eq!(rows.len(), 1);
+        let rows = model_picker_rows(Some(&agent), &availability, None, "router");
+        assert_eq!(rows.len(), 2);
         assert!(rows[0].title.contains("inherit runtime default"));
+
+        let rows = model_picker_rows(Some(&agent), &availability, Some("anthropic"), "sonnet");
+        assert_eq!(rows.len(), 2);
+        assert!(rows[1].title.contains("claude-sonnet"));
     }
 
     #[test]
@@ -286,9 +421,12 @@ mod tests {
         let agent = summary();
         let availability = model_availability();
         assert_eq!(
-            clamp_model_picker_selection(Some(&agent), &availability, "gpt", 10),
+            clamp_model_picker_selection(Some(&agent), &availability, Some("openai"), "gpt", 10),
             1
         );
-        assert!(selected_model_choice(Some(&agent), &availability, "", 1).is_some());
+        assert!(selected_model_choice(Some(&agent), &availability, None, "", 1).is_some());
+        assert!(
+            selected_model_choice(Some(&agent), &availability, Some("anthropic"), "", 1).is_none()
+        );
     }
 }

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -51,17 +51,16 @@ pub(super) fn model_picker_rows(
     rows
 }
 
-pub(super) fn selected_model_choice(
+pub(super) fn selected_model_picker_row(
     agent: Option<&AgentSummary>,
     model_availability: &[ResolvedModelAvailability],
     provider: Option<&str>,
     filter: &str,
     selected: usize,
-) -> Option<ModelPickerChoice> {
+) -> Option<ModelPickerRow> {
     model_picker_rows(agent, model_availability, provider, filter)
         .into_iter()
         .nth(selected)
-        .and_then(|row| row.available.then_some(row.choice))
 }
 
 pub(super) fn clamp_model_picker_selection(
@@ -224,11 +223,12 @@ fn model_availability_row(entry: &ResolvedModelAvailability) -> ModelPickerRow {
 
 fn supports_reasoning_effort(entry: &ResolvedModelAvailability) -> bool {
     entry.policy.capabilities.reasoning_summaries
+        && entry.transport.as_deref() == Some("openai_codex_responses")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{clamp_model_picker_selection, model_picker_rows, selected_model_choice};
+    use super::{clamp_model_picker_selection, model_picker_rows, selected_model_picker_row};
     use crate::system::{ExecutionProfile, ExecutionSnapshot};
     use crate::{
         config::{ModelRef, ProviderId},
@@ -424,9 +424,11 @@ mod tests {
             clamp_model_picker_selection(Some(&agent), &availability, Some("openai"), "gpt", 10),
             1
         );
-        assert!(selected_model_choice(Some(&agent), &availability, None, "", 1).is_some());
+        assert!(selected_model_picker_row(Some(&agent), &availability, None, "", 1).is_some());
         assert!(
-            selected_model_choice(Some(&agent), &availability, Some("anthropic"), "", 1).is_none()
+            !selected_model_picker_row(Some(&agent), &availability, Some("anthropic"), "", 1)
+                .unwrap()
+                .available
         );
     }
 }

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -26,6 +26,7 @@ pub(super) enum OverlayState {
         detail_scroll: u16,
     },
     ModelPicker {
+        provider: Option<String>,
         filter: String,
         selected: usize,
     },
@@ -62,9 +63,11 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
             selected,
             detail_scroll,
         } => draw_tasks_overlay(frame, app, *selected, *detail_scroll),
-        OverlayState::ModelPicker { filter, selected } => {
-            draw_model_picker_overlay(frame, app, filter, *selected)
-        }
+        OverlayState::ModelPicker {
+            provider,
+            filter,
+            selected,
+        } => draw_model_picker_overlay(frame, app, provider.as_deref(), filter, *selected),
         OverlayState::ModelEffortPicker {
             model, selected, ..
         } => draw_model_effort_picker_overlay(frame, app, model, *selected),
@@ -304,7 +307,13 @@ fn draw_tasks_overlay(frame: &mut Frame<'_>, app: &TuiApp, selected: usize, deta
     frame.render_widget(detail, layout[1]);
 }
 
-fn draw_model_picker_overlay(frame: &mut Frame<'_>, app: &TuiApp, filter: &str, selected: usize) {
+fn draw_model_picker_overlay(
+    frame: &mut Frame<'_>,
+    app: &TuiApp,
+    provider: Option<&str>,
+    filter: &str,
+    selected: usize,
+) {
     let popup = centered_rect(92, 80, frame.area());
     let layout = Layout::default()
         .direction(Direction::Vertical)
@@ -321,19 +330,26 @@ fn draw_model_picker_overlay(frame: &mut Frame<'_>, app: &TuiApp, filter: &str, 
     } else {
         format!("Filter: {filter}")
     };
+    let title = provider
+        .map(|provider| format!("Model · provider:{provider}"))
+        .unwrap_or_else(|| "Model · providers".to_string());
     let filter_widget =
-        Paragraph::new(filter_text).block(Block::default().title("Model").borders(Borders::ALL));
+        Paragraph::new(filter_text).block(Block::default().title(title).borders(Borders::ALL));
     frame.render_widget(filter_widget, layout[0]);
 
     let rows = crate::tui::model_picker::model_picker_rows(
         app.selected_agent_summary(),
         &app.model_availability,
+        provider,
         filter,
     );
     let items = if rows.is_empty() {
-        vec![ListItem::new(
-            "No runtime-provided model availability matches the filter",
-        )]
+        let message = provider
+            .map(|provider| {
+                format!("No runtime-provided models for provider {provider} match the filter")
+            })
+            .unwrap_or_else(|| "No runtime-provided model providers match the filter".to_string());
+        vec![ListItem::new(message)]
     } else {
         rows.iter()
             .map(|row| {
@@ -347,7 +363,15 @@ fn draw_model_picker_overlay(frame: &mut Frame<'_>, app: &TuiApp, filter: &str, 
         state.select(Some(selected.min(rows.len().saturating_sub(1))));
     }
     let list = List::new(items)
-        .block(Block::default().title("Models").borders(Borders::ALL))
+        .block(
+            Block::default()
+                .title(if provider.is_some() {
+                    "Models"
+                } else {
+                    "Providers"
+                })
+                .borders(Borders::ALL),
+        )
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
     frame.render_stateful_widget(list, layout[1], &mut state);
@@ -357,7 +381,12 @@ fn draw_model_picker_overlay(frame: &mut Frame<'_>, app: &TuiApp, filter: &str, 
         .map(render::render_model_status)
         .unwrap_or_else(|| "model: <no agent selected>".into());
     let help = Paragraph::new(format!(
-        "{current}\nType to filter, Backspace edits, Up/Down moves, Enter selects, Esc cancels"
+        "{current}\nType to filter, Backspace edits, Up/Down moves, Enter selects, Esc {}",
+        if provider.is_some() {
+            "goes back"
+        } else {
+            "cancels"
+        }
     ))
     .block(Block::default().borders(Borders::ALL))
     .wrap(Wrap { trim: false });

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -240,6 +240,47 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
     }
 }
 
+fn sample_model_availability(
+    model: &str,
+    display_name: &str,
+    available: bool,
+    reasoning: bool,
+) -> crate::types::ResolvedModelAvailability {
+    let model_ref = crate::config::ModelRef::parse(model).unwrap();
+    crate::types::ResolvedModelAvailability {
+        model: model.into(),
+        provider: model_ref.provider.as_str().into(),
+        display_name: display_name.into(),
+        metadata_source: "remote_discovered".into(),
+        provider_configured: true,
+        provider_source: Some("config".into()),
+        transport: Some("openai_chat_completions".into()),
+        credential_source: Some("env".into()),
+        credential_kind: Some("api_key".into()),
+        credential_configured: available,
+        available,
+        unavailable_reason: (!available).then_some("credential_missing".into()),
+        policy: crate::model_catalog::ResolvedRuntimeModelPolicy {
+            model_ref,
+            display_name: display_name.into(),
+            description: "Sample policy".into(),
+            context_window_tokens: Some(128_000),
+            effective_context_window_percent: 90,
+            prompt_budget_estimated_tokens: 115_200,
+            compaction_trigger_estimated_tokens: 115_200,
+            compaction_keep_recent_estimated_tokens: 43_776,
+            runtime_max_output_tokens: 16_000,
+            tool_output_truncation_estimated_tokens: 2_500,
+            max_output_tokens_upper_limit: Some(64_000),
+            capabilities: crate::model_catalog::ModelCapabilityFlags {
+                reasoning_summaries: reasoning,
+                ..crate::model_catalog::ModelCapabilityFlags::default()
+            },
+            source: crate::model_catalog::ModelMetadataSource::RemoteDiscovered,
+        },
+    }
+}
+
 fn sample_snapshot(agent_id: &str, _cursor: &str) -> AgentStateSnapshot {
     AgentStateSnapshot {
         agent: sample_agent_summary(agent_id),
@@ -1138,6 +1179,7 @@ async fn paste_updates_model_picker_filter() {
         crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
     );
     app.overlay = OverlayState::ModelPicker {
+        provider: None,
         filter: "gpt".into(),
         selected: 0,
     };
@@ -1147,6 +1189,7 @@ async fn paste_updates_model_picker_filter() {
     assert_eq!(
         app.overlay,
         OverlayState::ModelPicker {
+            provider: None,
             filter: "gpt-5.3".into(),
             selected: 0,
         }
@@ -1503,6 +1546,7 @@ async fn slash_model_opens_model_picker_overlay() {
     assert_eq!(
         app.overlay,
         OverlayState::ModelPicker {
+            provider: None,
             filter: String::new(),
             selected: 0
         }
@@ -1536,6 +1580,75 @@ fn loaded_models_clear_lazy_load_in_flight_flag() {
     app.apply_loaded_models(Ok(Vec::new()));
 
     assert!(!app.model_availability_load_in_flight);
+}
+
+#[tokio::test]
+async fn model_picker_enter_opens_provider_model_page() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.apply_agent_list(vec![sample_agent_summary("default")]);
+    app.model_availability = vec![sample_model_availability(
+        "openrouter/deepseek-v3",
+        "DeepSeek V3",
+        true,
+        false,
+    )];
+    app.overlay = OverlayState::ModelPicker {
+        provider: None,
+        filter: String::new(),
+        selected: 1,
+    };
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app.overlay,
+        OverlayState::ModelPicker {
+            provider: Some("openrouter".into()),
+            filter: String::new(),
+            selected: 0,
+        }
+    );
+}
+
+#[tokio::test]
+async fn model_picker_opens_effort_for_models_with_reasoning_support() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.apply_agent_list(vec![sample_agent_summary("default")]);
+    app.model_availability = vec![sample_model_availability(
+        "openai/gpt-5.4",
+        "GPT-5.4",
+        true,
+        true,
+    )];
+    app.overlay = OverlayState::ModelPicker {
+        provider: Some("openai".into()),
+        filter: String::new(),
+        selected: 1,
+    };
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app.overlay,
+        OverlayState::ModelEffortPicker {
+            model: "openai/gpt-5.4".into(),
+            selected: 0,
+            return_filter: String::new(),
+            return_selected: 1,
+        }
+    );
 }
 
 #[tokio::test]
@@ -1626,6 +1739,7 @@ async fn slash_menu_enter_runs_selected_prefix_command() {
     assert_eq!(
         app.overlay,
         OverlayState::ModelPicker {
+            provider: None,
             filter: String::new(),
             selected: 0
         }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -254,7 +254,11 @@ fn sample_model_availability(
         metadata_source: "remote_discovered".into(),
         provider_configured: true,
         provider_source: Some("config".into()),
-        transport: Some("openai_chat_completions".into()),
+        transport: Some(if model_ref.provider.as_str() == "openai_codex" {
+            "openai_codex_responses".into()
+        } else {
+            "openai_chat_completions".into()
+        }),
         credential_source: Some("env".into()),
         credential_kind: Some("api_key".into()),
         credential_configured: available,
@@ -1625,13 +1629,13 @@ async fn model_picker_opens_effort_for_models_with_reasoning_support() {
     );
     app.apply_agent_list(vec![sample_agent_summary("default")]);
     app.model_availability = vec![sample_model_availability(
-        "openai/gpt-5.4",
-        "GPT-5.4",
+        "openai_codex/gpt-5.4",
+        "GPT-5.4 Codex",
         true,
         true,
     )];
     app.overlay = OverlayState::ModelPicker {
-        provider: Some("openai".into()),
+        provider: Some("openai_codex".into()),
         filter: String::new(),
         selected: 1,
     };
@@ -1643,10 +1647,74 @@ async fn model_picker_opens_effort_for_models_with_reasoning_support() {
     assert_eq!(
         app.overlay,
         OverlayState::ModelEffortPicker {
-            model: "openai/gpt-5.4".into(),
+            model: "openai_codex/gpt-5.4".into(),
             selected: 0,
             return_filter: String::new(),
             return_selected: 1,
+        }
+    );
+}
+
+#[tokio::test]
+async fn model_picker_enter_on_unavailable_model_keeps_provider_page_open() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.apply_agent_list(vec![sample_agent_summary("default")]);
+    app.model_availability = vec![sample_model_availability(
+        "openrouter/deepseek-v3",
+        "DeepSeek V3",
+        false,
+        false,
+    )];
+    app.overlay = OverlayState::ModelPicker {
+        provider: Some("openrouter".into()),
+        filter: String::new(),
+        selected: 1,
+    };
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app.overlay,
+        OverlayState::ModelPicker {
+            provider: Some("openrouter".into()),
+            filter: String::new(),
+            selected: 1,
+        }
+    );
+    assert!(app.status_line.contains("Model unavailable"));
+    assert!(app.status_line.contains("credential_missing"));
+}
+
+#[tokio::test]
+async fn model_effort_picker_esc_returns_to_provider_model_page() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.overlay = OverlayState::ModelEffortPicker {
+        model: "openai_codex/gpt-5.4".into(),
+        selected: 0,
+        return_filter: "gpt".into(),
+        return_selected: 1,
+    };
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app.overlay,
+        OverlayState::ModelPicker {
+            provider: Some("openai_codex".into()),
+            filter: "gpt".into(),
+            selected: 1,
         }
     );
 }


### PR DESCRIPTION
## Summary

- Change the TUI `/model` flow from a flat model list to provider-first navigation.
- Show provider-level availability, transport, credential, and remote-discovery counts before entering a provider-specific model list.
- Keep unavailable provider models visible on provider pages with clear reasons, and skip the reasoning effort picker for models without reasoning support.

Closes #1568.

## Verification

- `cargo fmt --all -- --check`
- `cargo test tui::model_picker --lib`
- `cargo test tui::tests::model_picker_ --lib`
- `cargo test tui::tests --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`