### PR TITLE
fix: record operator ack as lifecycle event

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -1,6 +1,17 @@
-use crate::types::{BriefKind, BriefRecord, MessageEnvelope};
+use crate::types::{AuditEvent, BriefKind, BriefRecord, MessageEnvelope};
 
 pub const QUEUED_WORK_ACK_PREFIX: &str = "Queued work: ";
+
+pub fn make_acknowledgement_event(message: &MessageEnvelope) -> AuditEvent {
+    AuditEvent::new(
+        "message_acknowledged",
+        serde_json::json!({
+            "agent_id": &message.agent_id,
+            "message_id": &message.id,
+            "summary": format!("{QUEUED_WORK_ACK_PREFIX}{}", preview_message(message)),
+        }),
+    )
+}
 
 pub fn make_ack(agent_id: &str, message: &MessageEnvelope) -> BriefRecord {
     let preview = preview_message(message);

--- a/src/context.rs
+++ b/src/context.rs
@@ -4020,14 +4020,6 @@ mod tests {
             },
         );
         storage.append_message(&prior_message).unwrap();
-        let ack = BriefRecord::new(
-            "default",
-            BriefKind::Ack,
-            "Acknowledged the request.",
-            Some(prior_message.id.clone()),
-            None,
-        );
-        storage.append_brief(&ack).unwrap();
         let result = BriefRecord::new(
             "default",
             BriefKind::Result,
@@ -4038,7 +4030,7 @@ mod tests {
         storage.append_brief(&result).unwrap();
         let mut turn = TurnRecord::new("default", "turn-previous", 1);
         turn.input_message_ids = vec![prior_message.id.clone()];
-        turn.produced_brief_ids = vec![ack.id.clone(), result.id.clone()];
+        turn.produced_brief_ids = vec![result.id.clone()];
         turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(
             &prior_message,
         ));
@@ -4080,7 +4072,7 @@ mod tests {
         assert!(recent_turns
             .content
             .contains("Unique latest result content."));
-        assert!(recent_turns.content.contains("Acknowledged the request."));
+        assert!(!recent_turns.content.contains("Acknowledged the request."));
         assert!(!built
             .sections
             .iter()

--- a/src/host.rs
+++ b/src/host.rs
@@ -3535,7 +3535,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        wait_for_brief_count(&runtime, 2).await;
+        wait_for_brief_count(&runtime, 1).await;
 
         host.shutdown().await.unwrap();
 
@@ -3562,7 +3562,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        wait_for_brief_count(&runtime2, 4).await;
+        wait_for_brief_count(&runtime2, 2).await;
 
         let final_state = runtime2.agent_state().await.unwrap();
         assert_ne!(final_state.status, AgentStatus::Stopped);
@@ -3686,7 +3686,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        wait_for_brief_count(&started, 2).await;
+        wait_for_brief_count(&started, 1).await;
 
         let agents = host.inner.agents.read().await;
         let entry = agents.get(&agent_id).expect("expected live runtime entry");
@@ -3697,8 +3697,12 @@ mod tests {
         drop(agents);
 
         let briefs = started.storage().read_recent_briefs(10).unwrap();
-        assert!(briefs.iter().any(|brief| brief.text.contains("start me")));
         assert!(briefs.iter().any(|brief| brief.text.contains("done")));
+        let events = started.storage().read_recent_events(100).unwrap();
+        assert!(events.iter().any(|event| {
+            event.kind == "message_acknowledged"
+                && event.data["summary"].as_str() == Some("Queued work: start me")
+        }));
     }
 
     #[test]

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -253,6 +253,7 @@ fn event_category(kind: &str) -> OperatorEventCategory {
         "operator_notification_requested" => OperatorEventCategory::OperatorNotification,
         "brief_created" => OperatorEventCategory::Brief,
         "operator_interjection_admitted"
+        | "message_acknowledged"
         | "message_enqueued"
         | "message_admitted"
         | "message_processing_started"
@@ -683,6 +684,7 @@ fn event_text(
     match kind {
         "operator_notification_requested" => operator_notification_text(payload, fallback_summary),
         "brief_created" => brief_text(payload),
+        "message_acknowledged" => simple_event_text("Message acknowledged", ack_body(payload)),
         "message_enqueued" => simple_event_text("Message queued", message_body_preview(payload)),
         "message_admitted" => simple_event_text("Message admitted", message_id_body(payload)),
         "message_processing_started" => {
@@ -944,6 +946,10 @@ fn first_string_field(payload: &Value, fields: &[&str]) -> Option<String> {
 
 fn message_id_body(payload: &Value) -> Option<String> {
     first_string_field(payload, &["message_id", "id"]).map(|id| format!("message {id}"))
+}
+
+fn ack_body(payload: &Value) -> Option<String> {
+    first_string_field(payload, &["summary"]).or_else(|| message_id_body(payload))
 }
 
 fn message_body_preview(payload: &Value) -> Option<String> {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1165,6 +1165,9 @@ impl PresentationReducer {
 fn brief_result_item(event: &ProjectionEventRecord) -> Option<(String, PresentationItem)> {
     match serde_json::from_value::<BriefRecord>(event.payload.clone()) {
         Ok(brief) => {
+            if brief.kind == BriefKind::Ack {
+                return None;
+            }
             let key = format!("id:{}", brief.id);
             Some((
                 key,
@@ -3376,7 +3379,7 @@ mod tests {
     }
 
     #[test]
-    fn reducer_keeps_legacy_ack_briefs_as_assistant_results() {
+    fn reducer_filters_legacy_ack_briefs_from_assistant_results() {
         let message = crate::types::MessageEnvelope::new(
             "default",
             crate::types::MessageKind::OperatorPrompt,
@@ -3394,7 +3397,7 @@ mod tests {
         let mut reducer = PresentationReducer::new();
         let items = reducer.reduce(&[event]);
 
-        assert_eq!(items.len(), 1);
+        assert!(items.is_empty());
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1164,7 +1164,6 @@ impl PresentationReducer {
 
 fn brief_result_item(event: &ProjectionEventRecord) -> Option<(String, PresentationItem)> {
     match serde_json::from_value::<BriefRecord>(event.payload.clone()) {
-        Ok(brief) if is_operator_queue_ack(&brief) => None,
         Ok(brief) => {
             let key = format!("id:{}", brief.id);
             Some((
@@ -1378,17 +1377,6 @@ fn operator_message_item(event: &ProjectionEventRecord) -> Option<(String, Strin
     Some((key, text))
 }
 
-fn is_operator_queue_ack(brief: &BriefRecord) -> bool {
-    // This matches the canonical operator-input acknowledgement from
-    // `brief::make_ack`; arbitrary Ack briefs should still render normally.
-    brief.kind == BriefKind::Ack
-        && brief.related_message_id.is_some()
-        && brief
-            .text
-            .trim_start()
-            .starts_with(crate::brief::QUEUED_WORK_ACK_PREFIX)
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct FinalBriefText {
     agent_id: String,
@@ -1400,7 +1388,6 @@ fn final_brief_texts(events: &[ProjectionEventRecord]) -> Vec<FinalBriefText> {
         .iter()
         .filter(|event| event.kind == "brief_created")
         .filter_map(|event| serde_json::from_value::<BriefRecord>(event.payload.clone()).ok())
-        .filter(|brief| !is_operator_queue_ack(brief))
         .filter(|brief| !brief.text.trim().is_empty())
         .map(|brief| FinalBriefText {
             agent_id: brief.agent_id,
@@ -3389,7 +3376,7 @@ mod tests {
     }
 
     #[test]
-    fn reducer_filters_canonical_operator_queue_ack_briefs() {
+    fn reducer_keeps_legacy_ack_briefs_as_assistant_results() {
         let message = crate::types::MessageEnvelope::new(
             "default",
             crate::types::MessageKind::OperatorPrompt,
@@ -3407,7 +3394,7 @@ mod tests {
         let mut reducer = PresentationReducer::new();
         let items = reducer.reduce(&[event]);
 
-        assert!(items.is_empty());
+        assert_eq!(items.len(), 1);
     }
 
     #[test]

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -17,8 +17,9 @@ impl RuntimeHandle {
         )
         .await?;
         self.record_incoming_transcript_entry(message)?;
-        let ack = brief::make_ack(&message.agent_id, message);
-        self.persist_brief(&ack).await?;
+        self.inner
+            .storage
+            .append_event(&brief::make_acknowledgement_event(message))?;
         let context_build_started = std::time::Instant::now();
         let identity = self.agent_identity_view().await?;
         let default_external_ingress = self

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -400,6 +400,29 @@ fn apply_brief_event(app: &mut TuiApp, brief: BriefRecord) {
     );
 }
 
+fn apply_event(app: &mut TuiApp, event_type: &str, payload: serde_json::Value) {
+    let event_id = format!("evt-{event_type}");
+    let projection = app
+        .projection
+        .get_or_insert_with(|| TuiProjection::from_snapshot(sample_snapshot("default", "evt-0")));
+    projection.apply_event(
+        AgentStreamEvent {
+            id: event_id.clone(),
+            event: event_type.into(),
+            data: StreamEventEnvelope {
+                id: event_id,
+                event_seq: 0,
+                ts: Utc::now(),
+                agent_id: "default".into(),
+                event_type: event_type.into(),
+                provenance: None,
+                payload,
+            },
+        },
+        &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+}
+
 fn rendered_buffer_text(terminal: &Terminal<TestBackend>) -> String {
     terminal
         .backend()
@@ -2445,25 +2468,21 @@ fn chat_text_renders_brief_events_from_projection() {
 }
 
 #[test]
-fn chat_text_filters_operator_queue_ack_but_keeps_result_brief_events() {
+fn chat_text_ignores_ack_lifecycle_event_but_keeps_result_brief_events() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(
         client,
         crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
     );
-    let message = crate::types::MessageEnvelope::new(
-        "default",
-        crate::types::MessageKind::OperatorPrompt,
-        crate::types::MessageOrigin::Operator { actor_id: None },
-        crate::types::AuthorityClass::OperatorInstruction,
-        crate::types::Priority::Normal,
-        crate::types::MessageBody::Text {
-            text: "duplicate".into(),
-        },
+    apply_event(
+        &mut app,
+        "message_acknowledged",
+        json!({
+            "agent_id": "default",
+            "message_id": "msg-duplicate",
+            "summary": "Queued work: duplicate",
+        }),
     );
-    let ack = crate::brief::make_ack("default", &message);
-    assert!(ack.text.starts_with(crate::brief::QUEUED_WORK_ACK_PREFIX));
-    apply_brief_event(&mut app, ack);
     apply_brief_event(
         &mut app,
         BriefRecord {

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -499,15 +499,6 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
     let mut operator_message_with_turn = operator_message.clone();
     operator_message_with_turn.turn_id = Some("turn_op_test".into());
     storage.append_message(&operator_message_with_turn)?;
-    let mut ack_brief = BriefRecord::new(
-        "default",
-        BriefKind::Ack,
-        "Started cargo test runtime_flow.",
-        Some(operator_message.id.clone()),
-        Some("task_exec_1".into()),
-    );
-    ack_brief.id = "brief_started_runtime_flow".into();
-    storage.append_brief(&ack_brief)?;
     let mut turn_index_brief = BriefRecord::new(
         "default",
         BriefKind::Result,
@@ -612,7 +603,6 @@ Recent turns:
   - continuation trigger: a task-result continuation
   - operator input: Run cargo test runtime_flow and report back.
   - produced briefs:
-    - Ack: Started cargo test runtime_flow. brief_ref=brief:brief_started_runtime_flow
     - Result: Captured completion report promotion. brief_ref=brief:brief_completion_report_promotion
   - tool executions:
     - [trusted_system][success] ExecCommand Run command: cargo test runtime_flow tool_execution_id=tool_exec_1
@@ -1831,7 +1821,7 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
     storage.append_message(&first_operator)?;
     storage.append_brief(&BriefRecord::new(
         "default",
-        BriefKind::Ack,
+        BriefKind::Result,
         "Started deterministic fixture construction.",
         Some(first_operator.id.clone()),
         None,
@@ -2217,7 +2207,7 @@ fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() ->
     storage.append_message(&recent_operator)?;
     storage.append_brief(&BriefRecord::new(
         "default",
-        BriefKind::Ack,
+        BriefKind::Result,
         "Active work resumed after compaction.",
         Some(recent_operator.id.clone()),
         None,

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -194,7 +194,7 @@ pub async fn subagent_task_updates_parent_state_and_child_summary_during_lifecyc
         if let Some(child) = summary.active_children.iter().find(|child| {
             child.identity.delegated_from_task_id.as_deref() == Some(task.id.as_str())
         }) {
-            if child.observability.last_progress_brief.is_some() {
+            if matches!(child.observability.phase, ChildAgentPhase::Running) {
                 saw_child_summary = true;
                 assert_eq!(child.identity.kind, AgentKind::Child);
                 assert_eq!(child.identity.parent_agent_id.as_deref(), Some("default"));
@@ -202,7 +202,6 @@ pub async fn subagent_task_updates_parent_state_and_child_summary_during_lifecyc
                     child.identity.delegated_from_task_id.as_deref(),
                     Some(task.id.as_str())
                 );
-                assert_eq!(child.observability.phase, ChildAgentPhase::Running);
                 assert!(child.observability.last_result_brief.is_none());
                 break;
             }
@@ -317,8 +316,7 @@ pub async fn subagent_task_status_exposes_live_and_terminal_child_observability(
             Ok(matches!(
                 child.phase,
                 ChildAgentPhase::Running | ChildAgentPhase::Waiting
-            ) && child.last_progress_brief.is_some()
-                && snapshot.child_agent_id.is_some())
+            ) && snapshot.child_agent_id.is_some())
         }
     })
     .await?;

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -121,7 +121,7 @@ pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> R
             && brief.text == "turn boundary result"
     }));
 
-    let events = runtime.recent_events(20).await?;
+    let events = runtime.recent_events(100).await?;
     assert!(events.iter().any(|event| {
         event.kind == "message_acknowledged"
             && event.data["message_id"].as_str() == Some(message.id.as_str())
@@ -155,13 +155,20 @@ pub async fn message_processing_creates_briefs_and_sleeps() -> Result<()> {
             text: "hello".into(),
         },
     );
-    runtime.enqueue(message).await?;
+    runtime.enqueue(message.clone()).await?;
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let briefs = runtime.recent_briefs(10).await?;
-    assert_eq!(briefs.len(), 2);
-    assert_eq!(briefs[0].text, "Queued work: hello");
-    assert_eq!(briefs[1].text, "stub result");
+    assert_eq!(briefs.len(), 1);
+    assert_eq!(briefs[0].kind, BriefKind::Result);
+    assert_eq!(briefs[0].text, "stub result");
+
+    let events = runtime.recent_events(100).await?;
+    assert!(events.iter().any(|event| {
+        event.kind == "message_acknowledged"
+            && event.data["message_id"].as_str() == Some(message.id.as_str())
+            && event.data["summary"].as_str() == Some("Queued work: hello")
+    }));
 
     let session = runtime.agent_state().await?;
     assert_eq!(session.status, AgentStatus::Asleep);
@@ -201,20 +208,25 @@ pub async fn terminal_brief_uses_last_assistant_message_without_terminal_deliver
     .await?;
 
     let briefs = runtime.recent_briefs(10).await?;
-    assert_eq!(briefs.len(), 2);
-    assert_eq!(briefs[0].text, "Queued work: write and verify a file");
+    assert_eq!(briefs.len(), 1);
+    assert_eq!(briefs[0].kind, BriefKind::Result);
     assert_eq!(
-        briefs[1].text,
+        briefs[0].text,
         "Verification is complete. I'll package the final answer now."
     );
     assert!(
-        !briefs[1]
+        !briefs[0]
             .text
             .contains("Let me create a summary document of what was changed."),
         "persisted result brief should come from the terminal turn, not a tool-round preamble: {}",
-        briefs[1].text
+        briefs[0].text
     );
-    let events = runtime.recent_events(20).await?;
+    let events = runtime.recent_events(100).await?;
+    assert!(events.iter().any(|event| {
+        event.kind == "message_acknowledged"
+            && event.data["message_id"].as_str() == Some(message.id.as_str())
+            && event.data["summary"].as_str() == Some("Queued work: write and verify a file")
+    }));
     let terminal_event = events
         .iter()
         .find(|event| event.kind == "turn_terminal")

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -549,7 +549,7 @@ pub async fn multi_session_state_is_isolated() -> Result<()> {
     let a = host.get_or_create_agent("alpha").await?;
     let b = host.get_or_create_agent("beta").await?;
 
-    a.enqueue(MessageEnvelope::new(
+    let alpha_message = MessageEnvelope::new(
         "alpha",
         MessageKind::OperatorPrompt,
         MessageOrigin::Operator { actor_id: None },
@@ -558,9 +558,9 @@ pub async fn multi_session_state_is_isolated() -> Result<()> {
         MessageBody::Text {
             text: "alpha".into(),
         },
-    ))
-    .await?;
-    b.enqueue(MessageEnvelope::new(
+    );
+    a.enqueue(alpha_message.clone()).await?;
+    let beta_message = MessageEnvelope::new(
         "beta",
         MessageKind::OperatorPrompt,
         MessageOrigin::Operator { actor_id: None },
@@ -569,16 +569,29 @@ pub async fn multi_session_state_is_isolated() -> Result<()> {
         MessageBody::Text {
             text: "beta".into(),
         },
-    ))
-    .await?;
+    );
+    b.enqueue(beta_message.clone()).await?;
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let alpha_briefs = a.recent_briefs(10).await?;
     let beta_briefs = b.recent_briefs(10).await?;
-    assert_eq!(alpha_briefs.len(), 2);
-    assert_eq!(beta_briefs.len(), 2);
+    assert_eq!(alpha_briefs.len(), 1);
+    assert_eq!(beta_briefs.len(), 1);
     assert_eq!(alpha_briefs[0].agent_id, "alpha");
     assert_eq!(beta_briefs[0].agent_id, "beta");
+
+    let alpha_events = a.recent_events(100).await?;
+    let beta_events = b.recent_events(100).await?;
+    assert!(alpha_events.iter().any(|event| {
+        event.kind == "message_acknowledged"
+            && event.data["message_id"].as_str() == Some(alpha_message.id.as_str())
+            && event.data["summary"].as_str() == Some("Queued work: alpha")
+    }));
+    assert!(beta_events.iter().any(|event| {
+        event.kind == "message_acknowledged"
+            && event.data["message_id"].as_str() == Some(beta_message.id.as_str())
+            && event.data["summary"].as_str() == Some("Queued work: beta")
+    }));
     Ok(())
 }
 

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -111,10 +111,9 @@ pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> R
     }));
 
     let briefs = runtime.recent_briefs(10).await?;
-    assert!(briefs.iter().any(|brief| {
+    assert!(!briefs.iter().any(|brief| {
         brief.kind == BriefKind::Ack
             && brief.related_message_id.as_deref() == Some(message.id.as_str())
-            && brief.text == "Queued work: exercise the turn boundary"
     }));
     assert!(briefs.iter().any(|brief| {
         brief.kind == BriefKind::Result
@@ -123,6 +122,11 @@ pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> R
     }));
 
     let events = runtime.recent_events(20).await?;
+    assert!(events.iter().any(|event| {
+        event.kind == "message_acknowledged"
+            && event.data["message_id"].as_str() == Some(message.id.as_str())
+            && event.data["summary"].as_str() == Some("Queued work: exercise the turn boundary")
+    }));
     let terminal_event = events
         .iter()
         .find(|event| event.kind == "turn_terminal")


### PR DESCRIPTION
## Summary
- record operator-input acknowledgements as `message_acknowledged` lifecycle audit events instead of persisted Ack briefs
- keep `brief_created` / produced briefs focused on semantic assistant results while preserving legacy Ack brief rendering behavior if old records exist
- update prompt-context and TUI tests so Ack lifecycle events no longer appear as produced briefs or chat result duplicates

Closes #1665

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test prompt_context_snapshots`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
