### PR TITLE
feat: standardize runtime memory refs

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -29,6 +29,7 @@ implementation and tests.
 - [Work Item Continuation Stack](./work-item-continuation-stack.md)
 - [Long-Lived Context Memory](./long-lived-context-memory.md)
 - [Agent and Workspace Memory](./agent-and-workspace-memory.md)
+- [Runtime Ref Resolution and MemoryGet](./runtime-ref-resolution-and-memory-get.md)
 - [Turn-Local Context Compaction](./turn-local-context-compaction.md)
 - [OpenAI Remote Compaction Boundary](./openai-remote-compaction.md)
 - [Turn Model Lineage And Recovery](./turn-model-lineage-and-recovery.md)

--- a/docs/rfcs/runtime-ref-resolution-and-memory-get.md
+++ b/docs/rfcs/runtime-ref-resolution-and-memory-get.md
@@ -1,0 +1,330 @@
+---
+title: RFC: Runtime Ref Resolution and MemoryGet
+date: 2026-06-10
+status: draft
+---
+
+# RFC: Runtime Ref Resolution and MemoryGet
+
+## Summary
+
+Holon prompt projection should expose compact retrieval anchors, and agents
+should be able to dereference those anchors through one stable runtime contract.
+
+This RFC defines a typed runtime ref model for `MemoryGet`:
+
+- `MemorySearch` discovers candidate refs through an index.
+- `MemoryGet` dereferences known refs through their authoritative runtime
+  stores wherever practical.
+- Prompt-projected refs are stable anchors, while inline previews are bounded
+  hints.
+
+The goal is to make context compaction recoverable without turning the search
+index into a source of truth or embedding large runtime records in every prompt.
+
+## Related documents
+
+- [Agent and Workspace Memory](./agent-and-workspace-memory.md)
+- [Long-Lived Context Memory](./long-lived-context-memory.md)
+- [Turn-Based Context Projection](./turn-based-context-projection.md)
+- [Runtime Ledger Files and Relations](./runtime-ledger-files-and-relations.md)
+- [Tool Surface Layering](./tool-surface-layering.md)
+- [Tool Result Envelope](./tool-result-envelope.md)
+
+## Problem
+
+Holon is moving prompt context toward smaller, ref-oriented surfaces:
+
+- `recent_turns` should show continuity and retrieval anchors, not replay every
+  tool detail.
+- `episode` should become an anchor surface rather than a transcript summary.
+- future WorkItem refs should point to files, tools, issues, tasks, or evidence
+  that may need to be reopened.
+
+That design only works if an agent can later fetch exact content behind a known
+anchor. Otherwise prompt compaction only moves information out of sight:
+
+- a prompt can mention `brief_ref`, `cmd_ref`, `stdout_ref`, or `task` evidence,
+  but lookup rules remain partly ad hoc;
+- `MemorySearch` can become the accidental source of truth because `MemoryGet`
+  only retrieves what the index already knows how to return;
+- each runtime object can grow its own ref syntax and validation path;
+- old previews can be mistaken for the authoritative content they summarize.
+
+Holon needs one explicit boundary:
+
+```text
+Search discovers refs.
+Get dereferences refs.
+Stores own the original content.
+Prompt previews are only hints.
+```
+
+## Goals
+
+- Define a canonical typed ref contract for model-visible runtime anchors.
+- Keep `MemorySearch` as an index-backed discovery tool, not a canonical store.
+- Make `MemoryGet` resolve known refs directly against original stores or
+  evidence repositories where practical.
+- Preserve trust, provenance, agent, and workspace visibility boundaries.
+- Keep prompt projection compact while ensuring exposed refs are fetchable.
+- Make missing, invalid, unsupported, and unauthorized refs fail with clear,
+  bounded tool errors.
+- Keep Ack lifecycle receipts outside the semantic `brief:` namespace.
+
+## Non-Goals
+
+- Do not make every internal runtime event dereferenceable.
+- Do not introduce LLM summarization into ref resolution.
+- Do not make the search index authoritative for runtime evidence.
+- Do not define the complete future `WorkItem.work_refs` schema.
+- Do not define a global cross-agent search capability.
+- Do not expose secrets, credentials, hidden prompt internals, or raw provider
+  requests through `MemoryGet`.
+
+## Terms
+
+### Runtime Ref
+
+A runtime ref is an opaque, typed handle that identifies retrievable Holon data.
+It is copied from prompt projection, `MemorySearch`, or another runtime-owned
+tool response.
+
+Refs are not file paths, URLs, search queries, or natural-language labels.
+
+### Resolver
+
+A resolver maps one supported ref namespace to an authoritative source. For
+example, a `brief:` resolver reads semantic brief evidence, and a
+`tool_execution:` resolver reads tool execution evidence.
+
+### Preview
+
+A preview is bounded model-facing text rendered near a ref. It helps the agent
+decide whether to dereference the ref, but it is not the source of truth.
+
+## Ref Syntax
+
+Refs should use a short namespace followed by opaque identifier segments:
+
+```text
+<namespace>:<id>
+<namespace>:<id>:<selector>
+<namespace>:<id>:<subresource>:<sub_id>:<selector>
+```
+
+General rules:
+
+- namespace names are lower snake case;
+- ids are opaque and should not be parsed for semantics outside the owning
+  resolver;
+- refs must be single tokens without whitespace;
+- refs should avoid embedding local absolute paths or capability URLs;
+- refs may include selectors when one runtime object has multiple retrievable
+  subresources.
+
+## Initial Namespaces
+
+| Namespace | Example | Source of truth | Notes |
+| --- | --- | --- | --- |
+| `agent_memory:` | `agent_memory:self` | curated agent memory file | Agent-scoped durable memory, not runtime evidence. |
+| `workspace_profile:` | `workspace_profile:ws-holon` | workspace profile store | Workspace-scoped profile content. |
+| `brief:` | `brief:brief_123` | semantic brief evidence | Only semantic user-facing delivery such as result or failure. Ordinary Ack is not a brief ref target. |
+| `tool_execution:` | `tool_execution:tool_123:stdout` | tool execution evidence | Supports selected command input/output subresources. |
+| `task:` | `task:task_123` | task lifecycle store/evidence | Returns bounded task state and terminal result evidence when available. |
+| `work_item:` | `work_item:work_123` | WorkItem state store | Returns current/latest WorkItem state and stable plan/result refs where available. |
+| `episode:` | `episode:ep_123` | context episode store | Returns archived episode record content and source refs. |
+
+The initial `tool_execution:` selectors are:
+
+```text
+tool_execution:<id>:cmd
+tool_execution:<id>:stdout
+tool_execution:<id>:stderr
+tool_execution:<id>:output
+tool_execution:<id>:batch_item:<index>:cmd
+tool_execution:<id>:batch_item:<index>:stdout
+tool_execution:<id>:batch_item:<index>:stderr
+tool_execution:<id>:batch_item:<index>:output
+```
+
+`<index>` is one-based and must identify a batch item in the stored tool
+execution record.
+
+## Brief Boundary
+
+After Ack normalization, `brief:` means semantic user-facing delivery.
+
+Allowed `brief:` targets include:
+
+- result briefs;
+- failure briefs;
+- WorkItem completion reports when represented as semantic delivery;
+- future explicit blocker or wait reports only when they are user-facing
+  outcomes rather than lifecycle receipts.
+
+Ordinary admission acknowledgements such as `Queued work: ...` are lifecycle
+or control-plane evidence. They should be stored and inspected through their
+own event/evidence surface if Holon later exposes one, not through `brief:`.
+
+Legacy `BriefKind::Ack` rows may remain readable for compatibility, but new
+prompt projection should not mint `brief:` refs for Ack rows, and ref resolution
+should not treat Ack as the semantic brief model.
+
+## Search and Get Contract
+
+### MemorySearch
+
+`MemorySearch` is discovery:
+
+- it reads an index projection;
+- it ranks and filters candidate refs;
+- it returns source refs, snippets, metadata, and provenance;
+- it may omit valid refs that are not indexed or not relevant to the query.
+
+Search results are not canonical object bodies. An indexed snippet must not be
+treated as exact historical content.
+
+### MemoryGet
+
+`MemoryGet` is dereference:
+
+- it validates the ref syntax and namespace;
+- it checks the caller-visible agent/workspace/trust boundary;
+- it resolves the ref through the namespace's authoritative store when
+  practical;
+- it returns exact bounded content plus metadata describing truncation and the
+  resolved source.
+
+When a known ref is available from prompt projection, `MemoryGet` should not
+require `MemorySearch` to be called first. Search can discover refs, but it
+should not be required to fetch a known prompt ref.
+
+### Index Fallback
+
+The search index may remain a compatibility fallback while a namespace is being
+migrated, but fallback behavior must be explicit:
+
+- source-of-truth resolver first;
+- index fallback only when no direct resolver exists yet;
+- clear tests for namespaces that promise direct resolution;
+- no write path should treat the index as canonical state.
+
+## Visibility and Trust
+
+Every resolver must preserve the runtime boundary of the underlying object.
+
+Minimum checks:
+
+- the requesting agent can see the object;
+- workspace-scoped data respects current workspace visibility unless the ref is
+  explicitly global or agent-scoped;
+- trust/provenance metadata is retained in the response where useful;
+- hidden provider internals, credentials, and capability secrets are not
+  exposed just because they appear in an evidence record.
+
+`MemoryGet` may return a clear unauthorized error instead of pretending a valid
+but hidden ref is missing when that distinction is safe. If revealing existence
+would leak sensitive information, it may return a bounded not-found style error
+with no secret details.
+
+## Error Classes
+
+The tool contract should distinguish these cases:
+
+- `invalid_ref`: the ref is malformed or uses an invalid selector.
+- `unsupported_ref_namespace`: the namespace is syntactically valid but not
+  exposed through `MemoryGet`.
+- `memory_source_not_found`: the ref is valid and supported, but no visible
+  source exists.
+- `memory_source_unauthorized`: the source exists but is outside the caller's
+  visibility boundary, when safe to disclose.
+- `memory_source_unavailable`: the source exists but cannot currently be read.
+
+All errors should be bounded and include recovery guidance. They must not dump
+large source bodies, secrets, or raw database errors.
+
+## Prompt Projection Requirements
+
+Any prompt section that exposes a runtime ref should follow these rules:
+
+- expose the exact ref string the resolver accepts;
+- include only a bounded preview near the ref;
+- make truncation explicit when preview text is incomplete;
+- avoid generating refs for unsupported or intentionally private objects;
+- keep refs stable across compaction and prompt budget changes;
+- prefer refs over embedding large stdout, stderr, tool outputs, episode text,
+  or older result bodies.
+
+For adjacent conversation continuity, prompt projection may inline recent
+semantic delivery text. That does not weaken the ref contract: the same
+semantic output should remain fetchable through `brief:` when a `brief_ref` is
+shown.
+
+## Resolver Shape
+
+Implementation should converge on a shared parser and resolver boundary instead
+of duplicating validation in each tool.
+
+Suggested shape:
+
+```text
+RuntimeRef
+  namespace
+  id
+  selector
+
+RuntimeRefResolver
+  validate(ref)
+  resolve(ref, caller_context, max_chars) -> MemoryGetResult
+```
+
+The parser owns syntax. Resolvers own namespace-specific semantics and source
+lookup.
+
+The caller context should include at least:
+
+- agent id;
+- active workspace id or visible workspace set;
+- authority class;
+- any future host-level capability for broader retrieval.
+
+## Rollout Plan
+
+1. Add this RFC and align tool documentation with the Search/Get boundary.
+2. Extract current `MemoryGet` source-ref validation into a shared runtime ref
+   parser.
+3. Add direct resolver coverage for existing prompt-visible refs:
+   `brief:`, `tool_execution:`, `task:`, `work_item:`, and `episode:`.
+4. Keep `MemorySearch` index-backed, but ensure search-returned refs can be
+   passed directly to `MemoryGet`.
+5. Update prompt projection code to use only refs accepted by the shared parser.
+6. Add compatibility handling for legacy Ack briefs without minting new
+   semantic `brief:` refs for Ack.
+7. Use this contract when adding future WorkItem-owned `work_refs`.
+
+## Test Expectations
+
+Focused tests should cover:
+
+- parser acceptance and rejection for every supported namespace;
+- direct `MemoryGet` of known prompt refs without calling `MemorySearch`;
+- `MemorySearch` returning refs that `MemoryGet` can dereference;
+- `brief:` returning semantic result/failure content and not depending on Ack;
+- tool execution stdout/stderr/output refs for command and batch executions;
+- task, WorkItem, and episode refs resolving from their source stores;
+- invalid, unsupported, missing, unauthorized, and unavailable errors;
+- prompt snapshots showing refs that are accepted by the parser.
+
+## Open Questions
+
+- Should Holon expose an `event:` or `audit_event:` namespace for selected
+  lifecycle receipts such as acknowledgements, or should those remain
+  operator/debug API concerns?
+- Should `turn:` become a direct `MemoryGet` namespace, or should turns remain
+  reachable only through episode, brief, task, and tool refs until turn
+  projection stabilizes?
+- How should future host-level or cross-agent retrieval be authorized without
+  weakening default agent/workspace isolation?
+- Should file refs ever be handled by `MemoryGet`, or should workspace files
+  remain exclusively under execution/file tools?

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -13,14 +13,15 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     agent_template::{agent_memory_operator_path, agent_memory_self_path},
+    memory::refs::{RuntimeRef, ToolExecutionRefSelector},
     runtime_db::{EvidenceKind, RuntimeDb},
     storage::AppStorage,
     tool::helpers::{
         command_digest, command_output_source_ref, command_preview, command_receipt_source_ref,
     },
     types::{
-        BriefRecord, CommandTaskStatusSnapshot, ContextEpisodeRecord, TaskRecord, TaskStatus,
-        ToolExecutionRecord, WorkItemRecord, WorkspaceEntry,
+        BriefKind, BriefRecord, CommandTaskStatusSnapshot, ContextEpisodeRecord, TaskRecord,
+        TaskStatus, ToolExecutionRecord, WorkItemRecord, WorkspaceEntry,
     },
 };
 
@@ -148,9 +149,39 @@ pub fn get_memory(
     max_chars: Option<usize>,
     active_workspace_id: Option<&str>,
 ) -> Result<Option<MemoryGetResult>> {
-    let index = ensure_memory_index_current(storage, active_workspace_id)?;
     let agent_id = storage_agent_id(storage);
+    if let Ok(runtime_ref) = RuntimeRef::parse(source_ref) {
+        let Some(document) = document_for_runtime_ref(storage, &runtime_ref)? else {
+            return Ok(None);
+        };
+        if document.agent_id != agent_id {
+            return Ok(None);
+        }
+        return Ok(Some(memory_get_result(document, max_chars)));
+    }
+
+    let index = ensure_memory_index_current(storage, active_workspace_id)?;
     index.get(source_ref, max_chars, &agent_id, active_workspace_id)
+}
+
+fn memory_get_result(document: MemoryDocument, max_chars: Option<usize>) -> MemoryGetResult {
+    let max_chars = max_chars
+        .unwrap_or(GET_CHARS_DEFAULT)
+        .clamp(1, GET_CHARS_MAX);
+    let (content, truncated) = truncate_chars(&document.body, max_chars);
+    MemoryGetResult {
+        kind: document.source_kind,
+        source_ref: document.source_ref,
+        scope_kind: document.scope_kind,
+        workspace_id: document.workspace_id,
+        agent_id: document.agent_id,
+        source_path: document.source_path.map(|path| path.display().to_string()),
+        title: document.title,
+        content,
+        truncated,
+        updated_at: document.updated_at,
+        metadata: document.metadata,
+    }
 }
 
 fn ensure_memory_index_current(
@@ -912,6 +943,32 @@ fn document_for_pending_source(
     }
 }
 
