### PR TITLE
fix: filter noisy TUI action display

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -408,6 +408,28 @@ impl PresentationItem {
             }
         )
     }
+
+    pub(crate) fn is_live_working_activity_item(&self) -> bool {
+        matches!(
+            self,
+            PresentationItem::AssistantProgress { .. }
+                | PresentationItem::ActionGroup { .. }
+                | PresentationItem::CommandExecuted { .. }
+                | PresentationItem::FileRead { .. }
+                | PresentationItem::FileChange { .. }
+                | PresentationItem::PatchFailure { .. }
+                | PresentationItem::ToolAction { .. }
+                | PresentationItem::PlanShown { .. }
+        )
+    }
+}
+
+pub(crate) fn event_has_live_working_activity_item(event: &ProjectionEventRecord) -> bool {
+    let mut reducer = PresentationReducer::new();
+    reducer
+        .reduce(&[event.clone()])
+        .iter()
+        .any(|timed| timed.item.is_live_working_activity_item() && timed.item.is_visible_at(4))
 }
 
 // ── Renderable trait ───────────────────────────────────────────────────────

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -904,11 +904,7 @@ fn assistant_message_from_event(
     event: &crate::tui::projection::ProjectionEventRecord,
 ) -> Option<String> {
     match event.kind.as_str() {
-        "assistant_round_recorded" => event
-            .presentation
-            .body
-            .clone()
-            .or_else(|| event.payload.get("text_preview").and_then(non_empty_value)),
+        "assistant_round_recorded" => event.payload.get("text_preview").and_then(non_empty_value),
         "provider_round_completed" => None,
         _ if is_progress_event(event) => event.presentation.body.clone(),
         _ => None,
@@ -1354,6 +1350,20 @@ mod tests {
             assistant_message_from_event(&assistant).as_deref(),
             Some("I will inspect the event path first.")
         );
+    }
+
+    #[test]
+    fn assistant_round_tool_request_is_not_activity_message() {
+        let assistant = event(
+            "assistant_round_recorded",
+            "Assistant requested tools: ExecCommand",
+            json!({
+                "text_preview": null,
+                "tool_names": ["ExecCommand"]
+            }),
+        );
+
+        assert!(assistant_message_from_event(&assistant).is_none());
     }
 
     #[test]

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -23,6 +23,7 @@ use crate::{
         is_operator_event_in_display_mode, present_operator_event, OperatorEventCategory,
         OperatorEventPresentation, OperatorPresentationContext,
     },
+    presentation::event_has_live_working_activity_item,
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
         ActiveWorkspaceEntry, AgentState, AgentSummary, BriefRecord, ClosureDecision,
@@ -846,6 +847,10 @@ impl TuiProjection {
         if self.is_visible_in_display_mode(record, OperatorDisplayMode::Info)
             || !self.is_visible_in_display_mode(record, OperatorDisplayMode::Debug)
         {
+            return;
+        }
+
+        if !event_has_live_working_activity_item(record) {
             return;
         }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2700,6 +2700,50 @@ fn chat_display_mode_info_shows_hidden_stream_activity_in_working_body() {
 }
 
 #[test]
+fn chat_display_mode_info_suppresses_successful_work_item_tool_activity() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.display_mode = OperatorDisplayMode::Info;
+    let mut snapshot = sample_snapshot("default", "evt-0");
+    snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+    let mut projection = TuiProjection::from_snapshot(snapshot);
+    projection.apply_stream_event(
+        AgentStreamEvent {
+            id: "evt-work-item-tool".into(),
+            event: "tool_executed".into(),
+            data: StreamEventEnvelope {
+                id: "evt-work-item-tool".into(),
+                event_seq: 2,
+                ts: Utc::now(),
+                agent_id: "default".into(),
+                event_type: "tool_executed".into(),
+                provenance: None,
+                payload: json!({
+                    "tool_name": "UpdateWorkItem",
+                    "status": "success",
+                    "summary": "updated work item"
+                }),
+            },
+        },
+        &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        app.display_mode,
+    );
+    app.projection = Some(projection);
+
+    let items = collect_chat_items(&app);
+    let active_item = items.last().expect("active activity item");
+    match active_item {
+        ConversationCell::ActiveActivity { body, .. } => {
+            assert!(body.is_empty());
+        }
+        other => panic!("expected active activity item, got {other:?}"),
+    }
+}
+
+#[test]
 fn chat_display_mode_verbose_keeps_working_marker_without_activity_body() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(


### PR DESCRIPTION
## Summary
- stop rendering assistant tool/action names as assistant message text when the assistant round has no text preview
- make the live working activity feed reuse presentation reducer visibility at level 4, so successful work-item/action-only tool events stay out of the working body
- add regression coverage for both assistant tool requests and successful work-item tool activity suppression

## Verification
- `cargo test tui::chat::tests::assistant_round_tool_request_is_not_activity_message`
- `cargo test chat_display_mode_info_suppresses_successful_work_item_tool_activity`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
