### PR TITLE
fix: persist remaining runtime ledgers in DB

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -514,6 +514,21 @@ fn prepare_runtime_storage(
             .transcript_entries()
             .import_legacy(storage.read_all_transcript()?)?;
     }
+    if !storage_domain_complete(&runtime_db, "work_item_delegations")? {
+        runtime_db
+            .work_item_delegations()
+            .import_legacy(storage.read_recent_work_item_delegations(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "working_memory_deltas")? {
+        runtime_db
+            .working_memory_deltas()
+            .import_legacy(storage.read_recent_working_memory_deltas(usize::MAX)?)?;
+    }
+    if !storage_domain_complete(&runtime_db, "context_episodes")? {
+        runtime_db
+            .context_episodes()
+            .import_legacy(storage.read_recent_context_episodes(usize::MAX)?)?;
+    }
 
     storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
     let snapshot = storage.recovery_snapshot(&agent_id)?;

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -12,10 +12,11 @@ use sha2::{Digest, Sha256};
 
 use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, CallbackDeliveryMode,
-    DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope, ExternalTriggerStatus,
-    MessageEnvelope, QueueEntryRecord, TaskRecord, TaskStatus, TimerRecord, TimerStatus,
-    ToolExecutionRecord, TranscriptEntry, TurnRecord, WaitConditionRecord, WorkItemRecord,
-    WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
+    ContextEpisodeRecord, DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope,
+    ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, TaskRecord, TaskStatus, TimerRecord,
+    TimerStatus, ToolExecutionRecord, TranscriptEntry, TurnRecord, WaitConditionRecord,
+    WorkItemDelegationRecord, WorkItemRecord, WorkItemState, WorkingMemoryDelta, WorkspaceEntry,
+    WorkspaceOccupancyRecord,
 };
 
 const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
@@ -85,6 +86,18 @@ pub struct WorkspaceOccupancyRepository<'a> {
 }
 
 pub struct AgentIdentityRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct WorkItemDelegationRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct WorkingMemoryDeltaRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct ContextEpisodeRepository<'a> {
     db: &'a RuntimeDb,
 }
 
@@ -423,6 +436,150 @@ impl AgentIdentityRepository<'_> {
             .optional()?
             .map(|payload| decode_agent_identity_payload(&payload))
             .transpose()
+    }
+}
+
+impl WorkItemDelegationRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<WorkItemDelegationRecord>) -> Result<()> {
+        if self
+            .db
+            .storage_domain_is_complete("work_item_delegations", "db")?
+        {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("work_item_delegations", "jsonl", "db", |tx| {
+                let latest = reduce_work_item_delegation_records(records);
+                for record in latest.values() {
+                    upsert_work_item_delegation_tx(tx, record)?;
+                }
+                Ok(serde_json::json!({ "imported_records": latest.len() }))
+            })
+    }
+
+    pub fn upsert(&self, record: &WorkItemDelegationRecord) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_work_item_delegation_tx(tx, record))
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<WorkItemDelegationRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_item_delegations
+             ORDER BY updated_at DESC, created_at DESC, delegation_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_work_item_delegation_payload(&row?))
+            .collect()
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<WorkItemDelegationRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_item_delegations
+             ORDER BY updated_at DESC, created_at DESC, delegation_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_work_item_delegation_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+}
+
+impl WorkingMemoryDeltaRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<WorkingMemoryDelta>) -> Result<()> {
+        if self
+            .db
+            .storage_domain_is_complete("working_memory_deltas", "db")?
+        {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("working_memory_deltas", "jsonl", "db", |tx| {
+                let imported_records = records.len();
+                for record in records {
+                    upsert_working_memory_delta_tx(tx, &record)?;
+                }
+                Ok(serde_json::json!({ "imported_records": imported_records }))
+            })
+    }
+
+    pub fn upsert(&self, record: &WorkingMemoryDelta) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_working_memory_delta_tx(tx, record))
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<WorkingMemoryDelta>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM working_memory_deltas
+             ORDER BY created_at DESC, memory_delta_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_working_memory_delta_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+}
+
+impl ContextEpisodeRepository<'_> {
+    pub fn import_legacy(&self, records: Vec<ContextEpisodeRecord>) -> Result<()> {
+        if self
+            .db
+            .storage_domain_is_complete("context_episodes", "db")?
+        {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("context_episodes", "jsonl", "db", |tx| {
+                let latest = reduce_context_episode_records(records);
+                for record in latest.values() {
+                    upsert_context_episode_tx(tx, record)?;
+                }
+                Ok(serde_json::json!({ "imported_records": latest.len() }))
+            })
+    }
+
+    pub fn upsert(&self, record: &ContextEpisodeRecord) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_context_episode_tx(tx, record))
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<ContextEpisodeRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM context_episodes
+             ORDER BY ended_at DESC, started_at DESC, episode_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_context_episode_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
     }
 }
 
@@ -2154,6 +2311,115 @@ fn truncate_string_in_place(value: &mut String, max_bytes: usize) {
     value.truncate(boundary);
 }
 
+fn upsert_work_item_delegation_tx(
+    tx: &Transaction<'_>,
+    record: &WorkItemDelegationRecord,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let state = enum_string(&record.state)?;
+    tx.execute(
+        "INSERT INTO work_item_delegations (
+            delegation_id, parent_agent_id, parent_work_item_id, child_agent_id,
+            child_work_item_id, state, created_at, updated_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(delegation_id) DO UPDATE SET
+            parent_agent_id = excluded.parent_agent_id,
+            parent_work_item_id = excluded.parent_work_item_id,
+            child_agent_id = excluded.child_agent_id,
+            child_work_item_id = excluded.child_work_item_id,
+            state = excluded.state,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            payload_json = excluded.payload_json
+         WHERE excluded.updated_at >= work_item_delegations.updated_at",
+        params![
+            record.delegation_id,
+            record.parent_agent_id,
+            record.parent_work_item_id,
+            record.child_agent_id,
+            record.child_work_item_id,
+            state,
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_working_memory_delta_tx(tx: &Transaction<'_>, record: &WorkingMemoryDelta) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let reason = enum_string(&record.reason)?;
+    let memory_delta_id = format!(
+        "memory-delta-{}-{}-{}",
+        record.from_revision, record.to_revision, record.created_at_turn
+    );
+    tx.execute(
+        "INSERT INTO working_memory_deltas (
+            memory_delta_id, from_revision, to_revision, created_at_turn, reason,
+            created_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(memory_delta_id) DO UPDATE SET
+            from_revision = excluded.from_revision,
+            to_revision = excluded.to_revision,
+            created_at_turn = excluded.created_at_turn,
+            reason = excluded.reason,
+            created_at = excluded.created_at,
+            payload_json = excluded.payload_json",
+        params![
+            memory_delta_id,
+            record.from_revision as i64,
+            record.to_revision as i64,
+            record.created_at_turn as i64,
+            reason,
+            timestamp_from_turn(record.created_at_turn),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_context_episode_tx(tx: &Transaction<'_>, record: &ContextEpisodeRecord) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let boundary_reason = enum_string(&record.boundary_reason)?;
+    tx.execute(
+        "INSERT INTO context_episodes (
+            episode_id, agent_id, workspace_id, work_item_id, boundary_reason,
+            start_turn_index, end_turn_index, started_at, ended_at, summary, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+         ON CONFLICT(episode_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            workspace_id = excluded.workspace_id,
+            work_item_id = excluded.work_item_id,
+            boundary_reason = excluded.boundary_reason,
+            start_turn_index = excluded.start_turn_index,
+            end_turn_index = excluded.end_turn_index,
+            started_at = excluded.started_at,
+            ended_at = excluded.ended_at,
+            summary = excluded.summary,
+            payload_json = excluded.payload_json
+         WHERE excluded.ended_at >= context_episodes.ended_at",
+        params![
+            record.id,
+            record.agent_id,
+            record.workspace_id,
+            record.current_work_item_id,
+            boundary_reason,
+            record.start_turn_index as i64,
+            record.end_turn_index as i64,
+            timestamp(record.created_at),
+            timestamp(record.finalized_at),
+            record.summary,
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn timestamp_from_turn(turn_index: u64) -> String {
+    format!("turn:{turn_index:020}")
+}
+
 fn upsert_external_trigger_tx(tx: &Transaction<'_>, record: &ExternalTriggerRecord) -> Result<()> {
     let payload_json = serde_json::to_string(record)?;
     let status = enum_string(&record.status)?;
@@ -2861,6 +3127,36 @@ fn reduce_task_records(records: Vec<TaskRecord>) -> BTreeMap<String, TaskRecord>
     latest
 }
 
+fn reduce_work_item_delegation_records(
+    records: Vec<WorkItemDelegationRecord>,
+) -> BTreeMap<String, WorkItemDelegationRecord> {
+    let mut latest = BTreeMap::<String, WorkItemDelegationRecord>::new();
+    for record in records {
+        let should_replace = latest
+            .get(&record.delegation_id)
+            .is_none_or(|existing| record.updated_at >= existing.updated_at);
+        if should_replace {
+            latest.insert(record.delegation_id.clone(), record);
+        }
+    }
+    latest
+}
+
+fn reduce_context_episode_records(
+    records: Vec<ContextEpisodeRecord>,
+) -> BTreeMap<String, ContextEpisodeRecord> {
+    let mut latest = BTreeMap::<String, ContextEpisodeRecord>::new();
+    for record in records {
+        let should_replace = latest
+            .get(&record.id)
+            .is_none_or(|existing| record.finalized_at >= existing.finalized_at);
+        if should_replace {
+            latest.insert(record.id.clone(), record);
+        }
+    }
+    latest
+}
+
 fn reduce_workspace_entry_records(
     records: Vec<WorkspaceEntry>,
 ) -> BTreeMap<String, WorkspaceEntry> {
@@ -2972,6 +3268,18 @@ fn decode_agent_identity_payload(payload: &str) -> Result<AgentIdentityRecord> {
 
 fn decode_work_item_payload(payload: &str) -> Result<WorkItemRecord> {
     serde_json::from_str(payload).context("decoding work item payload from runtime db")
+}
+
+fn decode_work_item_delegation_payload(payload: &str) -> Result<WorkItemDelegationRecord> {
+    serde_json::from_str(payload).context("decoding work item delegation payload from runtime db")
+}
+
+fn decode_working_memory_delta_payload(payload: &str) -> Result<WorkingMemoryDelta> {
+    serde_json::from_str(payload).context("decoding working memory delta payload from runtime db")
+}
+
+fn decode_context_episode_payload(payload: &str) -> Result<ContextEpisodeRecord> {
+    serde_json::from_str(payload).context("decoding context episode payload from runtime db")
 }
 
 fn decode_external_trigger_payload(payload: &str) -> Result<ExternalTriggerRecord> {
@@ -3627,6 +3935,60 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_agent_seq_created
   ON audit_events(agent_id, event_seq, created_at);
 "#,
     },
+    Migration {
+        version: 11,
+        name: "memory_episode_delegation_domains",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS work_item_delegations (
+  delegation_id TEXT PRIMARY KEY,
+  parent_agent_id TEXT NOT NULL,
+  parent_work_item_id TEXT NOT NULL,
+  child_agent_id TEXT NOT NULL,
+  child_work_item_id TEXT NOT NULL,
+  state TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS working_memory_deltas (
+  memory_delta_id TEXT PRIMARY KEY,
+  from_revision INTEGER NOT NULL,
+  to_revision INTEGER NOT NULL,
+  created_at_turn INTEGER NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS context_episodes (
+  episode_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  work_item_id TEXT,
+  boundary_reason TEXT NOT NULL,
+  start_turn_index INTEGER NOT NULL,
+  end_turn_index INTEGER NOT NULL,
+  started_at TEXT NOT NULL,
+  ended_at TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_item_delegations_parent
+  ON work_item_delegations(parent_agent_id, parent_work_item_id);
+CREATE INDEX IF NOT EXISTS idx_work_item_delegations_child
+  ON work_item_delegations(child_agent_id, child_work_item_id);
+CREATE INDEX IF NOT EXISTS idx_work_item_delegations_state
+  ON work_item_delegations(state);
+CREATE INDEX IF NOT EXISTS idx_working_memory_deltas_revision
+  ON working_memory_deltas(to_revision, created_at);
+CREATE INDEX IF NOT EXISTS idx_context_episodes_agent_turn
+  ON context_episodes(agent_id, end_turn_index);
+CREATE INDEX IF NOT EXISTS idx_context_episodes_work_item
+  ON context_episodes(work_item_id);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -3734,6 +4096,18 @@ impl RuntimeDb {
         AgentIdentityRepository { db: self }
     }
 
+    pub fn work_item_delegations(&self) -> WorkItemDelegationRepository<'_> {
+        WorkItemDelegationRepository { db: self }
+    }
+
+    pub fn working_memory_deltas(&self) -> WorkingMemoryDeltaRepository<'_> {
+        WorkingMemoryDeltaRepository { db: self }
+    }
+
+    pub fn context_episodes(&self) -> ContextEpisodeRepository<'_> {
+        ContextEpisodeRepository { db: self }
+    }
+
     pub const fn expected_storage_domains() -> &'static [ExpectedStorageDomain] {
         &[
             ExpectedStorageDomain {
@@ -3758,6 +4132,21 @@ impl RuntimeDb {
             },
             ExpectedStorageDomain {
                 domain: "work_items",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
+            },
+            ExpectedStorageDomain {
+                domain: "work_item_delegations",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
+            },
+            ExpectedStorageDomain {
+                domain: "working_memory_deltas",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
+            },
+            ExpectedStorageDomain {
+                domain: "context_episodes",
                 canonical_source: "db",
                 legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
             },

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -493,6 +493,26 @@ impl WorkItemDelegationRepository<'_> {
         records.reverse();
         Ok(records)
     }
+
+    pub fn latest_for_child(
+        &self,
+        child_agent_id: &str,
+    ) -> Result<Option<WorkItemDelegationRecord>> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT payload_json
+                 FROM work_item_delegations
+                 WHERE child_agent_id = ?1
+                 ORDER BY updated_at DESC, created_at DESC, delegation_id ASC
+                 LIMIT 1",
+                [child_agent_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| decode_work_item_delegation_payload(&payload))
+            .transpose()
+    }
 }
 
 impl WorkingMemoryDeltaRepository<'_> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -533,6 +533,10 @@ impl AppStorage {
     }
 
     pub fn append_work_item_delegation(&self, record: &WorkItemDelegationRecord) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.work_item_delegations().upsert(record)?;
+            return Ok(());
+        }
         self.append_jsonl(&self.work_item_delegations_path, record)
     }
 
@@ -680,10 +684,18 @@ impl AppStorage {
     }
 
     pub fn append_working_memory_delta(&self, record: &WorkingMemoryDelta) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.working_memory_deltas().upsert(record)?;
+            return Ok(());
+        }
         self.append_jsonl(&self.working_memory_deltas_path, record)
     }
 
     pub fn append_context_episode(&self, record: &ContextEpisodeRecord) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.context_episodes().upsert(record)?;
+            return self.enqueue_memory_index_context_episode(record);
+        }
         self.append_jsonl(&self.context_episodes_path, record)?;
         self.enqueue_memory_index_context_episode(record)
     }
@@ -1101,6 +1113,9 @@ impl AppStorage {
         &self,
         limit: usize,
     ) -> Result<Vec<WorkItemDelegationRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.work_item_delegations().recent(limit);
+        }
         read_recent_jsonl(&self.work_item_delegations_path, limit)
     }
 
@@ -1204,10 +1219,16 @@ impl AppStorage {
         &self,
         limit: usize,
     ) -> Result<Vec<WorkingMemoryDelta>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.working_memory_deltas().recent(limit);
+        }
         read_recent_jsonl(&self.working_memory_deltas_path, limit)
     }
 
     pub fn read_recent_context_episodes(&self, limit: usize) -> Result<Vec<ContextEpisodeRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.context_episodes().recent(limit);
+        }
         read_recent_jsonl(&self.context_episodes_path, limit)
     }
 
@@ -2693,7 +2714,7 @@ mod tests {
         MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
         TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TodoItem, TodoItemState,
         ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, WorkItemPlanStatus,
-        WorkItemState,
+        WorkItemState, WorkingMemoryUpdateReason,
     };
 
     use super::*;
@@ -3427,6 +3448,95 @@ mod tests {
             Some("delivery evidence".into())
         );
         assert_eq!(storage.count_briefs().unwrap(), 1);
+    }
+
+    #[test]
+    fn runtime_db_memory_episode_and_delegation_writes_skip_live_jsonl_after_cutover() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        let delegation = WorkItemDelegationRecord::new(
+            "parent-agent",
+            "parent-work",
+            "child-agent",
+            "child-work",
+        );
+        let memory_delta = WorkingMemoryDelta {
+            from_revision: 1,
+            to_revision: 2,
+            created_at_turn: 7,
+            reason: WorkingMemoryUpdateReason::TaskRejoined,
+            changed_fields: vec!["pending_followups".into()],
+            summary_lines: vec!["updated pending follow-ups".into()],
+        };
+        let now = Utc::now();
+        let episode = ContextEpisodeRecord {
+            id: "ep_db_only".into(),
+            agent_id: "default".into(),
+            workspace_id: "agent_home".into(),
+            created_at: now,
+            finalized_at: now + chrono::Duration::seconds(1),
+            start_turn_index: 3,
+            end_turn_index: 4,
+            start_message_count: 6,
+            end_message_count: 8,
+            boundary_reason: EpisodeBoundaryReason::TaskRejoined,
+            current_work_item_id: Some("work-db-only".into()),
+            objective: Some("migrate remaining domains".into()),
+            work_summary: None,
+            scope_hints: Vec::new(),
+            source_turn_ids: vec!["turn-1".into()],
+            source_refs: Vec::new(),
+            generated_by: None,
+            operator_intents: Vec::new(),
+            runtime_facts: Vec::new(),
+            task_results: Vec::new(),
+            unresolved_items: Vec::new(),
+            model_inferences: Vec::new(),
+            summary: "episode summary".into(),
+            working_set_files: Vec::new(),
+            commands: Vec::new(),
+            verification: Vec::new(),
+            decisions: Vec::new(),
+            carry_forward: Vec::new(),
+            waiting_on: Vec::new(),
+        };
+
+        storage.append_work_item_delegation(&delegation).unwrap();
+        storage.append_working_memory_delta(&memory_delta).unwrap();
+        storage.append_context_episode(&episode).unwrap();
+
+        for file_name in [
+            "work_item_delegations.jsonl",
+            "working_memory_deltas.jsonl",
+            "context_episodes.jsonl",
+        ] {
+            assert!(
+                !storage.ledger_dir().join(file_name).exists(),
+                "{file_name} should not be a live compat export after db cutover"
+            );
+        }
+
+        assert_eq!(
+            storage.read_recent_work_item_delegations(10).unwrap(),
+            vec![delegation]
+        );
+        assert_eq!(
+            storage.read_recent_working_memory_deltas(10).unwrap(),
+            vec![memory_delta]
+        );
+        assert_eq!(
+            storage.read_recent_context_episodes(10).unwrap(),
+            vec![episode]
+        );
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1970,6 +1970,11 @@ impl AppStorage {
         &self,
         child_agent_id: &str,
     ) -> Result<Option<WorkItemDelegationRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .work_item_delegations()
+                .latest_for_child(child_agent_id);
+        }
         read_latest_jsonl_matching(
             &self.work_item_delegations_path,
             |record: &WorkItemDelegationRecord| record.child_agent_id == child_agent_id,
@@ -3527,7 +3532,13 @@ mod tests {
 
         assert_eq!(
             storage.read_recent_work_item_delegations(10).unwrap(),
-            vec![delegation]
+            vec![delegation.clone()]
+        );
+        assert_eq!(
+            storage
+                .latest_work_item_delegation_for_child("child-agent")
+                .unwrap(),
+            Some(delegation)
         );
         assert_eq!(
             storage.read_recent_working_memory_deltas(10).unwrap(),


### PR DESCRIPTION
## Summary
- persist work item delegations, working memory deltas, and context episodes through `RuntimeDb`
- keep legacy JSONL import/fallback compatibility while skipping live JSONL writes for those domains after DB cutover
- extend migration metadata and focused storage tests to cover the remaining runtime ledger domains

## Verification
- `cargo fmt --all && cargo test runtime_db_migration && cargo test runtime_db_memory_episode_and_delegation_writes_skip_live_jsonl_after_cutover`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