+fn document_for_runtime_ref(
+    storage: &AppStorage,
+    runtime_ref: &RuntimeRef,
+) -> Result<Option<MemoryDocument>> {
+    match runtime_ref {
+        RuntimeRef::AgentMemory { name } => known_memory_markdown_sources(storage)
+            .into_iter()
+            .find(|known| known.name == name)
+            .map(|known| agent_memory_document(storage, known.name, known.title, &known.path))
+            .transpose()
+            .map(|value| value.flatten()),
+        RuntimeRef::WorkspaceProfile { workspace_id } => {
+            workspace_profile_document_by_id(storage, workspace_id)
+        }
+        RuntimeRef::Brief { id } => brief_document_by_id(storage, id),
+        RuntimeRef::Episode { id } => context_episode_document_by_id(storage, id),
+        RuntimeRef::WorkItem { id } => work_item_document_by_id(storage, id),
+        RuntimeRef::Task { id } => task_document_by_id(storage, id),
+        RuntimeRef::ToolExecution {
+            id,
+            batch_item_index,
+            selector,
+        } => command_tool_execution_document(storage, id, *batch_item_index, *selector),
+    }
+}
+
 fn agent_memory_documents(storage: &AppStorage) -> Result<Vec<MemoryDocument>> {
     let mut documents = Vec::new();
     for source in known_memory_markdown_sources(storage) {
@@ -1020,9 +1077,13 @@ fn brief_documents(
     };
     Ok(briefs
         .into_iter()
-        .filter(|brief| !brief.text.trim().is_empty())
+        .filter(semantic_brief_is_retrievable)
         .map(|brief| brief_document(storage, brief))
         .collect())
+}
+
+fn semantic_brief_is_retrievable(brief: &BriefRecord) -> bool {
+    brief.kind != BriefKind::Ack && !brief.text.trim().is_empty()
 }
 
 fn brief_document(storage: &AppStorage, brief: BriefRecord) -> MemoryDocument {
@@ -1064,7 +1125,7 @@ fn brief_document_by_id(storage: &AppStorage, brief_id: &str) -> Result<Option<M
             .find(|brief| brief.id == brief_id)
     };
     Ok(brief
-        .filter(|brief| !brief.text.trim().is_empty())
+        .filter(semantic_brief_is_retrievable)
         .map(|brief| brief_document(storage, brief)))
 }
 
