### PR TITLE
docs: add runtime ref RFC handle

### DIFF
--- a/docs/rfcs/runtime-ref-resolution-and-memory-get.md
+++ b/docs/rfcs/runtime-ref-resolution-and-memory-get.md
@@ -2,6 +2,7 @@
 title: RFC: Runtime Ref Resolution and MemoryGet
 date: 2026-06-10
 status: draft
+Handle: rfc-runtime-ref-resolution-and-memory-get
 ---
 
 # RFC: Runtime Ref Resolution and MemoryGet


### PR DESCRIPTION
## Summary
- add the missing `Handle: rfc-runtime-ref-resolution-and-memory-get` frontmatter metadata to the runtime ref RFC

## Context
Follow-up to Copilot review feedback on #1667.

## Verification
- `git diff --check`
