### PR TITLE
feat: add daemon runtime config API

### DIFF
--- a/docs/rfcs/runtime-configuration-surface.md
+++ b/docs/rfcs/runtime-configuration-surface.md
@@ -137,6 +137,19 @@ Holon should keep mutation surfaces aligned with lifecycle class:
 
 These surfaces should not be collapsed into one generic `config` abstraction.
 
+The daemon control API exposes this split through:
+
+- `GET /control/runtime/config`, which returns the effective runtime
+  configuration surface for the running host
+- `PATCH /control/runtime/config`, which persists supported runtime-mutable
+  keys to `config.json` and returns a per-key effect classification
+
+Until live reload is implemented, supported persisted updates return
+`accepted_requires_restart`: the file-backed runtime config changes, while the
+current process keeps using its already-loaded effective configuration.
+Startup-only and unsupported keys are rejected with structured reasons instead
+of silently editing files.
+
 ## Status And Inspectability
 
 Holon should make the active source of truth inspectable:

--- a/docs/website/reference/http-control-plane.md
+++ b/docs/website/reference/http-control-plane.md
@@ -513,6 +513,48 @@ Reverts to the default model. Accepts an optional body:
 Returns daemon and runtime health info including configured models, control
 token status, and activity markers.
 
+**`GET /control/runtime/config`** — Runtime config
+
+Returns the daemon's current effective runtime configuration surface and the
+`config.json` path that backs persisted runtime-mutable settings.
+
+**`PATCH /control/runtime/config`** — Update runtime config
+
+Persists runtime-mutable config key updates and classifies each attempted
+change. The current implementation writes supported keys to `config.json` and
+returns `accepted_requires_restart` because the running host keeps its current
+effective config until live reload support exists. Startup-only or unsupported
+keys return `rejected` with a reason.
+
+```json
+{
+  "updates": [
+    { "key": "model.default", "value": "openai/gpt-4.1" },
+    { "key": "home_dir", "value": "/tmp/other-home" }
+  ]
+}
+```
+
+```json
+{
+  "ok": true,
+  "changed": true,
+  "results": [
+    {
+      "key": "model.default",
+      "effect": "accepted_requires_restart",
+      "reason": "persisted in config.json; the running host keeps its current effective config until restart/reload support is added"
+    },
+    {
+      "key": "home_dir",
+      "effect": "rejected",
+      "reason": "unsupported or startup-only config key"
+    }
+  ],
+  "runtime_surface": { "...": "..." }
+}
+```
+
 **`POST /control/runtime/shutdown`** — Graceful shutdown
 
 Shuts down the runtime and daemon gracefully.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -5490,6 +5490,110 @@
         ]
       }
     },
