### PR TITLE
fix: add DB-backed turn record spine

### DIFF
--- a/docs/rfc-implementation-notes/runtime-database-storage-migration.md
+++ b/docs/rfc-implementation-notes/runtime-database-storage-migration.md
@@ -115,6 +115,7 @@ but their role is explicit per domain:
 | `work_items` | `canonical_source = db`; runtime reads current state from the `work_items` table. | Legacy compatibility/export mirror only. `work_items.jsonl` must not be replayed as current state after DB import completes. |
 | `tasks` | `canonical_source = db`; runtime task queries use the `tasks` table. | Legacy compatibility/export mirror only. `tasks.jsonl` remains a historical stream, not a recovery source after cutover. |
 | `external_triggers` | `canonical_source = db`; active trigger lookup and token routing use `external_triggers`. | Legacy compatibility/export mirror only. |
+| `turn_records` | `canonical_source = db`; recent context reads the turn spine from the `turn_records` table. | Disabled as a compatibility input. Legacy import derives turn records from published evidence JSONL and ignores the unpublished `turns.jsonl` experiment. |
 | `evidence` | `canonical_source = jsonl+db-index`; DB tables index bounded evidence previews and query keys. | `messages.jsonl`, `transcript.jsonl`, `tools.jsonl`, `briefs.jsonl`, and `delivery_summaries.jsonl` remain the import/source streams for large evidence content. |
 | `audit_events` | `canonical_source = jsonl+db-index`; `audit_events` is the query/index sink. | `events.jsonl` remains the live audit mirror and cursor compatibility stream. |
 
@@ -455,6 +456,10 @@ Scope:
   - `briefs`;
   - `delivery_summaries`;
   - `artifact_metadata`.
+- Add a `turn_records` spine table as DB canonical after the evidence import
+  surface is stable. Import legacy turn records by deriving them from published
+  evidence JSONL (`messages`, `tools`, `briefs`, delivery summaries, waits)
+  rather than by reading the unpublished `turns.jsonl` experiment.
 - Store large payloads through `content_ref`, `content_hash`, `preview`, and
   `payload_json`.
 - Add `EvidenceRepository` and `AuditEventSink`.

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,7 +13,7 @@ use crate::{
         ContextEpisodeRecord, ContinuationClass, ContinuationResolution, ContinuationTriggerKind,
         ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView,
-        TodoItemState, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind,
+        TodoItemState, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind, TurnRecord,
         WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus, WorkItemRecord,
         WorkingMemoryDelta, WorkingMemorySnapshot,
     },
@@ -107,6 +107,7 @@ pub fn build_context_with_default_external_ingress(
     let continuation_anchor_messages = storage.read_all_messages()?;
     let briefs = storage.read_recent_briefs(config.recent_briefs)?;
     let tools = storage.read_recent_tool_executions(config.recent_messages)?;
+    let turn_records = storage.read_recent_turns(config.recent_messages)?;
     let transcript = storage.read_recent_transcript(config.recent_messages)?;
     let active_waiting_intents = storage
         .latest_waiting_intents()?
@@ -369,6 +370,7 @@ pub fn build_context_with_default_external_ingress(
     }
 
     if let Some(content) = render_recent_turns_with_budget(
+        &turn_records,
         &messages,
         &briefs,
         &tools,
@@ -1627,6 +1629,7 @@ fn render_recent_briefs_with_budget(briefs: &[BriefRecord], budget: usize) -> Op
 }
 
 fn render_recent_turns_with_budget(
+    turn_records: &[TurnRecord],
     messages: &[MessageEnvelope],
     briefs: &[BriefRecord],
     tools: &[ToolExecutionRecord],
@@ -1634,6 +1637,18 @@ fn render_recent_turns_with_budget(
     current_work_item: Option<&WorkItemRecord>,
     budget: usize,
 ) -> Option<String> {
+    if let Some(rendered) = render_turn_records_with_budget(
+        turn_records,
+        messages,
+        briefs,
+        tools,
+        current_message,
+        current_work_item,
+        budget,
+    ) {
+        return Some(rendered);
+    }
+
     let latest_operator_for_continuation = (!is_trusted_operator_input(current_message))
         .then(|| latest_trusted_operator_input(messages, current_message))
         .flatten();
@@ -1670,6 +1685,200 @@ fn render_recent_turns_with_budget(
     }
 
     render_budgeted_lines("Recent turns:", rendered_turns, budget)
+}
+
+fn render_turn_records_with_budget(
+    turn_records: &[TurnRecord],
+    messages: &[MessageEnvelope],
+    briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
+    current_message: &MessageEnvelope,
+    current_work_item: Option<&WorkItemRecord>,
+    budget: usize,
+) -> Option<String> {
+    if turn_records.is_empty() {
+        return None;
+    }
+
+    let latest_operator_for_continuation = (!is_trusted_operator_input(current_message))
+        .then(|| latest_trusted_operator_input(messages, current_message))
+        .flatten();
+    let continuation_turn_id = latest_operator_for_continuation
+        .and_then(|operator| {
+            turn_records
+                .iter()
+                .find(|record| turn_record_matches_message(record, operator))
+        })
+        .map(|record| record.turn_id.as_str());
+
+    let mut rendered_turns = turn_records
+        .iter()
+        .filter(|record| continuation_turn_id.is_none_or(|turn_id| record.turn_id != turn_id))
+        .filter_map(|record| render_turn_record_projection(record, messages, briefs, tools, None))
+        .collect::<Vec<_>>();
+
+    if let Some(operator) = latest_operator_for_continuation {
+        if let Some(record) = turn_records
+            .iter()
+            .find(|record| turn_record_matches_message(record, operator))
+        {
+            if let Some(rendered) = render_current_continuation_turn_record_projection(
+                record,
+                current_message,
+                operator,
+                messages,
+                briefs,
+                tools,
+                current_work_item,
+            ) {
+                rendered_turns.push(rendered);
+            }
+        } else {
+            rendered_turns.push(render_current_continuation_turn_projection(
+                current_message,
+                operator,
+                briefs,
+                tools,
+                current_work_item,
+            ));
+        }
+    }
+
+    if rendered_turns.is_empty() {
+        return None;
+    }
+
+    render_budgeted_lines("Recent turns:", rendered_turns, budget)
+}
+
+fn render_turn_record_projection(
+    record: &TurnRecord,
+    messages: &[MessageEnvelope],
+    briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
+    continuation: Option<&MessageEnvelope>,
+) -> Option<String> {
+    let trigger_message = record
+        .input_message_ids
+        .iter()
+        .find_map(|id| messages.iter().find(|message| message.id == *id))
+        .or_else(|| {
+            record
+                .trigger
+                .as_ref()
+                .and_then(|trigger| trigger.message_id.as_ref())
+                .and_then(|id| messages.iter().find(|message| message.id == *id))
+        });
+    let Some(trigger_message) = trigger_message else {
+        return None;
+    };
+
+    let mut lines = vec![format!(
+        "- Turn {}:",
+        if record.turn_index != 0 {
+            format!("turn_index {}", record.turn_index)
+        } else {
+            record.turn_id.clone()
+        }
+    )];
+    lines.push(format!("  - turn_id: {}", sanitize_inline(&record.turn_id)));
+    lines.push(format!(
+        "  - trigger: {}",
+        turn_trigger_label(trigger_message)
+    ));
+    if let Some(continuation) = continuation {
+        lines.push(format!(
+            "  - continues input: {}",
+            trigger_message
+                .message_seq
+                .map(|seq| format!("message_seq {seq}"))
+                .unwrap_or_else(|| trigger_message.id.clone())
+        ));
+        lines.push(format!(
+            "  - continuation trigger: {}",
+            turn_trigger_label(continuation)
+        ));
+    }
+    if is_trusted_operator_input(trigger_message) {
+        lines.push(format!(
+            "  - operator asked: {}",
+            sanitize_inline(&body_preview(&trigger_message.body))
+        ));
+    } else {
+        lines.push(format!(
+            "  - input: {}",
+            sanitize_inline(&body_preview(&trigger_message.body))
+        ));
+    }
+
+    let related_briefs = record
+        .produced_brief_ids
+        .iter()
+        .filter_map(|id| briefs.iter().find(|brief| brief.id == *id))
+        .map(|brief| {
+            format!(
+                "    - {:?}: {}",
+                brief.kind,
+                sanitize_inline(&truncate_text(&brief.text, 160))
+            )
+        })
+        .collect::<Vec<_>>();
+    if !related_briefs.is_empty() {
+        lines.push("  - produced briefs:".to_string());
+        lines.extend(related_briefs);
+    }
+
+    let related_tools = record
+        .tool_execution_ids
+        .iter()
+        .filter_map(|id| tools.iter().find(|tool| tool.id == *id))
+        .map(render_recent_tool_execution)
+        .collect::<Vec<_>>();
+    if !related_tools.is_empty() {
+        lines.push("  - tool executions:".to_string());
+        lines.extend(related_tools.into_iter().map(|tool| format!("    {tool}")));
+    }
+
+    Some(lines.join("\n"))
+}
+
+fn render_current_continuation_turn_record_projection(
+    record: &TurnRecord,
+    current_message: &MessageEnvelope,
+    operator: &MessageEnvelope,
+    messages: &[MessageEnvelope],
+    briefs: &[BriefRecord],
+    tools: &[ToolExecutionRecord],
+    current_work_item: Option<&WorkItemRecord>,
+) -> Option<String> {
+    let mut rendered =
+        render_turn_record_projection(record, messages, briefs, tools, Some(current_message))?;
+    let mut lines = vec![
+        format!(
+            "  - current relation: {}",
+            runtime_continuation_label(current_message)
+        ),
+        format!(
+            "  - current input: {}",
+            sanitize_inline(&body_preview(&current_message.body))
+        ),
+    ];
+    if let Some(work_item) = current_work_item {
+        lines.push(format!(
+            "  - current work item: {} :: {}",
+            sanitize_inline(&work_item.id),
+            sanitize_inline(&truncate_text(&work_item.objective, 160))
+        ));
+    }
+    if !turn_record_matches_message(record, operator) {
+        lines.push(format!(
+            "  - continues input id: {}",
+            sanitize_inline(&operator.id)
+        ));
+    }
+    rendered.push('\n');
+    rendered.push_str(&lines.join("\n"));
+    Some(rendered)
 }
 
 fn render_turn_projection(
@@ -1768,6 +1977,19 @@ fn render_current_continuation_turn_projection(
     rendered.push('\n');
     rendered.push_str(&lines.join("\n"));
     rendered
+}
+
+fn turn_record_matches_message(record: &TurnRecord, message: &MessageEnvelope) -> bool {
+    message
+        .turn_id
+        .as_deref()
+        .is_some_and(|turn_id| !turn_id.trim().is_empty() && turn_id.trim() == record.turn_id)
+        || record.input_message_ids.iter().any(|id| id == &message.id)
+        || record
+            .trigger
+            .as_ref()
+            .and_then(|trigger| trigger.message_id.as_ref())
+            .is_some_and(|id| id == &message.id)
 }
 
 fn brief_matches_message(brief: &BriefRecord, message: &MessageEnvelope) -> bool {
@@ -2255,6 +2477,7 @@ mod tests {
 
     use crate::{
         prompt::build_effective_prompt,
+        runtime_db::RuntimeDb,
         storage::AppStorage,
         types::{
             AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
@@ -2297,6 +2520,83 @@ mod tests {
             ..ContextConfig::default()
         };
         assert_eq!(ceiling.turn_projection_budget(), 64_000);
+    }
+
+    #[test]
+    fn recent_turns_prefers_db_turn_records_when_available() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        let mut operator = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Use the database turn spine.".into(),
+            },
+        );
+        operator.turn_id = Some("turn-db-context".into());
+        storage.append_message(&operator).unwrap();
+        let mut brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "Rendered from DB turn record.",
+            Some(operator.id.clone()),
+            None,
+        );
+        brief.id = "brief-db-context".into();
+        brief.turn_id = Some("turn-db-context".into());
+        storage.append_brief(&brief).unwrap();
+        let mut turn = TurnRecord::new("default", "turn-db-context", 1);
+        turn.input_message_ids = vec![operator.id.clone()];
+        turn.produced_brief_ids = vec![brief.id.clone()];
+        turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&operator));
+        storage.append_turn(&turn).unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue.".into(),
+            },
+        );
+        let context = build_context(
+            &storage,
+            &AgentState::new("default"),
+            &execution_snapshot_for(&AgentState::new("default")),
+            &SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig::default(),
+        )
+        .unwrap();
+        let recent_turns = context
+            .sections
+            .iter()
+            .find(|section| section.name == "recent_turns")
+            .expect("recent_turns section")
+            .content
+            .clone();
+        assert!(recent_turns.contains("- Turn turn_index 1:"));
+        assert!(recent_turns.contains("  - turn_id: turn-db-context"));
+        assert!(recent_turns.contains("Rendered from DB turn record."));
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1769,10 +1769,6 @@ fn render_turn_record_projection(
                 .and_then(|trigger| trigger.message_id.as_ref())
                 .and_then(|id| messages.iter().find(|message| message.id == *id))
         });
