### PR TITLE
feat: migrate task lifecycle state to runtime db

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -315,6 +315,9 @@ impl RuntimeHandle {
         runtime_db
             .work_items()
             .import_legacy(legacy_work_items, state.current_work_item_id.as_deref())?;
+        runtime_db
+            .tasks()
+            .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
 
         let resolved_context_config = if provider_reconfig.is_some() {
             model_catalog

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -1765,6 +1765,7 @@ mod tests {
             false,
         );
         runtime.inner.storage.append_task(&task).unwrap();
+        runtime.inner.runtime_db.tasks().upsert(&task).unwrap();
 
         let result = runtime.task_input(&task.id, "hello\n").await.unwrap();
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -469,8 +469,9 @@ impl RuntimeHandle {
     pub async fn active_tasks(&self, limit: usize) -> Result<Vec<TaskRecord>> {
         let agent_id = self.agent_id().await?;
         self.inner
-            .storage
-            .latest_active_task_records_for_agent(&agent_id, limit)
+            .runtime_db
+            .tasks()
+            .active_for_agent(&agent_id, limit)
     }
 
     pub async fn recent_transcript(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -4,19 +4,19 @@ pub(super) fn is_terminal_task_status(status: &TaskStatus) -> bool {
     scheduler::is_terminal_task_status(status)
 }
 
-pub(super) fn should_ignore_task_update(storage: &AppStorage, task: &TaskRecord) -> Result<bool> {
-    let Some(latest) = storage.latest_task_record(&task.id)? else {
-        return Ok(false);
+pub(super) fn should_ignore_task_update(latest: Option<TaskRecord>, task: &TaskRecord) -> bool {
+    let Some(latest) = latest else {
+        return false;
     };
 
     if is_terminal_task_status(&latest.status)
         && is_terminal_task_status(&task.status)
         && latest.status != task.status
     {
-        return Ok(true);
+        return true;
     }
 
-    Ok(task_status_phase(&latest.status) > task_status_phase(&task.status))
+    task_status_phase(&latest.status) > task_status_phase(&task.status)
 }
 
 fn task_status_phase(status: &TaskStatus) -> u8 {
@@ -45,10 +45,11 @@ impl<'a> TaskTransition<'a> {
 impl RuntimeHandle {
     pub(super) async fn apply_task_transition(&self, transition: TaskTransition<'_>) -> Result<()> {
         let task = transition.task;
-        if should_ignore_task_update(&self.inner.storage, task)? {
+        if should_ignore_task_update(self.inner.runtime_db.tasks().latest(&task.id)?, task) {
             return Ok(());
         }
 
+        self.inner.runtime_db.tasks().upsert(task)?;
         self.inner.storage.append_task(task)?;
         {
             let mut guard = self.inner.agent.lock().await;
@@ -86,7 +87,7 @@ impl RuntimeHandle {
         model_reentry: bool,
         continuation_resolution: Option<&ContinuationResolution>,
     ) -> Result<()> {
-        if should_ignore_task_update(&self.inner.storage, &task)? {
+        if should_ignore_task_update(self.inner.runtime_db.tasks().latest(&task.id)?, &task) {
             return Ok(());
         }
         self.persist_task_transition(&task, "task_result_received")
@@ -244,8 +245,9 @@ mod tests {
             .append_task(&task("task-1", TaskStatus::Completed, true))
             .unwrap();
 
+        let latest = storage.latest_task_record("task-1").unwrap();
         let stale = task("task-1", TaskStatus::Running, true);
-        assert!(should_ignore_task_update(&storage, &stale).unwrap());
+        assert!(should_ignore_task_update(latest, &stale));
     }
 
     #[test]
@@ -256,8 +258,9 @@ mod tests {
             .append_task(&task("task-1", TaskStatus::Completed, true))
             .unwrap();
 
+        let latest = storage.latest_task_record("task-1").unwrap();
         let late_terminal = task("task-1", TaskStatus::Failed, true);
-        assert!(should_ignore_task_update(&storage, &late_terminal).unwrap());
+        assert!(should_ignore_task_update(latest, &late_terminal));
     }
 
     #[test]
@@ -268,8 +271,9 @@ mod tests {
             .append_task(&task("task-1", TaskStatus::Failed, true))
             .unwrap();
 
+        let latest = storage.latest_task_record("task-1").unwrap();
         let repeated_terminal = task("task-1", TaskStatus::Failed, true);
-        assert!(!should_ignore_task_update(&storage, &repeated_terminal).unwrap());
+        assert!(!should_ignore_task_update(latest, &repeated_terminal));
     }
 
     #[test]
@@ -280,8 +284,9 @@ mod tests {
             .append_task(&task("task-1", TaskStatus::Cancelling, true))
             .unwrap();
 
+        let latest = storage.latest_task_record("task-1").unwrap();
         let stale = task("task-1", TaskStatus::Running, true);
-        assert!(should_ignore_task_update(&storage, &stale).unwrap());
+        assert!(should_ignore_task_update(latest, &stale));
     }
 
     #[test]

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1294,7 +1294,7 @@ impl RuntimeHandle {
     }
 
     pub async fn latest_task_records(&self) -> Result<Vec<TaskRecord>> {
-        let mut tasks = self.inner.storage.latest_task_records()?;
+        let mut tasks = self.inner.runtime_db.tasks().latest_all()?;
         tasks.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
         Ok(tasks)
     }
@@ -1310,8 +1310,9 @@ impl RuntimeHandle {
     ) -> Result<Vec<TaskListEntry>> {
         Ok(self
             .inner
-            .storage
-            .latest_active_task_records_for_agent(agent_id, usize::MAX)?
+            .runtime_db
+            .tasks()
+            .active_for_agent(agent_id, usize::MAX)?
             .into_iter()
             .map(|task| {
                 let wait_policy = task.wait_policy();
@@ -1440,12 +1441,7 @@ impl RuntimeHandle {
     }
 
     pub async fn task_record(&self, task_id: &str) -> Result<Option<TaskRecord>> {
-        Ok(self
-            .inner
-            .storage
-            .latest_task_records()?
-            .into_iter()
-            .find(|task| task.id == task_id))
+        self.inner.runtime_db.tasks().latest(task_id)
     }
 
     pub async fn task_status_snapshot(&self, task_id: &str) -> Result<TaskStatusSnapshot> {

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -795,6 +795,7 @@ async fn cancelling_task_ignores_late_running_status_update() {
         recovery: None,
     };
     runtime.storage().append_task(&task).unwrap();
+    runtime.inner.runtime_db.tasks().upsert(&task).unwrap();
 
     let stale_running = TaskRecord {
         status: TaskStatus::Running,
@@ -828,48 +829,47 @@ async fn latest_task_list_entries_return_compact_projection() {
         context_config(),
     )
     .unwrap();
-    runtime
-        .storage()
-        .append_task(&TaskRecord {
-            id: "task-list-1".into(),
-            agent_id: "default".into(),
-            kind: TaskKind::CommandTask,
-            status: TaskStatus::Running,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id: None,
-            summary: Some("watch logs".into()),
-            detail: Some(serde_json::json!({
-                "wait_policy": "blocking",
-                "cmd": "tail -f app.log",
-                "cmd_digest": crate::tool::helpers::command_digest("tail -f app.log"),
-                "workdir": "/tmp/workspace",
-                "shell": "/bin/bash",
-                "login": false,
-                "output_path": "/tmp/output.log",
-                "output_summary": "large output summary should not appear in TaskList",
-                "tty": false,
-                "promoted_from_exec_command": false,
-            })),
-            recovery: Some(TaskRecoverySpec::CommandTask {
-                summary: "watch logs".into(),
-                spec: crate::types::CommandTaskSpec {
-                    cmd: "tail -f app.log".into(),
-                    workdir: None,
-                    shell: None,
-                    login: true,
-                    tty: false,
-                    yield_time_ms: 100,
-                    max_output_tokens: None,
-                    accepts_input: false,
-                    terminal_reentry: true,
-                },
-                authority_class: AuthorityClass::OperatorInstruction,
-                promoted_from_exec_command: false,
-            }),
-        })
-        .unwrap();
+    let task = TaskRecord {
+        id: "task-list-1".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Running,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: None,
+        summary: Some("watch logs".into()),
+        detail: Some(serde_json::json!({
+            "wait_policy": "blocking",
+            "cmd": "tail -f app.log",
+            "cmd_digest": crate::tool::helpers::command_digest("tail -f app.log"),
+            "workdir": "/tmp/workspace",
+            "shell": "/bin/bash",
+            "login": false,
+            "output_path": "/tmp/output.log",
+            "output_summary": "large output summary should not appear in TaskList",
+            "tty": false,
+            "promoted_from_exec_command": false,
+        })),
+        recovery: Some(TaskRecoverySpec::CommandTask {
+            summary: "watch logs".into(),
+            spec: crate::types::CommandTaskSpec {
+                cmd: "tail -f app.log".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 100,
+                max_output_tokens: None,
+                accepts_input: false,
+                terminal_reentry: true,
+            },
+            authority_class: AuthorityClass::OperatorInstruction,
+            promoted_from_exec_command: false,
+        }),
+    };
+    runtime.storage().append_task(&task).unwrap();
+    runtime.inner.runtime_db.tasks().upsert(&task).unwrap();
 
     let entries = runtime.latest_task_list_entries().await.unwrap();
     assert_eq!(entries.len(), 1);
@@ -912,99 +912,118 @@ async fn latest_task_list_entries_filters_to_active_statuses_only() {
     )
     .unwrap();
 
+    let active_task = TaskRecord {
+        id: "task-active-1".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Running,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: None,
+        summary: Some("active task".into()),
+        detail: Some(serde_json::json!({
+            "task_status": "running",
+            "wait_policy": "background"
+        })),
+        recovery: None,
+    };
+    runtime.storage().append_task(&active_task).unwrap();
     runtime
-        .storage()
-        .append_task(&TaskRecord {
-            id: "task-active-1".into(),
-            agent_id: "default".into(),
-            kind: TaskKind::CommandTask,
-            status: TaskStatus::Running,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id: None,
-            summary: Some("active task".into()),
-            detail: Some(serde_json::json!({
-                "task_status": "running",
-                "wait_policy": "background"
-            })),
-            recovery: None,
-        })
+        .inner
+        .runtime_db
+        .tasks()
+        .upsert(&active_task)
         .unwrap();
 
+    let historical_running = TaskRecord {
+        id: "task-historical".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Running,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: None,
+        summary: Some("historical active".into()),
+        detail: Some(serde_json::json!({
+            "task_status": "running",
+            "wait_policy": "background"
+        })),
+        recovery: None,
+    };
+    runtime.storage().append_task(&historical_running).unwrap();
     runtime
-        .storage()
-        .append_task(&TaskRecord {
-            id: "task-historical".into(),
-            agent_id: "default".into(),
-            kind: TaskKind::CommandTask,
-            status: TaskStatus::Running,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id: None,
-            summary: Some("historical active".into()),
-            detail: Some(serde_json::json!({
-                "task_status": "running",
-                "wait_policy": "background"
-            })),
-            recovery: None,
-        })
+        .inner
+        .runtime_db
+        .tasks()
+        .upsert(&historical_running)
         .unwrap();
 
+    let historical_completed = TaskRecord {
+        id: "task-historical".into(),
+        agent_id: "default".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Completed,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: None,
+        summary: Some("historical active".into()),
+        detail: Some(serde_json::json!({
+            "task_status": "completed",
+            "wait_policy": "background"
+        })),
+        recovery: Some(TaskRecoverySpec::CommandTask {
+            summary: "historical active".into(),
+            spec: crate::types::CommandTaskSpec {
+                cmd: "true".into(),
+                workdir: None,
+                shell: None,
+                login: true,
+                tty: false,
+                yield_time_ms: 100,
+                max_output_tokens: None,
+                accepts_input: false,
+                terminal_reentry: true,
+            },
+            authority_class: AuthorityClass::OperatorInstruction,
+            promoted_from_exec_command: false,
+        }),
+    };
     runtime
         .storage()
-        .append_task(&TaskRecord {
-            id: "task-historical".into(),
-            agent_id: "default".into(),
-            kind: TaskKind::CommandTask,
-            status: TaskStatus::Completed,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id: None,
-            summary: Some("historical active".into()),
-            detail: Some(serde_json::json!({
-                "task_status": "completed",
-                "wait_policy": "background"
-            })),
-            recovery: Some(TaskRecoverySpec::CommandTask {
-                summary: "historical active".into(),
-                spec: crate::types::CommandTaskSpec {
-                    cmd: "true".into(),
-                    workdir: None,
-                    shell: None,
-                    login: true,
-                    tty: false,
-                    yield_time_ms: 100,
-                    max_output_tokens: None,
-                    accepts_input: false,
-                    terminal_reentry: true,
-                },
-                authority_class: AuthorityClass::OperatorInstruction,
-                promoted_from_exec_command: false,
-            }),
-        })
+        .append_task(&historical_completed)
+        .unwrap();
+    runtime
+        .inner
+        .runtime_db
+        .tasks()
+        .upsert(&historical_completed)
         .unwrap();
 
+    let other_agent_task = TaskRecord {
+        id: "other-agent-task".into(),
+        agent_id: "other".into(),
+        kind: TaskKind::CommandTask,
+        status: TaskStatus::Running,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        parent_message_id: None,
+        work_item_id: None,
+        summary: Some("other agent".into()),
+        detail: Some(serde_json::json!({
+            "task_status": "running",
+            "wait_policy": "background"
+        })),
+        recovery: None,
+    };
+    runtime.storage().append_task(&other_agent_task).unwrap();
     runtime
-        .storage()
-        .append_task(&TaskRecord {
-            id: "other-agent-task".into(),
-            agent_id: "other".into(),
-            kind: TaskKind::CommandTask,
-            status: TaskStatus::Running,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            parent_message_id: None,
-            work_item_id: None,
-            summary: Some("other agent".into()),
-            detail: Some(serde_json::json!({
-                "task_status": "running",
-                "wait_policy": "background"
-            })),
-            recovery: None,
-        })
+        .inner
+        .runtime_db
+        .tasks()
+        .upsert(&other_agent_task)
         .unwrap();
 
     let entries = runtime

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -10,6 +10,9 @@ use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
 use crate::types::{TaskRecord, TaskStatus, WorkItemRecord, WorkItemState};
 
+const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
+const TASK_PAYLOAD_ARRAY_LIMIT: usize = 64;
+
 #[derive(Debug, Clone)]
 pub struct RuntimeDb {
     path: PathBuf,
@@ -337,19 +340,20 @@ fn upsert_work_item_tx(
 }
 
 fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<()> {
-    let payload_json = serde_json::to_string(record)?;
     let kind = record.kind.as_str();
     let status = enum_string(&record.status)?;
-    let parent_agent_id = Some(record.agent_id.clone());
     let child_agent_id = task_detail_string(&record.detail, "child_agent_id");
+    let parent_agent_id = child_agent_id.as_ref().map(|_| record.agent_id.clone());
     let input_target = task_detail_string(&record.detail, "input_target");
     let wait_policy = enum_string(&record.wait_policy())?;
     let output_path = task_detail_string(&record.detail, "output_path");
-    let result_summary = task_detail_string(&record.detail, "output_summary");
+    let result_summary = task_detail_string(&record.detail, "output_summary")
+        .map(|summary| truncate_task_payload_string(&summary));
     let exit_status = task_detail_i64(&record.detail, "exit_status");
     let terminal_reentry = i64::from(record.terminal_reentry());
     let completed_at =
         is_terminal_task_status(&record.status).then(|| timestamp(record.updated_at));
+    let payload_json = serde_json::to_string(&slim_task_record_for_payload(record))?;
     tx.execute(
         "INSERT INTO tasks (
             task_id, owner_agent_id, parent_agent_id, child_agent_id, kind, status,
@@ -416,6 +420,12 @@ fn reduce_task_records(records: Vec<TaskRecord>) -> BTreeMap<String, TaskRecord>
     for record in records {
         if let Some(previous) = latest.get(&record.id) {
             let mut merged = record.clone();
+            if merged.summary.is_none() {
+                merged.summary = previous.summary.clone();
+            }
+            if merged.detail.is_none() {
+                merged.detail = previous.detail.clone();
+            }
             if merged.recovery.is_none() {
                 merged.recovery = previous.recovery.clone();
             }
@@ -427,6 +437,42 @@ fn reduce_task_records(records: Vec<TaskRecord>) -> BTreeMap<String, TaskRecord>
         }
     }
     latest
+}
+
+fn slim_task_record_for_payload(record: &TaskRecord) -> TaskRecord {
+    let mut slim = record.clone();
+    slim.detail = slim.detail.as_ref().map(slim_task_detail_value);
+    slim
+}
+
+fn slim_task_detail_value(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut slim = serde_json::Map::new();
+            for (key, value) in map {
+                if key == "initial_output" {
+                    continue;
+                }
+                slim.insert(key.clone(), slim_task_detail_value(value));
+            }
+            serde_json::Value::Object(slim)
+        }
+        serde_json::Value::Array(values) => serde_json::Value::Array(
+            values
+                .iter()
+                .take(TASK_PAYLOAD_ARRAY_LIMIT)
+                .map(slim_task_detail_value)
+                .collect(),
+        ),
+        serde_json::Value::String(value) => {
+            serde_json::Value::String(truncate_task_payload_string(value))
+        }
+        _ => value.clone(),
+    }
+}
+
+fn truncate_task_payload_string(value: &str) -> String {
+    value.chars().take(TASK_PAYLOAD_STRING_LIMIT).collect()
 }
 
 fn newer_task_record(candidate: &TaskRecord, existing: &TaskRecord) -> bool {
@@ -1227,6 +1273,100 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(terminal_rows, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn task_import_merges_legacy_metadata_when_latest_update_is_sparse() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let queued = task_record("task-sparse", "agent-a", TaskStatus::Queued, 0);
+        let mut completed = task_record("task-sparse", "agent-a", TaskStatus::Completed, 10);
+        completed.summary = None;
+        completed.detail = None;
+        completed.recovery = None;
+
+        db.tasks().import_legacy(vec![queued, completed])?;
+
+        let imported = db.tasks().latest("task-sparse")?.expect("task imported");
+        assert_eq!(imported.status, TaskStatus::Completed);
+        assert_eq!(imported.summary.as_deref(), Some("task-sparse"));
+        assert_eq!(
+            imported
+                .detail
+                .as_ref()
+                .and_then(|detail| detail.get("output_path"))
+                .and_then(serde_json::Value::as_str),
+            Some("/tmp/task-sparse.log")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn task_parent_agent_column_is_only_set_for_child_agent_tasks() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let command = task_record("task-command", "agent-a", TaskStatus::Running, 0);
+        let mut child = task_record("task-child", "agent-a", TaskStatus::Running, 1);
+        child.detail = Some(serde_json::json!({
+            "child_agent_id": "child-a",
+            "input_target": "child_followup",
+        }));
+
+        db.tasks().upsert(&command)?;
+        db.tasks().upsert(&child)?;
+
+        let connection = db.connection()?;
+        let command_parent: Option<String> = connection.query_row(
+            "SELECT parent_agent_id FROM tasks WHERE task_id = 'task-command'",
+            [],
+            |row| row.get(0),
+        )?;
+        let child_parent: Option<String> = connection.query_row(
+            "SELECT parent_agent_id FROM tasks WHERE task_id = 'task-child'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(command_parent, None);
+        assert_eq!(child_parent.as_deref(), Some("agent-a"));
+        Ok(())
+    }
+
+    #[test]
+    fn task_payload_json_slimguards_large_preview_fields() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut task = task_record("task-large", "agent-a", TaskStatus::Running, 0);
+        task.detail = Some(serde_json::json!({
+            "output_path": "/tmp/task-large.log",
+            "initial_output": "i".repeat(TASK_PAYLOAD_STRING_LIMIT + 10),
+            "output_summary": "s".repeat(TASK_PAYLOAD_STRING_LIMIT + 10),
+            "lines": (0..(TASK_PAYLOAD_ARRAY_LIMIT + 10)).collect::<Vec<_>>(),
+        }));
+
+        db.tasks().upsert(&task)?;
+
+        let connection = db.connection()?;
+        let (payload_json, result_summary): (String, Option<String>) = connection.query_row(
+            "SELECT payload_json, result_summary FROM tasks WHERE task_id = 'task-large'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let payload: serde_json::Value = serde_json::from_str(&payload_json)?;
+        let detail = &payload["detail"];
+        assert!(detail.get("initial_output").is_none());
+        assert_eq!(
+            detail["output_summary"].as_str().expect("summary").len(),
+            TASK_PAYLOAD_STRING_LIMIT
+        );
+        assert_eq!(
+            detail["lines"].as_array().expect("lines").len(),
+            TASK_PAYLOAD_ARRAY_LIMIT
+        );
+        assert_eq!(
+            result_summary.expect("result summary").len(),
+            TASK_PAYLOAD_STRING_LIMIT
+        );
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
-use crate::types::{WorkItemRecord, WorkItemState};
+use crate::types::{TaskRecord, TaskStatus, WorkItemRecord, WorkItemState};
 
 #[derive(Debug, Clone)]
 pub struct RuntimeDb {
@@ -17,6 +17,10 @@ pub struct RuntimeDb {
 }
 
 pub struct WorkItemRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct TaskRepository<'a> {
     db: &'a RuntimeDb,
 }
 
@@ -118,6 +122,105 @@ impl WorkItemRepository<'_> {
         )?;
         let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
         rows.map(|row| decode_work_item_payload(&row?)).collect()
+    }
+}
+
+impl TaskRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<TaskRecord>) -> Result<()> {
+        self.db.transaction(|tx| {
+            let domain = read_storage_domain(tx, "tasks")?;
+            if domain.as_ref().is_some_and(|domain| {
+                domain.import_status == "complete" && domain.canonical_source == "db"
+            }) {
+                return Ok(());
+            }
+
+            upsert_storage_domain(tx, "tasks", "importing", "jsonl", None)?;
+            let latest = reduce_task_records(records);
+            for record in latest.values() {
+                upsert_task_tx(tx, record)?;
+            }
+            let active_records = latest
+                .values()
+                .filter(|record| is_active_task_status(&record.status))
+                .count();
+            upsert_storage_domain(
+                tx,
+                "tasks",
+                "complete",
+                "db",
+                Some(serde_json::json!({
+                    "imported_records": latest.len(),
+                    "active_records": active_records,
+                })),
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn upsert(&self, record: &TaskRecord) -> Result<()> {
+        self.db.transaction(|tx| upsert_task_tx(tx, record))
+    }
+
+    pub fn latest(&self, task_id: &str) -> Result<Option<TaskRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json FROM tasks WHERE task_id = ?1",
+                [task_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_task_payload(&payload))
+            .transpose()
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<TaskRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM tasks
+             ORDER BY updated_at DESC, created_at DESC, task_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_task_payload(&row?)).collect()
+    }
+
+    pub fn latest_for_agent(&self, agent_id: &str, limit: usize) -> Result<Vec<TaskRecord>> {
+        self.query_for_agent(agent_id, "owner_agent_id = ?1", [agent_id], limit)
+    }
+
+    pub fn active_for_agent(&self, agent_id: &str, limit: usize) -> Result<Vec<TaskRecord>> {
+        self.query_for_agent(
+            agent_id,
+            "owner_agent_id = ?1 AND status IN ('queued', 'running', 'cancelling')",
+            [agent_id],
+            limit,
+        )
+    }
+
+    fn query_for_agent(
+        &self,
+        _agent_id: &str,
+        where_clause: &str,
+        params: [&str; 1],
+        limit: usize,
+    ) -> Result<Vec<TaskRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let sql = format!(
+            "SELECT payload_json
+             FROM tasks
+             WHERE {where_clause}
+             ORDER BY updated_at DESC, created_at DESC, task_id ASC
+             LIMIT {limit}",
+        );
+        let mut statement = connection.prepare(&sql)?;
+        let rows = statement.query_map(params, |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_task_payload(&row?)).collect()
     }
 }
 
@@ -233,6 +336,72 @@ fn upsert_work_item_tx(
     Ok(())
 }
 
+fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let kind = record.kind.as_str();
+    let status = enum_string(&record.status)?;
+    let parent_agent_id = Some(record.agent_id.clone());
+    let child_agent_id = task_detail_string(&record.detail, "child_agent_id");
+    let input_target = task_detail_string(&record.detail, "input_target");
+    let wait_policy = enum_string(&record.wait_policy())?;
+    let output_path = task_detail_string(&record.detail, "output_path");
+    let result_summary = task_detail_string(&record.detail, "output_summary");
+    let exit_status = task_detail_i64(&record.detail, "exit_status");
+    let terminal_reentry = i64::from(record.terminal_reentry());
+    let completed_at =
+        is_terminal_task_status(&record.status).then(|| timestamp(record.updated_at));
+    tx.execute(
+        "INSERT INTO tasks (
+            task_id, owner_agent_id, parent_agent_id, child_agent_id, kind, status,
+            summary, input_target, wait_policy, output_path, result_summary,
+            exit_status, terminal_reentry, revision, created_at, updated_at,
+            completed_at, last_message_id, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
+         ON CONFLICT(task_id) DO UPDATE SET
+            owner_agent_id = excluded.owner_agent_id,
+            parent_agent_id = excluded.parent_agent_id,
+            child_agent_id = excluded.child_agent_id,
+            kind = excluded.kind,
+            status = excluded.status,
+            summary = excluded.summary,
+            input_target = excluded.input_target,
+            wait_policy = excluded.wait_policy,
+            output_path = excluded.output_path,
+            result_summary = excluded.result_summary,
+            exit_status = excluded.exit_status,
+            terminal_reentry = excluded.terminal_reentry,
+            revision = excluded.revision,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            completed_at = excluded.completed_at,
+            last_message_id = excluded.last_message_id,
+            payload_json = excluded.payload_json
+         WHERE excluded.revision >= tasks.revision",
+        params![
+            record.id,
+            record.agent_id,
+            parent_agent_id,
+            child_agent_id,
+            kind,
+            status,
+            record.summary,
+            input_target,
+            wait_policy,
+            output_path,
+            result_summary,
+            exit_status,
+            terminal_reentry,
+            task_revision(record),
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            completed_at,
+            record.parent_message_id,
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
 fn newer_work_item_record(candidate: &WorkItemRecord, existing: &WorkItemRecord) -> bool {
     candidate
         .revision
@@ -242,8 +411,42 @@ fn newer_work_item_record(candidate: &WorkItemRecord, existing: &WorkItemRecord)
         .is_gt()
 }
 
+fn reduce_task_records(records: Vec<TaskRecord>) -> BTreeMap<String, TaskRecord> {
+    let mut latest = BTreeMap::<String, TaskRecord>::new();
+    for record in records {
+        if let Some(previous) = latest.get(&record.id) {
+            let mut merged = record.clone();
+            if merged.recovery.is_none() {
+                merged.recovery = previous.recovery.clone();
+            }
+            if newer_task_record(&merged, previous) {
+                latest.insert(record.id.clone(), merged);
+            }
+        } else {
+            latest.insert(record.id.clone(), record);
+        }
+    }
+    latest
+}
+
+fn newer_task_record(candidate: &TaskRecord, existing: &TaskRecord) -> bool {
+    task_revision(candidate)
+        .cmp(&task_revision(existing))
+        .then_with(|| candidate.updated_at.cmp(&existing.updated_at))
+        .then_with(|| candidate.created_at.cmp(&existing.created_at))
+        .is_gt()
+}
+
+fn task_revision(record: &TaskRecord) -> i64 {
+    record.updated_at.timestamp_millis()
+}
+
 fn decode_work_item_payload(payload: &str) -> Result<WorkItemRecord> {
     serde_json::from_str(payload).context("decoding work item payload from runtime db")
+}
+
+fn decode_task_payload(payload: &str) -> Result<TaskRecord> {
+    serde_json::from_str(payload).context("decoding task payload from runtime db")
 }
 
 fn enum_string<T: serde::Serialize>(value: &T) -> Result<String> {
@@ -252,6 +455,38 @@ fn enum_string<T: serde::Serialize>(value: &T) -> Result<String> {
         .as_str()
         .map(ToString::to_string)
         .ok_or_else(|| anyhow!("expected enum to serialize as string"))
+}
+
+fn task_detail_string(detail: &Option<serde_json::Value>, key: &str) -> Option<String> {
+    detail
+        .as_ref()
+        .and_then(|value| value.get(key))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+}
+
+fn task_detail_i64(detail: &Option<serde_json::Value>, key: &str) -> Option<i64> {
+    detail
+        .as_ref()
+        .and_then(|value| value.get(key))
+        .and_then(|value| value.as_i64())
+}
+
+fn is_active_task_status(status: &TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling
+    )
+}
+
+fn is_terminal_task_status(status: &TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::Completed
+            | TaskStatus::Failed
+            | TaskStatus::Cancelled
+            | TaskStatus::Interrupted
+    )
 }
 
 fn timestamp(value: DateTime<Utc>) -> String {
@@ -362,6 +597,51 @@ CREATE INDEX IF NOT EXISTS idx_work_items_current_focus
   ON work_items(agent_id, current_focus);
 "#,
     },
+    Migration {
+        version: 3,
+        name: "tasks_current_state",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS tasks (
+  task_id TEXT PRIMARY KEY,
+  owner_agent_id TEXT NOT NULL,
+  parent_agent_id TEXT,
+  child_agent_id TEXT,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  summary TEXT,
+  input_target TEXT,
+  wait_policy TEXT,
+  output_path TEXT,
+  result_summary TEXT,
+  exit_status INTEGER,
+  terminal_reentry INTEGER NOT NULL DEFAULT 0,
+  revision INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  last_turn_id TEXT,
+  last_message_id TEXT,
+  causation_id TEXT,
+  correlation_id TEXT,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_owner_agent
+  ON tasks(owner_agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_parent_agent
+  ON tasks(parent_agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_child_agent
+  ON tasks(child_agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status
+  ON tasks(status);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_owner_active
+  ON tasks(owner_agent_id, status, updated_at);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -411,6 +691,10 @@ impl RuntimeDb {
 
     pub fn work_items(&self) -> WorkItemRepository<'_> {
         WorkItemRepository { db: self }
+    }
+
+    pub fn tasks(&self) -> TaskRepository<'_> {
+        TaskRepository { db: self }
     }
 
     pub fn migrate(&self) -> Result<()> {
@@ -648,6 +932,30 @@ mod tests {
         Ok((temp_dir, db_path, lock_path))
     }
 
+    fn task_record(id: &str, agent_id: &str, status: TaskStatus, offset: i64) -> TaskRecord {
+        let created_at = Utc::now();
+        TaskRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            kind: crate::types::TaskKind::CommandTask,
+            status,
+            created_at,
+            updated_at: created_at + chrono::Duration::seconds(offset),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some(id.into()),
+            detail: Some(serde_json::json!({
+                "cmd": "printf test",
+                "output_path": format!("/tmp/{id}.log"),
+                "output_summary": format!("{id} summary"),
+                "exit_status": 0,
+                "accepts_input": true,
+                "input_target": "stdin",
+            })),
+            recovery: None,
+        }
+    }
+
     #[test]
     fn runtime_db_fresh_migration_creates_foundation_schema() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
@@ -655,13 +963,14 @@ mod tests {
         let connection = db.connection()?;
 
         let version = db.current_schema_version()?;
-        assert_eq!(version, 2);
+        assert_eq!(version, 3);
         for table in [
             "schema_migrations",
             "storage_domains",
             "agents",
             "audit_events",
             "work_items",
+            "tasks",
         ] {
             let count: i64 = connection.query_row(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
@@ -685,8 +994,8 @@ mod tests {
             connection.query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| {
                 row.get(0)
             })?;
-        assert_eq!(count, 2);
-        assert_eq!(current_schema_version(&connection)?, 2);
+        assert_eq!(count, 3);
+        assert_eq!(current_schema_version(&connection)?, 3);
         Ok(())
     }
 
@@ -804,7 +1113,7 @@ mod tests {
         let temp_db = test_support::TempRuntimeDb::new()?;
         assert!(temp_db.db.path().ends_with("state/runtime.sqlite"));
         assert!(temp_db.db.lock_path().ends_with("state/runtime.lock"));
-        assert_eq!(temp_db.db.current_schema_version()?, 2);
+        assert_eq!(temp_db.db.current_schema_version()?, 3);
         Ok(())
     }
 
@@ -885,6 +1194,71 @@ mod tests {
         let agent_items = db.work_items().latest_for_agent("agent-a", 20)?;
         assert_eq!(agent_items.len(), 1);
         assert_eq!(agent_items[0].id, "work-first");
+        Ok(())
+    }
+
+    #[test]
+    fn task_import_is_idempotent_and_preserves_latest_lifecycle_state() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let queued = task_record("task-import", "agent-a", TaskStatus::Queued, 0);
+        let completed = task_record("task-import", "agent-a", TaskStatus::Completed, 10);
+
+        db.tasks()
+            .import_legacy(vec![queued.clone(), completed.clone()])?;
+        db.tasks().import_legacy(vec![queued, completed])?;
+
+        let imported = db.tasks().latest("task-import")?.expect("task imported");
+        assert_eq!(imported.status, TaskStatus::Completed);
+        assert_eq!(
+            imported
+                .detail
+                .as_ref()
+                .and_then(|detail| detail.get("output_path"))
+                .and_then(serde_json::Value::as_str),
+            Some("/tmp/task-import.log")
+        );
+        let connection = db.connection()?;
+        let rows: i64 = connection.query_row("SELECT COUNT(*) FROM tasks", [], |row| row.get(0))?;
+        assert_eq!(rows, 1);
+        let terminal_rows: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'completed' AND completed_at IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(terminal_rows, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn task_active_listing_is_partitioned_by_agent_and_excludes_terminal() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.tasks().import_legacy(Vec::new())?;
+        db.tasks().upsert(&task_record(
+            "agent-a-running",
+            "agent-a",
+            TaskStatus::Running,
+            1,
+        ))?;
+        db.tasks().upsert(&task_record(
+            "agent-a-completed",
+            "agent-a",
+            TaskStatus::Completed,
+            2,
+        ))?;
+        db.tasks().upsert(&task_record(
+            "agent-b-running",
+            "agent-b",
+            TaskStatus::Running,
+            3,
+        ))?;
+
+        let active = db.tasks().active_for_agent("agent-a", 20)?;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, "agent-a-running");
+        let all_agent_a = db.tasks().latest_for_agent("agent-a", 20)?;
+        assert_eq!(all_agent_a.len(), 2);
         Ok(())
     }
 

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -748,7 +748,7 @@ pub async fn state_snapshot_bounds_large_projection_fields() -> Result<()> {
     let runtime = host.default_runtime().await?;
     let now = chrono::Utc::now();
 
-    runtime.storage().append_task(&TaskRecord {
+    let task = TaskRecord {
         id: "large-task".into(),
         agent_id: "default".into(),
         kind: TaskKind::CommandTask,
@@ -764,7 +764,9 @@ pub async fn state_snapshot_bounds_large_projection_fields() -> Result<()> {
             "lines": (0..120).collect::<Vec<_>>()
         })),
         recovery: None,
-    })?;
+    };
+    runtime.storage().append_task(&task)?;
+    host.runtime_db().tasks().upsert(&task)?;
     let snapshot: serde_json::Value = reqwest::Client::new()
         .get(format!("{base}/agents/default/state"))
         .send()

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -198,18 +198,15 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
         recovery: None,
     };
 
-    runtime
-        .storage()
-        .append_task(&task("task-terminal", TaskStatus::Queued, 0))?;
-    runtime
-        .storage()
-        .append_task(&task("task-running", TaskStatus::Running, 1))?;
-    runtime
-        .storage()
-        .append_task(&task("task-terminal", TaskStatus::Completed, 2))?;
-    runtime
-        .storage()
-        .append_task(&task("task-cancelling", TaskStatus::Cancelling, 3))?;
+    for task in [
+        task("task-terminal", TaskStatus::Queued, 0),
+        task("task-running", TaskStatus::Running, 1),
+        task("task-terminal", TaskStatus::Completed, 2),
+        task("task-cancelling", TaskStatus::Cancelling, 3),
+    ] {
+        runtime.storage().append_task(&task)?;
+        host.runtime_db().tasks().upsert(&task)?;
+    }
 
     let tasks: serde_json::Value = client
         .get(format!("{base}/agents/default/tasks"))


### PR DESCRIPTION
## Summary

Closes #1589.

- Add runtime DB migration v3 with a `tasks` current-state table plus owner/parent/child/status/active indexes.
- Add `TaskRepository` for legacy import, upsert, single-task lookup, all-task listing, and active/agent-partitioned queries.
- Move task lifecycle transition writes and `TaskList`/`TaskStatus`/`TaskInput`/`TaskStop`/`TaskOutput` lifecycle reads to the DB-backed current state while keeping legacy JSONL appends as an audit/compatibility mirror.
- Import legacy task records during runtime bootstrap, reducing transitions to latest lifecycle state and preserving terminal/output metadata in the task payload.
- Update task tests to seed DB-backed current state where they intentionally construct task records directly.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test task --quiet`
- `cargo test task_recovery --quiet`
- `cargo test runtime_db --quiet`
