### PR TITLE
fix: repair DB cutover agent evidence

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     future::Future,
     path::{Path, PathBuf},
@@ -59,6 +59,7 @@ pub struct RuntimeHost {
 pub(crate) const TEMP_AGENT_PREFIX: &str = "tmp_";
 const TEMP_RUN_AGENT_PREFIX: &str = "tmp_run_";
 const TEMP_CHILD_AGENT_PREFIX: &str = "tmp_child_";
+const HOST_AGENT_LEGACY_EVIDENCE_REPAIR_DOMAIN: &str = "host_agent_legacy_evidence_repair";
 // Give runtime loops a short cleanup window while keeping daemon stop bounded.
 #[cfg(not(test))]
 const HOST_SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
@@ -152,6 +153,7 @@ impl RuntimeHost {
     pub fn prepare_runtime_storage(config: &AppConfig) -> Result<()> {
         let runtime_db =
             RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+        import_host_registry_domains(config, &runtime_db)?;
         RuntimeHandle::prepare_runtime_storage(
             config.default_agent_id.clone(),
             config.agent_root_dir().join(&config.default_agent_id),
@@ -1403,6 +1405,148 @@ impl RuntimeHost {
     }
 }
 
+fn import_host_registry_domains(config: &AppConfig, runtime_db: &RuntimeDb) -> Result<()> {
+    let host_storage = AppStorage::new(config.home_dir.join("host"))?;
+    if !runtime_db.storage_domain_is_complete("workspace_entries", "db")? {
+        runtime_db
+            .workspace_entries()
+            .import_legacy(host_storage.read_recent_workspace_entries(usize::MAX)?)?;
+    }
+    if !runtime_db.storage_domain_is_complete("workspace_occupancies", "db")? {
+        runtime_db
+            .workspace_occupancies()
+            .import_legacy(host_storage.read_recent_workspace_occupancies(usize::MAX)?)?;
+    }
+    if !runtime_db.storage_domain_is_complete("agent_identities", "db")? {
+        runtime_db
+            .agent_identities()
+            .import_legacy(host_storage.read_recent_agent_identities(usize::MAX)?)?;
+    } else {
+        repair_completed_host_agent_identity_import(&host_storage, runtime_db)?;
+    }
+    repair_host_agent_legacy_evidence_import(config, &host_storage, runtime_db)?;
+    Ok(())
+}
+
+fn repair_completed_host_agent_identity_import(
+    host_storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+) -> Result<()> {
+    let host_identities = host_storage.latest_agent_identities()?;
+    if host_identities.is_empty() {
+        return Ok(());
+    }
+    let db_identities = runtime_db
+        .agent_identities()
+        .latest_all()?
+        .into_iter()
+        .map(|record| (record.agent_id.clone(), record.updated_at))
+        .collect::<BTreeMap<_, _>>();
+    for record in host_identities {
+        let should_repair = db_identities
+            .get(&record.agent_id)
+            .is_none_or(|db_updated_at| record.updated_at > *db_updated_at);
+        if should_repair {
+            runtime_db.agent_identities().upsert(&record)?;
+        }
+    }
+    Ok(())
+}
+
+fn repair_host_agent_legacy_evidence_import(
+    config: &AppConfig,
+    host_storage: &AppStorage,
+    runtime_db: &RuntimeDb,
+) -> Result<()> {
+    if runtime_db.storage_domain_is_complete(HOST_AGENT_LEGACY_EVIDENCE_REPAIR_DOMAIN, "db")? {
+        return Ok(());
+    }
+    let mut agent_ids = host_storage
+        .latest_agent_identities()?
+        .into_iter()
+        .map(|record| record.agent_id)
+        .collect::<BTreeSet<_>>();
+    agent_ids.insert(config.default_agent_id.clone());
+
+    for agent_id in &agent_ids {
+        let agent_home = config.agent_root_dir().join(agent_id.as_str());
+        if !agent_home.exists() {
+            continue;
+        }
+        let storage = AppStorage::new(agent_home)?;
+        match storage.read_all_messages() {
+            Ok(messages) => {
+                let db_count = runtime_db.messages().count(Some(agent_id.as_str()))?;
+                if db_count < messages.len() {
+                    runtime_db.messages().upsert_many(&messages)?;
+                }
+            }
+            Err(error) => {
+                warn!(
+                    agent_id = %agent_id,
+                    error = %error,
+                    "failed to repair legacy message import for agent"
+                );
+            }
+        }
+        match storage.read_all_transcript() {
+            Ok(entries) => {
+                let db_count = runtime_db
+                    .transcript_entries()
+                    .count(Some(agent_id.as_str()))?;
+                if db_count < entries.len() {
+                    runtime_db.transcript_entries().upsert_many(&entries)?;
+                }
+            }
+            Err(error) => {
+                warn!(
+                    agent_id = %agent_id,
+                    error = %error,
+                    "failed to repair legacy transcript import for agent"
+                );
+            }
+        }
+        match storage.latest_event_seq() {
+            Ok(Some(legacy_latest_seq)) => {
+                let db_latest_seq = runtime_db
+                    .audit_events()
+                    .latest_event_seq(Some(agent_id.as_str()))?
+                    .unwrap_or_default();
+                if db_latest_seq < legacy_latest_seq {
+                    match storage.read_legacy_events_jsonl() {
+                        Ok(events) => {
+                            runtime_db
+                                .audit_events()
+                                .append_many(Some(agent_id.as_str()), &events)?;
+                        }
+                        Err(error) => {
+                            warn!(
+                                agent_id = %agent_id,
+                                error = %error,
+                                "failed to repair legacy audit event import for agent"
+                            );
+                        }
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    agent_id = %agent_id,
+                    error = %error,
+                    "failed to inspect legacy audit event import for agent"
+                );
+            }
+        }
+    }
+    runtime_db.mark_storage_domain_complete(
+        HOST_AGENT_LEGACY_EVIDENCE_REPAIR_DOMAIN,
+        "db",
+        json!({ "scanned_agents": agent_ids.len() }),
+    )?;
+    Ok(())
+}
+
 impl RuntimeHostBridge {
     fn host(&self) -> Result<RuntimeHost> {
         let inner = self
@@ -1658,6 +1802,7 @@ mod tests {
         config::{provider_registry_for_tests, ControlAuthMode, ModelRef},
         provider::{AgentProvider, ProviderTurnRequest, ProviderTurnResponse, StubProvider},
         runtime::RuntimeHandle,
+        runtime_db::RuntimeDb,
         storage::AppStorage,
         system::WorkspaceProjectionKind,
         types::{
@@ -1837,6 +1982,208 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(listed.contains(&host.config().default_agent_id));
         assert!(listed.contains(&"release-bot".to_string()));
+    }
+
+    #[tokio::test]
+    async fn pre_server_prepare_does_not_empty_cutover_host_agent_registry() {
+        let home = tempdir().unwrap();
+        write_test_model_config(home.path());
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let host_storage = AppStorage::new(config.home_dir.join("host")).unwrap();
+        host_storage
+            .append_agent_identity(&AgentIdentityRecord::new(
+                "release-bot",
+                AgentKind::Named,
+                AgentVisibility::Public,
+                AgentOwnership::SelfOwned,
+                AgentProfilePreset::PublicNamed,
+                None,
+                None,
+            ))
+            .unwrap();
+
+        RuntimeHost::prepare_runtime_storage(&config).unwrap();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        assert!(
+            runtime_db
+                .storage_domain_is_complete("agent_identities", "db")
+                .unwrap(),
+            "pre-server preparation should complete host-wide agent identity import from host storage"
+        );
+        assert_eq!(
+            runtime_db
+                .agent_identities()
+                .latest("release-bot")
+                .unwrap()
+                .expect("release-bot identity should be imported before per-agent preparation")
+                .agent_id,
+            "release-bot"
+        );
+
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("ok"))).unwrap();
+        let listed = host
+            .list_agent_entries()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.identity.agent_id)
+            .collect::<Vec<_>>();
+        assert!(listed.contains(&"release-bot".to_string()));
+        assert!(listed.contains(&host.config().default_agent_id));
+    }
+
+    #[tokio::test]
+    async fn pre_server_prepare_repairs_completed_empty_host_agent_registry_cutover() {
+        let home = tempdir().unwrap();
+        write_test_model_config(home.path());
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let host_storage = AppStorage::new(config.home_dir.join("host")).unwrap();
+        host_storage
+            .append_agent_identity(&AgentIdentityRecord::new(
+                "release-bot",
+                AgentKind::Named,
+                AgentVisibility::Public,
+                AgentOwnership::SelfOwned,
+                AgentProfilePreset::PublicNamed,
+                None,
+                None,
+            ))
+            .unwrap();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        runtime_db
+            .agent_identities()
+            .import_legacy(Vec::new())
+            .unwrap();
+        assert!(runtime_db
+            .storage_domain_is_complete("agent_identities", "db")
+            .unwrap());
+        assert!(runtime_db
+            .agent_identities()
+            .latest("release-bot")
+            .unwrap()
+            .is_none());
+
+        RuntimeHost::prepare_runtime_storage(&config).unwrap();
+
+        assert_eq!(
+            runtime_db
+                .agent_identities()
+                .latest("release-bot")
+                .unwrap()
+                .expect("release-bot identity should be repaired from host storage")
+                .agent_id,
+            "release-bot"
+        );
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("ok"))).unwrap();
+        let listed = host
+            .list_agent_entries()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.identity.agent_id)
+            .collect::<Vec<_>>();
+        assert!(listed.contains(&"release-bot".to_string()));
+    }
+
+    #[tokio::test]
+    async fn pre_server_prepare_repairs_completed_empty_agent_message_cutover() {
+        let home = tempdir().unwrap();
+        write_test_model_config(home.path());
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let host_storage = AppStorage::new(config.home_dir.join("host")).unwrap();
+        host_storage
+            .append_agent_identity(&AgentIdentityRecord::new(
+                "release-bot",
+                AgentKind::Named,
+                AgentVisibility::Public,
+                AgentOwnership::SelfOwned,
+                AgentProfilePreset::PublicNamed,
+                None,
+                None,
+            ))
+            .unwrap();
+        let agent_storage = AppStorage::new(config.agent_root_dir().join("release-bot")).unwrap();
+        let message = MessageEnvelope::new(
+            "release-bot",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "legacy message".into(),
+            },
+        );
+        agent_storage.append_message(&message).unwrap();
+        let transcript = TranscriptEntry::new(
+            "release-bot",
+            TranscriptEntryKind::IncomingMessage,
+            Some(1),
+            Some(message.id.clone()),
+            json!({"text": "legacy message"}),
+        );
+        agent_storage.append_transcript_entry(&transcript).unwrap();
+        agent_storage
+            .append_event(&crate::types::AuditEvent::new(
+                "legacy_chat_event",
+                json!({"text": "legacy message"}),
+            ))
+            .unwrap();
+
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        runtime_db.messages().import_legacy(Vec::new()).unwrap();
+        runtime_db
+            .transcript_entries()
+            .import_legacy(Vec::new())
+            .unwrap();
+        runtime_db
+            .audit_events()
+            .import_legacy(Some("release-bot"), Vec::new())
+            .unwrap();
+        assert_eq!(runtime_db.messages().count(Some("release-bot")).unwrap(), 0);
+        assert_eq!(
+            runtime_db
+                .transcript_entries()
+                .all(Some("release-bot"))
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            runtime_db
+                .audit_events()
+                .recent(Some("release-bot"), 10)
+                .unwrap()
+                .len(),
+            0
+        );
+
+        RuntimeHost::prepare_runtime_storage(&config).unwrap();
+
+        assert_eq!(runtime_db.messages().count(Some("release-bot")).unwrap(), 1);
+        assert_eq!(
+            runtime_db
+                .transcript_entries()
+                .all(Some("release-bot"))
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            runtime_db
+                .audit_events()
+                .recent(Some("release-bot"), 10)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -1476,8 +1476,15 @@ fn repair_host_agent_legacy_evidence_import(
         let storage = AppStorage::new(agent_home)?;
         match storage.read_all_messages() {
             Ok(messages) => {
-                let db_count = runtime_db.messages().count(Some(agent_id.as_str()))?;
-                if db_count < messages.len() {
+                let legacy_max_seq = messages
+                    .iter()
+                    .filter_map(|message| message.message_seq)
+                    .max()
+                    .unwrap_or_default();
+                let db_max_seq = runtime_db
+                    .messages()
+                    .max_message_seq(Some(agent_id.as_str()))?;
+                if db_max_seq < legacy_max_seq {
                     runtime_db.messages().upsert_many(&messages)?;
                 }
             }
@@ -1491,10 +1498,15 @@ fn repair_host_agent_legacy_evidence_import(
         }
         match storage.read_all_transcript() {
             Ok(entries) => {
-                let db_count = runtime_db
+                let legacy_max_seq = entries
+                    .iter()
+                    .filter_map(|entry| entry.transcript_seq)
+                    .max()
+                    .unwrap_or_default();
+                let db_max_seq = runtime_db
                     .transcript_entries()
-                    .count(Some(agent_id.as_str()))?;
-                if db_count < entries.len() {
+                    .max_transcript_seq(Some(agent_id.as_str()))?;
+                if db_max_seq < legacy_max_seq {
                     runtime_db.transcript_entries().upsert_many(&entries)?;
                 }
             }

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -933,6 +933,15 @@ impl MessageRepository<'_> {
         self.db.transaction(|tx| upsert_message_tx(tx, message))
     }
 
+    pub fn upsert_many(&self, messages: &[MessageEnvelope]) -> Result<()> {
+        self.db.transaction(|tx| {
+            for message in messages {
+                upsert_message_tx(tx, message)?;
+            }
+            Ok(())
+        })
+    }
+
     pub fn recent(&self, agent_id: Option<&str>, limit: usize) -> Result<Vec<MessageEnvelope>> {
         if limit == 0 {
             return Ok(Vec::new());
@@ -1090,6 +1099,15 @@ impl TranscriptRepository<'_> {
             .transaction(|tx| upsert_transcript_entry_tx(tx, entry))
     }
 
+    pub fn upsert_many(&self, entries: &[TranscriptEntry]) -> Result<()> {
+        self.db.transaction(|tx| {
+            for entry in entries {
+                upsert_transcript_entry_tx(tx, entry)?;
+            }
+            Ok(())
+        })
+    }
+
     pub fn recent(&self, agent_id: Option<&str>, limit: usize) -> Result<Vec<TranscriptEntry>> {
         if limit == 0 {
             return Ok(Vec::new());
@@ -1145,6 +1163,22 @@ impl TranscriptRepository<'_> {
             rows.map(|row| decode_transcript_entry_payload(&row?))
                 .collect()
         }
+    }
+
+    pub fn count(&self, agent_id: Option<&str>) -> Result<usize> {
+        let connection = self.db.connection()?;
+        let count: i64 = if let Some(agent_id) = agent_id {
+            connection.query_row(
+                "SELECT COUNT(*) FROM transcript_entries WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get(0),
+            )?
+        } else {
+            connection.query_row("SELECT COUNT(*) FROM transcript_entries", [], |row| {
+                row.get(0)
+            })?
+        };
+        Ok(usize::try_from(count).unwrap_or(usize::MAX))
     }
 
     pub fn max_transcript_seq(&self, agent_id: Option<&str>) -> Result<u64> {
@@ -1411,6 +1445,15 @@ impl AuditEventSink<'_> {
             .transaction(|tx| insert_audit_event_tx(tx, agent_id, event))
     }
 
+    pub fn append_many(&self, agent_id: Option<&str>, events: &[AuditEvent]) -> Result<()> {
+        self.db.transaction(|tx| {
+            for event in events {
+                insert_audit_event_tx(tx, agent_id, event)?;
+            }
+            Ok(())
+        })
+    }
+
     pub fn import_legacy(&self, agent_id: Option<&str>, events: Vec<AuditEvent>) -> Result<()> {
         if self.db.storage_domain_is_complete("audit_events", "db")? {
             return Ok(());
@@ -1434,7 +1477,7 @@ impl AuditEventSink<'_> {
         if agent_id.is_some() {
             sql.push_str(" WHERE agent_id = ?1");
         }
-        sql.push_str(" ORDER BY COALESCE(event_seq, 0) DESC, created_at DESC LIMIT ?");
+        sql.push_str(" ORDER BY event_seq DESC, created_at DESC LIMIT ?");
         let mut statement = connection.prepare(&sql)?;
         let mut events = if let Some(agent_id) = agent_id {
             statement
@@ -1499,19 +1542,18 @@ impl AuditEventSink<'_> {
             .transpose()?;
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
-        let mut sql =
-            String::from("SELECT data_json FROM audit_events WHERE COALESCE(event_seq, 0) > ?1");
+        let mut sql = String::from("SELECT data_json FROM audit_events WHERE event_seq > ?1");
         if upper.is_some() {
-            sql.push_str(" AND COALESCE(event_seq, 0) < ?2");
+            sql.push_str(" AND event_seq < ?2");
         }
         if agent_id.is_some() {
             let param_index = if upper.is_some() { 3 } else { 2 };
             sql.push_str(&format!(" AND agent_id = ?{param_index}"));
         }
         if descending {
-            sql.push_str(" ORDER BY COALESCE(event_seq, 0) DESC, created_at DESC");
+            sql.push_str(" ORDER BY event_seq DESC, created_at DESC");
         } else {
-            sql.push_str(" ORDER BY COALESCE(event_seq, 0) ASC, created_at ASC");
+            sql.push_str(" ORDER BY event_seq ASC, created_at ASC");
         }
         let limit_param_index = 2 + usize::from(upper.is_some()) + usize::from(agent_id.is_some());
         sql.push_str(&format!(" LIMIT ?{limit_param_index}"));
@@ -1547,8 +1589,7 @@ impl AuditEventSink<'_> {
         }
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
-        let mut sql =
-            String::from("SELECT data_json FROM audit_events WHERE COALESCE(event_seq, 0) > ?1");
+        let mut sql = String::from("SELECT data_json FROM audit_events WHERE event_seq > ?1");
         if agent_id.is_some() {
             sql.push_str(" AND agent_id = ?2");
         }
@@ -3594,6 +3635,14 @@ CREATE INDEX IF NOT EXISTS idx_agent_identities_status
   ON agent_identities(status);
 "#,
     },
+    Migration {
+        version: 10,
+        name: "audit_events_agent_seq_index",
+        sql: r#"
+CREATE INDEX IF NOT EXISTS idx_audit_events_agent_seq_created
+  ON audit_events(agent_id, event_seq, created_at);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -3880,6 +3929,17 @@ impl RuntimeDb {
             return Ok(false);
         };
         Ok(snapshot.import_status == "complete" && snapshot.canonical_source == canonical_source)
+    }
+
+    pub(crate) fn mark_storage_domain_complete(
+        &self,
+        domain: &'static str,
+        canonical_source: &'static str,
+        checkpoint: serde_json::Value,
+    ) -> Result<()> {
+        self.transaction(|tx| {
+            upsert_storage_domain(tx, domain, "complete", canonical_source, Some(checkpoint))
+        })
     }
 
     fn run_storage_domain_import(

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1165,22 +1165,6 @@ impl TranscriptRepository<'_> {
         }
     }
 
-    pub fn count(&self, agent_id: Option<&str>) -> Result<usize> {
-        let connection = self.db.connection()?;
-        let count: i64 = if let Some(agent_id) = agent_id {
-            connection.query_row(
-                "SELECT COUNT(*) FROM transcript_entries WHERE agent_id = ?1",
-                [agent_id],
-                |row| row.get(0),
-            )?
-        } else {
-            connection.query_row("SELECT COUNT(*) FROM transcript_entries", [], |row| {
-                row.get(0)
-            })?
-        };
-        Ok(usize::try_from(count).unwrap_or(usize::MAX))
-    }
-
     pub fn max_transcript_seq(&self, agent_id: Option<&str>) -> Result<u64> {
         let connection = self.db.connection()?;
         let max_seq: Option<i64> = if let Some(agent_id) = agent_id {


### PR DESCRIPTION
## Summary

- import host-level workspace and agent identity ledgers before per-agent runtime storage preparation
- repair cutover states where DB domains were marked complete before host agent identities or legacy agent evidence were actually present
- batch-copy legacy messages, transcript entries, and audit events into the runtime DB, then add an indexed audit event query path

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test pre_server_prepare --quiet`
- `cargo test bootstrap --quiet`
- `cargo test tui --quiet`
- `cargo build --release`

## Local verification

- `holon-dev` `/state` returned HTTP 200 in about 0.69s after DB index repair
- `holon-dev` `/events?limit=200&order=desc` returned HTTP 200 in about 0.64s
- `holon-dev` filtered events with `max_level=info` returned HTTP 200 in about 0.09s
