### PR TITLE
fix: align work item event tui rendering

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1615,7 +1615,7 @@ fn is_successful_work_item_tool_event(event: &ProjectionEventRecord) -> bool {
     }
     matches!(
         event.payload.get("tool_name").and_then(Value::as_str),
-        Some("CreateWorkItem" | "UpdateWorkItem" | "CompleteWorkItem")
+        Some("CreateWorkItem" | "UpdateWorkItem" | "PickWorkItem" | "CompleteWorkItem")
     )
 }
 
@@ -2613,6 +2613,24 @@ mod tests {
                 "tool_name": "UpdateWorkItem",
                 "status": "success",
                 "summary": "updated work item"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[event]);
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn reducer_suppresses_successful_pick_work_item_tool_bookkeeping() {
+        let event = make_event(
+            "tool_executed",
+            "Picked work item: PickWorkItem",
+            json!({
+                "tool_name": "PickWorkItem",
+                "status": "success",
+                "summary": "picked work item"
             }),
         );
 

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -887,7 +887,7 @@ fn latest_action_event<'a>(
     events.iter().rev().copied().find(|event| {
         event.presentation.is_current_activity_candidate()
             && !is_progress_event(event)
-            && !action_event_body(event).is_empty()
+            && rendered_activity_body(event).is_some()
     })
 }
 
@@ -966,27 +966,33 @@ fn active_activity_body(
     latest_action: Option<&crate::tui::projection::ProjectionEventRecord>,
 ) -> String {
     let mut lines = Vec::new();
-    // Try the new presentation pipeline for a cleaner activity display.
-    let presentation_text = latest_action.and_then(|action| presentation_activity_text(action));
-    if let Some(text) = presentation_text.or_else(|| latest_assistant.map(|s| s.to_string())) {
+    if let Some(text) = latest_assistant {
         lines.push(format!("Assistant {}", trim_activity_line(&text, 120)));
     }
     if let Some(action) = latest_action {
-        lines.push(format!(
-            "Action    {}",
-            trim_activity_line(&action_event_body(action), 120)
-        ));
+        if let Some(text) = rendered_activity_body(action) {
+            lines.push(format!("Action    {}", trim_activity_line(&text, 120)));
+        }
     }
     lines.join("\n")
 }
 
-/// Try to produce a clean activity line via the PresentationReducer.
+fn rendered_activity_body(event: &ProjectionEventRecord) -> Option<String> {
+    presentation_activity_text(event).or_else(|| {
+        let body = action_event_body(event);
+        (!body.is_empty()).then_some(body)
+    })
+}
+
+/// Try to produce the same activity text that the level-4 timeline renders.
 fn presentation_activity_text(event: &ProjectionEventRecord) -> Option<String> {
     let mut reducer = PresentationReducer::new();
     let items = reducer.reduce(&[event.clone()]);
     for timed in &items {
-        if let PresentationItem::AssistantProgress { text, .. } = &timed.item {
-            return Some(text.clone());
+        if timed.item.is_live_working_activity_item() && timed.item.is_visible_at(4) {
+            if let Some(cell) = timed.item.render(4).into_iter().next() {
+                return Some(cell.body);
+            }
         }
     }
     None

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2763,6 +2763,64 @@ fn chat_display_mode_info_suppresses_successful_work_item_tool_activity() {
 }
 
 #[test]
+fn chat_display_mode_info_uses_rendered_list_work_items_activity() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.display_mode = OperatorDisplayMode::Info;
+    let mut snapshot = sample_snapshot("default", "evt-0");
+    snapshot.agent.agent.status = AgentStatus::AwakeRunning;
+    let mut projection = TuiProjection::from_snapshot(snapshot);
+    projection.apply_stream_event(
+        AgentStreamEvent {
+            id: "evt-list-work-items".into(),
+            event: "tool_executed".into(),
+            data: StreamEventEnvelope {
+                id: "evt-list-work-items".into(),
+                event_seq: 2,
+                ts: Utc::now(),
+                agent_id: "default".into(),
+                event_type: "tool_executed".into(),
+                provenance: None,
+                payload: json!({
+                    "tool_name": "ListWorkItems",
+                    "status": "success",
+                    "summary": "Tool finished: ListWorkItems",
+                    "tool_result": {
+                        "filter": "open",
+                        "returned": 1,
+                        "total_matching": 1,
+                        "limit": 20,
+                        "work_items": [{
+                            "id": "work_123456789abcdef",
+                            "objective": "fix work item tui rendering",
+                            "state": "open",
+                            "readiness": "runnable"
+                        }]
+                    }
+                }),
+            },
+        },
+        &crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+        app.display_mode,
+    );
+    app.projection = Some(projection);
+
+    let items = collect_chat_items(&app);
+    let active_item = items.last().expect("active activity item");
+    match active_item {
+        ConversationCell::ActiveActivity { body, .. } => {
+            assert!(body.contains("Work items: filter=open returned=1 total=1 limit=20"));
+            assert!(body.contains("fix work item tui rendering"));
+            assert!(!body.contains("Tool finished: ListWorkItems"));
+        }
+        other => panic!("expected active activity item, got {other:?}"),
+    }
+}
+
+#[test]
 fn chat_display_mode_verbose_keeps_working_marker_without_activity_body() {
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(
@@ -3474,7 +3532,7 @@ fn chat_deduplicates_replayed_projected_tool_events() {
         client,
         crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
     );
-    let event = tool_executed_event_envelope("evt-tool", 43, "default", "PickWorkItem");
+    let event = tool_executed_event_envelope("evt-tool", 43, "default", "AgentGet");
     let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
     for _ in 0..2 {
         projection.apply_event(
@@ -3496,7 +3554,7 @@ fn chat_deduplicates_replayed_projected_tool_events() {
             matches!(
                 item,
                 ConversationCell::SystemNotice { body, .. }
-                    if body.contains("PickWorkItem")
+                    if body.contains("AgentGet")
             )
         })
         .count();
@@ -3512,7 +3570,7 @@ fn chat_keeps_distinct_projected_tool_events_with_same_body() {
     );
     let mut projection = TuiProjection::from_snapshot(sample_snapshot("default", "evt-0"));
     for (id, event_seq) in [("evt-tool-1", 43), ("evt-tool-2", 44)] {
-        let event = tool_executed_event_envelope(id, event_seq, "default", "PickWorkItem");
+        let event = tool_executed_event_envelope(id, event_seq, "default", "AgentGet");
         projection.apply_event(
             AgentStreamEvent {
                 id: event.id.clone(),
@@ -3531,7 +3589,7 @@ fn chat_keeps_distinct_projected_tool_events_with_same_body() {
             matches!(
                 item,
                 ConversationCell::SystemNotice { body, .. }
-                    if body.contains("PickWorkItem")
+                    if body.contains("AgentGet")
             )
         })
         .count();


### PR DESCRIPTION
## Summary
- render info-mode working activity from the same presentation reducer output used by the level-4 timeline
- suppress successful PickWorkItem tool completions so they do not duplicate work_item_picked bookkeeping
- add regression coverage for ListWorkItems working-row rendering and PickWorkItem suppression

## Verification
- cargo fmt --all -- --check
- cargo test presentation::tests -- --nocapture
- cargo test tui::tests -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets