### PR TITLE
feat: make transcript and message history DB canonical

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -577,6 +577,16 @@ fn prepare_runtime_storage(
             .timers()
             .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
     }
+    if !storage_domain_complete(&runtime_db, "messages")? {
+        runtime_db
+            .messages()
+            .import_legacy(storage.read_all_message_values()?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "transcript_entries")? {
+        runtime_db
+            .transcript_entries()
+            .import_legacy(storage.read_all_transcript()?)?;
+    }
     let turn_records_complete = storage_domain_complete(&runtime_db, "turn_records")?;
     let evidence_complete = storage_domain_complete(&runtime_db, "evidence")?;
     let legacy_messages =

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -441,6 +441,56 @@ fn prepare_runtime_storage(
         }
     }
 
+    let recovered_agent_for_import = storage.read_agent()?;
+    if !storage_domain_complete(&runtime_db, "work_items")? {
+        let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
+        for record in &mut legacy_work_items {
+            crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
+        }
+        runtime_db.work_items().import_legacy(
+            legacy_work_items,
+            recovered_agent_for_import
+                .as_ref()
+                .and_then(|agent| agent.current_work_item_id.as_deref()),
+        )?;
+    }
+    if !storage_domain_complete(&runtime_db, "tasks")? {
+        runtime_db
+            .tasks()
+            .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "external_triggers")? {
+        runtime_db
+            .external_triggers()
+            .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "wait_conditions")? {
+        runtime_db
+            .wait_conditions()
+            .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "queue_entries")? {
+        runtime_db
+            .queue_entries()
+            .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "timers")? {
+        runtime_db
+            .timers()
+            .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "messages")? {
+        runtime_db
+            .messages()
+            .import_legacy(storage.read_all_message_values()?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "transcript_entries")? {
+        runtime_db
+            .transcript_entries()
+            .import_legacy(storage.read_all_transcript()?)?;
+    }
+
+    storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
     let snapshot = storage.recovery_snapshot()?;
     let mut queue = RuntimeQueue::default();
     for message in &snapshot.replay_messages {
@@ -543,50 +593,6 @@ fn prepare_runtime_storage(
         },
     );
     storage.write_agent(&state)?;
-    if !storage_domain_complete(&runtime_db, "work_items")? {
-        let mut legacy_work_items = storage.read_recent_work_items(usize::MAX)?;
-        for record in &mut legacy_work_items {
-            crate::work_item_plan::refresh_plan_artifact_metadata(storage.data_dir(), record)?;
-        }
-        runtime_db
-            .work_items()
-            .import_legacy(legacy_work_items, state.current_work_item_id.as_deref())?;
-    }
-    if !storage_domain_complete(&runtime_db, "tasks")? {
-        runtime_db
-            .tasks()
-            .import_legacy(storage.read_recent_tasks(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "external_triggers")? {
-        runtime_db
-            .external_triggers()
-            .import_legacy(storage.read_recent_external_triggers(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "wait_conditions")? {
-        runtime_db
-            .wait_conditions()
-            .import_legacy(storage.read_recent_wait_conditions(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "queue_entries")? {
-        runtime_db
-            .queue_entries()
-            .import_legacy(storage.read_recent_queue_entries(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "timers")? {
-        runtime_db
-            .timers()
-            .import_legacy(storage.read_recent_timers(usize::MAX)?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "messages")? {
-        runtime_db
-            .messages()
-            .import_legacy(storage.read_all_message_values()?)?;
-    }
-    if !storage_domain_complete(&runtime_db, "transcript_entries")? {
-        runtime_db
-            .transcript_entries()
-            .import_legacy(storage.read_all_transcript()?)?;
-    }
     let turn_records_complete = storage_domain_complete(&runtime_db, "turn_records")?;
     let evidence_complete = storage_domain_complete(&runtime_db, "evidence")?;
     let legacy_messages =
@@ -619,7 +625,6 @@ fn prepare_runtime_storage(
         crate::runtime_db::RuntimeDb::expected_storage_domains(),
     )?;
     storage.enable_audit_event_index(runtime_db.clone(), Some(state.id.clone()))?;
-    storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
 
     Ok(PreparedRuntimeStorage {
         storage,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -269,8 +269,13 @@ impl RuntimeHandle {
                 Err(err) => (format!("child agent failed: {err:#}"), TaskStatus::Failed),
             };
             let status_label = task_status_label(&status);
+            let mut task_detail = task_record
+                .detail
+                .clone()
+                .unwrap_or_else(|| serde_json::json!({}));
+            task_detail["output_summary"] = serde_json::json!(text.clone());
 
-            let terminal_task = task_with_status(&task_record, status, task_record.detail.clone());
+            let terminal_task = task_with_status(&task_record, status, Some(task_detail.clone()));
             if let Err(error) = runtime
                 .persist_task_status_direct(&terminal_task, "task_status_updated")
                 .await
@@ -287,7 +292,7 @@ impl RuntimeHandle {
                     "task_kind": task_record.kind,
                     "task_status": status_label,
                     "task_summary": task_record.summary,
-                    "task_detail": task_record.detail,
+                    "task_detail": task_detail,
                     "task_recovery": task_record.recovery,
                     "work_item_id": task_record.work_item_id.clone(),
                 })),
@@ -740,6 +745,7 @@ impl RuntimeHandle {
                 }
             }
 
+            task_detail["output_summary"] = serde_json::json!(text.clone());
             let status_label = task_status_label(&status);
             let mut metadata = serde_json::json!({
                 "task_id": task_record.id,
@@ -1182,6 +1188,7 @@ impl RuntimeHandle {
         if let Some(worktree) = metadata["task_detail"].get("worktree").cloned() {
             metadata["worktree"] = worktree;
         }
+        task_detail["output_summary"] = serde_json::json!(text.clone());
         let terminal_task = task_with_status(&task_record, status, Some(task_detail.clone()));
         if let Err(error) = self
             .persist_task_status_direct(&terminal_task, "task_status_updated")
@@ -1555,6 +1562,7 @@ impl RuntimeHandle {
                 let output = latest_message
                     .as_ref()
                     .map(|message| message.text.clone())
+                    .or_else(|| detail_string(&task.detail, "output_summary"))
                     .unwrap_or_else(|| summary.clone().unwrap_or_default());
                 let result_summary = if output.trim().is_empty() {
                     None

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -528,22 +528,35 @@ impl QueueEntryRepository<'_> {
         rows.map(|row| decode_queue_entry_payload(&row?)).collect()
     }
 
-    pub fn recent(&self, limit: usize) -> Result<Vec<QueueEntryRecord>> {
+    pub fn recent(&self, agent_id: Option<&str>, limit: usize) -> Result<Vec<QueueEntryRecord>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
-        let mut statement = connection.prepare(
-            "SELECT payload_json
-             FROM queue_entries
-             ORDER BY updated_at DESC, created_at DESC, message_id ASC
-             LIMIT ?1",
-        )?;
-        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
-        let mut records: Vec<_> = rows
-            .map(|row| decode_queue_entry_payload(&row?))
-            .collect::<Result<_>>()?;
+        let mut records = if let Some(agent_id) = agent_id {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM queue_entries
+                 WHERE agent_id = ?1
+                 ORDER BY updated_at DESC, created_at DESC, message_id ASC
+                 LIMIT ?2",
+            )?;
+            let rows =
+                statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_queue_entry_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM queue_entries
+                 ORDER BY updated_at DESC, created_at DESC, message_id ASC
+                 LIMIT ?1",
+            )?;
+            let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_queue_entry_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        };
         records.reverse();
         Ok(records)
     }
@@ -727,79 +740,135 @@ impl MessageRepository<'_> {
         self.db.transaction(|tx| upsert_message_tx(tx, message))
     }
 
-    pub fn recent(&self, limit: usize) -> Result<Vec<MessageEnvelope>> {
+    pub fn recent(&self, agent_id: Option<&str>, limit: usize) -> Result<Vec<MessageEnvelope>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
-        let mut statement = connection.prepare(
-            "SELECT payload_json
-             FROM messages
-             ORDER BY COALESCE(message_seq, 9223372036854775807) DESC, created_at DESC, message_id ASC
-             LIMIT ?1",
-        )?;
-        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
-        let mut records: Vec<_> = rows
-            .map(|row| decode_message_payload(&row?))
-            .collect::<Result<_>>()?;
+        let mut records = if let Some(agent_id) = agent_id {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM messages
+                 WHERE agent_id = ?1
+                 ORDER BY COALESCE(message_seq, 9223372036854775807) DESC, created_at DESC, message_id ASC
+                 LIMIT ?2",
+            )?;
+            let rows =
+                statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_message_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM messages
+                 ORDER BY COALESCE(message_seq, 9223372036854775807) DESC, created_at DESC, message_id ASC
+                 LIMIT ?1",
+            )?;
+            let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_message_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        };
         records.reverse();
         Ok(records)
     }
 
-    pub fn from(&self, offset: usize, limit: usize) -> Result<Vec<MessageEnvelope>> {
+    pub fn from(
+        &self,
+        agent_id: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<MessageEnvelope>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
         let offset = i64::try_from(offset).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
-        let mut statement = connection.prepare(
-            "SELECT payload_json
-             FROM messages
-             ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC
-             LIMIT -1 OFFSET ?1",
-        )?;
-        let rows = statement.query_map([offset], |row| row.get::<_, String>(0))?;
-        let mut records: Vec<_> = rows
-            .map(|row| decode_message_payload(&row?))
-            .collect::<Result<_>>()?;
+        let mut records = if let Some(agent_id) = agent_id {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM messages
+                 WHERE agent_id = ?1
+                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC
+                 LIMIT -1 OFFSET ?2",
+            )?;
+            let rows =
+                statement.query_map(params![agent_id, offset], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_message_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM messages
+                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC
+                 LIMIT -1 OFFSET ?1",
+            )?;
+            let rows = statement.query_map([offset], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_message_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        };
         if records.len() > limit {
             records.drain(0..(records.len() - limit));
         }
         Ok(records)
     }
 
-    pub fn all(&self) -> Result<Vec<MessageEnvelope>> {
+    pub fn all(&self, agent_id: Option<&str>) -> Result<Vec<MessageEnvelope>> {
         let connection = self.db.connection()?;
-        let mut statement = connection.prepare(
-            "SELECT payload_json
-             FROM messages
-             ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC",
-        )?;
-        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
-        rows.map(|row| decode_message_payload(&row?)).collect()
+        if let Some(agent_id) = agent_id {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM messages
+                 WHERE agent_id = ?1
+                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC",
+            )?;
+            let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_message_payload(&row?)).collect()
+        } else {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM messages
+                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC",
+            )?;
+            let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_message_payload(&row?)).collect()
+        }
     }
 
-    pub fn all_values(&self) -> Result<Vec<serde_json::Value>> {
-        self.all()?
+    pub fn all_values(&self, agent_id: Option<&str>) -> Result<Vec<serde_json::Value>> {
+        self.all(agent_id)?
             .into_iter()
             .map(|message| serde_json::to_value(message).map_err(Into::into))
             .collect()
     }
 
-    pub fn count(&self) -> Result<usize> {
+    pub fn count(&self, agent_id: Option<&str>) -> Result<usize> {
         let connection = self.db.connection()?;
-        let count: i64 =
-            connection.query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))?;
+        let count: i64 = if let Some(agent_id) = agent_id {
+            connection.query_row(
+                "SELECT COUNT(*) FROM messages WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get(0),
+            )?
+        } else {
+            connection.query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))?
+        };
         Ok(usize::try_from(count).unwrap_or(usize::MAX))
     }
 
-    pub fn max_message_seq(&self) -> Result<u64> {
+    pub fn max_message_seq(&self, agent_id: Option<&str>) -> Result<u64> {
         let connection = self.db.connection()?;
-        let max_seq: Option<i64> =
+        let max_seq: Option<i64> = if let Some(agent_id) = agent_id {
+            connection.query_row(
+                "SELECT MAX(message_seq) FROM messages WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get(0),
+            )?
+        } else {
             connection.query_row("SELECT MAX(message_seq) FROM messages", [], |row| {
                 row.get(0)
-            })?;
+            })?
+        };
         Ok(max_seq.unwrap_or_default().max(0) as u64)
     }
 }
@@ -828,45 +897,78 @@ impl TranscriptRepository<'_> {
             .transaction(|tx| upsert_transcript_entry_tx(tx, entry))
     }
 
-    pub fn recent(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
+    pub fn recent(&self, agent_id: Option<&str>, limit: usize) -> Result<Vec<TranscriptEntry>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
-        let mut statement = connection.prepare(
-            "SELECT payload_json
-             FROM transcript_entries
-             ORDER BY COALESCE(transcript_seq, 9223372036854775807) DESC, created_at DESC, evidence_id ASC
-             LIMIT ?1",
-        )?;
-        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
-        let mut records: Vec<_> = rows
-            .map(|row| decode_transcript_entry_payload(&row?))
-            .collect::<Result<_>>()?;
+        let mut records = if let Some(agent_id) = agent_id {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM transcript_entries
+                 WHERE agent_id = ?1
+                 ORDER BY COALESCE(transcript_seq, 9223372036854775807) DESC, created_at DESC, evidence_id ASC
+                 LIMIT ?2",
+            )?;
+            let rows =
+                statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_transcript_entry_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM transcript_entries
+                 ORDER BY COALESCE(transcript_seq, 9223372036854775807) DESC, created_at DESC, evidence_id ASC
+                 LIMIT ?1",
+            )?;
+            let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_transcript_entry_payload(&row?))
+                .collect::<Result<Vec<_>>>()?
+        };
         records.reverse();
         Ok(records)
     }
 
-    pub fn all(&self) -> Result<Vec<TranscriptEntry>> {
+    pub fn all(&self, agent_id: Option<&str>) -> Result<Vec<TranscriptEntry>> {
         let connection = self.db.connection()?;
-        let mut statement = connection.prepare(
-            "SELECT payload_json
-             FROM transcript_entries
-             ORDER BY COALESCE(transcript_seq, 9223372036854775807) ASC, created_at ASC, evidence_id ASC",
-        )?;
-        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
-        rows.map(|row| decode_transcript_entry_payload(&row?))
-            .collect()
+        if let Some(agent_id) = agent_id {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM transcript_entries
+                 WHERE agent_id = ?1
+                 ORDER BY COALESCE(transcript_seq, 9223372036854775807) ASC, created_at ASC, evidence_id ASC",
+            )?;
+            let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_transcript_entry_payload(&row?))
+                .collect()
+        } else {
+            let mut statement = connection.prepare(
+                "SELECT payload_json
+                 FROM transcript_entries
+                 ORDER BY COALESCE(transcript_seq, 9223372036854775807) ASC, created_at ASC, evidence_id ASC",
+            )?;
+            let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+            rows.map(|row| decode_transcript_entry_payload(&row?))
+                .collect()
+        }
     }
 
-    pub fn max_transcript_seq(&self) -> Result<u64> {
+    pub fn max_transcript_seq(&self, agent_id: Option<&str>) -> Result<u64> {
         let connection = self.db.connection()?;
-        let max_seq: Option<i64> = connection.query_row(
-            "SELECT MAX(transcript_seq) FROM transcript_entries",
-            [],
-            |row| row.get(0),
-        )?;
+        let max_seq: Option<i64> = if let Some(agent_id) = agent_id {
+            connection.query_row(
+                "SELECT MAX(transcript_seq) FROM transcript_entries WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get(0),
+            )?
+        } else {
+            connection.query_row(
+                "SELECT MAX(transcript_seq) FROM transcript_entries",
+                [],
+                |row| row.get(0),
+            )?
+        };
         Ok(max_seq.unwrap_or_default().max(0) as u64)
     }
 }

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -54,6 +54,14 @@ pub struct TurnRecordRepository<'a> {
     db: &'a RuntimeDb,
 }
 
+pub struct MessageRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct TranscriptRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
 pub struct EvidenceRepository<'a> {
     db: &'a RuntimeDb,
 }
@@ -690,6 +698,180 @@ impl TurnRecordRepository<'_> {
     }
 }
 
+impl MessageRepository<'_> {
+    pub fn import_legacy(&self, messages: Vec<serde_json::Value>) -> Result<()> {
+        if self.db.storage_domain_is_complete("messages", "db")? {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("messages", "jsonl", "db", |tx| {
+                let mut imported_messages = 0_u64;
+                let mut dropped_messages = 0_u64;
+                for raw_message in messages {
+                    match normalize_legacy_message_value(raw_message)? {
+                        Some(message) => {
+                            upsert_message_tx(tx, &message)?;
+                            imported_messages += 1;
+                        }
+                        None => dropped_messages += 1,
+                    }
+                }
+                Ok(serde_json::json!({
+                    "imported_messages": imported_messages,
+                    "dropped_messages": dropped_messages,
+                }))
+            })
+    }
+
+    pub fn upsert(&self, message: &MessageEnvelope) -> Result<()> {
+        self.db.transaction(|tx| upsert_message_tx(tx, message))
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<MessageEnvelope>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM messages
+             ORDER BY COALESCE(message_seq, 9223372036854775807) DESC, created_at DESC, message_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_message_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn from(&self, offset: usize, limit: usize) -> Result<Vec<MessageEnvelope>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let offset = i64::try_from(offset).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM messages
+             ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC
+             LIMIT ?1 OFFSET ?2",
+        )?;
+        let rows = statement.query_map(params![limit, offset], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_message_payload(&row?))
+            .collect::<Result<_>>()?;
+        if records.len() > limit as usize {
+            records.drain(0..(records.len() - limit as usize));
+        }
+        Ok(records)
+    }
+
+    pub fn all(&self) -> Result<Vec<MessageEnvelope>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM messages
+             ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_message_payload(&row?)).collect()
+    }
+
+    pub fn all_values(&self) -> Result<Vec<serde_json::Value>> {
+        self.all()?
+            .into_iter()
+            .map(|message| serde_json::to_value(message).map_err(Into::into))
+            .collect()
+    }
+
+    pub fn count(&self) -> Result<usize> {
+        let connection = self.db.connection()?;
+        let count: i64 =
+            connection.query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))?;
+        Ok(usize::try_from(count).unwrap_or(usize::MAX))
+    }
+
+    pub fn max_message_seq(&self) -> Result<u64> {
+        let connection = self.db.connection()?;
+        let max_seq: Option<i64> =
+            connection.query_row("SELECT MAX(message_seq) FROM messages", [], |row| {
+                row.get(0)
+            })?;
+        Ok(max_seq.unwrap_or_default().max(0) as u64)
+    }
+}
+
+impl TranscriptRepository<'_> {
+    pub fn import_legacy(&self, entries: Vec<TranscriptEntry>) -> Result<()> {
+        if self
+            .db
+            .storage_domain_is_complete("transcript_entries", "db")?
+        {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("transcript_entries", "jsonl", "db", |tx| {
+                for entry in &entries {
+                    upsert_transcript_entry_tx(tx, entry)?;
+                }
+                Ok(serde_json::json!({
+                    "imported_transcript_entries": entries.len(),
+                }))
+            })
+    }
+
+    pub fn upsert(&self, entry: &TranscriptEntry) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_transcript_entry_tx(tx, entry))
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM transcript_entries
+             ORDER BY COALESCE(transcript_seq, 9223372036854775807) DESC, created_at DESC, evidence_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_transcript_entry_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn all(&self) -> Result<Vec<TranscriptEntry>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM transcript_entries
+             ORDER BY COALESCE(transcript_seq, 9223372036854775807) ASC, created_at ASC, evidence_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_transcript_entry_payload(&row?))
+            .collect()
+    }
+
+    pub fn max_transcript_seq(&self) -> Result<u64> {
+        let connection = self.db.connection()?;
+        let max_seq: Option<i64> = connection.query_row(
+            "SELECT MAX(transcript_seq) FROM transcript_entries",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(max_seq.unwrap_or_default().max(0) as u64)
+    }
+}
+
 impl EvidenceRepository<'_> {
     pub fn import_legacy(
         &self,
@@ -1030,25 +1212,54 @@ fn insert_evidence_tx(tx: &Transaction<'_>, evidence: EvidenceInsert<'_>) -> Res
 }
 
 fn insert_message_evidence_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<()> {
-    insert_evidence_tx(
-        tx,
-        EvidenceInsert {
-            table: EvidenceKind::Message.table_name(),
-            evidence_id: &message.id,
-            agent_id: &message.agent_id,
-            turn_id: message.turn_id.as_deref(),
-            message_id: Some(&message.id),
-            task_id: message.task_id.as_deref(),
-            work_item_id: message.work_item_id.as_deref(),
-            created_at: message.created_at,
-            kind: enum_string(&message.kind)?,
-            preview: evidence_preview(&message.body),
-            payload_json: bounded_payload_json(message)?,
-        },
-    )
+    upsert_message_tx(tx, message)
 }
 
 fn insert_transcript_evidence_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) -> Result<()> {
+    upsert_transcript_entry_tx(tx, entry)
+}
+
+fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<()> {
+    let payload_json = serde_json::to_string(message)?;
+    let kind = enum_string(&message.kind)?;
+    tx.execute(
+        "INSERT INTO messages (
+            evidence_id, agent_id, turn_id, message_id, message_seq, task_id, work_item_id,
+            created_at, kind, content_ref, content_hash, preview, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(evidence_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            turn_id = excluded.turn_id,
+            message_id = excluded.message_id,
+            message_seq = excluded.message_seq,
+            task_id = excluded.task_id,
+            work_item_id = excluded.work_item_id,
+            created_at = excluded.created_at,
+            kind = excluded.kind,
+            content_ref = excluded.content_ref,
+            content_hash = excluded.content_hash,
+            preview = excluded.preview,
+            payload_json = excluded.payload_json",
+        params![
+            message.id,
+            message.agent_id,
+            message.turn_id,
+            message.id,
+            message.message_seq.map(|seq| seq as i64),
+            message.task_id,
+            message.work_item_id,
+            timestamp(message.created_at),
+            kind,
+            Option::<String>::None,
+            Option::<String>::None,
+            evidence_preview(&message.body),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_transcript_entry_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) -> Result<()> {
     let turn_id = entry
         .data
         .get("turn_id")
@@ -1061,22 +1272,43 @@ fn insert_transcript_evidence_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) 
         .data
         .get("work_item_id")
         .and_then(serde_json::Value::as_str);
-    insert_evidence_tx(
-        tx,
-        EvidenceInsert {
-            table: EvidenceKind::TranscriptEntry.table_name(),
-            evidence_id: &entry.id,
-            agent_id: &entry.agent_id,
+    let payload_json = serde_json::to_string(entry)?;
+    let kind = enum_string(&entry.kind)?;
+    tx.execute(
+        "INSERT INTO transcript_entries (
+            evidence_id, agent_id, turn_id, message_id, transcript_seq, task_id, work_item_id,
+            created_at, kind, content_ref, content_hash, preview, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(evidence_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            turn_id = excluded.turn_id,
+            message_id = excluded.message_id,
+            transcript_seq = excluded.transcript_seq,
+            task_id = excluded.task_id,
+            work_item_id = excluded.work_item_id,
+            created_at = excluded.created_at,
+            kind = excluded.kind,
+            content_ref = excluded.content_ref,
+            content_hash = excluded.content_hash,
+            preview = excluded.preview,
+            payload_json = excluded.payload_json",
+        params![
+            entry.id,
+            entry.agent_id,
             turn_id,
-            message_id: entry.related_message_id.as_deref(),
+            entry.related_message_id,
+            entry.transcript_seq.map(|seq| seq as i64),
             task_id,
             work_item_id,
-            created_at: entry.created_at,
-            kind: enum_string(&entry.kind)?,
-            preview: evidence_preview(&entry.data),
-            payload_json: bounded_payload_json(entry)?,
-        },
-    )
+            timestamp(entry.created_at),
+            kind,
+            Option::<String>::None,
+            Option::<String>::None,
+            evidence_preview(&entry.data),
+            payload_json,
+        ],
+    )?;
+    Ok(())
 }
 
 fn insert_tool_evidence_tx(tx: &Transaction<'_>, record: &ToolExecutionRecord) -> Result<()> {
@@ -2021,6 +2253,14 @@ fn decode_turn_record_payload(payload: &str) -> Result<TurnRecord> {
     serde_json::from_str(payload).context("decoding turn record payload from runtime db")
 }
 
+fn decode_message_payload(payload: &str) -> Result<MessageEnvelope> {
+    serde_json::from_str(payload).context("decoding message payload from runtime db")
+}
+
+fn decode_transcript_entry_payload(payload: &str) -> Result<TranscriptEntry> {
+    serde_json::from_str(payload).context("decoding transcript entry payload from runtime db")
+}
+
 fn enum_string<T: serde::Serialize>(value: &T) -> Result<String> {
     let value = serde_json::to_value(value)?;
     value
@@ -2252,6 +2492,7 @@ CREATE TABLE IF NOT EXISTS messages (
   agent_id TEXT NOT NULL,
   turn_id TEXT,
   message_id TEXT,
+  message_seq INTEGER,
   task_id TEXT,
   work_item_id TEXT,
   created_at TEXT NOT NULL,
@@ -2267,6 +2508,7 @@ CREATE TABLE IF NOT EXISTS transcript_entries (
   agent_id TEXT NOT NULL,
   turn_id TEXT,
   message_id TEXT,
+  transcript_seq INTEGER,
   task_id TEXT,
   work_item_id TEXT,
   created_at TEXT NOT NULL,
@@ -2371,6 +2613,8 @@ CREATE INDEX IF NOT EXISTS idx_messages_agent_turn
   ON messages(agent_id, turn_id);
 CREATE INDEX IF NOT EXISTS idx_messages_message
   ON messages(message_id);
+CREATE INDEX IF NOT EXISTS idx_messages_seq
+  ON messages(message_seq);
 CREATE INDEX IF NOT EXISTS idx_messages_task
   ON messages(task_id);
 CREATE INDEX IF NOT EXISTS idx_messages_work_item
@@ -2380,6 +2624,8 @@ CREATE INDEX IF NOT EXISTS idx_transcript_entries_agent_turn
   ON transcript_entries(agent_id, turn_id);
 CREATE INDEX IF NOT EXISTS idx_transcript_entries_message
   ON transcript_entries(message_id);
+CREATE INDEX IF NOT EXISTS idx_transcript_entries_seq
+  ON transcript_entries(transcript_seq);
 CREATE INDEX IF NOT EXISTS idx_transcript_entries_task
   ON transcript_entries(task_id);
 CREATE INDEX IF NOT EXISTS idx_transcript_entries_work_item
@@ -2633,6 +2879,14 @@ impl RuntimeDb {
         TurnRecordRepository { db: self }
     }
 
+    pub fn messages(&self) -> MessageRepository<'_> {
+        MessageRepository { db: self }
+    }
+
+    pub fn transcript_entries(&self) -> TranscriptRepository<'_> {
+        TranscriptRepository { db: self }
+    }
+
     pub fn evidence(&self) -> EvidenceRepository<'_> {
         EvidenceRepository { db: self }
     }
@@ -2677,6 +2931,16 @@ impl RuntimeDb {
                 domain: "turn_records",
                 canonical_source: "db",
                 legacy_jsonl_posture: LegacyJsonlPosture::Disabled,
+            },
+            ExpectedStorageDomain {
+                domain: "messages",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
+            },
+            ExpectedStorageDomain {
+                domain: "transcript_entries",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
             },
             ExpectedStorageDomain {
                 domain: "evidence",

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -751,21 +751,20 @@ impl MessageRepository<'_> {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let offset = i64::try_from(offset).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
             "SELECT payload_json
              FROM messages
              ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC
-             LIMIT ?1 OFFSET ?2",
+             LIMIT -1 OFFSET ?1",
         )?;
-        let rows = statement.query_map(params![limit, offset], |row| row.get::<_, String>(0))?;
+        let rows = statement.query_map([offset], |row| row.get::<_, String>(0))?;
         let mut records: Vec<_> = rows
             .map(|row| decode_message_payload(&row?))
             .collect::<Result<_>>()?;
-        if records.len() > limit as usize {
-            records.drain(0..(records.len() - limit as usize));
+        if records.len() > limit {
+            records.drain(0..(records.len() - limit));
         }
         Ok(records)
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2653,6 +2653,43 @@ mod tests {
     }
 
     #[test]
+    fn read_messages_from_preserves_recent_window_semantics_after_db_cutover() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        for text in ["one", "two", "three", "four"] {
+            storage
+                .append_message(&MessageEnvelope::new(
+                    "default",
+                    MessageKind::OperatorPrompt,
+                    MessageOrigin::Operator { actor_id: None },
+                    AuthorityClass::OperatorInstruction,
+                    Priority::Normal,
+                    MessageBody::Text { text: text.into() },
+                ))
+                .unwrap();
+        }
+
+        let messages = storage.read_messages_from(1, 2).unwrap();
+        let texts = messages
+            .into_iter()
+            .map(|message| match message.body {
+                MessageBody::Text { text } => text,
+                _ => panic!("expected text body"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(texts, vec!["three", "four"]);
+    }
+
+    #[test]
     fn append_transcript_entry_uses_runtime_db_after_cutover_without_transcript_jsonl() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -296,19 +296,24 @@ impl AppStorage {
     }
 
     pub(crate) fn enable_scheduler_control_plane_db(&self, runtime_db: RuntimeDb) -> Result<()> {
+        let agent_id = self.current_agent_id()?;
         {
             let mut counter = self
                 .message_seq_counter
                 .lock()
                 .map_err(|_| anyhow::anyhow!("message sequence counter mutex poisoned"))?;
-            *counter = (*counter).max(runtime_db.messages().max_message_seq()?);
+            *counter = (*counter).max(runtime_db.messages().max_message_seq(agent_id.as_deref())?);
         }
         {
             let mut counter = self
                 .transcript_seq_counter
                 .lock()
                 .map_err(|_| anyhow::anyhow!("transcript sequence counter mutex poisoned"))?;
-            *counter = (*counter).max(runtime_db.transcript_entries().max_transcript_seq()?);
+            *counter = (*counter).max(
+                runtime_db
+                    .transcript_entries()
+                    .max_transcript_seq(agent_id.as_deref())?,
+            );
         }
         let mut guard = self
             .scheduler_control_plane_db
@@ -324,6 +329,27 @@ impl AppStorage {
             .lock()
             .map_err(|_| anyhow::anyhow!("scheduler control-plane db mutex poisoned"))?
             .clone())
+    }
+
+    fn current_agent_id(&self) -> Result<Option<String>> {
+        if let Some(agent) = self.read_agent()? {
+            return Ok(Some(agent.id));
+        }
+        let parent_is_agents_dir = self
+            .data_dir
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            == Some("agents");
+        if !parent_is_agents_dir {
+            return Ok(None);
+        }
+        Ok(self
+            .data_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .map(ToString::to_string))
     }
 
     pub fn data_dir(&self) -> &Path {
@@ -766,7 +792,9 @@ impl AppStorage {
 
     pub fn read_recent_messages(&self, limit: usize) -> Result<Vec<MessageEnvelope>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.messages().recent(limit);
+            return runtime_db
+                .messages()
+                .recent(self.current_agent_id()?.as_deref(), limit);
         }
         read_recent_jsonl(&self.messages_path, limit)
     }
@@ -778,21 +806,27 @@ impl AppStorage {
     /// at `offset`; it preserves recent-message window semantics.
     pub fn read_messages_from(&self, offset: usize, limit: usize) -> Result<Vec<MessageEnvelope>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.messages().from(offset, limit);
+            return runtime_db
+                .messages()
+                .from(self.current_agent_id()?.as_deref(), offset, limit);
         }
         read_jsonl_from(&self.messages_path, offset, limit)
     }
 
     pub fn read_all_messages(&self) -> Result<Vec<MessageEnvelope>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.messages().all();
+            return runtime_db
+                .messages()
+                .all(self.current_agent_id()?.as_deref());
         }
         read_recent_jsonl(&self.messages_path, usize::MAX)
     }
 
     pub fn read_all_message_values(&self) -> Result<Vec<Value>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.messages().all_values();
+            return runtime_db
+                .messages()
+                .all_values(self.current_agent_id()?.as_deref());
         }
         read_recent_jsonl(&self.messages_path, usize::MAX)
     }
@@ -839,14 +873,18 @@ impl AppStorage {
 
     pub fn read_recent_transcript(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.transcript_entries().recent(limit);
+            return runtime_db
+                .transcript_entries()
+                .recent(self.current_agent_id()?.as_deref(), limit);
         }
         read_recent_jsonl(&self.transcript_path, limit)
     }
 
     pub fn read_all_transcript(&self) -> Result<Vec<TranscriptEntry>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.transcript_entries().all();
+            return runtime_db
+                .transcript_entries()
+                .all(self.current_agent_id()?.as_deref());
         }
         read_recent_jsonl(&self.transcript_path, usize::MAX)
     }
@@ -864,7 +902,9 @@ impl AppStorage {
 
     pub fn read_recent_queue_entries(&self, limit: usize) -> Result<Vec<QueueEntryRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.queue_entries().recent(limit);
+            return runtime_db
+                .queue_entries()
+                .recent(self.current_agent_id()?.as_deref(), limit);
         }
         read_recent_jsonl(&self.queue_entries_path, limit)
     }
@@ -1782,7 +1822,9 @@ impl AppStorage {
 
     pub fn count_messages(&self) -> Result<usize> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.messages().count();
+            return runtime_db
+                .messages()
+                .count(self.current_agent_id()?.as_deref());
         }
         if !self.messages_path.exists() {
             return Ok(0);
@@ -2649,7 +2691,7 @@ mod tests {
         let messages = storage.read_recent_messages(10).unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].message_seq, Some(1));
-        assert_eq!(runtime_db.messages().count().unwrap(), 1);
+        assert_eq!(runtime_db.messages().count(None).unwrap(), 1);
     }
 
     #[test]
@@ -2716,7 +2758,7 @@ mod tests {
         let transcript = storage.read_recent_transcript(10).unwrap();
         assert_eq!(transcript.len(), 1);
         assert_eq!(transcript[0].transcript_seq, Some(1));
-        assert_eq!(runtime_db.transcript_entries().all().unwrap().len(), 1);
+        assert_eq!(runtime_db.transcript_entries().all(None).unwrap().len(), 1);
     }
 
     #[test]
@@ -2764,8 +2806,8 @@ mod tests {
             .import_legacy(vec![entry])
             .unwrap();
 
-        assert_eq!(runtime_db.messages().count().unwrap(), 1);
-        assert_eq!(runtime_db.transcript_entries().all().unwrap().len(), 1);
+        assert_eq!(runtime_db.messages().count(None).unwrap(), 1);
+        assert_eq!(runtime_db.transcript_entries().all(None).unwrap().len(), 1);
         assert_eq!(
             runtime_db
                 .storage_domain("messages")
@@ -2801,7 +2843,7 @@ mod tests {
         assert!(error
             .to_string()
             .contains("importing legacy storage domain messages"));
-        assert_eq!(runtime_db.messages().count().unwrap(), 0);
+        assert_eq!(runtime_db.messages().count(None).unwrap(), 0);
 
         let failed = runtime_db
             .storage_domain("messages")
@@ -2816,7 +2858,7 @@ mod tests {
         .unwrap();
         assert_eq!(failed.import_status, "failed");
         assert_eq!(failed.canonical_source, "jsonl");
-        assert_eq!(runtime_db.messages().count().unwrap(), 0);
+        assert_eq!(runtime_db.messages().count(None).unwrap(), 0);
         assert_eq!(
             checkpoint.get("retry").and_then(serde_json::Value::as_str),
             Some("restart runtime to retry legacy import")

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -296,6 +296,20 @@ impl AppStorage {
     }
 
     pub(crate) fn enable_scheduler_control_plane_db(&self, runtime_db: RuntimeDb) -> Result<()> {
+        {
+            let mut counter = self
+                .message_seq_counter
+                .lock()
+                .map_err(|_| anyhow::anyhow!("message sequence counter mutex poisoned"))?;
+            *counter = (*counter).max(runtime_db.messages().max_message_seq()?);
+        }
+        {
+            let mut counter = self
+                .transcript_seq_counter
+                .lock()
+                .map_err(|_| anyhow::anyhow!("transcript sequence counter mutex poisoned"))?;
+            *counter = (*counter).max(runtime_db.transcript_entries().max_transcript_seq()?);
+        }
         let mut guard = self
             .scheduler_control_plane_db
             .lock()
@@ -415,6 +429,10 @@ impl AppStorage {
             .map_err(|_| anyhow::anyhow!("message sequence counter mutex poisoned"))?;
         *counter += 1;
         message.message_seq = Some(*counter);
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.messages().upsert(&message)?;
+            return Ok(());
+        }
         let bytes = jsonl_bytes(&message)?;
         append_jsonl_bytes(&self.messages_path, &bytes)
     }
@@ -489,6 +507,10 @@ impl AppStorage {
             .map_err(|_| anyhow::anyhow!("transcript sequence counter mutex poisoned"))?;
         *counter += 1;
         entry.transcript_seq = Some(*counter);
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.transcript_entries().upsert(&entry)?;
+            return Ok(());
+        }
         let bytes = jsonl_bytes(&entry)?;
         append_jsonl_bytes(&self.transcript_path, &bytes)
     }
@@ -743,6 +765,9 @@ impl AppStorage {
     }
 
     pub fn read_recent_messages(&self, limit: usize) -> Result<Vec<MessageEnvelope>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.messages().recent(limit);
+        }
         read_recent_jsonl(&self.messages_path, limit)
     }
 
@@ -752,14 +777,23 @@ impl AppStorage {
     /// This is not equivalent to returning the first `limit` messages starting
     /// at `offset`; it preserves recent-message window semantics.
     pub fn read_messages_from(&self, offset: usize, limit: usize) -> Result<Vec<MessageEnvelope>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.messages().from(offset, limit);
+        }
         read_jsonl_from(&self.messages_path, offset, limit)
     }
 
     pub fn read_all_messages(&self) -> Result<Vec<MessageEnvelope>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.messages().all();
+        }
         read_recent_jsonl(&self.messages_path, usize::MAX)
     }
 
     pub fn read_all_message_values(&self) -> Result<Vec<Value>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.messages().all_values();
+        }
         read_recent_jsonl(&self.messages_path, usize::MAX)
     }
 
@@ -804,10 +838,16 @@ impl AppStorage {
     }
 
     pub fn read_recent_transcript(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.transcript_entries().recent(limit);
+        }
         read_recent_jsonl(&self.transcript_path, limit)
     }
 
     pub fn read_all_transcript(&self) -> Result<Vec<TranscriptEntry>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.transcript_entries().all();
+        }
         read_recent_jsonl(&self.transcript_path, usize::MAX)
     }
 
@@ -1741,6 +1781,9 @@ impl AppStorage {
     }
 
     pub fn count_messages(&self) -> Result<usize> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.messages().count();
+        }
         if !self.messages_path.exists() {
             return Ok(0);
         }
@@ -2574,6 +2617,243 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn append_message_uses_runtime_db_after_cutover_without_messages_jsonl() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+
+        storage
+            .append_message(&MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "db only".into(),
+                },
+            ))
+            .unwrap();
+
+        assert!(!storage.ledger_dir().join("messages.jsonl").exists());
+        let messages = storage.read_recent_messages(10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].message_seq, Some(1));
+        assert_eq!(runtime_db.messages().count().unwrap(), 1);
+    }
+
+    #[test]
+    fn append_transcript_entry_uses_runtime_db_after_cutover_without_transcript_jsonl() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+
+        storage
+            .append_transcript_entry(&TranscriptEntry::new(
+                "default",
+                TranscriptEntryKind::IncomingMessage,
+                None,
+                Some("message-1".into()),
+                serde_json::json!({ "text": "db only" }),
+            ))
+            .unwrap();
+
+        assert!(!storage.ledger_dir().join("transcript.jsonl").exists());
+        let transcript = storage.read_recent_transcript(10).unwrap();
+        assert_eq!(transcript.len(), 1);
+        assert_eq!(transcript[0].transcript_seq, Some(1));
+        assert_eq!(runtime_db.transcript_entries().all().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn runtime_db_message_and_transcript_import_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "legacy message".into(),
+            },
+        );
+        message.message_seq = Some(7);
+        let entry = TranscriptEntry::new(
+            "default",
+            TranscriptEntryKind::IncomingMessage,
+            None,
+            Some(message.id.clone()),
+            serde_json::json!({ "text": "legacy transcript" }),
+        );
+
+        runtime_db
+            .messages()
+            .import_legacy(vec![serde_json::to_value(&message).unwrap()])
+            .unwrap();
+        runtime_db
+            .transcript_entries()
+            .import_legacy(vec![entry.clone()])
+            .unwrap();
+        runtime_db
+            .messages()
+            .import_legacy(vec![serde_json::to_value(&message).unwrap()])
+            .unwrap();
+        runtime_db
+            .transcript_entries()
+            .import_legacy(vec![entry])
+            .unwrap();
+
+        assert_eq!(runtime_db.messages().count().unwrap(), 1);
+        assert_eq!(runtime_db.transcript_entries().all().unwrap().len(), 1);
+        assert_eq!(
+            runtime_db
+                .storage_domain("messages")
+                .unwrap()
+                .expect("messages storage domain")
+                .canonical_source,
+            "db"
+        );
+        assert_eq!(
+            runtime_db
+                .storage_domain("transcript_entries")
+                .unwrap()
+                .expect("transcript storage domain")
+                .canonical_source,
+            "db"
+        );
+    }
+
+    #[test]
+    fn runtime_db_message_import_failure_records_retryable_domain_state() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+
+        let error = runtime_db
+            .messages()
+            .import_legacy(vec![serde_json::json!({ "turn_index": 1 })])
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("importing legacy storage domain messages"));
+        assert_eq!(runtime_db.messages().count().unwrap(), 0);
+
+        let failed = runtime_db
+            .storage_domain("messages")
+            .unwrap()
+            .expect("failed messages storage domain");
+        let checkpoint: serde_json::Value = serde_json::from_str(
+            failed
+                .source_checkpoint_json
+                .as_deref()
+                .expect("messages failure checkpoint"),
+        )
+        .unwrap();
+        assert_eq!(failed.import_status, "failed");
+        assert_eq!(failed.canonical_source, "jsonl");
+        assert_eq!(runtime_db.messages().count().unwrap(), 0);
+        assert_eq!(
+            checkpoint.get("retry").and_then(serde_json::Value::as_str),
+            Some("restart runtime to retry legacy import")
+        );
+    }
+
+    #[test]
+    fn message_and_transcript_reads_ignore_legacy_jsonl_after_db_cutover() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        let db_message = MessageEnvelope::new(
+            "default",
+            MessageKind::InternalFollowup,
+            MessageOrigin::System {
+                subsystem: "test".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "from db".into(),
+            },
+        );
+        let db_entry = TranscriptEntry::new(
+            "default",
+            TranscriptEntryKind::AssistantRound,
+            None,
+            Some(db_message.id.clone()),
+            serde_json::json!({ "text": "from db" }),
+        );
+        runtime_db.messages().upsert(&db_message).unwrap();
+        runtime_db.transcript_entries().upsert(&db_entry).unwrap();
+
+        fs::write(
+            storage.ledger_dir().join("messages.jsonl"),
+            serde_json::to_string(&MessageEnvelope::new(
+                "default",
+                MessageKind::OperatorPrompt,
+                MessageOrigin::Operator { actor_id: None },
+                AuthorityClass::OperatorInstruction,
+                Priority::Normal,
+                MessageBody::Text {
+                    text: "from jsonl".into(),
+                },
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            storage.ledger_dir().join("transcript.jsonl"),
+            serde_json::to_string(&TranscriptEntry::new(
+                "default",
+                TranscriptEntryKind::IncomingMessage,
+                None,
+                Some("legacy-message".into()),
+                serde_json::json!({ "text": "from jsonl" }),
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let messages = storage.read_recent_messages(10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id, db_message.id);
+        let transcript = storage.read_recent_transcript(10).unwrap();
+        assert_eq!(transcript.len(), 1);
+        assert_eq!(transcript[0].id, db_entry.id);
     }
 
     #[test]

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -509,7 +509,7 @@ pub async fn multiple_subagent_tasks_do_not_cross_contaminate_outputs() -> Resul
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         let alpha_done = tasks.iter().any(|record| {
             record.id == alpha.id && record.status == holon::types::TaskStatus::Completed


### PR DESCRIPTION
Closes #1622

## Summary
- add RuntimeDb repositories/import paths for canonical message and transcript payloads
- route RuntimeDb-enabled message/transcript writes and reads through DB instead of live JSONL
- import legacy messages/transcript entries before server startup with idempotent storage-domain state
- add focused coverage for DB cutover reads, import idempotency/failure state, and monotonic sequence assignment

## Verification
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test --quiet runtime_db::
- cargo test --quiet runtime_db_message_import_failure_records_retryable_domain_state
- cargo test --quiet runtime_db_message_and_transcript_import_is_idempotent
- cargo test --quiet message_and_transcript_reads_ignore_legacy_jsonl_after_db_cutover
- cargo test --quiet append_message_assigns_monotonic_message_seq
- cargo test --quiet append_transcript_entry_assigns_monotonic_transcript_seq