### PR TITLE
fix: merge duplicate apply-patch modify entries

### DIFF
--- a/docs/rfcs/apply-patch-unified-diff-contract.md
+++ b/docs/rfcs/apply-patch-unified-diff-contract.md
@@ -250,7 +250,10 @@ The apply layer should:
 - apply all hunks for a file atomically
 - write all files atomically for the whole tool call when practical
 - treat hunk line counts as advisory when context matching succeeds
-- reject duplicate file patches for the same normalized path
+- merge duplicate plain modify patches for the same normalized path only when
+  their hunks touch distinct original locations
+- reject duplicate add/delete/rename patches and conflicting duplicate modify
+  hunks for the same normalized path
 
 This keeps the model-facing format standard while preserving agent-friendly
 robustness. Models can write familiar unified diff headers, but small line
@@ -349,8 +352,8 @@ Examples:
 - `context_not_found`: hunk context does not match the current file
 - `ambiguous_context`: hunk context matches multiple locations; include more
   surrounding context
-- `duplicate_file_patch`: the same normalized file path appears in more than
-  one add, delete, rename, or otherwise unsupported duplicate file patch
+- `duplicate_file_patch`: multiple file patches for the same normalized path
+  use add, delete, rename, or another unsupported duplicate operation
 - `conflicting_duplicate_file_patch`: duplicate modify patches for the same
   normalized file path touch overlapping original hunk locations
 
@@ -425,7 +428,10 @@ Implementation should include:
 - Common mode metadata is accepted and ignored. V1 does not execute chmod or
   other metadata mutations.
 - Multiple hunks for the same file are allowed inside one file patch. Multiple
-  file patches for the same normalized path are rejected.
+  plain modify patches for the same normalized path may be merged when their
+  hunks touch distinct original locations; duplicate add/delete/rename patches
+  and conflicting duplicate modify hunks for the same normalized path are
+  rejected.
 - Rename-only operations require `diff --git` plus `rename from` and
   `rename to`.
 - `similarity index` and `index` are accepted and ignored.

--- a/docs/rfcs/apply-patch-unified-diff-contract.md
+++ b/docs/rfcs/apply-patch-unified-diff-contract.md
@@ -350,7 +350,14 @@ Examples:
 - `ambiguous_context`: hunk context matches multiple locations; include more
   surrounding context
 - `duplicate_file_patch`: the same normalized file path appears in more than
-  one file patch; merge hunks into a single file patch
+  one add, delete, rename, or otherwise unsupported duplicate file patch
+- `conflicting_duplicate_file_patch`: duplicate modify patches for the same
+  normalized file path touch overlapping original hunk locations
+
+Plain modify patches for the same normalized file path may be merged
+automatically when their hunks touch distinct original locations. Duplicate
+add/delete/rename patches and overlapping duplicate modify hunks still fail
+before any workspace writes.
 
 Hunk count mismatches should not fail the patch when context matching succeeds.
 They should be recorded as advisory diagnostics in the canonical result.

--- a/src/tool/apply_patch.rs
+++ b/src/tool/apply_patch.rs
@@ -182,6 +182,7 @@ pub(crate) async fn apply_patch(
             }
         }
     };
+    let patches = merge_same_file_modify_patches(workspace_root, patches)?;
     let file_count = patches.len();
     let hunk_count = patches.iter().map(|patch| patch.hunks.len()).sum::<usize>();
     let (changed_files, touched, ignored_metadata, diagnostics) =
@@ -225,6 +226,71 @@ fn parse_patch_for_format(input: &str, format: PatchFormat) -> Result<Vec<FilePa
             "submit the patch format advertised for this turn",
         )),
     }
+}
+
+fn merge_same_file_modify_patches(
+    workspace_root: &Path,
+    patches: Vec<FilePatch>,
+) -> Result<Vec<FilePatch>> {
+    let mut merged = Vec::<FilePatch>::new();
+    let mut modify_indexes = HashMap::<String, usize>::new();
+    let mut modify_touches = HashMap::<String, BTreeSet<HunkTouch>>::new();
+
+    for patch in patches {
+        let PatchOperationKind::Modify { path } = patch_operation_kind(&patch)? else {
+            merged.push(patch);
+            continue;
+        };
+
+        let resolved = resolve_patch_path(workspace_root, path)?;
+        let normalized = normalize_path(&resolved)?.display().to_string();
+        let touches = hunk_touches(&patch.hunks);
+        let existing_touches = modify_touches.entry(normalized.clone()).or_default();
+        if let Some(touch) = touches.intersection(existing_touches).next() {
+            return Err(conflicting_duplicate_file_patch(&normalized, *touch));
+        }
+        existing_touches.extend(touches);
+
+        if let Some(&index) = modify_indexes.get(&normalized) {
+            let existing = &mut merged[index];
+            existing.hunks.extend(patch.hunks);
+            existing.ignored_metadata.extend(patch.ignored_metadata);
+            existing.diagnostics.extend(patch.diagnostics);
+        } else {
+            modify_indexes.insert(normalized, merged.len());
+            merged.push(patch);
+        }
+    }
+
+    Ok(merged)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum HunkTouch {
+    OldLine(usize),
+    InsertBeforeOldLine(usize),
+}
+
+fn hunk_touches(hunks: &[PatchHunk]) -> BTreeSet<HunkTouch> {
+    let mut touches = BTreeSet::new();
+    for hunk in hunks {
+        let mut old_line = hunk.old_start;
+        for line in &hunk.lines {
+            match line.kind {
+                HunkLineKind::Context => {
+                    old_line += 1;
+                }
+                HunkLineKind::Add => {
+                    touches.insert(HunkTouch::InsertBeforeOldLine(old_line));
+                }
+                HunkLineKind::Remove => {
+                    touches.insert(HunkTouch::OldLine(old_line));
+                    old_line += 1;
+                }
+            }
+        }
+    }
+    touches
 }
 
 fn detect_patch_format(input: &str) -> PatchFormat {
@@ -1480,6 +1546,27 @@ fn duplicate_file_patch(path: &str) -> anyhow::Error {
     )
 }
 
+fn conflicting_duplicate_file_patch(path: &str, touch: HunkTouch) -> anyhow::Error {
+    let (touch_kind, old_line) = match touch {
+        HunkTouch::OldLine(line) => ("old_line", line),
+        HunkTouch::InsertBeforeOldLine(line) => ("insert_before_old_line", line),
+    };
+    anyhow::Error::from(
+        ToolError::new(
+            "conflicting_duplicate_file_patch",
+            format!("duplicate modify patches touch the same original location in {path}"),
+        )
+        .with_details(serde_json::json!({
+            "path": path,
+            "touch_kind": touch_kind,
+            "old_line": old_line,
+        }))
+        .with_recovery_hint(
+            "merge the same-file hunks into one ordered file patch, or read the file and submit a non-overlapping patch",
+        ),
+    )
+}
+
 fn context_not_found(
     path: &str,
     needle: &[String],
@@ -2386,9 +2473,70 @@ rename to new.txt
     }
 
     #[tokio::test]
-    async fn apply_patch_rejects_duplicate_normalized_file_patch() {
+    async fn apply_patch_merges_duplicate_modify_file_patches() {
         let dir = tempdir().unwrap();
-        tokio::fs::write(dir.path().join("sample.txt"), "one\n")
+        let file = dir.path().join("sample.txt");
+        tokio::fs::write(&file, "one\ntwo\nthree\nfour\n")
+            .await
+            .unwrap();
+
+        let patch = r#"--- a/sample.txt
++++ b/sample.txt
+@@ -1,2 +1,2 @@
+-one
++ONE
+ two
+--- a/sample.txt
++++ b/sample.txt
+@@ -3,2 +3,2 @@
+ three
+-four
++FOUR
+"#;
+
+        let outcome = apply_patch(dir.path(), patch).await.unwrap();
+
+        assert_eq!(
+            tokio::fs::read_to_string(&file).await.unwrap(),
+            "ONE\ntwo\nthree\nFOUR\n"
+        );
+        assert_eq!(outcome.changed_files.len(), 1);
+        assert_eq!(outcome.changed_files[0].action, ApplyPatchAction::Modify);
+        assert_eq!(outcome.changed_files[0].hunks.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn apply_patch_merges_normalized_duplicate_modify_paths() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("sample.txt");
+        tokio::fs::write(&file, "one\ntwo\nthree\n").await.unwrap();
+
+        let patch = r#"--- a/sample.txt
++++ b/sample.txt
+@@ -1,1 +1,1 @@
+-one
++ONE
+--- a/./sample.txt
++++ b/./sample.txt
+@@ -3,1 +3,1 @@
+-three
++THREE
+"#;
+
+        let outcome = apply_patch(dir.path(), patch).await.unwrap();
+
+        assert_eq!(
+            tokio::fs::read_to_string(&file).await.unwrap(),
+            "ONE\ntwo\nTHREE\n"
+        );
+        assert_eq!(outcome.changed_files.len(), 1);
+        assert_eq!(outcome.changed_paths.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn apply_patch_rejects_conflicting_duplicate_modify_hunks() {
+        let dir = tempdir().unwrap();
+        tokio::fs::write(dir.path().join("sample.txt"), "one\ntwo\n")
             .await
             .unwrap();
 
@@ -2396,12 +2544,57 @@ rename to new.txt
 +++ b/sample.txt
 @@ -1,1 +1,1 @@
 -one
-+two
---- a/./sample.txt
-+++ b/./sample.txt
++ONE
+--- a/sample.txt
++++ b/sample.txt
 @@ -1,1 +1,1 @@
--two
-+three
+-one
++won
+"#;
+
+        let error = apply_patch(dir.path(), patch).await.unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "conflicting_duplicate_file_patch");
+    }
+
+    #[tokio::test]
+    async fn apply_patch_still_rejects_duplicate_add_file_patches() {
+        let dir = tempdir().unwrap();
+
+        let patch = r#"--- /dev/null
++++ b/sample.txt
+@@ -0,0 +1,1 @@
++one
+--- /dev/null
++++ b/./sample.txt
+@@ -0,0 +1,1 @@
++two
+"#;
+
+        let error = apply_patch(dir.path(), patch).await.unwrap_err();
+        let tool_error = ToolError::from_anyhow(&error);
+        assert_eq!(tool_error.kind, "duplicate_file_patch");
+    }
+
+    #[tokio::test]
+    async fn apply_patch_still_rejects_rename_and_modify_same_path() {
+        let dir = tempdir().unwrap();
+        tokio::fs::write(dir.path().join("old.txt"), "old\n")
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("new.txt"), "one\n")
+            .await
+            .unwrap();
+
+        let patch = r#"diff --git a/old.txt b/new.txt
+rename from old.txt
+rename to new.txt
+diff --git a/new.txt b/new.txt
+--- a/new.txt
++++ b/new.txt
+@@ -1,1 +1,1 @@
+-one
++two
 "#;
 
         let error = apply_patch(dir.path(), patch).await.unwrap_err();


### PR DESCRIPTION
## Summary
- Automatically merge duplicate ApplyPatch modify entries for the same normalized path when hunks touch distinct original locations.
- Reject overlapping duplicate modify hunks with `conflicting_duplicate_file_patch`.
- Preserve existing duplicate rejection for add/delete/rename path overlaps and document the updated contract.

Fixes #1571

## Verification
- `cargo fmt --all -- --check`
- `cargo test tool::apply_patch --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
