### PR TITLE
fix: filter unavailable model picker choices

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -452,6 +452,7 @@
         "properties": {
           "include_unavailable": {
             "default": false,
+            "description": "Diagnostic-only. Defaults to false so normal selection paths only see usable providers; set true only to inspect blocked provider options and unavailable reasons.",
             "type": "boolean"
           }
         },
@@ -469,7 +470,7 @@
       "stability": "stable"
     },
     {
-      "description": "List models for a provider. Use provider from ListModelProviders; cursor is a model_ref returned by a previous page.",
+      "description": "List selectable models for a provider. By default unavailable models are omitted; set include_unavailable=true only to inspect blocked models and unavailability reasons. Use provider from ListModelProviders; cursor is a model_ref returned by a previous page.",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {
@@ -484,6 +485,7 @@
           },
           "include_unavailable": {
             "default": false,
+            "description": "Diagnostic-only. Defaults to false so normal selection paths only see usable models; set true only to inspect blocked models and unavailable reasons.",
             "type": "boolean"
           },
           "limit": {

--- a/src/tool/tools/list_model_providers.rs
+++ b/src/tool/tools/list_model_providers.rs
@@ -17,6 +17,9 @@ pub(crate) const NAME: &str = "ListModelProviders";
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ListModelProvidersArgs {
+    #[schemars(
+        description = "Diagnostic-only. Defaults to false so normal selection paths only see usable providers; set true only to inspect blocked provider options and unavailable reasons."
+    )]
     #[serde(default)]
     pub(crate) include_unavailable: bool,
 }

--- a/src/tool/tools/list_provider_models.rs
+++ b/src/tool/tools/list_provider_models.rs
@@ -24,6 +24,9 @@ pub(crate) struct ListProviderModelsArgs {
     pub(crate) cursor: Option<String>,
     #[serde(default)]
     pub(crate) limit: Option<usize>,
+    #[schemars(
+        description = "Diagnostic-only. Defaults to false so normal selection paths only see usable models; set true only to inspect blocked models and unavailable reasons."
+    )]
     #[serde(default)]
     pub(crate) include_unavailable: bool,
 }
