### PR TITLE
feat: migrate external triggers to runtime db

### DIFF
--- a/docs/rfc-implementation-notes/runtime-database-storage-migration.md
+++ b/docs/rfc-implementation-notes/runtime-database-storage-migration.md
@@ -367,8 +367,6 @@ external_triggers(
   external_trigger_id text primary key,
   target_agent_id text not null,
   waiting_intent_id text,
-  scope text not null,
-  delivery_mode text not null,
   trigger_url text,
   token_hash text not null,
   status text not null,
@@ -376,7 +374,6 @@ external_triggers(
   revoked_at text,
   last_delivered_at text,
   delivery_count integer not null,
-  revision integer not null,
   payload_json text
 );
 ```
@@ -384,6 +381,10 @@ external_triggers(
 The first DB version intentionally keeps `external_triggers` as a standalone
 state table because it maps directly to the current `external_triggers.jsonl`
 domain and avoids mixing capability lifecycle state into `agents` too early.
+The current product contract is one active default wake-hint trigger per agent,
+so `scope` and `delivery_mode` are not first-class DB dimensions. Legacy import
+normalizes old records to agent-scoped `wake_hint` records and preserves the
+full runtime record in `payload_json` for compatibility.
 Default agent ingress can be folded into an agent property or split into a
 dedicated secret/capability service later, after DB-backed state is stable.
 Until then, `trigger_url` and `token_hash` remain capability-bearing fields:

--- a/docs/rfcs/external-trigger-capability.md
+++ b/docs/rfcs/external-trigger-capability.md
@@ -15,10 +15,10 @@ Trigger Capability**.
 
 An external trigger capability is an agent-level ingress capability. It is not a
 WorkItem-owned waiting resource, and it is not partitioned by provider/source.
-Capability identity is the target agent plus the delivery mode.
+Capability identity is the target agent.
 
-The runtime should provision and expose a default external ingress capability
-for each agent and delivery mode. Agents should not normally create or cancel
+The runtime should provision and expose one default wake-hint external ingress
+capability for each agent. Agents should not normally create or cancel
 callback ingress as part of a wait. Waiting state records what the agent is
 waiting for; the ingress capability is long-lived agent infrastructure.
 
@@ -36,8 +36,8 @@ An external trigger lets an agent say:
 
 - this agent has a stable external ingress endpoint
 - an external system may use that endpoint later
-- when that endpoint is used, Holon should either wake the agent or enqueue the
-  delivered content according to `delivery_mode`
+- when that endpoint is used, Holon should wake the agent with the delivered
+  content as a wake hint
 
 This keeps Holon providerless. Holon does not need to understand GitHub,
 AgentInbox, Slack, CI, email, or any provider-specific subscription schema.
@@ -59,10 +59,10 @@ The runtime meaning is narrower and more useful:
 
 - the runtime provisions an agent-level ingress capability
 - Holon exposes or returns the existing capability for that agent and
-  delivery mode
+  default wake-hint ingress
 - an external system may use that capability later
 - Holon validates the capability and reactivates the target agent according to
-  an explicit delivery mode
+  the wake-hint ingress contract
 
 `ExternalTrigger` is also easier to distinguish from:
 
@@ -92,10 +92,9 @@ It is not:
 The capability is the token-bearing object returned to the agent. The agent may
 hand it to an external tool, skill, MCP server, worker, or integration service.
 
-The capability should be treated as bearer authority for one agent ingress
-surface and one delivery mode. Possession of the capability is enough to deliver
-to that specific external trigger, subject to descriptor status and
-delivery-mode checks.
+The capability should be treated as bearer authority for one agent's default
+wake-hint ingress surface. Possession of the capability is enough to deliver to
+that specific external trigger, subject to descriptor status checks.
 
 ### Waiting intent
 
@@ -125,7 +124,7 @@ CI, Slack, or another external system.
 The default public contract is:
 
 - the runtime provisions one active external trigger descriptor per target agent
-  and `delivery_mode`
+  for default wake-hint delivery
 - the agent context, status, or provider configuration may expose the descriptor
   needed by trusted integration code
 - provider adapters, skills, MCP servers, or external systems register their
@@ -148,16 +147,16 @@ returning the default agent ingress capability:
 
 Fields:
 
-- `delivery_mode`: `wake_hint` or `enqueue_message`
+- `delivery_mode`: accepted for compatibility, but normalized to `wake_hint`
 
 `source`, `description`, and `scope` are intentionally not part of the external
 trigger capability creation contract. Source is delivery provenance, provider
 subscription metadata, or waiting-intent metadata. Description belongs to the
 wait or WorkItem state that explains what the agent should inspect after waking.
 
-The tool is idempotent for the current agent and `delivery_mode`: if an active
-capability already exists, the runtime should return it instead of minting a new
-URL. One agent may have one default ingress per delivery mode. It is not the
+The tool is idempotent for the current agent: if an active capability already
+exists, the runtime should return it instead of minting a new URL. One agent has
+one default ingress. It is not the
 ordinary workflow for waiting on external conditions.
 
 The runtime creates, if needed:
@@ -172,7 +171,7 @@ ExternalTriggerCapability {
   external_trigger_id: string
   trigger_url: string
   target_agent_id: string
-  delivery_mode: 'wake_hint' | 'enqueue_message'
+  delivery_mode: 'wake_hint'
   status: 'active'
 }
 ```
@@ -204,21 +203,10 @@ Normal WorkItem completion or waiting-intent cleanup should not call
 the ingress capability. If this operation remains model-facing, a clearer
 long-term name is `RevokeExternalIngress` or `RotateExternalIngress`.
 
-## Delivery Modes
+## Wake-Hint Delivery
 
-External triggers have an explicit delivery mode. The external caller should
-not choose delivery semantics by request body.
-
-### `enqueue_message`
-
-`enqueue_message` means the delivered payload is meaningful input.
-
-On valid delivery:
-
-- Holon validates the trigger token
-- Holon checks the descriptor is still active and targets the agent
-- Holon preserves the request body as opaque content
-- Holon enqueues an integration event for the target agent
+External triggers use the default `wake_hint` delivery contract. The external
+caller should not choose delivery semantics by request body.
 
 The payload is opaque to Holon:
 
@@ -245,7 +233,7 @@ Activation context should include:
 
 - external trigger id
 - target agent id
-- delivery mode
+- delivery mode (`wake_hint`)
 - optional or correlated source
 - content type
 - callback body or opaque body envelope
@@ -272,8 +260,7 @@ The trigger URL is an opaque capability URL from the external system's
 perspective.
 
 Holon may encode delivery mode in the URL path and should still verify that the
-URL path mode matches the descriptor's stored delivery mode. A mode mismatch
-must be rejected.
+URL path mode is the supported wake-hint mode. A mode mismatch must be rejected.
 
 Every delivery must resolve to:
 
@@ -294,17 +281,8 @@ side effects and should tell the caller that the agent must be resumed first.
 External trigger deliveries should use the provenance and authority model from
 [Provenance, Admission, and Authority](./default-trust-auth-and-control.md).
 
-For `enqueue_message`, the message projects to:
-
-```ts
-origin: { kind: 'callback', descriptor_id: '...', source?: '...' }
-delivery_surface: 'http_callback_enqueue'
-admission_context: 'external_trigger_capability'
-authority_class: 'integration_signal'
-```
-
 For `wake_hint`, the wake hint or resulting runtime-owned system tick should
-preserve equivalent trigger provenance in metadata:
+preserve trigger provenance in metadata:
 
 ```ts
 delivery_surface: 'http_callback_wake'
@@ -382,8 +360,8 @@ remains active. Cleanup depends on the resource being cleaned up:
   the ingress capability, configured expiry fires, administrative cleanup runs,
   or the agent is removed.
 
-One agent may keep one active default ingress per `delivery_mode`. It should not
-be cancelled by WorkItem cleanup or by the absence of an active work item.
+One agent may keep one active default ingress. It should not be cancelled by
+WorkItem cleanup or by the absence of an active work item.
 
 Time-based expiry remains a future enhancement unless implemented separately.
 
@@ -424,15 +402,14 @@ This RFC does not define:
 The phase-1 direction is:
 
 1. rename the public concept to External Trigger Capability
-2. provision default agent-level external ingress for each supported
-   `delivery_mode`
-3. use `wake_hint` and `enqueue_message` as the model-facing delivery modes
+2. provision one default agent-level external ingress
+3. use `wake_hint` as the model-facing delivery mode
 4. project deliveries as `integration_signal`
 5. keep callback payloads opaque to Holon core
 6. preserve current token validation, mode mismatch rejection, stopped-agent
    rejection, cancellation, and restart behavior
 7. remove user-visible `work_item`/`agent` trigger scopes and make capability
-   identity agent-level, partitioned only by `delivery_mode`
+   identity agent-level
 8. keep `CreateExternalTrigger`/`CancelExternalTrigger` only as compatibility,
    diagnostic, or admin surfaces; do not require them for ordinary waits
 9. align prompt guidance, docs, tests, and event surfaces with the new

--- a/src/context.rs
+++ b/src/context.rs
@@ -80,6 +80,28 @@ pub fn build_context(
     continuation: Option<&ContinuationResolution>,
     config: &ContextConfig,
 ) -> Result<BuiltContext> {
+    build_context_with_default_external_ingress(
+        storage,
+        agent,
+        execution,
+        skills,
+        current_message,
+        continuation,
+        config,
+        None,
+    )
+}
+
+pub fn build_context_with_default_external_ingress(
+    storage: &AppStorage,
+    agent: &AgentState,
+    execution: &ExecutionSnapshot,
+    skills: &SkillsRuntimeView,
+    current_message: &MessageEnvelope,
+    continuation: Option<&ContinuationResolution>,
+    config: &ContextConfig,
+    default_external_ingress_override: Option<&ExternalTriggerRecord>,
+) -> Result<BuiltContext> {
     let messages =
         storage.read_messages_from(agent.compacted_message_count, config.recent_messages)?;
     let continuation_anchor_messages = storage.read_all_messages()?;
@@ -108,7 +130,11 @@ pub fn build_context(
         &mut remaining_budget,
         section("agent", format!("Agent id: {}", agent.id)),
     );
-    if let Some(default_ingress) = default_external_ingress(storage, &agent.id)? {
+    let default_ingress = match default_external_ingress_override {
+        Some(record) => Some(record.clone()),
+        None => default_external_ingress(storage, &agent.id)?,
+    };
+    if let Some(default_ingress) = default_ingress {
         push_budgeted_section(
             &mut sections,
             &mut remaining_budget,

--- a/src/host.rs
+++ b/src/host.rs
@@ -37,10 +37,9 @@ use crate::{
         AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry,
         AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus,
         AgentSummary, AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome,
-        ExternalTriggerRecord, ExternalTriggerStatus, OperatorNotificationRecord,
-        RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
-        TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkspaceEntry,
-        WorkspaceOccupancyRecord,
+        ExternalTriggerRecord, OperatorNotificationRecord, RuntimeFailureSummary,
+        SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskRecord, TaskStatus,
+        TranscriptEntry, TranscriptEntryKind, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -177,6 +176,7 @@ impl RuntimeHost {
         };
         host.ensure_default_agent_identity()?;
         host.converge_private_child_identities()?;
+        host.import_legacy_external_triggers()?;
         Ok(host)
     }
 
@@ -543,6 +543,22 @@ impl RuntimeHost {
         self.inner.registry.agent_identity_records()
     }
 
+    fn import_legacy_external_triggers(&self) -> Result<()> {
+        let mut records = Vec::new();
+        for identity in self
+            .agent_identity_records()?
+            .into_iter()
+            .filter(|record| record.status == AgentRegistryStatus::Active)
+        {
+            let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
+            records.extend(storage.read_recent_external_triggers(usize::MAX)?);
+        }
+        self.inner
+            .runtime_db
+            .external_triggers()
+            .import_legacy(records)
+    }
+
     fn append_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
         self.inner.registry.append_agent_identity(record)
     }
@@ -761,19 +777,13 @@ impl RuntimeHost {
         callback_token: &str,
     ) -> Result<Option<(String, ExternalTriggerRecord)>> {
         let token_hash = hash_callback_token(callback_token);
-        for agent_id in self.known_agent_ids().await? {
-            let storage = AppStorage::new(self.agent_data_dir(&agent_id))?;
-            if let Some(descriptor) =
-                storage
-                    .latest_external_triggers()?
-                    .into_iter()
-                    .find(|record| {
-                        record.token_hash == token_hash
-                            && record.status == ExternalTriggerStatus::Active
-                    })
-            {
-                return Ok(Some((agent_id, descriptor)));
-            }
+        if let Some(descriptor) = self
+            .inner
+            .runtime_db
+            .external_triggers()
+            .active_by_token_hash(&token_hash)?
+        {
+            return Ok(Some((descriptor.target_agent_id.clone(), descriptor)));
         }
         Ok(None)
     }
@@ -1214,22 +1224,6 @@ impl RuntimeHost {
 
     fn validate_agent_id(&self, agent_id: &str) -> Result<()> {
         self.inner.registry.validate_agent_id(agent_id)
-    }
-
-    async fn known_agent_ids(&self) -> Result<Vec<String>> {
-        let mut ids = {
-            let agents = self.inner.agents.read().await;
-            agents.keys().cloned().collect::<Vec<_>>()
-        };
-        ids.extend(
-            self.agent_identity_records()?
-                .into_iter()
-                .filter(|record| record.status == AgentRegistryStatus::Active)
-                .map(|record| record.agent_id),
-        );
-        ids.sort();
-        ids.dedup();
-        Ok(ids)
     }
 
     fn runtime_context_config(&self) -> ContextConfig {

--- a/src/host.rs
+++ b/src/host.rs
@@ -550,7 +550,11 @@ impl RuntimeHost {
             .into_iter()
             .filter(|record| record.status == AgentRegistryStatus::Active)
         {
-            let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
+            let agent_home = self.agent_data_dir(&identity.agent_id);
+            if !agent_home.exists() {
+                continue;
+            }
+            let storage = AppStorage::new(agent_home)?;
             records.extend(storage.read_recent_external_triggers(usize::MAX)?);
         }
         self.inner

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -16,14 +16,14 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 
 use crate::{
-    context::{build_context, BuiltContext, ContextConfig},
+    context::{build_context_with_default_external_ingress, BuiltContext, ContextConfig},
     storage::AppStorage,
     system::{execution_policy_summary_lines, ExecutionSnapshot},
     tool::ToolSpec,
     types::{
         AgentIdentityView, AgentKind, AgentState, AgentsMdKind, AgentsMdSource,
-        ContinuationResolution, LoadedAgentsMd, MessageBody, MessageEnvelope, MessageOrigin,
-        SkillsRuntimeView,
+        ContinuationResolution, ExternalTriggerRecord, LoadedAgentsMd, MessageBody,
+        MessageEnvelope, MessageOrigin, SkillsRuntimeView,
     },
 };
 
@@ -274,7 +274,39 @@ pub fn build_effective_prompt(
     available_tools: &[ToolSpec],
     continuation: Option<&ContinuationResolution>,
 ) -> Result<EffectivePrompt> {
-    let built_context = build_context(
+    build_effective_prompt_with_default_external_ingress(
+        storage,
+        session,
+        execution,
+        current_message,
+        config,
+        workspace_root,
+        agent_home,
+        identity,
+        loaded_agents_md,
+        skills,
+        available_tools,
+        continuation,
+        None,
+    )
+}
+
+pub fn build_effective_prompt_with_default_external_ingress(
+    storage: &AppStorage,
+    session: &AgentState,
+    execution: &ExecutionSnapshot,
+    current_message: &MessageEnvelope,
+    config: &ContextConfig,
+    workspace_root: &Path,
+    agent_home: &Path,
+    identity: &AgentIdentityView,
+    loaded_agents_md: LoadedAgentsMd,
+    skills: &SkillsRuntimeView,
+    available_tools: &[ToolSpec],
+    continuation: Option<&ContinuationResolution>,
+    default_external_ingress: Option<&ExternalTriggerRecord>,
+) -> Result<EffectivePrompt> {
+    let built_context = build_context_with_default_external_ingress(
         storage,
         session,
         execution,
@@ -282,6 +314,7 @@ pub fn build_effective_prompt(
         current_message,
         continuation,
         config,
+        default_external_ingress,
     )?;
     let system_sections = build_system_sections(
         identity,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -58,7 +58,10 @@ use crate::{
     host::RuntimeHostBridge,
     ingress::WakeDisposition,
     memory::{mark_working_memory_prompted, refresh_episode_memory, refresh_working_memory},
-    prompt::{build_effective_prompt, EffectivePrompt},
+    prompt::{
+        build_effective_prompt, build_effective_prompt_with_default_external_ingress,
+        EffectivePrompt,
+    },
     provider::{
         provider_attempt_timeline, AgentProvider, ModelBlock, ProviderBuiltinWebSearchCapability,
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -318,6 +318,9 @@ impl RuntimeHandle {
         runtime_db
             .tasks()
             .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
+        runtime_db
+            .external_triggers()
+            .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
 
         let resolved_context_config = if provider_reconfig.is_some() {
             model_catalog

--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -42,17 +42,12 @@ impl RuntimeHandle {
         let delivery_mode = CallbackDeliveryMode::WakeHint;
         let agent_id = self.agent_id().await?;
         let now = Utc::now();
-        if let Some(descriptor) =
-            self.latest_external_triggers()
-                .await?
-                .into_iter()
-                .find(|descriptor| {
-                    descriptor.status == ExternalTriggerStatus::Active
-                        && descriptor.scope == ExternalTriggerScope::Agent
-                        && descriptor.target_agent_id == agent_id
-                        && descriptor.delivery_mode == delivery_mode
-                        && descriptor.trigger_url.is_some()
-                })
+        if let Some(descriptor) = self
+            .inner
+            .runtime_db
+            .external_triggers()
+            .active_default_for_agent(&agent_id)?
+            .filter(|descriptor| descriptor.trigger_url.is_some())
         {
             return capability_from_record(&descriptor);
         }
@@ -75,7 +70,10 @@ impl RuntimeHandle {
             delivery_count: 0,
         };
 
-        self.inner.storage.append_external_trigger(&descriptor)?;
+        self.inner
+            .runtime_db
+            .external_triggers()
+            .upsert(&descriptor)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "external_trigger_created",
             serde_json::json!({
@@ -101,10 +99,10 @@ impl RuntimeHandle {
         payload: CallbackDeliveryPayload,
     ) -> Result<CallbackDeliveryResult> {
         let descriptor = self
-            .latest_external_triggers()
-            .await?
-            .into_iter()
-            .find(|record| record.external_trigger_id == descriptor_id)
+            .inner
+            .runtime_db
+            .external_triggers()
+            .latest(descriptor_id)?
             .ok_or_else(|| anyhow!("external trigger {} not found", descriptor_id))?;
         if descriptor.status != ExternalTriggerStatus::Active {
             return Err(anyhow!("external trigger is not active"));
@@ -174,8 +172,9 @@ impl RuntimeHandle {
         updated_descriptor.last_delivered_at = Some(now);
         updated_descriptor.delivery_count += 1;
         self.inner
-            .storage
-            .append_external_trigger(&updated_descriptor)?;
+            .runtime_db
+            .external_triggers()
+            .upsert(&updated_descriptor)?;
 
         let updated_descriptor_id = updated_descriptor.external_trigger_id.clone();
         let descriptor_delivery_mode = updated_descriptor.delivery_mode.clone();
@@ -218,10 +217,10 @@ impl RuntimeHandle {
         external_trigger_id: &str,
     ) -> Result<ExternalTriggerRecord> {
         let descriptor = self
-            .latest_external_triggers()
-            .await?
-            .into_iter()
-            .find(|record| record.external_trigger_id == external_trigger_id)
+            .inner
+            .runtime_db
+            .external_triggers()
+            .latest(external_trigger_id)?
             .ok_or_else(|| anyhow!("external trigger {} not found", external_trigger_id))?;
         if descriptor.status == ExternalTriggerStatus::Revoked {
             return Ok(descriptor);
@@ -230,7 +229,7 @@ impl RuntimeHandle {
         let mut revoked = descriptor;
         revoked.status = ExternalTriggerStatus::Revoked;
         revoked.revoked_at = Some(Utc::now());
-        self.inner.storage.append_external_trigger(&revoked)?;
+        self.inner.runtime_db.external_triggers().upsert(&revoked)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "external_trigger_revoked",
             serde_json::json!({
@@ -246,11 +245,20 @@ impl RuntimeHandle {
         &self,
         waiting_intent_id: &str,
     ) -> Result<ExternalTriggerRecord> {
+        let agent_id = self.agent_id().await?;
         let descriptor = self
             .latest_external_triggers()
             .await?
             .into_iter()
             .find(|record| record.waiting_intent_id.as_deref() == Some(waiting_intent_id))
+            .or_else(|| {
+                self.inner
+                    .runtime_db
+                    .external_triggers()
+                    .active_default_for_agent(&agent_id)
+                    .ok()
+                    .flatten()
+            })
             .ok_or_else(|| {
                 anyhow!(
                     "external trigger for waiting intent {} not found",

--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -47,9 +47,14 @@ impl RuntimeHandle {
             .runtime_db
             .external_triggers()
             .active_default_for_agent(&agent_id)?
-            .filter(|descriptor| descriptor.trigger_url.is_some())
         {
-            return capability_from_record(&descriptor);
+            if descriptor.trigger_url.is_some() {
+                return capability_from_record(&descriptor);
+            }
+            let mut revoked = descriptor;
+            revoked.status = ExternalTriggerStatus::Revoked;
+            revoked.revoked_at = Some(now);
+            self.inner.runtime_db.external_triggers().upsert(&revoked)?;
         }
 
         let external_trigger_id = crate::ids::external_trigger_id();
@@ -245,20 +250,11 @@ impl RuntimeHandle {
         &self,
         waiting_intent_id: &str,
     ) -> Result<ExternalTriggerRecord> {
-        let agent_id = self.agent_id().await?;
         let descriptor = self
             .latest_external_triggers()
             .await?
             .into_iter()
             .find(|record| record.waiting_intent_id.as_deref() == Some(waiting_intent_id))
-            .or_else(|| {
-                self.inner
-                    .runtime_db
-                    .external_triggers()
-                    .active_default_for_agent(&agent_id)
-                    .ok()
-                    .flatten()
-            })
             .ok_or_else(|| {
                 anyhow!(
                     "external trigger for waiting intent {} not found",

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -1582,8 +1582,10 @@ mod tests {
             .unwrap();
         runtime.pick_work_item(work.id.clone()).await.unwrap();
         runtime
-            .storage()
-            .append_external_trigger(&ExternalTriggerRecord {
+            .inner
+            .runtime_db
+            .external_triggers()
+            .upsert(&ExternalTriggerRecord {
                 external_trigger_id: "legacy-work-item-trigger".into(),
                 target_agent_id: "default".into(),
                 waiting_intent_id: None,

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -21,8 +21,14 @@ impl RuntimeHandle {
         self.persist_brief(&ack).await?;
         let context_build_started = std::time::Instant::now();
         let identity = self.agent_identity_view().await?;
-        self.ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
+        let default_external_ingress = self
+            .ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
             .await?;
+        let default_external_ingress = self
+            .inner
+            .runtime_db
+            .external_triggers()
+            .latest(&default_external_ingress.external_trigger_id)?;
         let context_config = self.current_context_config().await;
 
         let built = {
@@ -44,7 +50,7 @@ impl RuntimeHandle {
             );
             let loaded_agents_md = self.loaded_agents_md_for_state(&state)?;
             let skills = self.skills_runtime_view_for_state(&state, &identity)?;
-            build_effective_prompt(
+            build_effective_prompt_with_default_external_ingress(
                 &self.inner.storage,
                 &state,
                 &execution,
@@ -57,6 +63,7 @@ impl RuntimeHandle {
                 &skills,
                 &prompt_tools,
                 continuation_resolution,
+                default_external_ingress.as_ref(),
             )?
         };
         let context_build_ms = context_build_started.elapsed().as_millis() as u64;
@@ -198,14 +205,20 @@ impl RuntimeHandle {
         let continuation = ContinuationTrigger::from_message(&message, None)
             .map(|trigger| resolve_continuation(&prior_closure, &trigger, None));
         let identity = self.agent_identity_view().await?;
-        self.ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
+        let default_external_ingress = self
+            .ensure_default_external_ingress(CallbackDeliveryMode::WakeHint)
             .await?;
+        let default_external_ingress = self
+            .inner
+            .runtime_db
+            .external_triggers()
+            .latest(&default_external_ingress.external_trigger_id)?;
         let (provider, available_tools, _, _) = self.provider_tool_selection(&identity).await?;
         let prompt_tools = provider.prompt_tool_specs(&available_tools);
         let execution = self.execution_snapshot().await?;
         let loaded_agents_md = self.loaded_agents_md_for_state(&agent)?;
         let skills = self.skills_runtime_view_for_state(&agent, &identity)?;
-        build_effective_prompt(
+        build_effective_prompt_with_default_external_ingress(
             &self.inner.storage,
             &agent,
             &execution,
@@ -218,6 +231,7 @@ impl RuntimeHandle {
             &skills,
             &prompt_tools,
             continuation.as_ref(),
+            default_external_ingress.as_ref(),
         )
     }
 

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -3254,8 +3254,10 @@ async fn legacy_descriptor_preserves_provenance_after_wait_cancel() {
         })
         .unwrap();
     runtime
-        .storage()
-        .append_external_trigger(&ExternalTriggerRecord {
+        .inner
+        .runtime_db
+        .external_triggers()
+        .upsert(&ExternalTriggerRecord {
             external_trigger_id: trigger_id.clone(),
             target_agent_id: "default".into(),
             waiting_intent_id: Some(waiting_id.clone()),
@@ -3476,8 +3478,10 @@ async fn external_wake_records_wait_reconciliation_without_resolving_wait() {
         })
         .unwrap();
     runtime
-        .storage()
-        .append_external_trigger(&ExternalTriggerRecord {
+        .inner
+        .runtime_db
+        .external_triggers()
+        .upsert(&ExternalTriggerRecord {
             external_trigger_id: trigger_id.clone(),
             target_agent_id: "default".into(),
             waiting_intent_id: Some(waiting_id.clone()),
@@ -3702,8 +3706,10 @@ async fn default_external_ingress_ignores_legacy_active_trigger_without_url() {
     let now = Utc::now();
     let legacy_trigger_id = "legacy-missing-url-trigger".to_string();
     runtime
-        .storage()
-        .append_external_trigger(&ExternalTriggerRecord {
+        .inner
+        .runtime_db
+        .external_triggers()
+        .upsert(&ExternalTriggerRecord {
             external_trigger_id: legacy_trigger_id.clone(),
             target_agent_id: "default".into(),
             waiting_intent_id: None,
@@ -3730,7 +3736,7 @@ async fn default_external_ingress_ignores_legacy_active_trigger_without_url() {
     let descriptors = runtime.latest_external_triggers().await.unwrap();
     assert!(descriptors.iter().any(|record| {
         record.external_trigger_id == legacy_trigger_id
-            && record.status == ExternalTriggerStatus::Active
+            && record.status == ExternalTriggerStatus::Revoked
             && record.trigger_url.is_none()
     }));
     assert!(descriptors.iter().any(|record| {

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -628,11 +628,9 @@ impl RuntimeHandle {
         let agent_id = self.agent_id().await?;
         let mut records = self
             .inner
-            .storage
-            .latest_external_triggers()?
-            .into_iter()
-            .filter(|record| record.target_agent_id == agent_id)
-            .collect::<Vec<_>>();
+            .runtime_db
+            .external_triggers()
+            .latest_for_agent(&agent_id)?;
         records.sort_by(|left, right| right.created_at.cmp(&left.created_at));
         Ok(records)
     }

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -406,7 +406,22 @@ fn upsert_external_trigger_tx(tx: &Transaction<'_>, record: &ExternalTriggerReco
             last_delivered_at = excluded.last_delivered_at,
             delivery_count = excluded.delivery_count,
             payload_json = excluded.payload_json
-         WHERE excluded.delivery_count >= external_triggers.delivery_count",
+         WHERE excluded.delivery_count > external_triggers.delivery_count
+            OR (
+                excluded.delivery_count = external_triggers.delivery_count
+                AND COALESCE(excluded.last_delivered_at, '') > COALESCE(external_triggers.last_delivered_at, '')
+            )
+            OR (
+                excluded.delivery_count = external_triggers.delivery_count
+                AND COALESCE(excluded.last_delivered_at, '') = COALESCE(external_triggers.last_delivered_at, '')
+                AND COALESCE(excluded.revoked_at, '') > COALESCE(external_triggers.revoked_at, '')
+            )
+            OR (
+                excluded.delivery_count = external_triggers.delivery_count
+                AND COALESCE(excluded.last_delivered_at, '') = COALESCE(external_triggers.last_delivered_at, '')
+                AND COALESCE(excluded.revoked_at, '') = COALESCE(external_triggers.revoked_at, '')
+                AND excluded.created_at >= external_triggers.created_at
+            )",
         params![
             record.external_trigger_id,
             record.target_agent_id,
@@ -1497,6 +1512,34 @@ mod tests {
             .expect("active trigger by token");
         assert_eq!(by_token.delivery_count, 2);
         assert_eq!(by_token.last_delivered_at, trigger.last_delivered_at);
+        Ok(())
+    }
+
+    #[test]
+    fn external_trigger_upsert_does_not_revert_newer_revocation() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.external_triggers().import_legacy(Vec::new())?;
+        let active = external_trigger_record(
+            "trigger-active",
+            "agent-a",
+            ExternalTriggerStatus::Active,
+            0,
+        );
+        db.external_triggers().upsert(&active)?;
+
+        let mut revoked = active.clone();
+        revoked.status = ExternalTriggerStatus::Revoked;
+        revoked.revoked_at = Some(active.created_at + chrono::Duration::seconds(30));
+        db.external_triggers().upsert(&revoked)?;
+        db.external_triggers().upsert(&active)?;
+
+        let latest = db
+            .external_triggers()
+            .latest("trigger-active")?
+            .expect("latest trigger");
+        assert_eq!(latest.status, ExternalTriggerStatus::Revoked);
+        assert_eq!(latest.revoked_at, revoked.revoked_at);
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -8,7 +8,10 @@ use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
-use crate::types::{TaskRecord, TaskStatus, WorkItemRecord, WorkItemState};
+use crate::types::{
+    CallbackDeliveryMode, ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus,
+    TaskRecord, TaskStatus, WorkItemRecord, WorkItemState,
+};
 
 const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
 const TASK_PAYLOAD_ARRAY_LIMIT: usize = 64;
@@ -24,6 +27,10 @@ pub struct WorkItemRepository<'a> {
 }
 
 pub struct TaskRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct ExternalTriggerRepository<'a> {
     db: &'a RuntimeDb,
 }
 
@@ -125,6 +132,100 @@ impl WorkItemRepository<'_> {
         )?;
         let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
         rows.map(|row| decode_work_item_payload(&row?)).collect()
+    }
+}
+
+impl ExternalTriggerRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<ExternalTriggerRecord>) -> Result<()> {
+        self.db.transaction(|tx| {
+            let domain = read_storage_domain(tx, "external_triggers")?;
+            if domain.as_ref().is_some_and(|domain| {
+                domain.import_status == "complete" && domain.canonical_source == "db"
+            }) {
+                return Ok(());
+            }
+
+            upsert_storage_domain(tx, "external_triggers", "importing", "jsonl", None)?;
+            let latest = reduce_external_trigger_records(records);
+            for record in latest.values() {
+                upsert_external_trigger_tx(tx, record)?;
+            }
+            upsert_storage_domain(
+                tx,
+                "external_triggers",
+                "complete",
+                "db",
+                Some(serde_json::json!({ "imported_records": latest.len() })),
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn upsert(&self, record: &ExternalTriggerRecord) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_external_trigger_tx(tx, record))
+    }
+
+    pub fn latest(&self, external_trigger_id: &str) -> Result<Option<ExternalTriggerRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json FROM external_triggers WHERE external_trigger_id = ?1",
+                [external_trigger_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_external_trigger_payload(&payload))
+            .transpose()
+    }
+
+    pub fn latest_for_agent(&self, agent_id: &str) -> Result<Vec<ExternalTriggerRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM external_triggers
+             WHERE target_agent_id = ?1
+             ORDER BY created_at DESC, external_trigger_id ASC",
+        )?;
+        let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_external_trigger_payload(&row?))
+            .collect()
+    }
+
+    pub fn active_default_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Option<ExternalTriggerRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json
+                 FROM external_triggers
+                 WHERE target_agent_id = ?1 AND status = 'active'
+                 ORDER BY created_at DESC, external_trigger_id ASC
+                 LIMIT 1",
+                [agent_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_external_trigger_payload(&payload))
+            .transpose()
+    }
+
+    pub fn active_by_token_hash(&self, token_hash: &str) -> Result<Option<ExternalTriggerRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json
+                 FROM external_triggers
+                 WHERE token_hash = ?1 AND status = 'active'
+                 LIMIT 1",
+                [token_hash],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_external_trigger_payload(&payload))
+            .transpose()
     }
 }
 
@@ -283,6 +384,46 @@ fn upsert_storage_domain(
     Ok(())
 }
 
+fn upsert_external_trigger_tx(tx: &Transaction<'_>, record: &ExternalTriggerRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let status = enum_string(&record.status)?;
+    let revoked_at = record.revoked_at.map(timestamp);
+    let last_delivered_at = record.last_delivered_at.map(timestamp);
+    tx.execute(
+        "INSERT INTO external_triggers (
+            external_trigger_id, target_agent_id, waiting_intent_id, trigger_url,
+            token_hash, status, created_at, revoked_at, last_delivered_at,
+            delivery_count, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+         ON CONFLICT(external_trigger_id) DO UPDATE SET
+            target_agent_id = excluded.target_agent_id,
+            waiting_intent_id = excluded.waiting_intent_id,
+            trigger_url = excluded.trigger_url,
+            token_hash = excluded.token_hash,
+            status = excluded.status,
+            created_at = excluded.created_at,
+            revoked_at = excluded.revoked_at,
+            last_delivered_at = excluded.last_delivered_at,
+            delivery_count = excluded.delivery_count,
+            payload_json = excluded.payload_json
+         WHERE excluded.delivery_count >= external_triggers.delivery_count",
+        params![
+            record.external_trigger_id,
+            record.target_agent_id,
+            record.waiting_intent_id,
+            record.trigger_url,
+            record.token_hash,
+            status,
+            timestamp(record.created_at),
+            revoked_at,
+            last_delivered_at,
+            record.delivery_count as i64,
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
 fn upsert_work_item_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
@@ -415,6 +556,75 @@ fn newer_work_item_record(candidate: &WorkItemRecord, existing: &WorkItemRecord)
         .is_gt()
 }
 
+fn reduce_external_trigger_records(
+    records: Vec<ExternalTriggerRecord>,
+) -> BTreeMap<String, ExternalTriggerRecord> {
+    let mut latest_by_id = BTreeMap::<String, ExternalTriggerRecord>::new();
+    for record in records {
+        if latest_by_id
+            .get(&record.external_trigger_id)
+            .is_none_or(|existing| newer_external_trigger_record(&record, existing))
+        {
+            latest_by_id.insert(
+                record.external_trigger_id.clone(),
+                normalize_external_trigger_record(record),
+            );
+        }
+    }
+
+    let mut active_by_agent = BTreeMap::<String, String>::new();
+    for record in latest_by_id.values() {
+        if record.status != ExternalTriggerStatus::Active {
+            continue;
+        }
+        let replace = active_by_agent
+            .get(&record.target_agent_id)
+            .and_then(|id| latest_by_id.get(id))
+            .is_none_or(|existing| newer_external_trigger_record(record, existing));
+        if replace {
+            active_by_agent.insert(
+                record.target_agent_id.clone(),
+                record.external_trigger_id.clone(),
+            );
+        }
+    }
+
+    for record in latest_by_id.values_mut() {
+        if record.status == ExternalTriggerStatus::Active
+            && active_by_agent.get(&record.target_agent_id) != Some(&record.external_trigger_id)
+        {
+            record.status = ExternalTriggerStatus::Revoked;
+            record.revoked_at.get_or_insert(record.created_at);
+        }
+    }
+    latest_by_id
+}
+
+fn normalize_external_trigger_record(mut record: ExternalTriggerRecord) -> ExternalTriggerRecord {
+    record.scope = ExternalTriggerScope::Agent;
+    record.delivery_mode = CallbackDeliveryMode::WakeHint;
+    record.waiting_intent_id = None;
+    record
+}
+
+fn newer_external_trigger_record(
+    candidate: &ExternalTriggerRecord,
+    existing: &ExternalTriggerRecord,
+) -> bool {
+    candidate
+        .delivery_count
+        .cmp(&existing.delivery_count)
+        .then_with(|| candidate.last_delivered_at.cmp(&existing.last_delivered_at))
+        .then_with(|| candidate.revoked_at.cmp(&existing.revoked_at))
+        .then_with(|| candidate.created_at.cmp(&existing.created_at))
+        .then_with(|| {
+            candidate
+                .external_trigger_id
+                .cmp(&existing.external_trigger_id)
+        })
+        .is_gt()
+}
+
 fn reduce_task_records(records: Vec<TaskRecord>) -> BTreeMap<String, TaskRecord> {
     let mut latest = BTreeMap::<String, TaskRecord>::new();
     for record in records {
@@ -489,6 +699,10 @@ fn task_revision(record: &TaskRecord) -> i64 {
 
 fn decode_work_item_payload(payload: &str) -> Result<WorkItemRecord> {
     serde_json::from_str(payload).context("decoding work item payload from runtime db")
+}
+
+fn decode_external_trigger_payload(payload: &str) -> Result<ExternalTriggerRecord> {
+    serde_json::from_str(payload).context("decoding external trigger payload from runtime db")
 }
 
 fn decode_task_payload(payload: &str) -> Result<TaskRecord> {
@@ -688,6 +902,35 @@ CREATE INDEX IF NOT EXISTS idx_tasks_owner_active
   ON tasks(owner_agent_id, status, updated_at);
 "#,
     },
+    Migration {
+        version: 4,
+        name: "external_triggers_current_state",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS external_triggers (
+  external_trigger_id TEXT PRIMARY KEY,
+  target_agent_id TEXT NOT NULL,
+  waiting_intent_id TEXT,
+  trigger_url TEXT,
+  token_hash TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  revoked_at TEXT,
+  last_delivered_at TEXT,
+  delivery_count INTEGER NOT NULL DEFAULT 0,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_triggers_agent_status
+  ON external_triggers(target_agent_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_external_triggers_token_hash
+  ON external_triggers(token_hash);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_triggers_active_default_agent
+  ON external_triggers(target_agent_id)
+  WHERE status = 'active';
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -741,6 +984,10 @@ impl RuntimeDb {
 
     pub fn tasks(&self) -> TaskRepository<'_> {
         TaskRepository { db: self }
+    }
+
+    pub fn external_triggers(&self) -> ExternalTriggerRepository<'_> {
+        ExternalTriggerRepository { db: self }
     }
 
     pub fn migrate(&self) -> Result<()> {
@@ -1002,6 +1249,29 @@ mod tests {
         }
     }
 
+    fn external_trigger_record(
+        id: &str,
+        agent_id: &str,
+        status: ExternalTriggerStatus,
+        offset: i64,
+    ) -> ExternalTriggerRecord {
+        let created_at = Utc::now() + chrono::Duration::seconds(offset);
+        ExternalTriggerRecord {
+            external_trigger_id: id.into(),
+            target_agent_id: agent_id.into(),
+            waiting_intent_id: Some(format!("wait-{id}")),
+            scope: ExternalTriggerScope::Agent,
+            delivery_mode: CallbackDeliveryMode::EnqueueMessage,
+            trigger_url: Some(format!("https://example.test/{id}")),
+            token_hash: format!("hash-{id}"),
+            status,
+            created_at,
+            revoked_at: None,
+            last_delivered_at: None,
+            delivery_count: 0,
+        }
+    }
+
     #[test]
     fn runtime_db_fresh_migration_creates_foundation_schema() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
@@ -1009,7 +1279,7 @@ mod tests {
         let connection = db.connection()?;
 
         let version = db.current_schema_version()?;
-        assert_eq!(version, 3);
+        assert_eq!(version, 4);
         for table in [
             "schema_migrations",
             "storage_domains",
@@ -1017,6 +1287,7 @@ mod tests {
             "audit_events",
             "work_items",
             "tasks",
+            "external_triggers",
         ] {
             let count: i64 = connection.query_row(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
@@ -1040,8 +1311,8 @@ mod tests {
             connection.query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| {
                 row.get(0)
             })?;
-        assert_eq!(count, 3);
-        assert_eq!(current_schema_version(&connection)?, 3);
+        assert_eq!(count, 4);
+        assert_eq!(current_schema_version(&connection)?, 4);
         Ok(())
     }
 
@@ -1159,7 +1430,73 @@ mod tests {
         let temp_db = test_support::TempRuntimeDb::new()?;
         assert!(temp_db.db.path().ends_with("state/runtime.sqlite"));
         assert!(temp_db.db.lock_path().ends_with("state/runtime.lock"));
-        assert_eq!(temp_db.db.current_schema_version()?, 3);
+        assert_eq!(temp_db.db.current_schema_version()?, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn external_trigger_import_normalizes_to_one_default_active_per_agent() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let older =
+            external_trigger_record("trigger-older", "agent-a", ExternalTriggerStatus::Active, 0);
+        let newer = external_trigger_record(
+            "trigger-newer",
+            "agent-a",
+            ExternalTriggerStatus::Active,
+            10,
+        );
+
+        db.external_triggers()
+            .import_legacy(vec![older.clone(), newer.clone()])?;
+        db.external_triggers()
+            .import_legacy(vec![older.clone(), newer.clone()])?;
+
+        let active = db
+            .external_triggers()
+            .active_default_for_agent("agent-a")?
+            .expect("active default trigger");
+        assert_eq!(active.external_trigger_id, "trigger-newer");
+        assert_eq!(active.scope, ExternalTriggerScope::Agent);
+        assert_eq!(active.delivery_mode, CallbackDeliveryMode::WakeHint);
+        assert_eq!(active.waiting_intent_id, None);
+
+        let all = db.external_triggers().latest_for_agent("agent-a")?;
+        assert_eq!(all.len(), 2);
+        assert_eq!(
+            all.into_iter()
+                .filter(|record| record.status == ExternalTriggerStatus::Active)
+                .count(),
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_trigger_upsert_tracks_delivery_and_token_lookup() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.external_triggers().import_legacy(Vec::new())?;
+        let mut trigger = external_trigger_record(
+            "trigger-active",
+            "agent-a",
+            ExternalTriggerStatus::Active,
+            0,
+        );
+        trigger.delivery_mode = CallbackDeliveryMode::WakeHint;
+        trigger.waiting_intent_id = None;
+        db.external_triggers().upsert(&trigger)?;
+
+        trigger.delivery_count = 2;
+        trigger.last_delivered_at = Some(trigger.created_at + chrono::Duration::seconds(30));
+        db.external_triggers().upsert(&trigger)?;
+
+        let by_token = db
+            .external_triggers()
+            .active_by_token_hash("hash-trigger-active")?
+            .expect("active trigger by token");
+        assert_eq!(by_token.delivery_count, 2);
+        assert_eq!(by_token.last_delivered_at, trigger.last_delivered_at);
         Ok(())
     }
 

--- a/tests/support/http_callback.rs
+++ b/tests/support/http_callback.rs
@@ -39,7 +39,7 @@ use super::{
     attach_default_workspace, callback_path, callback_token, connect_addr, git, init_git_repo,
     spawn_delivery_callback, spawn_server, spawn_server_for_host, spawn_server_with_config,
     spawn_server_with_runtime_config, tempdir, test_config, test_config_with_paths, wait_until,
-    DeliveryCallbackRecord,
+    wait_until_async, DeliveryCallbackRecord,
 };
 
 pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
@@ -88,16 +88,20 @@ pub async fn callback_enqueue_message_repeats_until_cancelled() -> Result<()> {
         .await?;
     assert!(second.status().is_success());
 
-    wait_until(|| {
-        let messages = runtime.storage().read_recent_messages(20)?;
-        let descriptors = runtime.storage().latest_external_triggers()?;
-        Ok(messages
-            .iter()
-            .all(|message| message.kind != MessageKind::CallbackEvent)
-            && descriptors
-                .first()
-                .map(|item| item.delivery_count == 2)
-                .unwrap_or(false))
+    let runtime_for_wait = runtime.clone();
+    wait_until_async(move || {
+        let runtime = runtime_for_wait.clone();
+        async move {
+            let messages = runtime.storage().read_recent_messages(20)?;
+            let descriptors = runtime.latest_external_triggers().await?;
+            Ok(messages
+                .iter()
+                .all(|message| message.kind != MessageKind::CallbackEvent)
+                && descriptors
+                    .first()
+                    .map(|item| item.delivery_count == 2)
+                    .unwrap_or(false))
+        }
     })
     .await?;
 
@@ -443,12 +447,16 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
     assert_eq!(first_payload["delivery_mode"], "wake_hint");
     assert_eq!(first_payload["disposition"], "triggered");
 
-    wait_until(|| {
-        let descriptors = runtime.storage().latest_external_triggers()?;
-        Ok(descriptors
-            .first()
-            .map(|item| item.delivery_count == 1)
-            .unwrap_or(false))
+    let runtime_for_wait = runtime.clone();
+    wait_until_async(move || {
+        let runtime = runtime_for_wait.clone();
+        async move {
+            let descriptors = runtime.latest_external_triggers().await?;
+            Ok(descriptors
+                .first()
+                .map(|item| item.delivery_count == 1)
+                .unwrap_or(false))
+        }
     })
     .await?;
 
@@ -489,16 +497,20 @@ pub async fn callback_enqueue_rejects_stopped_public_agent_after_restart() -> Re
         .unwrap_or_default()
         .contains("start first"));
 
-    wait_until(|| {
-        let messages = runtime2.storage().read_recent_messages(20)?;
-        let descriptors = runtime2.storage().latest_external_triggers()?;
-        Ok(messages
-            .iter()
-            .all(|message| message.kind != MessageKind::CallbackEvent)
-            && descriptors
-                .first()
-                .map(|item| item.delivery_count == 1)
-                .unwrap_or(false))
+    let runtime_for_wait = runtime2.clone();
+    wait_until_async(move || {
+        let runtime = runtime_for_wait.clone();
+        async move {
+            let messages = runtime.storage().read_recent_messages(20)?;
+            let descriptors = runtime.latest_external_triggers().await?;
+            Ok(messages
+                .iter()
+                .all(|message| message.kind != MessageKind::CallbackEvent)
+                && descriptors
+                    .first()
+                    .map(|item| item.delivery_count == 1)
+                    .unwrap_or(false))
+        }
     })
     .await?;
 


### PR DESCRIPTION
Closes #1590.

## Summary

- Adds a runtime DB `external_triggers` current-state table and repository with one active default trigger per agent.
- Imports legacy JSONL external trigger records idempotently, normalizing old scope/delivery-mode variants to the current agent-level `wake_hint` contract.
- Moves default trigger creation, revocation, callback delivery accounting, host callback-token resolution, runtime state listing, prompt context, and command-task env projection to DB-backed reads/writes.
- Updates the external trigger RFC and DB migration notes to remove multi-scope/multi-delivery-mode persistence as a first-class schema concern.

## Verification

- `cargo fmt --all -- --check`
- `cargo test runtime_db::tests:: -- --nocapture`
- `cargo test external_trigger -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
