### PR TITLE
fix: bound episode recall to recent turns

### DIFF
--- a/docs/website/concepts/context-continuity.md
+++ b/docs/website/concepts/context-continuity.md
@@ -31,6 +31,9 @@ A Holon prompt is assembled from several sections with different jobs:
 These sections are not separate sources of truth competing with each other.
 They are projections of runtime evidence. The durable ledger remains the audit
 trail; the prompt is the budgeted view used for the next model decision.
+When sections overlap, the current work item is the task lifecycle source of
+truth. Relevant episode memory is historical evidence and should not override
+the active work item's objective, plan, todo list, or waiting state.
 
 ## Turns Are the Causal Unit
 
@@ -83,6 +86,12 @@ When older turn ranges age out of the hot prompt budget, Holon can archive them
 as structured episodes. An episode records the covered turn range, source turn
 IDs, source references, decisions, results, verification, unresolved items,
 operator intents, and model inferences.
+
+By default, prompt assembly recalls only episodes whose covered turn range is
+older than the `recent_turns` window. Recent turns provide the high-fidelity
+view of current interaction; episodes provide the compressed mid-term archive
+for turns no longer shown directly. Diagnostic modes may choose to show both,
+but ordinary prompts should avoid replaying the same turn evidence twice.
 
 Model-generated summaries may help describe an episode, but they are evidence,
 not authority. They do not change the trust level of an input, overwrite

--- a/docs/website/concepts/memory.md
+++ b/docs/website/concepts/memory.md
@@ -77,7 +77,9 @@ the runtime finalizes the builder into an immutable **episode record** and
 stores it.
 
 Archived episodes are selected into prompt context by relevance and budget,
-not rendered in full by default.
+not rendered in full by default. Default prompt assembly treats episodes as a
+mid-term archive: it excludes episodes that overlap the `recent_turns` window
+so recent turn evidence is not duplicated by a summary of the same turns.
 
 ### Context Assembly
 
@@ -130,6 +132,9 @@ Memory is tightly coupled to work items:
   plan, todo list, and blocked status.
 - **Episode records** are scoped to work items. When a work item completes,
   its accumulated evidence becomes an archived episode.
+- If a current work item and an episode both match the prompt, the work item
+  remains authoritative for current objective, plan, todo, and wait state; the
+  episode is supporting historical evidence.
 - **MemorySearch** indexes across completed episodes, making past work
   findable by content rather than by timestamp alone.
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -181,17 +181,6 @@ pub fn build_context_with_default_external_ingress(
         }
     }
 
