### PR TITLE
feat: make runtime evidence DB canonical

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2566,6 +2566,7 @@ mod tests {
     fn recent_turns_prefers_db_turn_records_when_available() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -2643,6 +2644,7 @@ mod tests {
     fn recent_turns_keeps_db_turn_when_trigger_message_is_outside_window() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1445,6 +1445,38 @@ mod tests {
     }
 
     #[test]
+    fn memory_get_returns_db_backed_runtime_evidence_content() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        let body = format!(
+            "db backed exact evidence {}\n{}",
+            "sentinel_1623",
+            "x".repeat(4096)
+        );
+        let brief = brief_with_workspace("default", BriefKind::Result, &body, "ws-holon");
+        let brief_ref = format!("brief:{}", brief.id);
+
+        storage.append_brief(&brief).unwrap();
+        assert!(!storage.ledger_dir().join("briefs.jsonl").exists());
+        rebuild_memory_index(&storage, Some("ws-holon")).unwrap();
+
+        let memory = get_memory(&storage, &brief_ref, None, Some("ws-holon"))
+            .unwrap()
+            .expect("DB-backed runtime evidence should be indexed");
+        assert_eq!(memory.content, body);
+        assert!(!memory.truncated);
+    }
+
+    #[test]
     fn deleting_known_memory_markdown_removes_index_row() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1109,7 +1109,7 @@ impl EvidenceRepository<'_> {
             "SELECT payload_json
              FROM {}
              WHERE agent_id = ?1
-             ORDER BY created_at DESC, evidence_id ASC
+             ORDER BY created_at DESC, evidence_id DESC
              LIMIT ?2",
             kind.table_name()
         );
@@ -1167,7 +1167,7 @@ impl EvidenceRepository<'_> {
                 "SELECT payload_json
                  FROM delivery_summaries
                  WHERE agent_id = ?1 AND work_item_id = ?2
-                 ORDER BY created_at DESC, evidence_id ASC
+                 ORDER BY created_at DESC, evidence_id DESC
                  LIMIT 1",
                 params![agent_id, work_item_id],
                 |row| row.get::<_, String>(0),
@@ -3483,6 +3483,7 @@ pub mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::BriefKind;
     use std::process::Command;
     use tempfile::tempdir;
 
@@ -3657,6 +3658,33 @@ mod tests {
         assert!(error
             .to_string()
             .contains("newer than this binary supports"));
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_db_recent_payloads_keep_evidence_id_ascending_after_reverse() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let created_at = Utc::now();
+        let mut later_id = BriefRecord::new("agent-a", BriefKind::Result, "later id", None, None);
+        later_id.id = "brief-b".into();
+        later_id.created_at = created_at;
+        let mut earlier_id =
+            BriefRecord::new("agent-a", BriefKind::Result, "earlier id", None, None);
+        earlier_id.id = "brief-a".into();
+        earlier_id.created_at = created_at;
+
+        db.evidence().append_brief(&later_id)?;
+        db.evidence().append_brief(&earlier_id)?;
+
+        let records = db.evidence().recent_briefs("agent-a", 2)?;
+        assert_eq!(
+            records
+                .into_iter()
+                .map(|record| record.id)
+                .collect::<Vec<_>>(),
+            vec!["brief-a", "brief-b"]
+        );
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::types::{
     AuditEvent, BriefRecord, CallbackDeliveryMode, DeliverySummaryRecord, ExternalTriggerRecord,
@@ -982,14 +983,11 @@ impl EvidenceRepository<'_> {
         briefs: Vec<BriefRecord>,
         delivery_summaries: Vec<DeliverySummaryRecord>,
     ) -> Result<()> {
-        if self
-            .db
-            .storage_domain_is_complete("evidence", "jsonl+db-index")?
-        {
+        if self.db.storage_domain_is_complete("evidence", "db")? {
             return Ok(());
         }
         self.db
-            .run_storage_domain_import("evidence", "jsonl", "jsonl+db-index", |tx| {
+            .run_storage_domain_import("evidence", "jsonl", "db", |tx| {
                 let mut imported_messages = 0_u64;
                 let mut dropped_messages = 0_u64;
                 for raw_message in messages {
@@ -1122,7 +1120,72 @@ impl EvidenceRepository<'_> {
                 payload_json: row.get(0)?,
             })
         })?;
-        rows.map(|row| row.map_err(Into::into)).collect()
+        let mut records: Vec<_> = rows
+            .map(|row| row.map_err(Into::into))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn recent_briefs(&self, agent_id: &str, limit: usize) -> Result<Vec<BriefRecord>> {
+        self.recent_payloads(EvidenceKind::Brief, agent_id, limit)?
+            .into_iter()
+            .map(|row| serde_json::from_str(&row.payload_json).map_err(Into::into))
+            .collect()
+    }
+
+    pub fn recent_tool_executions(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ToolExecutionRecord>> {
+        self.recent_payloads(EvidenceKind::ToolExecution, agent_id, limit)?
+            .into_iter()
+            .map(|row| serde_json::from_str(&row.payload_json).map_err(Into::into))
+            .collect()
+    }
+
+    pub fn recent_delivery_summaries(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<DeliverySummaryRecord>> {
+        self.recent_payloads(EvidenceKind::DeliverySummary, agent_id, limit)?
+            .into_iter()
+            .map(|row| serde_json::from_str(&row.payload_json).map_err(Into::into))
+            .collect()
+    }
+
+    pub fn latest_delivery_summary(
+        &self,
+        agent_id: &str,
+        work_item_id: &str,
+    ) -> Result<Option<DeliverySummaryRecord>> {
+        let connection = self.db.connection()?;
+        let payload = connection
+            .query_row(
+                "SELECT payload_json
+                 FROM delivery_summaries
+                 WHERE agent_id = ?1 AND work_item_id = ?2
+                 ORDER BY created_at DESC, evidence_id ASC
+                 LIMIT 1",
+                params![agent_id, work_item_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        payload
+            .map(|payload| serde_json::from_str(&payload).map_err(Into::into))
+            .transpose()
+    }
+
+    pub fn count_briefs(&self, agent_id: &str) -> Result<usize> {
+        let connection = self.db.connection()?;
+        let count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM briefs WHERE agent_id = ?1",
+            [agent_id],
+            |row| row.get(0),
+        )?;
+        Ok(usize::try_from(count).unwrap_or(usize::MAX))
     }
 }
 
@@ -1284,12 +1347,24 @@ struct EvidenceInsert<'a> {
 }
 
 fn insert_evidence_tx(tx: &Transaction<'_>, evidence: EvidenceInsert<'_>) -> Result<()> {
+    let content_hash = content_hash(&evidence.payload_json);
     let sql = format!(
         "INSERT INTO {} (
             evidence_id, agent_id, turn_id, message_id, task_id, work_item_id,
             created_at, kind, content_ref, content_hash, preview, payload_json
          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-         ON CONFLICT(evidence_id) DO NOTHING",
+         ON CONFLICT(evidence_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            turn_id = excluded.turn_id,
+            message_id = excluded.message_id,
+            task_id = excluded.task_id,
+            work_item_id = excluded.work_item_id,
+            created_at = excluded.created_at,
+            kind = excluded.kind,
+            content_ref = excluded.content_ref,
+            content_hash = excluded.content_hash,
+            preview = excluded.preview,
+            payload_json = excluded.payload_json",
         evidence.table
     );
     tx.execute(
@@ -1304,7 +1379,7 @@ fn insert_evidence_tx(tx: &Transaction<'_>, evidence: EvidenceInsert<'_>) -> Res
             timestamp(evidence.created_at),
             evidence.kind,
             Option::<String>::None,
-            Option::<String>::None,
+            content_hash,
             evidence.preview,
             evidence.payload_json,
         ],
@@ -1322,6 +1397,7 @@ fn insert_transcript_evidence_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) 
 
 fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<()> {
     let payload_json = serde_json::to_string(message)?;
+    let content_hash = content_hash(&payload_json);
     let kind = enum_string(&message.kind)?;
     tx.execute(
         "INSERT INTO messages (
@@ -1352,7 +1428,7 @@ fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<
             timestamp(message.created_at),
             kind,
             Option::<String>::None,
-            Option::<String>::None,
+            content_hash,
             evidence_preview(&message.body),
             payload_json,
         ],
@@ -1374,6 +1450,7 @@ fn upsert_transcript_entry_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) -> 
         .get("work_item_id")
         .and_then(serde_json::Value::as_str);
     let payload_json = serde_json::to_string(entry)?;
+    let content_hash = content_hash(&payload_json);
     let kind = enum_string(&entry.kind)?;
     tx.execute(
         "INSERT INTO transcript_entries (
@@ -1404,7 +1481,7 @@ fn upsert_transcript_entry_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) -> 
             timestamp(entry.created_at),
             kind,
             Option::<String>::None,
-            Option::<String>::None,
+            content_hash,
             evidence_preview(&entry.data),
             payload_json,
         ],
@@ -1426,7 +1503,7 @@ fn insert_tool_evidence_tx(tx: &Transaction<'_>, record: &ToolExecutionRecord) -
             created_at: record.created_at,
             kind: record.tool_name.clone(),
             preview: Some(truncate_evidence_string(&record.summary)),
-            payload_json: bounded_payload_json(record)?,
+            payload_json: full_payload_json(record)?,
         },
     )
 }
@@ -1445,7 +1522,7 @@ fn insert_brief_evidence_tx(tx: &Transaction<'_>, brief: &BriefRecord) -> Result
             created_at: brief.created_at,
             kind: enum_string(&brief.kind)?,
             preview: Some(truncate_evidence_string(&brief.text)),
-            payload_json: bounded_payload_json(brief)?,
+            payload_json: full_payload_json(brief)?,
         },
     )
 }
@@ -1467,7 +1544,7 @@ fn insert_delivery_summary_evidence_tx(
             created_at: record.created_at,
             kind: "delivery_summary".to_string(),
             preview: Some(truncate_evidence_string(&record.text)),
-            payload_json: bounded_payload_json(record)?,
+            payload_json: full_payload_json(record)?,
         },
     )
 }
@@ -1536,38 +1613,20 @@ fn push_optional_clause(
     }
 }
 
-fn bounded_payload_json<T: Serialize>(value: &T) -> Result<String> {
-    let mut payload = serde_json::to_value(value)?;
-    bound_json_value(&mut payload);
-    serde_json::to_string(&payload).map_err(Into::into)
+fn full_payload_json<T: Serialize>(value: &T) -> Result<String> {
+    serde_json::to_string(value).map_err(Into::into)
+}
+
+fn content_hash(payload_json: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(payload_json.as_bytes());
+    format!("sha256:{:x}", hasher.finalize())
 }
 
 fn evidence_preview(value: &impl Serialize) -> Option<String> {
     serde_json::to_string(value)
         .ok()
         .map(|value| truncate_evidence_string(&value))
-}
-
-fn bound_json_value(value: &mut serde_json::Value) {
-    match value {
-        serde_json::Value::String(text) if text.len() > EVIDENCE_PREVIEW_LIMIT => {
-            truncate_string_in_place(text, EVIDENCE_PREVIEW_LIMIT);
-        }
-        serde_json::Value::Array(items) => {
-            if items.len() > TASK_PAYLOAD_ARRAY_LIMIT {
-                items.truncate(TASK_PAYLOAD_ARRAY_LIMIT);
-            }
-            for item in items {
-                bound_json_value(item);
-            }
-        }
-        serde_json::Value::Object(map) => {
-            for value in map.values_mut() {
-                bound_json_value(value);
-            }
-        }
-        _ => {}
-    }
 }
 
 fn truncate_evidence_string(value: &str) -> String {
@@ -3045,7 +3104,7 @@ impl RuntimeDb {
             },
             ExpectedStorageDomain {
                 domain: "evidence",
-                canonical_source: "jsonl+db-index",
+                canonical_source: "db",
                 legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
             },
             ExpectedStorageDomain {
@@ -3684,7 +3743,7 @@ mod tests {
             .as_deref()
             .is_some_and(|checkpoint| checkpoint.contains("restart runtime to retry")));
 
-        db.run_storage_domain_import("evidence", "jsonl", "jsonl+db-index", |tx| {
+        db.run_storage_domain_import("evidence", "jsonl", "db", |tx| {
             let checkpoint: Option<String> = tx.query_row(
                 "SELECT source_checkpoint_json FROM storage_domains WHERE domain = 'evidence'",
                 [],
@@ -3697,7 +3756,7 @@ mod tests {
             .storage_domain("evidence")?
             .expect("complete storage domain row");
         assert_eq!(complete.import_status, "complete");
-        assert_eq!(complete.canonical_source, "jsonl+db-index");
+        assert_eq!(complete.canonical_source, "db");
         Ok(())
     }
 
@@ -3721,7 +3780,7 @@ mod tests {
                 Some(serde_json::json!({ "error": "forced failure" })),
             )?;
             upsert_storage_domain(tx, "external_triggers", "complete", "db", None)?;
-            upsert_storage_domain(tx, "evidence", "complete", "jsonl+db-index", None)?;
+            upsert_storage_domain(tx, "evidence", "complete", "db", None)?;
             upsert_storage_domain(tx, "audit_events", "complete", "jsonl+db-index", None)?;
             Ok(())
         })?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -671,10 +671,7 @@ impl AppStorage {
     }
 
     fn storage_agent_id(&self) -> Result<String> {
-        Ok(self
-            .read_agent()?
-            .map(|agent| agent.id)
-            .unwrap_or_else(|| "unknown".into()))
+        Ok(self.current_agent_id()?.unwrap_or_else(|| "unknown".into()))
     }
 
     pub fn write_agent(&self, agent: &AgentState) -> Result<()> {
@@ -2862,6 +2859,41 @@ mod tests {
             Some("delivery evidence".into())
         );
         assert_eq!(storage.count_briefs().unwrap(), 1);
+    }
+
+    #[test]
+    fn runtime_db_evidence_reads_use_directory_agent_id_without_agent_json() {
+        let dir = tempdir().unwrap();
+        let agent_dir = dir.path().join("agents/default");
+        fs::create_dir_all(&agent_dir).unwrap();
+        let storage = AppStorage::new(&agent_dir).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        let brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "directory agent id",
+            None,
+            None,
+        );
+        storage.append_brief(&brief).unwrap();
+
+        assert_eq!(storage.read_recent_briefs(10).unwrap(), vec![brief]);
+        assert_eq!(storage.count_briefs().unwrap(), 1);
+        assert!(storage
+            .shared_indexes_dir()
+            .join(format!(
+                "memory.{}.dirty",
+                memory_index_agent_key("default")
+            ))
+            .exists());
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -438,6 +438,7 @@ impl AppStorage {
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.evidence().append_brief(brief)?;
+            return self.mark_memory_index_dirty();
         }
         self.append_jsonl(&self.briefs_path, brief)?;
         self.mark_memory_index_dirty()
@@ -485,6 +486,10 @@ impl AppStorage {
     }
 
     pub fn append_delivery_summary(&self, record: &DeliverySummaryRecord) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.evidence().append_delivery_summary(record)?;
+            return Ok(());
+        }
         self.append_jsonl(&self.delivery_summaries_path, record)
     }
 
@@ -502,6 +507,13 @@ impl AppStorage {
     pub fn append_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.evidence().append_tool_execution(record)?;
+            if matches!(
+                record.tool_name.as_str(),
+                "ExecCommand" | "ExecCommandBatch"
+            ) {
+                self.mark_memory_index_dirty()?;
+            }
+            return Ok(());
         }
         self.append_jsonl(&self.tools_path, record)?;
         if matches!(
@@ -646,10 +658,7 @@ impl AppStorage {
     }
 
     pub fn mark_memory_index_dirty(&self) -> Result<()> {
-        let agent_id = self
-            .read_agent()?
-            .map(|agent| agent.id)
-            .unwrap_or_else(|| "unknown".into());
+        let agent_id = self.storage_agent_id()?;
         let dirty_path = self.shared_indexes_dir().join(format!(
             "memory.{}.dirty",
             memory_index_agent_key(&agent_id)
@@ -659,6 +668,13 @@ impl AppStorage {
         }
         fs::create_dir_all(self.shared_indexes_dir())?;
         fs::write(&dirty_path, b"dirty").with_context(|| "failed to mark memory index dirty")
+    }
+
+    fn storage_agent_id(&self) -> Result<String> {
+        Ok(self
+            .read_agent()?
+            .map(|agent| agent.id)
+            .unwrap_or_else(|| "unknown".into()))
     }
 
     pub fn write_agent(&self, agent: &AgentState) -> Result<()> {
@@ -787,6 +803,11 @@ impl AppStorage {
     }
 
     pub fn read_recent_briefs(&self, limit: usize) -> Result<Vec<BriefRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .evidence()
+                .recent_briefs(&self.storage_agent_id()?, limit);
+        }
         read_recent_jsonl(&self.briefs_path, limit)
     }
 
@@ -843,6 +864,11 @@ impl AppStorage {
         &self,
         limit: usize,
     ) -> Result<Vec<DeliverySummaryRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .evidence()
+                .recent_delivery_summaries(&self.storage_agent_id()?, limit);
+        }
         read_recent_jsonl(&self.delivery_summaries_path, limit)
     }
 
@@ -861,6 +887,11 @@ impl AppStorage {
     }
 
     pub fn read_recent_tool_executions(&self, limit: usize) -> Result<Vec<ToolExecutionRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .evidence()
+                .recent_tool_executions(&self.storage_agent_id()?, limit);
+        }
         read_recent_jsonl(&self.tools_path, limit)
     }
 
@@ -1571,6 +1602,11 @@ impl AppStorage {
         &self,
         work_item_id: &str,
     ) -> Result<Option<DeliverySummaryRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .evidence()
+                .latest_delivery_summary(&self.storage_agent_id()?, work_item_id);
+        }
         if !self.delivery_summaries_path.exists() {
             return Ok(None);
         }
@@ -1810,6 +1846,11 @@ impl AppStorage {
     }
 
     pub fn count_briefs(&self) -> Result<usize> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .evidence()
+                .count_briefs(&self.storage_agent_id()?);
+        }
         if !self.briefs_path.exists() {
             return Ok(0);
         }
@@ -2341,10 +2382,11 @@ mod tests {
     use chrono::Utc;
 
     use crate::types::{
-        AgentState, AgentStatus, AuthorityClass, CallbackDeliveryMode, EpisodeBoundaryReason,
-        MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord,
-        QueueEntryStatus, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TodoItem,
-        TodoItemState, TranscriptEntry, TranscriptEntryKind, WorkItemPlanStatus, WorkItemState,
+        AgentState, AgentStatus, AuthorityClass, BriefKind, CallbackDeliveryMode,
+        EpisodeBoundaryReason, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+        QueueEntryRecord, QueueEntryStatus, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus,
+        TodoItem, TodoItemState, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind,
+        WorkItemPlanStatus, WorkItemState,
     };
 
     use super::*;
@@ -2759,6 +2801,67 @@ mod tests {
         assert_eq!(transcript.len(), 1);
         assert_eq!(transcript[0].transcript_seq, Some(1));
         assert_eq!(runtime_db.transcript_entries().all(None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn runtime_db_evidence_writes_skip_live_jsonl_after_cutover() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        let brief = BriefRecord::new("default", BriefKind::Result, "db brief", None, None);
+        let tool = ToolExecutionRecord {
+            id: "tool-db-evidence".into(),
+            agent_id: "default".into(),
+            work_item_id: Some("work-db-evidence".into()),
+            turn_index: 0,
+            turn_id: Some("turn-db-evidence".into()),
+            tool_name: "ExecCommand".into(),
+            created_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+            duration_ms: 1,
+            authority_class: AuthorityClass::OperatorInstruction,
+            status: ToolExecutionStatus::Success,
+            input: serde_json::json!({ "cmd": "echo db evidence" }),
+            output: serde_json::json!({ "exit_code": 0 }),
+            summary: "command exited".into(),
+            invocation_surface: None,
+        };
+        let delivery = DeliverySummaryRecord::new(
+            "default",
+            "work-db-evidence",
+            "delivery evidence",
+            None,
+            None,
+        );
+
+        storage.append_brief(&brief).unwrap();
+        storage.append_tool_execution(&tool).unwrap();
+        storage.append_delivery_summary(&delivery).unwrap();
+
+        assert!(!storage.ledger_dir().join("briefs.jsonl").exists());
+        assert!(!storage.ledger_dir().join("tools.jsonl").exists());
+        assert!(!storage
+            .ledger_dir()
+            .join("delivery_summaries.jsonl")
+            .exists());
+        assert_eq!(storage.read_recent_briefs(10).unwrap(), vec![brief]);
+        assert_eq!(storage.read_recent_tool_executions(10).unwrap(), vec![tool]);
+        assert_eq!(
+            storage
+                .latest_delivery_summary("work-db-evidence")
+                .unwrap()
+                .map(|record| record.text),
+            Some("delivery evidence".into())
+        );
+        assert_eq!(storage.count_briefs().unwrap(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- store complete runtime evidence payloads in RuntimeDb for message, transcript, tool execution, brief, and delivery summary evidence
- route live evidence reads/source-ref lookup through RuntimeDb after cutover while preserving legacy JSONL import
- add coverage for DB-backed runtime evidence writes and MemoryGet runtime evidence retrieval

Closes #1623

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test evidence --all-targets
- cargo test source_ref --all-targets
- cargo test memory_search --all-targets