### PR TITLE
fix(provider): reject text-form anthropic tool calls

### DIFF
--- a/src/provider/http_trace.rs
+++ b/src/provider/http_trace.rs
@@ -62,6 +62,14 @@ struct ProviderHttpTraceRequestState {
 }
 
 impl ProviderHttpTrace {
+    #[cfg(test)]
+    pub(crate) fn failure_only_for_tests(home_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            home_dir: home_dir.into(),
+            mode: ProviderHttpTraceMode::FailureOnly,
+        }
+    }
+
     pub(crate) fn from_env(home_dir: impl Into<PathBuf>) -> Option<Self> {
         let mode = if std::env::var(PROVIDER_HTTP_TRACE_ENV).ok().as_deref() == Some("1") {
             ProviderHttpTraceMode::All

--- a/src/provider/http_trace.rs
+++ b/src/provider/http_trace.rs
@@ -479,6 +479,43 @@ mod tests {
     }
 
     #[test]
+    fn provider_http_failure_trace_flushes_request_for_protocol_diagnostics() {
+        let home = tempfile::tempdir().unwrap();
+        let trace = ProviderHttpTrace {
+            home_dir: home.path().to_path_buf(),
+            mode: super::ProviderHttpTraceMode::FailureOnly,
+        };
+        let request = trace
+            .begin_request(
+                Some("agent/one"),
+                "anthropic",
+                Some("anthropic/mimo"),
+                "https://api.example.com/v1/messages",
+                "messages",
+                &[("authorization", "Bearer secret".into())],
+                &json!({
+                    "model": "mimo",
+                    "messages": [{ "role": "user", "content": "use a tool" }],
+                    "tools": [{ "name": "ExecCommand" }]
+                }),
+            )
+            .expect("trace should be created");
+        request.write_response_body(
+            r#"{"content":[{"type":"text","text":"<tool_call><function=ExecCommand>{}</function></tool_call>"}],"stop_reason":"tool_use"}"#,
+        );
+
+        let diagnostics = request
+            .diagnostics(None)
+            .expect("protocol diagnostics should write trace");
+        let trace_text = fs::read_to_string(diagnostics.path).unwrap();
+        assert!(trace_text.contains("\"type\":\"request\""));
+        assert!(trace_text.contains("\"type\":\"response_body\""));
+        assert!(trace_text.contains("\"name\":\"ExecCommand\""));
+        assert!(trace_text.contains("[REDACTED]"));
+        assert!(!trace_text.contains("Bearer secret"));
+    }
+
+    #[test]
     fn provider_http_failure_trace_keeps_buffer_when_trace_file_cannot_be_created() {
         let home = tempfile::tempdir().unwrap();
         let home_file = home.path().join("not-a-directory");

--- a/src/provider/retry.rs
+++ b/src/provider/retry.rs
@@ -306,6 +306,36 @@ pub(crate) fn invalid_response_error(
     )
 }
 
+pub(crate) fn invalid_response_error_with_trace(
+    context: &str,
+    stage: &str,
+    provider: &str,
+    model_ref: Option<&str>,
+    url: Option<&str>,
+    error: impl std::fmt::Display,
+    trace: Option<&ProviderHttpTraceRequest>,
+) -> anyhow::Error {
+    let error = error.to_string();
+    provider_transport_error(
+        ProviderFailureClassification {
+            kind: ProviderFailureKind::InvalidResponse,
+            disposition: RetryDisposition::FailFast,
+        },
+        None,
+        Some(ProviderTransportDiagnostics {
+            stage: stage.to_string(),
+            provider: Some(provider.to_string()),
+            model_ref: model_ref.map(ToString::to_string),
+            url: url.map(sanitize_transport_url),
+            status: None,
+            reqwest: None,
+            http_trace: trace.and_then(|trace| trace.diagnostics(None)),
+            source_chain: vec![error.clone()],
+        }),
+        format!("{context}: {error}"),
+    )
+}
+
 pub(crate) fn timeout_transport_error_with_trace(
     context: &str,
     stage: &str,

--- a/src/provider/tests/anthropic_messages.rs
+++ b/src/provider/tests/anthropic_messages.rs
@@ -5,33 +5,10 @@ use std::sync::{Arc, Mutex};
 use super::support::*;
 use super::*;
 use crate::config::{AnthropicCacheStrategy, ProviderId};
-use crate::provider::provider_transport_diagnostics;
+use crate::provider::{http_trace::ProviderHttpTrace, provider_transport_diagnostics};
 use axum::{http::HeaderMap, routing::post, Json, Router};
 use serde_json::{json, Value};
 use std::path::Path;
-
-struct ScopedEnv {
-    key: String,
-    original: Option<String>,
-}
-
-impl Drop for ScopedEnv {
-    fn drop(&mut self) {
-        match self.original.as_ref() {
-            Some(value) => std::env::set_var(&self.key, value),
-            None => std::env::remove_var(&self.key),
-        }
-    }
-}
-
-fn scoped_env(key: &str, value: &str) -> ScopedEnv {
-    let original = std::env::var(key).ok();
-    std::env::set_var(key, value);
-    ScopedEnv {
-        key: key.to_string(),
-        original,
-    }
-}
 
 #[tokio::test]
 async fn anthropic_request_lowers_prompt_frame_blocks_to_cache_control() {
@@ -135,9 +112,11 @@ async fn anthropic_text_form_tool_call_protocol_failure_writes_failure_trace() {
         .get_mut(&ProviderId::anthropic())
         .unwrap()
         .base_url = base_url;
-    let provider = AnthropicProvider::from_config(&fixture.config).unwrap();
-
-    let _env_guard = scoped_env("HOLON_PROVIDER_HTTP_FAILURE_TRACE", "1");
+    let provider = AnthropicProvider::from_config(&fixture.config)
+        .unwrap()
+        .with_http_trace_for_tests(ProviderHttpTrace::failure_only_for_tests(
+            fixture.config.home_dir.clone(),
+        ));
     let error = provider
         .complete_turn(ProviderTurnRequest::plain(
             "use a tool",

--- a/src/provider/tests/anthropic_messages.rs
+++ b/src/provider/tests/anthropic_messages.rs
@@ -5,8 +5,33 @@ use std::sync::{Arc, Mutex};
 use super::support::*;
 use super::*;
 use crate::config::{AnthropicCacheStrategy, ProviderId};
+use crate::provider::provider_transport_diagnostics;
 use axum::{http::HeaderMap, routing::post, Json, Router};
 use serde_json::{json, Value};
+use std::path::Path;
+
+struct ScopedEnv {
+    key: String,
+    original: Option<String>,
+}
+
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        match self.original.as_ref() {
+            Some(value) => std::env::set_var(&self.key, value),
+            None => std::env::remove_var(&self.key),
+        }
+    }
+}
+
+fn scoped_env(key: &str, value: &str) -> ScopedEnv {
+    let original = std::env::var(key).ok();
+    std::env::set_var(key, value);
+    ScopedEnv {
+        key: key.to_string(),
+        original,
+    }
+}
 
 #[tokio::test]
 async fn anthropic_request_lowers_prompt_frame_blocks_to_cache_control() {
@@ -79,6 +104,75 @@ async fn anthropic_request_lowers_prompt_frame_blocks_to_cache_control() {
         body["messages"][0]["content"][0]["cache_control"],
         json!({ "type": "ephemeral" })
     );
+}
+
+#[tokio::test]
+async fn anthropic_text_form_tool_call_protocol_failure_writes_failure_trace() {
+    let base_url = spawn_test_server(Router::new().route(
+        "/v1/messages",
+        post(|| async {
+            Json(json!({
+                "content": [{
+                    "type": "text",
+                    "text": "<tool_call><function=ExecCommand>{\"cmd\":\"echo ok\"}</function></tool_call>"
+                }],
+                "stop_reason": "tool_use",
+                "usage": { "input_tokens": 4, "output_tokens": 2 }
+            }))
+        }),
+    ))
+    .await;
+    let mut fixture = test_config(
+        "anthropic/claude-sonnet-4-6",
+        &[],
+        None,
+        Some("anthropic-token"),
+        false,
+    );
+    fixture
+        .config
+        .providers
+        .get_mut(&ProviderId::anthropic())
+        .unwrap()
+        .base_url = base_url;
+    let provider = AnthropicProvider::from_config(&fixture.config).unwrap();
+
+    let _env_guard = scoped_env("HOLON_PROVIDER_HTTP_FAILURE_TRACE", "1");
+    let error = provider
+        .complete_turn(ProviderTurnRequest::plain(
+            "use a tool",
+            Vec::new(),
+            vec![crate::tool::ToolSpec {
+                name: "ExecCommand".into(),
+                description: "Run a command".into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "cmd": { "type": "string" }
+                    },
+                    "required": ["cmd"]
+                }),
+                freeform_grammar: None,
+            }],
+        ))
+        .await
+        .expect_err("text-form tool calls with stop_reason=tool_use should fail");
+
+    let diagnostics =
+        provider_transport_diagnostics(&error).expect("error should include diagnostics");
+    assert_eq!(diagnostics.stage, "response_protocol");
+    assert_eq!(diagnostics.provider.as_deref(), Some("anthropic"));
+    let trace = diagnostics
+        .http_trace
+        .as_ref()
+        .expect("failure trace should be written");
+    assert_eq!(trace.mode, "failure_only");
+    assert!(Path::new(&trace.path).exists());
+    let trace_text = std::fs::read_to_string(&trace.path).unwrap();
+    assert!(trace_text.contains("\"type\":\"request\""));
+    assert!(trace_text.contains("\"type\":\"response_body\""));
+    assert!(trace_text.contains("\"name\":\"ExecCommand\""));
+    assert!(!trace_text.contains("anthropic-token"));
 }
 
 #[tokio::test]

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -43,6 +43,8 @@ pub struct AnthropicProvider {
     context_management: AnthropicContextManagementConfig,
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     trace_home_dir: PathBuf,
+    #[cfg(test)]
+    http_trace_override: Option<ProviderHttpTrace>,
 }
 
 #[derive(Debug, Serialize)]
@@ -169,7 +171,15 @@ impl AnthropicProvider {
             context_management: provider_config.context_management.clone(),
             builtin_web_search: provider_config.builtin_web_search.clone(),
             trace_home_dir: trace_home_dir.to_path_buf(),
+            #[cfg(test)]
+            http_trace_override: None,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_http_trace_for_tests(mut self, trace: ProviderHttpTrace) -> Self {
+        self.http_trace_override = Some(trace);
+        self
     }
 }
 
@@ -208,6 +218,12 @@ impl AgentProvider for AnthropicProvider {
                 "context-management-2025-06-27".to_string(),
             ));
         }