+    "/control/runtime/config": {
+      "get": {
+        "description": "Return the daemon effective runtime configuration surface.",
+        "operationId": "runtimeConfig",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeConfigReadResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime config",
+        "tags": [
+          "runtime"
+        ]
+      },
+      "patch": {
+        "description": "Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.",
+        "operationId": "runtimeConfigUpdate",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeConfigUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeConfigUpdateResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update runtime config",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
     "/control/runtime/readiness": {
       "get": {
         "description": "Return daemon readiness metadata.",

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -671,6 +671,273 @@
         "title": "PickWorkItemResponse",
         "type": "object"
       },
+      "RuntimeConfigReadResponse": {
+        "properties": {
+          "config_file_path": {
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "runtime_surface": {
+            "properties": {
+              "default_tool_output_tokens": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "disable_provider_fallback": {
+                "type": "boolean"
+              },
+              "max_tool_output_tokens": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "model_catalog": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "model_default": {
+                "type": "string"
+              },
+              "model_fallbacks": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "providers": {
+                "items": {
+                  "properties": {
+                    "base_url": {
+                      "type": "string"
+                    },
+                    "credential_configured": {
+                      "type": "boolean"
+                    },
+                    "credential_kind": {
+                      "type": "string"
+                    },
+                    "credential_source": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "transport": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "transport",
+                    "base_url",
+                    "credential_source",
+                    "credential_kind",
+                    "credential_configured"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "runtime_max_output_tokens": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "unknown_model_fallback_configured": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "model_default",
+              "model_fallbacks",
+              "model_catalog",
+              "unknown_model_fallback_configured",
+              "runtime_max_output_tokens",
+              "default_tool_output_tokens",
+              "max_tool_output_tokens",
+              "disable_provider_fallback",
+              "providers"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ok",
+          "config_file_path",
+          "runtime_surface"
+        ],
+        "title": "RuntimeConfigReadResponse",
+        "type": "object"
+      },
+      "RuntimeConfigUpdateRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "updates": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "unset": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "value": true
+              },
+              "required": [
+                "key"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "updates"
+        ],
+        "title": "RuntimeConfigUpdateRequest",
+        "type": "object"
+      },
+      "RuntimeConfigUpdateResponse": {
+        "properties": {
+          "changed": {
+            "type": "boolean"
+          },
+          "config_file_path": {
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "results": {
+            "items": {
+              "properties": {
+                "effect": {
+                  "enum": [
+                    "accepted_requires_restart",
+                    "rejected"
+                  ],
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "effect",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "runtime_surface": {
+            "properties": {
+              "default_tool_output_tokens": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "disable_provider_fallback": {
+                "type": "boolean"
+              },
+              "max_tool_output_tokens": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "model_catalog": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "model_default": {
+                "type": "string"
+              },
+              "model_fallbacks": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "providers": {
+                "items": {
+                  "properties": {
+                    "base_url": {
+                      "type": "string"
+                    },
+                    "credential_configured": {
+                      "type": "boolean"
+                    },
+                    "credential_kind": {
+                      "type": "string"
+                    },
+                    "credential_source": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "transport": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "transport",
+                    "base_url",
+                    "credential_source",
+                    "credential_kind",
+                    "credential_configured"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "runtime_max_output_tokens": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "unknown_model_fallback_configured": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "model_default",
+              "model_fallbacks",
+              "model_catalog",
+              "unknown_model_fallback_configured",
+              "runtime_max_output_tokens",
+              "default_tool_output_tokens",
+              "max_tool_output_tokens",
+              "disable_provider_fallback",
+              "providers"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ok",
+          "changed",
+          "config_file_path",
+          "results",
+          "runtime_surface"
+        ],
+        "title": "RuntimeConfigUpdateResponse",
+        "type": "object"
+      },
       "SetAgentModelRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,8 +11,9 @@ use crate::{
     daemon::{RuntimeShutdownResponse, RuntimeStatusResponse},
     http::{
         AttachWorkspaceRequest, ClearAgentModelRequest, ControlPromptRequest, CreateAgentRequest,
-        DebugPromptRequest, DetachWorkspaceRequest, ExitWorkspaceRequest, SetAgentModelRequest,
-        TaskInputRequest, TaskStopRequest,
+        DebugPromptRequest, DetachWorkspaceRequest, ExitWorkspaceRequest,
+        RuntimeConfigReadResponse, RuntimeConfigUpdateRequest, RuntimeConfigUpdateResponse,
+        SetAgentModelRequest, TaskInputRequest, TaskStopRequest,
     },
     model_catalog::BuiltInModelMetadata,
     system::ExecutionSnapshot,
@@ -384,6 +385,18 @@ impl LocalClient {
         self.get_control_json("/control/runtime/readiness").await
     }
 
+    pub async fn runtime_config(&self) -> Result<RuntimeConfigReadResponse> {
+        self.get_control_json("/control/runtime/config").await
+    }
+
+    pub async fn update_runtime_config(
+        &self,
+        request: &RuntimeConfigUpdateRequest,
+    ) -> Result<RuntimeConfigUpdateResponse> {
+        self.patch_control_json("/control/runtime/config", request)
+            .await
+    }
+
     #[cfg(unix)]
     pub async fn runtime_readiness_unix_only(&self) -> Result<RuntimeStatusResponse> {
         let body = self
@@ -726,6 +739,18 @@ impl LocalClient {
             .with_context(|| format!("failed to decode response body for POST {}", path))
     }
 
+    async fn patch_control_json<B: Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        payload: &B,
+    ) -> Result<T> {
+        let body = self
+            .send(RequestSpec::patch_json(path, payload)?, true)
+            .await?;
+        serde_json::from_slice(&body)
+            .with_context(|| format!("failed to decode response body for PATCH {}", path))
+    }
+
     async fn send(&self, request: RequestSpec, include_control_auth: bool) -> Result<Vec<u8>> {
         #[cfg(unix)]
         if self.remote.is_none() && self.config.socket_path.exists() {
@@ -797,6 +822,7 @@ impl LocalClient {
         let mut builder = match request.method {
             HttpMethod::Get => self.http.get(self.http_url_for(&request.path)),
             HttpMethod::Post => self.http.post(self.http_url_for(&request.path)),
+            HttpMethod::Patch => self.http.patch(self.http_url_for(&request.path)),
         };
         if let Some(remote) = &self.remote {
             builder = builder.bearer_auth(&remote.token);
@@ -847,6 +873,7 @@ impl LocalClient {
         let method = match request.method {
             HttpMethod::Get => "GET",
             HttpMethod::Post => "POST",
+            HttpMethod::Patch => "PATCH",
         };
         let mut raw = format!(
             "{method} {} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nAccept: application/json\r\n",
@@ -1016,12 +1043,21 @@ impl RequestSpec {
             body: Some(serde_json::to_vec(payload)?),
         })
     }
+
+    fn patch_json<B: Serialize>(path: &str, payload: &B) -> Result<Self> {
+        Ok(Self {
+            method: HttpMethod::Patch,
+            path: path.to_string(),
+            body: Some(serde_json::to_vec(payload)?),
+        })
+    }
 }
 
 #[derive(Clone, Copy)]
 enum HttpMethod {
     Get,
     Post,
+    Patch,
 }
 
 impl LocalEventStream {

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -2,6 +2,7 @@ use std::{fs, path::PathBuf, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
@@ -73,7 +74,7 @@ impl From<ControlAuthMode> for RuntimeControlAuthMode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RuntimeConfigSurface {
     pub model_default: String,
     pub model_fallbacks: Vec<String>,
@@ -86,7 +87,7 @@ pub struct RuntimeConfigSurface {
     pub providers: Vec<RuntimeProviderSummary>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RuntimeProviderSummary {
     pub id: String,
     pub transport: String,

--- a/src/http.rs
+++ b/src/http.rs
@@ -44,8 +44,9 @@ use tower::ServiceExt;
 
 use crate::{
     config::{
-        load_persisted_config_at, save_persisted_config_at, set_config_key, unset_config_key,
-        ControlTransportKind, ModelRef,
+        credential_store_path, load_credential_store_at, load_persisted_config_at,
+        save_persisted_config_at, set_config_key, unset_config_key, ControlTransportKind,
+        HolonConfigFile, ModelRef,
     },
     daemon::{
         graceful_runtime_shutdown, runtime_activity_summary, RuntimeConfigSurface,
@@ -802,19 +803,21 @@ pub async fn runtime_readiness(
     ))
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RuntimeConfigReadResponse {
     pub ok: bool,
     pub config_file_path: std::path::PathBuf,
     pub runtime_surface: RuntimeConfigSurface,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct RuntimeConfigUpdateRequest {
     pub updates: Vec<RuntimeConfigUpdateEntry>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct RuntimeConfigUpdateEntry {
     pub key: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -823,7 +826,7 @@ pub struct RuntimeConfigUpdateEntry {
     pub unset: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RuntimeConfigUpdateResponse {
     pub ok: bool,
     pub changed: bool,
@@ -832,14 +835,14 @@ pub struct RuntimeConfigUpdateResponse {
     pub runtime_surface: RuntimeConfigSurface,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RuntimeConfigUpdateResult {
     pub key: String,
     pub effect: RuntimeConfigUpdateEffect,
     pub reason: String,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeConfigUpdateEffect {
     AcceptedRequiresRestart,
@@ -867,6 +870,7 @@ pub async fn runtime_config_update(
     authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let config = state.host.config();
     let mut stored = load_persisted_config_at(&config.config_file_path).map_err(error_response)?;
+    let mut candidate = stored.clone();
     let mut changed = false;
     let mut results = Vec::new();
 
@@ -881,11 +885,11 @@ pub async fn runtime_config_update(
         }
 
         let result = if update.unset {
-            unset_config_key(&mut stored, &update.key)
+            unset_config_key(&mut candidate, &update.key)
         } else {
             match update.value {
                 Some(value) => {
-                    set_config_key(&mut stored, &update.key, &config_value_as_raw(value))
+                    set_config_key(&mut candidate, &update.key, &config_value_as_raw(value))
                 }
                 None => Err(anyhow!(
                     "runtime config update for {} requires value or unset=true",
@@ -912,6 +916,20 @@ pub async fn runtime_config_update(
     }
 
     if changed {
+        if let Err(error) = validate_runtime_config_candidate(config, &candidate) {
+            changed = false;
+            let reason = format!("updated config is invalid: {error}");
+            for result in &mut results {
+                if result.effect == RuntimeConfigUpdateEffect::AcceptedRequiresRestart {
+                    result.effect = RuntimeConfigUpdateEffect::Rejected;
+                    result.reason = reason.clone();
+                }
+            }
+        }
+    }
+
+    if changed {
+        stored = candidate;
         save_persisted_config_at(&config.config_file_path, &stored).map_err(error_response)?;
     }
 
@@ -922,6 +940,15 @@ pub async fn runtime_config_update(
         results,
         runtime_surface: RuntimeConfigSurface::new(config),
     }))
+}
+
+fn validate_runtime_config_candidate(
+    config: &crate::config::AppConfig,
+    candidate: &HolonConfigFile,
+) -> Result<()> {
+    let credentials = load_credential_store_at(&credential_store_path(&config.home_dir))?;
+    crate::web::materialize_web_config(&candidate.web, &credentials)?;
+    Ok(())
 }
 
 fn is_runtime_mutable_config_key(key: &str) -> bool {

--- a/src/http.rs
+++ b/src/http.rs
@@ -43,7 +43,10 @@ use tokio::{net::UnixListener, sync::watch};
 use tower::ServiceExt;
 
 use crate::{
-    config::{ControlTransportKind, ModelRef},
+    config::{
+        load_persisted_config_at, save_persisted_config_at, set_config_key, unset_config_key,
+        ControlTransportKind, ModelRef,
+    },
     daemon::{
         graceful_runtime_shutdown, runtime_activity_summary, RuntimeConfigSurface,
         RuntimeServiceHandle,
@@ -266,6 +269,8 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/control/runtime/readiness", get(runtime_readiness))
         .route("/control/runtime/status", get(runtime_status))
+        .route("/control/runtime/config", get(runtime_config))
+        .route("/control/runtime/config", patch(runtime_config_update))
         .route("/control/runtime/shutdown", post(runtime_shutdown))
         .route(
             "/control/agents/{agent_id}/debug-prompt",
@@ -795,6 +800,155 @@ pub async fn runtime_readiness(
     Ok(Json(
         runtime_service.readiness_response(startup_surface, runtime_surface),
     ))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeConfigReadResponse {
+    pub ok: bool,
+    pub config_file_path: std::path::PathBuf,
+    pub runtime_surface: RuntimeConfigSurface,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeConfigUpdateRequest {
+    pub updates: Vec<RuntimeConfigUpdateEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeConfigUpdateEntry {
+    pub key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    #[serde(default)]
+    pub unset: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeConfigUpdateResponse {
+    pub ok: bool,
+    pub changed: bool,
+    pub config_file_path: std::path::PathBuf,
+    pub results: Vec<RuntimeConfigUpdateResult>,
+    pub runtime_surface: RuntimeConfigSurface,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeConfigUpdateResult {
+    pub key: String,
+    pub effect: RuntimeConfigUpdateEffect,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeConfigUpdateEffect {
+    AcceptedRequiresRestart,
+    Rejected,
+}
+
+pub async fn runtime_config(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let config = state.host.config();
+    Ok(Json(RuntimeConfigReadResponse {
+        ok: true,
+        config_file_path: config.config_file_path.clone(),
+        runtime_surface: RuntimeConfigSurface::new(config),
+    }))
+}
+
+pub async fn runtime_config_update(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<RuntimeConfigUpdateRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let config = state.host.config();
+    let mut stored = load_persisted_config_at(&config.config_file_path).map_err(error_response)?;
+    let mut changed = false;
+    let mut results = Vec::new();
+
+    for update in request.updates {
+        if !is_runtime_mutable_config_key(&update.key) {
+            results.push(RuntimeConfigUpdateResult {
+                key: update.key,
+                effect: RuntimeConfigUpdateEffect::Rejected,
+                reason: "unsupported or startup-only config key".into(),
+            });
+            continue;
+        }
+
+        let result = if update.unset {
+            unset_config_key(&mut stored, &update.key)
+        } else {
+            match update.value {
+                Some(value) => {
+                    set_config_key(&mut stored, &update.key, &config_value_as_raw(value))
+                }
+                None => Err(anyhow!(
+                    "runtime config update for {} requires value or unset=true",
+                    update.key
+                )),
+            }
+        };
+
+        match result {
+            Ok(()) => {
+                changed = true;
+                results.push(RuntimeConfigUpdateResult {
+                    key: update.key,
+                    effect: RuntimeConfigUpdateEffect::AcceptedRequiresRestart,
+                    reason: "persisted in config.json; the running host keeps its current effective config until restart/reload support is added".into(),
+                });
+            }
+            Err(error) => results.push(RuntimeConfigUpdateResult {
+                key: update.key,
+                effect: RuntimeConfigUpdateEffect::Rejected,
+                reason: error.to_string(),
+            }),
+        }
+    }
+
+    if changed {
+        save_persisted_config_at(&config.config_file_path, &stored).map_err(error_response)?;
+    }
+
+    Ok(Json(RuntimeConfigUpdateResponse {
+        ok: true,
+        changed,
+        config_file_path: config.config_file_path.clone(),
+        results,
+        runtime_surface: RuntimeConfigSurface::new(config),
+    }))
+}
+
+fn is_runtime_mutable_config_key(key: &str) -> bool {
+    matches!(
+        key,
+        "model.default"
+            | "model.fallbacks"
+            | "models.catalog"
+            | "model.unknown_fallback"
+            | "model.unknown_fallback.context_window_tokens"
+            | "model.unknown_fallback.effective_context_window_percent"
+            | "model.unknown_fallback.prompt_budget_estimated_tokens"
+            | "model.unknown_fallback.compaction_trigger_estimated_tokens"
+            | "model.unknown_fallback.compaction_keep_recent_estimated_tokens"
+            | "model.unknown_fallback.runtime_max_output_tokens"
+            | "runtime.max_output_tokens"
+            | "runtime.default_tool_output_tokens"
+            | "runtime.max_tool_output_tokens"
+            | "runtime.disable_provider_fallback"
+    ) || key.starts_with("web.")
+}
+
+fn config_value_as_raw(value: Value) -> String {
+    match value {
+        Value::String(value) => value,
+        other => other.to_string(),
+    }
 }
 
 fn runtime_surfaces(

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -103,6 +103,8 @@ const ROUTES: &[RouteSpec] = &[
     route("post", "/control/agents/{agent_id}/operator-ingress", "operatorIngress", "control", "Operator ingress", "Deliver an authenticated remote operator prompt.", Some("OperatorIngressRequest"), AuthKind::Control),
     route("get", "/control/runtime/readiness", "runtimeReadiness", "runtime", "Runtime readiness", "Return daemon readiness metadata.", None, AuthKind::Control),
     route("get", "/control/runtime/status", "runtimeStatus", "runtime", "Runtime status", "Return daemon status and runtime activity metadata.", None, AuthKind::Control),
+    route_with_response("get", "/control/runtime/config", "runtimeConfig", "runtime", "Runtime config", "Return the daemon effective runtime configuration surface.", None, "RuntimeConfigReadResponse", AuthKind::Control),
+    route_with_response("patch", "/control/runtime/config", "runtimeConfigUpdate", "runtime", "Update runtime config", "Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.", Some("RuntimeConfigUpdateRequest"), "RuntimeConfigUpdateResponse", AuthKind::Control),
     route("post", "/control/runtime/shutdown", "runtimeShutdown", "runtime", "Runtime shutdown", "Request graceful runtime shutdown.", None, AuthKind::Control),
     route("post", "/control/agents/{agent_id}/debug-prompt", "debugPrompt", "control", "Debug prompt", "Render a diagnostic prompt preview.", Some("DebugPromptRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/wake", "controlWake", "control", "Wake agent", "Submit a trusted wake hint.", Some("ControlWakeRequest"), AuthKind::Control),

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -8,7 +8,8 @@ use serde_json::{json, Value};
 use crate::{
     http::{
         CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest, PickWorkItemRequest,
-        PickWorkItemResponse, UpdateWorkItemRequest,
+        PickWorkItemResponse, RuntimeConfigReadResponse, RuntimeConfigUpdateRequest,
+        RuntimeConfigUpdateResponse, UpdateWorkItemRequest,
     },
     types::{
         TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult, TimerRecord,
@@ -486,6 +487,18 @@ fn component_schemas() -> Value {
     schemas.insert(
         "PickWorkItemResponse".into(),
         component_schema::<PickWorkItemResponse>(),
+    );
+    schemas.insert(
+        "RuntimeConfigReadResponse".into(),
+        component_schema::<RuntimeConfigReadResponse>(),
+    );
+    schemas.insert(
+        "RuntimeConfigUpdateRequest".into(),
+        component_schema::<RuntimeConfigUpdateRequest>(),
+    );
+    schemas.insert(
+        "RuntimeConfigUpdateResponse".into(),
+        component_schema::<RuntimeConfigUpdateResponse>(),
     );
     schemas.insert(
         "PickWorkItemRequest".into(),

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -30,6 +30,7 @@ http_async_tests!(
     daemon_shutdown_restart_preserves_public_agent_http_runnability,
     runtime_status_route_reports_runtime_metadata,
     runtime_readiness_route_omits_activity_summary,
+    runtime_config_route_reads_and_updates_persisted_runtime_config,
     runtime_status_route_reports_waiting_activity_summary,
     runtime_status_route_reports_last_runtime_failure_summary,
     runtime_shutdown_route_requests_shutdown,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 56, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 58, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -400,6 +400,22 @@
   },
   {
     "method": "get",
+    "path": "/control/runtime/config",
+    "handler": "runtime_config",
+    "operation_id": "runtimeConfig",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/control/runtime/readiness",
     "handler": "runtime_readiness",
     "operation_id": "runtimeReadiness",
@@ -546,6 +562,22 @@
     ],
     "request_schema": "UpdateWorkItemRequest",
     "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "patch",
+    "path": "/control/runtime/config",
+    "handler": "runtime_config_update",
+    "operation_id": "runtimeConfigUpdate",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": "RuntimeConfigUpdateRequest",
+    "request_strict": null,
     "response_content_types": [
       "application/json"
     ],

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -577,7 +577,7 @@
     "tag": "runtime",
     "parameters": [],
     "request_schema": "RuntimeConfigUpdateRequest",
-    "request_strict": null,
+    "request_strict": true,
     "response_content_types": [
       "application/json"
     ],

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use axum::Router;
 use holon::{
     client::LocalClient,
-    config::{AppConfig, ControlAuthMode},
+    config::{load_persisted_config_at, AppConfig, ControlAuthMode},
     daemon::RuntimeServiceHandle,
     host::RuntimeHost,
     http::{self, AppState},
@@ -492,6 +492,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         "/handshake",
         "/",
         "/control/runtime/status",
+        "/control/runtime/config",
         "/agents/list",
         "/agents/default/status",
         "/agents/default/state",
@@ -1106,6 +1107,72 @@ pub async fn runtime_readiness_route_omits_activity_summary() -> Result<()> {
     );
     assert!(payload.get("activity").is_none());
     assert!(payload.get("last_failure").is_none());
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -> Result<()> {
+    let config = test_config();
+    std::fs::create_dir_all(&config.workspace_dir)?;
+    init_git_repo(&config.workspace_dir)?;
+    let host = RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    let runtime_service = RuntimeServiceHandle::new(&config)?;
+    let router: Router = http::router(AppState::for_tcp_with_runtime_service(
+        host.clone(),
+        Some(runtime_service.clone()),
+    ));
+    let listener = TcpListener::bind(&config.http_addr).await?;
+    let addr = connect_addr(listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let client = reqwest::Client::new();
+    let read_response = client
+        .get(format!("http://{addr}/control/runtime/config"))
+        .bearer_auth("secret")
+        .send()
+        .await?;
+    assert!(read_response.status().is_success());
+    let read_payload: serde_json::Value = read_response.json().await?;
+    assert_eq!(read_payload["ok"], true);
+    assert_eq!(
+        read_payload["runtime_surface"]["model_default"],
+        config.default_model.as_string()
+    );
+
+    let update_response = client
+        .patch(format!("http://{addr}/control/runtime/config"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({
+            "updates": [
+                { "key": "model.default", "value": "openai/gpt-4.1" },
+                { "key": "home_dir", "value": "/tmp/other-home" }
+            ]
+        }))
+        .send()
+        .await?;
+    assert!(update_response.status().is_success());
+    let update_payload: serde_json::Value = update_response.json().await?;
+    assert_eq!(update_payload["ok"], true);
+    assert_eq!(update_payload["changed"], true);
+    assert_eq!(update_payload["results"][0]["key"], "model.default");
+    assert_eq!(
+        update_payload["results"][0]["effect"],
+        "accepted_requires_restart"
+    );
+    assert_eq!(update_payload["results"][1]["key"], "home_dir");
+    assert_eq!(update_payload["results"][1]["effect"], "rejected");
+    assert_eq!(
+        update_payload["runtime_surface"]["model_default"],
+        config.default_model.as_string()
+    );
+
+    let persisted = load_persisted_config_at(&config.config_file_path)?;
+    assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-4.1"));
 
     server.abort();
     Ok(())

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1174,6 +1174,61 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     let persisted = load_persisted_config_at(&config.config_file_path)?;
     assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-4.1"));
 
+    let valid_web_response = client
+        .patch(format!("http://{addr}/control/runtime/config"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({
+            "updates": [
+                { "key": "web.providers.review.kind", "value": "command" },
+                { "key": "web.providers.review.command.argv", "value": ["echo", "{{query}}"] },
+                { "key": "web.providers.review.output.format", "value": "json" }
+            ]
+        }))
+        .send()
+        .await?;
+    assert!(
+        valid_web_response.status().is_success(),
+        "valid command provider update failed: {:?}",
+        valid_web_response.text().await?
+    );
+    let valid_web_payload: serde_json::Value = valid_web_response.json().await?;
+    assert_eq!(valid_web_payload["changed"], true);
+
+    let invalid_web_response = client
+        .patch(format!("http://{addr}/control/runtime/config"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({
+            "updates": [
+                { "key": "model.default", "value": "openai/gpt-4.2" },
+                { "key": "web.providers.review.kind", "value": "brave" }
+            ]
+        }))
+        .send()
+        .await?;
+    assert!(invalid_web_response.status().is_success());
+    let invalid_web_payload: serde_json::Value = invalid_web_response.json().await?;
+    assert_eq!(invalid_web_payload["changed"], false);
+    assert_eq!(invalid_web_payload["results"][0]["effect"], "rejected");
+    assert_eq!(invalid_web_payload["results"][1]["effect"], "rejected");
+    assert!(
+        invalid_web_payload["results"][1]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("must not configure command.argv"),
+        "unexpected invalid config reason: {invalid_web_payload}"
+    );
+
+    let persisted = load_persisted_config_at(&config.config_file_path)?;
+    assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-4.1"));
+    assert_eq!(
+        persisted
+            .web
+            .providers
+            .get("review")
+            .map(|provider| provider.kind.as_str()),
+        Some("command")
+    );
+
     server.abort();
     Ok(())
 }


### PR DESCRIPTION
Closes #1606.

## Summary
- add GET/PATCH /control/runtime/config for effective runtime config reads and persisted runtime-mutable updates
- classify update effects as accepted_requires_restart or rejected, preserving startup-only key boundaries
- add LocalClient PATCH support plus HTTP/OpenAPI route docs and snapshots

## Verification
- cargo fmt --all -- --check
- cargo test --test http_control runtime_config_route_reads_and_updates_persisted_runtime_config
- cargo test runtime_status_route_reports_runtime_metadata
- cargo test --test openapi_snapshot
- cargo test --test http_route_snapshot
- RUSTFLAGS="-D warnings" cargo check --all-targets