### PR TITLE
feat: add work item runtime db repository

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1260,6 +1260,7 @@ impl RuntimeHost {
                 provider.clone(),
                 self.config().default_agent_id.clone(),
                 self.runtime_context_config(),
+                self.inner.runtime_db.clone(),
                 self.bridge(),
                 RuntimeModelCatalog::from_config(self.config()),
             )?
@@ -1272,6 +1273,7 @@ impl RuntimeHost {
                 self.config().clone(),
                 self.config().default_agent_id.clone(),
                 self.runtime_context_config(),
+                self.inner.runtime_db.clone(),
                 self.bridge(),
             )?
         };
@@ -2327,6 +2329,7 @@ mod tests {
             fixture.config.clone(),
             fixture.config.default_agent_id.clone(),
             host.runtime_context_config(),
+            host.runtime_db().clone(),
             bridge,
         )
         .unwrap();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -64,6 +64,7 @@ use crate::{
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
     },
     queue::RuntimeQueue,
+    runtime_db::RuntimeDb,
     skills::{
         find_skill_by_entrypoint, find_skill_by_script_path, load_skills_runtime_view,
         SkillVisibility,
@@ -222,6 +223,7 @@ struct RuntimeInner {
     agent: Mutex<RuntimeAgent>,
     notify: Notify,
     storage: AppStorage,
+    runtime_db: RuntimeDb,
     provider: RwLock<Arc<dyn AgentProvider>>,
     provider_reconfig: Option<ProviderReconfigurator>,
     model_catalog: RuntimeModelCatalog,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -15,6 +15,7 @@ use crate::{
     model_discovery::{discovery_cache_path, load_discovery_cache_at},
     provider::{build_provider_from_model_chain, resolved_model_availability, AgentProvider},
     queue::RuntimeQueue,
+    runtime_db::RuntimeDb,
     storage::AppStorage,
     system::{LocalSystem, WorkspaceAccessMode, WorkspaceProjectionKind},
     tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
@@ -61,6 +62,7 @@ impl RuntimeHandle {
             crate::web::WebConfig::default(),
             None,
             None,
+            None,
         )
     }
 
@@ -72,6 +74,7 @@ impl RuntimeHandle {
         provider: Arc<dyn AgentProvider>,
         default_agent_id: String,
         context_config: ContextConfig,
+        runtime_db: RuntimeDb,
         host_bridge: RuntimeHostBridge,
         model_catalog: RuntimeModelCatalog,
     ) -> Result<Self> {
@@ -91,6 +94,7 @@ impl RuntimeHandle {
             crate::tool::helpers::MAX_TOOL_OUTPUT_TOKENS,
             crate::web::WebConfig::default(),
             None,
+            Some(runtime_db),
             Some(host_bridge),
         )
     }
@@ -103,6 +107,7 @@ impl RuntimeHandle {
         config: AppConfig,
         default_agent_id: String,
         context_config: ContextConfig,
+        runtime_db: RuntimeDb,
         host_bridge: RuntimeHostBridge,
     ) -> Result<Self> {
         let model_catalog = RuntimeModelCatalog::from_config(&config);
@@ -131,6 +136,7 @@ impl RuntimeHandle {
             config.max_tool_output_tokens as u64,
             config.web_config.clone(),
             Some(ProviderReconfigurator { config }),
+            Some(runtime_db),
             Some(host_bridge),
         )
     }
@@ -150,10 +156,18 @@ impl RuntimeHandle {
         max_tool_output_tokens: u64,
         web_config: crate::web::WebConfig,
         provider_reconfig: Option<ProviderReconfigurator>,
+        runtime_db: Option<RuntimeDb>,
         host_bridge: Option<RuntimeHostBridge>,
     ) -> Result<Self> {
         let mut provider = provider;
         let storage = AppStorage::new(data_dir)?;
+        let runtime_db = match runtime_db {
+            Some(runtime_db) => runtime_db,
+            None => RuntimeDb::open_and_migrate(
+                storage.runtime_dir().join("state/runtime.sqlite"),
+                storage.runtime_dir().join("state/runtime.lock"),
+            )?,
+        };
         let agent_id = agent_id.into();
         let initial_workspace = initial_workspace.into();
         let initial_workspace_entry = match &initial_workspace {
@@ -294,6 +308,13 @@ impl RuntimeHandle {
             provider = build_provider_from_model_chain(&provider_config, &chain)?;
         }
         storage.write_agent(&state)?;
+        let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
+        for record in &mut legacy_work_items {
+            crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
+        }
+        runtime_db
+            .work_items()
+            .import_legacy(legacy_work_items, state.current_work_item_id.as_deref())?;
 
         let resolved_context_config = if provider_reconfig.is_some() {
             model_catalog
@@ -311,6 +332,7 @@ impl RuntimeHandle {
                 }),
                 notify: Notify::new(),
                 storage,
+                runtime_db,
                 provider: RwLock::new(provider),
                 provider_reconfig,
                 model_catalog,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -110,6 +110,12 @@ impl RuntimeHandle {
                 turn_id: current_turn_id,
                 ..refreshed
             };
+            let current_focus = self.agent_state().await?.current_work_item_id.as_deref()
+                == Some(record.id.as_str());
+            self.inner
+                .runtime_db
+                .work_items()
+                .upsert(&record, current_focus)?;
             self.inner.storage.append_work_item(&record)?;
             if plan_artifact_changed {
                 self.inner.storage.append_event(&AuditEvent::new(
@@ -526,7 +532,7 @@ impl RuntimeHandle {
     }
 
     pub async fn latest_work_items(&self) -> Result<Vec<crate::types::WorkItemRecord>> {
-        self.inner.storage.latest_work_items()
+        self.inner.runtime_db.work_items().latest_all()
     }
 
     pub async fn latest_work_items_for_agent(
@@ -535,15 +541,16 @@ impl RuntimeHandle {
         limit: usize,
     ) -> Result<Vec<crate::types::WorkItemRecord>> {
         self.inner
-            .storage
-            .latest_work_items_for_agent(agent_id, limit)
+            .runtime_db
+            .work_items()
+            .latest_for_agent(agent_id, limit)
     }
 
     pub async fn latest_work_item(
         &self,
         work_item_id: &str,
     ) -> Result<Option<crate::types::WorkItemRecord>> {
-        self.inner.storage.latest_work_item(work_item_id)
+        self.inner.runtime_db.work_items().latest(work_item_id)
     }
 
     pub async fn search_memory(

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -73,7 +73,7 @@ impl RuntimeHandle {
         };
 
         let closure = self.current_closure_decision().await?;
-        let Some(latest) = self.inner.storage.latest_work_item(&work_item_id)? else {
+        let Some(latest) = self.inner.runtime_db.work_items().latest(&work_item_id)? else {
             self.inner.storage.append_event(&AuditEvent::new(
                 "work_item_turn_end_commit_skipped",
                 serde_json::json!({

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -903,24 +903,34 @@ mod tests {
     fn add_queued_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
         let mut record = WorkItemRecord::new("default", target, WorkItemState::Open);
         record.id = id.to_string();
+        persist_test_work_item(test_runtime, &record, false);
+        record
+    }
+
+    fn persist_test_work_item(
+        test_runtime: &TestRuntime,
+        record: &WorkItemRecord,
+        current_focus: bool,
+    ) {
+        test_runtime
+            .runtime
+            .inner
+            .runtime_db
+            .work_items()
+            .upsert(record, current_focus)
+            .unwrap();
         test_runtime
             .runtime
             .inner
             .storage
-            .append_work_item(&record)
+            .append_work_item(record)
             .unwrap();
-        record
     }
 
     fn add_current_work_item(test_runtime: &TestRuntime, id: &str, target: &str) -> WorkItemRecord {
         let mut record = WorkItemRecord::new("default", target, WorkItemState::Open);
         record.id = id.to_string();
-        test_runtime
-            .runtime
-            .inner
-            .storage
-            .append_work_item(&record)
-            .unwrap();
+        persist_test_work_item(test_runtime, &record, true);
         let mut guard = test_runtime.runtime.inner.agent.blocking_lock();
         guard.state.current_work_item_id = Some(record.id.clone());
         test_runtime
@@ -940,12 +950,7 @@ mod tests {
         let mut updated = record.clone();
         updated.blocked_by = Some(blocked_by.to_string());
         updated.updated_at = chrono::Utc::now();
-        test_runtime
-            .runtime
-            .inner
-            .storage
-            .append_work_item(&updated)
-            .unwrap();
+        persist_test_work_item(test_runtime, &updated, false);
         updated
     }
 
@@ -959,12 +964,7 @@ mod tests {
         updated.recheck_at = Some(chrono::Utc::now() - chrono::Duration::seconds(1));
         updated.recheck_consumed_at = None;
         updated.updated_at = chrono::Utc::now();
-        test_runtime
-            .runtime
-            .inner
-            .storage
-            .append_work_item(&updated)
-            .unwrap();
+        persist_test_work_item(test_runtime, &updated, false);
         updated
     }
 
@@ -972,8 +972,9 @@ mod tests {
         test_runtime
             .runtime
             .inner
-            .storage
-            .latest_work_item(id)
+            .runtime_db
+            .work_items()
+            .latest(id)
             .unwrap()
             .expect("work item should exist")
     }

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2107,6 +2107,7 @@ impl RuntimeHandle {
             .active_workspace_entry
             .map(|entry| entry.workspace_id)
             .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
+        self.inner.runtime_db.work_items().upsert(&record, false)?;
         self.inner.storage.append_work_item(&record)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_written",
@@ -2135,7 +2136,7 @@ impl RuntimeHandle {
         let agent_id = self.agent_id().await?;
         let current_id = self.agent_state().await?.current_work_item_id;
         let previous = match current_id.as_deref() {
-            Some(id) => self.inner.storage.latest_work_item(id)?,
+            Some(id) => self.inner.runtime_db.work_items().latest(id)?,
             None => None,
         };
         let record = self.validate_owned_work_item(&agent_id, &work_item_id)?;
@@ -2179,6 +2180,10 @@ impl RuntimeHandle {
             guard.state.current_turn_work_item_id = Some(record.id.clone());
             self.inner.storage.write_agent(&guard.state)?;
         }
+        self.inner
+            .runtime_db
+            .work_items()
+            .set_current_focus(&agent_id, Some(&record.id))?;
         let transition = WorkItemFocusTransition {
             previous_work_item_id: current_id.clone(),
             current_work_item_id: record.id.clone(),
@@ -2299,6 +2304,12 @@ impl RuntimeHandle {
                 &mut record,
             )?;
             record.revision = existing.revision + 1;
+            let current_focus = self.agent_state().await?.current_work_item_id.as_deref()
+                == Some(record.id.as_str());
+            self.inner
+                .runtime_db
+                .work_items()
+                .upsert(&record, current_focus)?;
             self.inner.storage.append_work_item(&record)?;
             if plan_artifact_changed && record.plan_artifact != existing.plan_artifact {
                 self.inner.storage.append_event(&AuditEvent::new(
@@ -2362,6 +2373,12 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
+        let current_focus =
+            self.agent_state().await?.current_work_item_id.as_deref() == Some(record.id.as_str());
+        self.inner
+            .runtime_db
+            .work_items()
+            .upsert(&record, current_focus)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
             self.inner.storage.append_event(&AuditEvent::new(
@@ -2409,6 +2426,7 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
+        self.inner.runtime_db.work_items().upsert(&record, false)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
             self.inner.storage.append_event(&AuditEvent::new(
@@ -2496,6 +2514,7 @@ impl RuntimeHandle {
             updated_at: Utc::now(),
             ..existing
         };
+        self.inner.runtime_db.work_items().upsert(&record, false)?;
         self.inner.storage.append_work_item(&record)?;
         let evidence = serde_json::json!({
             "source": "same_round_complete_work_item",
@@ -2579,8 +2598,9 @@ impl RuntimeHandle {
     ) -> Result<WorkItemRecord> {
         let record = self
             .inner
-            .storage
-            .latest_work_item(work_item_id)?
+            .runtime_db
+            .work_items()
+            .latest(work_item_id)?
             .ok_or_else(|| anyhow!("unknown work item {}", work_item_id))?;
         if record.agent_id != agent_id {
             return Err(anyhow!(
@@ -2615,6 +2635,12 @@ impl RuntimeHandle {
             self.inner.storage.write_agent(&guard.state)?;
             release_current || release_turn
         };
+        if released {
+            self.inner
+                .runtime_db
+                .work_items()
+                .set_current_focus(agent_id, None)?;
+        }
         if released {
             self.inner.storage.append_event(&AuditEvent::new(
                 "work_item_focus_released",

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1506,17 +1506,6 @@ async fn update_work_item_can_refine_objective() {
 async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
-        "default",
-        dir.path().to_path_buf(),
-        workspace.path().to_path_buf(),
-        "http://127.0.0.1:7878".into(),
-        Arc::new(StubProvider::new("done")),
-        "default".into(),
-        context_config(),
-    )
-    .unwrap();
-
     let mut legacy = WorkItemRecord::new("default", "Migrate inline plan", WorkItemState::Open);
     legacy.id = "legacy-plan-item".into();
     legacy.legacy_inline_plan = Some("Keep this legacy plan body in the artifact.".into());
@@ -1527,12 +1516,24 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
         .join(".holon")
         .join("ledger")
         .join("work_items.jsonl");
+    std::fs::create_dir_all(work_items_path.parent().unwrap()).unwrap();
     let mut work_items_file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(&work_items_path)
         .unwrap();
     writeln!(work_items_file, "{}", legacy_json).unwrap();
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
 
     let updated = runtime
         .update_work_item_fields(
@@ -1570,13 +1571,21 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
         WorkItemRecord::new("default", "Keep existing artifact", WorkItemState::Open);
     legacy_with_artifact.id = "legacy-plan-item-with-artifact".into();
     legacy_with_artifact.legacy_inline_plan = Some("Stale inline plan body.".into());
-    let mut legacy_with_artifact_json = serde_json::to_value(&legacy_with_artifact).unwrap();
-    legacy_with_artifact_json["plan"] = serde_json::json!("Stale inline plan body.");
-    writeln!(work_items_file, "{}", legacy_with_artifact_json).unwrap();
     let existing_plan_path =
         crate::work_item_plan::plan_path(runtime.agent_home().as_path(), &legacy_with_artifact.id);
     std::fs::create_dir_all(existing_plan_path.parent().unwrap()).unwrap();
     std::fs::write(&existing_plan_path, "Existing artifact body.").unwrap();
+    crate::work_item_plan::refresh_plan_artifact_metadata(
+        runtime.agent_home().as_path(),
+        &mut legacy_with_artifact,
+    )
+    .unwrap();
+    runtime
+        .inner
+        .runtime_db
+        .work_items()
+        .upsert(&legacy_with_artifact, false)
+        .unwrap();
 
     let updated_with_artifact = runtime
         .update_work_item_fields(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -250,6 +250,12 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
+        let current_focus =
+            self.agent_state().await?.current_work_item_id.as_deref() == Some(record.id.as_str());
+        self.inner
+            .runtime_db
+            .work_items()
+            .upsert(&record, current_focus)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
             self.inner.storage.append_event(&AuditEvent::new(
@@ -278,7 +284,7 @@ impl RuntimeHandle {
         let Some(work_item_id) = condition.work_item_id.as_deref() else {
             return Ok(());
         };
-        let Some(existing) = self.inner.storage.latest_work_item(work_item_id)? else {
+        let Some(existing) = self.inner.runtime_db.work_items().latest(work_item_id)? else {
             return Ok(());
         };
         if existing.state != WorkItemState::Open {
@@ -299,6 +305,12 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
             &mut record,
         )?;
+        let current_focus =
+            self.agent_state().await?.current_work_item_id.as_deref() == Some(record.id.as_str());
+        self.inner
+            .runtime_db
+            .work_items()
+            .upsert(&record, current_focus)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
             self.inner.storage.append_event(&AuditEvent::new(

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1,16 +1,262 @@
 use std::{
+    collections::BTreeMap,
     fs::{self, File, OpenOptions},
     path::{Path, PathBuf},
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use chrono::Utc;
-use rusqlite::{Connection, OptionalExtension, Transaction};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+
+use crate::types::{WorkItemRecord, WorkItemState};
 
 #[derive(Debug, Clone)]
 pub struct RuntimeDb {
     path: PathBuf,
     lock_path: PathBuf,
+}
+
+pub struct WorkItemRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+impl WorkItemRepository<'_> {
+    pub fn import_legacy(
+        &self,
+        records: Vec<WorkItemRecord>,
+        current_work_item_id: Option<&str>,
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            let domain = read_storage_domain(tx, "work_items")?;
+            if domain.as_ref().is_some_and(|domain| {
+                domain.import_status == "complete" && domain.canonical_source == "db"
+            }) {
+                return Ok(());
+            }
+
+            upsert_storage_domain(tx, "work_items", "importing", "jsonl", None)?;
+            let mut latest = BTreeMap::<String, WorkItemRecord>::new();
+            for record in records {
+                let should_replace = latest
+                    .get(&record.id)
+                    .is_none_or(|existing| newer_work_item_record(&record, existing));
+                if should_replace {
+                    latest.insert(record.id.clone(), record);
+                }
+            }
+            for record in latest.values() {
+                upsert_work_item_tx(tx, record, current_work_item_id == Some(record.id.as_str()))?;
+            }
+            upsert_storage_domain(
+                tx,
+                "work_items",
+                "complete",
+                "db",
+                Some(serde_json::json!({ "imported_records": latest.len() })),
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn upsert(&self, record: &WorkItemRecord, current_focus: bool) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_work_item_tx(tx, record, current_focus))
+    }
+
+    pub fn set_current_focus(&self, agent_id: &str, work_item_id: Option<&str>) -> Result<()> {
+        self.db.transaction(|tx| {
+            tx.execute(
+                "UPDATE work_items SET current_focus = 0 WHERE agent_id = ?1 AND current_focus != 0",
+                [agent_id],
+            )?;
+            if let Some(work_item_id) = work_item_id {
+                tx.execute(
+                    "UPDATE work_items SET current_focus = 1 WHERE agent_id = ?1 AND work_item_id = ?2",
+                    params![agent_id, work_item_id],
+                )?;
+            }
+            Ok(())
+        })
+    }
+
+    pub fn latest(&self, work_item_id: &str) -> Result<Option<WorkItemRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json FROM work_items WHERE work_item_id = ?1",
+                [work_item_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_work_item_payload(&payload))
+            .transpose()
+    }
+
+    pub fn latest_for_agent(&self, agent_id: &str, limit: usize) -> Result<Vec<WorkItemRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_items
+             WHERE agent_id = ?1
+             ORDER BY updated_at DESC, created_at DESC, work_item_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit as i64], |row| {
+            row.get::<_, String>(0)
+        })?;
+        rows.map(|row| decode_work_item_payload(&row?)).collect()
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<WorkItemRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_items
+             ORDER BY updated_at DESC, created_at DESC, work_item_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_work_item_payload(&row?)).collect()
+    }
+}
+
+#[derive(Debug)]
+struct StorageDomainState {
+    import_status: String,
+    canonical_source: String,
+}
+
+fn read_storage_domain(tx: &Transaction<'_>, domain: &str) -> Result<Option<StorageDomainState>> {
+    tx.query_row(
+        "SELECT import_status, canonical_source FROM storage_domains WHERE domain = ?1",
+        [domain],
+        |row| {
+            Ok(StorageDomainState {
+                import_status: row.get(0)?,
+                canonical_source: row.get(1)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn upsert_storage_domain(
+    tx: &Transaction<'_>,
+    domain: &str,
+    import_status: &str,
+    canonical_source: &str,
+    checkpoint: Option<serde_json::Value>,
+) -> Result<()> {
+    let now = timestamp(Utc::now());
+    let imported_at = (import_status == "complete").then(|| now.clone());
+    let checkpoint = checkpoint.map(|value| value.to_string());
+    tx.execute(
+        "INSERT INTO storage_domains (
+            domain, schema_version, import_status, canonical_source,
+            source_checkpoint_json, imported_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(domain) DO UPDATE SET
+            schema_version = excluded.schema_version,
+            import_status = excluded.import_status,
+            canonical_source = excluded.canonical_source,
+            source_checkpoint_json = excluded.source_checkpoint_json,
+            imported_at = excluded.imported_at,
+            updated_at = excluded.updated_at",
+        params![
+            domain,
+            max_known_migration_version(),
+            import_status,
+            canonical_source,
+            checkpoint,
+            imported_at,
+            now
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_work_item_tx(
+    tx: &Transaction<'_>,
+    record: &WorkItemRecord,
+    current_focus: bool,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let state = enum_string(&record.state)?;
+    let plan_status = enum_string(&record.plan_status)?;
+    let readiness = enum_string(&record.readiness())?;
+    let completed_at =
+        (record.state == WorkItemState::Completed).then(|| timestamp(record.updated_at));
+    let plan_artifact_path = record
+        .plan_artifact
+        .as_ref()
+        .map(|artifact| artifact.path.display().to_string());
+    tx.execute(
+        "INSERT INTO work_items (
+            work_item_id, agent_id, state, objective, plan_status, readiness,
+            revision, current_focus, created_at, updated_at, completed_at,
+            plan_artifact_path, last_turn_id, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+         ON CONFLICT(work_item_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            state = excluded.state,
+            objective = excluded.objective,
+            plan_status = excluded.plan_status,
+            readiness = excluded.readiness,
+            revision = excluded.revision,
+            current_focus = excluded.current_focus,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            completed_at = excluded.completed_at,
+            plan_artifact_path = excluded.plan_artifact_path,
+            last_turn_id = excluded.last_turn_id,
+            payload_json = excluded.payload_json
+         WHERE excluded.revision >= work_items.revision",
+        params![
+            record.id,
+            record.agent_id,
+            state,
+            record.objective,
+            plan_status,
+            readiness,
+            record.revision as i64,
+            i64::from(current_focus),
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            completed_at,
+            plan_artifact_path,
+            record.turn_id,
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn newer_work_item_record(candidate: &WorkItemRecord, existing: &WorkItemRecord) -> bool {
+    candidate
+        .revision
+        .cmp(&existing.revision)
+        .then_with(|| candidate.updated_at.cmp(&existing.updated_at))
+        .then_with(|| candidate.created_at.cmp(&existing.created_at))
+        .is_gt()
+}
+
+fn decode_work_item_payload(payload: &str) -> Result<WorkItemRecord> {
+    serde_json::from_str(payload).context("decoding work item payload from runtime db")
+}
+
+fn enum_string<T: serde::Serialize>(value: &T) -> Result<String> {
+    let value = serde_json::to_value(value)?;
+    value
+        .as_str()
+        .map(ToString::to_string)
+        .ok_or_else(|| anyhow!("expected enum to serialize as string"))
+}
+
+fn timestamp(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
 #[derive(Debug)]
@@ -26,10 +272,11 @@ struct Migration {
     sql: &'static str,
 }
 
-const MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    name: "runtime_db_foundation",
-    sql: r#"
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        name: "runtime_db_foundation",
+        sql: r#"
 CREATE TABLE IF NOT EXISTS schema_migrations (
   version INTEGER PRIMARY KEY,
   name TEXT NOT NULL,
@@ -78,7 +325,45 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_agent_created
 CREATE INDEX IF NOT EXISTS idx_audit_events_event_seq
   ON audit_events(event_seq);
 "#,
-}];
+    },
+    Migration {
+        version: 2,
+        name: "work_items_current_state",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS work_items (
+  work_item_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  state TEXT NOT NULL,
+  objective TEXT NOT NULL,
+  plan_status TEXT,
+  readiness TEXT,
+  revision INTEGER NOT NULL,
+  current_focus INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  plan_artifact_path TEXT,
+  last_turn_id TEXT,
+  last_message_id TEXT,
+  causation_id TEXT,
+  correlation_id TEXT,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_items_agent
+  ON work_items(agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_work_items_state
+  ON work_items(state);
+
+CREATE INDEX IF NOT EXISTS idx_work_items_readiness
+  ON work_items(readiness);
+
+CREATE INDEX IF NOT EXISTS idx_work_items_current_focus
+  ON work_items(agent_id, current_focus);
+"#,
+    },
+];
 
 impl RuntimeDb {
     pub fn open_and_migrate(
@@ -123,6 +408,10 @@ impl RuntimeDb {
     pub fn current_schema_version(&self) -> Result<i64> {
         let connection = self.connection()?;
         current_schema_version(&connection)
+    }
+
+    pub fn work_items(&self) -> WorkItemRepository<'_> {
+        WorkItemRepository { db: self }
     }
 
     pub fn migrate(&self) -> Result<()> {
@@ -367,12 +656,13 @@ mod tests {
         let connection = db.connection()?;
 
         let version = db.current_schema_version()?;
-        assert_eq!(version, 1);
+        assert_eq!(version, 2);
         for table in [
             "schema_migrations",
             "storage_domains",
             "agents",
             "audit_events",
+            "work_items",
         ] {
             let count: i64 = connection.query_row(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
@@ -396,8 +686,8 @@ mod tests {
             connection.query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| {
                 row.get(0)
             })?;
-        assert_eq!(count, 1);
-        assert_eq!(current_schema_version(&connection)?, 1);
+        assert_eq!(count, 2);
+        assert_eq!(current_schema_version(&connection)?, 2);
         Ok(())
     }
 
@@ -515,7 +805,87 @@ mod tests {
         let temp_db = test_support::TempRuntimeDb::new()?;
         assert!(temp_db.db.path().ends_with("state/runtime.sqlite"));
         assert!(temp_db.db.lock_path().ends_with("state/runtime.lock"));
-        assert_eq!(temp_db.db.current_schema_version()?, 1);
+        assert_eq!(temp_db.db.current_schema_version()?, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_import_is_idempotent_and_preserves_latest_revision() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut older = WorkItemRecord::new("agent-a", "older objective", WorkItemState::Open);
+        older.id = "work-test".into();
+        older.revision = 1;
+        older.updated_at = older.created_at;
+        let mut newer = older.clone();
+        newer.objective = "newer objective".into();
+        newer.revision = 3;
+        newer.updated_at = older.updated_at + chrono::Duration::seconds(10);
+
+        db.work_items()
+            .import_legacy(vec![older.clone(), newer.clone()], Some("work-test"))?;
+        db.work_items()
+            .import_legacy(vec![older.clone(), newer.clone()], Some("work-test"))?;
+
+        let imported = db
+            .work_items()
+            .latest("work-test")?
+            .expect("work item imported");
+        assert_eq!(imported.revision, 3);
+        assert_eq!(imported.objective, "newer objective");
+        let connection = db.connection()?;
+        let rows: i64 =
+            connection.query_row("SELECT COUNT(*) FROM work_items", [], |row| row.get(0))?;
+        assert_eq!(rows, 1);
+        let current_focus: i64 = connection.query_row(
+            "SELECT current_focus FROM work_items WHERE work_item_id = 'work-test'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(current_focus, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_upsert_rejects_revision_rollback() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.work_items().import_legacy(Vec::new(), None)?;
+        let mut current = WorkItemRecord::new("agent-a", "current", WorkItemState::Open);
+        current.id = "work-revision".into();
+        current.revision = 5;
+        db.work_items().upsert(&current, false)?;
+
+        let mut stale = current.clone();
+        stale.objective = "stale".into();
+        stale.revision = 4;
+        stale.updated_at = current.updated_at + chrono::Duration::seconds(10);
+        db.work_items().upsert(&stale, false)?;
+
+        let persisted = db
+            .work_items()
+            .latest("work-revision")?
+            .expect("work item persisted");
+        assert_eq!(persisted.revision, 5);
+        assert_eq!(persisted.objective, "current");
+        Ok(())
+    }
+
+    #[test]
+    fn work_item_listing_is_partitioned_by_agent() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.work_items().import_legacy(Vec::new(), None)?;
+        let mut first = WorkItemRecord::new("agent-a", "first", WorkItemState::Open);
+        first.id = "work-first".into();
+        let mut second = WorkItemRecord::new("agent-b", "second", WorkItemState::Open);
+        second.id = "work-second".into();
+        db.work_items().upsert(&first, false)?;
+        db.work_items().upsert(&second, false)?;
+
+        let agent_items = db.work_items().latest_for_agent("agent-a", 20)?;
+        assert_eq!(agent_items.len(), 1);
+        assert_eq!(agent_items[0].id, "work-first");
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -96,6 +96,7 @@ impl WorkItemRepository<'_> {
         if limit == 0 {
             return Ok(Vec::new());
         }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
             "SELECT payload_json
@@ -104,9 +105,7 @@ impl WorkItemRepository<'_> {
              ORDER BY updated_at DESC, created_at DESC, work_item_id ASC
              LIMIT ?2",
         )?;
-        let rows = statement.query_map(params![agent_id, limit as i64], |row| {
-            row.get::<_, String>(0)
-        })?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
         rows.map(|row| decode_work_item_payload(&row?)).collect()
     }
 

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -82,7 +82,10 @@ pub(crate) async fn execute(
     let filter = args.filter.unwrap_or(ListWorkItemsFilter::All);
     let limit = args.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
     let context = query_context(runtime).await?;
-    let mut records = runtime.latest_work_items().await?;
+    let agent_id = runtime.agent_state().await?.id;
+    let mut records = runtime
+        .latest_work_items_for_agent(&agent_id, usize::MAX)
+        .await?;
     records.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
     let all_wait_conditions = active_wait_conditions_by_work_item(runtime, &records)?;
     let matching = records


### PR DESCRIPTION
## Summary

Closes #1588.

Implements the work item current-state runtime DB migration:

- adds the `work_items` current-state table and indexes for agent, state, readiness, and current focus
- adds a `WorkItemRepository` on `RuntimeDb` with DB-backed create/read/list/update/focus operations
- imports legacy `work_items.jsonl` state idempotently, reducing snapshots to latest revisions and restoring focus
- keeps work item plan bodies in `agent_home/work-items/<id>/plan.md` while storing metadata/path in DB payloads
- prevents revision rollback on DB upsert once work items are canonical in DB

## Verification

- `cargo fmt --all -- --check`
- `cargo test work_item --quiet`
- `cargo test work_item_import --quiet`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