-    if let Some(section) = build_relevant_episode_memory_section(
-        &episodes,
-        agent,
-        current_work_item,
-        current_message,
-        config,
-        remaining_budget,
-    ) {
-        push_budgeted_section(&mut sections, &mut remaining_budget, section);
-    }
-
     if let Some(delta) = &agent.working_memory.pending_working_memory_delta {
         if let Some(content) = render_working_memory_delta_with_budget(delta, remaining_budget) {
             push_budgeted_section(
@@ -211,6 +200,19 @@ pub fn build_context_with_default_external_ingress(
                 render_current_work_item(work_item, storage.data_dir(), &active_waiting_intents),
             ),
         );
+    }
+
+    let recent_turn_window_start = recent_turn_window_start(&turn_records);
+    if let Some(section) = build_relevant_episode_memory_section(
+        &episodes,
+        agent,
+        current_work_item,
+        current_message,
+        config,
+        remaining_budget,
+        recent_turn_window_start,
+    ) {
+        push_budgeted_section(&mut sections, &mut remaining_budget, section);
     }
 
     if let Some(work_item) = current_work_item {
@@ -2147,6 +2149,7 @@ fn build_relevant_episode_memory_section(
     current_message: &MessageEnvelope,
     config: &ContextConfig,
     budget: usize,
+    recent_turn_window_start: Option<u64>,
 ) -> Option<PromptSection> {
     if episodes.is_empty() || config.max_relevant_episodes == 0 || budget == 0 {
         return None;
@@ -2181,6 +2184,9 @@ fn build_relevant_episode_memory_section(
     let mut ranked = episodes
         .iter()
         .enumerate()
+        .filter(|(_, episode)| {
+            episode_is_before_recent_turn_window(episode, recent_turn_window_start)
+        })
         .map(|(index, episode)| {
             let recency_index = episode_count.saturating_sub(index + 1);
             (
@@ -2220,6 +2226,19 @@ fn build_relevant_episode_memory_section(
         "relevant_episode_memory",
         format!("Relevant episode memory:\n{}", blocks.join("\n")),
     ))
+}
+
+fn recent_turn_window_start(turn_records: &[crate::types::TurnRecord]) -> Option<u64> {
+    turn_records.iter().map(|turn| turn.turn_index).min()
+}
+
+fn episode_is_before_recent_turn_window(
+    episode: &ContextEpisodeRecord,
+    recent_turn_window_start: Option<u64>,
+) -> bool {
+    recent_turn_window_start
+        .map(|start| episode.end_turn_index < start)
+        .unwrap_or(true)
 }
 
 fn render_episode_block(episode: &ContextEpisodeRecord) -> String {
@@ -5395,6 +5414,7 @@ mod tests {
                 ..ContextConfig::default()
             },
             120,
+            None,
         )
         .expect("relevant episode memory section should be present");
 
@@ -5416,6 +5436,199 @@ mod tests {
             .content
             .contains("keep behavior unchanged outside the wake path"));
         assert!(!episode_section.content.contains("ep_old"));
+    }
+
+    #[test]
+    fn build_context_excludes_episode_overlapping_recent_turn_window() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+
+        let archived_episode = ContextEpisodeRecord {
+            id: "ep_archived".into(),
+            agent_id: "default".into(),
+            workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
+            created_at: chrono::Utc::now(),
+            finalized_at: chrono::Utc::now(),
+            start_turn_index: 1,
+            end_turn_index: 2,
+            start_message_count: 1,
+            end_message_count: 4,
+            boundary_reason: EpisodeBoundaryReason::HardTurnCap,
+            current_work_item_id: Some("work_wake".into()),
+            objective: Some("Fix wake path".into()),
+            work_summary: Some("wake path patching".into()),
+            scope_hints: vec![],
+            source_turn_ids: vec![],
+            source_refs: vec![],
+            generated_by: None,
+            operator_intents: vec![],
+            runtime_facts: vec![],
+            task_results: vec![],
+            unresolved_items: vec![],
+            model_inferences: vec![],
+            summary: "Archived wake path evidence from older turns.".into(),
+            working_set_files: vec!["src/runtime.rs".into()],
+            commands: vec![],
+            verification: vec![],
+            decisions: vec![],
+            carry_forward: vec![],
+            waiting_on: vec![],
+        };
+        storage.append_context_episode(&archived_episode).unwrap();
+
+        let overlapping_episode = ContextEpisodeRecord {
+            id: "ep_recent_overlap".into(),
+            start_turn_index: 4,
+            end_turn_index: 5,
+            summary: "Recent wake path evidence already covered by recent_turns.".into(),
+            ..archived_episode.clone()
+        };
+        storage
+            .append_context_episode(&overlapping_episode)
+            .unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue fixing the wake path in src/runtime.rs.".to_string(),
+            },
+        );
+
+        let mut session = AgentState::new("default");
+        session.working_memory.current_working_memory = WorkingMemorySnapshot {
+            current_work_item_id: Some("work_wake".into()),
+            objective: Some("Fix wake path".into()),
+            work_summary: Some("wake path patching".into()),
+            working_set_files: vec!["src/runtime.rs".into()],
+            ..WorkingMemorySnapshot::default()
+        };
+
+        let episodes = storage.read_recent_context_episodes(4).unwrap();
+        let section = build_relevant_episode_memory_section(
+            &episodes,
+            &session,
+            None,
+            &current_message,
+            &ContextConfig {
+                max_relevant_episodes: 3,
+                ..ContextConfig::default()
+            },
+            240,
+            Some(4),
+        )
+        .expect("archived episode should still be recalled");
+
+        assert!(section.content.contains("ep_archived"));
+        assert!(!section.content.contains("ep_recent_overlap"));
+    }
+
+    #[test]
+    fn build_context_orders_work_item_before_relevant_episode_memory() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+
+        let mut work_item =
+            crate::types::WorkItemRecord::new("default", "Fix wake path", WorkItemState::Open);
+        work_item.id = "work_wake".into();
+        work_item.plan_status = crate::types::WorkItemPlanStatus::Ready;
+        storage.append_work_item(&work_item).unwrap();
+
+        let mut agent = AgentState::new("default");
+        agent.current_work_item_id = Some(work_item.id.clone());
+        agent.working_memory.current_working_memory = WorkingMemorySnapshot {
+            current_work_item_id: Some(work_item.id.clone()),
+            objective: Some("Fix wake path".into()),
+            work_summary: Some("wake path patching".into()),
+            working_set_files: vec!["src/runtime.rs".into()],
+            ..WorkingMemorySnapshot::default()
+        };
+        storage.write_agent(&agent).unwrap();
+
+        storage
+            .append_context_episode(&ContextEpisodeRecord {
+                id: "ep_archived".into(),
+                agent_id: "default".into(),
+                workspace_id: crate::types::AGENT_HOME_WORKSPACE_ID.into(),
+                created_at: chrono::Utc::now(),
+                finalized_at: chrono::Utc::now(),
+                start_turn_index: 1,
+                end_turn_index: 2,
+                start_message_count: 1,
+                end_message_count: 4,
+                boundary_reason: EpisodeBoundaryReason::HardTurnCap,
+                current_work_item_id: Some(work_item.id.clone()),
+                objective: Some("Fix wake path".into()),
+                work_summary: Some("wake path patching".into()),
+                scope_hints: vec![],
+                source_turn_ids: vec![],
+                source_refs: vec![],
+                generated_by: None,
+                operator_intents: vec![],
+                runtime_facts: vec![],
+                task_results: vec![],
+                unresolved_items: vec![],
+                model_inferences: vec![],
+                summary: "Archived wake path evidence from older turns.".into(),
+                working_set_files: vec!["src/runtime.rs".into()],
+                commands: vec![],
+                verification: vec![],
+                decisions: vec![],
+                carry_forward: vec![],
+                waiting_on: vec![],
+            })
+            .unwrap();
+
+        storage
+            .append_turn(&TurnRecord::new("default", "turn-4", 4))
+            .unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue fixing the wake path in src/runtime.rs.".to_string(),
+            },
+        );
+
+        let built = build_context(
+            &storage,
+            &agent,
+            &execution_snapshot_for(&agent),
+            &crate::types::SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig {
+                recent_messages: 4,
+                recent_episode_candidates: 4,
+                max_relevant_episodes: 2,
+                prompt_budget_estimated_tokens: 2048,
+                ..ContextConfig::default()
+            },
+        )
+        .unwrap();
+
+        let names = built
+            .sections
+            .iter()
+            .map(|section| section.name.as_str())
+            .collect::<Vec<_>>();
+        let work_item_index = names
+            .iter()
+            .position(|name| *name == "current_work_item")
+            .expect("current_work_item section");
+        let episode_index = names
+            .iter()
+            .position(|name| *name == "relevant_episode_memory")
+            .expect("relevant_episode_memory section");
+
+        assert!(work_item_index < episode_index);
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -2229,7 +2229,10 @@ fn build_relevant_episode_memory_section(
 }
 
 fn recent_turn_window_start(turn_records: &[crate::types::TurnRecord]) -> Option<u64> {
-    turn_records.iter().map(|turn| turn.turn_index).min()
+    turn_records
+        .iter()
+        .filter_map(|turn| (turn.turn_index != 0).then_some(turn.turn_index))
+        .min()
 }
 
 fn episode_is_before_recent_turn_window(
@@ -5524,6 +5527,14 @@ mod tests {
 
         assert!(section.content.contains("ep_archived"));
         assert!(!section.content.contains("ep_recent_overlap"));
+    }
+
+    #[test]
+    fn recent_turn_window_start_ignores_zero_sentinel_turn_index() {
+        let sentinel = crate::types::TurnRecord::new("default", "turn-zero", 0);
+        let recent = crate::types::TurnRecord::new("default", "turn-recent", 6);
+
+        assert_eq!(recent_turn_window_start(&[sentinel, recent]), Some(6));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1643

## Summary
- filter relevant episode recall to episodes older than the recent_turns window
- keep current_work_item ahead of relevant_episode_memory in prompt section ordering
- document the recent_turns / WorkItem / episode recall boundary

## Verification
- cargo test build_context_
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets