### PR TITLE
feat: add work item continuation stack

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -26,6 +26,7 @@ implementation and tests.
 - [Objective, Delta, and Acceptance Boundary](./objective-delta-and-acceptance-boundary.md)
 - [Work Item Runtime Model](./work-item-runtime-model.md)
 - [Work Item Centered Agent Runtime](./work-item-centered-agent-runtime.md)
+- [Work Item Continuation Stack](./work-item-continuation-stack.md)
 - [Long-Lived Context Memory](./long-lived-context-memory.md)
 - [Agent and Workspace Memory](./agent-and-workspace-memory.md)
 - [Turn-Local Context Compaction](./turn-local-context-compaction.md)

--- a/docs/rfcs/work-item-continuation-stack.md
+++ b/docs/rfcs/work-item-continuation-stack.md
@@ -1,0 +1,476 @@
+---
+title: RFC: Work Item Continuation Stack
+date: 2026-06-09
+status: draft
+issue:
+  - 1617
+---
+
+# RFC: Work Item Continuation Stack
+
+## Summary
+
+Holon should let an open WorkItem yield execution to another WorkItem without
+marking the yielding WorkItem as blocked.
+
+The missing state is a runtime-owned continuation frame:
+
+```text
+A yielded to B
+resume A when B reaches the configured return condition
+```
+
+This is different from `WaitFor`. A wait says useful progress is blocked by a
+future condition. A continuation frame says the agent intentionally moved the
+active control flow from one WorkItem to another and expects to return.
+
+## Problem
+
+Track or orchestrator WorkItems often create or select concrete WorkItems.
+
+Example:
+
+```text
+T = track umbrella WorkItem
+A = concrete WorkItem for one issue or PR
+```
+
+The agent starts in `T`, switches to `A`, and waits for `A`'s CI/review/merge
+state. While `A` is active, `T` should not keep getting scheduled just because it
+is open. But `T` also should not be represented as blocked by CI, because the CI
+belongs to `A`.
+
+The current model leaves two poor choices:
+
+- keep `T` runnable, which can cause repeated work-queue ticks and prompt
+  pressure to re-enter `T`;
+- mark `T` blocked, which suppresses repeated scheduling but loses the natural
+  return path when `A` completes.
+
+This is not primarily a parent/child modeling problem. It is a control-flow
+problem: the runtime needs to remember that `T` yielded to `A`.
+
+## Goals
+
+- Represent "temporarily not schedulable because execution yielded to another
+  WorkItem" as a first-class runtime fact.
+- Keep yielded WorkItems out of queued runnable scheduling.
+- Resume the yielded WorkItem when the active WorkItem reaches the configured
+  return condition.
+- Keep WorkItem waits scoped to the WorkItem that actually owns the external,
+  task, timer, operator, or system condition.
+- Preserve the invariant that queued WorkItems do not silently become current
+  without an explicit or runtime-explained transition.
+
+## Non-Goals
+
+- Do not make WorkItems a strict parent/child tree.
+- Do not replace `WaitFor`.
+- Do not make every relation between WorkItems a scheduling dependency.
+- Do not require a general graph scheduler before the WorkItem control-flow
+  problem is solved.
+- Do not make blocked state a catch-all for "not currently selected".
+
+## Terms
+
+### Runnable
+
+An open WorkItem that is eligible for work-queue scheduling.
+
+### Blocked
+
+An open WorkItem whose own progress is waiting on a blocking condition such as
+task result, external change, operator input, timer, or an explicit blocker.
+
+### Parked / Yielded
+
+An open WorkItem that is not runnable because it yielded control to another
+WorkItem. It is not blocked. The runtime knows what WorkItem currently owns the
+continuation and when to resume the yielded item.
+
+### Continuation Frame
+
+A runtime record that captures a temporary WorkItem control-flow transfer.
+
+```text
+WorkItemContinuationFrame {
+  id
+  agent_id
+  suspended_work_item_id
+  active_work_item_id
+  return_policy
+  state
+  created_at
+  updated_at
+  resolved_at?
+  cancelled_at?
+  reason?
+}
+```
+
+Initial return policies:
+
+- `on_completed`: resume the suspended WorkItem when the active WorkItem is
+  completed.
+
+Phase one implements only `on_completed`. Other return policies can be added
+when there is a concrete runtime need.
+
+Initial states:
+
+- `active`
+- `resumed`
+- `cancelled`
+
+## Proposed Model
+
+### Scheduling State
+
+Extend WorkItem scheduling posture with a yielded state:
+
+```text
+Open WorkItem scheduling posture:
+- current/runnable
+- queued/runnable
+- yielded_to_work_item
+- waiting_task
+- waiting_external
+- waiting_operator
+- waiting_timer
+- waiting_system
+- blocked/manual
+- completed
+```
+
+`yielded_to_work_item` is derived from an active continuation frame where the
+WorkItem is `suspended_work_item_id`.
+
+The yielded WorkItem:
+
+- remains `state = open`;
+- does not need `blocked_by`;
+- does not appear in queued runnable candidates;
+- may appear in prompt/list projections as parked/yielded;
+- becomes runnable again when its continuation frame is resumed or cancelled.
+
+### Tool Surface
+
+Phase one should improve `PickWorkItem` rather than introduce a separate
+continuation tool.
+
+When the agent has an open runnable current WorkItem `A` and calls
+`PickWorkItem(B)` for a different open WorkItem, phase one defaults to yielding
+the current item:
+
+```text
+current = A
+PickWorkItem(B)
+=> create WorkItemContinuationFrame(A yielded_to B, return_policy=on_completed)
+=> make B current
+```
+
+This matches the agent's natural control-flow action: "switch to B, then come
+back to A when B is done."
+
+Defaulting rules:
+
+- if there is a different open runnable current WorkItem, create an active
+  `on_completed` frame from current to target;
+- if there is no current WorkItem, the target is the current WorkItem, the
+  current WorkItem is not runnable, or the target is not open, do not create a
+  frame and keep existing pick validation semantics;
+- if the target WorkItem is already parked/yielded, explicit pick resumes the
+  matching frame with reason `explicit_pick` so the target cannot remain
+  yielded after becoming current.
+
+Phase one intentionally does not add public `mode`, `return_to`, or `replace`
+parameters. The runtime infers the return target from current focus. The stored
+fact is still an explicit continuation frame rather than a synthetic blocker.
+
+### CompleteWorkItem
+
+When `CompleteWorkItem(B)` succeeds:
+
+1. Complete `B` using the existing completion rules.
+2. Cancel or resolve active wait conditions owned by `B` as today.
+3. Find the active direct-caller continuation frame with
+   `active_work_item_id = B`.
+4. If its return policy is satisfied:
+   - mark the frame `resumed`;
+   - set `current_work_item_id` to `suspended_work_item_id`;
+   - set the current turn binding to `suspended_work_item_id` when continuing
+     inside the same runtime turn would otherwise require another model pick;
+   - emit visible audit/scheduler evidence with reason
+     `continuation_resumed`.
+
+This is an explicit stack return, not a queued WorkItem silently replacing
+current focus. The continuation frame is the evidence that authorizes the focus
+restore.
+
+After completing `B` and restoring `A`, the current model turn should close as
+continuable. The scheduler should then start the next pass anchored on the
+resumed WorkItem. The agent should not need to call `PickWorkItem(A)` merely to
+restore the stack.
+
+### Explicit Switching
+
+If the agent explicitly picks a parked WorkItem before the frame is resumed, the
+runtime should either:
+
+- cancel the matching continuation frame with reason `explicit_pick`; or
+- mark it resumed if the explicit pick is treated as the return.
+
+The important invariant is that a parked WorkItem cannot remain parked after the
+agent has explicitly made it current.
+
+### Relation Boundary
+
+WorkItem relations describe durable work structure:
+
+```text
+T tracks A
+T depends_on A
+T spawned A
+```
+
+Relations are not enough to define scheduling. A tracking relation does not
+mean `T` is blocked by `A`, and it does not by itself define whether `T` should
+yield to `A`.
+
+The control-flow handoff is represented by a continuation frame:
+
+```text
+T yielded to A until A completed
+```
+
+This keeps three concepts separate:
+
+- relation: long-lived structure between WorkItems;
+- continuation frame: temporary control-flow transfer;
+- wait condition: blocking future condition owned by a WorkItem.
+
+### WaitFor Boundary
+
+`WaitFor` remains the right tool when the WorkItem itself cannot continue until
+a condition is satisfied:
+
+```text
+A waits for github_ci:123
+A waits for operator input
+A waits for task result
+```
+
+`WaitFor(resource = work_item:B)` may still be useful for true dependencies:
+
+```text
+Release waits for PackageBuild to complete
+```
+
+But a track WorkItem yielding to a concrete WorkItem is not necessarily a wait.
+It is a continuation transfer. Treating it as a wait works mechanically, but it
+overloads waiting language and makes the WorkItem look blocked when it is only
+parked.
+
+## Prompt And Query Projection
+
+Prompt projection should expose yielded WorkItems compactly, separate from
+blocked WorkItems:
+
+```text
+Parked work items:
+- [yielded_to_work_item] T :: tracking issue set :: yielded_to=A return=on_completed
+```
+
+`ListWorkItems` supports a yielded readiness value and a `yielded` filter.
+`GetWorkItem(T)` reports yielded readiness/focus when `T` is suspended by an
+active frame.
+
+Completion tool results should consider returning a compact reactivation hint:
+
+```text
+continuation_resumed:
+  suspended_work_item_id: T
+  reason: continuation_resumed
+  active_work_item_id: A
+```
+
+This is optional. The preferred phase-one behavior is for
+`CompleteWorkItem(active)` to finish the current turn after restoring the caller
+and let the scheduler resume execution from the restored WorkItem. A compact
+reactivation hint can still be useful for logs or clients, but it is not the
+primary agent control path.
+
+## Scheduler Contract
+
+The scheduler should treat yielded WorkItems as non-runnable until their
+continuation frame is resolved or cancelled.
+
+Priority order becomes:
+
+1. current runnable WorkItem;
+2. current WorkItem restored by a resumed continuation frame;
+3. triggered blocked WorkItems as review candidates;
+4. queued runnable WorkItems;
+5. yielded/parked WorkItems as compact context only;
+6. blocked WorkItems as compact context or recheck candidates;
+7. idle or sleep.
+
+Yielded WorkItems should not emit `queued_available` ticks while their
+continuation frame remains active.
+
+When a frame resumes, the scheduler should use a distinct reason such as:
+
+```text
+work_queue:continuation_resumed:<suspended_work_item_id>:<frame_id>:<revision>
+```
+
+This keeps the wake explainable and avoids conflating it with ordinary queued
+work.
+
+Because stack resume restores `current_work_item_id`, this tick is not asking
+the model to choose among queued candidates. It is a continuation pass for the
+resumed caller.
+
+## Storage And Ledger
+
+The persisted record should be separate from `WorkItemRecord`.
+
+Table/log:
+
+```text
+work_item_continuations
+```
+
+Fields:
+
+- `id`
+- `agent_id`
+- `suspended_work_item_id`
+- `active_work_item_id`
+- `return_policy`
+- `state`
+- `reason`
+- `created_at`
+- `updated_at`
+- `resolved_at`
+- `cancelled_at`
+- `resolution_reason`
+
+Indexes should support:
+
+- active frames by suspended WorkItem;
+- active frames by active WorkItem;
+- latest frames by agent;
+- reactivation lookup during `CompleteWorkItem`.
+
+The runtime should emit audit events for:
+
+- frame created;
+- frame resumed;
+- frame cancelled;
+- yielded WorkItem reactivated.
+
+## Invariants
+
+- A completed WorkItem cannot be active or suspended in a new active frame.
+- A WorkItem with an active frame as `suspended_work_item_id` is not queued
+  runnable.
+- A WorkItem made current by explicit pick cannot remain suspended by an active
+  frame.
+- Phase one active frames form a stack: each suspended WorkItem has at most one
+  active callee, each active WorkItem has at most one direct caller, and active
+  frames must be acyclic.
+- A WorkItem's own wait conditions still belong to that WorkItem, even when it
+  is the active target of another WorkItem's continuation frame.
+- Completion of the active WorkItem resumes only frames whose return policy is
+  satisfied.
+- Frame resumption should be idempotent.
+
+## Example Flow
+
+```text
+T = Track issue set
+A = Fix issue 1617
+
+1. Agent is current on T.
+2. Agent creates or selects A.
+3. Agent calls `PickWorkItem(A)`.
+4. Runtime records:
+   WorkItemContinuationFrame(T yielded_to A, return_policy=on_completed)
+5. Runtime makes A current.
+6. A calls WaitFor(resource=github_ci, wake=external).
+7. T is projected as yielded, not runnable and not blocked.
+8. CI wakes A.
+9. Agent completes A.
+10. Runtime resumes the frame and restores T as current.
+11. The turn closes as continuable.
+12. Scheduler starts the next pass anchored on T.
+13. T updates progress or yields to the next item.
+```
+
+## Implementation Phases
+
+### Phase 1: RFC And Projection Terms
+
+- Add the RFC.
+- Add terminology to WorkItem scheduler and prompt projection docs.
+
+### Phase 2: Runtime Record
+
+- Add `WorkItemContinuationFrame` type and storage.
+- Derive yielded scheduling state from active frames.
+- Add query/projection support.
+
+### Phase 3: Tool Surface
+
+- Default from a different open runnable current WorkItem to runtime-owned
+  yield.
+- Do not add public `mode`, `return_to`, or `replace` arguments in phase one.
+- Validate agent ownership and open WorkItem state.
+- Cancel or resume frames on explicit picks.
+
+### Phase 4: Reactivation
+
+- Resume frames from `CompleteWorkItem`.
+- Restore `current_work_item_id` to the suspended caller.
+- Close the completion turn as continuable.
+- Emit continuation-specific scheduler/audit events.
+- Optionally include `continuation_resumed` in completion tool output for
+  clients and logs, not as the primary agent control path.
+
+### Phase 5: Relation Integration
+
+- If WorkItem relations are added, allow tools to create relation and
+  continuation records together, while keeping relation semantics distinct from
+  scheduling.
+
+## Open Questions
+
+- When `CompleteWorkItem(B)` restores `A`, should the runtime always close the
+  current turn immediately, or only when the completion consumed the active
+  stack frame?
+- Should nested stack depth be capped in phase one to prevent accidental long
+  chains?
+- Should clients receive `continuation_resumed` in tool results even though
+  scheduler-driven resume is the primary control path?
+
+## Decision
+
+Adopt the concept of WorkItem continuation frames as the canonical way to model
+"A yielded to B; resume A when B is done."
+
+Phase one should use stack semantics:
+
+- `PickWorkItem(B)` from an open runnable current WorkItem `A` yields `A` to
+  `B` by default.
+- No public `PickWorkItem` mode is added in phase one.
+- `CompleteWorkItem(B)` resumes the direct caller `A`, restores current focus to
+  `A`, and lets the scheduler continue from that restored frame.
+- Active frames form an acyclic single-caller/single-callee chain, not a general
+  dependency graph.
+
+Do not encode this state as `blocked_by`.
+
+Do not rely only on WorkItem relation metadata.
+
+Keep waits, relations, and continuation frames as separate runtime facts.

--- a/docs/rfcs/work-item-continuation-stack.md
+++ b/docs/rfcs/work-item-continuation-stack.md
@@ -1,5 +1,6 @@
 ---
 title: RFC: Work Item Continuation Stack
+Handle: rfc-work-item-continuation-stack
 date: 2026-06-09
 status: draft
 issue:

--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -603,7 +603,7 @@
       "stability": "stable"
     },
     {
-      "description": "Make an existing open work item the current work-item focus for this agent. Include reason when switching away from runnable current work; blocked work items may be picked for inspection but remain non-runnable.\n",
+      "description": "Make an existing open work item the current work-item focus for this agent. When switching from a different runnable current work item, the runtime yields that current item to the picked item and resumes it when the picked item completes. Blocked work items may be picked for inspection but remain non-runnable.\n",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {
@@ -672,7 +672,7 @@
       "stability": "stable"
     },
     {
-      "description": "List recent work items with explicit current, open, completed, queued, blocked, waiting_for_operator, and runnable views. Use this before relying on memory briefs for work-item focus.\n",
+      "description": "List recent work items with explicit current, open, completed, queued, yielded, blocked, waiting_for_operator, and runnable views. Use this before relying on memory briefs for work-item focus.\n",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {
@@ -686,6 +686,7 @@
               "completed",
               "current",
               "queued",
+              "yielded",
               "blocked",
               "waiting_for_operator",
               "runnable",
@@ -803,7 +804,7 @@
       "stability": "stable"
     },
     {
-      "description": "Mark an open work item completed. Write the operator-facing completion report as assistant text in the same round; the runtime promotes that text after this tool succeeds.\n",
+      "description": "Mark an open work item completed. Write the operator-facing completion report as assistant text in the same round; the runtime promotes that text after this tool succeeds. If this work item has a yielded direct caller, completion resumes that caller as current and the turn closes for scheduler continuation.\n",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -598,6 +598,7 @@
               "current_readiness": {
                 "enum": [
                   "runnable",
+                  "yielded",
                   "waiting_for_operator",
                   "blocked",
                   "completed"
@@ -610,6 +611,7 @@
               "previous_readiness": {
                 "enum": [
                   "runnable",
+                  "yielded",
                   "waiting_for_operator",
                   "blocked",
                   "completed",

--- a/src/context.rs
+++ b/src/context.rs
@@ -1022,6 +1022,13 @@ fn render_work_item_candidates(
     )?;
     append_candidate_group(
         &mut lines,
+        "Parked/Yielded work items:",
+        &projection.yielded,
+        &completion_reports,
+        agent_home,
+    )?;
+    append_candidate_group(
+        &mut lines,
         "Waiting for operator:",
         &projection.waiting_for_operator,
         &completion_reports,
@@ -1083,6 +1090,7 @@ fn append_candidate_group(
         let view = match item.candidate_class {
             crate::storage::WorkItemCandidateClass::TriggeredBlocked => "triggered_blocked",
             crate::storage::WorkItemCandidateClass::QueuedRunnable => "queued_runnable",
+            crate::storage::WorkItemCandidateClass::Yielded => "yielded",
             crate::storage::WorkItemCandidateClass::WaitingForOperator => "waiting_for_operator",
             crate::storage::WorkItemCandidateClass::Blocked => "blocked",
             crate::storage::WorkItemCandidateClass::CompletedRecent => "completed_recent",

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -94,6 +94,10 @@ pub fn work_item_delegation_id() -> String {
     runtime_id("delegation")
 }
 
+pub fn work_item_continuation_id() -> String {
+    runtime_id("wic")
+}
+
 pub fn capability_id(prefix: &str) -> String {
     format!(
         "{prefix}_{}{}",
@@ -135,6 +139,7 @@ mod tests {
             (workspace_occupancy_id(), "occ"),
             (audit_event_id(), "event"),
             (work_item_delegation_id(), "delegation"),
+            (work_item_continuation_id(), "wic"),
         ] {
             assert_runtime_id(&id, prefix);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1536,6 +1536,7 @@ fn export_scheduler_fixture(
             "current_work_item_id": work_queue.current.as_ref().map(|item| item.id.clone()),
             "current_work_item_revision": work_queue.current.as_ref().map(|item| item.revision),
             "queued_work_items": work_queue.queued_runnable.len(),
+            "yielded_work_items": work_queue.yielded.len(),
             "triggered_blocked_work_items": work_queue.triggered_blocked.len(),
             "waiting_for_operator_work_items": work_queue.waiting_for_operator.len(),
             "blocked_work_items": work_queue.blocked.len(),

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -469,6 +469,14 @@ fn collect_pending_followups(
     );
     items.extend(
         projection
+            .yielded
+            .iter()
+            .filter(|item| !item.is_current)
+            .take(2)
+            .map(|item| format!("yielded: {}", truncate_line(&item.record().objective, 120))),
+    );
+    items.extend(
+        projection
             .waiting_for_operator
             .iter()
             .filter(|item| !item.is_current)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -24,7 +24,10 @@ mod waiting;
 mod workspace;
 mod worktree;
 
-pub use tasks::{PickedWorkItem, WorkItemFocusTransition, WorkItemFocusTransitionWarning};
+pub use tasks::{
+    PickedWorkItem, WorkItemContinuationSummary, WorkItemFocusTransition,
+    WorkItemFocusTransitionWarning,
+};
 pub(crate) use waiting::{WaitForScope, WaitForWakeKind};
 
 use std::{

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -519,6 +519,9 @@ fn prepare_runtime_storage(
             .work_item_delegations()
             .import_legacy(storage.read_recent_work_item_delegations(usize::MAX)?)?;
     }
+    if !storage_domain_complete(&runtime_db, "work_item_continuations")? {
+        runtime_db.work_item_continuations().import_empty()?;
+    }
     if !storage_domain_complete(&runtime_db, "working_memory_deltas")? {
         runtime_db
             .working_memory_deltas()

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2205,16 +2205,12 @@ impl RuntimeHandle {
         let mut warnings = Vec::new();
         let mut continuation_created = None;
         let mut continuation_resolved = None;
-        let target_was_yielded = self
+        let target_yielded_frame = self
             .inner
             .storage
-            .latest_active_work_item_continuation_for_suspended(&agent_id, &record.id)?
-            .is_some();
-        if let Some(frame) = self
-            .inner
-            .storage
-            .latest_active_work_item_continuation_for_suspended(&agent_id, &record.id)?
-        {
+            .latest_active_work_item_continuation_for_suspended(&agent_id, &record.id)?;
+        let target_was_yielded = target_yielded_frame.is_some();
+        if let Some(frame) = target_yielded_frame {
             let resolved = frame.resume("explicit_pick");
             self.inner
                 .storage
@@ -2229,25 +2225,25 @@ impl RuntimeHandle {
                 }),
             ))?;
         }
-        if let Some(frame) = current_id.as_deref().and_then(|id| {
-            self.inner
+        if let Some(id) = current_id.as_deref() {
+            if let Some(frame) = self
+                .inner
                 .storage
-                .latest_active_work_item_continuation_for_suspended(&agent_id, id)
-                .ok()
-                .flatten()
-        }) {
-            let cancelled = frame.cancel("current_focus_reselected");
-            self.inner
-                .storage
-                .append_work_item_continuation(&cancelled)?;
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_continuation_cancelled",
-                serde_json::json!({
-                    "agent_id": agent_id,
-                    "frame": cancelled,
-                    "reason": "current_focus_reselected",
-                }),
-            ))?;
+                .latest_active_work_item_continuation_for_suspended(&agent_id, id)?
+            {
+                let cancelled = frame.cancel("current_focus_reselected");
+                self.inner
+                    .storage
+                    .append_work_item_continuation(&cancelled)?;
+                self.inner.storage.append_event(&AuditEvent::new(
+                    "work_item_continuation_cancelled",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "frame": cancelled,
+                        "reason": "current_focus_reselected",
+                    }),
+                ))?;
+            }
         }
         let yield_current = switching
             && !target_was_yielded

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -8,9 +8,9 @@ use crate::types::{
     DeliverySummaryRecord, FailureArtifact, FailureArtifactCategory, SpawnAgentModelRequest,
     SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle,
     TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus,
-    TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef, WorkItemDelegationRecord,
-    WorkItemDelegationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState,
-    CHILD_AGENT_TASK_KIND,
+    TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef, WorkItemContinuationFrame,
+    WorkItemContinuationReturnPolicy, WorkItemDelegationRecord, WorkItemDelegationState,
+    WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -46,11 +46,28 @@ pub struct WorkItemFocusTransition {
     pub warnings: Vec<WorkItemFocusTransitionWarning>,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkItemContinuationSummary {
+    pub frame_id: String,
+    pub suspended_work_item_id: String,
+    pub active_work_item_id: String,
+    pub return_policy: WorkItemContinuationReturnPolicy,
+    pub reason: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct PickedWorkItem {
     pub previous_work_item: Option<WorkItemRecord>,
     pub current_work_item: WorkItemRecord,
     pub transition: WorkItemFocusTransition,
+    pub continuation_created: Option<WorkItemContinuationSummary>,
+    pub continuation_resolved: Option<WorkItemContinuationSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompletedWorkItem {
+    pub work_item: WorkItemRecord,
+    pub continuation_resumed: Option<WorkItemContinuationSummary>,
 }
 
 fn child_agent_task_detail(workspace_mode: ChildAgentWorkspaceMode) -> serde_json::Value {
@@ -2155,7 +2172,8 @@ impl RuntimeHandle {
         reason: Option<String>,
     ) -> Result<PickedWorkItem> {
         let agent_id = self.agent_id().await?;
-        let current_id = self.agent_state().await?.current_work_item_id;
+        let state = self.agent_state().await?;
+        let current_id = state.current_work_item_id.clone();
         let previous = match current_id.as_deref() {
             Some(id) => self.inner.runtime_db.work_items().latest(id)?,
             None => None,
@@ -2169,12 +2187,109 @@ impl RuntimeHandle {
             let trimmed = value.trim();
             (!trimmed.is_empty()).then(|| trimmed.to_string())
         });
-        let previous_readiness = previous.as_ref().map(WorkItemRecord::readiness);
-        let current_readiness = record.readiness();
+        let work_queue = self.inner.storage.work_queue_prompt_projection()?;
+        let previous_readiness = previous.as_ref().map(|record| {
+            work_queue
+                .readiness
+                .iter()
+                .find(|item| item.work_item.id == record.id)
+                .map(|item| item.readiness)
+                .unwrap_or_else(|| record.readiness())
+        });
+        let current_readiness = work_queue
+            .readiness
+            .iter()
+            .find(|item| item.work_item.id == record.id)
+            .map(|item| item.readiness)
+            .unwrap_or_else(|| record.readiness());
         let mut warnings = Vec::new();
-        if switching
-            && previous.as_ref().is_some_and(WorkItemRecord::is_runnable)
+        let mut continuation_created = None;
+        let mut continuation_resolved = None;
+        let target_was_yielded = self
+            .inner
+            .storage
+            .latest_active_work_item_continuation_for_suspended(&agent_id, &record.id)?
+            .is_some();
+        if let Some(frame) = self
+            .inner
+            .storage
+            .latest_active_work_item_continuation_for_suspended(&agent_id, &record.id)?
+        {
+            let resolved = frame.resume("explicit_pick");
+            self.inner
+                .storage
+                .append_work_item_continuation(&resolved)?;
+            continuation_resolved = Some(continuation_summary(&resolved, "explicit_pick"));
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_continuation_resumed",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "frame": resolved,
+                    "reason": "explicit_pick",
+                }),
+            ))?;
+        }
+        if let Some(frame) = current_id.as_deref().and_then(|id| {
+            self.inner
+                .storage
+                .latest_active_work_item_continuation_for_suspended(&agent_id, id)
+                .ok()
+                .flatten()
+        }) {
+            let cancelled = frame.cancel("current_focus_reselected");
+            self.inner
+                .storage
+                .append_work_item_continuation(&cancelled)?;
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_continuation_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "frame": cancelled,
+                    "reason": "current_focus_reselected",
+                }),
+            ))?;
+        }
+        let yield_current = switching
+            && !target_was_yielded
+            && previous_readiness == Some(WorkItemReadiness::Runnable)
+            && previous
+                .as_ref()
+                .is_some_and(|record| record.state == WorkItemState::Open)
+            && record.state == WorkItemState::Open;
+        if yield_current {
+            if let Some(existing) = self
+                .inner
+                .storage
+                .latest_active_work_item_continuation_for_active(&agent_id, &record.id)?
+            {
+                return Err(anyhow!(
+                    "cannot yield to work item {} because continuation {} already uses it as active work item",
+                    record.id,
+                    existing.id
+                ));
+            }
+            if let Some(previous) = previous.as_ref() {
+                let frame = WorkItemContinuationFrame::new_on_completed(
+                    agent_id.clone(),
+                    previous.id.clone(),
+                    record.id.clone(),
+                    state.current_turn_id.clone(),
+                );
+                self.inner.storage.append_work_item_continuation(&frame)?;
+                continuation_created = Some(continuation_summary(&frame, "pick_work_item"));
+                self.inner.storage.append_event(&AuditEvent::new(
+                    "work_item_continuation_created",
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "frame": frame,
+                        "reason": "pick_work_item",
+                    }),
+                ))?;
+            }
+        } else if switching
+            && previous_readiness == Some(WorkItemReadiness::Runnable)
             && normalized_reason.is_none()
+            && !target_was_yielded
         {
             warnings.push(WorkItemFocusTransitionWarning {
                 code: "missing_pick_reason_for_runnable_focus_switch".into(),
@@ -2183,13 +2298,17 @@ impl RuntimeHandle {
         }
         let switch_kind = if !switching {
             "same_work_item"
-        } else if previous.as_ref().is_some_and(WorkItemRecord::is_runnable) {
+        } else if continuation_created.is_some() {
+            "yield_current"
+        } else if continuation_resolved.is_some() {
+            "explicit_yield_return"
+        } else if previous_readiness == Some(WorkItemReadiness::Runnable) {
             "explicit_focus_override"
         } else {
             "explicit_focus_pick"
         }
         .to_string();
-        let current_focus_mode = if record.is_runnable() {
+        let current_focus_mode = if current_readiness == WorkItemReadiness::Runnable {
             "runnable"
         } else {
             "inspection"
@@ -2227,12 +2346,16 @@ impl RuntimeHandle {
                 "switch_kind": transition.switch_kind.clone(),
                 "current_focus_mode": transition.current_focus_mode.clone(),
                 "warnings": transition.warnings.clone(),
+                "continuation_created": continuation_created.clone(),
+                "continuation_resolved": continuation_resolved.clone(),
             }),
         ))?;
         Ok(PickedWorkItem {
             previous_work_item: previous,
             current_work_item: record,
             transition,
+            continuation_created,
+            continuation_resolved,
         })
     }
 
@@ -2428,10 +2551,24 @@ impl RuntimeHandle {
         work_item_id: String,
         warnings: Vec<serde_json::Value>,
     ) -> Result<WorkItemRecord> {
+        Ok(self
+            .complete_work_item_with_continuation(work_item_id, warnings)
+            .await?
+            .work_item)
+    }
+
+    pub async fn complete_work_item_with_continuation(
+        &self,
+        work_item_id: String,
+        warnings: Vec<serde_json::Value>,
+    ) -> Result<CompletedWorkItem> {
         let agent_id = self.agent_id().await?;
         let existing = self.validate_owned_work_item(&agent_id, &work_item_id)?;
         if existing.state == WorkItemState::Completed {
-            return Ok(existing);
+            return Ok(CompletedWorkItem {
+                work_item: existing,
+                continuation_resumed: None,
+            });
         }
         let mut record = WorkItemRecord {
             revision: existing.revision + 1,
@@ -2469,6 +2606,9 @@ impl RuntimeHandle {
             "work_item_completed",
         )
         .await?;
+        let continuation_resumed = self
+            .resume_direct_caller_after_work_item_completed(&agent_id, &record)
+            .await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_written",
             serde_json::json!({
@@ -2476,10 +2616,14 @@ impl RuntimeHandle {
                 "record": record,
                 "warnings": warnings.clone(),
                 "warning_count": warnings.len(),
+                "continuation_resumed": continuation_resumed.clone(),
             }),
         ))?;
         self.inner.notify.notify_one();
-        Ok(record)
+        Ok(CompletedWorkItem {
+            work_item: record,
+            continuation_resumed,
+        })
     }
 
     pub async fn promote_work_item_completion_report(
@@ -2610,6 +2754,91 @@ impl RuntimeHandle {
         Ok(())
     }
 
+    async fn resume_direct_caller_after_work_item_completed(
+        &self,
+        agent_id: &str,
+        completed: &WorkItemRecord,
+    ) -> Result<Option<WorkItemContinuationSummary>> {
+        let Some(frame) = self
+            .inner
+            .storage
+            .latest_active_work_item_continuation_for_active(agent_id, &completed.id)?
+        else {
+            return Ok(None);
+        };
+        let Some(suspended) = self
+            .inner
+            .runtime_db
+            .work_items()
+            .latest(&frame.suspended_work_item_id)?
+        else {
+            let cancelled = frame.cancel("suspended_work_item_missing");
+            self.inner
+                .storage
+                .append_work_item_continuation(&cancelled)?;
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_continuation_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "frame": cancelled,
+                    "reason": "suspended_work_item_missing",
+                }),
+            ))?;
+            return Ok(None);
+        };
+        if suspended.agent_id != agent_id || suspended.state != WorkItemState::Open {
+            let cancelled = frame.cancel("suspended_work_item_not_open");
+            self.inner
+                .storage
+                .append_work_item_continuation(&cancelled)?;
+            self.inner.storage.append_event(&AuditEvent::new(
+                "work_item_continuation_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
+                    "frame": cancelled,
+                    "reason": "suspended_work_item_not_open",
+                    "suspended_work_item_state": suspended.state,
+                }),
+            ))?;
+            return Ok(None);
+        }
+
+        let resumed = frame.resume("active_work_item_completed");
+        self.inner.storage.append_work_item_continuation(&resumed)?;
+        {
+            let mut guard = self.inner.agent.lock().await;
+            guard.state.current_work_item_id = Some(suspended.id.clone());
+            guard.state.current_turn_work_item_id = Some(suspended.id.clone());
+            self.inner.storage.write_agent(&guard.state)?;
+        }
+        self.inner
+            .runtime_db
+            .work_items()
+            .set_current_focus(agent_id, Some(&suspended.id))?;
+        let summary = continuation_summary(&resumed, "active_work_item_completed");
+        self.inner.storage.append_event(&AuditEvent::new(
+            "work_item_continuation_resumed",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "frame": resumed,
+                "reason": "active_work_item_completed",
+                "completed_work_item_id": completed.id,
+                "resumed_work_item_id": suspended.id,
+            }),
+        ))?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            "work_item_continuation_scheduler_evidence",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "reason": "continuation_resumed",
+                "work_item_id": suspended.id,
+                "completed_work_item_id": completed.id,
+                "continuation_frame_id": summary.frame_id,
+            }),
+        ))?;
+        Ok(Some(summary))
+    }
+
     pub(super) fn validate_owned_work_item(
         &self,
         agent_id: &str,
@@ -2673,6 +2902,19 @@ impl RuntimeHandle {
             ))?;
         }
         Ok(released)
+    }
+}
+
+fn continuation_summary(
+    frame: &WorkItemContinuationFrame,
+    reason: impl Into<String>,
+) -> WorkItemContinuationSummary {
+    WorkItemContinuationSummary {
+        frame_id: frame.id.clone(),
+        suspended_work_item_id: frame.suspended_work_item_id.clone(),
+        active_work_item_id: frame.active_work_item_id.clone(),
+        return_policy: frame.return_policy,
+        reason: reason.into(),
     }
 }
 

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2,7 +2,8 @@ use super::super::*;
 use super::support::*;
 use crate::types::{
     WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WaitingIntentScope, WakeSource,
-    WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState, AGENT_HOME_WORKSPACE_ID,
+    WorkItemContinuationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState,
+    AGENT_HOME_WORKSPACE_ID,
 };
 use std::{fs::OpenOptions, io::Write};
 
@@ -4698,7 +4699,7 @@ async fn pick_blocked_work_item_reports_inspection_focus() {
 }
 
 #[tokio::test]
-async fn pick_without_reason_warns_when_switching_from_runnable_current_work() {
+async fn pick_from_runnable_current_yields_and_complete_resumes_caller() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
     let runtime = RuntimeHandle::new(
@@ -4727,27 +4728,212 @@ async fn pick_without_reason_warns_when_switching_from_runnable_current_work() {
         .await
         .unwrap();
 
-    assert_eq!(picked.transition.previous_work_item_id, Some(current.id));
+    assert_eq!(
+        picked.transition.previous_work_item_id,
+        Some(current.id.clone())
+    );
     assert_eq!(
         picked.transition.previous_readiness,
         Some(WorkItemReadiness::Runnable)
     );
-    assert_eq!(picked.transition.switch_kind, "explicit_focus_override");
-    assert_eq!(picked.transition.warnings.len(), 1);
-    assert_eq!(
-        picked.transition.warnings[0].code,
-        "missing_pick_reason_for_runnable_focus_switch"
-    );
-    let events = runtime.storage().read_recent_events(10).unwrap();
-    let event = events
+    assert_eq!(picked.transition.switch_kind, "yield_current");
+    assert!(picked.transition.warnings.is_empty());
+    let created = picked
+        .continuation_created
+        .as_ref()
+        .expect("continuation frame should be created");
+    assert_eq!(created.suspended_work_item_id.as_str(), current.id.as_str());
+    assert_eq!(created.active_work_item_id.as_str(), next.id.as_str());
+    let frames = runtime.storage().latest_work_item_continuations().unwrap();
+    assert_eq!(frames.len(), 1);
+    assert_eq!(frames[0].state, WorkItemContinuationState::Active);
+
+    let projection = runtime.storage().work_queue_prompt_projection().unwrap();
+    let yielded = projection
+        .yielded
         .iter()
-        .find(|event| {
-            event.kind == "work_item_picked"
-                && event.data["current_work_item_id"].as_str() == Some(next.id.as_str())
-        })
-        .expect("work_item_picked event");
+        .find(|item| item.work_item.id == current.id)
+        .expect("current should be yielded after picking next");
     assert_eq!(
-        event.data["warnings"][0]["code"].as_str(),
-        Some("missing_pick_reason_for_runnable_focus_switch")
+        yielded.scheduling_state,
+        WorkItemSchedulingState::YieldedToWorkItem
     );
+    assert_eq!(yielded.readiness, WorkItemReadiness::Yielded);
+    assert!(!projection
+        .queued_runnable
+        .iter()
+        .any(|item| item.work_item.id == current.id));
+    assert!(!projection
+        .blocked
+        .iter()
+        .any(|item| item.work_item.id == current.id));
+    let registry = crate::tool::ToolRegistry::new(runtime.workspace_root());
+    let (yielded_result, _) = registry
+        .execute(
+            &runtime,
+            "default",
+            &AuthorityClass::OperatorInstruction,
+            &crate::tool::ToolCall {
+                id: "yielded".into(),
+                name: "ListWorkItems".into(),
+                input: serde_json::json!({"filter": "yielded"}),
+            },
+        )
+        .await
+        .unwrap();
+    let yielded_payload = yielded_result.envelope.result.unwrap();
+    assert_eq!(yielded_payload["total_matching"].as_u64(), Some(1));
+    assert_eq!(
+        yielded_payload["work_items"][0]["id"].as_str(),
+        Some(current.id.as_str())
+    );
+    assert_eq!(
+        yielded_payload["work_items"][0]["focus"].as_str(),
+        Some("yielded")
+    );
+    assert_eq!(
+        yielded_payload["work_items"][0]["readiness"].as_str(),
+        Some("yielded")
+    );
+
+    let completed = runtime
+        .complete_work_item_with_continuation(next.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let resumed = completed
+        .continuation_resumed
+        .expect("completion should resume direct caller");
+    assert_eq!(resumed.suspended_work_item_id.as_str(), current.id.as_str());
+    assert_eq!(resumed.active_work_item_id.as_str(), next.id.as_str());
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(current.id.as_str())
+    );
+    assert_eq!(
+        state.current_turn_work_item_id.as_deref(),
+        Some(current.id.as_str())
+    );
+    let frames = runtime.storage().latest_work_item_continuations().unwrap();
+    assert_eq!(frames[0].state, WorkItemContinuationState::Resumed);
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(events.iter().any(|event| {
+        event.kind == "work_item_continuation_scheduler_evidence"
+            && event.data["reason"].as_str() == Some("continuation_resumed")
+            && event.data["work_item_id"].as_str() == Some(current.id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn work_item_continuation_stack_resumes_nested_callers() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let track = runtime
+        .create_work_item("track".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let issue = runtime
+        .create_work_item("issue".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let review = runtime
+        .create_work_item("review".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+
+    runtime.pick_work_item(track.id.clone()).await.unwrap();
+    runtime.pick_work_item(issue.id.clone()).await.unwrap();
+    runtime.pick_work_item(review.id.clone()).await.unwrap();
+
+    let active = runtime
+        .storage()
+        .latest_active_work_item_continuations_for_agent("default")
+        .unwrap();
+    assert_eq!(active.len(), 2);
+
+    runtime
+        .complete_work_item_with_continuation(review.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(issue.id.as_str())
+    );
+    let active = runtime
+        .storage()
+        .latest_active_work_item_continuations_for_agent("default")
+        .unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].suspended_work_item_id, track.id);
+    assert_eq!(active[0].active_work_item_id, issue.id);
+
+    runtime
+        .complete_work_item_with_continuation(issue.id.clone(), Vec::new())
+        .await
+        .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(track.id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn explicit_pick_of_yielded_work_item_resolves_frame_without_new_yield() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let current = runtime
+        .create_work_item("current runnable".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    let next = runtime
+        .create_work_item("next runnable".into(), None, None, Vec::new())
+        .await
+        .unwrap();
+    runtime.pick_work_item(current.id.clone()).await.unwrap();
+    runtime.pick_work_item(next.id.clone()).await.unwrap();
+
+    let picked = runtime
+        .pick_work_item_with_reason(current.id.clone(), None)
+        .await
+        .unwrap();
+    assert_eq!(picked.transition.switch_kind, "explicit_yield_return");
+    assert!(picked.continuation_created.is_none());
+    assert!(picked.continuation_resolved.is_some());
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.current_work_item_id.as_deref(),
+        Some(current.id.as_str())
+    );
+    assert!(runtime
+        .storage()
+        .latest_active_work_item_continuation_for_suspended("default", &current.id)
+        .unwrap()
+        .is_none());
+    let frames = runtime.storage().latest_work_item_continuations().unwrap();
+    assert_eq!(frames.len(), 1);
+    assert_eq!(frames[0].state, WorkItemContinuationState::Resumed);
 }

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -15,8 +15,8 @@ use crate::types::{
     ContextEpisodeRecord, DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope,
     ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, TaskRecord, TaskStatus, TimerRecord,
     TimerStatus, ToolExecutionRecord, TranscriptEntry, TurnRecord, WaitConditionRecord,
-    WorkItemDelegationRecord, WorkItemRecord, WorkItemState, WorkingMemoryDelta, WorkspaceEntry,
-    WorkspaceOccupancyRecord,
+    WorkItemContinuationFrame, WorkItemDelegationRecord, WorkItemRecord, WorkItemState,
+    WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 
 const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
@@ -90,6 +90,10 @@ pub struct AgentIdentityRepository<'a> {
 }
 
 pub struct WorkItemDelegationRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+pub struct WorkItemContinuationRepository<'a> {
     db: &'a RuntimeDb,
 }
 
@@ -537,6 +541,84 @@ impl WorkItemDelegationRepository<'_> {
             .optional()?
             .map(|payload| decode_work_item_delegation_payload(&payload))
             .transpose()
+    }
+}
+
+impl WorkItemContinuationRepository<'_> {
+    pub fn import_empty(&self) -> Result<()> {
+        if self
+            .db
+            .storage_domain_is_complete("work_item_continuations", "db")?
+        {
+            return Ok(());
+        }
+        self.db
+            .run_storage_domain_import("work_item_continuations", "new-domain", "db", |_tx| {
+                Ok(serde_json::json!({ "imported_records": 0 }))
+            })
+    }
+
+    pub fn upsert(&self, record: &WorkItemContinuationFrame) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_work_item_continuation_tx(tx, record))
+    }
+
+    pub fn recent(&self, limit: usize) -> Result<Vec<WorkItemContinuationFrame>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_item_continuations
+             ORDER BY updated_at DESC, created_at DESC, continuation_id ASC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_work_item_continuation_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<WorkItemContinuationFrame>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_item_continuations
+             WHERE agent_id = ?1
+             ORDER BY updated_at DESC, created_at DESC, continuation_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_work_item_continuation_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn active_for_agent(&self, agent_id: &str) -> Result<Vec<WorkItemContinuationFrame>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM work_item_continuations
+             WHERE agent_id = ?1 AND state = 'active'
+             ORDER BY updated_at DESC, created_at DESC, continuation_id ASC",
+        )?;
+        let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_work_item_continuation_payload(&row?))
+            .collect()
     }
 }
 
@@ -2518,6 +2600,52 @@ fn upsert_work_item_delegation_tx(
     Ok(())
 }
 
+fn upsert_work_item_continuation_tx(
+    tx: &Transaction<'_>,
+    record: &WorkItemContinuationFrame,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let return_policy = enum_string(&record.return_policy)?;
+    let state = enum_string(&record.state)?;
+    tx.execute(
+        "INSERT INTO work_item_continuations (
+            continuation_id, agent_id, suspended_work_item_id, active_work_item_id,
+            return_policy, state, created_at, updated_at, resolved_at, cancelled_at,
+            resolution_reason, last_turn_id, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(continuation_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            suspended_work_item_id = excluded.suspended_work_item_id,
+            active_work_item_id = excluded.active_work_item_id,
+            return_policy = excluded.return_policy,
+            state = excluded.state,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at,
+            resolved_at = excluded.resolved_at,
+            cancelled_at = excluded.cancelled_at,
+            resolution_reason = excluded.resolution_reason,
+            last_turn_id = excluded.last_turn_id,
+            payload_json = excluded.payload_json
+         WHERE excluded.updated_at >= work_item_continuations.updated_at",
+        params![
+            record.id,
+            record.agent_id,
+            record.suspended_work_item_id,
+            record.active_work_item_id,
+            return_policy,
+            state,
+            timestamp(record.created_at),
+            timestamp(record.updated_at),
+            record.resolved_at.map(timestamp),
+            record.cancelled_at.map(timestamp),
+            record.resolution_reason.as_deref(),
+            record.turn_id.as_deref(),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
 fn upsert_working_memory_delta_tx(tx: &Transaction<'_>, record: &WorkingMemoryDelta) -> Result<()> {
     anyhow::ensure!(
         !record.agent_id.trim().is_empty(),
@@ -3451,6 +3579,10 @@ fn decode_work_item_delegation_payload(payload: &str) -> Result<WorkItemDelegati
     serde_json::from_str(payload).context("decoding work item delegation payload from runtime db")
 }
 
+fn decode_work_item_continuation_payload(payload: &str) -> Result<WorkItemContinuationFrame> {
+    serde_json::from_str(payload).context("decoding work item continuation payload from runtime db")
+}
+
 fn decode_working_memory_delta_payload(payload: &str) -> Result<WorkingMemoryDelta> {
     serde_json::from_str(payload).context("decoding working memory delta payload from runtime db")
 }
@@ -4167,6 +4299,34 @@ CREATE INDEX IF NOT EXISTS idx_context_episodes_work_item
   ON context_episodes(work_item_id);
 "#,
     },
+    Migration {
+        version: 12,
+        name: "work_item_continuation_stack",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS work_item_continuations (
+  continuation_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  suspended_work_item_id TEXT NOT NULL,
+  active_work_item_id TEXT NOT NULL,
+  return_policy TEXT NOT NULL,
+  state TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  resolved_at TEXT,
+  cancelled_at TEXT,
+  resolution_reason TEXT,
+  last_turn_id TEXT,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_item_continuations_agent_state
+  ON work_item_continuations(agent_id, state);
+CREATE INDEX IF NOT EXISTS idx_work_item_continuations_suspended
+  ON work_item_continuations(agent_id, suspended_work_item_id, state);
+CREATE INDEX IF NOT EXISTS idx_work_item_continuations_active
+  ON work_item_continuations(agent_id, active_work_item_id, state);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -4278,6 +4438,10 @@ impl RuntimeDb {
         WorkItemDelegationRepository { db: self }
     }
 
+    pub fn work_item_continuations(&self) -> WorkItemContinuationRepository<'_> {
+        WorkItemContinuationRepository { db: self }
+    }
+
     pub fn working_memory_deltas(&self) -> WorkingMemoryDeltaRepository<'_> {
         WorkingMemoryDeltaRepository { db: self }
     }
@@ -4317,6 +4481,11 @@ impl RuntimeDb {
                 domain: "work_item_delegations",
                 canonical_source: "db",
                 legacy_jsonl_posture: LegacyJsonlPosture::LegacyImportOnly,
+            },
+            ExpectedStorageDomain {
+                domain: "work_item_continuations",
+                canonical_source: "db",
+                legacy_jsonl_posture: LegacyJsonlPosture::Disabled,
             },
             ExpectedStorageDomain {
                 domain: "working_memory_deltas",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -24,9 +24,9 @@ use crate::{
         TaskRecord, TaskStatus, TimerRecord, TodoItem, TodoItemState, ToolExecutionRecord,
         TranscriptEntry, TurnRecord, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
         WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus, WakeSource,
-        WorkItemDelegationRecord, WorkItemDelegationState, WorkItemReadiness, WorkItemRecord,
-        WorkItemSchedulingState, WorkItemState, WorkingMemoryDelta, WorkspaceEntry,
-        WorkspaceOccupancyRecord,
+        WorkItemContinuationFrame, WorkItemContinuationState, WorkItemDelegationRecord,
+        WorkItemDelegationState, WorkItemReadiness, WorkItemRecord, WorkItemSchedulingState,
+        WorkItemState, WorkingMemoryDelta, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -44,6 +44,7 @@ pub struct WorkQueuePromptProjection {
     pub current_runnable: Option<WorkItemReadinessProjection>,
     pub triggered_blocked: Vec<WorkItemReadinessProjection>,
     pub queued_runnable: Vec<WorkItemReadinessProjection>,
+    pub yielded: Vec<WorkItemReadinessProjection>,
     pub waiting_for_operator: Vec<WorkItemReadinessProjection>,
     pub blocked: Vec<WorkItemReadinessProjection>,
     pub completed_recent: Vec<WorkItemReadinessProjection>,
@@ -66,6 +67,7 @@ impl WorkQueuePromptProjection {
     pub fn has_non_current_candidates(&self) -> bool {
         self.triggered_blocked.iter().any(|item| !item.is_current)
             || self.queued_runnable.iter().any(|item| !item.is_current)
+            || self.yielded.iter().any(|item| !item.is_current)
             || self
                 .waiting_for_operator
                 .iter()
@@ -95,6 +97,7 @@ pub enum WorkItemCandidateClass {
     TriggeredBlocked,
     QueuedRunnable,
     WaitingForOperator,
+    Yielded,
     Blocked,
     CompletedRecent,
 }
@@ -175,6 +178,7 @@ pub struct AppStorage {
     work_items_path: PathBuf,
     delivery_summaries_path: PathBuf,
     work_item_delegations_path: PathBuf,
+    work_item_continuations_path: PathBuf,
     timers_path: PathBuf,
     tools_path: PathBuf,
     turns_path: PathBuf,
@@ -278,6 +282,7 @@ impl AppStorage {
             work_items_path: ledger_dir.join("work_items.jsonl"),
             delivery_summaries_path: ledger_dir.join("delivery_summaries.jsonl"),
             work_item_delegations_path: ledger_dir.join("work_item_delegations.jsonl"),
+            work_item_continuations_path: ledger_dir.join("work_item_continuations.jsonl"),
             timers_path: ledger_dir.join("timers.jsonl"),
             tools_path: ledger_dir.join("tools.jsonl"),
             turns_path: ledger_dir.join("turns.jsonl"),
@@ -545,6 +550,14 @@ impl AppStorage {
             return Ok(());
         }
         self.append_jsonl(&self.work_item_delegations_path, record)
+    }
+
+    pub fn append_work_item_continuation(&self, record: &WorkItemContinuationFrame) -> Result<()> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.work_item_continuations().upsert(record)?;
+            return Ok(());
+        }
+        self.append_jsonl(&self.work_item_continuations_path, record)
     }
 
     pub fn append_timer(&self, timer: &TimerRecord) -> Result<()> {
@@ -1226,6 +1239,21 @@ impl AppStorage {
         read_recent_jsonl(&self.work_item_delegations_path, limit)
     }
 
+    pub fn read_recent_work_item_continuations(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<WorkItemContinuationFrame>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .work_item_continuations()
+                    .recent_for_agent(&agent_id, limit);
+            }
+            return runtime_db.work_item_continuations().recent(limit);
+        }
+        read_recent_jsonl(&self.work_item_continuations_path, limit)
+    }
+
     pub fn read_recent_timers(&self, limit: usize) -> Result<Vec<TimerRecord>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             if let Some(agent_id) = self.current_agent_id()? {
@@ -1724,6 +1752,13 @@ impl AppStorage {
             .filter(|task| task.is_blocking())
             .filter_map(|task| task.effective_work_item_id().map(str::to_string))
             .collect::<std::collections::BTreeSet<_>>();
+        let active_continuation_suspended_ids = self
+            .latest_active_work_item_continuations_for_agent(
+                self.current_agent_id()?.as_deref().unwrap_or_default(),
+            )?
+            .into_iter()
+            .map(|frame| frame.suspended_work_item_id)
+            .collect::<std::collections::BTreeSet<_>>();
         let mut readiness = latest
             .values()
             .cloned()
@@ -1739,15 +1774,19 @@ impl AppStorage {
                 let has_active_task_waits = active_task_waits.contains(&item.id)
                     || wait_condition.is_some_and(|states| states.task);
                 let has_triggered_waits = last_triggered_at.is_some();
-                let scheduling_state = item.scheduling_state(if has_active_task_waits {
-                    Some(WorkItemSchedulingState::WaitingTask)
+                let yielded = item.state == WorkItemState::Open
+                    && active_continuation_suspended_ids.contains(&item.id);
+                let scheduling_state = if yielded {
+                    WorkItemSchedulingState::YieldedToWorkItem
+                } else if has_active_task_waits {
+                    item.scheduling_state(Some(WorkItemSchedulingState::WaitingTask))
                 } else {
-                    wait_condition_state.or_else(|| {
+                    item.scheduling_state(wait_condition_state.or_else(|| {
                         active_waits
                             .contains_key(&item.id)
                             .then_some(WorkItemSchedulingState::WaitingExternal)
-                    })
-                });
+                    }))
+                };
                 let readiness = readiness_for_scheduling_state(scheduling_state);
                 let candidate_class =
                     if is_current && scheduling_state == WorkItemSchedulingState::Runnable {
@@ -1758,6 +1797,8 @@ impl AppStorage {
                         WorkItemCandidateClass::TriggeredBlocked
                     } else if scheduling_state == WorkItemSchedulingState::Runnable {
                         WorkItemCandidateClass::QueuedRunnable
+                    } else if scheduling_state == WorkItemSchedulingState::YieldedToWorkItem {
+                        WorkItemCandidateClass::Yielded
                     } else if scheduling_state == WorkItemSchedulingState::WaitingOperator {
                         WorkItemCandidateClass::WaitingForOperator
                     } else {
@@ -1795,6 +1836,12 @@ impl AppStorage {
             .take(5)
             .cloned()
             .collect::<Vec<_>>();
+        let yielded = readiness
+            .iter()
+            .filter(|item| item.candidate_class == WorkItemCandidateClass::Yielded)
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>();
         let waiting_for_operator = readiness
             .iter()
             .filter(|item| item.candidate_class == WorkItemCandidateClass::WaitingForOperator)
@@ -1819,6 +1866,7 @@ impl AppStorage {
             .filter(|item| {
                 item.state == WorkItemState::Open
                     && Some(item.id.as_str()) != current_work_item_id.as_deref()
+                    && !active_continuation_suspended_ids.contains(&item.id)
                     && !active_task_waits.contains(&item.id)
                     && !active_wait_conditions
                         .get(&item.id)
@@ -1835,6 +1883,7 @@ impl AppStorage {
             current_runnable,
             triggered_blocked,
             queued_runnable,
+            yielded,
             waiting_for_operator,
             blocked,
             completed_recent,
@@ -2107,6 +2156,49 @@ impl AppStorage {
             latest.insert(record.delegation_id.clone(), record);
         }
         Ok(latest.into_values().collect())
+    }
+
+    pub fn latest_work_item_continuations(&self) -> Result<Vec<WorkItemContinuationFrame>> {
+        let records = self.read_recent_work_item_continuations(usize::MAX)?;
+        let mut latest = std::collections::BTreeMap::new();
+        for record in records {
+            latest.insert(record.id.clone(), record);
+        }
+        Ok(latest.into_values().collect())
+    }
+
+    pub fn latest_active_work_item_continuations_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<WorkItemContinuationFrame>> {
+        Ok(self
+            .latest_work_item_continuations()?
+            .into_iter()
+            .filter(|record| record.agent_id == agent_id)
+            .filter(|record| record.state == WorkItemContinuationState::Active)
+            .collect())
+    }
+
+    pub fn latest_active_work_item_continuation_for_suspended(
+        &self,
+        agent_id: &str,
+        work_item_id: &str,
+    ) -> Result<Option<WorkItemContinuationFrame>> {
+        Ok(self
+            .latest_active_work_item_continuations_for_agent(agent_id)?
+            .into_iter()
+            .find(|record| record.suspended_work_item_id == work_item_id))
+    }
+
+    pub fn latest_active_work_item_continuation_for_active(
+        &self,
+        agent_id: &str,
+        work_item_id: &str,
+    ) -> Result<Option<WorkItemContinuationFrame>> {
+        Ok(self
+            .latest_active_work_item_continuations_for_agent(agent_id)?
+            .into_iter()
+            .find(|record| record.active_work_item_id == work_item_id))
     }
 
     pub fn open_work_item_delegation_for_child(
@@ -2773,6 +2865,9 @@ fn compare_readiness_projection_order(
                         compare_timestamp_asc(left.work_item.created_at, right.work_item.created_at)
                     })
             }
+            WorkItemCandidateClass::Yielded => {
+                compare_timestamp_desc(left.work_item.updated_at, right.work_item.updated_at)
+            }
             WorkItemCandidateClass::WaitingForOperator
             | WorkItemCandidateClass::Blocked
             | WorkItemCandidateClass::CompletedRecent => {
@@ -2801,6 +2896,7 @@ fn blocked_rank(record: &WorkItemRecord) -> u8 {
 fn readiness_for_scheduling_state(state: WorkItemSchedulingState) -> WorkItemReadiness {
     match state {
         WorkItemSchedulingState::Runnable => WorkItemReadiness::Runnable,
+        WorkItemSchedulingState::YieldedToWorkItem => WorkItemReadiness::Yielded,
         WorkItemSchedulingState::WaitingOperator => WorkItemReadiness::WaitingForOperator,
         WorkItemSchedulingState::WaitingTask
         | WorkItemSchedulingState::WaitingExternal
@@ -2816,9 +2912,10 @@ fn candidate_class_rank(class: WorkItemCandidateClass) -> u8 {
         WorkItemCandidateClass::CurrentRunnable => 0,
         WorkItemCandidateClass::TriggeredBlocked => 1,
         WorkItemCandidateClass::QueuedRunnable => 2,
-        WorkItemCandidateClass::WaitingForOperator => 3,
-        WorkItemCandidateClass::Blocked => 4,
-        WorkItemCandidateClass::CompletedRecent => 5,
+        WorkItemCandidateClass::Yielded => 3,
+        WorkItemCandidateClass::WaitingForOperator => 4,
+        WorkItemCandidateClass::Blocked => 5,
+        WorkItemCandidateClass::CompletedRecent => 6,
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2171,6 +2171,11 @@ impl AppStorage {
         &self,
         agent_id: &str,
     ) -> Result<Vec<WorkItemContinuationFrame>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db
+                .work_item_continuations()
+                .active_for_agent(agent_id);
+        }
         Ok(self
             .latest_work_item_continuations()?
             .into_iter()

--- a/src/tool/tool_descriptions/complete_work_item.md
+++ b/src/tool/tool_descriptions/complete_work_item.md
@@ -1,1 +1,1 @@
-Mark an open work item completed. Write the operator-facing completion report as assistant text in the same round; the runtime promotes that text after this tool succeeds.
+Mark an open work item completed. Write the operator-facing completion report as assistant text in the same round; the runtime promotes that text after this tool succeeds. If this work item has a yielded direct caller, completion resumes that caller as current and the turn closes for scheduler continuation.

--- a/src/tool/tool_descriptions/list_work_items.md
+++ b/src/tool/tool_descriptions/list_work_items.md
@@ -1,1 +1,1 @@
-List recent work items with explicit current, open, completed, queued, blocked, waiting_for_operator, and runnable views. Use this before relying on memory briefs for work-item focus.
+List recent work items with explicit current, open, completed, queued, yielded, blocked, waiting_for_operator, and runnable views. Use this before relying on memory briefs for work-item focus.

--- a/src/tool/tool_descriptions/pick_work_item.md
+++ b/src/tool/tool_descriptions/pick_work_item.md
@@ -1,1 +1,1 @@
-Make an existing open work item the current work-item focus for this agent. Include reason when switching away from runnable current work; blocked work items may be picked for inspection but remain non-runnable.
+Make an existing open work item the current work-item focus for this agent. When switching from a different runnable current work item, the runtime yields that current item to the picked item and resumes it when the picked item completes. Blocked work items may be picked for inspection but remain non-runnable.

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -68,8 +68,16 @@ pub(crate) async fn execute(
         .complete_work_item_with_continuation(work_item_id, warnings_json(&warnings))
         .await?;
     let context = query_context(runtime).await?;
-    let work_item =
-        view_for_record(runtime, &context, completed.work_item, true, None, None).await?;
+    let work_item = view_for_record(
+        runtime,
+        &context,
+        completed.work_item,
+        true,
+        None,
+        None,
+        None,
+    )
+    .await?;
     serialize_success(
         NAME,
         &WorkItemMutationResult::with_completion_transition(

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -64,18 +64,20 @@ pub(crate) async fn execute(
         .map(|record| record.state != WorkItemState::Completed)
         .unwrap_or(false);
     let warnings = before.as_ref().map(completion_warnings).unwrap_or_default();
-    let work_item = runtime
-        .complete_work_item(work_item_id, warnings_json(&warnings))
+    let completed = runtime
+        .complete_work_item_with_continuation(work_item_id, warnings_json(&warnings))
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true, None, None).await?;
+    let work_item =
+        view_for_record(runtime, &context, completed.work_item, true, None, None).await?;
     serialize_success(
         NAME,
         &WorkItemMutationResult::with_completion_transition(
             work_item,
             warnings_json(&warnings),
             completed_transition,
-        ),
+        )
+        .with_continuation_resumed(completed.continuation_resumed),
     )
 }
 

--- a/src/tool/tools/create_work_item.rs
+++ b/src/tool/tools/create_work_item.rs
@@ -88,6 +88,6 @@ pub(crate) async fn execute(
         )
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true, None, None).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None, None, None).await?;
     serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/get_work_item.rs
+++ b/src/tool/tools/get_work_item.rs
@@ -67,6 +67,7 @@ pub(crate) async fn execute(
         args.include_todo_list,
         None,
         None,
+        None,
     )
     .await?;
     serialize_success(NAME, &GetWorkItemResult { context, work_item })

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -126,6 +126,7 @@ pub(crate) async fn execute(
                 args.include_todo_list,
                 delivery_summaries.as_ref(),
                 Some(&wait_conditions),
+                Some(&yielded_ids),
             )
             .await?,
         );

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -36,6 +36,7 @@ pub(crate) enum ListWorkItemsFilter {
     Completed,
     Current,
     Queued,
+    Yielded,
     Blocked,
     WaitingForOperator,
     Runnable,
@@ -88,6 +89,12 @@ pub(crate) async fn execute(
         .await?;
     records.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
     let all_wait_conditions = active_wait_conditions_by_work_item(runtime, &records)?;
+    let yielded_ids = runtime
+        .storage()
+        .latest_active_work_item_continuations_for_agent(&agent_id)?
+        .into_iter()
+        .map(|frame| frame.suspended_work_item_id)
+        .collect::<std::collections::BTreeSet<_>>();
     let matching = records
         .into_iter()
         .filter(|record| {
@@ -95,7 +102,7 @@ pub(crate) async fn execute(
                 .get(&record.id)
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
-            matches_filter(record, waits, &context, &filter)
+            matches_filter(record, waits, &yielded_ids, &context, &filter)
         })
         .collect::<Vec<_>>();
     let total_matching = matching.len();
@@ -139,12 +146,14 @@ pub(crate) async fn execute(
 fn matches_filter(
     record: &crate::types::WorkItemRecord,
     active_wait_conditions: &[WaitConditionSummary],
+    yielded_ids: &std::collections::BTreeSet<String>,
     context: &WorkItemQueryContext,
     filter: &ListWorkItemsFilter,
 ) -> bool {
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
-    let readiness = readiness_for_view(record, active_wait_conditions);
+    let is_yielded = record.state == WorkItemState::Open && yielded_ids.contains(&record.id);
+    let readiness = readiness_for_view(record, active_wait_conditions, is_yielded);
     match filter {
         ListWorkItemsFilter::All => true,
         ListWorkItemsFilter::Open => lifecycle_view(&record.state) == WorkItemLifecycleView::Open,
@@ -157,6 +166,7 @@ fn matches_filter(
                 && record.state == WorkItemState::Open
                 && readiness == WorkItemReadiness::Runnable
         }
+        ListWorkItemsFilter::Yielded => readiness == WorkItemReadiness::Yielded,
         ListWorkItemsFilter::Blocked => !is_current && readiness == WorkItemReadiness::Blocked,
         ListWorkItemsFilter::WaitingForOperator => {
             readiness == WorkItemReadiness::WaitingForOperator

--- a/src/tool/tools/pick_work_item.rs
+++ b/src/tool/tools/pick_work_item.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    runtime::{RuntimeHandle, WorkItemFocusTransition},
+    runtime::{RuntimeHandle, WorkItemContinuationSummary, WorkItemFocusTransition},
     tool::helpers::{normalize_optional_non_empty, parse_tool_args, validate_non_empty},
     tool::spec::typed_spec,
     types::{AuthorityClass, ToolCapabilityFamily, WorkItemRecord},
@@ -29,6 +29,10 @@ pub(crate) struct PickWorkItemResult {
     pub(crate) current_work_item: WorkItemRecord,
     pub(crate) current_work_item_id: String,
     pub(crate) transition: WorkItemFocusTransition,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) continuation_created: Option<WorkItemContinuationSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) continuation_resolved: Option<WorkItemContinuationSummary>,
     pub(crate) binding_note: String,
 }
 
@@ -63,6 +67,8 @@ pub(crate) async fn execute(
             current_work_item,
             current_work_item_id,
             transition: picked.transition,
+            continuation_created: picked.continuation_created,
+            continuation_resolved: picked.continuation_resolved,
             binding_note: "subsequent tool calls in this turn are bound to the new current work item unless they explicitly specify another work_item_id".into(),
         },
     )

--- a/src/tool/tools/update_work_item.rs
+++ b/src/tool/tools/update_work_item.rs
@@ -72,6 +72,6 @@ pub(crate) async fn execute(
         )
         .await?;
     let context = query_context(runtime).await?;
-    let work_item = view_for_record(runtime, &context, work_item, true, None, None).await?;
+    let work_item = view_for_record(runtime, &context, work_item, true, None, None, None).await?;
     serialize_success(NAME, &WorkItemMutationResult::new(work_item))
 }

--- a/src/tool/tools/wait_for.rs
+++ b/src/tool/tools/wait_for.rs
@@ -93,7 +93,7 @@ pub(crate) async fn execute(
     let updated_context = query_context(runtime).await?;
     let work_item = match registration.work_item {
         Some(record) => {
-            Some(view_for_record(runtime, &updated_context, record, true, None, None).await?)
+            Some(view_for_record(runtime, &updated_context, record, true, None, None, None).await?)
         }
         None => None,
     };

--- a/src/tool/tools/work_item_action.rs
+++ b/src/tool/tools/work_item_action.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    runtime::WorkItemContinuationSummary,
     tool::helpers::{parse_tool_args_with_recovery_hint, validate_non_empty},
     types::{TodoItem, TodoItemState},
 };
@@ -79,6 +80,8 @@ pub(crate) struct WorkItemMutationResult {
     pub(crate) warnings: Vec<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) completed_transition: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) continuation_resumed: Option<WorkItemContinuationSummary>,
 }
 
 impl WorkItemMutationResult {
@@ -87,6 +90,7 @@ impl WorkItemMutationResult {
             work_item,
             warnings: Vec::new(),
             completed_transition: None,
+            continuation_resumed: None,
         }
     }
 
@@ -99,6 +103,15 @@ impl WorkItemMutationResult {
             work_item,
             warnings,
             completed_transition: Some(completed_transition),
+            continuation_resumed: None,
         }
+    }
+
+    pub(crate) fn with_continuation_resumed(
+        mut self,
+        continuation_resumed: Option<WorkItemContinuationSummary>,
+    ) -> Self {
+        self.continuation_resumed = continuation_resumed;
+        self
     }
 }

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -24,6 +24,7 @@ pub(crate) enum WorkItemLifecycleView {
 pub(crate) enum WorkItemFocusView {
     Current,
     Queued,
+    Yielded,
     Blocked,
     Completed,
 }
@@ -145,7 +146,16 @@ pub(crate) async fn view_for_record(
             .map(WaitConditionSummary::from)
             .collect(),
     };
-    let readiness = readiness_for_view(&record, &active_wait_conditions);
+    let is_yielded = runtime
+        .storage()
+        .latest_active_work_item_continuation_for_suspended(&record.agent_id, &record.id)?
+        .is_some();
+    let readiness = readiness_for_view(&record, &active_wait_conditions, is_yielded);
+    let focus = if is_yielded && !is_current && record.state == WorkItemState::Open {
+        WorkItemFocusView::Yielded
+    } else {
+        focus
+    };
     Ok(WorkItemView {
         id: record.id,
         agent_id: record.agent_id,
@@ -290,9 +300,13 @@ pub(crate) fn focus_view(record: &WorkItemRecord, is_current: bool) -> WorkItemF
 pub(crate) fn readiness_for_view(
     record: &WorkItemRecord,
     active_wait_conditions: &[WaitConditionSummary],
+    is_yielded: bool,
 ) -> WorkItemReadiness {
     if record.state == WorkItemState::Completed {
         return WorkItemReadiness::Completed;
+    }
+    if is_yielded {
+        return WorkItemReadiness::Yielded;
     }
     if active_wait_conditions
         .iter()

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -85,6 +85,7 @@ pub(crate) struct WorkItemQueryContext {
 
 pub(crate) type WorkItemDeliverySummaryMap = BTreeMap<String, DeliverySummaryRecord>;
 pub(crate) type WorkItemWaitConditionSummaryMap = BTreeMap<String, Vec<WaitConditionSummary>>;
+pub(crate) type WorkItemYieldedSet = BTreeSet<String>;
 
 pub(crate) async fn query_context(runtime: &RuntimeHandle) -> Result<WorkItemQueryContext> {
     let state = runtime.agent_state().await?;
@@ -117,6 +118,7 @@ pub(crate) async fn view_for_record(
     include_todo_list: bool,
     delivery_summaries: Option<&WorkItemDeliverySummaryMap>,
     wait_conditions: Option<&WorkItemWaitConditionSummaryMap>,
+    yielded_ids: Option<&WorkItemYieldedSet>,
 ) -> Result<WorkItemView> {
     let is_current = context.current_work_item_id.as_deref() == Some(record.id.as_str())
         && record.state == WorkItemState::Open;
@@ -146,10 +148,13 @@ pub(crate) async fn view_for_record(
             .map(WaitConditionSummary::from)
             .collect(),
     };
-    let is_yielded = runtime
-        .storage()
-        .latest_active_work_item_continuation_for_suspended(&record.agent_id, &record.id)?
-        .is_some();
+    let is_yielded = match yielded_ids {
+        Some(yielded_ids) => yielded_ids.contains(&record.id),
+        None => runtime
+            .storage()
+            .latest_active_work_item_continuation_for_suspended(&record.agent_id, &record.id)?
+            .is_some(),
+    };
     let readiness = readiness_for_view(&record, &active_wait_conditions, is_yielded);
     let focus = if is_yielded && !is_current && record.state == WorkItemState::Open {
         WorkItemFocusView::Yielded

--- a/src/types.rs
+++ b/src/types.rs
@@ -3291,6 +3291,7 @@ pub enum WorkItemPlanStatus {
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemReadiness {
     Runnable,
+    Yielded,
     WaitingForOperator,
     Blocked,
     Completed,
@@ -3300,6 +3301,7 @@ pub enum WorkItemReadiness {
 #[serde(rename_all = "snake_case")]
 pub enum WorkItemSchedulingState {
     Runnable,
+    YieldedToWorkItem,
     WaitingOperator,
     WaitingTask,
     WaitingExternal,
@@ -3452,6 +3454,7 @@ impl WorkItemRecord {
     pub fn readiness(&self) -> WorkItemReadiness {
         match self.scheduling_state(None) {
             WorkItemSchedulingState::Runnable => WorkItemReadiness::Runnable,
+            WorkItemSchedulingState::YieldedToWorkItem => WorkItemReadiness::Yielded,
             WorkItemSchedulingState::WaitingOperator => WorkItemReadiness::WaitingForOperator,
             WorkItemSchedulingState::WaitingTask
             | WorkItemSchedulingState::WaitingExternal
@@ -3468,6 +3471,85 @@ impl WorkItemRecord {
 
     pub fn is_waiting_for_operator(&self) -> bool {
         self.readiness() == WorkItemReadiness::WaitingForOperator
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkItemContinuationReturnPolicy {
+    OnCompleted,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkItemContinuationState {
+    Active,
+    Resumed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkItemContinuationFrame {
+    pub id: String,
+    pub agent_id: String,
+    pub suspended_work_item_id: String,
+    pub active_work_item_id: String,
+    pub return_policy: WorkItemContinuationReturnPolicy,
+    pub state: WorkItemContinuationState,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancelled_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+}
+
+impl WorkItemContinuationFrame {
+    pub fn new_on_completed(
+        agent_id: impl Into<String>,
+        suspended_work_item_id: impl Into<String>,
+        active_work_item_id: impl Into<String>,
+        turn_id: Option<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: ids::work_item_continuation_id(),
+            agent_id: agent_id.into(),
+            suspended_work_item_id: suspended_work_item_id.into(),
+            active_work_item_id: active_work_item_id.into(),
+            return_policy: WorkItemContinuationReturnPolicy::OnCompleted,
+            state: WorkItemContinuationState::Active,
+            created_at: now,
+            updated_at: now,
+            resolved_at: None,
+            cancelled_at: None,
+            resolution_reason: None,
+            turn_id,
+        }
+    }
+
+    pub fn resume(mut self, reason: impl Into<String>) -> Self {
+        let now = Utc::now();
+        self.state = WorkItemContinuationState::Resumed;
+        self.updated_at = now;
+        self.resolved_at = Some(now);
+        self.cancelled_at = None;
+        self.resolution_reason = Some(reason.into());
+        self
+    }
+
+    pub fn cancel(mut self, reason: impl Into<String>) -> Self {
+        let now = Utc::now();
+        self.state = WorkItemContinuationState::Cancelled;
+        self.updated_at = now;
+        self.cancelled_at = Some(now);
+        self.resolved_at = None;
+        self.resolution_reason = Some(reason.into());
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

- add WorkItem continuation frames with DB/JSONL storage and yielded scheduler projection
- make PickWorkItem from a runnable current WorkItem create an on_completed yield frame by default
- make CompleteWorkItem resume the direct caller, restore current focus, and expose optional continuation_resumed output
- add ListWorkItems(filter=yielded), prompt/tool docs, RFC alignment, and refreshed schemas

## Validation

- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test runtime::tests::work_items -- --nocapture
- cargo test runtime::tests::scheduler -- --nocapture
- cargo test runtime_db::tests -- --nocapture
- cargo test --test openapi_snapshot -- --nocapture
- cargo test --test tool_schema_inventory_snapshot -- --nocapture