-    let Some(trigger_message) = trigger_message else {
-        return None;
-    };
-
     let mut lines = vec![format!(
         "- Turn {}:",
         if record.turn_index != 0 {
@@ -1782,33 +1778,53 @@ fn render_turn_record_projection(
         }
     )];
     lines.push(format!("  - turn_id: {}", sanitize_inline(&record.turn_id)));
-    lines.push(format!(
-        "  - trigger: {}",
-        turn_trigger_label(trigger_message)
-    ));
+    if let Some(trigger_message) = trigger_message {
+        lines.push(format!(
+            "  - trigger: {}",
+            turn_trigger_label(trigger_message)
+        ));
+    } else if let Some(trigger) = &record.trigger {
+        lines.push(format!(
+            "  - trigger: {} (message not in recent window)",
+            turn_trigger_summary_label(trigger)
+        ));
+    } else {
+        lines.push("  - trigger: unavailable in recent message window".to_string());
+    }
     if let Some(continuation) = continuation {
         lines.push(format!(
             "  - continues input: {}",
             trigger_message
-                .message_seq
-                .map(|seq| format!("message_seq {seq}"))
-                .unwrap_or_else(|| trigger_message.id.clone())
+                .and_then(|message| message.message_seq.map(|seq| format!("message_seq {seq}")))
+                .or_else(|| {
+                    trigger_message
+                        .map(|message| message.id.clone())
+                        .or_else(|| {
+                            record
+                                .trigger
+                                .as_ref()
+                                .and_then(|trigger| trigger.message_id.clone())
+                        })
+                })
+                .unwrap_or_else(|| record.turn_id.clone())
         ));
         lines.push(format!(
             "  - continuation trigger: {}",
             turn_trigger_label(continuation)
         ));
     }
-    if is_trusted_operator_input(trigger_message) {
-        lines.push(format!(
-            "  - operator asked: {}",
-            sanitize_inline(&body_preview(&trigger_message.body))
-        ));
-    } else {
-        lines.push(format!(
-            "  - input: {}",
-            sanitize_inline(&body_preview(&trigger_message.body))
-        ));
+    if let Some(trigger_message) = trigger_message {
+        if is_trusted_operator_input(trigger_message) {
+            lines.push(format!(
+                "  - operator asked: {}",
+                sanitize_inline(&body_preview(&trigger_message.body))
+            ));
+        } else {
+            lines.push(format!(
+                "  - input: {}",
+                sanitize_inline(&body_preview(&trigger_message.body))
+            ));
+        }
     }
 
     let related_briefs = record
@@ -2024,6 +2040,30 @@ fn turn_trigger_label(message: &MessageEnvelope) -> &'static str {
         return "trusted operator input";
     }
     runtime_continuation_label(message)
+}
+
+fn turn_trigger_summary_label(trigger: &crate::types::TurnTriggerSummary) -> &'static str {
+    if matches!(trigger.authority_class, AuthorityClass::OperatorInstruction) {
+        return "trusted operator input";
+    }
+    match trigger.trigger_kind {
+        Some(ContinuationTriggerKind::TaskResult) => "a task-result continuation",
+        Some(ContinuationTriggerKind::ExternalEvent) => "an external-event continuation",
+        Some(ContinuationTriggerKind::TimerFire) => "a timer continuation",
+        Some(ContinuationTriggerKind::InternalFollowup) => "an internal-followup continuation",
+        Some(ContinuationTriggerKind::SystemTick) => "a runtime system-tick continuation",
+        Some(ContinuationTriggerKind::OperatorInput) => "operator-triggered input",
+        None => match trigger.kind {
+            MessageKind::TaskResult | MessageKind::TaskStatus => "a task-result continuation",
+            MessageKind::CallbackEvent | MessageKind::WebhookEvent | MessageKind::ChannelEvent => {
+                "an external-event continuation"
+            }
+            MessageKind::TimerTick => "a timer continuation",
+            MessageKind::InternalFollowup => "an internal-followup continuation",
+            MessageKind::SystemTick => "a runtime system-tick continuation",
+            _ => "runtime-originated input",
+        },
+    }
 }
 
 fn sanitize_inline(value: &str) -> String {
@@ -2597,6 +2637,80 @@ mod tests {
         assert!(recent_turns.contains("- Turn turn_index 1:"));
         assert!(recent_turns.contains("  - turn_id: turn-db-context"));
         assert!(recent_turns.contains("Rendered from DB turn record."));
+    }
+
+    #[test]
+    fn recent_turns_keeps_db_turn_when_trigger_message_is_outside_window() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        let mut brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "Rendered without trigger hydration.",
+            Some("missing-trigger-message".into()),
+            None,
+        );
+        brief.id = "brief-missing-trigger".into();
+        brief.turn_id = Some("turn-missing-trigger".into());
+        storage.append_brief(&brief).unwrap();
+
+        let mut turn = TurnRecord::new("default", "turn-missing-trigger", 2);
+        turn.input_message_ids = vec!["missing-trigger-message".into()];
+        turn.produced_brief_ids = vec![brief.id.clone()];
+        turn.trigger = Some(crate::types::TurnTriggerSummary {
+            message_id: Some("missing-trigger-message".into()),
+            kind: MessageKind::OperatorPrompt,
+            origin: MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            authority_class: AuthorityClass::OperatorInstruction,
+            priority: Priority::Normal,
+            trigger_kind: None,
+            task_id: None,
+        });
+        storage.append_turn(&turn).unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue.".into(),
+            },
+        );
+        let context = build_context(
+            &storage,
+            &AgentState::new("default"),
+            &execution_snapshot_for(&AgentState::new("default")),
+            &SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig::default(),
+        )
+        .unwrap();
+        let recent_turns = context
+            .sections
+            .iter()
+            .find(|section| section.name == "recent_turns")
+            .expect("recent_turns section")
+            .content
+            .clone();
+        assert!(recent_turns.contains("- Turn turn_index 2:"));
+        assert!(recent_turns.contains("message not in recent window"));
+        assert!(recent_turns.contains("Rendered without trigger hydration."));
     }
 
     #[test]

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -577,6 +577,15 @@ fn prepare_runtime_storage(
             .timers()
             .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
     }
