### PR TITLE
fix: migrate scheduler control plane to runtime db

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -321,6 +321,15 @@ impl RuntimeHandle {
         runtime_db
             .external_triggers()
             .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
+        runtime_db
+            .wait_conditions()
+            .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
+        runtime_db
+            .queue_entries()
+            .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
+        runtime_db
+            .timers()
+            .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
         runtime_db.evidence().import_legacy(
             storage.read_all_message_values()?,
             storage.read_all_transcript()?,
@@ -335,6 +344,7 @@ impl RuntimeHandle {
             crate::runtime_db::RuntimeDb::expected_storage_domains(),
         )?;
         storage.enable_audit_event_index(runtime_db.clone(), Some(state.id.clone()))?;
+        storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
 
         let resolved_context_config = if provider_reconfig.is_some() {
             model_catalog

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1391,7 +1391,24 @@ fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
          WHERE excluded.fire_count > timers.fire_count
             OR (
                 excluded.fire_count = timers.fire_count
-                AND excluded.updated_at >= timers.updated_at
+                AND (
+                    CASE excluded.status
+                        WHEN 'active' THEN 0
+                        WHEN 'cancelled' THEN 1
+                        WHEN 'completed' THEN 2
+                        ELSE 0
+                    END
+                    > CASE timers.status
+                        WHEN 'active' THEN 0
+                        WHEN 'cancelled' THEN 1
+                        WHEN 'completed' THEN 2
+                        ELSE 0
+                    END
+                    OR (
+                        excluded.status = timers.status
+                        AND excluded.updated_at >= timers.updated_at
+                    )
+                )
             )",
         params![
             record.id,
@@ -1504,10 +1521,21 @@ fn newer_timer_record(candidate: &TimerRecord, existing: &TimerRecord) -> bool {
     candidate
         .fire_count
         .cmp(&existing.fire_count)
+        .then_with(|| {
+            timer_status_rank(&candidate.status).cmp(&timer_status_rank(&existing.status))
+        })
         .then_with(|| timer_updated_at(candidate).cmp(&timer_updated_at(existing)))
         .then_with(|| candidate.created_at.cmp(&existing.created_at))
         .then_with(|| candidate.id.cmp(&existing.id))
         .is_gt()
+}
+
+fn timer_status_rank(status: &TimerStatus) -> u8 {
+    match status {
+        TimerStatus::Active => 0,
+        TimerStatus::Cancelled => 1,
+        TimerStatus::Completed => 2,
+    }
 }
 
 fn timer_updated_at(record: &TimerRecord) -> DateTime<Utc> {

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -11,9 +11,9 @@ use serde::Serialize;
 
 use crate::types::{
     AuditEvent, BriefRecord, CallbackDeliveryMode, DeliverySummaryRecord, ExternalTriggerRecord,
-    ExternalTriggerScope, ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord,
-    QueueEntryStatus, TaskRecord, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
-    TranscriptEntry, WaitConditionRecord, WorkItemRecord, WorkItemState,
+    ExternalTriggerScope, ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, TaskRecord,
+    TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
+    WaitConditionRecord, WorkItemRecord, WorkItemState,
 };
 
 const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
@@ -488,11 +488,11 @@ impl QueueEntryRepository<'_> {
         }
         self.db
             .run_storage_domain_import("queue_entries", "jsonl", "db", |tx| {
-                let latest = reduce_queue_entry_records(records);
-                for record in latest.values() {
-                    upsert_queue_entry_tx(tx, record)?;
+                let imported_records = records.len();
+                for record in records {
+                    upsert_queue_entry_tx(tx, &record)?;
                 }
-                Ok(serde_json::json!({ "imported_records": latest.len() }))
+                Ok(serde_json::json!({ "imported_records": imported_records }))
             })
     }
 
@@ -1372,7 +1372,7 @@ fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Res
         "INSERT INTO queue_entries (
             message_id, agent_id, priority, status, created_at, updated_at, payload_json
          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-         ON CONFLICT(message_id) DO UPDATE SET
+         ON CONFLICT(message_id, status) DO UPDATE SET
             agent_id = excluded.agent_id,
             priority = excluded.priority,
             status = excluded.status,
@@ -1491,45 +1491,6 @@ fn newer_wait_condition_record(
         .then_with(|| candidate.created_at.cmp(&existing.created_at))
         .then_with(|| candidate.id.cmp(&existing.id))
         .is_gt()
-}
-
-fn reduce_queue_entry_records(
-    records: Vec<QueueEntryRecord>,
-) -> BTreeMap<String, QueueEntryRecord> {
-    let mut latest = BTreeMap::<String, QueueEntryRecord>::new();
-    for record in records {
-        if latest
-            .get(&record.message_id)
-            .is_none_or(|existing| newer_queue_entry_record(&record, existing))
-        {
-            latest.insert(record.message_id.clone(), record);
-        }
-    }
-    latest
-}
-
-fn newer_queue_entry_record(candidate: &QueueEntryRecord, existing: &QueueEntryRecord) -> bool {
-    candidate
-        .updated_at
-        .cmp(&existing.updated_at)
-        .then_with(|| candidate.created_at.cmp(&existing.created_at))
-        .then_with(|| {
-            queue_entry_status_rank(&candidate.status)
-                .cmp(&queue_entry_status_rank(&existing.status))
-        })
-        .then_with(|| candidate.message_id.cmp(&existing.message_id))
-        .is_gt()
-}
-
-fn queue_entry_status_rank(status: &QueueEntryStatus) -> u8 {
-    match status {
-        QueueEntryStatus::Queued => 0,
-        QueueEntryStatus::Dequeued => 1,
-        QueueEntryStatus::Interjected => 2,
-        QueueEntryStatus::Processed => 3,
-        QueueEntryStatus::Dropped => 4,
-        QueueEntryStatus::Aborted => 5,
-    }
 }
 
 fn reduce_timer_records(records: Vec<TimerRecord>) -> BTreeMap<String, TimerRecord> {
@@ -2180,13 +2141,14 @@ CREATE TABLE IF NOT EXISTS wait_conditions (
 );
 
 CREATE TABLE IF NOT EXISTS queue_entries (
-  message_id TEXT PRIMARY KEY,
+  message_id TEXT NOT NULL,
   agent_id TEXT NOT NULL,
   priority TEXT NOT NULL,
   status TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  payload_json TEXT NOT NULL
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (message_id, status)
 );
 
 CREATE TABLE IF NOT EXISTS timers (
@@ -2219,6 +2181,35 @@ CREATE INDEX IF NOT EXISTS idx_queue_entries_agent_status
 
 CREATE INDEX IF NOT EXISTS idx_timers_agent_status
   ON timers(agent_id, status, next_fire_at);
+"#,
+    },
+    Migration {
+        version: 7,
+        name: "queue_entries_preserve_lifecycle_history",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS queue_entries_v2 (
+  message_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  priority TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (message_id, status)
+);
+
+INSERT OR REPLACE INTO queue_entries_v2 (
+  message_id, agent_id, priority, status, created_at, updated_at, payload_json
+)
+SELECT message_id, agent_id, priority, status, created_at, updated_at, payload_json
+FROM queue_entries;
+
+DROP TABLE queue_entries;
+
+ALTER TABLE queue_entries_v2 RENAME TO queue_entries;
+
+CREATE INDEX IF NOT EXISTS idx_queue_entries_agent_status
+  ON queue_entries(agent_id, status, updated_at);
 "#,
     },
 ];
@@ -2831,10 +2822,17 @@ mod tests {
         let connection = open_connection(&db_path)?;
         connection.execute(
             "INSERT INTO schema_migrations (version, name, applied_at) VALUES (?1, ?2, ?3)",
-            (7_i64, "future_test", Utc::now().to_rfc3339()),
+            (
+                max_known_migration_version() + 1,
+                "future_test",
+                Utc::now().to_rfc3339(),
+            ),
         )?;
 
-        assert_eq!(current_schema_version(&connection)?, 7);
+        assert_eq!(
+            current_schema_version(&connection)?,
+            max_known_migration_version() + 1
+        );
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -11,8 +11,9 @@ use serde::Serialize;
 
 use crate::types::{
     AuditEvent, BriefRecord, CallbackDeliveryMode, DeliverySummaryRecord, ExternalTriggerRecord,
-    ExternalTriggerScope, ExternalTriggerStatus, MessageEnvelope, TaskRecord, TaskStatus,
-    ToolExecutionRecord, TranscriptEntry, WorkItemRecord, WorkItemState,
+    ExternalTriggerScope, ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord,
+    QueueEntryStatus, TaskRecord, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
+    TranscriptEntry, WaitConditionRecord, WorkItemRecord, WorkItemState,
 };
 
 const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
@@ -34,6 +35,18 @@ pub struct TaskRepository<'a> {
 }
 
 pub struct ExternalTriggerRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct WaitConditionRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct QueueEntryRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct TimerRepository<'a> {
     db: &'a RuntimeDb,
 }
 
@@ -396,6 +409,169 @@ impl TaskRepository<'_> {
         let mut statement = connection.prepare(&sql)?;
         let rows = statement.query_map(params, |row| row.get::<_, String>(0))?;
         rows.map(|row| decode_task_payload(&row?)).collect()
+    }
+}
+
+impl WaitConditionRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<WaitConditionRecord>) -> Result<()> {
+        if self
+            .db
+            .storage_domain_is_complete("wait_conditions", "db")?
+        {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("wait_conditions", "jsonl", "db", |tx| {
+                let latest = reduce_wait_condition_records(records);
+                for record in latest.values() {
+                    upsert_wait_condition_tx(tx, record)?;
+                }
+                Ok(serde_json::json!({ "imported_records": latest.len() }))
+            })
+    }
+
+    pub fn upsert(&self, record: &WaitConditionRecord) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_wait_condition_tx(tx, record))
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<WaitConditionRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM wait_conditions
+             ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_wait_condition_payload(&row?))
+            .collect()
+    }
+
+    pub fn active_for_agent(&self, agent_id: &str) -> Result<Vec<WaitConditionRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM wait_conditions
+             WHERE agent_id = ?1 AND status = 'active'
+             ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
+        )?;
+        let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_wait_condition_payload(&row?))
+            .collect()
+    }
+}
+
+impl QueueEntryRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<QueueEntryRecord>) -> Result<()> {
+        if self.db.storage_domain_is_complete("queue_entries", "db")? {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("queue_entries", "jsonl", "db", |tx| {
+                let latest = reduce_queue_entry_records(records);
+                for record in latest.values() {
+                    upsert_queue_entry_tx(tx, record)?;
+                }
+                Ok(serde_json::json!({ "imported_records": latest.len() }))
+            })
+    }
+
+    pub fn upsert(&self, record: &QueueEntryRecord) -> Result<()> {
+        self.db.transaction(|tx| upsert_queue_entry_tx(tx, record))
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<QueueEntryRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM queue_entries
+             ORDER BY updated_at DESC, created_at DESC, message_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_queue_entry_payload(&row?)).collect()
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<QueueEntryRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM queue_entries
+             ORDER BY updated_at DESC, created_at DESC, message_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_queue_entry_payload(&row?)).collect()
+    }
+}
+
+impl TimerRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<TimerRecord>) -> Result<()> {
+        if self.db.storage_domain_is_complete("timers", "db")? {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("timers", "jsonl", "db", |tx| {
+                let latest = reduce_timer_records(records);
+                for record in latest.values() {
+                    upsert_timer_tx(tx, record)?;
+                }
+                let active_records = latest
+                    .values()
+                    .filter(|record| record.status == TimerStatus::Active)
+                    .count();
+                Ok(serde_json::json!({
+                    "imported_records": latest.len(),
+                    "active_records": active_records,
+                }))
+            })
+    }
+
+    pub fn upsert(&self, record: &TimerRecord) -> Result<()> {
+        self.db.transaction(|tx| upsert_timer_tx(tx, record))
+    }
+
+    pub fn latest(&self, timer_id: &str) -> Result<Option<TimerRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json FROM timers WHERE timer_id = ?1",
+                [timer_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_timer_payload(&payload))
+            .transpose()
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<TimerRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM timers
+             ORDER BY created_at DESC, timer_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_timer_payload(&row?)).collect()
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<TimerRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM timers
+             ORDER BY created_at DESC, timer_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_timer_payload(&row?)).collect()
     }
 }
 
@@ -1113,6 +1289,129 @@ fn upsert_task_tx(tx: &Transaction<'_>, record: &TaskRecord) -> Result<()> {
     Ok(())
 }
 
+fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let status = enum_string(&record.status)?;
+    let kind = enum_string(&record.kind)?;
+    tx.execute(
+        "INSERT INTO wait_conditions (
+            wait_condition_id, agent_id, work_item_id, status, kind, source,
+            subject_ref, waiting_for, created_at, updated_at, expires_at,
+            resolved_at, cancelled_at, last_turn_id, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+         ON CONFLICT(wait_condition_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            work_item_id = excluded.work_item_id,
+            status = excluded.status,
+            kind = excluded.kind,
+            source = excluded.source,
+            subject_ref = excluded.subject_ref,
+            waiting_for = excluded.waiting_for,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            expires_at = excluded.expires_at,
+            resolved_at = excluded.resolved_at,
+            cancelled_at = excluded.cancelled_at,
+            last_turn_id = excluded.last_turn_id,
+            payload_json = excluded.payload_json
+         WHERE excluded.updated_at >= wait_conditions.updated_at",
+        params![
+            record.id,
+            record.agent_id,
+            record.work_item_id,
+            status,
+            kind,
+            record.source,
+            record.subject_ref,
+            record.waiting_for,
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            record.expires_at.map(timestamp),
+            record.resolved_at.map(timestamp),
+            record.cancelled_at.map(timestamp),
+            record.turn_id,
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let priority = enum_string(&record.priority)?;
+    let status = enum_string(&record.status)?;
+    tx.execute(
+        "INSERT INTO queue_entries (
+            message_id, agent_id, priority, status, created_at, updated_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(message_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            priority = excluded.priority,
+            status = excluded.status,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            payload_json = excluded.payload_json
+         WHERE excluded.updated_at >= queue_entries.updated_at",
+        params![
+            record.message_id,
+            record.agent_id,
+            priority,
+            status,
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let status = enum_string(&record.status)?;
+    let updated_at = timer_updated_at(record);
+    tx.execute(
+        "INSERT INTO timers (
+            timer_id, agent_id, status, summary, created_at, duration_ms,
+            interval_ms, repeat, next_fire_at, last_fired_at, fire_count,
+            updated_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(timer_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            status = excluded.status,
+            summary = excluded.summary,
+            created_at = excluded.created_at,
+            duration_ms = excluded.duration_ms,
+            interval_ms = excluded.interval_ms,
+            repeat = excluded.repeat,
+            next_fire_at = excluded.next_fire_at,
+            last_fired_at = excluded.last_fired_at,
+            fire_count = excluded.fire_count,
+            updated_at = excluded.updated_at,
+            payload_json = excluded.payload_json
+         WHERE excluded.fire_count > timers.fire_count
+            OR (
+                excluded.fire_count = timers.fire_count
+                AND excluded.updated_at >= timers.updated_at
+            )",
+        params![
+            record.id,
+            record.agent_id,
+            status,
+            record.summary,
+            timestamp(record.created_at),
+            record.duration_ms as i64,
+            record.interval_ms.map(|value| value as i64),
+            i64::from(record.repeat),
+            record.next_fire_at.map(timestamp),
+            record.last_fired_at.map(timestamp),
+            record.fire_count as i64,
+            timestamp(updated_at),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
 fn newer_work_item_record(candidate: &WorkItemRecord, existing: &WorkItemRecord) -> bool {
     candidate
         .revision
@@ -1120,6 +1419,102 @@ fn newer_work_item_record(candidate: &WorkItemRecord, existing: &WorkItemRecord)
         .then_with(|| candidate.updated_at.cmp(&existing.updated_at))
         .then_with(|| candidate.created_at.cmp(&existing.created_at))
         .is_gt()
+}
+
+fn reduce_wait_condition_records(
+    records: Vec<WaitConditionRecord>,
+) -> BTreeMap<String, WaitConditionRecord> {
+    let mut latest = BTreeMap::<String, WaitConditionRecord>::new();
+    for record in records {
+        if latest
+            .get(&record.id)
+            .is_none_or(|existing| newer_wait_condition_record(&record, existing))
+        {
+            latest.insert(record.id.clone(), record);
+        }
+    }
+    latest
+}
+
+fn newer_wait_condition_record(
+    candidate: &WaitConditionRecord,
+    existing: &WaitConditionRecord,
+) -> bool {
+    candidate
+        .updated_at
+        .cmp(&existing.updated_at)
+        .then_with(|| candidate.created_at.cmp(&existing.created_at))
+        .then_with(|| candidate.id.cmp(&existing.id))
+        .is_gt()
+}
+
+fn reduce_queue_entry_records(
+    records: Vec<QueueEntryRecord>,
+) -> BTreeMap<String, QueueEntryRecord> {
+    let mut latest = BTreeMap::<String, QueueEntryRecord>::new();
+    for record in records {
+        if latest
+            .get(&record.message_id)
+            .is_none_or(|existing| newer_queue_entry_record(&record, existing))
+        {
+            latest.insert(record.message_id.clone(), record);
+        }
+    }
+    latest
+}
+
+fn newer_queue_entry_record(candidate: &QueueEntryRecord, existing: &QueueEntryRecord) -> bool {
+    candidate
+        .updated_at
+        .cmp(&existing.updated_at)
+        .then_with(|| candidate.created_at.cmp(&existing.created_at))
+        .then_with(|| {
+            queue_entry_status_rank(&candidate.status)
+                .cmp(&queue_entry_status_rank(&existing.status))
+        })
+        .then_with(|| candidate.message_id.cmp(&existing.message_id))
+        .is_gt()
+}
+
+fn queue_entry_status_rank(status: &QueueEntryStatus) -> u8 {
+    match status {
+        QueueEntryStatus::Queued => 0,
+        QueueEntryStatus::Dequeued => 1,
+        QueueEntryStatus::Interjected => 2,
+        QueueEntryStatus::Processed => 3,
+        QueueEntryStatus::Dropped => 4,
+        QueueEntryStatus::Aborted => 5,
+    }
+}
+
+fn reduce_timer_records(records: Vec<TimerRecord>) -> BTreeMap<String, TimerRecord> {
+    let mut latest = BTreeMap::<String, TimerRecord>::new();
+    for record in records {
+        if latest
+            .get(&record.id)
+            .is_none_or(|existing| newer_timer_record(&record, existing))
+        {
+            latest.insert(record.id.clone(), record);
+        }
+    }
+    latest
+}
+
+fn newer_timer_record(candidate: &TimerRecord, existing: &TimerRecord) -> bool {
+    candidate
+        .fire_count
+        .cmp(&existing.fire_count)
+        .then_with(|| timer_updated_at(candidate).cmp(&timer_updated_at(existing)))
+        .then_with(|| candidate.created_at.cmp(&existing.created_at))
+        .then_with(|| candidate.id.cmp(&existing.id))
+        .is_gt()
+}
+
+fn timer_updated_at(record: &TimerRecord) -> DateTime<Utc> {
+    record
+        .last_fired_at
+        .or(record.next_fire_at)
+        .unwrap_or(record.created_at)
 }
 
 fn reduce_external_trigger_records(
@@ -1273,6 +1668,18 @@ fn decode_external_trigger_payload(payload: &str) -> Result<ExternalTriggerRecor
 
 fn decode_task_payload(payload: &str) -> Result<TaskRecord> {
     serde_json::from_str(payload).context("decoding task payload from runtime db")
+}
+
+fn decode_wait_condition_payload(payload: &str) -> Result<WaitConditionRecord> {
+    serde_json::from_str(payload).context("decoding wait condition payload from runtime db")
+}
+
+fn decode_queue_entry_payload(payload: &str) -> Result<QueueEntryRecord> {
+    serde_json::from_str(payload).context("decoding queue entry payload from runtime db")
+}
+
+fn decode_timer_payload(payload: &str) -> Result<TimerRecord> {
+    serde_json::from_str(payload).context("decoding timer payload from runtime db")
 }
 
 fn enum_string<T: serde::Serialize>(value: &T) -> Result<String> {
@@ -1694,6 +2101,70 @@ CREATE INDEX IF NOT EXISTS idx_artifact_metadata_work_item
   ON artifact_metadata(work_item_id);
 "#,
     },
+    Migration {
+        version: 6,
+        name: "scheduler_control_plane_current_state",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS wait_conditions (
+  wait_condition_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  work_item_id TEXT,
+  status TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  source TEXT,
+  subject_ref TEXT,
+  waiting_for TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  expires_at TEXT,
+  resolved_at TEXT,
+  cancelled_at TEXT,
+  last_turn_id TEXT,
+  payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS queue_entries (
+  message_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  priority TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS timers (
+  timer_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  summary TEXT,
+  created_at TEXT NOT NULL,
+  duration_ms INTEGER NOT NULL,
+  interval_ms INTEGER,
+  repeat INTEGER NOT NULL DEFAULT 0,
+  next_fire_at TEXT,
+  last_fired_at TEXT,
+  fire_count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_wait_conditions_agent_status
+  ON wait_conditions(agent_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_wait_conditions_work_item_status
+  ON wait_conditions(work_item_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_wait_conditions_subject
+  ON wait_conditions(kind, subject_ref);
+
+CREATE INDEX IF NOT EXISTS idx_queue_entries_agent_status
+  ON queue_entries(agent_id, status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_timers_agent_status
+  ON timers(agent_id, status, next_fire_at);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -1753,6 +2224,18 @@ impl RuntimeDb {
         ExternalTriggerRepository { db: self }
     }
 
+    pub fn wait_conditions(&self) -> WaitConditionRepository<'_> {
+        WaitConditionRepository { db: self }
+    }
+
+    pub fn queue_entries(&self) -> QueueEntryRepository<'_> {
+        QueueEntryRepository { db: self }
+    }
+
+    pub fn timers(&self) -> TimerRepository<'_> {
+        TimerRepository { db: self }
+    }
+
     pub fn evidence(&self) -> EvidenceRepository<'_> {
         EvidenceRepository { db: self }
     }
@@ -1775,6 +2258,21 @@ impl RuntimeDb {
             },
             ExpectedStorageDomain {
                 domain: "external_triggers",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+            },
+            ExpectedStorageDomain {
+                domain: "wait_conditions",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+            },
+            ExpectedStorageDomain {
+                domain: "queue_entries",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+            },
+            ExpectedStorageDomain {
+                domain: "timers",
                 canonical_source: "db",
                 legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
             },
@@ -2219,7 +2717,7 @@ mod tests {
         let connection = db.connection()?;
 
         let version = db.current_schema_version()?;
-        assert_eq!(version, 5);
+        assert_eq!(version, max_known_migration_version());
         for table in [
             "schema_migrations",
             "storage_domains",
@@ -2236,6 +2734,9 @@ mod tests {
             "briefs",
             "delivery_summaries",
             "artifact_metadata",
+            "wait_conditions",
+            "queue_entries",
+            "timers",
         ] {
             let count: i64 = connection.query_row(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
@@ -2259,8 +2760,11 @@ mod tests {
             connection.query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| {
                 row.get(0)
             })?;
-        assert_eq!(count, 5);
-        assert_eq!(current_schema_version(&connection)?, 5);
+        assert_eq!(count, max_known_migration_version());
+        assert_eq!(
+            current_schema_version(&connection)?,
+            max_known_migration_version()
+        );
         Ok(())
     }
 
@@ -2462,7 +2966,10 @@ mod tests {
         let temp_db = test_support::TempRuntimeDb::new()?;
         assert!(temp_db.db.path().ends_with("state/runtime.sqlite"));
         assert!(temp_db.db.lock_path().ends_with("state/runtime.lock"));
-        assert_eq!(temp_db.db.current_schema_version()?, 5);
+        assert_eq!(
+            temp_db.db.current_schema_version()?,
+            max_known_migration_version()
+        );
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -447,6 +447,26 @@ impl WaitConditionRepository<'_> {
             .collect()
     }
 
+    pub fn recent(&self, limit: usize) -> Result<Vec<WaitConditionRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM wait_conditions
+             ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_wait_condition_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
     pub fn active_for_agent(&self, agent_id: &str) -> Result<Vec<WaitConditionRecord>> {
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
@@ -504,7 +524,11 @@ impl QueueEntryRepository<'_> {
              LIMIT ?1",
         )?;
         let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
-        rows.map(|row| decode_queue_entry_payload(&row?)).collect()
+        let mut records: Vec<_> = rows
+            .map(|row| decode_queue_entry_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
     }
 }
 
@@ -552,7 +576,7 @@ impl TimerRepository<'_> {
         let mut statement = connection.prepare(
             "SELECT payload_json
              FROM timers
-             ORDER BY created_at DESC, timer_id ASC",
+             ORDER BY updated_at DESC, created_at DESC, timer_id ASC",
         )?;
         let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
         rows.map(|row| decode_timer_payload(&row?)).collect()
@@ -567,11 +591,15 @@ impl TimerRepository<'_> {
         let mut statement = connection.prepare(
             "SELECT payload_json
              FROM timers
-             ORDER BY created_at DESC, timer_id ASC
+             ORDER BY updated_at DESC, created_at DESC, timer_id ASC
              LIMIT ?1",
         )?;
         let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
-        rows.map(|row| decode_timer_payload(&row?)).collect()
+        let mut records: Vec<_> = rows
+            .map(|row| decode_timer_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -194,6 +194,7 @@ pub struct AppStorage {
     message_seq_counter: Arc<Mutex<u64>>,
     transcript_seq_counter: Arc<Mutex<u64>>,
     audit_event_index: Arc<Mutex<Option<AuditEventIndexSink>>>,
+    scheduler_control_plane_db: Arc<Mutex<Option<RuntimeDb>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -273,6 +274,7 @@ impl AppStorage {
             message_seq_counter: Arc::new(Mutex::new(message_seq_counter)),
             transcript_seq_counter: Arc::new(Mutex::new(transcript_seq_counter)),
             audit_event_index: Arc::new(Mutex::new(None)),
+            scheduler_control_plane_db: Arc::new(Mutex::new(None)),
             data_dir,
         })
     }
@@ -291,6 +293,23 @@ impl AppStorage {
             agent_id,
         });
         Ok(())
+    }
+
+    pub(crate) fn enable_scheduler_control_plane_db(&self, runtime_db: RuntimeDb) -> Result<()> {
+        let mut guard = self
+            .scheduler_control_plane_db
+            .lock()
+            .map_err(|_| anyhow::anyhow!("scheduler control-plane db mutex poisoned"))?;
+        *guard = Some(runtime_db);
+        Ok(())
+    }
+
+    fn scheduler_control_plane_db(&self) -> Result<Option<RuntimeDb>> {
+        Ok(self
+            .scheduler_control_plane_db
+            .lock()
+            .map_err(|_| anyhow::anyhow!("scheduler control-plane db mutex poisoned"))?
+            .clone())
     }
 
     pub fn data_dir(&self) -> &Path {
@@ -401,6 +420,9 @@ impl AppStorage {
     }
 
     pub fn append_timer(&self, timer: &TimerRecord) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.timers().upsert(timer)?;
+        }
         self.append_jsonl(&self.timers_path, timer)
     }
 
@@ -436,6 +458,9 @@ impl AppStorage {
     }
 
     pub fn append_queue_entry(&self, record: &QueueEntryRecord) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.queue_entries().upsert(record)?;
+        }
         self.append_jsonl(&self.queue_entries_path, record)
     }
 
@@ -456,6 +481,9 @@ impl AppStorage {
             .append_mutex
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.wait_conditions().upsert(&wait_condition)?;
+        }
         append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
         append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
         if let Some(event) = event.as_ref() {
@@ -472,6 +500,9 @@ impl AppStorage {
             .append_mutex
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.wait_conditions().upsert(record)?;
+        }
         append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
         if let Some(event) = event.as_ref() {
             self.append_event_with_append_mutex_held(event)?;
@@ -712,6 +743,9 @@ impl AppStorage {
     }
 
     pub fn read_recent_timers(&self, limit: usize) -> Result<Vec<TimerRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.timers().recent(limit);
+        }
         read_recent_jsonl(&self.timers_path, limit)
     }
 
@@ -736,10 +770,18 @@ impl AppStorage {
     }
 
     pub fn read_recent_wait_conditions(&self, limit: usize) -> Result<Vec<WaitConditionRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            let mut records = runtime_db.wait_conditions().latest_all()?;
+            records.truncate(limit);
+            return Ok(records);
+        }
         read_recent_jsonl(&self.wait_conditions_path, limit)
     }
 
     pub fn read_recent_queue_entries(&self, limit: usize) -> Result<Vec<QueueEntryRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.queue_entries().recent(limit);
+        }
         read_recent_jsonl(&self.queue_entries_path, limit)
     }
 
@@ -1470,6 +1512,9 @@ impl AppStorage {
     }
 
     pub fn latest_timer_record(&self, timer_id: &str) -> Result<Option<TimerRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.timers().latest(timer_id);
+        }
         read_latest_jsonl_matching(&self.timers_path, |record: &TimerRecord| {
             record.id == timer_id
         })
@@ -2234,6 +2279,113 @@ mod tests {
         assert_eq!(indexed.len(), 1);
         assert_eq!(indexed[0].kind, "live_event");
         assert_eq!(indexed[0].event_seq, 1);
+    }
+
+    #[test]
+    fn scheduler_control_plane_storage_uses_runtime_db_after_cutover() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        runtime_db
+            .wait_conditions()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db
+            .queue_entries()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db.timers().import_legacy(Vec::new()).unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+
+        let now = Utc::now();
+        let wait_condition = WaitConditionRecord {
+            id: "wait-1".into(),
+            agent_id: "default".into(),
+            work_item_id: Some("work-1".into()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pr-1".into()),
+            waiting_for: "checks passed".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-1".into()),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        };
+        let queue_entry = QueueEntryRecord {
+            message_id: "msg-1".into(),
+            agent_id: "default".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        let timer = TimerRecord {
+            id: "timer-1".into(),
+            agent_id: "default".into(),
+            created_at: now,
+            duration_ms: 1000,
+            interval_ms: None,
+            repeat: false,
+            status: crate::types::TimerStatus::Active,
+            summary: Some("wake later".into()),
+            next_fire_at: Some(now + chrono::Duration::seconds(1)),
+            last_fired_at: None,
+            fire_count: 0,
+        };
+
+        storage.append_wait_condition(&wait_condition).unwrap();
+        storage.append_queue_entry(&queue_entry).unwrap();
+        storage.append_timer(&timer).unwrap();
+
+        assert!(fs::read_to_string(&storage.wait_conditions_path)
+            .unwrap()
+            .contains("\"wait-1\""));
+        assert!(fs::read_to_string(&storage.queue_entries_path)
+            .unwrap()
+            .contains("\"msg-1\""));
+        assert!(fs::read_to_string(&storage.timers_path)
+            .unwrap()
+            .contains("\"timer-1\""));
+
+        fs::write(
+            &storage.wait_conditions_path,
+            "{jsonl compat ignored after db cutover}\n",
+        )
+        .unwrap();
+        fs::write(
+            &storage.queue_entries_path,
+            "{jsonl compat ignored after db cutover}\n",
+        )
+        .unwrap();
+        fs::write(
+            &storage.timers_path,
+            "{jsonl compat ignored after db cutover}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            storage.latest_wait_conditions().unwrap(),
+            vec![wait_condition]
+        );
+        assert_eq!(storage.latest_queue_entries().unwrap(), vec![queue_entry]);
+        assert_eq!(
+            storage.latest_timer_record("timer-1").unwrap(),
+            Some(timer.clone())
+        );
+        assert_eq!(storage.latest_timer_records().unwrap(), vec![timer]);
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -771,9 +771,7 @@ impl AppStorage {
 
     pub fn read_recent_wait_conditions(&self, limit: usize) -> Result<Vec<WaitConditionRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            let mut records = runtime_db.wait_conditions().latest_all()?;
-            records.truncate(limit);
-            return Ok(records);
+            return runtime_db.wait_conditions().recent(limit);
         }
         read_recent_jsonl(&self.wait_conditions_path, limit)
     }
@@ -2350,6 +2348,37 @@ mod tests {
         storage.append_queue_entry(&queue_entry).unwrap();
         storage.append_timer(&timer).unwrap();
 
+        let mut later_wait_condition = wait_condition.clone();
+        later_wait_condition.id = "wait-2".into();
+        later_wait_condition.updated_at = now + chrono::Duration::seconds(1);
+        let mut latest_wait_condition = wait_condition.clone();
+        latest_wait_condition.id = "wait-3".into();
+        latest_wait_condition.updated_at = now + chrono::Duration::seconds(2);
+        storage
+            .append_wait_condition(&later_wait_condition)
+            .unwrap();
+        storage
+            .append_wait_condition(&latest_wait_condition)
+            .unwrap();
+
+        let mut later_queue_entry = queue_entry.clone();
+        later_queue_entry.message_id = "msg-2".into();
+        later_queue_entry.updated_at = now + chrono::Duration::seconds(1);
+        let mut latest_queue_entry = queue_entry.clone();
+        latest_queue_entry.message_id = "msg-3".into();
+        latest_queue_entry.updated_at = now + chrono::Duration::seconds(2);
+        storage.append_queue_entry(&later_queue_entry).unwrap();
+        storage.append_queue_entry(&latest_queue_entry).unwrap();
+
+        let mut later_timer = timer.clone();
+        later_timer.id = "timer-2".into();
+        later_timer.next_fire_at = Some(now + chrono::Duration::seconds(2));
+        let mut latest_timer = timer.clone();
+        latest_timer.id = "timer-3".into();
+        latest_timer.next_fire_at = Some(now + chrono::Duration::seconds(3));
+        storage.append_timer(&later_timer).unwrap();
+        storage.append_timer(&latest_timer).unwrap();
+
         assert!(fs::read_to_string(&storage.wait_conditions_path)
             .unwrap()
             .contains("\"wait-1\""));
@@ -2378,14 +2407,51 @@ mod tests {
 
         assert_eq!(
             storage.latest_wait_conditions().unwrap(),
-            vec![wait_condition]
+            vec![
+                wait_condition.clone(),
+                later_wait_condition,
+                latest_wait_condition
+            ]
         );
-        assert_eq!(storage.latest_queue_entries().unwrap(), vec![queue_entry]);
+        assert_eq!(
+            storage.latest_queue_entries().unwrap(),
+            vec![queue_entry.clone(), later_queue_entry, latest_queue_entry]
+        );
         assert_eq!(
             storage.latest_timer_record("timer-1").unwrap(),
             Some(timer.clone())
         );
-        assert_eq!(storage.latest_timer_records().unwrap(), vec![timer]);
+        assert_eq!(
+            storage.latest_timer_records().unwrap(),
+            vec![timer, later_timer, latest_timer]
+        );
+        assert_eq!(
+            storage
+                .read_recent_wait_conditions(2)
+                .unwrap()
+                .into_iter()
+                .map(|record| record.id)
+                .collect::<Vec<_>>(),
+            vec!["wait-2", "wait-3"]
+        );
+        assert_eq!(
+            storage
+                .read_recent_queue_entries(2)
+                .unwrap()
+                .into_iter()
+                .map(|record| record.message_id)
+                .collect::<Vec<_>>(),
+            vec!["msg-2", "msg-3"]
+        );
+        assert_eq!(
+            storage
+                .read_recent_timers(2)
+                .unwrap()
+                .into_iter()
+                .map(|record| record.id)
+                .collect::<Vec<_>>(),
+            vec!["timer-2", "timer-3"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1601.

Migrates the remaining scheduler control-plane records to Runtime DB as the canonical post-cutover source:

- adds Runtime DB schema/repositories/import paths for `wait_conditions`, `queue_entries`, and `timers`
- switches scheduler storage writes and projection reads to DB-backed paths after cutover
- imports legacy JSONL scheduler records during runtime bootstrap before enabling DB-backed scheduler storage
- declares the scheduler domains in cutover diagnostics/expected storage domains
- adds focused coverage for legacy import and post-cutover DB canonical reads

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test scheduler_control_plane_storage_uses_runtime_db_after_cutover --lib`
- `cargo test runtime_db --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