+        #[cfg(test)]
+        let trace = self
+            .http_trace_override
+            .clone()
+            .or_else(|| ProviderHttpTrace::from_env(self.trace_home_dir.clone()));
+        #[cfg(not(test))]
         let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
         let request_trace = trace.and_then(|trace| {
             trace.begin_request(
@@ -922,6 +938,9 @@ fn text_contains_tool_call_markup(text: &str) -> bool {
     lowered.contains("<tool_call")
         || lowered.contains("<function=")
         || lowered.contains("<function name=")
+        || lowered.contains("&lt;tool_call")
+        || lowered.contains("&lt;function=")
+        || lowered.contains("&lt;function name=")
         || text.contains("<｜｜DSML｜｜tool_calls>")
         || text.contains("<｜｜DSML｜｜invoke")
 }
@@ -1611,6 +1630,29 @@ mod tests {
             &blocks,
             Some("tool_use"),
             false,
+        ));
+    }
+
+    #[test]
+    fn anthropic_response_flags_html_escaped_text_form_tool_call_violation() {
+        let blocks = vec![ApiResponseBlock {
+            kind: "text".to_string(),
+            text: Some(
+                "&lt;tool_call&gt;&lt;function=ExecCommand&gt;{}&lt;/function&gt;&lt;/tool_call&gt;"
+                    .to_string(),
+            ),
+            thinking: None,
+            signature: None,
+            data: None,
+            id: None,
+            name: None,
+            input: None,
+        }];
+
+        assert!(anthropic_response_has_text_form_tool_call_violation(
+            &blocks,
+            Some("tool_use"),
+            true,
         ));
     }
 

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -29,7 +29,7 @@ use crate::{
 use super::{build_http_client, request_send_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
-    invalid_response_error,
+    invalid_response_error, invalid_response_error_with_trace,
 };
 
 #[derive(Clone)]
@@ -306,6 +306,28 @@ impl AgentProvider for AnthropicProvider {
                 parsed.stop_reason.as_deref(),
                 tools_available,
             );
+        }
+        if anthropic_response_has_text_form_tool_call_violation(
+            &parsed.content,
+            parsed.stop_reason.as_deref(),
+            tools_available,
+        ) {
+            warn!(
+                provider = %self.provider_id,
+                model = %self.model,
+                stop_reason = ?parsed.stop_reason,
+                tools_available,
+                "anthropic response stopped for tool_use but returned only text-form tool-call markup"
+            );
+            return Err(invalid_response_error_with_trace(
+                "invalid Anthropic tool response",
+                "response_protocol",
+                "anthropic",
+                Some(&model_ref),
+                Some(url.as_str()),
+                "stop_reason=tool_use without native tool_use block; text block contains tool-call-looking markup",
+                request_trace.as_ref(),
+            ));
         }
         let blocks = parsed
             .content
@@ -868,6 +890,40 @@ fn warn_unsupported_anthropic_response_block(
         tools_available,
         "anthropic response contained unsupported content block"
     );
+}
+
+fn anthropic_response_has_text_form_tool_call_violation(
+    blocks: &[ApiResponseBlock],
+    stop_reason: Option<&str>,
+    tools_available: bool,
+) -> bool {
+    if stop_reason != Some("tool_use") || !tools_available {
+        return false;
+    }
+    let mut has_text_form_tool_call = false;
+    for block in blocks {
+        if block.kind == "tool_use" {
+            return false;
+        }
+        if block.kind == "text"
+            && block
+                .text
+                .as_deref()
+                .is_some_and(text_contains_tool_call_markup)
+        {
+            has_text_form_tool_call = true;
+        }
+    }
+    has_text_form_tool_call
+}
+
+fn text_contains_tool_call_markup(text: &str) -> bool {
+    let lowered = text.to_ascii_lowercase();
+    lowered.contains("<tool_call")
+        || lowered.contains("<function=")
+        || lowered.contains("<function name=")
+        || text.contains("<｜｜DSML｜｜tool_calls>")
+        || text.contains("<｜｜DSML｜｜invoke")
 }
 
 fn api_response_block_to_model(block: ApiResponseBlock) -> Option<ModelBlock> {
@@ -1519,6 +1575,75 @@ mod tests {
             }
             other => panic!("unexpected block: {other:?}"),
         }
+    }
+
+    #[test]
+    fn anthropic_response_flags_text_form_tool_call_violation() {
+        let blocks = vec![ApiResponseBlock {
+            kind: "text".to_string(),
+            text: Some(
+                r#"<tool_call>
+<function=ExecCommand>
+{"cmd":"echo ok"}
+</function>
+</tool_call>"#
+                    .to_string(),
+            ),
+            thinking: None,
+            signature: None,
+            data: None,
+            id: None,
+            name: None,
+            input: None,
+        }];
+
+        assert!(anthropic_response_has_text_form_tool_call_violation(
+            &blocks,
+            Some("tool_use"),
+            true,
+        ));
+        assert!(!anthropic_response_has_text_form_tool_call_violation(
+            &blocks,
+            Some("end_turn"),
+            true,
+        ));
+        assert!(!anthropic_response_has_text_form_tool_call_violation(
+            &blocks,
+            Some("tool_use"),
+            false,
+        ));
+    }
+
+    #[test]
+    fn anthropic_response_native_tool_use_is_not_text_form_violation() {
+        let blocks = vec![
+            ApiResponseBlock {
+                kind: "text".to_string(),
+                text: Some("<tool_call>ignored text</tool_call>".to_string()),
+                thinking: None,
+                signature: None,
+                data: None,
+                id: None,
+                name: None,
+                input: None,
+            },
+            ApiResponseBlock {
+                kind: "tool_use".to_string(),
+                text: None,
+                thinking: None,
+                signature: None,
+                data: None,
+                id: Some("toolu_1".to_string()),
+                name: Some("ExecCommand".to_string()),
+                input: Some(json!({ "cmd": "echo ok" })),
+            },
+        ];
+
+        assert!(!anthropic_response_has_text_form_tool_call_violation(
+            &blocks,
+            Some("tool_use"),
+            true,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #1615 by treating Anthropic-compatible responses as malformed when they stop with `tool_use` but contain only text-form tool-call markup instead of a native `tool_use` block.
- Keeps normal text-form tool-looking content as text for non-tool stop reasons, and does not parse arbitrary text into executable tool calls.
- Reuses `HOLON_PROVIDER_HTTP_FAILURE_TRACE=1` diagnostics so the triggering request/response is flushed to the existing provider HTTP trace path for reproduction.

## Context

Observed with `tuptup-assistant` on `xiaomi-anthropic/mimo-v2-pro`: the provider returned `stop_reason=tool_use`, but the content block was ordinary text containing markup like `<tool_call><function=ExecCommand>...` instead of native Anthropic `tool_use`. Previously Holon recorded that as an assistant text-only round, which let the pseudo-tool call enter transcript history and be repeated on later wakes.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test -q anthropic_text_form_tool_call_protocol_failure_writes_failure_trace`
- `cargo test -q provider_http_failure_trace_flushes_request_for_protocol_diagnostics`
- `cargo test -q anthropic_response_flags_text_form_tool_call_violation`
- `cargo test -q anthropic_response_native_tool_use_is_not_text_form_violation`
