### PR TITLE
fix: expose command output source refs

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -872,7 +872,7 @@
       "stability": "stable"
     },
     {
-      "description": "Fetch exact bounded Holon memory content by a source_ref copied verbatim from MemorySearch results or from runtime prompt refs such as brief_ref/cmd_ref. Do not invent source_ref values or use MemoryGet for skill paths, file paths, or URLs.",
+      "description": "Fetch exact bounded Holon memory content by a source_ref copied verbatim from MemorySearch results or from runtime prompt refs such as brief_ref/cmd_ref/stdout_ref/stderr_ref/output_ref. Do not invent source_ref values or use MemoryGet for skill paths, file paths, or URLs.",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {

--- a/src/context.rs
+++ b/src/context.rs
@@ -2051,6 +2051,57 @@ fn sanitize_inline(value: &str) -> String {
     sanitized
 }
 
+fn command_output_refs(record: &ToolExecutionRecord, batch_item_index: Option<usize>) -> String {
+    let output = match (record.tool_name.as_str(), batch_item_index) {
+        ("ExecCommand", None) => record
+            .output
+            .get("result")
+            .or_else(|| {
+                record
+                    .output
+                    .get("envelope")
+                    .and_then(|value| value.get("result"))
+            })
+            .unwrap_or(&record.output),
+        ("ExecCommandBatch", Some(index)) => match record
+            .output
+            .get("result")
+            .or_else(|| {
+                record
+                    .output
+                    .get("envelope")
+                    .and_then(|value| value.get("result"))
+            })
+            .unwrap_or(&record.output)
+            .get("items")
+            .and_then(Value::as_array)
+            .and_then(|items| items.get(index.saturating_sub(1)))
+        {
+            Some(item) => item.get("result").unwrap_or(item),
+            None => return String::new(),
+        },
+        _ => return String::new(),
+    };
+    let has_output_evidence = [
+        "stdout_preview",
+        "stderr_preview",
+        "initial_output_preview",
+        "stdout_artifact",
+        "stderr_artifact",
+    ]
+    .iter()
+    .any(|key| output.get(key).is_some());
+    if !has_output_evidence {
+        return String::new();
+    }
+    format!(
+        " stdout_ref={} stderr_ref={} output_ref={}",
+        crate::tool::helpers::command_output_source_ref(&record.id, batch_item_index, "stdout"),
+        crate::tool::helpers::command_output_source_ref(&record.id, batch_item_index, "stderr"),
+        crate::tool::helpers::command_output_source_ref(&record.id, batch_item_index, "output")
+    )
+}
+
 fn render_recent_tool_execution(record: &ToolExecutionRecord) -> String {
     let prefix = format!(
         "- [{}][{:?}] {}",
@@ -2065,13 +2116,11 @@ fn render_recent_tool_execution(record: &ToolExecutionRecord) -> String {
             .and_then(Value::as_str)
             .map(|cmd| {
                 format!(
-                    "{prefix} tool_execution_id={} cmd_digest={} cmd_ref={} stdout_ref={} stderr_ref={} output_ref={} cmd_preview={}",
+                    "{prefix} tool_execution_id={} cmd_digest={} cmd_ref={}{} cmd_preview={}",
                     record.id,
                     crate::tool::helpers::command_digest(cmd),
                     crate::tool::helpers::command_receipt_source_ref(&record.id, None),
-                    crate::tool::helpers::command_output_source_ref(&record.id, None, "stdout"),
-                    crate::tool::helpers::command_output_source_ref(&record.id, None, "stderr"),
-                    crate::tool::helpers::command_output_source_ref(&record.id, None, "output"),
+                    command_output_refs(record, None),
                     crate::tool::helpers::command_preview(cmd)
                 )
             })
@@ -2087,12 +2136,10 @@ fn render_recent_tool_execution(record: &ToolExecutionRecord) -> String {
                     let cmd = item.get("cmd").and_then(Value::as_str)?;
                     let index = offset + 1;
                     Some(format!(
-                        "{{index={index}, cmd_digest={}, cmd_ref={}, stdout_ref={}, stderr_ref={}, output_ref={}, cmd_preview={}}}",
+                        "{{index={index}, cmd_digest={}, cmd_ref={},{} cmd_preview={}}}",
                         crate::tool::helpers::command_digest(cmd),
                         crate::tool::helpers::command_receipt_source_ref(&record.id, Some(index)),
-                        crate::tool::helpers::command_output_source_ref(&record.id, Some(index), "stdout"),
-                        crate::tool::helpers::command_output_source_ref(&record.id, Some(index), "stderr"),
-                        crate::tool::helpers::command_output_source_ref(&record.id, Some(index), "output"),
+                        command_output_refs(record, Some(index)),
                         crate::tool::helpers::command_preview(cmd)
                     ))
                 })
@@ -3204,7 +3251,12 @@ mod tests {
             authority_class: AuthorityClass::OperatorInstruction,
             status: ToolExecutionStatus::Success,
             input: json!({"cmd": command}),
-            output: json!({"exit_code": 0}),
+            output: json!({
+                "exit_code": 0,
+                "stdout_preview": "context_stdout_1246\n",
+                "stderr_preview": "",
+                "artifacts": []
+            }),
             summary: "command exited with status 0".to_string(),
             invocation_surface: None,
         };
@@ -3241,7 +3293,14 @@ mod tests {
                     {"cmd": "node - <<'NODE'\nconsole.log('hidden_batch_1246')\nNODE"}
                 ]
             }),
-            output: json!({"completed_count": 2}),
+            output: json!({
+                "result": {
+                    "items": [
+                        {"result": {"stdout_preview": "foo\n", "stderr_preview": "", "artifacts": []}},
+                        {"result": {"stdout_preview": "hidden_batch_1246\n", "stderr_preview": "", "artifacts": []}}
+                    ]
+                }
+            }),
             summary: "ExecCommandBatch completed 2/2 items".to_string(),
             invocation_surface: None,
         };
@@ -3263,6 +3322,34 @@ mod tests {
             .contains("output_ref=tool_execution:tool-context-batch-1246:batch_item:2:output"));
         assert!(rendered.contains("cmd_digest="));
         assert!(!rendered.contains("hidden_batch_1246"));
+    }
+
+    #[test]
+    fn recent_tool_context_omits_output_refs_without_output_evidence() {
+        let record = ToolExecutionRecord {
+            id: "tool-context-old-1246".to_string(),
+            agent_id: "default".to_string(),
+            work_item_id: None,
+            turn_index: 0,
+            turn_id: None,
+            tool_name: "ExecCommand".to_string(),
+            created_at: chrono::Utc::now(),
+            completed_at: Some(chrono::Utc::now()),
+            duration_ms: 123,
+            authority_class: AuthorityClass::OperatorInstruction,
+            status: ToolExecutionStatus::Success,
+            input: json!({"cmd": "echo old_context_1246"}),
+            output: json!({"exit_code": 0}),
+            summary: "command exited with status 0".to_string(),
+            invocation_surface: None,
+        };
+
+        let rendered = render_recent_tool_execution(&record);
+
+        assert!(rendered.contains("cmd_ref=tool_execution:tool-context-old-1246:cmd"));
+        assert!(!rendered.contains("stdout_ref="));
+        assert!(!rendered.contains("stderr_ref="));
+        assert!(!rendered.contains("output_ref="));
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -2065,10 +2065,13 @@ fn render_recent_tool_execution(record: &ToolExecutionRecord) -> String {
             .and_then(Value::as_str)
             .map(|cmd| {
                 format!(
-                    "{prefix} tool_execution_id={} cmd_digest={} cmd_ref={} cmd_preview={}",
+                    "{prefix} tool_execution_id={} cmd_digest={} cmd_ref={} stdout_ref={} stderr_ref={} output_ref={} cmd_preview={}",
                     record.id,
                     crate::tool::helpers::command_digest(cmd),
                     crate::tool::helpers::command_receipt_source_ref(&record.id, None),
+                    crate::tool::helpers::command_output_source_ref(&record.id, None, "stdout"),
+                    crate::tool::helpers::command_output_source_ref(&record.id, None, "stderr"),
+                    crate::tool::helpers::command_output_source_ref(&record.id, None, "output"),
                     crate::tool::helpers::command_preview(cmd)
                 )
             })
@@ -2084,9 +2087,12 @@ fn render_recent_tool_execution(record: &ToolExecutionRecord) -> String {
                     let cmd = item.get("cmd").and_then(Value::as_str)?;
                     let index = offset + 1;
                     Some(format!(
-                        "{{index={index}, cmd_digest={}, cmd_ref={}, cmd_preview={}}}",
+                        "{{index={index}, cmd_digest={}, cmd_ref={}, stdout_ref={}, stderr_ref={}, output_ref={}, cmd_preview={}}}",
                         crate::tool::helpers::command_digest(cmd),
                         crate::tool::helpers::command_receipt_source_ref(&record.id, Some(index)),
+                        crate::tool::helpers::command_output_source_ref(&record.id, Some(index), "stdout"),
+                        crate::tool::helpers::command_output_source_ref(&record.id, Some(index), "stderr"),
+                        crate::tool::helpers::command_output_source_ref(&record.id, Some(index), "output"),
                         crate::tool::helpers::command_preview(cmd)
                     ))
                 })
@@ -3207,6 +3213,9 @@ mod tests {
 
         assert!(rendered.contains("tool_execution_id=tool-context-1246"));
         assert!(rendered.contains("cmd_ref=tool_execution:tool-context-1246:cmd"));
+        assert!(rendered.contains("stdout_ref=tool_execution:tool-context-1246:stdout"));
+        assert!(rendered.contains("stderr_ref=tool_execution:tool-context-1246:stderr"));
+        assert!(rendered.contains("output_ref=tool_execution:tool-context-1246:output"));
         assert!(rendered.contains("cmd_digest="));
         assert!(rendered.contains("[omitted: command contains heredoc or inline script]"));
         assert!(!rendered.contains("context_receipt_middle_1246"));
@@ -3246,6 +3255,12 @@ mod tests {
         assert!(
             rendered.contains("cmd_ref=tool_execution:tool-context-batch-1246:batch_item:2:cmd")
         );
+        assert!(rendered
+            .contains("stdout_ref=tool_execution:tool-context-batch-1246:batch_item:1:stdout"));
+        assert!(rendered
+            .contains("stderr_ref=tool_execution:tool-context-batch-1246:batch_item:2:stderr"));
+        assert!(rendered
+            .contains("output_ref=tool_execution:tool-context-batch-1246:batch_item:2:output"));
         assert!(rendered.contains("cmd_digest="));
         assert!(!rendered.contains("hidden_batch_1246"));
     }

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1502,9 +1502,10 @@ fn parse_tool_execution_source_ref(source_ref: &str) -> Option<ParsedToolExecuti
     let rest = source_ref.strip_prefix("tool_execution:")?;
     if let Some((tool_execution_id, tail)) = rest.rsplit_once(":batch_item:") {
         let (index, selector) = tail.split_once(':')?;
+        let index = index.parse().ok().filter(|index| *index >= 1)?;
         return Some(ParsedToolExecutionRef {
             tool_execution_id: tool_execution_id.to_string(),
-            batch_item_index: Some(index.parse().ok()?),
+            batch_item_index: Some(index),
             selector: parse_tool_execution_selector(selector)?,
         });
     }
@@ -1603,10 +1604,18 @@ fn command_output_envelope(
             .unwrap_or(&record.output),
         ("ExecCommandBatch", Some(index)) => record
             .output
+            .get("result")
+            .or_else(|| {
+                record
+                    .output
+                    .get("envelope")
+                    .and_then(|value| value.get("result"))
+            })
+            .unwrap_or(&record.output)
             .get("items")
             .and_then(Value::as_array)
             .and_then(|items| items.get(index - 1))
-            .and_then(|item| item.get("result"))?,
+            .map(|item| item.get("result").unwrap_or(item))?,
         _ => return None,
     };
     let content = match stream {
@@ -3076,5 +3085,102 @@ mod tests {
             .pending_sources_for_agent("default")
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn command_output_resolves_exec_command_batch_envelope_items() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-batch-output-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: None,
+                turn_index: 0,
+                turn_id: None,
+                tool_name: "ExecCommandBatch".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 20,
+                authority_class: crate::types::AuthorityClass::OperatorInstruction,
+                status: crate::types::ToolExecutionStatus::Success,
+                input: json!({
+                    "items": [
+                        {"cmd": "echo first"},
+                        {"cmd": "echo second"}
+                    ]
+                }),
+                output: json!({
+                    "envelope": {
+                        "result": {
+                            "items": [
+                                {"result": {"stdout_preview": "first_batch_output_1246\n", "stderr_preview": "", "truncated": false, "artifacts": []}},
+                                {"result": {"stdout_preview": "second_batch_output_1246\n", "stderr_preview": "", "truncated": false, "artifacts": []}}
+                            ]
+                        }
+                    }
+                }),
+                summary: "ExecCommandBatch completed 2/2 items".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let memory = get_memory(
+            &storage,
+            "tool_execution:tool-batch-output-1246:batch_item:2:stdout",
+            None,
+            Some("ws-holon"),
+        )
+        .unwrap()
+        .expect("batch command output should be retrievable");
+
+        assert!(memory.content.contains("second_batch_output_1246"));
+        assert!(!memory.content.contains("first_batch_output_1246"));
+    }
+
+    #[test]
+    fn command_output_indexes_unavailable_batch_item_without_result() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-batch-unavailable-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: None,
+                turn_index: 0,
+                turn_id: None,
+                tool_name: "ExecCommandBatch".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 20,
+                authority_class: crate::types::AuthorityClass::OperatorInstruction,
+                status: crate::types::ToolExecutionStatus::Success,
+                input: json!({"items": [{"cmd": "echo skipped"}]}),
+                output: json!({
+                    "result": {
+                        "items": [
+                            {"disposition": "skipped"}
+                        ]
+                    }
+                }),
+                summary: "ExecCommandBatch completed 0/1 items".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let memory = get_memory(
+            &storage,
+            "tool_execution:tool-batch-unavailable-1246:batch_item:1:stdout",
+            None,
+            Some("ws-holon"),
+        )
+        .unwrap()
+        .expect("unavailable batch command output should still be retrievable");
+
+        assert!(memory
+            .content
+            .contains("\"availability\": \"output_unavailable\""));
     }
 }

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -15,7 +15,9 @@ use crate::{
     agent_template::{agent_memory_operator_path, agent_memory_self_path},
     runtime_db::{EvidenceKind, RuntimeDb},
     storage::AppStorage,
-    tool::helpers::{command_digest, command_preview, command_receipt_source_ref},
+    tool::helpers::{
+        command_digest, command_output_source_ref, command_preview, command_receipt_source_ref,
+    },
     types::{
         BriefRecord, CommandTaskStatusSnapshot, ContextEpisodeRecord, TaskRecord, TaskStatus,
         ToolExecutionRecord, WorkItemRecord, WorkspaceEntry,
@@ -903,7 +905,9 @@ fn document_for_pending_source(
         "context_episode" => context_episode_document_by_id(storage, &source.source_id),
         "work_item" => work_item_document_by_id(storage, &source.source_id),
         "task" => task_document_by_id(storage, &source.source_id),
-        "tool_command_receipt" => command_receipt_document_by_ref(storage, &source.source_ref),
+        "tool_command_receipt" | "tool_command_output" => {
+            command_tool_execution_document_by_ref(storage, &source.source_ref)
+        }
         _ => Ok(None),
     }
 }
@@ -1400,18 +1404,21 @@ fn command_execution_documents(
             "ExecCommand" => {
                 if let Some(cmd) = record.input.get("cmd").and_then(Value::as_str) {
                     documents.push(command_receipt_document(&record, None, None, cmd));
+                    documents.extend(command_output_documents(&record, None));
                 }
             }
             "ExecCommandBatch" => {
                 if let Some(items) = record.input.get("items").and_then(Value::as_array) {
                     for (offset, item) in items.iter().enumerate() {
                         if let Some(cmd) = item.get("cmd").and_then(Value::as_str) {
+                            let index = offset + 1;
                             documents.push(command_receipt_document(
                                 &record,
-                                Some(offset + 1),
+                                Some(index),
                                 Some(item),
                                 cmd,
                             ));
+                            documents.extend(command_output_documents(&record, Some(index)));
                         }
                     }
                 }
@@ -1422,12 +1429,11 @@ fn command_execution_documents(
     Ok(documents)
 }
 
-fn command_receipt_document_by_ref(
+fn command_tool_execution_document_by_ref(
     storage: &AppStorage,
     source_ref: &str,
 ) -> Result<Option<MemoryDocument>> {
-    let Some((tool_execution_id, batch_item_index)) = parse_command_receipt_source_ref(source_ref)
-    else {
+    let Some(parsed_ref) = parse_tool_execution_source_ref(source_ref) else {
         return Ok(None);
     };
     let runtime_db = storage.runtime_db()?;
@@ -1437,7 +1443,7 @@ fn command_receipt_document_by_ref(
             .payload_by_id(
                 EvidenceKind::ToolExecution,
                 &storage_agent_id(storage),
-                &tool_execution_id,
+                &parsed_ref.tool_execution_id,
             )?
             .map(|row| serde_json::from_str::<ToolExecutionRecord>(&row.payload_json))
             .transpose()?
@@ -1445,18 +1451,22 @@ fn command_receipt_document_by_ref(
         storage
             .read_recent_tool_executions(usize::MAX)?
             .into_iter()
-            .find(|record| record.id == tool_execution_id)
+            .find(|record| record.id == parsed_ref.tool_execution_id)
     };
     let Some(record) = record else {
         return Ok(None);
     };
-    match (record.tool_name.as_str(), batch_item_index) {
-        ("ExecCommand", None) => Ok(record
+    match (
+        record.tool_name.as_str(),
+        parsed_ref.batch_item_index,
+        parsed_ref.selector,
+    ) {
+        ("ExecCommand", None, ToolExecutionRefSelector::Cmd) => Ok(record
             .input
             .get("cmd")
             .and_then(Value::as_str)
             .map(|cmd| command_receipt_document(&record, None, None, cmd))),
-        ("ExecCommandBatch", Some(index)) => Ok(record
+        ("ExecCommandBatch", Some(index), ToolExecutionRefSelector::Cmd) => Ok(record
             .input
             .get("items")
             .and_then(Value::as_array)
@@ -1466,17 +1476,185 @@ fn command_receipt_document_by_ref(
                     .and_then(Value::as_str)
                     .map(|cmd| command_receipt_document(&record, Some(index), Some(item), cmd))
             })),
+        ("ExecCommand", None, ToolExecutionRefSelector::Output(stream)) => {
+            Ok(command_output_document(&record, None, stream))
+        }
+        ("ExecCommandBatch", Some(index), ToolExecutionRefSelector::Output(stream)) => {
+            Ok(command_output_document(&record, Some(index), stream))
+        }
         _ => Ok(None),
     }
 }
 
-fn parse_command_receipt_source_ref(source_ref: &str) -> Option<(String, Option<usize>)> {
+#[derive(Debug, Clone, Copy)]
+enum ToolExecutionRefSelector {
+    Cmd,
+    Output(&'static str),
+}
+
+struct ParsedToolExecutionRef {
+    tool_execution_id: String,
+    batch_item_index: Option<usize>,
+    selector: ToolExecutionRefSelector,
+}
+
+fn parse_tool_execution_source_ref(source_ref: &str) -> Option<ParsedToolExecutionRef> {
     let rest = source_ref.strip_prefix("tool_execution:")?;
-    let rest = rest.strip_suffix(":cmd")?;
-    if let Some((tool_execution_id, index)) = rest.rsplit_once(":batch_item:") {
-        return Some((tool_execution_id.to_string(), Some(index.parse().ok()?)));
+    if let Some((tool_execution_id, tail)) = rest.rsplit_once(":batch_item:") {
+        let (index, selector) = tail.split_once(':')?;
+        return Some(ParsedToolExecutionRef {
+            tool_execution_id: tool_execution_id.to_string(),
+            batch_item_index: Some(index.parse().ok()?),
+            selector: parse_tool_execution_selector(selector)?,
+        });
     }
-    Some((rest.to_string(), None))
+    let (tool_execution_id, selector) = rest.rsplit_once(':')?;
+    Some(ParsedToolExecutionRef {
+        tool_execution_id: tool_execution_id.to_string(),
+        batch_item_index: None,
+        selector: parse_tool_execution_selector(selector)?,
+    })
+}
+
+fn parse_tool_execution_selector(selector: &str) -> Option<ToolExecutionRefSelector> {
+    match selector {
+        "cmd" => Some(ToolExecutionRefSelector::Cmd),
+        "stdout" => Some(ToolExecutionRefSelector::Output("stdout")),
+        "stderr" => Some(ToolExecutionRefSelector::Output("stderr")),
+        "output" => Some(ToolExecutionRefSelector::Output("output")),
+        _ => None,
+    }
+}
+
+fn command_output_documents(
+    record: &ToolExecutionRecord,
+    batch_item_index: Option<usize>,
+) -> Vec<MemoryDocument> {
+    ["stdout", "stderr", "output"]
+        .into_iter()
+        .filter_map(|stream| command_output_document(record, batch_item_index, stream))
+        .collect()
+}
+
+fn command_output_document(
+    record: &ToolExecutionRecord,
+    batch_item_index: Option<usize>,
+    stream: &'static str,
+) -> Option<MemoryDocument> {
+    let output = command_output_envelope(record, batch_item_index, stream)?;
+    let source_ref = command_output_source_ref(&record.id, batch_item_index, stream);
+    let title = match batch_item_index {
+        Some(index) => format!("{} {stream} output item {}", record.tool_name, index),
+        None => format!("{} {stream} output", record.tool_name),
+    };
+    let body = serde_json::to_string_pretty(&output).unwrap_or_else(|_| output.to_string());
+    let preview = output
+        .get("preview")
+        .and_then(Value::as_str)
+        .or_else(|| output.get("content").and_then(Value::as_str))
+        .unwrap_or("");
+    Some(MemoryDocument {
+        source_ref,
+        source_kind: "tool_command_output".into(),
+        scope_kind: "agent".into(),
+        workspace_id: None,
+        agent_id: record.agent_id.clone(),
+        source_path: None,
+        title,
+        sanitized_excerpt: format!(
+            "tool_execution_id={} tool_name={} selector={} batch_item_index={:?} preview={}",
+            record.id,
+            record.tool_name,
+            stream,
+            batch_item_index,
+            truncate_chars(preview, 240).0
+        ),
+        body,
+        metadata: json!({
+            "tool_execution_id": record.id,
+            "tool_name": record.tool_name,
+            "turn_index": record.turn_index,
+            "work_item_id": record.work_item_id,
+            "batch_item_index": batch_item_index,
+            "selector": stream,
+            "governance_surface": "runtime_evidence",
+            "provenance_class": "tool_execution_record",
+            "trust_class": "runtime_evidence",
+        }),
+        updated_at: record.completed_at.unwrap_or(record.created_at),
+    })
+}
+
+fn command_output_envelope(
+    record: &ToolExecutionRecord,
+    batch_item_index: Option<usize>,
+    stream: &'static str,
+) -> Option<Value> {
+    let output = match (record.tool_name.as_str(), batch_item_index) {
+        ("ExecCommand", None) => record
+            .output
+            .get("result")
+            .or_else(|| {
+                record
+                    .output
+                    .get("envelope")
+                    .and_then(|value| value.get("result"))
+            })
+            .unwrap_or(&record.output),
+        ("ExecCommandBatch", Some(index)) => record
+            .output
+            .get("items")
+            .and_then(Value::as_array)
+            .and_then(|items| items.get(index - 1))
+            .and_then(|item| item.get("result"))?,
+        _ => return None,
+    };
+    let content = match stream {
+        "stdout" => output.get("stdout_preview").and_then(Value::as_str),
+        "stderr" => output.get("stderr_preview").and_then(Value::as_str),
+        "output" => output
+            .get("stdout_preview")
+            .and_then(Value::as_str)
+            .or_else(|| output.get("stderr_preview").and_then(Value::as_str))
+            .or_else(|| output.get("initial_output_preview").and_then(Value::as_str)),
+        _ => None,
+    };
+    let artifact_key = match stream {
+        "stdout" => Some("stdout_artifact"),
+        "stderr" => Some("stderr_artifact"),
+        _ => None,
+    };
+    let artifact = artifact_key
+        .and_then(|key| output.get(key).and_then(Value::as_u64))
+        .and_then(|index| {
+            output
+                .get("artifacts")
+                .and_then(Value::as_array)
+                .and_then(|artifacts| artifacts.get(index as usize))
+        })
+        .cloned();
+    let available = content.is_some() || artifact.is_some();
+    Some(json!({
+        "source_type": "tool_command_output",
+        "tool_execution_id": record.id,
+        "tool_name": record.tool_name,
+        "batch_item_index": batch_item_index,
+        "selector": stream,
+        "status": record.status,
+        "disposition": output.get("disposition").and_then(Value::as_str).unwrap_or("unknown"),
+        "content": content,
+        "preview": content.unwrap_or(""),
+        "output_available": available,
+        "availability": if available { "available" } else { "output_unavailable" },
+        "truncated": output.get("truncated").and_then(Value::as_bool).unwrap_or(false)
+            || output.get("initial_output_truncated").and_then(Value::as_bool).unwrap_or(false),
+        "artifact": artifact,
+        "message": if available {
+            "Output evidence recovered from the tool execution record. If artifact is present, use that pointer for full bytes rather than expecting MemoryGet to stream them."
+        } else {
+            "No persisted output evidence is available for this tool execution stream; older records may contain command input only."
+        },
+    }))
 }
 
 fn command_receipt_document(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::{
     memory::index::enqueue_memory_index_upsert,
     runtime_db::RuntimeDb,
-    tool::helpers::command_receipt_source_ref,
+    tool::helpers::{command_output_source_ref, command_receipt_source_ref},
     types::{
         AgentIdentityRecord, AgentPostureProjection, AgentSchedulingPosture, AgentState,
         AgentStatus, AuditEvent, BriefRecord, ContextEpisodeRecord, DeliverySummaryRecord,
@@ -794,6 +794,15 @@ impl AppStorage {
                         &source_ref,
                         &source_ref,
                     )?;
+                    for stream in ["stdout", "stderr", "output"] {
+                        let source_ref = command_output_source_ref(&record.id, None, stream);
+                        enqueue_memory_index_upsert(
+                            self,
+                            "tool_command_output",
+                            &source_ref,
+                            &source_ref,
+                        )?;
+                    }
                 }
             }
             "ExecCommandBatch" => {
@@ -808,6 +817,16 @@ impl AppStorage {
                                 &source_ref,
                                 &source_ref,
                             )?;
+                            for stream in ["stdout", "stderr", "output"] {
+                                let source_ref =
+                                    command_output_source_ref(&record.id, Some(offset + 1), stream);
+                                enqueue_memory_index_upsert(
+                                    self,
+                                    "tool_command_output",
+                                    &source_ref,
+                                    &source_ref,
+                                )?;
+                            }
                         }
                     }
                 }

--- a/src/tool/helpers.rs
+++ b/src/tool/helpers.rs
@@ -179,6 +179,19 @@ pub(crate) fn command_receipt_source_ref(
     }
 }
 
+pub(crate) fn command_output_source_ref(
+    tool_execution_id: &str,
+    batch_item_index: Option<usize>,
+    stream: &str,
+) -> String {
+    match batch_item_index {
+        Some(index) => {
+            format!("tool_execution:{tool_execution_id}:batch_item:{index}:{stream}")
+        }
+        None => format!("tool_execution:{tool_execution_id}:{stream}"),
+    }
+}
+
 pub(crate) fn command_cost_diagnostics(
     cmd: &str,
     effective_max_output_tokens: u64,

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -42,7 +42,7 @@ pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
         family: ToolCapabilityFamily::CoreAgent,
         spec: typed_spec::<MemoryGetArgs>(
             NAME,
-            "Fetch exact bounded Holon memory content by a source_ref copied verbatim from MemorySearch results or from runtime prompt refs such as brief_ref/cmd_ref. Do not invent source_ref values or use MemoryGet for skill paths, file paths, or URLs.",
+            "Fetch exact bounded Holon memory content by a source_ref copied verbatim from MemorySearch results or from runtime prompt refs such as brief_ref/cmd_ref/stdout_ref/stderr_ref/output_ref. Do not invent source_ref values or use MemoryGet for skill paths, file paths, or URLs.",
         )?,
     })
 }
@@ -67,7 +67,7 @@ pub(crate) async fn execute(
             "reason": "source_ref was syntactically valid but is not present in the current visible memory index",
         }))
         .with_recovery_hint(
-            "call MemorySearch again and pass one of its returned source_ref values verbatim, or copy an available prompt source_ref such as brief_ref/cmd_ref verbatim",
+            "call MemorySearch again and pass one of its returned source_ref values verbatim, or copy an available prompt source_ref such as brief_ref/cmd_ref/stdout_ref/stderr_ref/output_ref verbatim",
         )
         .into());
     };
@@ -129,21 +129,28 @@ fn validate_source_ref(source_ref: String) -> Result<String> {
 fn validate_tool_execution_source_ref(source_ref: &str, suffix: &str) -> Result<String> {
     let parts = suffix.split(':').collect::<Vec<_>>();
     let valid = match parts.as_slice() {
-        [tool_execution_id, "cmd"] => valid_source_ref_segment(tool_execution_id),
-        [tool_execution_id, "batch_item", index, "cmd"] => {
+        [tool_execution_id, selector] => {
+            valid_source_ref_segment(tool_execution_id) && valid_tool_execution_selector(selector)
+        }
+        [tool_execution_id, "batch_item", index, selector] => {
             valid_source_ref_segment(tool_execution_id)
                 && !index.is_empty()
                 && index.chars().all(|ch| ch.is_ascii_digit())
+                && valid_tool_execution_selector(selector)
         }
         _ => false,
     };
     if !valid {
         return Err(invalid_source_ref_error(
             source_ref,
-            "tool_execution source_ref must match tool_execution:<id>:cmd or tool_execution:<id>:batch_item:<index>:cmd",
+            "tool_execution source_ref must match tool_execution:<id>:{cmd,stdout,stderr,output} or tool_execution:<id>:batch_item:<index>:{cmd,stdout,stderr,output}",
         ));
     }
     Ok(source_ref.to_string())
+}
+
+fn valid_tool_execution_selector(selector: &str) -> bool {
+    matches!(selector, "cmd" | "stdout" | "stderr" | "output")
 }
 
 fn valid_source_ref_segment(segment: &str) -> bool {
@@ -224,7 +231,13 @@ mod tests {
             "work_item:work_123",
             "task:task_123",
             "tool_execution:tool-123:cmd",
+            "tool_execution:tool-123:stdout",
+            "tool_execution:tool-123:stderr",
+            "tool_execution:tool-123:output",
             "tool_execution:tool-123:batch_item:2:cmd",
+            "tool_execution:tool-123:batch_item:2:stdout",
+            "tool_execution:tool-123:batch_item:2:stderr",
+            "tool_execution:tool-123:batch_item:2:output",
         ] {
             assert_eq!(
                 validate_source_ref(source_ref.to_string()).unwrap(),
@@ -248,6 +261,8 @@ mod tests {
             "tool_execution:tool-123",
             "tool_execution:tool-123:batch_item:abc:cmd",
             "tool_execution:tool-123:batch_item:2",
+            "tool_execution:tool-123:batch_item:2:artifact",
+            "tool_execution:tool-123:artifact",
         ] {
             let error = tool_error(validate_source_ref(source_ref.to_string()).unwrap_err());
             assert_eq!(error.kind, "invalid_tool_input");
@@ -362,6 +377,68 @@ mod tests {
         assert!(content.contains("\"workdir\": \"src\""));
         assert!(content.contains("\"yield_time_ms\": 1000"));
         assert!(content.contains("\"max_output_tokens\": 1200"));
+    }
+
+    #[tokio::test]
+    async fn memory_get_tool_accepts_command_output_source_refs() {
+        let dir = tempdir().unwrap();
+        let workspace = tempdir().unwrap();
+        let runtime = RuntimeHandle::new(
+            "default",
+            dir.path().to_path_buf(),
+            workspace.path().to_path_buf(),
+            "http://127.0.0.1:7878".into(),
+            Arc::new(StubProvider::new("done")),
+            "default".into(),
+            ContextConfig::default(),
+        )
+        .unwrap();
+        runtime
+            .storage()
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-output-1246".into(),
+                agent_id: "default".into(),
+                work_item_id: None,
+                turn_index: 0,
+                turn_id: None,
+                tool_name: "ExecCommand".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 10,
+                authority_class: AuthorityClass::OperatorInstruction,
+                status: ToolExecutionStatus::Success,
+                input: json!({"cmd": "printf memory_get_stdout_1246"}),
+                output: json!({
+                    "disposition": "completed",
+                    "exit_status": 0,
+                    "stdout_preview": "memory_get_stdout_1246\n",
+                    "stderr_preview": "",
+                    "truncated": false,
+                    "artifacts": []
+                }),
+                summary: "command exited with status 0".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        let result = execute(
+            &runtime,
+            "default",
+            &AuthorityClass::OperatorInstruction,
+            &json!({
+                "source_ref": "tool_execution:tool-output-1246:stdout"
+            }),
+        )
+        .await
+        .unwrap();
+        let content = result.envelope.result.unwrap()["memory"]["content"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert!(content.contains("\"selector\": \"stdout\""));
+        assert!(content.contains("memory_get_stdout_1246"));
+        assert!(content.contains("\"output_available\": true"));
     }
 
     #[tokio::test]

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -134,8 +134,7 @@ fn validate_tool_execution_source_ref(source_ref: &str, suffix: &str) -> Result<
         }
         [tool_execution_id, "batch_item", index, selector] => {
             valid_source_ref_segment(tool_execution_id)
-                && !index.is_empty()
-                && index.chars().all(|ch| ch.is_ascii_digit())
+                && valid_batch_item_index(index)
                 && valid_tool_execution_selector(selector)
         }
         _ => false,
@@ -151,6 +150,10 @@ fn validate_tool_execution_source_ref(source_ref: &str, suffix: &str) -> Result<
 
 fn valid_tool_execution_selector(selector: &str) -> bool {
     matches!(selector, "cmd" | "stdout" | "stderr" | "output")
+}
+
+fn valid_batch_item_index(index: &str) -> bool {
+    index.parse::<usize>().is_ok_and(|index| index >= 1) && !index.starts_with('0')
 }
 
 fn valid_source_ref_segment(segment: &str) -> bool {
@@ -259,6 +262,8 @@ mod tests {
             "episode:../ledger/episode-1",
             "work_item:work_123?raw=true",
             "tool_execution:tool-123",
+            "tool_execution:tool-123:batch_item:0:cmd",
+            "tool_execution:tool-123:batch_item:02:cmd",
             "tool_execution:tool-123:batch_item:abc:cmd",
             "tool_execution:tool-123:batch_item:2",
             "tool_execution:tool-123:batch_item:2:artifact",


### PR DESCRIPTION
## Summary
- expose copyable stdout_ref/stderr_ref/output_ref alongside cmd_ref in recent tool context
- index command output source refs for ExecCommand and ExecCommandBatch items
- allow MemoryGet to resolve output refs into bounded output envelopes with preview/artifact metadata

Closes #1638

## Verification
- cargo fmt --all
- cargo test memory_get_tool_accepts_command_output_source_refs
- cargo test recent_tool_context_includes_recoverable_command_receipt_ref
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets