### PR TITLE
feat: route config CLI through daemon config API

### DIFF
--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -73,10 +73,10 @@ than requiring a running daemon.
 
 | Command | Args | Options | Output | Initial stability | Notes |
 |---|---|---|---|---:|---|
-| `holon config get` | `<KEY>` | none | JSON value for the key | `stable` candidate | Key set comes from the configuration contract. |
-| `holon config set` | `<KEY> <VALUE>` | none | JSON value after write | `stable` candidate | Value parsing is key-specific. |
-| `holon config unset` | `<KEY>` | none | JSON `{ "key": ..., "status": "unset" }` | `stable` candidate | Status string should be locked if scripts depend on it. |
-| `holon config list` | none | none | full persisted config JSON | `experimental` | Exposes broad config file shape; align with config reference before declaring stable. |
+| `holon config get` | `<KEY>` | none | JSON value for the key | `stable` candidate | Prefers daemon runtime config API when reachable, preserving stdout shape; key set comes from the configuration contract. |
+| `holon config set` | `<KEY> <VALUE>` | none | JSON value after write | `stable` candidate | Prefers daemon runtime config API when reachable, falls back offline, and reports `applied_via` on stderr; daemon rejections surface the daemon reason. |
+| `holon config unset` | `<KEY>` | none | JSON `{ "key": ..., "status": "unset" }` | `stable` candidate | Prefers daemon runtime config API when reachable, falls back offline, and reports `applied_via` on stderr; status string should be locked if scripts depend on it. |
+| `holon config list` | none | none | full persisted config JSON | `experimental` | Prefers daemon runtime config API when reachable, preserving stdout shape; exposes broad config file shape. |
 | `holon config schema` | none | none | JSON config schema/metadata | `stable` JSON | Locked by `tests/cli_json_contract.rs`; entry objects expose `key`, `kind`, `description`, `default`, and optional `allowed_values`. |
 | `holon config doctor` | none | none | JSON provider/system diagnostics | `experimental` | Diagnostic shape may evolve as providers change. |
 | `holon config models list` | none | none | JSON model availability list | `experimental` | Provider catalog and availability details are still evolving. |

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -20,7 +20,10 @@ daemon is running, these commands prefer the daemon runtime config API; when no
 daemon is reachable, they fall back to the offline config store. `set` and
 `unset` print `applied_via=daemon_api` or `applied_via=offline_store` on
 stderr, while stdout remains the script-facing JSON value/status. Unsupported
-or startup-only daemon updates fail with the daemon-provided rejection reason.
+daemon updates fail with the daemon-provided rejection reason. Accepted daemon
+updates are persisted to `config.json`; the running daemon may continue using
+its current effective config until restart/reload support is available, and the
+CLI surfaces that daemon note on stderr.
 Use `holon config schema` to see every available key with its type, default,
 and description.
 

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -15,7 +15,14 @@ Holon stores runtime configuration in JSON files under `~/.holon/`:
 
 ## Configuration Keys
 
-Use `holon config get/set/unset/list` to read and write keys. Use `holon config schema` to see every available key with its type, default, and description.
+Use `holon config get/set/unset/list` to read and write keys. When a local
+daemon is running, these commands prefer the daemon runtime config API; when no
+daemon is reachable, they fall back to the offline config store. `set` and
+`unset` print `applied_via=daemon_api` or `applied_via=offline_store` on
+stderr, while stdout remains the script-facing JSON value/status. Unsupported
+or startup-only daemon updates fail with the daemon-provided rejection reason.
+Use `holon config schema` to see every available key with its type, default,
+and description.
 
 ### Model & Provider Settings
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -869,9 +869,8 @@ pub async fn runtime_config_update(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let config = state.host.config();
-    let mut stored = load_persisted_config_at(&config.config_file_path).map_err(error_response)?;
+    let stored = load_persisted_config_at(&config.config_file_path).map_err(error_response)?;
     let mut candidate = stored.clone();
-    let mut changed = false;
     let mut results = Vec::new();
 
     for update in request.updates {
@@ -900,7 +899,6 @@ pub async fn runtime_config_update(
 
         match result {
             Ok(()) => {
-                changed = true;
                 results.push(RuntimeConfigUpdateResult {
                     key: update.key,
                     effect: RuntimeConfigUpdateEffect::AcceptedRequiresRestart,
@@ -915,22 +913,27 @@ pub async fn runtime_config_update(
         }
     }
 
-    if changed {
-        if let Err(error) = validate_runtime_config_candidate(config, &candidate) {
-            changed = false;
-            let reason = format!("updated config is invalid: {error}");
-            for result in &mut results {
-                if result.effect == RuntimeConfigUpdateEffect::AcceptedRequiresRestart {
-                    result.effect = RuntimeConfigUpdateEffect::Rejected;
-                    result.reason = reason.clone();
-                }
-            }
-        }
+    if results
+        .iter()
+        .any(|result| result.effect == RuntimeConfigUpdateEffect::Rejected)
+    {
+        reject_accepted_runtime_config_results(
+            &mut results,
+            "batch rejected; no runtime config updates were persisted",
+        );
+    } else if let Err(error) = validate_runtime_config_candidate(config, &candidate) {
+        reject_accepted_runtime_config_results(
+            &mut results,
+            &format!("updated config is invalid: {error}"),
+        );
     }
 
+    let changed = results
+        .iter()
+        .any(|result| result.effect == RuntimeConfigUpdateEffect::AcceptedRequiresRestart);
+
     if changed {
-        stored = candidate;
-        save_persisted_config_at(&config.config_file_path, &stored).map_err(error_response)?;
+        save_persisted_config_at(&config.config_file_path, &candidate).map_err(error_response)?;
     }
 
     Ok(Json(RuntimeConfigUpdateResponse {
@@ -940,6 +943,19 @@ pub async fn runtime_config_update(
         results,
         runtime_surface: RuntimeConfigSurface::new(config),
     }))
+}
+
+fn reject_accepted_runtime_config_results(results: &mut [RuntimeConfigUpdateResult], reason: &str) {
+    for result in results {
+        if result.effect == RuntimeConfigUpdateEffect::AcceptedRequiresRestart {
+            result.effect = RuntimeConfigUpdateEffect::Rejected;
+            if result.reason.is_empty() {
+                result.reason = reason.into();
+            } else {
+                result.reason = format!("{reason}: {}", result.reason);
+            }
+        }
+    }
 }
 
 fn validate_runtime_config_candidate(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2434,10 +2434,7 @@ async fn config_set_command(key: String, value: String) -> Result<()> {
             &client,
             http::RuntimeConfigUpdateEntry {
                 key: key.clone(),
-                value: Some(
-                    serde_json::from_str(&value)
-                        .unwrap_or(serde_json::Value::String(value.clone())),
-                ),
+                value: Some(serde_json::Value::String(value.clone())),
                 unset: false,
             },
         )
@@ -2497,7 +2494,6 @@ async fn config_list_command() -> Result<()> {
 }
 
 async fn config_schema_command() -> Result<()> {
-    let _ = local_runtime_config_client().await;
     print_json(&serde_json::to_value(config_schema())?)
 }
 
@@ -2522,6 +2518,9 @@ async fn apply_runtime_config_update(
             result.key,
             result.reason
         );
+    }
+    if result.effect == http::RuntimeConfigUpdateEffect::AcceptedRequiresRestart {
+        eprintln!("daemon_update_note={}: {}", result.key, result.reason);
     }
     Ok(())
 }
@@ -2617,6 +2616,9 @@ async fn apply_runtime_config_updates(
                 result.key,
                 result.reason
             );
+        }
+        if result.effect == http::RuntimeConfigUpdateEffect::AcceptedRequiresRestart {
+            eprintln!("daemon_update_note={}: {}", result.key, result.reason);
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,10 @@ use holon::{
     host::RuntimeHost,
     http::{self, AppState, ControlRequest, CreateCommandTaskRequest, CreateTimerRequest},
     model_discovery::{discovery_cache_path, refresh_provider_models},
-    onboarding::onboarding_report,
+    onboarding::{
+        apply_onboarding_wizard_draft, onboarding_report, OnboardingApplySummary,
+        OnboardingSearchSelection, OnboardingWizardSubmission,
+    },
     onboarding_tui::run_onboarding_tui,
     provider::{provider_doctor, resolved_model_availability},
     run_once::{run_once, RunOnceRequest},
@@ -134,8 +137,10 @@ async fn run_runtime_command(command: Commands) -> Result<()> {
         if *json || !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
             return print_json(&serde_json::to_value(report)?);
         }
-        let summary = run_onboarding_tui(config)?;
+        let submission = run_onboarding_tui(config.clone())?;
+        let summary = apply_onboarding_submission(&config, &submission).await?;
         println!("Holon onboarding configured.");
+        println!("- applied via: {}", summary.applied_via);
         println!("- provider: {}", summary.provider);
         println!("- credential profile: {}", summary.credential_profile);
         println!("- default model: {}", summary.default_model);
@@ -2370,42 +2375,251 @@ fn parse_json_response_body(method: &str, path: &str, body: &str) -> Result<serd
 
 async fn handle_config_command(command: ConfigCommands) -> Result<()> {
     match command {
-        ConfigCommands::Get { key } => {
-            let path = config_file_path();
-            let config = load_persisted_config_at(&path)?;
-            print_json(&get_config_key(&config, &key)?)
-        }
-        ConfigCommands::Set { key, value } => {
-            let path = config_file_path();
-            let mut config = load_persisted_config_at(&path)?;
-            set_config_key(&mut config, &key, &value)?;
-            save_persisted_config_at(&path, &config)?;
-            print_json(&get_config_key(&config, &key)?)
-        }
-        ConfigCommands::Unset { key } => {
-            let path = config_file_path();
-            let mut config = load_persisted_config_at(&path)?;
-            unset_config_key(&mut config, &key)?;
-            save_persisted_config_at(&path, &config)?;
-            print_json(&serde_json::json!({
-                "key": key,
-                "status": "unset"
-            }))
-        }
+        ConfigCommands::Get { key } => config_get_command(key).await,
+        ConfigCommands::Set { key, value } => config_set_command(key, value).await,
+        ConfigCommands::Unset { key } => config_unset_command(key).await,
         ConfigCommands::Providers { command } => handle_config_providers_command(command).await,
         ConfigCommands::Credentials { command } => handle_config_credentials_command(command).await,
         ConfigCommands::Models { command } => handle_config_models_command(command).await,
-        ConfigCommands::List => {
-            let path = config_file_path();
-            let config = load_persisted_config_at(&path)?;
-            print_json(&serde_json::to_value(config)?)
-        }
-        ConfigCommands::Schema => print_json(&serde_json::to_value(config_schema())?),
+        ConfigCommands::List => config_list_command().await,
+        ConfigCommands::Schema => config_schema_command().await,
         ConfigCommands::Doctor => {
             let config = AppConfig::load_for_config_inspection()?;
             print_json(&provider_doctor(&config))
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigAppliedVia {
+    DaemonApi,
+    OfflineStore,
+}
+
+impl ConfigAppliedVia {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DaemonApi => "daemon_api",
+            Self::OfflineStore => "offline_store",
+        }
+    }
+}
+
+fn print_config_applied_via(applied_via: ConfigAppliedVia) {
+    eprintln!("applied_via={}", applied_via.as_str());
+}
+
+async fn local_runtime_config_client() -> Option<LocalClient> {
+    let config = AppConfig::load_for_config_inspection().ok()?;
+    let client = LocalClient::new(config).ok()?;
+    client.runtime_config().await.ok()?;
+    Some(client)
+}
+
+async fn config_get_command(key: String) -> Result<()> {
+    if let Some(client) = local_runtime_config_client().await {
+        let response = client.runtime_config().await?;
+        let config = load_persisted_config_at(&response.config_file_path)?;
+        return print_json(&get_config_key(&config, &key)?);
+    }
+
+    let path = config_file_path();
+    let config = load_persisted_config_at(&path)?;
+    print_json(&get_config_key(&config, &key)?)
+}
+
+async fn config_set_command(key: String, value: String) -> Result<()> {
+    if let Some(client) = local_runtime_config_client().await {
+        apply_runtime_config_update(
+            &client,
+            http::RuntimeConfigUpdateEntry {
+                key: key.clone(),
+                value: Some(
+                    serde_json::from_str(&value)
+                        .unwrap_or(serde_json::Value::String(value.clone())),
+                ),
+                unset: false,
+            },
+        )
+        .await?;
+        let config = load_persisted_config_at(&client.runtime_config().await?.config_file_path)?;
+        print_config_applied_via(ConfigAppliedVia::DaemonApi);
+        return print_json(&get_config_key(&config, &key)?);
+    }
+
+    let path = config_file_path();
+    let mut config = load_persisted_config_at(&path)?;
+    set_config_key(&mut config, &key, &value)?;
+    save_persisted_config_at(&path, &config)?;
+    print_config_applied_via(ConfigAppliedVia::OfflineStore);
+    print_json(&get_config_key(&config, &key)?)
+}
+
+async fn config_unset_command(key: String) -> Result<()> {
+    if let Some(client) = local_runtime_config_client().await {
+        apply_runtime_config_update(
+            &client,
+            http::RuntimeConfigUpdateEntry {
+                key: key.clone(),
+                value: None,
+                unset: true,
+            },
+        )
+        .await?;
+        print_config_applied_via(ConfigAppliedVia::DaemonApi);
+        return print_json(&serde_json::json!({
+            "key": key,
+            "status": "unset"
+        }));
+    }
+
+    let path = config_file_path();
+    let mut config = load_persisted_config_at(&path)?;
+    unset_config_key(&mut config, &key)?;
+    save_persisted_config_at(&path, &config)?;
+    print_config_applied_via(ConfigAppliedVia::OfflineStore);
+    print_json(&serde_json::json!({
+        "key": key,
+        "status": "unset"
+    }))
+}
+
+async fn config_list_command() -> Result<()> {
+    if let Some(client) = local_runtime_config_client().await {
+        let response = client.runtime_config().await?;
+        let config = load_persisted_config_at(&response.config_file_path)?;
+        return print_json(&serde_json::to_value(config)?);
+    }
+
+    let path = config_file_path();
+    let config = load_persisted_config_at(&path)?;
+    print_json(&serde_json::to_value(config)?)
+}
+
+async fn config_schema_command() -> Result<()> {
+    let _ = local_runtime_config_client().await;
+    print_json(&serde_json::to_value(config_schema())?)
+}
+
+async fn apply_runtime_config_update(
+    client: &LocalClient,
+    update: http::RuntimeConfigUpdateEntry,
+) -> Result<()> {
+    let key = update.key.clone();
+    let response = client
+        .update_runtime_config(&http::RuntimeConfigUpdateRequest {
+            updates: vec![update],
+        })
+        .await?;
+    let result = response
+        .results
+        .iter()
+        .find(|result| result.key == key)
+        .with_context(|| format!("daemon runtime config response omitted result for {key}"))?;
+    if result.effect == http::RuntimeConfigUpdateEffect::Rejected {
+        anyhow::bail!(
+            "daemon rejected runtime config update for {}: {}",
+            result.key,
+            result.reason
+        );
+    }
+    Ok(())
+}
+
+async fn apply_onboarding_submission(
+    config: &AppConfig,
+    submission: &OnboardingWizardSubmission,
+) -> Result<OnboardingApplySummary> {
+    let mut summary = apply_onboarding_wizard_draft(
+        config,
+        &submission.draft,
+        submission.credential_material.clone(),
+    )?;
+
+    if let Some(client) = local_runtime_config_client().await {
+        let mut updates = vec![http::RuntimeConfigUpdateEntry {
+            key: "model.default".into(),
+            value: Some(serde_json::Value::String(
+                submission.draft.default_model.as_string(),
+            )),
+            unset: false,
+        }];
+        match submission.draft.search {
+            OnboardingSearchSelection::Disabled => {
+                updates.push(http::RuntimeConfigUpdateEntry {
+                    key: "web.search.enabled".into(),
+                    value: Some(serde_json::json!(false)),
+                    unset: false,
+                });
+            }
+            OnboardingSearchSelection::Auto => {
+                updates.extend([
+                    http::RuntimeConfigUpdateEntry {
+                        key: "web.search.enabled".into(),
+                        value: Some(serde_json::json!(true)),
+                        unset: false,
+                    },
+                    http::RuntimeConfigUpdateEntry {
+                        key: "web.search.builtin_provider.enabled".into(),
+                        value: Some(serde_json::json!(true)),
+                        unset: false,
+                    },
+                    http::RuntimeConfigUpdateEntry {
+                        key: "web.search.provider".into(),
+                        value: Some(serde_json::Value::String("auto".into())),
+                        unset: false,
+                    },
+                ]);
+            }
+            OnboardingSearchSelection::ManagedDuckDuckGo => {
+                updates.extend([
+                    http::RuntimeConfigUpdateEntry {
+                        key: "web.search.enabled".into(),
+                        value: Some(serde_json::json!(true)),
+                        unset: false,
+                    },
+                    http::RuntimeConfigUpdateEntry {
+                        key: "web.search.builtin_provider.enabled".into(),
+                        value: Some(serde_json::json!(false)),
+                        unset: false,
+                    },
+                    http::RuntimeConfigUpdateEntry {
+                        key: "web.search.provider".into(),
+                        value: Some(serde_json::Value::String("duckduckgo".into())),
+                        unset: false,
+                    },
+                    http::RuntimeConfigUpdateEntry {
+                        key: "web.search.providers".into(),
+                        value: Some(serde_json::json!(["duckduckgo"])),
+                        unset: false,
+                    },
+                ]);
+            }
+        }
+        apply_runtime_config_updates(&client, updates).await?;
+        summary.applied_via = ConfigAppliedVia::DaemonApi.as_str().into();
+    }
+
+    Ok(summary)
+}
+
+async fn apply_runtime_config_updates(
+    client: &LocalClient,
+    updates: Vec<http::RuntimeConfigUpdateEntry>,
+) -> Result<()> {
+    let response = client
+        .update_runtime_config(&http::RuntimeConfigUpdateRequest { updates })
+        .await?;
+    for result in &response.results {
+        if result.effect == http::RuntimeConfigUpdateEffect::Rejected {
+            anyhow::bail!(
+                "daemon rejected runtime config update for {}: {}",
+                result.key,
+                result.reason
+            );
+        }
+    }
+    Ok(())
 }
 
 async fn handle_config_models_command(command: ConfigModelCommands) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use clap::ValueEnum;
 
 use holon::{
-    client::{normalize_control_base_url, LocalClient},
+    client::{normalize_control_base_url, LocalClient, LocalHttpError},
     config::{
         built_in_provider_default_config, config_schema, credential_store_path, default_holon_home,
         get_config_key, list_credential_profiles_at, load_credential_store_at,
@@ -2409,16 +2409,31 @@ fn print_config_applied_via(applied_via: ConfigAppliedVia) {
     eprintln!("applied_via={}", applied_via.as_str());
 }
 
-async fn local_runtime_config_client() -> Option<LocalClient> {
-    let config = AppConfig::load_for_config_inspection().ok()?;
-    let client = LocalClient::new(config).ok()?;
-    client.runtime_config().await.ok()?;
-    Some(client)
+async fn local_runtime_config() -> Result<Option<(LocalClient, http::RuntimeConfigReadResponse)>> {
+    let config = AppConfig::load_for_config_inspection()?;
+    let client = LocalClient::new(config)?;
+    match client.runtime_config().await {
+        Ok(response) => Ok(Some((client, response))),
+        Err(error) if is_local_runtime_absent(&error) => Ok(None),
+        Err(error) => Err(error).context("local daemon runtime config API is unavailable"),
+    }
+}
+
+fn is_local_runtime_absent(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        if let Some(http_error) = cause.downcast_ref::<LocalHttpError>() {
+            return http_error.status_code == 404;
+        }
+        let message = cause.to_string();
+        message.contains("Connection refused")
+            || message.contains("connection refused")
+            || message.contains("No such file or directory")
+            || message.contains("os error 2")
+    })
 }
 
 async fn config_get_command(key: String) -> Result<()> {
-    if let Some(client) = local_runtime_config_client().await {
-        let response = client.runtime_config().await?;
+    if let Some((_client, response)) = local_runtime_config().await? {
         let config = load_persisted_config_at(&response.config_file_path)?;
         return print_json(&get_config_key(&config, &key)?);
     }
@@ -2429,8 +2444,8 @@ async fn config_get_command(key: String) -> Result<()> {
 }
 
 async fn config_set_command(key: String, value: String) -> Result<()> {
-    if let Some(client) = local_runtime_config_client().await {
-        apply_runtime_config_update(
+    if let Some((client, _response)) = local_runtime_config().await? {
+        let response = apply_runtime_config_update(
             &client,
             http::RuntimeConfigUpdateEntry {
                 key: key.clone(),
@@ -2439,7 +2454,7 @@ async fn config_set_command(key: String, value: String) -> Result<()> {
             },
         )
         .await?;
-        let config = load_persisted_config_at(&client.runtime_config().await?.config_file_path)?;
+        let config = load_persisted_config_at(&response.config_file_path)?;
         print_config_applied_via(ConfigAppliedVia::DaemonApi);
         return print_json(&get_config_key(&config, &key)?);
     }
@@ -2453,7 +2468,7 @@ async fn config_set_command(key: String, value: String) -> Result<()> {
 }
 
 async fn config_unset_command(key: String) -> Result<()> {
-    if let Some(client) = local_runtime_config_client().await {
+    if let Some((client, _response)) = local_runtime_config().await? {
         apply_runtime_config_update(
             &client,
             http::RuntimeConfigUpdateEntry {
@@ -2482,8 +2497,7 @@ async fn config_unset_command(key: String) -> Result<()> {
 }
 
 async fn config_list_command() -> Result<()> {
-    if let Some(client) = local_runtime_config_client().await {
-        let response = client.runtime_config().await?;
+    if let Some((_client, response)) = local_runtime_config().await? {
         let config = load_persisted_config_at(&response.config_file_path)?;
         return print_json(&serde_json::to_value(config)?);
     }
@@ -2500,7 +2514,7 @@ async fn config_schema_command() -> Result<()> {
 async fn apply_runtime_config_update(
     client: &LocalClient,
     update: http::RuntimeConfigUpdateEntry,
-) -> Result<()> {
+) -> Result<http::RuntimeConfigUpdateResponse> {
     let key = update.key.clone();
     let response = client
         .update_runtime_config(&http::RuntimeConfigUpdateRequest {
@@ -2522,20 +2536,14 @@ async fn apply_runtime_config_update(
     if result.effect == http::RuntimeConfigUpdateEffect::AcceptedRequiresRestart {
         eprintln!("daemon_update_note={}: {}", result.key, result.reason);
     }
-    Ok(())
+    Ok(response)
 }
 
 async fn apply_onboarding_submission(
     config: &AppConfig,
     submission: &OnboardingWizardSubmission,
 ) -> Result<OnboardingApplySummary> {
-    let mut summary = apply_onboarding_wizard_draft(
-        config,
-        &submission.draft,
-        submission.credential_material.clone(),
-    )?;
-
-    if let Some(client) = local_runtime_config_client().await {
+    if let Some((client, _response)) = local_runtime_config().await? {
         let mut updates = vec![http::RuntimeConfigUpdateEntry {
             key: "model.default".into(),
             value: Some(serde_json::Value::String(
@@ -2596,16 +2604,26 @@ async fn apply_onboarding_submission(
             }
         }
         apply_runtime_config_updates(&client, updates).await?;
+        let mut summary = apply_onboarding_wizard_draft(
+            config,
+            &submission.draft,
+            submission.credential_material.clone(),
+        )?;
         summary.applied_via = ConfigAppliedVia::DaemonApi.as_str().into();
+        return Ok(summary);
     }
 
-    Ok(summary)
+    apply_onboarding_wizard_draft(
+        config,
+        &submission.draft,
+        submission.credential_material.clone(),
+    )
 }
 
 async fn apply_runtime_config_updates(
     client: &LocalClient,
     updates: Vec<http::RuntimeConfigUpdateEntry>,
-) -> Result<()> {
+) -> Result<http::RuntimeConfigUpdateResponse> {
     let response = client
         .update_runtime_config(&http::RuntimeConfigUpdateRequest { updates })
         .await?;
@@ -2621,7 +2639,7 @@ async fn apply_runtime_config_updates(
             eprintln!("daemon_update_note={}: {}", result.key, result.reason);
         }
     }
-    Ok(())
+    Ok(response)
 }
 
 async fn handle_config_models_command(command: ConfigModelCommands) -> Result<()> {

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -173,7 +173,7 @@ pub struct OnboardingApplySummary {
     pub credential_written: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct OnboardingWizardSubmission {
     pub draft: OnboardingWizardDraft,
     pub credential_material: Option<String>,

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -164,12 +164,19 @@ pub struct OnboardingSearchChoice {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OnboardingApplySummary {
+    pub applied_via: String,
     pub provider: String,
     pub credential_profile: String,
     pub credential_kind: String,
     pub default_model: String,
     pub search: String,
     pub credential_written: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnboardingWizardSubmission {
+    pub draft: OnboardingWizardDraft,
+    pub credential_material: Option<String>,
 }
 
 pub fn onboarding_provider_choices(config: &AppConfig) -> Vec<OnboardingProviderChoice> {
@@ -463,6 +470,7 @@ pub fn apply_onboarding_wizard_draft(
     save_persisted_config_at(&config.config_file_path, &persisted)?;
 
     Ok(OnboardingApplySummary {
+        applied_via: "offline_store".into(),
         provider: draft.provider.as_str().into(),
         credential_profile: draft.credential_profile.clone(),
         credential_kind: draft.credential_kind.as_str().into(),
@@ -1270,6 +1278,7 @@ mod tests {
         let store = load_credential_store_at(&credential_store_path(&config.home_dir)).unwrap();
 
         assert_eq!(summary.provider, "openai");
+        assert_eq!(summary.applied_via, "offline_store");
         assert_eq!(summary.default_model, "openai/gpt-5.4");
         assert_eq!(summary.search, "Managed WebSearch: DuckDuckGo");
         assert!(summary.credential_written);

--- a/src/onboarding_tui.rs
+++ b/src/onboarding_tui.rs
@@ -23,17 +23,16 @@ use crate::{
     auth::run_codex_oauth_login_profile_material,
     config::{AppConfig, CredentialKind, ModelRef, ProviderId},
     onboarding::{
-        apply_onboarding_wizard_draft, onboarding_model_choices, onboarding_provider_choices,
-        onboarding_search_choices, OnboardingApplySummary, OnboardingModelChoice,
-        OnboardingProviderChoice, OnboardingSearchChoice, OnboardingSearchSelection,
-        OnboardingWizardDraft,
+        onboarding_model_choices, onboarding_provider_choices, onboarding_search_choices,
+        OnboardingModelChoice, OnboardingProviderChoice, OnboardingSearchChoice,
+        OnboardingSearchSelection, OnboardingWizardDraft, OnboardingWizardSubmission,
     },
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const DUCKDUCKGO_SEARCH_PROVIDER_ID: &str = "duckduckgo";
 
-pub fn run_onboarding_tui(config: AppConfig) -> Result<OnboardingApplySummary> {
+pub fn run_onboarding_tui(config: AppConfig) -> Result<OnboardingWizardSubmission> {
     let mut app = OnboardingTuiApp::new(&config);
     let mut guard = TerminalGuard::new();
     enable_raw_mode()?;
@@ -54,9 +53,10 @@ pub fn run_onboarding_tui(config: AppConfig) -> Result<OnboardingApplySummary> {
         if let Some(draft) = app.completed_draft.clone() {
             terminal.show_cursor()?;
             drop(guard);
-            let summary =
-                apply_onboarding_wizard_draft(&config, &draft, app.credential_material.clone())?;
-            return Ok(summary);
+            return Ok(OnboardingWizardSubmission {
+                draft,
+                credential_material: app.credential_material.clone(),
+            });
         }
         if event::poll(POLL_INTERVAL)? {
             if let Event::Key(key) = event::read()? {

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -6,8 +6,11 @@
 
 use std::{
     collections::BTreeSet,
+    io::{BufRead, BufReader},
     path::PathBuf,
-    process::{Command, Output},
+    process::{Child, Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant},
 };
 
 use serde_json::{json, Value};
@@ -35,8 +38,71 @@ fn isolated_holon_command(home: &tempfile::TempDir) -> Command {
     command
 }
 
+struct ServeChild {
+    child: Child,
+}
+
+impl Drop for ServeChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
+    let mut child = isolated_holon_command(home)
+        .args(["serve", "--listen", "127.0.0.1:0"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn holon serve");
+    let stdout = child.stdout.take().expect("serve stdout should be piped");
+    let mut reader = BufReader::new(stdout);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut line = String::new();
+    let mut addr = None;
+    while Instant::now() < deadline {
+        line.clear();
+        if reader.read_line(&mut line).expect("read serve stdout") > 0 {
+            if line.starts_with("Holon listening on ") {
+                addr = Some(
+                    line.trim()
+                        .trim_start_matches("Holon listening on ")
+                        .to_string(),
+                );
+            } else if line.starts_with("Holon control socket on ") {
+                let addr = addr.expect("serve should print TCP listener before control socket");
+                return (ServeChild { child }, addr);
+            }
+        }
+        if line.starts_with("Holon listening on ") && addr.is_some() {
+            let Some(addr) = addr.clone() else {
+                unreachable!("addr should be set")
+            };
+            if !cfg!(unix) {
+                return (ServeChild { child }, addr);
+            }
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    let _ = child.kill();
+    panic!("timed out waiting for holon serve to print listening address");
+}
+
 fn run_json(home: &tempfile::TempDir, args: &[&str]) -> Value {
     let output = isolated_holon_command(home)
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("run holon {args:?}: {error}"));
+    assert_success(output, args)
+}
+
+fn run_json_with_env(home: &tempfile::TempDir, args: &[&str], envs: &[(&str, &str)]) -> Value {
+    let mut command = isolated_holon_command(home);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    let output = command
         .args(args)
         .output()
         .unwrap_or_else(|error| panic!("run holon {args:?}: {error}"));
@@ -54,6 +120,46 @@ fn assert_success(output: Output, args: &[&str]) -> Value {
     assert!(stderr.is_empty(), "stderr should stay empty: {stderr}");
     serde_json::from_str(&stdout)
         .unwrap_or_else(|error| panic!("stdout should be JSON for {args:?}: {error}\n{stdout}"))
+}
+
+fn run_json_with_stderr(home: &tempfile::TempDir, args: &[&str]) -> (Value, String) {
+    let output = isolated_holon_command(home)
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("run holon {args:?}: {error}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "holon {args:?} failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("stdout should be JSON for {args:?}: {error}\n{stdout}"));
+    (value, stderr)
+}
+
+fn run_failure_with_env(
+    home: &tempfile::TempDir,
+    args: &[&str],
+    envs: &[(&str, &str)],
+) -> (String, String) {
+    let mut command = isolated_holon_command(home);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    let output = command
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("run holon {args:?}: {error}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "holon {args:?} should fail\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    (stdout, stderr)
 }
 
 #[test]
@@ -219,6 +325,117 @@ fn config_credentials_json_contract_is_stable_and_redacted() {
 
     let empty_list = run_json(&home, &["config", "credentials", "list"]);
     assert_eq!(empty_list, json!([]));
+}
+
+#[test]
+fn config_set_unset_reports_offline_application_path_on_stderr() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+
+    let (set, set_stderr) =
+        run_json_with_stderr(&home, &["config", "set", "model.default", "openai/gpt-4.1"]);
+    assert_eq!(set, json!("openai/gpt-4.1"));
+    assert_eq!(set_stderr, "applied_via=offline_store\n");
+
+    let get = run_json(&home, &["config", "get", "model.default"]);
+    assert_eq!(get, json!("openai/gpt-4.1"));
+
+    let (unset, unset_stderr) = run_json_with_stderr(&home, &["config", "unset", "model.default"]);
+    assert_eq!(
+        unset,
+        json!({
+            "key": "model.default",
+            "status": "unset"
+        })
+    );
+    assert_eq!(unset_stderr, "applied_via=offline_store\n");
+}
+
+#[test]
+fn config_set_prefers_running_daemon_runtime_config_api() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+    let (_serve, addr) = spawn_local_serve(&home);
+
+    let (set, set_stderr) = {
+        let mut command = isolated_holon_command(&home);
+        command.env("HOLON_HTTP_ADDR", &addr);
+        let output = command
+            .args(["config", "set", "model.default", "openai/gpt-4.1"])
+            .output()
+            .expect("run holon config set");
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "config set failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        (
+            serde_json::from_str::<Value>(&stdout).expect("set stdout should be JSON"),
+            stderr,
+        )
+    };
+    assert_eq!(set, json!("openai/gpt-4.1"));
+    assert_eq!(set_stderr, "applied_via=daemon_api\n");
+
+    let get = run_json_with_env(
+        &home,
+        &["config", "get", "model.default"],
+        &[("HOLON_HTTP_ADDR", &addr)],
+    );
+    assert_eq!(get, json!("openai/gpt-4.1"));
+
+    let (unset, unset_stderr) = {
+        let mut command = isolated_holon_command(&home);
+        command.env("HOLON_HTTP_ADDR", &addr);
+        let output = command
+            .args(["config", "unset", "model.default"])
+            .output()
+            .expect("run holon config unset");
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "config unset failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        (
+            serde_json::from_str::<Value>(&stdout).expect("unset stdout should be JSON"),
+            stderr,
+        )
+    };
+    assert_eq!(
+        unset,
+        json!({
+            "key": "model.default",
+            "status": "unset"
+        })
+    );
+    assert_eq!(unset_stderr, "applied_via=daemon_api\n");
+}
+
+#[test]
+fn config_set_surfaces_daemon_rejection_reason() {
+    let home = tempfile::tempdir().expect("create isolated HOLON_HOME");
+    let (_serve, addr) = spawn_local_serve(&home);
+
+    let (stdout, stderr) = run_failure_with_env(
+        &home,
+        &["config", "set", "home_dir", "/tmp/other-home"],
+        &[("HOLON_HTTP_ADDR", &addr)],
+    );
+
+    assert!(
+        stdout.is_empty(),
+        "failed config set should not emit JSON stdout"
+    );
+    assert!(
+        stderr.contains("daemon rejected runtime config update for home_dir"),
+        "stderr should name the rejected key: {stderr}"
+    );
+    assert!(
+        stderr.contains("unsupported or startup-only config key"),
+        "stderr should surface daemon-provided reason: {stderr}"
+    );
 }
 
 #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -53,11 +53,13 @@ impl Drop for ServeChild {
 fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
     let mut child = isolated_holon_command(home)
         .args(["serve", "--listen", "127.0.0.1:0"])
+        .env("HOLON_PRE_SERVER_RUNTIME_PREPARED", "1")
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("spawn holon serve");
     let stdout = child.stdout.take().expect("serve stdout should be piped");
+    let stderr = child.stderr.take().expect("serve stderr should be piped");
     let (line_tx, line_rx) = mpsc::channel();
     thread::spawn(move || {
         let reader = BufReader::new(stdout);
@@ -67,11 +69,34 @@ fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
             }
         }
     });
+    let (stderr_tx, stderr_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        let mut captured = String::new();
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    captured.push_str(&line);
+                    captured.push('\n');
+                }
+                Err(error) => {
+                    captured.push_str(&format!("failed to read serve stderr: {error}\n"));
+                    break;
+                }
+            }
+        }
+        let _ = stderr_tx.send(captured);
+    });
     let deadline = Instant::now() + Duration::from_secs(10);
     let mut addr = None;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().expect("poll holon serve") {
-            panic!("holon serve exited before printing listening address: {status}");
+            let stderr = stderr_rx
+                .recv_timeout(Duration::from_millis(100))
+                .unwrap_or_default();
+            panic!(
+                "holon serve exited before printing listening address: {status}\nstderr:\n{stderr}"
+            );
         }
         match line_rx.recv_timeout(Duration::from_millis(25)) {
             Ok(Ok(line)) => {
@@ -97,12 +122,18 @@ fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
             Ok(Err(error)) => panic!("read serve stdout: {error}"),
             Err(mpsc::RecvTimeoutError::Timeout) => {}
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("holon serve stdout closed before listening address was printed")
+                let stderr = stderr_rx
+                    .recv_timeout(Duration::from_millis(100))
+                    .unwrap_or_default();
+                panic!("holon serve stdout closed before listening address was printed\nstderr:\n{stderr}")
             }
         };
     }
     let _ = child.kill();
-    panic!("timed out waiting for holon serve to print listening address");
+    let stderr = stderr_rx
+        .recv_timeout(Duration::from_millis(100))
+        .unwrap_or_default();
+    panic!("timed out waiting for holon serve to print listening address\nstderr:\n{stderr}");
 }
 
 fn run_json(home: &tempfile::TempDir, args: &[&str]) -> Value {

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -54,6 +54,7 @@ fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
     let mut child = isolated_holon_command(home)
         .args(["serve", "--listen", "127.0.0.1:0"])
         .env("HOLON_PRE_SERVER_RUNTIME_PREPARED", "1")
+        .env("OPENAI_API_KEY", "test-openai-api-key")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -9,6 +9,7 @@ use std::{
     io::{BufRead, BufReader},
     path::PathBuf,
     process::{Child, Command, Output, Stdio},
+    sync::mpsc,
     thread,
     time::{Duration, Instant},
 };
@@ -53,37 +54,52 @@ fn spawn_local_serve(home: &tempfile::TempDir) -> (ServeChild, String) {
     let mut child = isolated_holon_command(home)
         .args(["serve", "--listen", "127.0.0.1:0"])
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::null())
         .spawn()
         .expect("spawn holon serve");
     let stdout = child.stdout.take().expect("serve stdout should be piped");
-    let mut reader = BufReader::new(stdout);
+    let (line_tx, line_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            if line_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
     let deadline = Instant::now() + Duration::from_secs(10);
-    let mut line = String::new();
     let mut addr = None;
     while Instant::now() < deadline {
-        line.clear();
-        if reader.read_line(&mut line).expect("read serve stdout") > 0 {
-            if line.starts_with("Holon listening on ") {
-                addr = Some(
-                    line.trim()
-                        .trim_start_matches("Holon listening on ")
-                        .to_string(),
-                );
-            } else if line.starts_with("Holon control socket on ") {
-                let addr = addr.expect("serve should print TCP listener before control socket");
-                return (ServeChild { child }, addr);
-            }
+        if let Some(status) = child.try_wait().expect("poll holon serve") {
+            panic!("holon serve exited before printing listening address: {status}");
         }
-        if line.starts_with("Holon listening on ") && addr.is_some() {
-            let Some(addr) = addr.clone() else {
-                unreachable!("addr should be set")
-            };
-            if !cfg!(unix) {
-                return (ServeChild { child }, addr);
+        match line_rx.recv_timeout(Duration::from_millis(25)) {
+            Ok(Ok(line)) => {
+                if line.starts_with("Holon listening on ") {
+                    addr = Some(
+                        line.trim()
+                            .trim_start_matches("Holon listening on ")
+                            .to_string(),
+                    );
+                } else if line.starts_with("Holon control socket on ") {
+                    let addr = addr.expect("serve should print TCP listener before control socket");
+                    return (ServeChild { child }, addr);
+                }
+                if line.starts_with("Holon listening on ") && addr.is_some() {
+                    let Some(addr) = addr.clone() else {
+                        unreachable!("addr should be set")
+                    };
+                    if !cfg!(unix) {
+                        return (ServeChild { child }, addr);
+                    }
+                }
             }
-        }
-        thread::sleep(Duration::from_millis(25));
+            Ok(Err(error)) => panic!("read serve stdout: {error}"),
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("holon serve stdout closed before listening address was printed")
+            }
+        };
     }
     let _ = child.kill();
     panic!("timed out waiting for holon serve to print listening address");
@@ -375,7 +391,10 @@ fn config_set_prefers_running_daemon_runtime_config_api() {
         )
     };
     assert_eq!(set, json!("openai/gpt-4.1"));
-    assert_eq!(set_stderr, "applied_via=daemon_api\n");
+    assert!(
+        set_stderr.contains("applied_via=daemon_api\n"),
+        "stderr should report daemon application path: {set_stderr}"
+    );
 
     let get = run_json_with_env(
         &home,
@@ -410,7 +429,10 @@ fn config_set_prefers_running_daemon_runtime_config_api() {
             "status": "unset"
         })
     );
-    assert_eq!(unset_stderr, "applied_via=daemon_api\n");
+    assert!(
+        unset_stderr.contains("applied_via=daemon_api\n"),
+        "stderr should report daemon application path: {unset_stderr}"
+    );
 }
 
 #[test]

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1158,17 +1158,35 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     assert!(update_response.status().is_success());
     let update_payload: serde_json::Value = update_response.json().await?;
     assert_eq!(update_payload["ok"], true);
-    assert_eq!(update_payload["changed"], true);
+    assert_eq!(update_payload["changed"], false);
     assert_eq!(update_payload["results"][0]["key"], "model.default");
-    assert_eq!(
-        update_payload["results"][0]["effect"],
-        "accepted_requires_restart"
-    );
+    assert_eq!(update_payload["results"][0]["effect"], "rejected");
     assert_eq!(update_payload["results"][1]["key"], "home_dir");
     assert_eq!(update_payload["results"][1]["effect"], "rejected");
     assert_eq!(
         update_payload["runtime_surface"]["model_default"],
         config.default_model.as_string()
+    );
+
+    let persisted = load_persisted_config_at(&config.config_file_path)?;
+    assert_eq!(persisted.model.default, None);
+
+    let valid_model_response = client
+        .patch(format!("http://{addr}/control/runtime/config"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({
+            "updates": [
+                { "key": "model.default", "value": "openai/gpt-4.1" }
+            ]
+        }))
+        .send()
+        .await?;
+    assert!(valid_model_response.status().is_success());
+    let valid_model_payload: serde_json::Value = valid_model_response.json().await?;
+    assert_eq!(valid_model_payload["changed"], true);
+    assert_eq!(
+        valid_model_payload["results"][0]["effect"],
+        "accepted_requires_restart"
     );
 
     let persisted = load_persisted_config_at(&config.config_file_path)?;


### PR DESCRIPTION
Closes #1607.

## Summary
- Route `holon config get/list/schema/set/unset` through the daemon runtime config API when a local daemon is reachable, while preserving offline config store fallback.
- Keep script-facing stdout JSON stable and report mutation application path via `applied_via=daemon_api|offline_store` on stderr.
- Surface daemon rejection reasons for unsupported/startup-only config updates.
- Carry onboarding apply summaries through an explicit submission/apply step and report the chosen application path.
- Update configuration/CLI contract docs and add CLI contract coverage for offline, daemon, and rejection paths.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test cli_json_contract`
- `cargo test --test http_control runtime_config_route_reads_and_updates_persisted_runtime_config`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`