### PR TITLE
fix: add pre-server runtime preparation phase

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7,7 +7,7 @@ mod tests;
 
 pub use lifecycle::{
     daemon_restart, daemon_start, daemon_status, daemon_stop, ensure_serve_preflight,
-    graceful_runtime_shutdown,
+    graceful_runtime_shutdown, prepare_runtime_before_server,
 };
 pub(crate) use service::runtime_activity_message;
 pub use service::{

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7,7 +7,7 @@ mod tests;
 
 pub use lifecycle::{
     daemon_restart, daemon_start, daemon_status, daemon_stop, ensure_serve_preflight,
-    graceful_runtime_shutdown, prepare_runtime_before_server,
+    graceful_runtime_shutdown, prepare_runtime_before_server, PRE_SERVER_PREPARED_ENV,
 };
 pub(crate) use service::runtime_activity_message;
 pub use service::{

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -33,6 +33,7 @@ const START_TIMEOUT: Duration = Duration::from_secs(10);
 const START_STABILITY_WINDOW: Duration = Duration::from_secs(2);
 const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+pub const PRE_SERVER_PREPARED_ENV: &str = "HOLON_PRE_SERVER_RUNTIME_PREPARED";
 const UNIX_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[cfg(test)]
@@ -190,6 +191,7 @@ pub async fn daemon_start(
     if let Some(token) = control_token_env {
         command.env("HOLON_CONTROL_TOKEN", token);
     }
+    command.env(PRE_SERVER_PREPARED_ENV, "1");
     let mut child = command.spawn().context("failed to spawn 'holon serve'")?;
 
     let deadline = tokio::time::Instant::now() + START_TIMEOUT;

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
+use tracing::info;
 
 #[cfg(unix)]
 use std::{io::ErrorKind, os::unix::fs::FileTypeExt};
@@ -33,6 +34,11 @@ const START_STABILITY_WINDOW: Duration = Duration::from_secs(2);
 const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const UNIX_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[cfg(test)]
+static PREPARE_RUNTIME_BEFORE_SERVER_HOOK: std::sync::Mutex<
+    Option<Box<dyn Fn(&AppConfig) -> Result<()> + Send + Sync>>,
+> = std::sync::Mutex::new(None);
 
 pub async fn daemon_status(config: &AppConfig) -> Result<DaemonStatusView> {
     let fingerprint = config_fingerprint(config)?;
@@ -162,6 +168,7 @@ pub async fn daemon_start(
     cleanup_daemon_state(config)?;
     fs::create_dir_all(config.run_dir())
         .with_context(|| format!("failed to create {}", config.run_dir().display()))?;
+    prepare_runtime_before_server(config)?;
 
     let log_path = daemon_paths(config).log_path;
     let log = fs::OpenOptions::new()
@@ -301,6 +308,39 @@ pub async fn daemon_start(
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
+
+pub fn prepare_runtime_before_server(config: &AppConfig) -> Result<()> {
+    info!(
+        home_dir = %config.home_dir.display(),
+        "starting pre-server runtime preparation"
+    );
+    #[cfg(test)]
+    if let Some(hook) = PREPARE_RUNTIME_BEFORE_SERVER_HOOK.lock().unwrap().as_ref() {
+        hook(config).with_context(|| {
+            "pre-server runtime preparation failed; fix the reported storage domain error and retry"
+        })?;
+        info!(
+            home_dir = %config.home_dir.display(),
+            "finished pre-server runtime preparation"
+        );
+        return Ok(());
+    }
+    RuntimeHost::prepare_runtime_storage(config).with_context(|| {
+        "pre-server runtime preparation failed; fix the reported storage domain error and retry"
+    })?;
+    info!(
+        home_dir = %config.home_dir.display(),
+        "finished pre-server runtime preparation"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn set_prepare_runtime_before_server_hook(
+    hook: Option<Box<dyn Fn(&AppConfig) -> Result<()> + Send + Sync>>,
+) {
+    *PREPARE_RUNTIME_BEFORE_SERVER_HOOK.lock().unwrap() = hook;
 }
 
 pub async fn daemon_stop(config: &AppConfig) -> Result<DaemonLifecycleResult> {

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -32,6 +32,21 @@ use tempfile::tempdir;
 
 static PREPARE_HOOK_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+struct PrepareHookGuard;
+
+impl Drop for PrepareHookGuard {
+    fn drop(&mut self) {
+        set_prepare_runtime_before_server_hook(None);
+    }
+}
+
+fn set_prepare_hook(
+    hook: impl Fn(&AppConfig) -> anyhow::Result<()> + Send + Sync + 'static,
+) -> PrepareHookGuard {
+    set_prepare_runtime_before_server_hook(Some(Box::new(hook)));
+    PrepareHookGuard
+}
+
 fn test_config() -> AppConfig {
     let home = tempdir().unwrap();
     let workspace = tempdir().unwrap();
@@ -569,17 +584,16 @@ fn daemon_start_runs_preparation_before_readiness_timeout_window() {
     let config = test_config();
     let calls = Arc::new(AtomicUsize::new(0));
     let hook_calls = calls.clone();
-    set_prepare_runtime_before_server_hook(Some(Box::new(move |_config| {
+    let _hook_guard = set_prepare_hook(move |_config| {
         hook_calls.fetch_add(1, Ordering::SeqCst);
         anyhow::bail!("test preparation domain failed")
-    })));
+    });
 
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let err = runtime
         .block_on(daemon_start(&config, &[], None))
         .unwrap_err()
         .to_string();
-    set_prepare_runtime_before_server_hook(None);
 
     assert_eq!(calls.load(Ordering::SeqCst), 1);
     assert!(err.contains("pre-server runtime preparation failed"));
@@ -595,19 +609,18 @@ fn pre_server_preparation_failure_is_retryable() {
     let config = test_config();
     let attempts = Arc::new(AtomicUsize::new(0));
     let hook_attempts = attempts.clone();
-    set_prepare_runtime_before_server_hook(Some(Box::new(move |_config| {
+    let _hook_guard = set_prepare_hook(move |_config| {
         let attempt = hook_attempts.fetch_add(1, Ordering::SeqCst);
         if attempt == 0 {
             anyhow::bail!("test storage domain incomplete")
         }
         Ok(())
-    })));
+    });
 
     let first = prepare_runtime_before_server(&config)
         .unwrap_err()
         .to_string();
     let second = prepare_runtime_before_server(&config);
-    set_prepare_runtime_before_server_hook(None);
 
     assert!(first.contains("pre-server runtime preparation failed"));
     second.unwrap();

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -1,16 +1,17 @@
 use super::lifecycle::{
     effective_config_mismatch_summary, probe_runtime, runtime_status_matches_metadata,
-    should_retry_startup_stability_probe, wait_for_startup_stability_with_probe, ProbeRuntime,
+    set_prepare_runtime_before_server_hook, should_retry_startup_stability_probe,
+    wait_for_startup_stability_with_probe, ProbeRuntime,
 };
 use super::state::{
     persist_last_runtime_failure, DAEMON_LOG_TAIL_LINE_CHAR_LIMIT, DAEMON_LOG_TAIL_READ_BYTE_LIMIT,
 };
 use super::{
     clear_persisted_daemon_lifecycle_failures, config_fingerprint, daemon_log_hint, daemon_logs,
-    daemon_paths, daemon_status, daemon_stop, ensure_serve_preflight, load_last_runtime_failure,
-    persist_daemon_lifecycle_failure, runtime_activity_summary, DaemonLifecycleState,
-    RuntimeActivityState, RuntimeConfigSurface, RuntimeControlAuthMode, RuntimeServiceMetadata,
-    RuntimeStartupSurface, RuntimeStatusResponse,
+    daemon_paths, daemon_start, daemon_status, daemon_stop, ensure_serve_preflight,
+    load_last_runtime_failure, persist_daemon_lifecycle_failure, prepare_runtime_before_server,
+    runtime_activity_summary, DaemonLifecycleState, RuntimeActivityState, RuntimeConfigSurface,
+    RuntimeControlAuthMode, RuntimeServiceMetadata, RuntimeStartupSurface, RuntimeStatusResponse,
 };
 use crate::config::{provider_registry_for_tests, AppConfig, ModelRef, ProviderId};
 use crate::{
@@ -19,8 +20,17 @@ use crate::{
     types::{AuthorityClass, CommandTaskSpec, RuntimeFailurePhase, RuntimeFailureSummary},
 };
 use chrono::Utc;
-use std::{fs, process::Command, sync::Arc};
+use std::{
+    fs,
+    process::Command,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 use tempfile::tempdir;
+
+static PREPARE_HOOK_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn test_config() -> AppConfig {
     let home = tempdir().unwrap();
@@ -549,6 +559,59 @@ async fn serve_preflight_cleans_dead_pid_and_leftover_socket_state() {
     assert!(!paths.pid_path.exists());
     assert!(!paths.metadata_path.exists());
     assert!(!paths.socket_path.exists());
+}
+
+#[test]
+fn daemon_start_runs_preparation_before_readiness_timeout_window() {
+    let _guard = PREPARE_HOOK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let config = test_config();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let hook_calls = calls.clone();
+    set_prepare_runtime_before_server_hook(Some(Box::new(move |_config| {
+        hook_calls.fetch_add(1, Ordering::SeqCst);
+        anyhow::bail!("test preparation domain failed")
+    })));
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let err = runtime
+        .block_on(daemon_start(&config, &[], None))
+        .unwrap_err()
+        .to_string();
+    set_prepare_runtime_before_server_hook(None);
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(err.contains("pre-server runtime preparation failed"));
+    assert!(!err.contains("timed out waiting for runtime"));
+    assert!(!daemon_paths(&config).log_path.exists());
+}
+
+#[test]
+fn pre_server_preparation_failure_is_retryable() {
+    let _guard = PREPARE_HOOK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let config = test_config();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let hook_attempts = attempts.clone();
+    set_prepare_runtime_before_server_hook(Some(Box::new(move |_config| {
+        let attempt = hook_attempts.fetch_add(1, Ordering::SeqCst);
+        if attempt == 0 {
+            anyhow::bail!("test storage domain incomplete")
+        }
+        Ok(())
+    })));
+
+    let first = prepare_runtime_before_server(&config)
+        .unwrap_err()
+        .to_string();
+    let second = prepare_runtime_before_server(&config);
+    set_prepare_runtime_before_server_hook(None);
+
+    assert!(first.contains("pre-server runtime preparation failed"));
+    second.unwrap();
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
 }
 
 #[cfg(unix)]

--- a/src/host.rs
+++ b/src/host.rs
@@ -149,6 +149,17 @@ async fn apply_spawn_model_resolution(
 }
 
 impl RuntimeHost {
+    pub fn prepare_runtime_storage(config: &AppConfig) -> Result<()> {
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+        RuntimeHandle::prepare_runtime_storage(
+            config.default_agent_id.clone(),
+            config.agent_root_dir().join(&config.default_agent_id),
+            InitialWorkspaceBinding::Detached,
+            runtime_db,
+        )
+    }
+
     pub fn new(config: AppConfig) -> Result<Self> {
         let _ = build_provider_from_config(&config)?;
         Self::new_inner(config, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use holon::{
     daemon::{
         daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
         ensure_serve_preflight, prepare_runtime_before_server, RuntimeServiceHandle,
+        PRE_SERVER_PREPARED_ENV,
     },
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
@@ -614,7 +615,9 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
         apply_nofile_limit_policy(DEFAULT_NOFILE_TARGET).startup_summary()
     );
     ensure_serve_preflight(&config).await?;
-    prepare_runtime_before_server(&config)?;
+    if std::env::var_os(PRE_SERVER_PREPARED_ENV).is_none() {
+        prepare_runtime_before_server(&config)?;
+    }
 
     let host = RuntimeHost::new(config.clone())?;
     host.default_runtime().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use holon::{
     },
     daemon::{
         daemon_logs, daemon_restart, daemon_start, daemon_status, daemon_stop,
-        ensure_serve_preflight, RuntimeServiceHandle,
+        ensure_serve_preflight, prepare_runtime_before_server, RuntimeServiceHandle,
     },
     fd_limit::{apply_nofile_limit_policy, DEFAULT_NOFILE_TARGET},
     host::RuntimeHost,
@@ -614,6 +614,7 @@ async fn serve(mut config: AppConfig, options: ServeOptions) -> Result<()> {
         apply_nofile_limit_policy(DEFAULT_NOFILE_TARGET).startup_summary()
     );
     ensure_serve_preflight(&config).await?;
+    prepare_runtime_before_server(&config)?;
 
     let host = RuntimeHost::new(config.clone())?;
     host.default_runtime().await?;

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -36,6 +36,16 @@ pub(super) struct ProviderReconfigurator {
 }
 
 impl RuntimeHandle {
+    pub(crate) fn prepare_runtime_storage(
+        agent_id: impl Into<String>,
+        data_dir: PathBuf,
+        initial_workspace: impl Into<InitialWorkspaceBinding>,
+        runtime_db: RuntimeDb,
+    ) -> Result<()> {
+        let _ = prepare_runtime_storage(agent_id, data_dir, initial_workspace, Some(runtime_db))?;
+        Ok(())
+    }
+
     pub fn new(
         agent_id: impl Into<String>,
         data_dir: PathBuf,
@@ -160,141 +170,14 @@ impl RuntimeHandle {
         host_bridge: Option<RuntimeHostBridge>,
     ) -> Result<Self> {
         let mut provider = provider;
-        let storage = AppStorage::new(data_dir)?;
-        let runtime_db = match runtime_db {
-            Some(runtime_db) => runtime_db,
-            None => RuntimeDb::open_and_migrate(
-                storage.runtime_dir().join("state/runtime.sqlite"),
-                storage.runtime_dir().join("state/runtime.lock"),
-            )?,
-        };
-        let agent_id = agent_id.into();
-        let initial_workspace = initial_workspace.into();
-        let initial_workspace_entry = match &initial_workspace {
-            InitialWorkspaceBinding::Entry(entry) => Some(entry.clone()),
-            InitialWorkspaceBinding::Anchor(anchor) => Some(crate::types::WorkspaceEntry::new(
-                crate::ids::workspace_id(),
-                anchor.clone(),
-                anchor
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .map(ToString::to_string),
-            )),
-            InitialWorkspaceBinding::Detached => Some(workspace::agent_home_workspace_entry(
-                storage.data_dir(),
-                &agent_id,
-            )),
-        };
-
-        if let Some(workspace) = initial_workspace_entry.as_ref() {
-            let known = storage.latest_workspace_entries()?;
-            if !known
-                .iter()
-                .any(|entry| entry.workspace_id == workspace.workspace_id)
-            {
-                storage.append_workspace_entry(workspace)?;
-            }
-        }
-
-        let snapshot = storage.recovery_snapshot()?;
-        let mut queue = RuntimeQueue::default();
-        for message in &snapshot.replay_messages {
-            queue.push(message.clone());
-        }
-        let recovered_agent = snapshot.agent;
-        let recovered_from_storage = recovered_agent.is_some();
-        let mut state = recovered_agent.unwrap_or_else(|| AgentState::new(agent_id.clone()));
-
-        if state.attached_workspaces.is_empty() {
-            if let Some(workspace) = initial_workspace_entry.as_ref() {
-                let should_seed_initial_binding = !recovered_from_storage
-                    || state
-                        .active_workspace_entry
-                        .as_ref()
-                        .is_some_and(|entry| entry.workspace_id == workspace.workspace_id);
-                if should_seed_initial_binding {
-                    state
-                        .attached_workspaces
-                        .push(workspace.workspace_id.clone());
-                }
-            }
-        }
-
-        if state.active_workspace_entry.is_none() {
-            if let Some(workspace) = initial_workspace_entry.as_ref() {
-                state.active_workspace_entry = Some(ActiveWorkspaceEntry {
-                    workspace_id: workspace.workspace_id.clone(),
-                    workspace_anchor: workspace.workspace_anchor.clone(),
-                    execution_root_id: workspace::build_execution_root_id(
-                        &workspace.workspace_id,
-                        WorkspaceProjectionKind::CanonicalRoot,
-                        &workspace.workspace_anchor,
-                    )?,
-                    execution_root: workspace.workspace_anchor.clone(),
-                    projection_kind: WorkspaceProjectionKind::CanonicalRoot,
-                    access_mode: WorkspaceAccessMode::ExclusiveWrite,
-                    cwd: workspace.workspace_anchor.clone(),
-                    occupancy_id: None,
-                    projection_metadata: None,
-                });
-            }
-        }
-
-        if state
-            .worktree_session
-            .as_ref()
-            .is_some_and(|worktree| !worktree.worktree_path.exists())
-        {
-            storage.append_event(&AuditEvent::new(
-                "recovery_cleared_missing_worktree_session",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "worktree_path": state
-                        .worktree_session
-                        .as_ref()
-                        .map(|w| w.worktree_path.display().to_string()),
-                    "reason": "worktree_path_does_not_exist"
-                }),
-            ))?;
-            state.worktree_session = None;
-            if state.active_workspace_entry.as_ref().is_some_and(|entry| {
-                entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot
-            }) {
-                let data_dir = storage.data_dir();
-                let workspace_entry = workspace::agent_home_workspace_entry(&data_dir, &agent_id);
-                let kind = WorkspaceProjectionKind::CanonicalRoot;
-                state.active_workspace_entry = Some(ActiveWorkspaceEntry {
-                    workspace_id: workspace_entry.workspace_id.clone(),
-                    workspace_anchor: workspace_entry.workspace_anchor.clone(),
-                    execution_root_id: workspace::build_execution_root_id(
-                        &workspace_entry.workspace_id,
-                        kind,
-                        &workspace_entry.workspace_anchor,
-                    )?,
-                    execution_root: workspace_entry.workspace_anchor.clone(),
-                    projection_kind: kind,
-                    access_mode: WorkspaceAccessMode::ExclusiveWrite,
-                    cwd: workspace_entry.workspace_anchor.clone(),
-                    occupancy_id: None,
-                    projection_metadata: None,
-                });
-            }
-        }
-
-        state
-            .active_skills
-            .retain(|skill| matches!(skill.activation_state, SkillActivationState::SessionActive));
-        for skill in &mut state.active_skills {
-            skill.activation_source = SkillActivationSource::Restored;
-        }
-        state.pending = queue.len();
-        state.total_message_count = storage.count_messages().unwrap_or_default();
-        scheduler_executor::apply_bootstrap_recovered_projection(
-            &mut state,
-            scheduler_executor::BootstrapRecoveryFacts {
-                queued_messages: queue.len(),
-            },
-        );
+        let PreparedRuntimeStorage {
+            storage,
+            runtime_db,
+            state,
+            queue,
+            active_tasks,
+            active_timers,
+        } = prepare_runtime_storage(agent_id, data_dir, initial_workspace, runtime_db)?;
 
         if let Some(reconfig) = provider_reconfig.as_ref() {
             let chain = model_catalog.provider_chain_for_turn(
@@ -307,45 +190,6 @@ impl RuntimeHandle {
                 .runtime_max_output_tokens;
             provider = build_provider_from_model_chain(&provider_config, &chain)?;
         }
-        storage.write_agent(&state)?;
-        let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
-        for record in &mut legacy_work_items {
-            crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
-        }
-        runtime_db
-            .work_items()
-            .import_legacy(legacy_work_items, state.current_work_item_id.as_deref())?;
-        runtime_db
-            .tasks()
-            .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
-        runtime_db
-            .external_triggers()
-            .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
-        runtime_db
-            .wait_conditions()
-            .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
-        runtime_db
-            .queue_entries()
-            .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
-        runtime_db
-            .timers()
-            .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
-        runtime_db.evidence().import_legacy(
-            storage.read_all_message_values()?,
-            storage.read_all_transcript()?,
-            storage.read_recent_tool_executions(usize::MAX)?,
-            storage.read_recent_briefs(usize::MAX)?,
-            storage.read_recent_delivery_summaries(usize::MAX)?,
-        )?;
-        runtime_db
-            .audit_events()
-            .import_legacy(Some(&state.id), storage.read_recent_events(usize::MAX)?)?;
-        runtime_db.validate_expected_storage_domains(
-            crate::runtime_db::RuntimeDb::expected_storage_domains(),
-        )?;
-        storage.enable_audit_event_index(runtime_db.clone(), Some(state.id.clone()))?;
-        storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
-
         let resolved_context_config = if provider_reconfig.is_some() {
             model_catalog
                 .resolved_context_config(&base_context_config, state.model_override.as_ref())
@@ -379,8 +223,8 @@ impl RuntimeHandle {
                 default_agent_id,
                 host_bridge,
                 task_handles: Mutex::new(HashMap::new()),
-                recovered_tasks: Mutex::new(Some(snapshot.active_tasks)),
-                recovered_timers: Mutex::new(Some(snapshot.active_timers)),
+                recovered_tasks: Mutex::new(Some(active_tasks)),
+                recovered_timers: Mutex::new(Some(active_timers)),
                 suppress_next_continue_active_tick: Mutex::new(false),
                 shutdown_requested: AtomicBool::new(false),
             }),
@@ -544,4 +388,205 @@ impl RuntimeHandle {
             .as_ref()
             .map(|reconfig| reconfig.config.clone())
     }
+}
+
+struct PreparedRuntimeStorage {
+    storage: AppStorage,
+    runtime_db: RuntimeDb,
+    state: AgentState,
+    queue: RuntimeQueue,
+    active_tasks: Vec<crate::types::TaskRecord>,
+    active_timers: Vec<crate::types::TimerRecord>,
+}
+
+fn prepare_runtime_storage(
+    agent_id: impl Into<String>,
+    data_dir: PathBuf,
+    initial_workspace: impl Into<InitialWorkspaceBinding>,
+    runtime_db: Option<RuntimeDb>,
+) -> Result<PreparedRuntimeStorage> {
+    let storage = AppStorage::new(data_dir)?;
+    let runtime_db = match runtime_db {
+        Some(runtime_db) => runtime_db,
+        None => RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )?,
+    };
+    let agent_id = agent_id.into();
+    let initial_workspace = initial_workspace.into();
+    let initial_workspace_entry = match &initial_workspace {
+        InitialWorkspaceBinding::Entry(entry) => Some(entry.clone()),
+        InitialWorkspaceBinding::Anchor(anchor) => Some(crate::types::WorkspaceEntry::new(
+            crate::ids::workspace_id(),
+            anchor.clone(),
+            anchor
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(ToString::to_string),
+        )),
+        InitialWorkspaceBinding::Detached => Some(workspace::agent_home_workspace_entry(
+            storage.data_dir(),
+            &agent_id,
+        )),
+    };
+
+    if let Some(workspace) = initial_workspace_entry.as_ref() {
+        let known = storage.latest_workspace_entries()?;
+        if !known
+            .iter()
+            .any(|entry| entry.workspace_id == workspace.workspace_id)
+        {
+            storage.append_workspace_entry(workspace)?;
+        }
+    }
+
+    let snapshot = storage.recovery_snapshot()?;
+    let mut queue = RuntimeQueue::default();
+    for message in &snapshot.replay_messages {
+        queue.push(message.clone());
+    }
+    let recovered_agent = snapshot.agent;
+    let recovered_from_storage = recovered_agent.is_some();
+    let mut state = recovered_agent.unwrap_or_else(|| AgentState::new(agent_id.clone()));
+
+    if state.attached_workspaces.is_empty() {
+        if let Some(workspace) = initial_workspace_entry.as_ref() {
+            let should_seed_initial_binding = !recovered_from_storage
+                || state
+                    .active_workspace_entry
+                    .as_ref()
+                    .is_some_and(|entry| entry.workspace_id == workspace.workspace_id);
+            if should_seed_initial_binding {
+                state
+                    .attached_workspaces
+                    .push(workspace.workspace_id.clone());
+            }
+        }
+    }
+
+    if state.active_workspace_entry.is_none() {
+        if let Some(workspace) = initial_workspace_entry.as_ref() {
+            state.active_workspace_entry = Some(ActiveWorkspaceEntry {
+                workspace_id: workspace.workspace_id.clone(),
+                workspace_anchor: workspace.workspace_anchor.clone(),
+                execution_root_id: workspace::build_execution_root_id(
+                    &workspace.workspace_id,
+                    WorkspaceProjectionKind::CanonicalRoot,
+                    &workspace.workspace_anchor,
+                )?,
+                execution_root: workspace.workspace_anchor.clone(),
+                projection_kind: WorkspaceProjectionKind::CanonicalRoot,
+                access_mode: WorkspaceAccessMode::ExclusiveWrite,
+                cwd: workspace.workspace_anchor.clone(),
+                occupancy_id: None,
+                projection_metadata: None,
+            });
+        }
+    }
+
+    if state
+        .worktree_session
+        .as_ref()
+        .is_some_and(|worktree| !worktree.worktree_path.exists())
+    {
+        storage.append_event(&AuditEvent::new(
+            "recovery_cleared_missing_worktree_session",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "worktree_path": state
+                    .worktree_session
+                    .as_ref()
+                    .map(|w| w.worktree_path.display().to_string()),
+                "reason": "worktree_path_does_not_exist"
+            }),
+        ))?;
+        state.worktree_session = None;
+        if state
+            .active_workspace_entry
+            .as_ref()
+            .is_some_and(|entry| entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot)
+        {
+            let data_dir = storage.data_dir();
+            let workspace_entry = workspace::agent_home_workspace_entry(&data_dir, &agent_id);
+            let kind = WorkspaceProjectionKind::CanonicalRoot;
+            state.active_workspace_entry = Some(ActiveWorkspaceEntry {
+                workspace_id: workspace_entry.workspace_id.clone(),
+                workspace_anchor: workspace_entry.workspace_anchor.clone(),
+                execution_root_id: workspace::build_execution_root_id(
+                    &workspace_entry.workspace_id,
+                    kind,
+                    &workspace_entry.workspace_anchor,
+                )?,
+                execution_root: workspace_entry.workspace_anchor.clone(),
+                projection_kind: kind,
+                access_mode: WorkspaceAccessMode::ExclusiveWrite,
+                cwd: workspace_entry.workspace_anchor.clone(),
+                occupancy_id: None,
+                projection_metadata: None,
+            });
+        }
+    }
+
+    state
+        .active_skills
+        .retain(|skill| matches!(skill.activation_state, SkillActivationState::SessionActive));
+    for skill in &mut state.active_skills {
+        skill.activation_source = SkillActivationSource::Restored;
+    }
+    state.pending = queue.len();
+    state.total_message_count = storage.count_messages().unwrap_or_default();
+    scheduler_executor::apply_bootstrap_recovered_projection(
+        &mut state,
+        scheduler_executor::BootstrapRecoveryFacts {
+            queued_messages: queue.len(),
+        },
+    );
+    storage.write_agent(&state)?;
+    let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
+    for record in &mut legacy_work_items {
+        crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
+    }
+    runtime_db
+        .work_items()
+        .import_legacy(legacy_work_items, state.current_work_item_id.as_deref())?;
+    runtime_db
+        .tasks()
+        .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
+    runtime_db
+        .external_triggers()
+        .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
+    runtime_db
+        .wait_conditions()
+        .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
+    runtime_db
+        .queue_entries()
+        .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
+    runtime_db
+        .timers()
+        .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
+    runtime_db.evidence().import_legacy(
+        storage.read_all_message_values()?,
+        storage.read_all_transcript()?,
+        storage.read_recent_tool_executions(usize::MAX)?,
+        storage.read_recent_briefs(usize::MAX)?,
+        storage.read_recent_delivery_summaries(usize::MAX)?,
+    )?;
+    runtime_db
+        .audit_events()
+        .import_legacy(Some(&state.id), storage.read_recent_events(usize::MAX)?)?;
+    runtime_db.validate_expected_storage_domains(
+        crate::runtime_db::RuntimeDb::expected_storage_domains(),
+    )?;
+    storage.enable_audit_event_index(runtime_db.clone(), Some(state.id.clone()))?;
+    storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
+
+    Ok(PreparedRuntimeStorage {
+        storage,
+        runtime_db,
+        state,
+        queue,
+        active_tasks: snapshot.active_tasks,
+        active_timers: snapshot.active_timers,
+    })
 }

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -543,38 +543,54 @@ fn prepare_runtime_storage(
         },
     );
     storage.write_agent(&state)?;
-    let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
-    for record in &mut legacy_work_items {
-        crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
+    if !storage_domain_complete(&runtime_db, "work_items")? {
+        let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
+        for record in &mut legacy_work_items {
+            crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
+        }
+        runtime_db
+            .work_items()
+            .import_legacy(legacy_work_items, state.current_work_item_id.as_deref())?;
     }
-    runtime_db
-        .work_items()
-        .import_legacy(legacy_work_items, state.current_work_item_id.as_deref())?;
-    runtime_db
-        .tasks()
-        .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
-    runtime_db
-        .external_triggers()
-        .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
-    runtime_db
-        .wait_conditions()
-        .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
-    runtime_db
-        .queue_entries()
-        .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
-    runtime_db
-        .timers()
-        .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
-    runtime_db.evidence().import_legacy(
-        storage.read_all_message_values()?,
-        storage.read_all_transcript()?,
-        storage.read_recent_tool_executions(usize::MAX)?,
-        storage.read_recent_briefs(usize::MAX)?,
-        storage.read_recent_delivery_summaries(usize::MAX)?,
-    )?;
-    runtime_db
-        .audit_events()
-        .import_legacy(Some(&state.id), storage.read_recent_events(usize::MAX)?)?;
+    if !storage_domain_complete(&runtime_db, "tasks")? {
+        runtime_db
+            .tasks()
+            .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "external_triggers")? {
+        runtime_db
+            .external_triggers()
+            .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "wait_conditions")? {
+        runtime_db
+            .wait_conditions()
+            .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "queue_entries")? {
+        runtime_db
+            .queue_entries()
+            .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "timers")? {
+        runtime_db
+            .timers()
+            .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "evidence")? {
+        runtime_db.evidence().import_legacy(
+            storage.read_all_message_values()?,
+            storage.read_all_transcript()?,
+            storage.read_recent_tool_executions(usize::MAX)?,
+            storage.read_recent_briefs(usize::MAX)?,
+            storage.read_recent_delivery_summaries(usize::MAX)?,
+        )?;
+    }
+    if !storage_domain_complete(&runtime_db, "audit_events")? {
+        runtime_db
+            .audit_events()
+            .import_legacy(Some(&state.id), storage.read_recent_events(usize::MAX)?)?;
+    }
     runtime_db.validate_expected_storage_domains(
         crate::runtime_db::RuntimeDb::expected_storage_domains(),
     )?;
@@ -589,4 +605,12 @@ fn prepare_runtime_storage(
         active_tasks: snapshot.active_tasks,
         active_timers: snapshot.active_timers,
     })
+}
+
+fn storage_domain_complete(runtime_db: &RuntimeDb, domain: &str) -> Result<bool> {
+    let expected = RuntimeDb::expected_storage_domains()
+        .iter()
+        .find(|expected| expected.domain == domain)
+        .ok_or_else(|| anyhow!("unknown runtime storage domain {domain}"))?;
+    runtime_db.storage_domain_is_complete(expected.domain, expected.canonical_source)
 }

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -2425,7 +2425,11 @@ impl RuntimeDb {
         )
     }
 
-    fn storage_domain_is_complete(&self, domain: &str, canonical_source: &str) -> Result<bool> {
+    pub(crate) fn storage_domain_is_complete(
+        &self,
+        domain: &str,
+        canonical_source: &str,
+    ) -> Result<bool> {
         let connection = self.connection()?;
         let Some(snapshot) = read_storage_domain_connection(&connection, domain)? else {
             return Ok(false);


### PR DESCRIPTION
## Summary

Fixes #1603.

Introduces a named pre-server runtime preparation phase that runs required storage preparation before the daemon starts the `holon serve` readiness window. Direct `holon serve` remains self-contained by invoking the same phase before constructing the runtime host.

## Changes

- Add `prepare_runtime_before_server` in daemon lifecycle with explicit start/finish logs and actionable retry context on failure.
- Move runtime bootstrap storage preparation (DB open/migrate, legacy imports, cutover validation, scheduler/control-plane indexes) into shared `RuntimeHandle::prepare_runtime_storage` / `RuntimeHost::prepare_runtime_storage`.
- Call preparation before daemon spawns `serve`, so migration/import duration is outside the daemon readiness timeout.
- Keep runtime startup idempotent by reusing the same preparation path from direct `serve` and host bootstrap.
- Add tests for:
  - preparation failure happening before server readiness timeout/log startup
  - retrying a failed/incomplete preparation domain by invoking preparation again

## Verification

- `cargo fmt --all -- --check`
- `cargo test preparation --lib`
- `cargo check --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
