### PR TITLE
fix: scope runtime DB storage by agent

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2654,7 +2654,7 @@ mod tests {
     #[test]
     fn recent_turns_prefers_db_turn_records_when_available() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -2734,7 +2734,7 @@ mod tests {
     #[test]
     fn recent_turns_keeps_db_turn_when_trigger_message_is_outside_window() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -2810,7 +2810,7 @@ mod tests {
     #[test]
     fn recent_turns_hydrates_turn_record_references_outside_recent_windows() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -3810,6 +3810,7 @@ mod tests {
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
+            agent_id: "default".into(),
             from_revision: 0,
             to_revision: 1,
             created_at_turn: 1,
@@ -5462,6 +5463,7 @@ mod tests {
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
+            agent_id: "default".into(),
             from_revision: 1,
             to_revision: 2,
             created_at_turn: 2,
@@ -5573,6 +5575,7 @@ mod tests {
             ..WorkingMemorySnapshot::default()
         };
         session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
+            agent_id: "default".into(),
             from_revision: 4,
             to_revision: 5,
             created_at_turn: 7,

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -271,7 +271,7 @@ pub(crate) fn clear_persisted_daemon_lifecycle_failures(config: &AppConfig) -> R
 }
 
 fn latest_public_runtime_failure(config: &AppConfig) -> Result<Option<RuntimeFailureSummary>> {
-    let host_storage = AppStorage::new(config.home_dir.join("host"))?;
+    let host_storage = AppStorage::new_global(config.home_dir.join("host"))?;
     let mut latest = None;
     for identity in host_storage
         .latest_agent_identities()?
@@ -281,7 +281,10 @@ fn latest_public_runtime_failure(config: &AppConfig) -> Result<Option<RuntimeFai
                 && record.visibility == AgentVisibility::Public
         })
     {
-        let storage = AppStorage::new(config.agent_root_dir().join(&identity.agent_id))?;
+        let storage = AppStorage::new_for_agent(
+            config.agent_root_dir().join(&identity.agent_id),
+            identity.agent_id.clone(),
+        )?;
         let failure = storage
             .read_agent()?
             .and_then(|agent| agent.last_runtime_failure);

--- a/src/host.rs
+++ b/src/host.rs
@@ -291,7 +291,7 @@ impl RuntimeHost {
         agent_id: &str,
     ) -> std::result::Result<RuntimeHandle, PublicAgentError> {
         self.public_agent_identity(agent_id)?;
-        let state = AppStorage::new(self.agent_data_dir(agent_id))
+        let state = AppStorage::new_for_agent(self.agent_data_dir(agent_id), agent_id.to_string())
             .map_err(PublicAgentError::Runtime)?
             .read_agent()
             .map_err(PublicAgentError::Runtime)?
@@ -567,7 +567,7 @@ impl RuntimeHost {
             if !agent_home.exists() {
                 continue;
             }
-            let storage = AppStorage::new(agent_home)?;
+            let storage = AppStorage::new_for_agent(agent_home, identity.agent_id.clone())?;
             records.extend(storage.read_recent_external_triggers(usize::MAX)?);
         }
         self.inner
@@ -658,7 +658,10 @@ impl RuntimeHost {
         &self,
         identity: &AgentIdentityRecord,
     ) -> Result<AgentListEntry> {
-        let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
+        let storage = AppStorage::new_for_agent(
+            self.agent_data_dir(&identity.agent_id),
+            identity.agent_id.clone(),
+        )?;
         let agent = match storage.read_agent() {
             Ok(Some(agent)) => agent,
             Ok(None) => stopped_unloaded_agent(&identity.agent_id),
@@ -723,7 +726,10 @@ impl RuntimeHost {
                 });
                 continue;
             }
-            let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
+            let storage = AppStorage::new_for_agent(
+                self.agent_data_dir(&identity.agent_id),
+                identity.agent_id.clone(),
+            )?;
             let state = storage
                 .read_agent()?
                 .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
@@ -749,7 +755,10 @@ impl RuntimeHost {
                 && record.kind == AgentKind::Child
                 && record.parent_agent_id.as_deref() == Some(parent_agent_id)
         }) {
-            let storage = AppStorage::new(self.agent_data_dir(&identity.agent_id))?;
+            let storage = AppStorage::new_for_agent(
+                self.agent_data_dir(&identity.agent_id),
+                identity.agent_id.clone(),
+            )?;
             let state = storage
                 .read_agent()?
                 .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
@@ -936,7 +945,8 @@ impl RuntimeHost {
         if !parent_data_dir.exists() {
             return Ok(true);
         }
-        let parent_storage = AppStorage::new(parent_data_dir)?;
+        let parent_storage =
+            AppStorage::new_for_agent(parent_data_dir, parent_agent_id.to_string())?;
         let Some(task) = parent_storage.latest_task_record(task_id)? else {
             return Ok(true);
         };
@@ -1133,7 +1143,10 @@ impl RuntimeHost {
         child_turn_baseline: u64,
         worktree: bool,
     ) -> Result<ChildTaskTerminalResult> {
-        let storage = AppStorage::new(self.agent_data_dir(child_agent_id))?;
+        let storage = AppStorage::new_for_agent(
+            self.agent_data_dir(child_agent_id),
+            child_agent_id.to_string(),
+        )?;
         if let Some(result) = self
             .completed_child_terminal_from_storage(&storage, child_agent_id, child_turn_baseline)
             .await?
@@ -1406,7 +1419,7 @@ impl RuntimeHost {
 }
 
 fn import_host_registry_domains(config: &AppConfig, runtime_db: &RuntimeDb) -> Result<()> {
-    let host_storage = AppStorage::new(config.home_dir.join("host"))?;
+    let host_storage = AppStorage::new_global(config.home_dir.join("host"))?;
     if !runtime_db.storage_domain_is_complete("workspace_entries", "db")? {
         runtime_db
             .workspace_entries()
@@ -1473,7 +1486,7 @@ fn repair_host_agent_legacy_evidence_import(
         if !agent_home.exists() {
             continue;
         }
-        let storage = AppStorage::new(agent_home)?;
+        let storage = AppStorage::new_for_agent(agent_home, agent_id.clone())?;
         match storage.read_all_messages() {
             Ok(messages) => {
                 let legacy_max_seq = messages
@@ -1595,7 +1608,10 @@ impl RuntimeHostBridge {
         {
             return Ok(None);
         }
-        let storage = AppStorage::new(host.agent_data_dir(child_agent_id))?;
+        let storage = AppStorage::new_for_agent(
+            host.agent_data_dir(child_agent_id),
+            child_agent_id.to_string(),
+        )?;
         let state = storage
             .read_agent()?
             .unwrap_or_else(|| AgentState::new(child_agent_id.to_string()));
@@ -2001,7 +2017,7 @@ mod tests {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
-        let host_storage = AppStorage::new(config.home_dir.join("host")).unwrap();
+        let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
         host_storage
             .append_agent_identity(&AgentIdentityRecord::new(
                 "release-bot",
@@ -2052,7 +2068,7 @@ mod tests {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
-        let host_storage = AppStorage::new(config.home_dir.join("host")).unwrap();
+        let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
         host_storage
             .append_agent_identity(&AgentIdentityRecord::new(
                 "release-bot",
@@ -2108,7 +2124,7 @@ mod tests {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
-        let host_storage = AppStorage::new(config.home_dir.join("host")).unwrap();
+        let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
         host_storage
             .append_agent_identity(&AgentIdentityRecord::new(
                 "release-bot",

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -26,7 +26,7 @@ struct RuntimeRegistryInner {
 
 impl RuntimeRegistry {
     pub(crate) fn new(config: AppConfig, runtime_db: RuntimeDb) -> Result<Self> {
-        let host_storage = AppStorage::new(config.home_dir.join("host"))?;
+        let host_storage = AppStorage::new_global(config.home_dir.join("host"))?;
         if !runtime_db.storage_domain_is_complete("workspace_entries", "db")? {
             runtime_db
                 .workspace_entries()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1111,8 +1111,9 @@ mod tests {
     #[test]
     fn export_scheduler_fixture_writes_replay_harness_shape() {
         let config = test_config();
+        let agent_id = "default";
         let agent_home = config.data_dir.join("agents/default");
-        let storage = AppStorage::new(&agent_home).unwrap();
+        let storage = AppStorage::new_for_agent(&agent_home, agent_id).unwrap();
         let mut agent = holon::types::AgentState::new("default");
         agent.current_work_item_id = Some("work-1".into());
         storage.write_agent(&agent).unwrap();
@@ -1479,7 +1480,7 @@ fn export_scheduler_fixture(
 ) -> Result<()> {
     let agent_id = agent.unwrap_or_else(|| config.default_agent_id.clone());
     let agent_home = config.data_dir.join("agents").join(&agent_id);
-    let storage = AppStorage::new(&agent_home)?;
+    let storage = AppStorage::new_for_agent(&agent_home, agent_id.clone())?;
     let agent = storage.read_agent()?.with_context(|| {
         format!(
             "agent state not found for {agent_id} in {}",
@@ -1671,7 +1672,7 @@ fn print_latency_diagnostics(
 ) -> Result<()> {
     let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
     let agent_home = config.data_dir.join("agents").join(&agent);
-    let storage = AppStorage::new(&agent_home)?;
+    let storage = AppStorage::new_for_agent(&agent_home, agent.clone())?;
     let events = storage.read_recent_events(events_limit)?;
     let diagnostics = build_latency_diagnostics(&events, limit);
     if diagnostics.is_empty() {

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1744,7 +1744,8 @@ fn todo_item_state_label(state: crate::types::TodoItemState) -> &'static str {
 fn storage_agent_id(storage: &AppStorage) -> String {
     storage
         .current_agent_id()
-        .expect("failed to read storage agent scope")
+        .ok()
+        .flatten()
         .unwrap_or_else(|| "global".into())
 }
 
@@ -1887,7 +1888,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_agent_memory_and_repairs_external_edits() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         fs::write(
@@ -2035,7 +2036,7 @@ mod tests {
     #[test]
     fn memory_get_returns_exact_markdown_and_runtime_source_content() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         let markdown = "The agent now remembers 混合 搜索 diagnostics.";
@@ -2092,7 +2093,7 @@ mod tests {
     #[test]
     fn memory_get_returns_db_backed_runtime_evidence_content() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -2124,7 +2125,7 @@ mod tests {
     #[test]
     fn deleting_known_memory_markdown_removes_index_row() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         let path = agent_memory_self_path(dir.path());
@@ -2150,7 +2151,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_workspace_profile_briefs_episodes_and_work_items() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -2314,7 +2315,7 @@ mod tests {
     #[test]
     fn missing_index_rebuilds_all_existing_memory_sources_before_repair() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -2391,7 +2392,7 @@ mod tests {
     #[test]
     fn controlled_changed_paths_repair_known_memory_markdown_only() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         fs::write(
@@ -2420,7 +2421,7 @@ mod tests {
     #[test]
     fn ordinary_workspace_markdown_is_not_indexed_as_memory() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         let workspace = dir.path().join("workspace");
@@ -2452,7 +2453,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_task_records_with_summary_and_work_item_lookup() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -2512,7 +2513,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_task_records_by_command_fragment_and_digest() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -2553,7 +2554,7 @@ mod tests {
     #[test]
     fn memory_search_task_index_uses_latest_snapshot_only() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -2604,7 +2605,7 @@ mod tests {
     #[test]
     fn memory_search_task_index_full_backfill_indexes_older_task_history() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -2652,7 +2653,7 @@ mod tests {
     #[test]
     fn pending_source_queue_incrementally_upserts_new_brief_after_backfill() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -2701,7 +2702,7 @@ mod tests {
     #[test]
     fn pending_delete_removes_stale_document_and_source_state() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         fs::write(
@@ -2737,7 +2738,7 @@ mod tests {
     #[test]
     fn missing_checkpoint_forces_full_backfill_recovery() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -2779,7 +2780,7 @@ mod tests {
     #[test]
     fn stale_source_state_schema_forces_rebuild() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -2820,7 +2821,7 @@ mod tests {
     #[test]
     fn extra_checkpoint_rows_do_not_hide_missing_required_backfill_kind() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_brief(&brief_with_workspace(
@@ -2861,7 +2862,7 @@ mod tests {
     #[test]
     fn memory_get_returns_latest_task_record_for_task_source_ref() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -2902,7 +2903,7 @@ mod tests {
     #[test]
     fn command_receipts_preserve_long_exec_command_input_for_memory_get() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let command = "python - <<'PY'\nprint('receipt_start')\nprint('sentinel_middle_line_1246')\nprint('receipt_end')\nPY";
         storage
@@ -2958,7 +2959,7 @@ mod tests {
     #[test]
     fn command_receipts_preserve_exec_command_batch_item_inputs() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let first_command = "rg -n \"MemorySearch\" src/memory/index.rs";
         let second_command = "node - <<'NODE'\nconsole.log('batch_receipt_middle_1246')\nNODE";
@@ -3014,7 +3015,7 @@ mod tests {
     #[test]
     fn pending_exec_command_batch_item_upsert_resolves_tool_execution_record() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_brief(&brief_with_workspace(
@@ -3089,7 +3090,7 @@ mod tests {
     #[test]
     fn command_output_resolves_exec_command_batch_envelope_items() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_tool_execution(&ToolExecutionRecord {
@@ -3141,7 +3142,7 @@ mod tests {
     #[test]
     fn command_output_indexes_unavailable_batch_item_without_result() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_tool_execution(&ToolExecutionRecord {

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1744,9 +1744,8 @@ fn todo_item_state_label(state: crate::types::TodoItemState) -> &'static str {
 fn storage_agent_id(storage: &AppStorage) -> String {
     storage
         .current_agent_id()
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| "unknown".into())
+        .expect("failed to read storage agent scope")
+        .unwrap_or_else(|| "global".into())
 }
 
 fn file_updated_at(path: &Path) -> DateTime<Utc> {

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -380,6 +380,7 @@ fn derive_working_memory_delta(
     );
 
     WorkingMemoryDelta {
+        agent_id: agent.id.clone(),
         from_revision: agent
             .working_memory
             .last_prompted_working_memory_revision
@@ -401,6 +402,7 @@ fn merge_pending_delta(
     };
 
     WorkingMemoryDelta {
+        agent_id: new_delta.agent_id.clone(),
         from_revision: pending.from_revision,
         to_revision: new_delta.to_revision,
         created_at_turn: new_delta.created_at_turn,
@@ -890,7 +892,7 @@ mod tests {
     #[test]
     fn derive_working_memory_snapshot_projects_work_state_and_tool_evidence() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
 
         let mut active = WorkItemRecord::new(
             "default",
@@ -1082,7 +1084,7 @@ mod tests {
     #[test]
     fn derive_working_memory_snapshot_uses_waiting_anchor_when_no_active_work_exists() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
 
         let queued = WorkItemRecord::new(
             "default",
@@ -1122,7 +1124,7 @@ mod tests {
     #[test]
     fn derive_working_memory_snapshot_prefers_active_work_bound_briefs_and_tools() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
 
         let active = WorkItemRecord::new("default", "current active summary", WorkItemState::Open);
         storage.append_work_item(&active).unwrap();
@@ -1253,7 +1255,7 @@ mod tests {
     #[test]
     fn derive_working_memory_snapshot_scans_past_trimmed_recent_noise_for_bound_evidence() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
 
         let active = WorkItemRecord::new("default", "current target", WorkItemState::Open);
         let other = WorkItemRecord::new("default", "other target", WorkItemState::Open);
@@ -1340,7 +1342,7 @@ mod tests {
     #[test]
     fn derive_working_memory_snapshot_sorts_waiting_on_by_work_relevance_and_recency() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         let base = Utc::now();
 
         let active = WorkItemRecord::new("default", "current waiting target", WorkItemState::Open);
@@ -1465,7 +1467,7 @@ mod tests {
     #[test]
     fn refresh_working_memory_merges_unprompted_updates_and_resets_after_prompt() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 1;
 
@@ -1592,7 +1594,7 @@ mod tests {
     #[test]
     fn refresh_working_memory_scrubs_legacy_prose_fields_without_empty_delta() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 1;
 
@@ -1655,7 +1657,7 @@ mod tests {
     #[test]
     fn refresh_working_memory_clears_stale_context_summary_when_memory_is_active() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         let mut agent = AgentState::new("default");
         agent.context_summary = Some("stale compacted summary".into());
 

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -405,7 +405,8 @@ fn prepare_runtime_storage(
     initial_workspace: impl Into<InitialWorkspaceBinding>,
     runtime_db: Option<RuntimeDb>,
 ) -> Result<PreparedRuntimeStorage> {
-    let storage = AppStorage::new(data_dir)?;
+    let agent_id = agent_id.into();
+    let storage = AppStorage::new_for_agent(data_dir, agent_id.clone())?;
     let runtime_db = match runtime_db {
         Some(runtime_db) => runtime_db,
         None => RuntimeDb::open_and_migrate(
@@ -413,7 +414,6 @@ fn prepare_runtime_storage(
             storage.runtime_dir().join("state/runtime.lock"),
         )?,
     };
-    let agent_id = agent_id.into();
     let initial_workspace = initial_workspace.into();
     let initial_workspace_entry = match &initial_workspace {
         InitialWorkspaceBinding::Entry(entry) => Some(entry.clone()),

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -1288,6 +1288,7 @@ async fn interactive_turn_keeps_pending_working_memory_delta_when_prompt_omits_i
         guard.state.working_memory.working_memory_revision = 5;
         guard.state.working_memory.pending_working_memory_delta =
             Some(crate::types::WorkingMemoryDelta {
+                agent_id: "default".into(),
                 from_revision: 4,
                 to_revision: 5,
                 created_at_turn: 7,

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -494,6 +494,31 @@ impl WorkItemDelegationRepository<'_> {
         Ok(records)
     }
 
+    pub fn recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<WorkItemDelegationRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_item_delegations
+             WHERE parent_agent_id = ?1 OR child_agent_id = ?1
+             ORDER BY updated_at DESC, created_at DESC, delegation_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_work_item_delegation_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
     pub fn latest_for_child(
         &self,
         child_agent_id: &str,
@@ -538,7 +563,11 @@ impl WorkingMemoryDeltaRepository<'_> {
             .transaction(|tx| upsert_working_memory_delta_tx(tx, record))
     }
 
-    pub fn recent(&self, limit: usize) -> Result<Vec<WorkingMemoryDelta>> {
+    pub fn recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<WorkingMemoryDelta>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
@@ -547,10 +576,11 @@ impl WorkingMemoryDeltaRepository<'_> {
         let mut statement = connection.prepare(
             "SELECT payload_json
              FROM working_memory_deltas
+             WHERE agent_id = ?1
              ORDER BY created_at DESC, memory_delta_id ASC
-             LIMIT ?1",
+             LIMIT ?2",
         )?;
-        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
         let mut records: Vec<_> = rows
             .map(|row| decode_working_memory_delta_payload(&row?))
             .collect::<Result<_>>()?;
@@ -595,6 +625,31 @@ impl ContextEpisodeRepository<'_> {
              LIMIT ?1",
         )?;
         let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_context_episode_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ContextEpisodeRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM context_episodes
+             WHERE agent_id = ?1
+             ORDER BY ended_at DESC, started_at DESC, episode_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
         let mut records: Vec<_> = rows
             .map(|row| decode_context_episode_payload(&row?))
             .collect::<Result<_>>()?;
@@ -854,6 +909,31 @@ impl WaitConditionRepository<'_> {
         Ok(records)
     }
 
+    pub fn recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<WaitConditionRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM wait_conditions
+             WHERE agent_id = ?1
+             ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_wait_condition_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
     pub fn active_for_agent(&self, agent_id: &str) -> Result<Vec<WaitConditionRecord>> {
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
@@ -995,6 +1075,27 @@ impl TimerRepository<'_> {
              LIMIT ?1",
         )?;
         let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_timer_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn recent_for_agent(&self, agent_id: &str, limit: usize) -> Result<Vec<TimerRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM timers
+             WHERE agent_id = ?1
+             ORDER BY updated_at DESC, created_at DESC, timer_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
         let mut records: Vec<_> = rows
             .map(|row| decode_timer_payload(&row?))
             .collect::<Result<_>>()?;
@@ -2418,18 +2519,23 @@ fn upsert_work_item_delegation_tx(
 }
 
 fn upsert_working_memory_delta_tx(tx: &Transaction<'_>, record: &WorkingMemoryDelta) -> Result<()> {
+    anyhow::ensure!(
+        !record.agent_id.trim().is_empty(),
+        "working memory delta requires an agent_id"
+    );
     let payload_json = serde_json::to_string(record)?;
     let reason = enum_string(&record.reason)?;
     let memory_delta_id = format!(
-        "memory-delta-{}-{}-{}",
-        record.from_revision, record.to_revision, record.created_at_turn
+        "memory-delta-{}-{}-{}-{}",
+        record.agent_id, record.from_revision, record.to_revision, record.created_at_turn
     );
     tx.execute(
         "INSERT INTO working_memory_deltas (
-            memory_delta_id, from_revision, to_revision, created_at_turn, reason,
+            memory_delta_id, agent_id, from_revision, to_revision, created_at_turn, reason,
             created_at, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
          ON CONFLICT(memory_delta_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
             from_revision = excluded.from_revision,
             to_revision = excluded.to_revision,
             created_at_turn = excluded.created_at_turn,
@@ -2438,6 +2544,7 @@ fn upsert_working_memory_delta_tx(tx: &Transaction<'_>, record: &WorkingMemoryDe
             payload_json = excluded.payload_json",
         params![
             memory_delta_id,
+            record.agent_id,
             record.from_revision as i64,
             record.to_revision as i64,
             record.created_at_turn as i64,
@@ -4023,6 +4130,7 @@ CREATE TABLE IF NOT EXISTS work_item_delegations (
 
 CREATE TABLE IF NOT EXISTS working_memory_deltas (
   memory_delta_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
   from_revision INTEGER NOT NULL,
   to_revision INTEGER NOT NULL,
   created_at_turn INTEGER NOT NULL,
@@ -4052,7 +4160,7 @@ CREATE INDEX IF NOT EXISTS idx_work_item_delegations_child
 CREATE INDEX IF NOT EXISTS idx_work_item_delegations_state
   ON work_item_delegations(state);
 CREATE INDEX IF NOT EXISTS idx_working_memory_deltas_revision
-  ON working_memory_deltas(to_revision, created_at);
+  ON working_memory_deltas(agent_id, to_revision, created_at);
 CREATE INDEX IF NOT EXISTS idx_context_episodes_agent_turn
   ON context_episodes(agent_id, end_turn_index);
 CREATE INDEX IF NOT EXISTS idx_context_episodes_work_item
@@ -4447,6 +4555,7 @@ impl RuntimeDb {
         for migration in MIGRATIONS {
             apply_migration(&mut connection, migration)?;
         }
+        repair_unreleased_working_memory_delta_scope(&mut connection)?;
         Ok(())
     }
 }
@@ -4559,6 +4668,59 @@ fn apply_migration(connection: &mut Connection, migration: &Migration) -> Result
     )?;
     transaction.commit()?;
     Ok(())
+}
+
+fn repair_unreleased_working_memory_delta_scope(connection: &mut Connection) -> Result<()> {
+    if !table_exists(connection, "working_memory_deltas")?
+        || table_has_column(connection, "working_memory_deltas", "agent_id")?
+    {
+        return Ok(());
+    }
+
+    let transaction = connection.transaction()?;
+    transaction.execute_batch(
+        r#"
+DROP TABLE working_memory_deltas;
+CREATE TABLE working_memory_deltas (
+  memory_delta_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  from_revision INTEGER NOT NULL,
+  to_revision INTEGER NOT NULL,
+  created_at_turn INTEGER NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_working_memory_deltas_revision
+  ON working_memory_deltas(agent_id, to_revision, created_at);
+"#,
+    )?;
+    transaction.execute(
+        "DELETE FROM storage_domains WHERE domain = ?1",
+        ["working_memory_deltas"],
+    )?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn table_exists(connection: &Connection, table_name: &str) -> Result<bool> {
+    let exists = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+        [table_name],
+        |row| row.get::<_, bool>(0),
+    )?;
+    Ok(exists)
+}
+
+fn table_has_column(connection: &Connection, table_name: &str, column_name: &str) -> Result<bool> {
+    let mut statement = connection.prepare(&format!("PRAGMA table_info({table_name})"))?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(1))?;
+    for row in rows {
+        if row? == column_name {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn current_schema_version(connection: &Connection) -> Result<i64> {
@@ -4821,6 +4983,56 @@ mod tests {
             current_schema_version(&connection)?,
             max_known_migration_version()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_db_migration_repairs_unreleased_working_memory_delta_scope() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        {
+            let connection = open_connection(&db_path)?;
+            connection.execute_batch(
+                r#"
+DROP TABLE working_memory_deltas;
+CREATE TABLE working_memory_deltas (
+  memory_delta_id TEXT PRIMARY KEY,
+  from_revision INTEGER NOT NULL,
+  to_revision INTEGER NOT NULL,
+  created_at_turn INTEGER NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+"#,
+            )?;
+            connection.execute(
+                "INSERT OR REPLACE INTO storage_domains (
+                    domain, schema_version, import_status, canonical_source, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                (
+                    "working_memory_deltas",
+                    max_known_migration_version(),
+                    "complete",
+                    "db",
+                    Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                ),
+            )?;
+        }
+
+        RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let connection = open_connection(&db_path)?;
+        assert!(table_has_column(
+            &connection,
+            "working_memory_deltas",
+            "agent_id"
+        )?);
+        let domain_count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM storage_domains WHERE domain = ?1",
+            ["working_memory_deltas"],
+            |row| row.get(0),
+        )?;
+        assert_eq!(domain_count, 0);
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -4677,10 +4677,13 @@ fn repair_unreleased_working_memory_delta_scope(connection: &mut Connection) -> 
         return Ok(());
     }
 
+    let backup_table =
+        next_legacy_backup_table_name(connection, "working_memory_deltas_unscoped_legacy")?;
     let transaction = connection.transaction()?;
-    transaction.execute_batch(
+    transaction.execute_batch(&format!(
         r#"
-DROP TABLE working_memory_deltas;
+DROP INDEX IF EXISTS idx_working_memory_deltas_revision;
+ALTER TABLE working_memory_deltas RENAME TO {backup_table};
 CREATE TABLE working_memory_deltas (
   memory_delta_id TEXT PRIMARY KEY,
   agent_id TEXT NOT NULL,
@@ -4694,13 +4697,26 @@ CREATE TABLE working_memory_deltas (
 CREATE INDEX IF NOT EXISTS idx_working_memory_deltas_revision
   ON working_memory_deltas(agent_id, to_revision, created_at);
 "#,
-    )?;
+    ))?;
     transaction.execute(
         "DELETE FROM storage_domains WHERE domain = ?1",
         ["working_memory_deltas"],
     )?;
     transaction.commit()?;
     Ok(())
+}
+
+fn next_legacy_backup_table_name(connection: &Connection, base_name: &str) -> Result<String> {
+    if !table_exists(connection, base_name)? {
+        return Ok(base_name.to_string());
+    }
+    for suffix in 2.. {
+        let candidate = format!("{base_name}_{suffix}");
+        if !table_exists(connection, &candidate)? {
+            return Ok(candidate);
+        }
+    }
+    unreachable!("unbounded suffix search should find a table name")
 }
 
 fn table_exists(connection: &Connection, table_name: &str) -> Result<bool> {
@@ -5007,6 +5023,21 @@ CREATE TABLE working_memory_deltas (
 "#,
             )?;
             connection.execute(
+                "INSERT INTO working_memory_deltas (
+                    memory_delta_id, from_revision, to_revision, created_at_turn,
+                    reason, created_at, payload_json
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                (
+                    "memory-delta-1-2-7",
+                    1_i64,
+                    2_i64,
+                    7_i64,
+                    "task_rejoined",
+                    Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                    "{}",
+                ),
+            )?;
+            connection.execute(
                 "INSERT OR REPLACE INTO storage_domains (
                     domain, schema_version, import_status, canonical_source, updated_at
                  ) VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -5027,6 +5058,16 @@ CREATE TABLE working_memory_deltas (
             "working_memory_deltas",
             "agent_id"
         )?);
+        assert!(table_exists(
+            &connection,
+            "working_memory_deltas_unscoped_legacy"
+        )?);
+        let backup_count: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM working_memory_deltas_unscoped_legacy",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(backup_count, 1);
         let domain_count: i64 = connection.query_row(
             "SELECT COUNT(*) FROM storage_domains WHERE domain = ?1",
             ["working_memory_deltas"],

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -167,6 +167,7 @@ pub struct RecoverySnapshot {
 #[derive(Debug, Clone)]
 pub struct AppStorage {
     data_dir: PathBuf,
+    agent_id: Option<String>,
     events_path: PathBuf,
     briefs_path: PathBuf,
     messages_path: PathBuf,
@@ -224,6 +225,28 @@ pub struct PollActivityMarker {
 impl AppStorage {
     pub fn new(data_dir: impl Into<PathBuf>) -> Result<Self> {
         let data_dir = data_dir.into();
+        let agent_id = infer_agent_id_from_data_dir(&data_dir);
+        Self::new_with_scope(data_dir, agent_id)
+    }
+
+    pub fn new_for_agent(
+        data_dir: impl Into<PathBuf>,
+        agent_id: impl Into<String>,
+    ) -> Result<Self> {
+        let agent_id = agent_id.into();
+        anyhow::ensure!(
+            !agent_id.trim().is_empty(),
+            "agent-scoped storage requires a non-empty agent id"
+        );
+        Self::new_with_scope(data_dir, Some(agent_id))
+    }
+
+    pub fn new_global(data_dir: impl Into<PathBuf>) -> Result<Self> {
+        Self::new_with_scope(data_dir, None)
+    }
+
+    fn new_with_scope(data_dir: impl Into<PathBuf>, agent_id: Option<String>) -> Result<Self> {
+        let data_dir = data_dir.into();
         fs::create_dir_all(&data_dir)
             .with_context(|| format!("failed to create {}", data_dir.display()))?;
         let runtime_dir = data_dir.join(RUNTIME_DIR);
@@ -247,6 +270,7 @@ impl AppStorage {
         let transcript_seq_counter = max_jsonl_u64_field(&transcript_path, "transcript_seq")?;
 
         Ok(Self {
+            agent_id,
             events_path,
             briefs_path: ledger_dir.join("briefs.jsonl"),
             messages_path,
@@ -345,24 +369,7 @@ impl AppStorage {
     }
 
     pub(crate) fn current_agent_id(&self) -> Result<Option<String>> {
-        if let Some(agent) = self.read_agent_file()? {
-            return Ok(Some(agent.id));
-        }
-        let parent_is_agents_dir = self
-            .data_dir
-            .parent()
-            .and_then(Path::file_name)
-            .and_then(|name| name.to_str())
-            == Some("agents");
-        if !parent_is_agents_dir {
-            return Ok(None);
-        }
-        Ok(self
-            .data_dir
-            .file_name()
-            .and_then(|name| name.to_str())
-            .filter(|name| !name.is_empty())
-            .map(ToString::to_string))
+        Ok(self.agent_id.clone())
     }
 
     pub fn data_dir(&self) -> &Path {
@@ -684,11 +691,12 @@ impl AppStorage {
     }
 
     pub fn append_working_memory_delta(&self, record: &WorkingMemoryDelta) -> Result<()> {
+        let record = self.working_memory_delta_for_scope(record)?;
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.working_memory_deltas().upsert(record)?;
+            runtime_db.working_memory_deltas().upsert(&record)?;
             return Ok(());
         }
-        self.append_jsonl(&self.working_memory_deltas_path, record)
+        self.append_jsonl(&self.working_memory_deltas_path, &record)
     }
 
     pub fn append_context_episode(&self, record: &ContextEpisodeRecord) -> Result<()> {
@@ -837,10 +845,39 @@ impl AppStorage {
     }
 
     fn storage_agent_id(&self) -> Result<String> {
-        Ok(self.current_agent_id()?.unwrap_or_else(|| "unknown".into()))
+        self.agent_id
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("agent-scoped storage operation requires an agent id"))
+    }
+
+    fn working_memory_delta_for_scope(
+        &self,
+        record: &WorkingMemoryDelta,
+    ) -> Result<WorkingMemoryDelta> {
+        let agent_id = self.storage_agent_id()?;
+        if record.agent_id.is_empty() {
+            let mut record = record.clone();
+            record.agent_id = agent_id;
+            return Ok(record);
+        }
+        anyhow::ensure!(
+            record.agent_id == agent_id,
+            "agent-scoped storage for `{}` cannot use working memory delta for `{}`",
+            agent_id,
+            record.agent_id
+        );
+        Ok(record.clone())
     }
 
     pub fn write_agent(&self, agent: &AgentState) -> Result<()> {
+        if let Some(storage_agent_id) = self.agent_id.as_deref() {
+            anyhow::ensure!(
+                agent.id == storage_agent_id,
+                "agent-scoped storage for `{}` cannot write agent state for `{}`",
+                storage_agent_id,
+                agent.id
+            );
+        }
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.agent_states().upsert(agent)?;
         }
@@ -1138,6 +1175,12 @@ impl AppStorage {
 
     pub fn read_recent_tasks(&self, limit: usize) -> Result<Vec<TaskRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return Ok(take_recent(
+                    runtime_db.tasks().latest_for_agent(&agent_id, limit)?,
+                    limit,
+                ));
+            }
             return Ok(take_recent(runtime_db.tasks().latest_all()?, limit));
         }
         read_recent_jsonl(&self.tasks_path, limit)
@@ -1145,6 +1188,12 @@ impl AppStorage {
 
     pub fn read_recent_work_items(&self, limit: usize) -> Result<Vec<WorkItemRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return Ok(take_recent(
+                    runtime_db.work_items().latest_for_agent(&agent_id, limit)?,
+                    limit,
+                ));
+            }
             return Ok(take_recent(runtime_db.work_items().latest_all()?, limit));
         }
         read_recent_jsonl(&self.work_items_path, limit)
@@ -1167,6 +1216,11 @@ impl AppStorage {
         limit: usize,
     ) -> Result<Vec<WorkItemDelegationRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .work_item_delegations()
+                    .recent_for_agent(&agent_id, limit);
+            }
             return runtime_db.work_item_delegations().recent(limit);
         }
         read_recent_jsonl(&self.work_item_delegations_path, limit)
@@ -1174,6 +1228,9 @@ impl AppStorage {
 
     pub fn read_recent_timers(&self, limit: usize) -> Result<Vec<TimerRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db.timers().recent_for_agent(&agent_id, limit);
+            }
             return runtime_db.timers().recent(limit);
         }
         read_recent_jsonl(&self.timers_path, limit)
@@ -1207,6 +1264,9 @@ impl AppStorage {
 
     pub fn read_recent_turns(&self, limit: usize) -> Result<Vec<TurnRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db.turn_records().recent_for_agent(&agent_id, limit);
+            }
             return runtime_db.turn_records().recent(limit);
         }
         read_recent_jsonl(&self.turns_path, limit)
@@ -1236,6 +1296,11 @@ impl AppStorage {
 
     pub fn read_recent_wait_conditions(&self, limit: usize) -> Result<Vec<WaitConditionRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .wait_conditions()
+                    .recent_for_agent(&agent_id, limit);
+            }
             return runtime_db.wait_conditions().recent(limit);
         }
         read_recent_jsonl(&self.wait_conditions_path, limit)
@@ -1290,13 +1355,24 @@ impl AppStorage {
         limit: usize,
     ) -> Result<Vec<WorkingMemoryDelta>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            return runtime_db.working_memory_deltas().recent(limit);
+            return runtime_db
+                .working_memory_deltas()
+                .recent_for_agent(&self.storage_agent_id()?, limit);
         }
-        read_recent_jsonl(&self.working_memory_deltas_path, limit)
+        let records = read_recent_jsonl(&self.working_memory_deltas_path, limit)?;
+        records
+            .into_iter()
+            .map(|record| self.working_memory_delta_for_scope(&record))
+            .collect()
     }
 
     pub fn read_recent_context_episodes(&self, limit: usize) -> Result<Vec<ContextEpisodeRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .context_episodes()
+                    .recent_for_agent(&agent_id, limit);
+            }
             return runtime_db.context_episodes().recent(limit);
         }
         read_recent_jsonl(&self.context_episodes_path, limit)
@@ -1341,6 +1417,14 @@ impl AppStorage {
 
     pub fn latest_task_records_from_recent(&self, history_limit: usize) -> Result<Vec<TaskRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return Ok(take_recent(
+                    runtime_db
+                        .tasks()
+                        .latest_for_agent(&agent_id, history_limit)?,
+                    history_limit,
+                ));
+            }
             return Ok(take_recent(runtime_db.tasks().latest_all()?, history_limit));
         }
         let records = self.read_recent_tasks(history_limit)?;
@@ -1361,6 +1445,9 @@ impl AppStorage {
 
     pub fn latest_active_task_records(&self, limit: usize) -> Result<Vec<TaskRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db.tasks().active_for_agent(&agent_id, limit);
+            }
             return Ok(take_recent(
                 runtime_db
                     .tasks()
@@ -2282,6 +2369,22 @@ fn memory_index_agent_key(agent_id: &str) -> String {
         .collect()
 }
 
+fn infer_agent_id_from_data_dir(data_dir: &Path) -> Option<String> {
+    let parent_is_agents_dir = data_dir
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        == Some("agents");
+    if !parent_is_agents_dir {
+        return None;
+    }
+    data_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(ToString::to_string)
+}
+
 fn migrate_events_ledger(path: &Path) -> Result<u64> {
     if !path.exists() {
         return Ok(0);
@@ -3119,7 +3222,7 @@ mod tests {
     #[test]
     fn runtime_db_state_writes_skip_live_jsonl_after_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -3337,7 +3440,8 @@ mod tests {
     #[test]
     fn append_turn_uses_runtime_db_after_cutover_without_turns_jsonl() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -3361,6 +3465,185 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn read_recent_turns_scopes_global_runtime_db_to_current_agent() {
+        let dir = tempdir().unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )
+        .unwrap();
+        let agent_a = AppStorage::new(dir.path().join("agents/agent-a")).unwrap();
+        let agent_b = AppStorage::new(dir.path().join("agents/agent-b")).unwrap();
+        agent_a
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        agent_b
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+
+        agent_a
+            .append_turn(&TurnRecord::new("agent-a", "turn-a", 1))
+            .unwrap();
+        agent_b
+            .append_turn(&TurnRecord::new("agent-b", "turn-b", 2))
+            .unwrap();
+
+        let turns = agent_a.read_recent_turns(10).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].agent_id, "agent-a");
+        assert_eq!(turns[0].turn_id, "turn-a");
+    }
+
+    #[test]
+    fn agent_local_runtime_db_reads_scope_current_state_domains_to_current_agent() {
+        let dir = tempdir().unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )
+        .unwrap();
+        let agent_a = AppStorage::new(dir.path().join("agents/agent-a")).unwrap();
+        let agent_b = AppStorage::new(dir.path().join("agents/agent-b")).unwrap();
+        agent_a
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        agent_b
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        let now = Utc::now();
+        let task_for = |agent_id: &str, id: &str| TaskRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now,
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some(id.into()),
+            detail: None,
+            recovery: None,
+        };
+        let timer_for = |agent_id: &str, id: &str| TimerRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            created_at: now,
+            duration_ms: 1000,
+            interval_ms: None,
+            repeat: false,
+            status: crate::types::TimerStatus::Active,
+            summary: Some(id.into()),
+            next_fire_at: Some(now),
+            last_fired_at: None,
+            fire_count: 0,
+        };
+        let wait_for = |agent_id: &str, id: &str| WaitConditionRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            work_item_id: None,
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::Operator,
+            source: None,
+            subject_ref: None,
+            waiting_for: id.into(),
+            wake_sources: Vec::new(),
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        };
+        let episode_for = |agent_id: &str, id: &str| ContextEpisodeRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            workspace_id: "agent_home".into(),
+            created_at: now,
+            finalized_at: now,
+            start_turn_index: 1,
+            end_turn_index: 2,
+            start_message_count: 1,
+            end_message_count: 2,
+            boundary_reason: EpisodeBoundaryReason::TaskRejoined,
+            current_work_item_id: None,
+            objective: None,
+            work_summary: None,
+            scope_hints: Vec::new(),
+            source_turn_ids: Vec::new(),
+            source_refs: Vec::new(),
+            generated_by: None,
+            operator_intents: Vec::new(),
+            runtime_facts: Vec::new(),
+            task_results: Vec::new(),
+            unresolved_items: Vec::new(),
+            model_inferences: Vec::new(),
+            summary: id.into(),
+            working_set_files: Vec::new(),
+            commands: Vec::new(),
+            verification: Vec::new(),
+            decisions: Vec::new(),
+            carry_forward: Vec::new(),
+            waiting_on: Vec::new(),
+        };
+
+        agent_a.append_task(&task_for("agent-a", "task-a")).unwrap();
+        agent_b.append_task(&task_for("agent-b", "task-b")).unwrap();
+        agent_a
+            .append_work_item(&WorkItemRecord::new(
+                "agent-a",
+                "work-a",
+                WorkItemState::Open,
+            ))
+            .unwrap();
+        agent_b
+            .append_work_item(&WorkItemRecord::new(
+                "agent-b",
+                "work-b",
+                WorkItemState::Open,
+            ))
+            .unwrap();
+        agent_a
+            .append_timer(&timer_for("agent-a", "timer-a"))
+            .unwrap();
+        agent_b
+            .append_timer(&timer_for("agent-b", "timer-b"))
+            .unwrap();
+        agent_a
+            .append_wait_condition(&wait_for("agent-a", "wait-a"))
+            .unwrap();
+        agent_b
+            .append_wait_condition(&wait_for("agent-b", "wait-b"))
+            .unwrap();
+        agent_a
+            .append_context_episode(&episode_for("agent-a", "episode-a"))
+            .unwrap();
+        agent_b
+            .append_context_episode(&episode_for("agent-b", "episode-b"))
+            .unwrap();
+
+        assert_eq!(agent_a.read_recent_tasks(10).unwrap()[0].id, "task-a");
+        assert_eq!(
+            agent_a.latest_active_task_records(10).unwrap()[0].id,
+            "task-a"
+        );
+        assert_eq!(
+            agent_a.read_recent_work_items(10).unwrap()[0].agent_id,
+            "agent-a"
+        );
+        assert_eq!(agent_a.read_recent_timers(10).unwrap()[0].id, "timer-a");
+        assert_eq!(
+            agent_a.read_recent_wait_conditions(10).unwrap()[0].id,
+            "wait-a"
+        );
+        assert_eq!(
+            agent_a.read_recent_context_episodes(10).unwrap()[0].id,
+            "episode-a"
         );
     }
 
@@ -3467,7 +3750,7 @@ mod tests {
     #[test]
     fn runtime_db_evidence_writes_skip_live_jsonl_after_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -3528,7 +3811,7 @@ mod tests {
     #[test]
     fn runtime_db_memory_episode_and_delegation_writes_skip_live_jsonl_after_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -3538,13 +3821,10 @@ mod tests {
             .enable_scheduler_control_plane_db(runtime_db)
             .unwrap();
 
-        let delegation = WorkItemDelegationRecord::new(
-            "parent-agent",
-            "parent-work",
-            "child-agent",
-            "child-work",
-        );
+        let delegation =
+            WorkItemDelegationRecord::new("default", "parent-work", "child-agent", "child-work");
         let memory_delta = WorkingMemoryDelta {
+            agent_id: "default".into(),
             from_revision: 1,
             to_revision: 2,
             created_at_turn: 7,
@@ -4035,7 +4315,7 @@ mod tests {
     #[test]
     fn write_agent_with_runtime_db_keeps_legacy_agent_json_export_current() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -4077,6 +4357,89 @@ mod tests {
 
         let restored = storage.read_agent().unwrap().unwrap();
         assert_eq!(restored.status, AgentStatus::Stopped);
+    }
+
+    #[test]
+    fn current_agent_id_is_fixed_at_storage_construction() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "agent-a").unwrap();
+
+        storage.write_agent(&AgentState::new("agent-a")).unwrap();
+        let mismatch = storage
+            .write_agent(&AgentState::new("agent-b"))
+            .unwrap_err();
+
+        assert_eq!(
+            storage.current_agent_id().unwrap().as_deref(),
+            Some("agent-a")
+        );
+        assert!(
+            mismatch
+                .to_string()
+                .contains("cannot write agent state for `agent-b`"),
+            "{mismatch}"
+        );
+    }
+
+    #[test]
+    fn global_storage_has_no_agent_scope_even_with_agent_json() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_global(dir.path()).unwrap();
+
+        storage.write_agent(&AgentState::new("default")).unwrap();
+
+        assert_eq!(storage.current_agent_id().unwrap(), None);
+    }
+
+    #[test]
+    fn db_backed_working_memory_deltas_are_scoped_to_current_agent() {
+        let dir = tempdir().unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            dir.path().join("state/runtime.sqlite"),
+            dir.path().join("state/runtime.lock"),
+        )
+        .unwrap();
+        let agent_a =
+            AppStorage::new_for_agent(dir.path().join("agents/agent-a"), "agent-a").unwrap();
+        let agent_b =
+            AppStorage::new_for_agent(dir.path().join("agents/agent-b"), "agent-b").unwrap();
+        agent_a
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        agent_b
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        let delta_a = WorkingMemoryDelta {
+            agent_id: "agent-a".into(),
+            from_revision: 0,
+            to_revision: 1,
+            created_at_turn: 1,
+            reason: WorkingMemoryUpdateReason::TerminalTurnCompleted,
+            changed_fields: vec!["plan".into()],
+            summary_lines: vec!["agent-a plan changed".into()],
+        };
+        let delta_b = WorkingMemoryDelta {
+            agent_id: "agent-b".into(),
+            from_revision: 0,
+            to_revision: 1,
+            created_at_turn: 1,
+            reason: WorkingMemoryUpdateReason::TaskRejoined,
+            changed_fields: vec!["waiting_on".into()],
+            summary_lines: vec!["agent-b wait changed".into()],
+        };
+
+        agent_a.append_working_memory_delta(&delta_a).unwrap();
+        agent_b.append_working_memory_delta(&delta_b).unwrap();
+
+        assert_eq!(
+            agent_a.read_recent_working_memory_deltas(10).unwrap(),
+            vec![delta_a]
+        );
+        assert_eq!(
+            agent_b.read_recent_working_memory_deltas(10).unwrap(),
+            vec![delta_b]
+        );
     }
 
     #[test]
@@ -4181,7 +4544,7 @@ mod tests {
     #[test]
     fn mark_memory_index_dirty_does_not_rewrite_existing_marker() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let dirty_path = storage.indexes_dir().join("memory.default.dirty");
 
@@ -5751,7 +6114,7 @@ mod tests {
     #[test]
     fn db_backed_work_queue_prompt_projection_filters_by_current_agent() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1440,6 +1440,8 @@ pub enum WorkingMemoryUpdateReason {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkingMemoryDelta {
+    #[serde(default)]
+    pub agent_id: String,
     pub from_revision: u64,
     pub to_revision: u64,
     pub created_at_turn: u64,

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -29,6 +29,7 @@ fn isolated_holon_command(home: &tempfile::TempDir) -> Command {
         .env("HOLON_HOME", home.path())
         .env("HOLON_AGENT_ID", "main")
         .env("HOLON_MODEL", "openai/gpt-5.4")
+        .env("HOLON_HTTP_ADDR", "127.0.0.1:9")
         .env(
             "HOLON_SOCKET_PATH",
             home.path().join("run").join("missing.sock"),

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -692,6 +692,7 @@ fn operator_turn_context_snapshot_includes_work_memory_and_active_work() -> Resu
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
+        agent_id: "default".into(),
         from_revision: 2,
         to_revision: 3,
         created_at_turn: 4,
@@ -1270,6 +1271,7 @@ fn callback_with_active_work_and_delta() -> Result<()> {
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
+        agent_id: "default".into(),
         from_revision: 5,
         to_revision: 6,
         created_at_turn: 12,
@@ -1545,6 +1547,7 @@ fn post_compaction_snapshot_preserves_continuity() -> Result<()> {
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
+        agent_id: "default".into(),
         from_revision: 7,
         to_revision: 8,
         created_at_turn: 15,
@@ -1698,6 +1701,7 @@ fn task_result_with_multiple_work_items() -> Result<()> {
         ..WorkingMemorySnapshot::default()
     };
     session.working_memory.pending_working_memory_delta = Some(WorkingMemoryDelta {
+        agent_id: "default".into(),
         from_revision: 3,
         to_revision: 4,
         created_at_turn: 8,


### PR DESCRIPTION
## Summary
- make `AppStorage` carry an immutable agent scope, with explicit `new_for_agent` and `new_global` constructors
- scope runtime DB reads for agent-owned domains instead of falling back to global data
- add `agent_id` to working memory deltas and query them by agent
- repair unreleased `working_memory_deltas` DB tables that were created without `agent_id`

## Validation
- `cargo test storage::tests:: --lib -- --test-threads=1`
- `cargo test memory::working::tests::refresh_working_memory --lib`
- `cargo test runtime_db_migration_repairs_unreleased_working_memory_delta_scope --lib`
- `cargo test recent_turns --lib`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes follow-up storage scoping issues from #1644.