@@ -1433,9 +1494,24 @@ fn command_tool_execution_document_by_ref(
     storage: &AppStorage,
     source_ref: &str,
 ) -> Result<Option<MemoryDocument>> {
-    let Some(parsed_ref) = parse_tool_execution_source_ref(source_ref) else {
-        return Ok(None);
+    let runtime_ref = RuntimeRef::parse(source_ref).ok();
+    if let Some(RuntimeRef::ToolExecution {
+        id,
+        batch_item_index,
+        selector,
+    }) = runtime_ref
+    {
+        return command_tool_execution_document(storage, &id, batch_item_index, selector);
     };
+    Ok(None)
+}
+
+fn command_tool_execution_document(
+    storage: &AppStorage,
+    tool_execution_id: &str,
+    batch_item_index: Option<usize>,
+    selector: ToolExecutionRefSelector,
+) -> Result<Option<MemoryDocument>> {
     let runtime_db = storage.runtime_db()?;
     let record = if let Some(runtime_db) = runtime_db.as_ref() {
         runtime_db
@@ -1443,7 +1519,7 @@ fn command_tool_execution_document_by_ref(
             .payload_by_id(
                 EvidenceKind::ToolExecution,
                 &storage_agent_id(storage),
-                &parsed_ref.tool_execution_id,
+                tool_execution_id,
             )?
             .map(|row| serde_json::from_str::<ToolExecutionRecord>(&row.payload_json))
             .transpose()?
@@ -1451,16 +1527,12 @@ fn command_tool_execution_document_by_ref(
         storage
             .read_recent_tool_executions(usize::MAX)?
             .into_iter()
-            .find(|record| record.id == parsed_ref.tool_execution_id)
+            .find(|record| record.id == tool_execution_id)
     };
     let Some(record) = record else {
         return Ok(None);
     };
-    match (
-        record.tool_name.as_str(),
-        parsed_ref.batch_item_index,
-        parsed_ref.selector,
-    ) {
+    match (record.tool_name.as_str(), batch_item_index, selector) {
         ("ExecCommand", None, ToolExecutionRefSelector::Cmd) => Ok(record
             .input
             .get("cmd")
@@ -1476,54 +1548,13 @@ fn command_tool_execution_document_by_ref(
                     .and_then(Value::as_str)
                     .map(|cmd| command_receipt_document(&record, Some(index), Some(item), cmd))
             })),
-        ("ExecCommand", None, ToolExecutionRefSelector::Output(stream)) => {
-            Ok(command_output_document(&record, None, stream))
-        }
-        ("ExecCommandBatch", Some(index), ToolExecutionRefSelector::Output(stream)) => {
-            Ok(command_output_document(&record, Some(index), stream))
-        }
+        ("ExecCommand", None, ToolExecutionRefSelector::Output(stream)) => Ok(
+            command_output_document(&record, None, stream.as_ref_selector()),
+        ),
+        ("ExecCommandBatch", Some(index), ToolExecutionRefSelector::Output(stream)) => Ok(
+            command_output_document(&record, Some(index), stream.as_ref_selector()),
+        ),
         _ => Ok(None),
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum ToolExecutionRefSelector {
-    Cmd,
-    Output(&'static str),
-}
-
-struct ParsedToolExecutionRef {
-    tool_execution_id: String,
-    batch_item_index: Option<usize>,
-    selector: ToolExecutionRefSelector,
-}
-
-fn parse_tool_execution_source_ref(source_ref: &str) -> Option<ParsedToolExecutionRef> {
-    let rest = source_ref.strip_prefix("tool_execution:")?;
-    if let Some((tool_execution_id, tail)) = rest.rsplit_once(":batch_item:") {
-        let (index, selector) = tail.split_once(':')?;
-        let index = index.parse().ok().filter(|index| *index >= 1)?;
-        return Some(ParsedToolExecutionRef {
-            tool_execution_id: tool_execution_id.to_string(),
-            batch_item_index: Some(index),
-            selector: parse_tool_execution_selector(selector)?,
-        });
-    }
-    let (tool_execution_id, selector) = rest.rsplit_once(':')?;
-    Some(ParsedToolExecutionRef {
-        tool_execution_id: tool_execution_id.to_string(),
-        batch_item_index: None,
-        selector: parse_tool_execution_selector(selector)?,
-    })
-}
-
-fn parse_tool_execution_selector(selector: &str) -> Option<ToolExecutionRefSelector> {
-    match selector {
-        "cmd" => Some(ToolExecutionRefSelector::Cmd),
-        "stdout" => Some(ToolExecutionRefSelector::Output("stdout")),
-        "stderr" => Some(ToolExecutionRefSelector::Output("stderr")),
-        "output" => Some(ToolExecutionRefSelector::Output("output")),
-        _ => None,
     }
 }
 
@@ -2091,6 +2122,168 @@ mod tests {
     }
 
     #[test]
+    fn memory_get_resolves_known_runtime_refs_without_search_index_hit() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        ensure_agent_home_layout(dir.path()).unwrap();
+        rebuild_memory_index(&storage, None).unwrap();
+
+        let brief = brief_with_workspace(
+            "default",
+            BriefKind::Result,
+            "direct result evidence after index rebuild",
+            "ws-holon",
+        );
+        let brief_ref = format!("brief:{}", brief.id);
+        storage.append_brief(&brief).unwrap();
+
+        storage
+            .append_task(&task_record(
+                "task-direct-1663",
+                "default",
+                TaskKind::CommandTask,
+                TaskStatus::Completed,
+                "direct task source evidence",
+                Some("work-direct-1663".into()),
+                Some(json!({"cmd": "echo direct-task-1663"})),
+                0,
+                0,
+            ))
+            .unwrap();
+
+        let mut work_item = work_item_with_workspace(
+            "default",
+            "direct work item ref",
+            WorkItemState::Open,
+            "ws-holon",
+        );
+        work_item.id = "work-direct-1663".into();
+        work_item.todo_list = vec![TodoItem {
+            text: "prove direct work item get".into(),
+            state: TodoItemState::InProgress,
+        }];
+        storage.append_work_item(&work_item).unwrap();
+
+        storage
+            .append_context_episode(&ContextEpisodeRecord {
+                id: "episode-direct-1663".into(),
+                agent_id: "default".into(),
+                workspace_id: "ws-holon".into(),
+                created_at: Utc::now(),
+                finalized_at: Utc::now(),
+                start_turn_index: 1,
+                end_turn_index: 2,
+                start_message_count: 1,
+                end_message_count: 2,
+                boundary_reason: EpisodeBoundaryReason::HardTurnCap,
+                current_work_item_id: Some("work-direct-1663".into()),
+                objective: Some("runtime refs".into()),
+                work_summary: Some("direct episode source".into()),
+                scope_hints: vec![],
+                source_turn_ids: vec![],
+                source_refs: vec![],
+                generated_by: None,
+                operator_intents: vec![],
+                runtime_facts: vec![],
+                task_results: vec![],
+                unresolved_items: vec![],
+                model_inferences: vec![],
+                summary: "direct episode evidence after stale index".into(),
+                working_set_files: vec![],
+                commands: vec![],
+                verification: vec![],
+                decisions: vec![],
+                carry_forward: vec![],
+                waiting_on: vec![],
+            })
+            .unwrap();
+
+        storage
+            .append_tool_execution(&ToolExecutionRecord {
+                id: "tool-direct-1663".into(),
+                agent_id: "default".into(),
+                work_item_id: Some("work-direct-1663".into()),
+                turn_index: 0,
+                turn_id: None,
+                tool_name: "ExecCommand".into(),
+                created_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+                duration_ms: 10,
+                authority_class: crate::types::AuthorityClass::OperatorInstruction,
+                status: crate::types::ToolExecutionStatus::Success,
+                input: json!({"cmd": "printf direct-tool-1663"}),
+                output: json!({
+                    "stdout_preview": "direct-tool-1663",
+                    "stderr_preview": "",
+                    "truncated": false
+                }),
+                summary: "command exited with status 0".into(),
+                invocation_surface: None,
+            })
+            .unwrap();
+
+        assert_eq!(
+            get_memory(&storage, &brief_ref, None, None)
+                .unwrap()
+                .unwrap()
+                .content,
+            "direct result evidence after index rebuild"
+        );
+        assert!(get_memory(&storage, "task:task-direct-1663", None, None)
+            .unwrap()
+            .unwrap()
+            .content
+            .contains("direct task source evidence"));
+        assert!(
+            get_memory(&storage, "work_item:work-direct-1663", None, None)
+                .unwrap()
+                .unwrap()
+                .content
+                .contains("prove direct work item get")
+        );
+        assert!(
+            get_memory(&storage, "episode:episode-direct-1663", None, None)
+                .unwrap()
+                .unwrap()
+                .content
+                .contains("direct episode evidence after stale index")
+        );
+        assert!(
+            get_memory(&storage, "tool_execution:tool-direct-1663:cmd", None, None)
+                .unwrap()
+                .unwrap()
+                .content
+                .contains("direct-tool-1663")
+        );
+    }
+
+    #[test]
+    fn ack_briefs_are_not_semantic_memory_get_sources() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let ack = brief_with_workspace(
+            "default",
+            BriefKind::Ack,
+            "Queued work: direct ack should stay lifecycle evidence",
+            "ws-holon",
+        );
+        let ack_ref = format!("brief:{}", ack.id);
+        storage.append_brief(&ack).unwrap();
+
+        assert!(get_memory(&storage, &ack_ref, None, Some("ws-holon"))
+            .unwrap()
+            .is_none());
+        assert!(
+            !search_memory(&storage, "direct ack", 10, Some("ws-holon"), false)
+                .unwrap()
+                .iter()
+                .any(|result| result.source_ref == ack_ref)
+        );
+    }
+
+    #[test]
     fn memory_get_returns_db_backed_runtime_evidence_content() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
@@ -2113,11 +2306,10 @@ mod tests {
 
         storage.append_brief(&brief).unwrap();
         assert!(!storage.ledger_dir().join("briefs.jsonl").exists());
-        rebuild_memory_index(&storage, Some("ws-holon")).unwrap();
 
         let memory = get_memory(&storage, &brief_ref, None, Some("ws-holon"))
             .unwrap()
-            .expect("DB-backed runtime evidence should be indexed");
+            .expect("DB-backed runtime evidence should be directly retrievable");
         assert_eq!(memory.content, body);
         assert!(!memory.truncated);
     }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,5 +1,6 @@
 pub mod episode;
 pub mod index;
+pub(crate) mod refs;
 pub mod working;
 
 pub use episode::refresh_episode_memory;

--- a/src/memory/refs.rs
+++ b/src/memory/refs.rs
@@ -1,0 +1,272 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeRef {
+    AgentMemory {
+        name: String,
+    },
+    WorkspaceProfile {
+        workspace_id: String,
+    },
+    Brief {
+        id: String,
+    },
+    Episode {
+        id: String,
+    },
+    WorkItem {
+        id: String,
+    },
+    Task {
+        id: String,
+    },
+    ToolExecution {
+        id: String,
+        batch_item_index: Option<usize>,
+        selector: ToolExecutionRefSelector,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolExecutionRefSelector {
+    Cmd,
+    Output(ToolOutputSelector),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolOutputSelector {
+    Stdout,
+    Stderr,
+    Output,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeRefParseError {
+    validation_error: &'static str,
+}
+
+impl RuntimeRefParseError {
+    pub(crate) fn validation_error(&self) -> &'static str {
+        self.validation_error
+    }
+}
+
+pub(crate) const ALLOWED_SOURCE_REF_PREFIXES: &[&str] = &[
+    "agent_memory:",
+    "workspace_profile:",
+    "brief:",
+    "episode:",
+    "work_item:",
+    "tool_execution:",
+    "task:",
+];
+
+impl RuntimeRef {
+    pub(crate) fn parse(source_ref: &str) -> Result<Self, RuntimeRefParseError> {
+        if source_ref.chars().any(char::is_whitespace) {
+            return Err(RuntimeRefParseError {
+                validation_error: "must not contain whitespace",
+            });
+        }
+        let Some((prefix, suffix)) = source_ref.split_once(':') else {
+            return Err(RuntimeRefParseError {
+                validation_error: "missing source_ref prefix",
+            });
+        };
+        if prefix == "tool_execution" {
+            return parse_tool_execution_ref(suffix);
+        }
+        if suffix.is_empty() {
+            return Err(RuntimeRefParseError {
+                validation_error: "missing source_ref identifier",
+            });
+        }
+        if !valid_source_ref_segment(suffix) {
+            return Err(RuntimeRefParseError {
+                validation_error:
+                    "source_ref identifier must be an opaque id, not a path, URL, or query",
+            });
+        }
+        match prefix {
+            "agent_memory" => Ok(Self::AgentMemory {
+                name: suffix.to_string(),
+            }),
+            "workspace_profile" => Ok(Self::WorkspaceProfile {
+                workspace_id: suffix.to_string(),
+            }),
+            "brief" => Ok(Self::Brief {
+                id: suffix.to_string(),
+            }),
+            "episode" => Ok(Self::Episode {
+                id: suffix.to_string(),
+            }),
+            "work_item" => Ok(Self::WorkItem {
+                id: suffix.to_string(),
+            }),
+            "task" => Ok(Self::Task {
+                id: suffix.to_string(),
+            }),
+            _ => Err(RuntimeRefParseError {
+                validation_error: "unsupported source_ref prefix",
+            }),
+        }
+    }
+
+    pub(crate) fn source_ref(&self) -> String {
+        match self {
+            Self::AgentMemory { name } => format!("agent_memory:{name}"),
+            Self::WorkspaceProfile { workspace_id } => {
+                format!("workspace_profile:{workspace_id}")
+            }
+            Self::Brief { id } => format!("brief:{id}"),
+            Self::Episode { id } => format!("episode:{id}"),
+            Self::WorkItem { id } => format!("work_item:{id}"),
+            Self::Task { id } => format!("task:{id}"),
+            Self::ToolExecution {
+                id,
+                batch_item_index,
+                selector,
+            } => {
+                let selector = selector.as_ref_selector();
+                if let Some(index) = batch_item_index {
+                    format!("tool_execution:{id}:batch_item:{index}:{selector}")
+                } else {
+                    format!("tool_execution:{id}:{selector}")
+                }
+            }
+        }
+    }
+}
+
+impl ToolExecutionRefSelector {
+    fn as_ref_selector(self) -> &'static str {
+        match self {
+            Self::Cmd => "cmd",
+            Self::Output(ToolOutputSelector::Stdout) => "stdout",
+            Self::Output(ToolOutputSelector::Stderr) => "stderr",
+            Self::Output(ToolOutputSelector::Output) => "output",
+        }
+    }
+}
+
+impl ToolOutputSelector {
+    pub(crate) fn as_ref_selector(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+            Self::Output => "output",
+        }
+    }
+}
+
+fn parse_tool_execution_ref(suffix: &str) -> Result<RuntimeRef, RuntimeRefParseError> {
+    let parts = suffix.split(':').collect::<Vec<_>>();
+    match parts.as_slice() {
+        [id, selector] if valid_source_ref_segment(id) => Ok(RuntimeRef::ToolExecution {
+            id: (*id).to_string(),
+            batch_item_index: None,
+            selector: parse_tool_execution_selector(selector)?,
+        }),
+        [id, "batch_item", index, selector] if valid_source_ref_segment(id) => {
+            Ok(RuntimeRef::ToolExecution {
+                id: (*id).to_string(),
+                batch_item_index: Some(parse_batch_item_index(index)?),
+                selector: parse_tool_execution_selector(selector)?,
+            })
+        }
+        _ => Err(RuntimeRefParseError {
+            validation_error: "tool_execution source_ref must match tool_execution:<id>:{cmd,stdout,stderr,output} or tool_execution:<id>:batch_item:<index>:{cmd,stdout,stderr,output}",
+        }),
+    }
+}
+
+fn parse_tool_execution_selector(
+    selector: &str,
+) -> Result<ToolExecutionRefSelector, RuntimeRefParseError> {
+    match selector {
+        "cmd" => Ok(ToolExecutionRefSelector::Cmd),
+        "stdout" => Ok(ToolExecutionRefSelector::Output(ToolOutputSelector::Stdout)),
+        "stderr" => Ok(ToolExecutionRefSelector::Output(ToolOutputSelector::Stderr)),
+        "output" => Ok(ToolExecutionRefSelector::Output(ToolOutputSelector::Output)),
+        _ => Err(RuntimeRefParseError {
+            validation_error: "unsupported tool_execution selector",
+        }),
+    }
+}
+
+fn parse_batch_item_index(index: &str) -> Result<usize, RuntimeRefParseError> {
+    if index.starts_with('0') {
+        return Err(RuntimeRefParseError {
+            validation_error: "batch item index must be a one-based integer without leading zeroes",
+        });
+    }
+    index
+        .parse::<usize>()
+        .ok()
+        .filter(|index| *index >= 1)
+        .ok_or(RuntimeRefParseError {
+            validation_error: "batch item index must be a one-based integer",
+        })
+}
+
+fn valid_source_ref_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_ref_accepts_supported_namespaces() {
+        for source_ref in [
+            "agent_memory:self",
+            "workspace_profile:ws-123",
+            "brief:abc",
+            "episode:ep_123",
+            "work_item:work_123",
+            "task:task_123",
+            "tool_execution:tool-123:cmd",
+            "tool_execution:tool-123:stdout",
+            "tool_execution:tool-123:stderr",
+            "tool_execution:tool-123:output",
+            "tool_execution:tool-123:batch_item:2:cmd",
+            "tool_execution:tool-123:batch_item:2:stdout",
+            "tool_execution:tool-123:batch_item:2:stderr",
+            "tool_execution:tool-123:batch_item:2:output",
+        ] {
+            assert_eq!(
+                RuntimeRef::parse(source_ref).unwrap().source_ref(),
+                source_ref
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_ref_rejects_paths_urls_and_unknown_prefixes() {
+        for source_ref in [
+            "/Users/jolestar/.agents/skills/agentinbox/SKILL.md",
+            "skill:/Users/jolestar/.agents/skills/agentinbox/SKILL.md",
+            "skill.md:/Users/jolestar/.agents/skills/agentinbox/SKILL.md",
+            "agentinbox:///SKILL.md",
+            "memory:invalid-ref-123",
+            "brief:/Users/jolestar/project/README.md",
+            "brief:https://example.com/memory",
+            "episode:../ledger/episode-1",
+            "work_item:work_123?raw=true",
+            "tool_execution:tool-123",
+            "tool_execution:tool-123:batch_item:0:cmd",
+            "tool_execution:tool-123:batch_item:02:cmd",
+            "tool_execution:tool-123:batch_item:abc:cmd",
+            "tool_execution:tool-123:batch_item:2",
+            "tool_execution:tool-123:batch_item:2:artifact",
+            "tool_execution:tool-123:artifact",
+        ] {
+            assert!(
+                RuntimeRef::parse(source_ref).is_err(),
+                "{source_ref} should be invalid"
+            );
+        }
+    }
+}

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -4,25 +4,17 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
+    memory::refs::{RuntimeRef, ALLOWED_SOURCE_REF_PREFIXES},
     runtime::RuntimeHandle,
     tool::{helpers::invalid_tool_input, spec::typed_spec, ToolError},
     types::{AuthorityClass, ToolCapabilityFamily},
 };
 
 use super::{serialize_success, BuiltinToolDefinition};
-use crate::tool::helpers::{parse_tool_args, validate_non_empty};
+use crate::tool::helpers::parse_tool_args;
 
 pub(crate) const NAME: &str = "MemoryGet";
 const MAX_CHARS_MAX: usize = 50_000;
-const ALLOWED_SOURCE_REF_PREFIXES: &[&str] = &[
-    "agent_memory:",
-    "workspace_profile:",
-    "brief:",
-    "episode:",
-    "work_item:",
-    "tool_execution:",
-    "task:",
-];
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -64,10 +56,10 @@ pub(crate) async fn execute(
         .with_details(json!({
             "source_ref": source_ref,
             "allowed_source_ref_prefixes": ALLOWED_SOURCE_REF_PREFIXES,
-            "reason": "source_ref was syntactically valid but is not present in the current visible memory index",
+            "reason": "source_ref was syntactically valid but is not present in the current visible runtime sources",
         }))
         .with_recovery_hint(
-            "call MemorySearch again and pass one of its returned source_ref values verbatim, or copy an available prompt source_ref such as brief_ref/cmd_ref/stdout_ref/stderr_ref/output_ref verbatim",
+            "copy an available prompt source_ref such as brief_ref/cmd_ref/stdout_ref/stderr_ref/output_ref verbatim, or call MemorySearch to discover a visible source_ref",
         )
         .into());
     };
@@ -75,92 +67,9 @@ pub(crate) async fn execute(
 }
 
 fn validate_source_ref(source_ref: String) -> Result<String> {
-    let source_ref = validate_non_empty(source_ref, NAME, "source_ref")?;
-    if source_ref.chars().any(char::is_whitespace) {
-        return Err(invalid_tool_input(
-            NAME,
-            "MemoryGet `source_ref` must be a single opaque handle without whitespace",
-            json!({
-                "field": "source_ref",
-                "source_ref": source_ref,
-                "validation_error": "must not contain whitespace",
-            }),
-            "copy a source_ref exactly from MemorySearch.results[].source_ref; do not paste snippets or paths",
-        ));
-    }
-
-    let Some((prefix, suffix)) = source_ref.split_once(':') else {
-        return Err(invalid_source_ref_error(
-            &source_ref,
-            "missing source_ref prefix",
-        ));
-    };
-    let prefix = format!("{prefix}:");
-    if prefix == "tool_execution:" {
-        return validate_tool_execution_source_ref(&source_ref, suffix);
-    }
-
-    if suffix.is_empty() {
-        return Err(invalid_source_ref_error(
-            &source_ref,
-            "missing source_ref identifier",
-        ));
-    }
-    if !suffix
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
-    {
-        return Err(invalid_source_ref_error(
-            &source_ref,
-            "source_ref identifier must be an opaque id, not a path, URL, or query",
-        ));
-    }
-
-    if !ALLOWED_SOURCE_REF_PREFIXES.contains(&prefix.as_str()) {
-        return Err(invalid_source_ref_error(
-            &source_ref,
-            "unsupported source_ref prefix",
-        ));
-    }
-
-    Ok(source_ref)
-}
-
-fn validate_tool_execution_source_ref(source_ref: &str, suffix: &str) -> Result<String> {
-    let parts = suffix.split(':').collect::<Vec<_>>();
-    let valid = match parts.as_slice() {
-        [tool_execution_id, selector] => {
-            valid_source_ref_segment(tool_execution_id) && valid_tool_execution_selector(selector)
-        }
-        [tool_execution_id, "batch_item", index, selector] => {
-            valid_source_ref_segment(tool_execution_id)
-                && valid_batch_item_index(index)
-                && valid_tool_execution_selector(selector)
-        }
-        _ => false,
-    };
-    if !valid {
-        return Err(invalid_source_ref_error(
-            source_ref,
-            "tool_execution source_ref must match tool_execution:<id>:{cmd,stdout,stderr,output} or tool_execution:<id>:batch_item:<index>:{cmd,stdout,stderr,output}",
-        ));
-    }
-    Ok(source_ref.to_string())
-}
-
-fn valid_tool_execution_selector(selector: &str) -> bool {
-    matches!(selector, "cmd" | "stdout" | "stderr" | "output")
-}
-
-fn valid_batch_item_index(index: &str) -> bool {
-    index.parse::<usize>().is_ok_and(|index| index >= 1) && !index.starts_with('0')
-}
-
-fn valid_source_ref_segment(segment: &str) -> bool {
-    !segment.is_empty()
-        && segment
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    RuntimeRef::parse(&source_ref)
+        .map(|parsed| parsed.source_ref())
+        .map_err(|error| invalid_source_ref_error(&source_ref, error.validation_error()))
 }
 
 fn validate_max_chars(max_chars: Option<usize>) -> Result<Option<usize>> {
@@ -187,14 +96,14 @@ fn validate_max_chars(max_chars: Option<usize>) -> Result<Option<usize>> {
 fn invalid_source_ref_error(source_ref: &str, validation_error: &'static str) -> anyhow::Error {
     invalid_tool_input(
         NAME,
-        "MemoryGet `source_ref` must be copied from MemorySearch results",
+        "MemoryGet `source_ref` must be a standardized runtime ref",
         json!({
             "field": "source_ref",
             "source_ref": source_ref,
             "validation_error": validation_error,
             "allowed_source_ref_prefixes": ALLOWED_SOURCE_REF_PREFIXES,
         }),
-        "call MemorySearch first and copy one returned source_ref verbatim; use ExecCommand for workspace files or skill docs instead of MemoryGet",
+        "copy an available prompt source_ref verbatim, or call MemorySearch to discover a visible source_ref; use ExecCommand for workspace files or skill docs instead of MemoryGet",
     )
 }
 
@@ -273,7 +182,7 @@ mod tests {
             assert_eq!(error.kind, "invalid_tool_input");
             assert_eq!(
                 error.recovery_hint.as_deref(),
-                Some("call MemorySearch first and copy one returned source_ref verbatim; use ExecCommand for workspace files or skill docs instead of MemoryGet")
+                Some("copy an available prompt source_ref verbatim, or call MemorySearch to discover a visible source_ref; use ExecCommand for workspace files or skill docs instead of MemoryGet")
             );
         }
     }


### PR DESCRIPTION
## Summary

Closes #1663.

- add the Runtime Ref Resolution and MemoryGet RFC
- move MemoryGet source_ref validation into a shared runtime ref parser
- resolve known MemoryGet refs directly from source stores before index fallback
- keep MemorySearch index-backed as discovery-only
- keep ordinary Ack lifecycle receipts out of semantic `brief:` retrieval

## Notes

This intentionally does not add `turn:`, `event:`, file refs, or `WorkItem.work_refs`.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test memory::refs --lib`
- `cargo test memory_get --lib`
- `cargo test memory::index --lib`
- `cargo test --test prompt_context_snapshots`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