+    if !storage_domain_complete(&runtime_db, "turn_records")? {
+        runtime_db.turn_records().import_legacy(
+            storage.read_all_message_values()?,
+            storage.read_recent_tool_executions(usize::MAX)?,
+            storage.read_recent_briefs(usize::MAX)?,
+            storage.read_recent_delivery_summaries(usize::MAX)?,
+            storage.read_recent_wait_conditions(usize::MAX)?,
+        )?;
+    }
     if !storage_domain_complete(&runtime_db, "evidence")? {
         runtime_db.evidence().import_legacy(
             storage.read_all_message_values()?,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -577,18 +577,23 @@ fn prepare_runtime_storage(
             .timers()
             .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
     }
-    if !storage_domain_complete(&runtime_db, "turn_records")? {
+    let turn_records_complete = storage_domain_complete(&runtime_db, "turn_records")?;
+    let evidence_complete = storage_domain_complete(&runtime_db, "evidence")?;
+    let legacy_messages =
+        (!turn_records_complete || !evidence_complete).then(|| storage.read_all_message_values());
+    let legacy_messages = legacy_messages.transpose()?;
+    if !turn_records_complete {
         runtime_db.turn_records().import_legacy(
-            storage.read_all_message_values()?,
+            legacy_messages.clone().unwrap_or_default(),
             storage.read_recent_tool_executions(usize::MAX)?,
             storage.read_recent_briefs(usize::MAX)?,
             storage.read_recent_delivery_summaries(usize::MAX)?,
             storage.read_recent_wait_conditions(usize::MAX)?,
         )?;
     }
-    if !storage_domain_complete(&runtime_db, "evidence")? {
+    if !evidence_complete {
         runtime_db.evidence().import_legacy(
-            storage.read_all_message_values()?,
+            legacy_messages.unwrap_or_default(),
             storage.read_all_transcript()?,
             storage.read_recent_tool_executions(usize::MAX)?,
             storage.read_recent_briefs(usize::MAX)?,

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1603,6 +1603,7 @@ fn derive_turn_records_from_legacy_evidence(
             let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
                 TurnRecord::new(&message.agent_id, &turn_key.turn_id, turn_key.turn_index)
             });
+            reinforce_turn_index(record, &turn_key);
             record.created_at = record.created_at.min(message.created_at);
             record.input_message_ids.push(message.id.clone());
             if record.trigger.is_none() {
@@ -1621,6 +1622,7 @@ fn derive_turn_records_from_legacy_evidence(
         let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
             TurnRecord::new(&tool.agent_id, &turn_key.turn_id, turn_key.turn_index)
         });
+        reinforce_turn_index(record, &turn_key);
         record.created_at = record.created_at.min(tool.created_at);
         record.tool_execution_ids.push(tool.id.clone());
         if record.current_work_item_id.is_none() {
@@ -1637,6 +1639,7 @@ fn derive_turn_records_from_legacy_evidence(
         let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
             TurnRecord::new(&brief.agent_id, &turn_key.turn_id, turn_key.turn_index)
         });
+        reinforce_turn_index(record, &turn_key);
         record.created_at = record.created_at.min(brief.created_at);
         record.produced_brief_ids.push(brief.id.clone());
         if record.current_work_item_id.is_none() {
@@ -1653,6 +1656,7 @@ fn derive_turn_records_from_legacy_evidence(
         let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
             TurnRecord::new(&summary.agent_id, &turn_key.turn_id, turn_key.turn_index)
         });
+        reinforce_turn_index(record, &turn_key);
         record.created_at = record.created_at.min(summary.created_at);
         record.delivery_summary_ids.push(summary.id.clone());
         record
@@ -1701,6 +1705,12 @@ struct DerivedTurnKey {
     turn_index: u64,
 }
 
+fn reinforce_turn_index(record: &mut TurnRecord, turn_key: &DerivedTurnKey) {
+    if record.turn_index == 0 && turn_key.turn_index != 0 {
+        record.turn_index = turn_key.turn_index;
+    }
+}
+
 fn turn_key_from_message(message: &MessageEnvelope) -> DerivedTurnKey {
     if let Some(turn_id) = message
         .turn_id
@@ -1709,7 +1719,7 @@ fn turn_key_from_message(message: &MessageEnvelope) -> DerivedTurnKey {
     {
         return DerivedTurnKey {
             turn_id: turn_id.trim().to_string(),
-            turn_index: message.message_seq.unwrap_or_default(),
+            turn_index: 0,
         };
     }
     let turn_index = message.message_seq.unwrap_or_default();
@@ -3350,6 +3360,7 @@ mod tests {
         );
         message.id = "msg-1".into();
         message.message_seq = Some(7);
+        message.turn_id = Some("turn-a".into());
         let mut brief = BriefRecord::new(
             "agent-a",
             crate::types::BriefKind::Result,
@@ -3358,13 +3369,14 @@ mod tests {
             None,
         );
         brief.id = "brief-1".into();
+        brief.turn_id = Some("turn-a".into());
         brief.turn_index = Some(7);
         let tool = ToolExecutionRecord {
             id: "tool-1".into(),
             agent_id: "agent-a".into(),
             work_item_id: Some("work-1".into()),
             turn_index: 7,
-            turn_id: None,
+            turn_id: Some("turn-a".into()),
             tool_name: "ExecCommand".into(),
             created_at: Utc::now(),
             completed_at: Some(Utc::now()),
@@ -3387,7 +3399,7 @@ mod tests {
 
         let records = db.turn_records().recent_for_agent("agent-a", 10)?;
         assert_eq!(records.len(), 1);
-        assert_eq!(records[0].turn_id, "legacy-turn-7");
+        assert_eq!(records[0].turn_id, "turn-a");
         assert_eq!(records[0].turn_index, 7);
         assert_eq!(records[0].input_message_ids, vec!["msg-1"]);
         assert_eq!(records[0].produced_brief_ids, vec!["brief-1"]);

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use crate::types::{
     AuditEvent, BriefRecord, CallbackDeliveryMode, DeliverySummaryRecord, ExternalTriggerRecord,
     ExternalTriggerScope, ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, TaskRecord,
-    TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
+    TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry, TurnRecord,
     WaitConditionRecord, WorkItemRecord, WorkItemState,
 };
 
@@ -47,6 +47,10 @@ pub struct QueueEntryRepository<'a> {
 }
 
 pub struct TimerRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct TurnRecordRepository<'a> {
     db: &'a RuntimeDb,
 }
 
@@ -603,6 +607,84 @@ impl TimerRepository<'_> {
     }
 }
 
+impl TurnRecordRepository<'_> {
+    pub fn import_legacy(
+        &self,
+        messages: Vec<serde_json::Value>,
+        tool_executions: Vec<ToolExecutionRecord>,
+        briefs: Vec<BriefRecord>,
+        delivery_summaries: Vec<DeliverySummaryRecord>,
+        wait_conditions: Vec<WaitConditionRecord>,
+    ) -> Result<()> {
+        if self.db.storage_domain_is_complete("turn_records", "db")? {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("turn_records", "jsonl-derived", "db", |tx| {
+                let records = derive_turn_records_from_legacy_evidence(
+                    messages,
+                    tool_executions,
+                    briefs,
+                    delivery_summaries,
+                    wait_conditions,
+                )?;
+                for record in &records {
+                    upsert_turn_record_tx(tx, record)?;
+                }
+                Ok(serde_json::json!({
+                    "imported_records": records.len(),
+                    "source": "legacy evidence jsonl",
+                    "ignored": "turns.jsonl"
+                }))
+            })
+    }
+
+    pub fn upsert(&self, record: &TurnRecord) -> Result<()> {
+        self.db.transaction(|tx| upsert_turn_record_tx(tx, record))
+    }
+
+    pub fn recent_for_agent(&self, agent_id: &str, limit: usize) -> Result<Vec<TurnRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM turn_records
+             WHERE agent_id = ?1
+             ORDER BY turn_index DESC, created_at DESC, turn_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        let mut records = rows
+            .map(|row| decode_turn_record_payload(&row?))
+            .collect::<Result<Vec<_>>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<TurnRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM turn_records
+             ORDER BY turn_index DESC, created_at DESC, turn_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records = rows
+            .map(|row| decode_turn_record_payload(&row?))
+            .collect::<Result<Vec<_>>>()?;
+        records.reverse();
+        Ok(records)
+    }
+}
+
 impl EvidenceRepository<'_> {
     pub fn import_legacy(
         &self,
@@ -1059,7 +1141,11 @@ fn normalize_legacy_message_value(
         .and_then(serde_json::Value::as_str)
         .is_some_and(|value| !value.trim().is_empty());
     if !has_turn_id {
-        let Some(turn_index) = object.get("turn_index").and_then(serde_json::Value::as_u64) else {
+        let Some(turn_index) = object
+            .get("turn_index")
+            .or_else(|| object.get("message_seq"))
+            .and_then(serde_json::Value::as_u64)
+        else {
             return Ok(None);
         };
         object.insert(
@@ -1457,6 +1543,195 @@ fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
     Ok(())
 }
 
+fn upsert_turn_record_tx(tx: &Transaction<'_>, record: &TurnRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let terminal_kind = record
+        .terminal
+        .as_ref()
+        .map(|terminal| enum_string(&terminal.kind))
+        .transpose()?;
+    let completed_at = record
+        .terminal
+        .as_ref()
+        .map(|terminal| timestamp(terminal.completed_at));
+    tx.execute(
+        "INSERT INTO turn_records (
+            turn_id, turn_index, agent_id, run_id, current_work_item_id,
+            trigger_message_id, terminal_kind, created_at, completed_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+         ON CONFLICT(turn_id) DO UPDATE SET
+            turn_index = excluded.turn_index,
+            agent_id = excluded.agent_id,
+            run_id = excluded.run_id,
+            current_work_item_id = excluded.current_work_item_id,
+            trigger_message_id = excluded.trigger_message_id,
+            terminal_kind = excluded.terminal_kind,
+            created_at = excluded.created_at,
+            completed_at = excluded.completed_at,
+            payload_json = excluded.payload_json
+         WHERE COALESCE(excluded.completed_at, excluded.created_at) >= COALESCE(turn_records.completed_at, turn_records.created_at)",
+        params![
+            record.turn_id,
+            record.turn_index as i64,
+            record.agent_id,
+            record.run_id,
+            record.current_work_item_id,
+            record
+                .trigger
+                .as_ref()
+                .and_then(|trigger| trigger.message_id.as_deref()),
+            terminal_kind,
+            timestamp(record.created_at),
+            completed_at,
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn derive_turn_records_from_legacy_evidence(
+    messages: Vec<serde_json::Value>,
+    tool_executions: Vec<ToolExecutionRecord>,
+    briefs: Vec<BriefRecord>,
+    delivery_summaries: Vec<DeliverySummaryRecord>,
+    wait_conditions: Vec<WaitConditionRecord>,
+) -> Result<Vec<TurnRecord>> {
+    let mut records = BTreeMap::<String, TurnRecord>::new();
+    for raw_message in messages {
+        if let Some(message) = normalize_legacy_message_value(raw_message)? {
+            let turn_key = turn_key_from_message(&message);
+            let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
+                TurnRecord::new(&message.agent_id, &turn_key.turn_id, turn_key.turn_index)
+            });
+            record.created_at = record.created_at.min(message.created_at);
+            record.input_message_ids.push(message.id.clone());
+            if record.trigger.is_none() {
+                record.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
+            }
+            if record.current_work_item_id.is_none() {
+                record.current_work_item_id = message.work_item_id.clone();
+            }
+        }
+    }
+    for tool in tool_executions {
+        let Some(turn_key) = turn_key_from_optional(tool.turn_id.as_deref(), tool.turn_index)
+        else {
+            continue;
+        };
+        let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
+            TurnRecord::new(&tool.agent_id, &turn_key.turn_id, turn_key.turn_index)
+        });
+        record.created_at = record.created_at.min(tool.created_at);
+        record.tool_execution_ids.push(tool.id.clone());
+        if record.current_work_item_id.is_none() {
+            record.current_work_item_id = tool.work_item_id.clone();
+        }
+    }
+    for brief in briefs {
+        let Some(turn_key) = turn_key_from_optional(
+            brief.turn_id.as_deref(),
+            brief.turn_index.unwrap_or_default(),
+        ) else {
+            continue;
+        };
+        let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
+            TurnRecord::new(&brief.agent_id, &turn_key.turn_id, turn_key.turn_index)
+        });
+        record.created_at = record.created_at.min(brief.created_at);
+        record.produced_brief_ids.push(brief.id.clone());
+        if record.current_work_item_id.is_none() {
+            record.current_work_item_id = brief.work_item_id.clone();
+        }
+    }
+    for summary in delivery_summaries {
+        let Some(turn_key) = turn_key_from_optional(
+            summary.turn_id.as_deref(),
+            summary.source_turn_index.unwrap_or_default(),
+        ) else {
+            continue;
+        };
+        let record = records.entry(turn_key.turn_id.clone()).or_insert_with(|| {
+            TurnRecord::new(&summary.agent_id, &turn_key.turn_id, turn_key.turn_index)
+        });
+        record.created_at = record.created_at.min(summary.created_at);
+        record.delivery_summary_ids.push(summary.id.clone());
+        record
+            .completed_work_item_ids
+            .push(summary.work_item_id.clone());
+        if record.current_work_item_id.is_none() {
+            record.current_work_item_id = Some(summary.work_item_id.clone());
+        }
+    }
+    for condition in wait_conditions {
+        let Some(turn_id) = condition
+            .turn_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        else {
+            continue;
+        };
+        let record = records
+            .entry(turn_id.trim().to_string())
+            .or_insert_with(|| TurnRecord::new(&condition.agent_id, turn_id.trim(), 0));
+        record.created_at = record.created_at.min(condition.created_at);
+        record.waiting_condition_ids.push(condition.id.clone());
+        if record.current_work_item_id.is_none() {
+            record.current_work_item_id = condition.work_item_id.clone();
+        }
+    }
+    for record in records.values_mut() {
+        record.input_message_ids.sort();
+        record.input_message_ids.dedup();
+        record.tool_execution_ids.sort();
+        record.tool_execution_ids.dedup();
+        record.produced_brief_ids.sort();
+        record.produced_brief_ids.dedup();
+        record.delivery_summary_ids.sort();
+        record.delivery_summary_ids.dedup();
+        record.completed_work_item_ids.sort();
+        record.completed_work_item_ids.dedup();
+        record.waiting_condition_ids.sort();
+        record.waiting_condition_ids.dedup();
+    }
+    Ok(records.into_values().collect())
+}
+
+struct DerivedTurnKey {
+    turn_id: String,
+    turn_index: u64,
+}
+
+fn turn_key_from_message(message: &MessageEnvelope) -> DerivedTurnKey {
+    if let Some(turn_id) = message
+        .turn_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return DerivedTurnKey {
+            turn_id: turn_id.trim().to_string(),
+            turn_index: message.message_seq.unwrap_or_default(),
+        };
+    }
+    let turn_index = message.message_seq.unwrap_or_default();
+    DerivedTurnKey {
+        turn_id: format!("legacy-turn-{turn_index}"),
+        turn_index,
+    }
+}
+
+fn turn_key_from_optional(turn_id: Option<&str>, turn_index: u64) -> Option<DerivedTurnKey> {
+    if let Some(turn_id) = turn_id.filter(|value| !value.trim().is_empty()) {
+        return Some(DerivedTurnKey {
+            turn_id: turn_id.trim().to_string(),
+            turn_index,
+        });
+    }
+    (turn_index != 0).then(|| DerivedTurnKey {
+        turn_id: format!("legacy-turn-{turn_index}"),
+        turn_index,
+    })
+}
+
 fn newer_work_item_record(candidate: &WorkItemRecord, existing: &WorkItemRecord) -> bool {
     candidate
         .revision
@@ -1697,6 +1972,10 @@ fn decode_queue_entry_payload(payload: &str) -> Result<QueueEntryRecord> {
 
 fn decode_timer_payload(payload: &str) -> Result<TimerRecord> {
     serde_json::from_str(payload).context("decoding timer payload from runtime db")
+}
+
+fn decode_turn_record_payload(payload: &str) -> Result<TurnRecord> {
+    serde_json::from_str(payload).context("decoding turn record payload from runtime db")
 }
 
 fn enum_string<T: serde::Serialize>(value: &T) -> Result<String> {
@@ -2212,6 +2491,30 @@ CREATE INDEX IF NOT EXISTS idx_queue_entries_agent_status
   ON queue_entries(agent_id, status, updated_at);
 "#,
     },
+    Migration {
+        version: 8,
+        name: "turn_records_spine",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS turn_records (
+  turn_id TEXT PRIMARY KEY,
+  turn_index INTEGER NOT NULL,
+  agent_id TEXT NOT NULL,
+  run_id TEXT,
+  current_work_item_id TEXT,
+  trigger_message_id TEXT,
+  terminal_kind TEXT,
+  created_at TEXT NOT NULL,
+  completed_at TEXT,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_turn_records_agent_recent
+  ON turn_records(agent_id, turn_index, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_turn_records_work_item
+  ON turn_records(current_work_item_id);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -2283,6 +2586,10 @@ impl RuntimeDb {
         TimerRepository { db: self }
     }
 
+    pub fn turn_records(&self) -> TurnRecordRepository<'_> {
+        TurnRecordRepository { db: self }
+    }
+
     pub fn evidence(&self) -> EvidenceRepository<'_> {
         EvidenceRepository { db: self }
     }
@@ -2322,6 +2629,11 @@ impl RuntimeDb {
                 domain: "timers",
                 canonical_source: "db",
                 legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+            },
+            ExpectedStorageDomain {
+                domain: "turn_records",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::Disabled,
             },
             ExpectedStorageDomain {
                 domain: "evidence",
@@ -2788,6 +3100,7 @@ mod tests {
             "wait_conditions",
             "queue_entries",
             "timers",
+            "turn_records",
         ] {
             let count: i64 = connection.query_row(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
@@ -3016,6 +3329,78 @@ mod tests {
         assert!(db
             .validate_expected_storage_domains(RuntimeDb::expected_storage_domains())
             .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn turn_record_repository_imports_legacy_evidence_without_turns_jsonl() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut message = MessageEnvelope::new(
+            "agent-a",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text {
+                text: "derive a turn record".into(),
+            },
+        );
+        message.id = "msg-1".into();
+        message.message_seq = Some(7);
+        let mut brief = BriefRecord::new(
+            "agent-a",
+            crate::types::BriefKind::Result,
+            "derived result",
+            Some("msg-1".into()),
+            None,
+        );
+        brief.id = "brief-1".into();
+        brief.turn_index = Some(7);
+        let tool = ToolExecutionRecord {
+            id: "tool-1".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: Some("work-1".into()),
+            turn_index: 7,
+            turn_id: None,
+            tool_name: "ExecCommand".into(),
+            created_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+            duration_ms: 1,
+            authority_class: crate::types::AuthorityClass::RuntimeInstruction,
+            status: crate::types::ToolExecutionStatus::Success,
+            input: serde_json::json!({ "cmd": "true" }),
+            output: serde_json::json!({ "exit": 0 }),
+            summary: "Run command: true".into(),
+            invocation_surface: None,
+        };
+
+        db.turn_records().import_legacy(
+            vec![serde_json::to_value(&message)?],
+            vec![tool],
+            vec![brief],
+            Vec::new(),
+            Vec::new(),
+        )?;
+
+        let records = db.turn_records().recent_for_agent("agent-a", 10)?;
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].turn_id, "legacy-turn-7");
+        assert_eq!(records[0].turn_index, 7);
+        assert_eq!(records[0].input_message_ids, vec!["msg-1"]);
+        assert_eq!(records[0].produced_brief_ids, vec!["brief-1"]);
+        assert_eq!(records[0].tool_execution_ids, vec!["tool-1"]);
+        assert_eq!(records[0].current_work_item_id.as_deref(), Some("work-1"));
+        let domain = db
+            .storage_domain("turn_records")?
+            .expect("turn_records domain");
+        assert_eq!(domain.canonical_source, "db");
+        assert!(domain
+            .source_checkpoint_json
+            .as_deref()
+            .is_some_and(|checkpoint| checkpoint.contains("turns.jsonl")));
         Ok(())
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -438,6 +438,10 @@ impl AppStorage {
     }
 
     pub fn append_turn(&self, record: &TurnRecord) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.turn_records().upsert(record)?;
+            return Ok(());
+        }
         self.append_jsonl(&self.turns_path, record)
     }
 
@@ -754,6 +758,9 @@ impl AppStorage {
     }
 
     pub fn read_recent_turns(&self, limit: usize) -> Result<Vec<TurnRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.turn_records().recent(limit);
+        }
         read_recent_jsonl(&self.turns_path, limit)
     }
 
@@ -2484,6 +2491,36 @@ mod tests {
         assert_eq!(
             turns[0].terminal.as_ref().map(|terminal| terminal.kind),
             Some(crate::types::TurnTerminalKind::Completed)
+        );
+    }
+
+    #[test]
+    fn append_turn_uses_runtime_db_after_cutover_without_turns_jsonl() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        let record = TurnRecord::new("default", "turn-db", 9);
+
+        storage.append_turn(&record).unwrap();
+
+        assert!(!storage.ledger_dir().join("turns.jsonl").exists());
+        let turns = storage.read_recent_turns(10).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].turn_id, "turn-db");
+        assert_eq!(
+            runtime_db
+                .turn_records()
+                .recent_for_agent("default", 10)
+                .unwrap()
+                .len(),
+            1
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #1593.

This adds a DB-backed `turn_records` spine for recent-turn context:

- adds a `turn_records` runtime DB table/domain and `TurnRecordRepository`
- writes finalized `TurnRecord` objects to DB after DB cutover instead of appending `turns.jsonl`
- derives legacy DB turn records from published evidence JSONL during import while explicitly ignoring the unpublished `turns.jsonl` experiment
- renders `recent_turns` from DB `TurnRecord` anchors when available, keeping the existing message/brief/tool projection as fallback
- updates the DB migration note to document the new domain posture

## Verification

- `cargo test runtime_db --quiet`
- `cargo test context --quiet`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