@@ -43,7 +46,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<ListProviderModelsArgs>(
             NAME,
-            "List models for a provider. Use provider from ListModelProviders; cursor is a model_ref returned by a previous page.",
+            "List selectable models for a provider. By default unavailable models are omitted; set include_unavailable=true only to inspect blocked models and unavailability reasons. Use provider from ListModelProviders; cursor is a model_ref returned by a previous page.",
         )?,
     })
 }

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -99,6 +99,9 @@ fn provider_rows(model_availability: &[ResolvedModelAvailability]) -> Vec<ModelP
     let mut providers =
         std::collections::BTreeMap::<String, Vec<&ResolvedModelAvailability>>::new();
     for entry in model_availability {
+        if !entry.available {
+            continue;
+        }
         providers
             .entry(entry.provider.clone())
             .or_default()
@@ -130,18 +133,10 @@ fn provider_row(provider: String, models: Vec<&ResolvedModelAvailability>) -> Mo
         .and_then(|entry| entry.credential_source.as_deref())
         .map(|source| format!(" credential:{source}"))
         .unwrap_or_default();
-    let status = if available_count > 0 {
-        format!(
-            "ready: {available_count}/{} models selectable",
-            models.len()
-        )
-    } else {
-        let reason = models
-            .iter()
-            .find_map(|entry| entry.unavailable_reason.as_deref())
-            .unwrap_or("provider unavailable");
-        format!("unavailable: {reason}")
-    };
+    let status = format!(
+        "ready: {available_count}/{} models selectable",
+        models.len()
+    );
     let discovery = if discovered_count > 0 {
         format!(" remote-discovered:{discovered_count}")
     } else {
@@ -166,6 +161,7 @@ fn provider_model_rows(
     model_availability
         .iter()
         .filter(|entry| entry.provider == provider)
+        .filter(|entry| entry.available)
         .map(model_availability_row)
         .collect()
 }
@@ -369,14 +365,15 @@ mod tests {
     }
 
     #[test]
-    fn picker_rows_start_with_provider_choices() {
+    fn picker_rows_start_with_available_provider_choices() {
         let agent = summary();
         let availability = model_availability();
         let rows = model_picker_rows(Some(&agent), &availability, None, "");
-        assert_eq!(rows.len(), 4);
+        assert_eq!(rows.len(), 3);
         assert!(rows[0].title.contains("inherit runtime default"));
         assert!(rows.iter().any(|row| row.title == "openai"));
         assert!(rows.iter().any(|row| row.title == "openrouter"));
+        assert!(!rows.iter().any(|row| row.title == "anthropic"));
     }
 
     #[test]
@@ -392,15 +389,15 @@ mod tests {
     }
 
     #[test]
-    fn provider_model_page_surfaces_unavailable_models() {
+    fn provider_model_page_omits_unavailable_models() {
         let agent = summary();
         let availability = model_availability();
         let rows = model_picker_rows(Some(&agent), &availability, Some("anthropic"), "");
-        assert!(rows
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].title.contains("inherit runtime default"));
+        assert!(!rows
             .iter()
             .any(|row| row.title.contains("anthropic/claude-sonnet-4-6")));
-        assert!(!rows[1].available);
-        assert!(rows[1].detail.contains("credential_missing"));
     }
 
     #[test]
@@ -412,8 +409,8 @@ mod tests {
         assert!(rows[0].title.contains("inherit runtime default"));
 
         let rows = model_picker_rows(Some(&agent), &availability, Some("anthropic"), "sonnet");
-        assert_eq!(rows.len(), 2);
-        assert!(rows[1].title.contains("claude-sonnet"));
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].title.contains("inherit runtime default"));
     }
 
     #[test]
@@ -426,9 +423,8 @@ mod tests {
         );
         assert!(selected_model_picker_row(Some(&agent), &availability, None, "", 1).is_some());
         assert!(
-            !selected_model_picker_row(Some(&agent), &availability, Some("anthropic"), "", 1)
-                .unwrap()
-                .available
+            selected_model_picker_row(Some(&agent), &availability, Some("anthropic"), "", 1)
+                .is_none()
         );
     }
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1655,40 +1655,20 @@ async fn model_picker_opens_effort_for_models_with_reasoning_support() {
     );
 }
 
-#[tokio::test]
-async fn model_picker_enter_on_unavailable_model_keeps_provider_page_open() {
-    let client = LocalClient::new(test_config()).unwrap();
-    let mut app = TuiApp::new(
-        client,
-        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
-    );
-    app.apply_agent_list(vec![sample_agent_summary("default")]);
-    app.model_availability = vec![sample_model_availability(
+#[test]
+fn model_picker_omits_unavailable_provider_choices() {
+    let agent = sample_agent_summary("default");
+    let model_availability = vec![sample_model_availability(
         "openrouter/deepseek-v3",
         "DeepSeek V3",
         false,
         false,
     )];
-    app.overlay = OverlayState::ModelPicker {
-        provider: Some("openrouter".into()),
-        filter: String::new(),
-        selected: 1,
-    };
+    let rows = super::model_picker::model_picker_rows(Some(&agent), &model_availability, None, "");
 
-    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
-        .await
-        .unwrap();
-
-    assert_eq!(
-        app.overlay,
-        OverlayState::ModelPicker {
-            provider: Some("openrouter".into()),
-            filter: String::new(),
-            selected: 1,
-        }
-    );
-    assert!(app.status_line.contains("Model unavailable"));
-    assert!(app.status_line.contains("credential_missing"));
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].title.contains("inherit runtime default"));
+    assert!(!rows.iter().any(|row| row.title == "openrouter"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Filter `/model` picker provider rows to providers with at least one available model
- Filter provider model pages to selectable/available models only, keeping inherit-default available
- Clarify `include_unavailable=true` on model listing tools as diagnostic-only and refresh schema inventory

## Verification
- `cargo test model_picker --all-targets`
- `cargo test --test tool_schema_inventory_snapshot refresh_tool_schema_inventory_snapshot -- --ignored`
- `cargo test tool_schema_inventory_snapshot --test tool_schema_inventory_snapshot`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
