### PR TITLE
feat: stop live legacy JSONL compat exports

### DIFF
--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -270,7 +270,7 @@ impl RuntimeServiceHandle {
 }
 
 pub async fn runtime_activity_summary(host: &RuntimeHost) -> Result<RuntimeActivitySummary> {
-    let agents = host.public_agent_activity_snapshots()?;
+    let agents = host.public_agent_activity_snapshots().await?;
     let active_task_count = agents
         .iter()
         .map(|agent| agent.active_task_count)

--- a/src/host.rs
+++ b/src/host.rs
@@ -701,13 +701,26 @@ impl RuntimeHost {
         })
     }
 
-    pub fn public_agent_activity_snapshots(&self) -> Result<Vec<PublicAgentActivitySnapshot>> {
+    pub async fn public_agent_activity_snapshots(
+        &self,
+    ) -> Result<Vec<PublicAgentActivitySnapshot>> {
         self.ensure_default_agent_identity()?;
         let mut snapshots = Vec::new();
         for identity in self.agent_identity_records()?.into_iter().filter(|record| {
             record.status == AgentRegistryStatus::Active
                 && record.visibility == AgentVisibility::Public
         }) {
+            if let Some(runtime) = self.loaded_runtime(&identity.agent_id).await {
+                let state = runtime.agent_state().await?;
+                let active_task_count = runtime.active_tasks(usize::MAX).await?.len();
+                snapshots.push(PublicAgentActivitySnapshot {
+                    agent_id: identity.agent_id,
+                    status: state.status.clone(),
+                    active_task_count,
+                    last_runtime_failure: state.last_runtime_failure,
+                });
+                continue;
+            }
             let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
             let state = storage
                 .read_agent()?
@@ -1841,7 +1854,7 @@ mod tests {
             .expect("release-bot should still be listed");
         assert_eq!(
             loaded_release_bot.scheduling_posture.posture,
-            AgentSchedulingPosture::Unknown
+            AgentSchedulingPosture::Idle
         );
 
         host.unload_runtime("release-bot").await;

--- a/src/http.rs
+++ b/src/http.rs
@@ -908,6 +908,7 @@ pub async fn runtime_status(
     let last_failure = state
         .host
         .public_agent_activity_snapshots()
+        .await
         .map_err(error_response)?
         .into_iter()
         .filter_map(|agent| agent.last_runtime_failure)

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -1507,7 +1507,7 @@ mod tests {
         task_id: &str,
         expected: TaskStatus,
     ) -> TaskRecord {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         loop {
             if let Some(task) = runtime.inner.storage.latest_task_record(task_id).unwrap() {
                 if task.status == expected {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1112,6 +1112,16 @@ impl RuntimeHandle {
                 task_detail["worktree"] = worktree_detail;
             }
         }
+        if task_detail.get("workspace_mode").is_none() {
+            if let Some(workspace_mode) = task_detail_for_result.get("workspace_mode").cloned() {
+                task_detail["workspace_mode"] = workspace_mode;
+            }
+        }
+        if task_detail.get("wait_policy").is_none() {
+            if let Some(wait_policy) = task_detail_for_result.get("wait_policy").cloned() {
+                task_detail["wait_policy"] = wait_policy;
+            }
+        }
 
         if worktree {
             if let Some(worktree) = task_detail.get("worktree").cloned() {

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -20,12 +20,12 @@ async fn runtime_tracks_background_task() {
         .schedule_command_task(
             "demo task".into(),
             crate::types::CommandTaskSpec {
-                cmd: "sleep 1".into(),
+                cmd: "true".into(),
                 workdir: None,
                 shell: None,
                 login: false,
                 tty: false,
-                yield_time_ms: 10,
+                yield_time_ms: 0,
                 max_output_tokens: None,
                 accepts_input: false,
                 terminal_reentry: false,
@@ -34,6 +34,25 @@ async fn runtime_tracks_background_task() {
         )
         .await
         .unwrap();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let latest = runtime.task_record(&task.id).await.unwrap().unwrap();
+        if matches!(
+            latest.status,
+            TaskStatus::Completed
+                | TaskStatus::Failed
+                | TaskStatus::Cancelled
+                | TaskStatus::Interrupted
+        ) {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "background task did not reach a terminal status before the deadline; latest status: {:?}",
+            latest.status
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         let active_tasks = runtime.active_tasks(10).await.unwrap();
@@ -42,7 +61,7 @@ async fn runtime_tracks_background_task() {
         }
         assert!(
             tokio::time::Instant::now() < deadline,
-            "background task remained active past test deadline"
+            "terminal background task remained in active task projection"
         );
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -475,6 +475,28 @@ impl ExternalTriggerRepository<'_> {
             .collect()
     }
 
+    pub fn latest_for_agent_limit(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ExternalTriggerRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM external_triggers
+             WHERE target_agent_id = ?1
+             ORDER BY created_at DESC, external_trigger_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_external_trigger_payload(&row?))
+            .collect()
+    }
+
     pub fn active_default_for_agent(
         &self,
         agent_id: &str,
@@ -4764,6 +4786,44 @@ mod tests {
                 .count(),
             1
         );
+        Ok(())
+    }
+
+    #[test]
+    fn external_trigger_latest_for_agent_limit_uses_bounded_recent_results() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        db.external_triggers().import_legacy(Vec::new())?;
+
+        for index in 0..4 {
+            db.external_triggers().upsert(&external_trigger_record(
+                &format!("trigger-{index}"),
+                "agent-a",
+                ExternalTriggerStatus::Revoked,
+                index,
+            ))?;
+        }
+        db.external_triggers().upsert(&external_trigger_record(
+            "trigger-other-agent",
+            "agent-b",
+            ExternalTriggerStatus::Revoked,
+            10,
+        ))?;
+
+        let recent = db
+            .external_triggers()
+            .latest_for_agent_limit("agent-a", 2)?;
+        assert_eq!(
+            recent
+                .into_iter()
+                .map(|record| record.external_trigger_id)
+                .collect::<Vec<_>>(),
+            vec!["trigger-3", "trigger-2"]
+        );
+        assert!(db
+            .external_triggers()
+            .latest_for_agent_limit("agent-a", 0)?
+            .is_empty());
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -102,18 +102,18 @@ pub struct StorageDomainSnapshot {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LegacyJsonlPosture {
     Disabled,
-    CompatExport,
+    DebugExportOnly,
     AuditMirror,
-    ImportSource,
+    LegacyImportOnly,
 }
 
 impl LegacyJsonlPosture {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Disabled => "disabled",
-            Self::CompatExport => "compat_export",
+            Self::DebugExportOnly => "debug_export_only",
             Self::AuditMirror => "audit_mirror",
-            Self::ImportSource => "import_source",
+            Self::LegacyImportOnly => "legacy_import_only",
         }
     }
 }
@@ -3660,52 +3660,52 @@ impl RuntimeDb {
             ExpectedStorageDomain {
                 domain: "agent_states",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "workspace_entries",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "workspace_occupancies",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "agent_identities",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "work_items",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "tasks",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "external_triggers",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "wait_conditions",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "queue_entries",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "timers",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::CompatExport,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "turn_records",
@@ -3715,22 +3715,22 @@ impl RuntimeDb {
             ExpectedStorageDomain {
                 domain: "messages",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "transcript_entries",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "evidence",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
             ExpectedStorageDomain {
                 domain: "audit_events",
                 canonical_source: "db",
-                legacy_jsonl_posture: LegacyJsonlPosture::ImportSource,
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },
         ]
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -617,8 +617,8 @@ impl AppStorage {
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.wait_conditions().upsert(&wait_condition)?;
             append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
+            runtime_db.wait_conditions().upsert(&wait_condition)?;
             if let Some(event) = event.as_ref() {
                 self.append_event_with_append_mutex_held(event)?;
             }
@@ -1100,10 +1100,9 @@ impl AppStorage {
     ) -> Result<Vec<ExternalTriggerRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             if let Some(agent_id) = self.current_agent_id()? {
-                return Ok(take_recent(
-                    runtime_db.external_triggers().latest_for_agent(&agent_id)?,
-                    limit,
-                ));
+                return runtime_db
+                    .external_triggers()
+                    .latest_for_agent_limit(&agent_id, limit);
             }
         }
         read_recent_jsonl(&self.external_triggers_path, limit)
@@ -1412,8 +1411,13 @@ impl AppStorage {
             .and_then(|agent| agent.current_work_item_id);
         let mut latest = std::collections::HashMap::<String, WorkItemRecord>::new();
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            for record in runtime_db.work_items().latest_all()? {
-                latest.insert(record.id.clone(), record);
+            if let Some(agent_id) = self.current_agent_id()? {
+                for record in runtime_db
+                    .work_items()
+                    .latest_for_agent(&agent_id, usize::MAX)?
+                {
+                    latest.insert(record.id.clone(), record);
+                }
             }
         } else {
             let content = fs::read_to_string(&self.work_items_path)
@@ -5477,6 +5481,50 @@ mod tests {
             rendered,
             vec!["queued first", "queued second", "waiting item"]
         );
+    }
+
+    #[test]
+    fn db_backed_work_queue_prompt_projection_filters_by_current_agent() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        runtime_db
+            .work_items()
+            .import_legacy(Vec::new(), None)
+            .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+
+        let mut current = WorkItemRecord::new("default", "current agent item", WorkItemState::Open);
+        current.updated_at = Utc::now();
+        let mut other_agent =
+            WorkItemRecord::new("other-agent", "other agent item", WorkItemState::Open);
+        other_agent.updated_at = current.updated_at + chrono::Duration::seconds(1);
+        storage.append_work_item(&current).unwrap();
+        storage.append_work_item(&other_agent).unwrap();
+        let mut agent = AgentState::new("default");
+        agent.current_work_item_id = Some(current.id.clone());
+        storage.write_agent(&agent).unwrap();
+        storage.append_work_item(&current).unwrap();
+
+        let projection = storage.work_queue_prompt_projection().unwrap();
+        assert_eq!(
+            projection
+                .current
+                .as_ref()
+                .map(|item| item.objective.as_str()),
+            Some("current agent item")
+        );
+        assert!(projection
+            .queued_blocked
+            .iter()
+            .all(|item| item.objective != "other agent item"));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -502,6 +502,7 @@ impl AppStorage {
     pub fn append_task(&self, task: &TaskRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.tasks().upsert(task)?;
+            return self.mark_memory_index_dirty();
         }
         self.append_jsonl(&self.tasks_path, task)?;
         self.mark_memory_index_dirty()
@@ -515,6 +516,7 @@ impl AppStorage {
                 .as_deref()
                 == Some(record.id.as_str());
             runtime_db.work_items().upsert(record, current_focus)?;
+            return self.mark_memory_index_dirty();
         }
         self.append_jsonl(&self.work_items_path, record)?;
         self.mark_memory_index_dirty()
@@ -535,6 +537,7 @@ impl AppStorage {
     pub fn append_timer(&self, timer: &TimerRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.timers().upsert(timer)?;
+            return Ok(());
         }
         self.append_jsonl(&self.timers_path, timer)
     }
@@ -591,6 +594,7 @@ impl AppStorage {
     pub fn append_queue_entry(&self, record: &QueueEntryRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.queue_entries().upsert(record)?;
+            return Ok(());
         }
         self.append_jsonl(&self.queue_entries_path, record)
     }
@@ -614,6 +618,11 @@ impl AppStorage {
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.wait_conditions().upsert(&wait_condition)?;
+            append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
+            if let Some(event) = event.as_ref() {
+                self.append_event_with_append_mutex_held(event)?;
+            }
+            return Ok(());
         }
         append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
         append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
@@ -633,6 +642,10 @@ impl AppStorage {
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.wait_conditions().upsert(record)?;
+            if let Some(event) = event.as_ref() {
+                self.append_event_with_append_mutex_held(event)?;
+            }
+            return Ok(());
         }
         append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
         if let Some(event) = event.as_ref() {
@@ -642,6 +655,10 @@ impl AppStorage {
     }
 
     pub fn append_external_trigger(&self, record: &ExternalTriggerRecord) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.external_triggers().upsert(record)?;
+            return Ok(());
+        }
         self.append_jsonl(&self.external_triggers_path, record)
     }
 
@@ -672,6 +689,7 @@ impl AppStorage {
     pub fn append_workspace_entry(&self, entry: &WorkspaceEntry) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.workspace_entries().upsert(entry)?;
+            return self.mark_memory_index_dirty();
         }
         self.append_jsonl(&self.workspaces_path, entry)?;
         self.mark_memory_index_dirty()
@@ -680,6 +698,7 @@ impl AppStorage {
     pub fn append_workspace_occupancy(&self, entry: &WorkspaceOccupancyRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.workspace_occupancies().upsert(entry)?;
+            return Ok(());
         }
         self.append_jsonl(&self.occupancies_path, entry)
     }
@@ -687,6 +706,7 @@ impl AppStorage {
     pub fn append_agent_identity(&self, entry: &AgentIdentityRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.agent_identities().upsert(entry)?;
+            return Ok(());
         }
         self.append_jsonl(&self.agent_identities_path, entry)
     }
@@ -981,10 +1001,16 @@ impl AppStorage {
     }
 
     pub fn read_recent_tasks(&self, limit: usize) -> Result<Vec<TaskRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return Ok(take_recent(runtime_db.tasks().latest_all()?, limit));
+        }
         read_recent_jsonl(&self.tasks_path, limit)
     }
 
     pub fn read_recent_work_items(&self, limit: usize) -> Result<Vec<WorkItemRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return Ok(take_recent(runtime_db.work_items().latest_all()?, limit));
+        }
         read_recent_jsonl(&self.work_items_path, limit)
     }
 
@@ -1072,6 +1098,14 @@ impl AppStorage {
         &self,
         limit: usize,
     ) -> Result<Vec<ExternalTriggerRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return Ok(take_recent(
+                    runtime_db.external_triggers().latest_for_agent(&agent_id)?,
+                    limit,
+                ));
+            }
+        }
         read_recent_jsonl(&self.external_triggers_path, limit)
     }
 
@@ -1145,6 +1179,9 @@ impl AppStorage {
     }
 
     pub fn latest_task_records_from_recent(&self, history_limit: usize) -> Result<Vec<TaskRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return Ok(take_recent(runtime_db.tasks().latest_all()?, history_limit));
+        }
         let records = self.read_recent_tasks(history_limit)?;
         let mut latest = std::collections::BTreeMap::<String, TaskRecord>::new();
         for record in records {
@@ -1344,6 +1381,9 @@ impl AppStorage {
         agent_id: &str,
         limit: usize,
     ) -> Result<Vec<WorkItemRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.work_items().latest_for_agent(agent_id, limit);
+        }
         if limit == 0 || !self.work_items_path.exists() {
             return Ok(Vec::new());
         }
@@ -1363,24 +1403,30 @@ impl AppStorage {
     }
 
     pub fn work_queue_prompt_projection(&self) -> Result<WorkQueuePromptProjection> {
-        if !self.work_items_path.exists() {
+        let db_enabled = self.scheduler_control_plane_db()?.is_some();
+        if !db_enabled && !self.work_items_path.exists() {
             return Ok(WorkQueuePromptProjection::default());
         }
         let current_work_item_id = self
             .read_agent()?
             .and_then(|agent| agent.current_work_item_id);
-
-        let content = fs::read_to_string(&self.work_items_path)
-            .with_context(|| format!("failed to read {}", self.work_items_path.display()))?;
         let mut latest = std::collections::HashMap::<String, WorkItemRecord>::new();
-        for line in content.lines().rev().filter(|line| !line.trim().is_empty()) {
-            let record: WorkItemRecord = serde_json::from_str(line).with_context(|| {
-                format!(
-                    "failed to decode line from {}",
-                    self.work_items_path.display()
-                )
-            })?;
-            latest.entry(record.id.clone()).or_insert(record);
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            for record in runtime_db.work_items().latest_all()? {
+                latest.insert(record.id.clone(), record);
+            }
+        } else {
+            let content = fs::read_to_string(&self.work_items_path)
+                .with_context(|| format!("failed to read {}", self.work_items_path.display()))?;
+            for line in content.lines().rev().filter(|line| !line.trim().is_empty()) {
+                let record: WorkItemRecord = serde_json::from_str(line).with_context(|| {
+                    format!(
+                        "failed to decode line from {}",
+                        self.work_items_path.display()
+                    )
+                })?;
+                latest.entry(record.id.clone()).or_insert(record);
+            }
         }
 
         let current = current_work_item_id
@@ -1746,6 +1792,9 @@ impl AppStorage {
     }
 
     pub fn latest_work_item(&self, work_item_id: &str) -> Result<Option<WorkItemRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.work_items().latest(work_item_id);
+        }
         if !self.work_items_path.exists() {
             return Ok(None);
         }
@@ -2565,10 +2614,11 @@ mod tests {
 
     use crate::types::{
         AgentState, AgentStatus, AuthorityClass, BriefKind, CallbackDeliveryMode,
-        EpisodeBoundaryReason, MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority,
-        QueueEntryRecord, QueueEntryStatus, TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus,
-        TodoItem, TodoItemState, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind,
-        WorkItemPlanStatus, WorkItemState,
+        EpisodeBoundaryReason, ExternalTriggerScope, ExternalTriggerStatus, MessageBody,
+        MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
+        TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TodoItem, TodoItemState,
+        ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, WorkItemPlanStatus,
+        WorkItemState,
     };
 
     use super::*;
@@ -2826,15 +2876,9 @@ mod tests {
         storage.append_timer(&later_timer).unwrap();
         storage.append_timer(&latest_timer).unwrap();
 
-        assert!(fs::read_to_string(&storage.wait_conditions_path)
-            .unwrap()
-            .contains("\"wait-1\""));
-        assert!(fs::read_to_string(&storage.queue_entries_path)
-            .unwrap()
-            .contains("\"msg-1\""));
-        assert!(fs::read_to_string(&storage.timers_path)
-            .unwrap()
-            .contains("\"timer-1\""));
+        assert!(!storage.wait_conditions_path.exists());
+        assert!(!storage.queue_entries_path.exists());
+        assert!(!storage.timers_path.exists());
 
         fs::write(
             &storage.wait_conditions_path,
@@ -2899,6 +2943,191 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["timer-2", "timer-3"]
         );
+    }
+
+    #[test]
+    fn runtime_db_state_writes_skip_live_jsonl_after_cutover() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        runtime_db.tasks().import_legacy(Vec::new()).unwrap();
+        runtime_db
+            .work_items()
+            .import_legacy(Vec::new(), None)
+            .unwrap();
+        runtime_db
+            .wait_conditions()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db
+            .queue_entries()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db.timers().import_legacy(Vec::new()).unwrap();
+        runtime_db
+            .external_triggers()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db
+            .workspace_entries()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db
+            .workspace_occupancies()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db
+            .agent_identities()
+            .import_legacy(Vec::new())
+            .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+
+        let now = Utc::now();
+        let task = TaskRecord {
+            id: "task-db-only".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("db only task".into()),
+            detail: None,
+            recovery: None,
+        };
+        let work_item = WorkItemRecord::new("default", "db only work", WorkItemState::Open);
+        let wait_condition = WaitConditionRecord {
+            id: "wait-db-only".into(),
+            agent_id: "default".into(),
+            work_item_id: Some(work_item.id.clone()),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pr-1".into()),
+            waiting_for: "checks".into(),
+            wake_sources: vec![],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        };
+        let queue_entry = QueueEntryRecord {
+            message_id: "message-db-only".into(),
+            agent_id: "default".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        let timer = TimerRecord {
+            id: "timer-db-only".into(),
+            agent_id: "default".into(),
+            created_at: now,
+            duration_ms: 1000,
+            interval_ms: None,
+            repeat: false,
+            status: crate::types::TimerStatus::Active,
+            summary: Some("timer".into()),
+            next_fire_at: Some(now + chrono::Duration::seconds(1)),
+            last_fired_at: None,
+            fire_count: 0,
+        };
+        let trigger = ExternalTriggerRecord {
+            external_trigger_id: "trigger-db-only".into(),
+            target_agent_id: "default".into(),
+            waiting_intent_id: None,
+            scope: ExternalTriggerScope::Agent,
+            delivery_mode: CallbackDeliveryMode::WakeHint,
+            trigger_url: Some("http://localhost/callback".into()),
+            token_hash: "token-hash".into(),
+            status: ExternalTriggerStatus::Active,
+            created_at: now,
+            revoked_at: None,
+            last_delivered_at: None,
+            delivery_count: 0,
+        };
+        let mut workspace =
+            WorkspaceEntry::new("ws-db-only", std::path::PathBuf::from("/repo"), None);
+        workspace.workspace_alias = Some("repo".into());
+        workspace.updated_at = now;
+        let occupancy = WorkspaceOccupancyRecord {
+            occupancy_id: "occ-db-only".into(),
+            execution_root_id: "root-db-only".into(),
+            workspace_id: workspace.workspace_id.clone(),
+            holder_agent_id: "default".into(),
+            access_mode: crate::system::types::WorkspaceAccessMode::ExclusiveWrite,
+            acquired_at: now,
+            released_at: None,
+        };
+        let identity = AgentIdentityRecord::new(
+            "default",
+            crate::types::AgentKind::Named,
+            crate::types::AgentVisibility::Public,
+            crate::types::AgentOwnership::SelfOwned,
+            crate::types::AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+
+        storage.append_task(&task).unwrap();
+        storage.append_work_item(&work_item).unwrap();
+        storage.append_wait_condition(&wait_condition).unwrap();
+        storage.append_queue_entry(&queue_entry).unwrap();
+        storage.append_timer(&timer).unwrap();
+        storage.append_external_trigger(&trigger).unwrap();
+        storage.append_workspace_entry(&workspace).unwrap();
+        storage.append_workspace_occupancy(&occupancy).unwrap();
+        storage.append_agent_identity(&identity).unwrap();
+
+        for file_name in [
+            "tasks.jsonl",
+            "work_items.jsonl",
+            "wait_conditions.jsonl",
+            "queue_entries.jsonl",
+            "timers.jsonl",
+            "external_triggers.jsonl",
+            "workspaces.jsonl",
+            "workspace_occupancies.jsonl",
+            "agent_identities.jsonl",
+        ] {
+            assert!(
+                !storage.ledger_dir().join(file_name).exists(),
+                "{file_name} should not be a live compat export after db cutover"
+            );
+        }
+
+        assert_eq!(
+            storage.latest_task_record("task-db-only").unwrap(),
+            Some(task)
+        );
+        assert_eq!(
+            storage.latest_work_item(&work_item.id).unwrap(),
+            Some(work_item)
+        );
+        assert_eq!(
+            storage.latest_wait_conditions().unwrap(),
+            vec![wait_condition]
+        );
+        assert_eq!(storage.latest_queue_entries().unwrap(), vec![queue_entry]);
+        assert_eq!(storage.latest_timer_records().unwrap(), vec![timer]);
+        assert_eq!(storage.latest_external_triggers().unwrap(), vec![trigger]);
+        assert_eq!(storage.latest_workspace_entries().unwrap(), vec![workspace]);
+        assert_eq!(
+            storage.latest_workspace_occupancies().unwrap(),
+            vec![occupancy]
+        );
+        assert_eq!(storage.latest_agent_identities().unwrap(), vec![identity]);
     }
 
     #[test]

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -924,7 +924,7 @@ async fn run_once_no_wait_stops_unfinished_command_tasks_before_exit() -> Result
     let workspace_dir = tempdir()?.keep();
     let host = RuntimeHost::new_with_provider(
         test_config(workspace_dir, home_dir),
-        Arc::new(CommandTaskProvider::new("sleep 5")),
+        Arc::new(CommandTaskProvider::new("sleep 60")),
     )?;
 
     let response = run_once_with_host(
@@ -939,10 +939,14 @@ async fn run_once_no_wait_stops_unfinished_command_tasks_before_exit() -> Result
     assert_eq!(response.final_status, RunFinalStatus::Completed);
     assert_eq!(response.tasks.len(), 1);
     assert_eq!(response.tasks[0].task.kind, "command_task");
-    assert!(matches!(
-        response.tasks[0].task.status,
-        TaskStatus::Cancelling | TaskStatus::Cancelled
-    ));
+    assert!(
+        matches!(
+            response.tasks[0].task.status,
+            TaskStatus::Cancelling | TaskStatus::Cancelled
+        ),
+        "unexpected task status: {:?}",
+        response.tasks[0].task.status
+    );
     Ok(())
 }
 

--- a/tests/support/http_client.rs
+++ b/tests/support/http_client.rs
@@ -372,8 +372,8 @@ pub async fn agent_list_entries_tolerate_unloaded_agent_with_corrupt_work_queue(
         .find(|entry| entry["identity"]["agent_id"] == "corrupt-list")
         .expect("corrupt-list entry should be present");
     assert_eq!(
-        corrupt_entry["status"], "stopped",
-        "unloaded agent without agent.json should not be shown as booting"
+        corrupt_entry["status"], "asleep",
+        "unloaded agent should use canonical RuntimeDb state and ignore corrupt legacy work queue"
     );
 
     let mut client_config = config;

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -388,7 +388,7 @@ pub async fn blocking_subagent_result_does_not_regress_to_running_task_status() 
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks
             .iter()
@@ -418,7 +418,7 @@ pub async fn blocking_subagent_result_does_not_regress_to_running_task_status() 
     };
     runtime.enqueue(stale_running).await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let state = runtime.storage().read_agent()?;
         let tasks = runtime.storage().latest_task_records()?;
         let latest = tasks
@@ -459,7 +459,7 @@ pub async fn subagent_task_failure_propagates_failed_output_to_parent() -> Resul
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Failed
@@ -558,7 +558,7 @@ pub async fn subagent_task_returns_result_to_parent_session() -> Result<()> {
             holon::types::ChildAgentWorkspaceMode::Inherit,
         )
         .await?;
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let briefs = runtime.storage().read_recent_briefs(20)?;
         Ok(briefs
             .iter()

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -143,7 +143,7 @@ pub async fn background_task_rejoins_main_session() -> Result<()> {
     assert_eq!(summary.closure.outcome, ClosureOutcome::Completed);
     assert_eq!(summary.closure.waiting_reason, None);
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let active_tasks = runtime.storage().latest_active_task_records(usize::MAX)?;
         let tasks = runtime.storage().latest_task_records()?;
         Ok(!active_tasks.iter().any(|record| record.id == task.id)
@@ -184,7 +184,7 @@ pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reent
         ))
         .await?;
 
-    wait_until_async(|| {
+    wait_until_async_for(Duration::from_secs(10), || {
         let runtime = runtime.clone();
         let provider = provider.clone();
         async move {
@@ -215,7 +215,7 @@ pub async fn background_command_task_result_wakes_sleeping_agent_for_model_reent
         )
         .await?;
 
-    wait_until_async(|| {
+    wait_until_async_for(Duration::from_secs(10), || {
         let provider = provider.clone();
         async move { Ok(provider.captured_requests().await.len() >= 2) }
     })
@@ -272,7 +272,7 @@ pub async fn stop_task_cancels_running_background_task() -> Result<()> {
         .stop_task(&task.id, &AuthorityClass::OperatorInstruction)
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Cancelled
@@ -307,7 +307,7 @@ pub async fn lifecycle_stop_interrupts_active_command_task() -> Result<()> {
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Running
@@ -454,11 +454,14 @@ pub async fn file_tools_can_modify_workspace_and_reenter_context() -> Result<()>
             },
         ))
         .await?;
-    wait_until(|| Ok(workspace.join("notes/result.txt").exists())).await?;
+    eventually_for(Duration::from_secs(10), || {
+        Ok(workspace.join("notes/result.txt").exists())
+    })
+    .await?;
 
     let content = std::fs::read_to_string(workspace.join("notes/result.txt"))?;
     assert_eq!(content, "hello from holon\n");
-    wait_until_async(|| {
+    wait_until_async_for(Duration::from_secs(10), || {
         let runtime = runtime.clone();
         async move {
             let briefs = runtime.recent_briefs(10).await?;
@@ -488,7 +491,7 @@ pub async fn shell_tools_capture_command_output() -> Result<()> {
             },
         ))
         .await?;
-    wait_until_async(|| {
+    wait_until_async_for(Duration::from_secs(10), || {
         let runtime = runtime.clone();
         async move {
             let briefs = runtime.recent_briefs(10).await?;
@@ -524,7 +527,7 @@ pub async fn shell_tools_truncate_large_output_before_provider_reinjection() -> 
             },
         ))
         .await?;
-    wait_until_async(|| {
+    wait_until_async_for(Duration::from_secs(10), || {
         let runtime = runtime.clone();
         async move {
             let briefs = runtime.recent_briefs(10).await?;
@@ -834,7 +837,7 @@ pub async fn tool_schema_and_dispatch_errors_are_recorded_without_corrupting_run
         ))
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let briefs = runtime.storage().read_recent_briefs(10)?;
         Ok(briefs
             .iter()
@@ -938,7 +941,7 @@ pub async fn runtime_provider_failure_surfaces_failure_brief_and_transcript_entr
         ))
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let briefs = runtime.storage().read_recent_briefs(10)?;
         Ok(briefs.iter().any(|brief| {
             brief.kind == BriefKind::Failure
@@ -1022,7 +1025,7 @@ pub async fn runtime_failure_brief_sanitizes_long_provider_error_but_transcript_
         ))
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let briefs = runtime.storage().read_recent_briefs(10)?;
         Ok(briefs.iter().any(|brief| {
             brief.kind == BriefKind::Failure
@@ -1089,7 +1092,7 @@ pub async fn command_task_runs_to_completion_and_persists_detail() -> Result<()>
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Completed
@@ -1136,7 +1139,7 @@ pub async fn task_output_returns_completed_command_task_output() -> Result<()> {
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Completed
@@ -1208,7 +1211,7 @@ pub async fn task_output_non_blocking_reports_running_command_task() -> Result<(
     runtime
         .stop_task(&task.id, &AuthorityClass::OperatorInstruction)
         .await?;
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Cancelled
@@ -1373,7 +1376,7 @@ pub async fn task_output_times_out_for_long_running_task() -> Result<()> {
     runtime
         .stop_task(&task.id, &AuthorityClass::OperatorInstruction)
         .await?;
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Cancelled
@@ -1407,7 +1410,7 @@ pub async fn task_output_prefers_terminal_task_record_over_stale_task_message() 
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Completed
@@ -1479,7 +1482,7 @@ pub async fn task_output_accepts_terminal_command_snapshot_without_explicit_read
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id
@@ -1539,7 +1542,7 @@ pub async fn task_output_accepts_terminal_command_without_snapshot_fields() -> R
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id
@@ -1601,7 +1604,7 @@ pub async fn task_output_rejects_message_only_terminal_status_for_running_comman
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Running
@@ -1641,7 +1644,7 @@ pub async fn task_output_rejects_message_only_terminal_status_for_running_comman
     runtime
         .stop_task(&task.id, &AuthorityClass::OperatorInstruction)
         .await?;
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Cancelled
@@ -1675,7 +1678,7 @@ pub async fn task_status_and_task_output_keep_lifecycle_and_output_boundaries() 
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Completed
@@ -1797,7 +1800,7 @@ pub async fn command_task_stop_cancels_running_command() -> Result<()> {
         .stop_task(&task.id, &AuthorityClass::OperatorInstruction)
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Cancelled
@@ -1870,7 +1873,7 @@ pub async fn background_command_task_persists_terminal_state_while_runtime_stopp
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Completed
@@ -1926,7 +1929,7 @@ pub async fn blocking_command_task_clears_active_state_while_runtime_stopped() -
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         let active_tasks = runtime.storage().latest_active_task_records(usize::MAX)?;
         Ok(tasks.iter().any(|record| {
@@ -1968,7 +1971,7 @@ pub async fn command_task_result_is_canonical_follow_up_on_completion() -> Resul
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let messages = runtime.storage().read_recent_messages(20)?;
         let agent = runtime.storage().read_agent()?.expect("agent should exist");
         Ok(messages.iter().any(|message| {
@@ -2017,7 +2020,7 @@ pub async fn task_result_rejoin_preserves_runtime_provenance_not_operator_author
         )
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let messages = runtime.storage().read_recent_messages(20)?;
         Ok(messages.iter().any(|message| {
             message.kind == MessageKind::TaskResult
@@ -2101,7 +2104,7 @@ pub async fn command_terminal_reentry_does_not_set_awaiting_task_closure() -> Re
         .stop_task(&task.id, &AuthorityClass::OperatorInstruction)
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Cancelled
@@ -2141,7 +2144,7 @@ pub async fn command_task_runner_failure_marks_task_failed_and_cleans_up() -> Re
         .join(format!("{}.log", task.id));
     std::fs::create_dir_all(&output_path)?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Failed
@@ -2284,7 +2287,7 @@ pub async fn exec_command_auto_promotes_long_running_command_task() -> Result<()
         ))
         .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let briefs = runtime.storage().read_recent_briefs(10)?;
         Ok(briefs
             .iter()
@@ -2292,7 +2295,7 @@ pub async fn exec_command_auto_promotes_long_running_command_task() -> Result<()
     })
     .await?;
 
-    wait_until(|| {
+    eventually_for(Duration::from_secs(10), || {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.kind.as_str() == "command_task"
@@ -2324,7 +2327,7 @@ pub async fn exec_command_reuses_equivalent_active_command_task_by_default() -> 
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
     let registry = ToolRegistry::new(runtime.workspace_root());
-    let cmd = "printf start && sleep 2 && printf done";
+    let cmd = "printf start && sleep 20 && printf done";
     let first_task = runtime
         .schedule_command_task(
             format!("Run command: {cmd}"),
@@ -2370,7 +2373,7 @@ pub async fn exec_command_reuses_equivalent_active_command_task_by_default() -> 
         .filter(|record| {
             record.kind.as_str() == "command_task"
                 && record.summary
-                    == Some("Run command: printf start && sleep 2 && printf done".into())
+                    == Some("Run command: printf start && sleep 20 && printf done".into())
         })
         .map(|record| record.id)
         .collect::<Vec<_>>();
@@ -2482,7 +2485,7 @@ pub async fn exec_command_can_start_new_with_duplicate_policy() -> Result<()> {
     attach_default_workspace(&host).await?;
     let runtime = host.default_runtime().await?;
     let registry = ToolRegistry::new(runtime.workspace_root());
-    let cmd = "printf start && sleep 2 && printf done";
+    let cmd = "printf start && sleep 20 && printf done";
 
     let first = registry
         .execute(
@@ -2535,8 +2538,8 @@ pub async fn exec_command_non_equivalent_same_preview_does_not_reuse() -> Result
     let runtime = host.default_runtime().await?;
     let registry = ToolRegistry::new(runtime.workspace_root());
     let shared = "x".repeat(300);
-    let first_cmd = format!("printf '{}'; sleep 2", shared);
-    let second_cmd = format!("printf '{}B'; sleep 2", shared);
+    let first_cmd = format!("printf '{}'; sleep 20", shared);
+    let second_cmd = format!("printf '{}B'; sleep 20", shared);
 
     let first = registry
         .execute(

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -660,7 +660,7 @@ pub async fn worktree_subagent_task_creates_dedicated_per_task_worktree() -> Res
             holon::types::ChildAgentWorkspaceMode::Worktree,
         )
         .await?;
-    wait_until(|| {
+    wait_until_async_for(Duration::from_secs(10), || async {
         let briefs = runtime.storage().read_recent_briefs(20)?;
         Ok(briefs
             .iter()
@@ -786,7 +786,7 @@ pub async fn worktree_child_agent_task_records_workspace_mode() -> Result<()> {
             holon::types::ChildAgentWorkspaceMode::Worktree,
         )
         .await?;
-    wait_until(|| {
+    wait_until_async_for(Duration::from_secs(10), || async {
         let briefs = runtime.storage().read_recent_briefs(20)?;
         Ok(briefs
             .iter()
@@ -865,7 +865,7 @@ pub async fn worktree_subagent_task_returns_metadata_to_parent_session() -> Resu
         )
         .await?;
 
-    wait_until(|| {
+    wait_until_async_for(Duration::from_secs(10), || async {
         let briefs = runtime.storage().read_recent_briefs(20)?;
         Ok(briefs.iter().any(|brief| {
             brief.text.contains("Worktree path:")
@@ -943,7 +943,7 @@ pub async fn worktree_subagent_task_auto_removes_worktree_when_no_changes_wt104(
         .await?;
 
     // Wait for task to complete
-    wait_until(|| {
+    wait_until_async_for(Duration::from_secs(10), || async {
         let tasks = runtime.storage().latest_task_records()?;
         Ok(tasks.iter().any(|record| {
             record.id == task.id && record.status == holon::types::TaskStatus::Completed


### PR DESCRIPTION
## Summary
- stop live legacy JSONL compat exports for DB-canonical runtime domains while keeping legacy import/backfill behavior
- update storage posture reporting to distinguish `legacy_import_only` and `debug_export_only`
- tighten DB read paths and related tests so RuntimeDb remains the canonical source after cutover

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test -q worktree_child_agent_task_records_workspace_mode --test runtime_workspace_worktree -- --exact --nocapture`
- `cargo test -q --test runtime_workspace_worktree -- --nocapture`
- `cargo test -q --test runtime_subagents -- --nocapture`
- `cargo test -q --test runtime_tasks -- --nocapture`
- `cargo test -q run_once_no_wait_stops_unfinished_command_tasks_before_exit --test run_once -- --exact --nocapture`
- `cargo test -q`

Closes #1626
