### PR TITLE
fix: atomically claim queued messages

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1149,14 +1149,6 @@ impl RuntimeHandle {
 
             let message = scheduled.message.clone();
             self.append_state_changed_events(&scheduled.running_state)?;
-            self.inner.storage.append_queue_entry(&QueueEntryRecord {
-                message_id: message.id.clone(),
-                agent_id: message.agent_id.clone(),
-                priority: message.priority.clone(),
-                status: QueueEntryStatus::Dequeued,
-                created_at: message.created_at,
-                updated_at: Utc::now(),
-            })?;
 
             if let Err(err) = self
                 .process_message_with_plan(

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -360,6 +360,24 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
 
             scheduler::append_scheduler_decision(&self.runtime.inner.storage, &decision)?;
+            let claimed =
+                self.runtime
+                    .inner
+                    .storage
+                    .try_claim_queued_message(&QueueEntryRecord {
+                        message_id: candidate.message.id.clone(),
+                        agent_id: candidate.message.agent_id.clone(),
+                        priority: candidate.message.priority.clone(),
+                        status: QueueEntryStatus::Dequeued,
+                        created_at: candidate.message.created_at,
+                        updated_at: Utc::now(),
+                    })?;
+            if !claimed {
+                let _ = guard.queue.pop_if_next(&candidate.message.id);
+                guard.state.pending = guard.queue.len();
+                self.runtime.inner.storage.write_agent(&guard.state)?;
+                return Ok(RunLoopPoll::Idle);
+            }
             let message = guard
                 .queue
                 .pop_if_next(&candidate.message.id)

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -13,10 +13,10 @@ use sha2::{Digest, Sha256};
 use crate::types::{
     AgentIdentityRecord, AgentState, AuditEvent, BriefRecord, CallbackDeliveryMode,
     ContextEpisodeRecord, DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope,
-    ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, TaskRecord, TaskStatus, TimerRecord,
-    TimerStatus, ToolExecutionRecord, TranscriptEntry, TurnRecord, WaitConditionRecord,
-    WorkItemContinuationFrame, WorkItemDelegationRecord, WorkItemRecord, WorkItemState,
-    WorkspaceEntry, WorkspaceOccupancyRecord,
+    ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TaskRecord,
+    TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry, TurnRecord,
+    WaitConditionRecord, WorkItemContinuationFrame, WorkItemDelegationRecord, WorkItemRecord,
+    WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 
 const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
@@ -995,6 +995,11 @@ impl QueueEntryRepository<'_> {
 
     pub fn upsert(&self, record: &QueueEntryRecord) -> Result<()> {
         self.db.transaction(|tx| upsert_queue_entry_tx(tx, record))
+    }
+
+    pub fn try_claim_queued_message(&self, record: &QueueEntryRecord) -> Result<bool> {
+        self.db
+            .transaction(|tx| try_claim_queued_message_tx(tx, record))
     }
 
     pub fn latest_all(&self) -> Result<Vec<QueueEntryRecord>> {
@@ -2901,6 +2906,45 @@ fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Res
         ],
     )?;
     Ok(())
+}
+
+fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<bool> {
+    let latest_status = tx
+        .query_row(
+            "SELECT status
+             FROM queue_entries
+             WHERE message_id = ?1 AND agent_id = ?2
+             ORDER BY updated_at DESC, created_at DESC
+             LIMIT 1",
+            params![record.message_id, record.agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    let queued_status = enum_string(&QueueEntryStatus::Queued)?;
+    if latest_status.as_deref() != Some(queued_status.as_str()) {
+        return Ok(false);
+    }
+
+    let mut claimed = record.clone();
+    claimed.status = QueueEntryStatus::Dequeued;
+    let payload_json = serde_json::to_string(&claimed)?;
+    let priority = enum_string(&claimed.priority)?;
+    let status = enum_string(&claimed.status)?;
+    let changed = tx.execute(
+        "INSERT OR IGNORE INTO queue_entries (
+            message_id, agent_id, priority, status, created_at, updated_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            claimed.message_id,
+            claimed.agent_id,
+            priority,
+            status,
+            timestamp(claimed.created_at),
+            timestamp(claimed.updated_at),
+            payload_json,
+        ],
+    )?;
+    Ok(changed == 1)
 }
 
 fn upsert_timer_tx(tx: &Transaction<'_>, record: &TimerRecord) -> Result<()> {
@@ -5271,6 +5315,70 @@ CREATE TABLE working_memory_deltas (
                 .collect::<Vec<_>>(),
             vec!["brief-a", "brief-b"]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn queue_claim_allows_only_one_consumer_for_queued_message() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let record = QueueEntryRecord {
+            message_id: "message-1".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&record)?;
+
+        let mut claim = record.clone();
+        claim.status = QueueEntryStatus::Dequeued;
+        claim.updated_at = now + chrono::Duration::seconds(1);
+        assert!(db.queue_entries().try_claim_queued_message(&claim)?);
+
+        let mut duplicate_claim = claim.clone();
+        duplicate_claim.updated_at = now + chrono::Duration::seconds(2);
+        assert!(!db
+            .queue_entries()
+            .try_claim_queued_message(&duplicate_claim)?);
+
+        let latest = db.queue_entries().latest_all()?;
+        assert_eq!(latest.len(), 2);
+        assert!(latest.iter().any(|record| {
+            record.message_id == "message-1" && record.status == QueueEntryStatus::Queued
+        }));
+        assert!(latest.iter().any(|record| {
+            record.message_id == "message-1" && record.status == QueueEntryStatus::Dequeued
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn queue_claim_rejects_message_whose_latest_lifecycle_is_terminal() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-1".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        let mut processed = queued.clone();
+        processed.status = QueueEntryStatus::Processed;
+        processed.updated_at = now + chrono::Duration::seconds(1);
+        db.queue_entries().upsert(&queued)?;
+        db.queue_entries().upsert(&processed)?;
+
+        let mut claim = queued;
+        claim.status = QueueEntryStatus::Dequeued;
+        claim.updated_at = now + chrono::Duration::seconds(2);
+        assert!(!db.queue_entries().try_claim_queued_message(&claim)?);
+
         Ok(())
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -623,6 +623,14 @@ impl AppStorage {
         self.append_jsonl(&self.queue_entries_path, record)
     }
 
+    pub fn try_claim_queued_message(&self, record: &QueueEntryRecord) -> Result<bool> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.queue_entries().try_claim_queued_message(record);
+        }
+        self.append_jsonl(&self.queue_entries_path, record)?;
+        Ok(true)
+    }
+
     pub fn append_waiting_intent(&self, record: &WaitingIntentRecord) -> Result<()> {
         let wait_condition = wait_condition_from_waiting_intent(record);
         let event = external_wait_recoverability_event(&wait_condition);
@@ -2336,11 +2344,11 @@ impl AppStorage {
             .latest_queue_entries()?
             .into_iter()
             .filter_map(|entry| match entry.status {
-                crate::types::QueueEntryStatus::Queued
-                | crate::types::QueueEntryStatus::Dequeued => {
+                crate::types::QueueEntryStatus::Queued => {
                     messages_by_id.get(&entry.message_id).cloned()
                 }
-                crate::types::QueueEntryStatus::Processed
+                crate::types::QueueEntryStatus::Dequeued
+                | crate::types::QueueEntryStatus::Processed
                 | crate::types::QueueEntryStatus::Interjected
                 | crate::types::QueueEntryStatus::Aborted
                 | crate::types::QueueEntryStatus::Dropped => None,
@@ -5633,7 +5641,7 @@ mod tests {
     }
 
     #[test]
-    fn storage_recovery_snapshot_replays_latest_unprocessed_messages() {
+    fn storage_recovery_snapshot_replays_latest_queued_messages() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
         let queued = MessageEnvelope::new(
@@ -5710,9 +5718,8 @@ mod tests {
             .unwrap();
 
         let snapshot = storage.recovery_snapshot("default").unwrap();
-        assert_eq!(snapshot.replay_messages.len(), 2);
+        assert_eq!(snapshot.replay_messages.len(), 1);
         assert_eq!(snapshot.replay_messages[0].id, queued.id);
-        assert_eq!(snapshot.replay_messages[1].id, dequeued.id);
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -627,8 +627,7 @@ impl AppStorage {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             return runtime_db.queue_entries().try_claim_queued_message(record);
         }
-        self.append_jsonl(&self.queue_entries_path, record)?;
-        Ok(true)
+        anyhow::bail!("cannot atomically claim queued message without scheduler control-plane db")
     }
 
     pub fn append_waiting_intent(&self, record: &WaitingIntentRecord) -> Result<()> {
@@ -4369,6 +4368,28 @@ mod tests {
         let restored = reopened_without_db.read_agent().unwrap().unwrap();
         assert_eq!(restored.status, AgentStatus::Stopped);
         assert_eq!(restored.turn_index, 7);
+    }
+
+    #[test]
+    fn queue_claim_fails_fast_without_scheduler_control_plane_db() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let now = Utc::now();
+        let claim = QueueEntryRecord {
+            message_id: "message-1".into(),
+            agent_id: "default".into(),
+            priority: Priority::Normal,
+            status: QueueEntryStatus::Dequeued,
+            created_at: now,
+            updated_at: now,
+        };
+
+        let error = storage.try_claim_queued_message(&claim).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("without scheduler control-plane db"));
+        assert!(!storage.queue_entries_path.exists());
     }
 
     #[test]

--- a/tests/fixtures/scheduler/dequeued_replay/expected.json
+++ b/tests/fixtures/scheduler/dequeued_replay/expected.json
@@ -10,5 +10,5 @@
   "active_agent_waiting_intents": 0,
   "active_timers": 0,
   "runtime_error": false,
-  "replay_message_ids": ["msg-queued", "msg-dequeued"]
+  "replay_message_ids": ["msg-queued"]
 }

--- a/tests/fixtures/scheduler/tool_call_replay_boundary/expected.json
+++ b/tests/fixtures/scheduler/tool_call_replay_boundary/expected.json
@@ -10,6 +10,6 @@
   "active_agent_waiting_intents": 0,
   "active_timers": 0,
   "runtime_error": false,
-  "replay_message_ids": ["msg-dequeued"],
+  "replay_message_ids": [],
   "tool_executions": 1
 }


### PR DESCRIPTION
## Summary
- atomically claim queued messages before dispatch so only one runtime can consume a queued message
- stop recovery from replaying messages whose latest queue lifecycle is already dequeued or terminal
- add regression coverage for duplicate claim rejection and queued-only recovery

Closes #1680
Closes #1686

## Verification
- cargo fmt --all -- --check
- cargo test queue_claim -- --nocapture
- cargo test storage_recovery_snapshot_replays_latest_queued_messages -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets