### PR TITLE
feat: make audit events db canonical

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -2961,6 +2961,9 @@ mod tests {
 
         let persisted = storage.read_agent().unwrap().unwrap();
         assert_eq!(persisted.status, AgentStatus::Stopped);
+        storage
+            .enable_scheduler_control_plane_db(host.runtime_db().clone())
+            .unwrap();
         let events = storage.read_recent_events(16).unwrap();
         assert!(events
             .iter()
@@ -3013,6 +3016,9 @@ mod tests {
         assert_eq!(terminal.kind, TurnTerminalKind::Aborted);
         assert_eq!(terminal.reason.as_deref(), Some("daemon_shutdown"));
 
+        storage
+            .enable_scheduler_control_plane_db(host.runtime_db().clone())
+            .unwrap();
         let events = storage.read_recent_events(32).unwrap();
         assert!(events.iter().any(|event| {
             event.kind == "runtime_service_shutdown_requested"

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -619,7 +619,7 @@ fn prepare_runtime_storage(
     if !storage_domain_complete(&runtime_db, "audit_events")? {
         runtime_db
             .audit_events()
-            .import_legacy(Some(&state.id), storage.read_recent_events(usize::MAX)?)?;
+            .import_legacy(Some(&state.id), storage.read_legacy_events_jsonl()?)?;
     }
     runtime_db.validate_expected_storage_domains(
         crate::runtime_db::RuntimeDb::expected_storage_domains(),

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1218,12 +1218,11 @@ impl AuditEventSink<'_> {
         if agent_id.is_some() {
             sql.push_str(" WHERE agent_id = ?1");
         }
-        sql.push_str(" ORDER BY COALESCE(event_seq, 0) DESC, created_at DESC LIMIT ");
-        sql.push_str(&limit.to_string());
+        sql.push_str(" ORDER BY COALESCE(event_seq, 0) DESC, created_at DESC LIMIT ?");
         let mut statement = connection.prepare(&sql)?;
         let mut events = if let Some(agent_id) = agent_id {
             statement
-                .query_map([agent_id], |row| row.get::<_, String>(0))?
+                .query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?
                 .map(|row| {
                     let payload = row?;
                     serde_json::from_str(&payload).map_err(Into::into)
@@ -1231,7 +1230,7 @@ impl AuditEventSink<'_> {
                 .collect::<Result<Vec<_>>>()?
         } else {
             statement
-                .query_map([], |row| row.get::<_, String>(0))?
+                .query_map(params![limit], |row| row.get::<_, String>(0))?
                 .map(|row| {
                     let payload = row?;
                     serde_json::from_str(&payload).map_err(Into::into)
@@ -1270,43 +1269,55 @@ impl AuditEventSink<'_> {
         before_seq: Option<u64>,
         after_seq: Option<u64>,
         descending: bool,
+        limit: usize,
     ) -> Result<Vec<AuditEvent>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
         let lower = i64::try_from(after_seq.unwrap_or(0))
             .context("audit event lower cursor exceeds SQLite integer range")?;
-        let upper = i64::try_from(before_seq.unwrap_or(u64::MAX))
-            .context("audit event upper cursor exceeds SQLite integer range")?;
+        let upper = before_seq
+            .map(|seq| {
+                i64::try_from(seq).context("audit event upper cursor exceeds SQLite integer range")
+            })
+            .transpose()?;
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
-        let mut sql = String::from(
-            "SELECT data_json FROM audit_events WHERE COALESCE(event_seq, 0) > ?1 AND COALESCE(event_seq, 0) < ?2",
-        );
+        let mut sql =
+            String::from("SELECT data_json FROM audit_events WHERE COALESCE(event_seq, 0) > ?1");
+        if upper.is_some() {
+            sql.push_str(" AND COALESCE(event_seq, 0) < ?2");
+        }
         if agent_id.is_some() {
-            sql.push_str(" AND agent_id = ?3");
+            let param_index = if upper.is_some() { 3 } else { 2 };
+            sql.push_str(&format!(" AND agent_id = ?{param_index}"));
         }
         if descending {
             sql.push_str(" ORDER BY COALESCE(event_seq, 0) DESC, created_at DESC");
         } else {
             sql.push_str(" ORDER BY COALESCE(event_seq, 0) ASC, created_at ASC");
         }
+        let limit_param_index = 2 + usize::from(upper.is_some()) + usize::from(agent_id.is_some());
+        sql.push_str(&format!(" LIMIT ?{limit_param_index}"));
         let mut statement = connection.prepare(&sql)?;
-        if let Some(agent_id) = agent_id {
-            statement
-                .query_map(params![lower, upper, agent_id], |row| {
-                    row.get::<_, String>(0)
-                })?
-                .map(|row| {
-                    let payload = row?;
-                    serde_json::from_str(&payload).map_err(Into::into)
-                })
-                .collect()
-        } else {
-            statement
-                .query_map(params![lower, upper], |row| row.get::<_, String>(0))?
-                .map(|row| {
-                    let payload = row?;
-                    serde_json::from_str(&payload).map_err(Into::into)
-                })
-                .collect()
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(lower)];
+        if let Some(upper) = upper {
+            params.push(Box::new(upper));
         }
+        if let Some(agent_id) = agent_id {
+            params.push(Box::new(agent_id.to_owned()));
+        }
+        params.push(Box::new(limit));
+        let events = statement
+            .query_map(rusqlite::params_from_iter(params.iter()), |row| {
+                row.get::<_, String>(0)
+            })?
+            .map(|row| {
+                let payload = row?;
+                serde_json::from_str(&payload).map_err(Into::into)
+            })
+            .collect();
+        events
     }
 
     pub fn page_after(
@@ -1325,13 +1336,15 @@ impl AuditEventSink<'_> {
         if agent_id.is_some() {
             sql.push_str(" AND agent_id = ?2");
         }
-        sql.push_str(" ORDER BY event_seq ASC, created_at ASC LIMIT ");
-        sql.push_str(&limit.to_string());
+        let limit_param_index = if agent_id.is_some() { 3 } else { 2 };
+        sql.push_str(&format!(
+            " ORDER BY event_seq ASC, created_at ASC LIMIT ?{limit_param_index}"
+        ));
         let mut statement = connection.prepare(&sql)?;
         if let Some(agent_id) = agent_id {
             let after_event_seq = i64::try_from(after_event_seq)
                 .context("audit event cursor exceeds SQLite integer range")?;
-            let rows = statement.query_map(params![after_event_seq, agent_id], |row| {
+            let rows = statement.query_map(params![after_event_seq, agent_id, limit], |row| {
                 row.get::<_, String>(0)
             })?;
             rows.map(|row| {
@@ -1342,8 +1355,9 @@ impl AuditEventSink<'_> {
         } else {
             let after_event_seq = i64::try_from(after_event_seq)
                 .context("audit event cursor exceeds SQLite integer range")?;
-            let rows =
-                statement.query_map(params![after_event_seq], |row| row.get::<_, String>(0))?;
+            let rows = statement.query_map(params![after_event_seq, limit], |row| {
+                row.get::<_, String>(0)
+            })?;
             rows.map(|row| {
                 let payload = row?;
                 serde_json::from_str(&payload).map_err(Into::into)

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1196,19 +1196,117 @@ impl AuditEventSink<'_> {
     }
 
     pub fn import_legacy(&self, agent_id: Option<&str>, events: Vec<AuditEvent>) -> Result<()> {
-        if self
-            .db
-            .storage_domain_is_complete("audit_events", "jsonl+db-index")?
-        {
+        if self.db.storage_domain_is_complete("audit_events", "db")? {
             return Ok(());
         }
         self.db
-            .run_storage_domain_import("audit_events", "jsonl", "jsonl+db-index", |tx| {
+            .run_storage_domain_import("audit_events", "jsonl", "db", |tx| {
                 for event in &events {
                     insert_audit_event_tx(tx, agent_id, event)?;
                 }
                 Ok(serde_json::json!({ "imported_records": events.len() }))
             })
+    }
+
+    pub fn recent(&self, agent_id: Option<&str>, limit: usize) -> Result<Vec<AuditEvent>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut sql = String::from("SELECT data_json FROM audit_events");
+        if agent_id.is_some() {
+            sql.push_str(" WHERE agent_id = ?1");
+        }
+        sql.push_str(" ORDER BY COALESCE(event_seq, 0) DESC, created_at DESC LIMIT ");
+        sql.push_str(&limit.to_string());
+        let mut statement = connection.prepare(&sql)?;
+        let mut events = if let Some(agent_id) = agent_id {
+            statement
+                .query_map([agent_id], |row| row.get::<_, String>(0))?
+                .map(|row| {
+                    let payload = row?;
+                    serde_json::from_str(&payload).map_err(Into::into)
+                })
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            statement
+                .query_map([], |row| row.get::<_, String>(0))?
+                .map(|row| {
+                    let payload = row?;
+                    serde_json::from_str(&payload).map_err(Into::into)
+                })
+                .collect::<Result<Vec<_>>>()?
+        };
+        events.reverse();
+        Ok(events)
+    }
+
+    pub fn latest_event_seq(&self, agent_id: Option<&str>) -> Result<Option<u64>> {
+        let connection = self.db.connection()?;
+        let value = if let Some(agent_id) = agent_id {
+            connection.query_row(
+                "SELECT MAX(event_seq) FROM audit_events WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )?
+        } else {
+            connection.query_row("SELECT MAX(event_seq) FROM audit_events", [], |row| {
+                row.get::<_, Option<i64>>(0)
+            })?
+        };
+        value
+            .map(|seq| u64::try_from(seq).context("stored audit event sequence is negative"))
+            .transpose()
+    }
+
+    pub fn max_event_seq(&self, agent_id: Option<&str>) -> Result<u64> {
+        Ok(self.latest_event_seq(agent_id)?.unwrap_or(0))
+    }
+
+    pub fn range(
+        &self,
+        agent_id: Option<&str>,
+        before_seq: Option<u64>,
+        after_seq: Option<u64>,
+        descending: bool,
+    ) -> Result<Vec<AuditEvent>> {
+        let lower = i64::try_from(after_seq.unwrap_or(0))
+            .context("audit event lower cursor exceeds SQLite integer range")?;
+        let upper = i64::try_from(before_seq.unwrap_or(u64::MAX))
+            .context("audit event upper cursor exceeds SQLite integer range")?;
+        let connection = self.db.connection()?;
+        let mut sql = String::from(
+            "SELECT data_json FROM audit_events WHERE COALESCE(event_seq, 0) > ?1 AND COALESCE(event_seq, 0) < ?2",
+        );
+        if agent_id.is_some() {
+            sql.push_str(" AND agent_id = ?3");
+        }
+        if descending {
+            sql.push_str(" ORDER BY COALESCE(event_seq, 0) DESC, created_at DESC");
+        } else {
+            sql.push_str(" ORDER BY COALESCE(event_seq, 0) ASC, created_at ASC");
+        }
+        let mut statement = connection.prepare(&sql)?;
+        if let Some(agent_id) = agent_id {
+            statement
+                .query_map(params![lower, upper, agent_id], |row| {
+                    row.get::<_, String>(0)
+                })?
+                .map(|row| {
+                    let payload = row?;
+                    serde_json::from_str(&payload).map_err(Into::into)
+                })
+                .collect()
+        } else {
+            statement
+                .query_map(params![lower, upper], |row| row.get::<_, String>(0))?
+                .map(|row| {
+                    let payload = row?;
+                    serde_json::from_str(&payload).map_err(Into::into)
+                })
+                .collect()
+        }
     }
 
     pub fn page_after(
@@ -3109,8 +3207,8 @@ impl RuntimeDb {
             },
             ExpectedStorageDomain {
                 domain: "audit_events",
-                canonical_source: "jsonl+db-index",
-                legacy_jsonl_posture: LegacyJsonlPosture::AuditMirror,
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
             },
         ]
     }
@@ -3789,6 +3887,46 @@ mod tests {
     }
 
     #[test]
+    fn audit_event_import_failure_is_retryable_and_idempotent() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut invalid = AuditEvent::new("legacy_audit", serde_json::json!({ "n": 1 }));
+        invalid.id = "audit-1".into();
+        invalid.event_seq = u64::MAX;
+
+        let error = db
+            .audit_events()
+            .import_legacy(Some("agent-a"), vec![invalid])
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("importing legacy storage domain audit_events"));
+        let failed = db
+            .storage_domain("audit_events")?
+            .expect("failed storage domain row");
+        assert_eq!(failed.import_status, "failed");
+
+        let mut valid = AuditEvent::new("legacy_audit", serde_json::json!({ "n": 1 }));
+        valid.id = "audit-1".into();
+        valid.event_seq = 7;
+        db.audit_events()
+            .import_legacy(Some("agent-a"), vec![valid.clone()])?;
+        db.audit_events()
+            .import_legacy(Some("agent-a"), vec![valid])?;
+
+        let complete = db
+            .storage_domain("audit_events")?
+            .expect("complete storage domain row");
+        assert_eq!(complete.import_status, "complete");
+        assert_eq!(complete.canonical_source, "db");
+        let imported = db.audit_events().recent(Some("agent-a"), 10)?;
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].id, "audit-1");
+        assert_eq!(imported[0].event_seq, 7);
+        Ok(())
+    }
+
+    #[test]
     fn cutover_diagnostics_detect_missing_failed_and_mixed_sources() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
@@ -3809,7 +3947,7 @@ mod tests {
             )?;
             upsert_storage_domain(tx, "external_triggers", "complete", "db", None)?;
             upsert_storage_domain(tx, "evidence", "complete", "db", None)?;
-            upsert_storage_domain(tx, "audit_events", "complete", "jsonl+db-index", None)?;
+            upsert_storage_domain(tx, "audit_events", "complete", "db", None)?;
             Ok(())
         })?;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -439,6 +439,14 @@ impl AppStorage {
                 .append(sink.agent_id.as_deref(), &event)?;
             return Ok(());
         }
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if runtime_db.storage_domain_is_complete("audit_events", "db")? {
+                runtime_db
+                    .audit_events()
+                    .append(self.current_agent_id()?.as_deref(), &event)?;
+                return Ok(());
+            }
+        }
         let line = serde_json::to_string(&event)?;
         let mut bytes = Vec::with_capacity(line.len() + 1);
         bytes.extend_from_slice(line.as_bytes());
@@ -2581,6 +2589,44 @@ mod tests {
         let events = storage.read_recent_events(10).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].kind, "db_canonical_event");
+        assert_eq!(events[0].event_seq, 1);
+        let legacy_len_after = std::fs::metadata(&storage.events_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        assert_eq!(legacy_len_after, legacy_len_before);
+    }
+
+    #[test]
+    fn audit_events_use_runtime_db_after_cutover_before_sink_is_enabled() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("agent-test")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        runtime_db
+            .audit_events()
+            .import_legacy(Some("agent-test"), Vec::new())
+            .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+
+        let legacy_len_before = std::fs::metadata(&storage.events_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        storage
+            .append_event(&AuditEvent::new(
+                "db_canonical_bootstrap_event",
+                serde_json::json!({ "source": "bootstrap_gap" }),
+            ))
+            .unwrap();
+
+        let events = storage.read_recent_events(10).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "db_canonical_bootstrap_event");
         assert_eq!(events[0].event_seq, 1);
         let legacy_len_after = std::fs::metadata(&storage.events_path)
             .map(|metadata| metadata.len())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -315,6 +315,17 @@ impl AppStorage {
                     .max_transcript_seq(agent_id.as_deref())?,
             );
         }
+        {
+            let mut counter = self
+                .event_seq_counter
+                .lock()
+                .map_err(|_| anyhow::anyhow!("event sequence counter mutex poisoned"))?;
+            *counter = (*counter).max(
+                runtime_db
+                    .audit_events()
+                    .max_event_seq(agent_id.as_deref())?,
+            );
+        }
         let mut guard = self
             .scheduler_control_plane_db
             .lock()
@@ -417,11 +428,6 @@ impl AppStorage {
             .map_err(|_| anyhow::anyhow!("event sequence counter mutex poisoned"))?;
         *counter += 1;
         event.event_seq = *counter;
-        let line = serde_json::to_string(&event)?;
-        let mut bytes = Vec::with_capacity(line.len() + 1);
-        bytes.extend_from_slice(line.as_bytes());
-        bytes.push(b'\n');
-        append_jsonl_bytes(&self.events_path, &bytes)?;
         if let Some(sink) = self
             .audit_event_index
             .lock()
@@ -431,7 +437,13 @@ impl AppStorage {
             sink.runtime_db
                 .audit_events()
                 .append(sink.agent_id.as_deref(), &event)?;
+            return Ok(());
         }
+        let line = serde_json::to_string(&event)?;
+        let mut bytes = Vec::with_capacity(line.len() + 1);
+        bytes.extend_from_slice(line.as_bytes());
+        bytes.push(b'\n');
+        append_jsonl_bytes(&self.events_path, &bytes)?;
         Ok(())
     }
 
@@ -702,10 +714,24 @@ impl AppStorage {
     }
 
     pub fn read_recent_events(&self, limit: usize) -> Result<Vec<AuditEvent>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .audit_events()
+                .recent(self.current_agent_id()?.as_deref(), limit);
+        }
         read_recent_jsonl(&self.events_path, limit)
     }
 
+    pub(crate) fn read_legacy_events_jsonl(&self) -> Result<Vec<AuditEvent>> {
+        read_recent_jsonl(&self.events_path, usize::MAX)
+    }
+
     pub fn latest_event_seq(&self) -> Result<Option<u64>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .audit_events()
+                .latest_event_seq(self.current_agent_id()?.as_deref());
+        }
         let mut latest = None;
         scan_jsonl_reverse::<AuditEvent, _>(&self.events_path, |event| {
             latest = Some(event.event_seq);
@@ -725,6 +751,46 @@ impl AppStorage {
     where
         F: FnMut(&AuditEvent) -> bool,
     {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if limit == 0 {
+                return Ok(EventLogPage {
+                    events: Vec::new(),
+                    has_older: false,
+                    has_newer: false,
+                });
+            }
+            let descending = matches!(order, EventLogPageOrder::Desc);
+            let mut page = Vec::with_capacity(limit.saturating_add(1).min(1024));
+            for event in runtime_db.audit_events().range(
+                self.current_agent_id()?.as_deref(),
+                before_seq,
+                after_seq,
+                descending,
+            )? {
+                if matches(&event) {
+                    page.push(event);
+                }
+                if page.len() > limit {
+                    break;
+                }
+            }
+            let has_more = page.len() > limit;
+            if has_more {
+                page.truncate(limit);
+            }
+            return Ok(match order {
+                EventLogPageOrder::Desc => EventLogPage {
+                    events: page,
+                    has_older: has_more,
+                    has_newer: false,
+                },
+                EventLogPageOrder::Asc => EventLogPage {
+                    events: page,
+                    has_older: false,
+                    has_newer: has_more,
+                },
+            });
+        }
         if limit == 0 || !self.events_path.exists() {
             return Ok(EventLogPage {
                 events: Vec::new(),
@@ -2460,6 +2526,47 @@ mod tests {
         assert_eq!(indexed.len(), 1);
         assert_eq!(indexed[0].kind, "live_event");
         assert_eq!(indexed[0].event_seq, 1);
+    }
+
+    #[test]
+    fn audit_events_use_runtime_db_after_cutover_without_live_jsonl_append() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("agent-test")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        runtime_db
+            .audit_events()
+            .import_legacy(Some("agent-test"), Vec::new())
+            .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        storage
+            .enable_audit_event_index(runtime_db.clone(), Some("agent-test".to_string()))
+            .unwrap();
+
+        let legacy_len_before = std::fs::metadata(&storage.events_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        storage
+            .append_event(&AuditEvent::new(
+                "db_canonical_event",
+                serde_json::json!({ "source": "runtime_db" }),
+            ))
+            .unwrap();
+
+        let events = storage.read_recent_events(10).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "db_canonical_event");
+        assert_eq!(events[0].event_seq, 1);
+        let legacy_len_after = std::fs::metadata(&storage.events_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        assert_eq!(legacy_len_after, legacy_len_before);
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -407,9 +407,24 @@ impl AppStorage {
             briefs: file_activity_marker(&self.briefs_path)?,
             tasks: file_activity_marker(&self.tasks_path)?,
             tools: file_activity_marker(&self.tools_path)?,
-            events: file_activity_marker(&self.events_path)?,
+            events: self.audit_events_activity_marker()?,
             transcript: file_activity_marker(&self.transcript_path)?,
         })
+    }
+
+    fn audit_events_activity_marker(&self) -> Result<FileActivityMarker> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            let latest_seq = runtime_db
+                .audit_events()
+                .latest_event_seq(self.current_agent_id()?.as_deref())?
+                .unwrap_or(0);
+            return Ok(FileActivityMarker {
+                exists: latest_seq > 0,
+                len: latest_seq,
+                modified_unix_ms: u128::from(latest_seq),
+            });
+        }
+        file_activity_marker(&self.events_path)
     }
 
     pub fn append_event(&self, event: &AuditEvent) -> Result<()> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -761,17 +761,36 @@ impl AppStorage {
             }
             let descending = matches!(order, EventLogPageOrder::Desc);
             let mut page = Vec::with_capacity(limit.saturating_add(1).min(1024));
-            for event in runtime_db.audit_events().range(
-                self.current_agent_id()?.as_deref(),
-                before_seq,
-                after_seq,
-                descending,
-            )? {
-                if matches(&event) {
-                    page.push(event);
+            let agent_id = self.current_agent_id()?;
+            let chunk_limit = limit.saturating_add(1).clamp(64, 1024);
+            let mut next_before_seq = before_seq;
+            let mut next_after_seq = after_seq;
+            loop {
+                let chunk = runtime_db.audit_events().range(
+                    agent_id.as_deref(),
+                    next_before_seq,
+                    next_after_seq,
+                    descending,
+                    chunk_limit,
+                )?;
+                let Some(last_seq) = chunk.last().map(|event| event.event_seq) else {
+                    break;
+                };
+                for event in chunk {
+                    if matches(&event) {
+                        page.push(event);
+                    }
+                    if page.len() > limit {
+                        break;
+                    }
                 }
                 if page.len() > limit {
                     break;
+                }
+                if descending {
+                    next_before_seq = Some(last_seq);
+                } else {
+                    next_after_seq = Some(last_seq);
                 }
             }
             let has_more = page.len() > limit;


### PR DESCRIPTION
## Summary
- make audit_events storage-domain canonical source `db` with legacy JSONL as import-only
- route audit append/recent/page/latest reads through RuntimeDb after cutover instead of live `events.jsonl`
- import legacy audit JSONL explicitly during bootstrap and add retry/idempotency coverage

Closes #1624

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test audit --all-targets
- cargo test storage_ --all-targets
