### PR TITLE
Fix WorkItem completion brief storage

### DIFF
--- a/docs/rfcs/runtime-ledger-files-and-relations.md
+++ b/docs/rfcs/runtime-ledger-files-and-relations.md
@@ -135,7 +135,7 @@ The current runtime storage creates the following files under
 | `transcript.jsonl` | `TranscriptEntry` | Model-facing conversation trace and provider round history. |
 | `tools.jsonl` | `ToolExecutionRecord` | Tool invocation, side-effect, and verification evidence. |
 | `briefs.jsonl` | `BriefRecord` | User/model-visible outcome or status summaries. |
-| `delivery_summaries.jsonl` | `DeliverySummaryRecord` | Delivery closure records for result/completion reporting. |
+| `delivery_summaries.jsonl` | `DeliverySummaryRecord` | Retired legacy delivery closure records; new WorkItem completion reports use result briefs. |
 | `events.jsonl` | `AuditEvent` | Audit/event-stream/debug mirror with event cursor semantics. |
 | `tasks.jsonl` | `TaskRecord` | Managed task lifecycle history. |
 | `work_items.jsonl` | `WorkItemRecord` | Work item lifecycle history, latest resumable objective state, and runtime-derived work refs. |
@@ -170,7 +170,7 @@ progress.
 | `transcript.jsonl` | Runtime turn execution, message dispatch, failure handling, subagent handling, and host bootstrap append model-facing entries and assign `transcript_seq`. | Prompt context currently reads recent transcript as a compatibility/context source. Runtime lifecycle and tests use it for provider round recovery and model-facing trace assertions. |
 | `tools.jsonl` | Tool execution paths append `ToolExecutionRecord`; command-like tools also mark the memory index dirty. | Prompt context, work-ref extraction, task output, and tests read recent tool evidence so agents can recover side effects without rerunning tools. |
 | `briefs.jsonl` | Runtime delivery, memory refresh, task reducer, tests, and completion paths append generated `BriefRecord` summaries. | Prompt context, delivery APIs, memory indexing, scheduler signals, and turn finalization read briefs as result/failure/status evidence. Current code still includes `Ack` briefs, but this RFC treats ordinary acks as a design gap. |
-| `delivery_summaries.jsonl` | Completion and delivery paths append `DeliverySummaryRecord`. | Work item query tools, run-once helpers, delivery helpers, and turn finalization use it to bind user-facing closure back to turns and work items. |
+| `delivery_summaries.jsonl` | Retired legacy completion evidence; new WorkItem completion promotion should not append `DeliverySummaryRecord`. | Legacy fallback readers may use it for old local data. Active WorkItem query, run-once, and turn projection should prefer `BriefRecord(kind=Result)` via `WorkItemRecord.result_brief_id` / `produced_brief_ids`. |
 | `events.jsonl` | `Runtime::append_audit_event`, HTTP/operator surfaces, scheduler, wait mirroring, turn finalization, command-task handling, and lifecycle paths append audit events and assign `event_seq`. | HTTP event streams, diagnostics, lifecycle counters, scheduler signals, recovery tests, and TUI/debug views use it for cursorable audit evidence. It is not the canonical domain store. |
 | `tasks.jsonl` | Task reducer, command task, child-agent supervision, task tools, tests, and run-once fixtures append task lifecycle snapshots. | Recovery snapshots, task list/status/output APIs, scheduler blocking checks, memory indexing, and prompt/work item projections reconstruct latest task state from this history. |
 | `work_items.jsonl` | Work item tools, lifecycle APIs, wait helpers, task helpers, turn-closure work-ref refresh, and tests append work item revisions/state snapshots. | Work queue projection, scheduler readiness, prompt current/queued/blocked sections, current work refs, memory indexing, work item query tools, and recovery reconstruct latest state by work item id. |
@@ -287,7 +287,10 @@ result/failure/wait. Long term, this RFC recommends moving ordinary admission
 acknowledgements out of the brief concept and into queue or turn lifecycle
 records.
 
-`delivery_summaries.jsonl` records user-facing closure and completion delivery.
+`delivery_summaries.jsonl` is retired legacy storage for user-facing closure and
+completion delivery. New WorkItem completion report text is stored once in a
+`BriefRecord(kind=Result, work_item_id=...)`, and the WorkItem stores the
+canonical brief id.
 `operator_notifications.jsonl` and `operator_delivery_records.jsonl` record
 operator notification and transport delivery lifecycle. These records should
 reference the brief, message, work item, or turn they deliver rather than
@@ -947,8 +950,8 @@ For example:
 - `messages` preserves authority-bearing admitted input and wake envelopes.
 - `transcript` preserves model-facing context and provider conversation trace.
 - `tools` preserves side-effect invocation/result evidence.
-- `briefs` and `delivery_summaries` preserve generated outcome and delivery
-  evidence.
+- `briefs` preserve generated outcome evidence; retired `delivery_summaries`
+  may remain only as legacy delivery evidence.
 - `context_episode_anchors` preserves compaction/recovery anchors.
 
 These records can be stored in specialized tables or a shared

--- a/docs/rfcs/work-item-runtime-model.md
+++ b/docs/rfcs/work-item-runtime-model.md
@@ -143,7 +143,7 @@ The minimal WorkItem state is:
 - `blocked_by`
 - `recheck_at`
 - `recheck_consumed_at`
-- `result_summary`
+- `result_brief_id`
 - `created_at`
 - `updated_at`
 
@@ -476,9 +476,10 @@ Other open WorkItems should be summarized compactly by id, objective, state,
 plan artifact preview, readiness, current todo, and blocker. Completed
 WorkItems should not replay raw transcript by default. They may appear as
 bounded recent completed summaries only when they have an explicit promoted
-completion report: prefer a non-empty `WorkItemRecord.result_summary`; otherwise
-use the newest non-empty `DeliverySummaryRecord.text` for the same work item
-(see [Work items spec](../website/spec/work-items.md) and the
+completion report: prefer `WorkItemRecord.result_brief_id` and resolve the
+referenced `BriefRecord(kind=Result, work_item_id=...)`; otherwise use
+legacy `result_summary` / `DeliverySummaryRecord.text` only as a best-effort
+fallback for old local data (see [Work items spec](../website/spec/work-items.md) and the
 [runtime spec aggregate index](../runtime-spec.md)).
 
 If the agent changes focus during a turn, the tool result must return the new

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -343,6 +343,12 @@
                   "null"
                 ]
               },
+              "result_brief_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "result_summary": {
                 "type": [
                   "string",
@@ -579,6 +585,12 @@
               },
               "recheck_consumed_at": {
                 "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "result_brief_id": {
                 "type": [
                   "string",
                   "null"
@@ -2854,6 +2866,12 @@
           },
           "recheck_consumed_at": {
             "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "result_brief_id": {
             "type": [
               "string",
               "null"

--- a/docs/website/spec/work-items.md
+++ b/docs/website/spec/work-items.md
@@ -37,7 +37,8 @@ A WorkItem is a durable objective record owned by an agent. It tracks:
 | `blocked_by` | Human-readable wait/blocker description for display |
 | `recheck_at` | Legacy fallback deadline for blocked re-evaluation |
 | `recheck_consumed_at` | Marker that the current recheck reminder was delivered |
-| `result_summary` | Completion summary (optional) |
+| `result_brief_id` | Canonical result `BriefRecord` id for a completed WorkItem report |
+| `result_summary` | Legacy completion summary fallback; new completion promotion should not write duplicate report text here |
 
 The Rust enum `WorkItemPlanStatus` uses PascalCase variants (`Draft`, `Ready`,
 `NeedsInput`), but all tool input/output uses snake_case (`draft`, `ready`,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1175,7 +1175,7 @@ fn render_work_item_candidates(
     agent_id: &str,
     agent_home: &std::path::Path,
 ) -> Result<Option<String>> {
-    let completion_reports = latest_delivery_summary_text_by_work_item(storage, agent_id)?;
+    let completion_reports = latest_completion_report_by_work_item(storage, agent_id)?;
     let mut lines = vec!["Work item candidates by scheduler ranking:".to_string()];
     append_candidate_group(
         &mut lines,
@@ -1229,7 +1229,7 @@ fn append_candidate_group(
     lines: &mut Vec<String>,
     title: &str,
     items: &[crate::storage::WorkItemReadinessProjection],
-    completion_reports: &BTreeMap<String, String>,
+    completion_reports: &BTreeMap<String, CompletionReportProjection>,
     agent_home: &std::path::Path,
 ) -> Result<()> {
     if items.is_empty() {
@@ -1279,9 +1279,12 @@ fn append_candidate_group(
         }
         lines.push(summary);
         if let Some(report) = completion_report {
+            if let Some(brief_id) = report.brief_id.as_deref() {
+                lines.push(format!("  - Result ref: brief:{brief_id}"));
+            }
             lines.push(format!(
                 "  - Completion report: {}",
-                truncate_text(&report.replace('\n', " "), 240)
+                truncate_text(&report.text.replace('\n', " "), 240)
             ));
         }
         lines.extend(render_work_item_plan_artifact_lines(
@@ -1292,27 +1295,53 @@ fn append_candidate_group(
 }
 
 fn completion_report_for_work_item(
-    completion_reports: &BTreeMap<String, String>,
+    completion_reports: &BTreeMap<String, CompletionReportProjection>,
     record: &WorkItemRecord,
-) -> Option<String> {
+) -> Option<CompletionReportProjection> {
+    if let Some(report) = completion_reports.get(&record.id) {
+        return Some(report.clone());
+    }
     if let Some(summary) = record
         .result_summary
         .as_ref()
         .filter(|text| !text.is_empty())
     {
-        return Some(summary.clone());
+        return Some(CompletionReportProjection {
+            text: summary.clone(),
+            brief_id: None,
+        });
     }
-    completion_reports
-        .get(&record.id)
-        .filter(|text| !text.is_empty())
-        .cloned()
+    None
 }
 
-fn latest_delivery_summary_text_by_work_item(
+#[derive(Debug, Clone)]
+struct CompletionReportProjection {
+    text: String,
+    brief_id: Option<String>,
+}
+
+fn latest_completion_report_by_work_item(
     storage: &AppStorage,
     agent_id: &str,
-) -> Result<BTreeMap<String, String>> {
+) -> Result<BTreeMap<String, CompletionReportProjection>> {
     let mut summaries = BTreeMap::new();
+    for brief in storage
+        .read_recent_briefs(usize::MAX)?
+        .into_iter()
+        .rev()
+        .filter(|brief| brief.agent_id == agent_id)
+        .filter(|brief| brief.kind == crate::types::BriefKind::Result)
+        .filter(|brief| !brief.text.is_empty())
+    {
+        if let Some(work_item_id) = brief.work_item_id.as_ref() {
+            summaries
+                .entry(work_item_id.clone())
+                .or_insert_with(|| CompletionReportProjection {
+                    text: brief.text.clone(),
+                    brief_id: Some(brief.id.clone()),
+                });
+        }
+    }
     for summary in storage
         .read_recent_delivery_summaries(usize::MAX)?
         .into_iter()
@@ -1322,7 +1351,10 @@ fn latest_delivery_summary_text_by_work_item(
     {
         summaries
             .entry(summary.work_item_id)
-            .or_insert(summary.text);
+            .or_insert_with(|| CompletionReportProjection {
+                text: summary.text,
+                brief_id: None,
+            });
     }
     Ok(summaries)
 }
@@ -5418,11 +5450,20 @@ mod tests {
             "Already finished item",
             crate::types::WorkItemState::Completed,
         );
-        completed.result_summary = Some("Promoted completion report only.".into());
+        let mut completion_brief = crate::types::BriefRecord::new(
+            "default",
+            crate::types::BriefKind::Result,
+            "Promoted completion report only.",
+            None,
+            None,
+        );
+        completion_brief.work_item_id = Some(completed.id.clone());
+        completed.result_brief_id = Some(completion_brief.id.clone());
         storage.append_work_item(&triggered).unwrap();
         storage.append_work_item(&queued).unwrap();
         storage.append_work_item(&waiting).unwrap();
         storage.append_work_item(&completed).unwrap();
+        storage.append_brief(&completion_brief).unwrap();
         storage
             .append_waiting_intent(&WaitingIntentRecord {
                 id: "wait-triggered".into(),
@@ -5481,6 +5522,9 @@ mod tests {
         assert!(summary.content.contains("[waiting_for_operator]"));
         assert!(summary.content.contains("Recently completed work items:"));
         assert!(summary.content.contains("Already finished item"));
+        assert!(summary
+            .content
+            .contains(&format!("Result ref: brief:{}", completion_brief.id)));
         assert!(summary
             .content
             .contains("Completion report: Promoted completion report only."));

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1474,6 +1474,21 @@ fn work_item_document_body(item: &WorkItemRecord) -> String {
             lines.push(plan_artifact.preview.clone());
         }
     }
+    if let Some(result_brief_id) = item
+        .result_brief_id
+        .as_ref()
+        .filter(|result_brief_id| !result_brief_id.trim().is_empty())
+    {
+        lines.push(format!("Result ref: brief:{result_brief_id}"));
+    }
+    if let Some(result_summary) = item
+        .result_summary
+        .as_ref()
+        .filter(|result_summary| !result_summary.trim().is_empty())
+    {
+        lines.push("Legacy result summary:".into());
+        lines.push(result_summary.clone());
+    }
     if !item.todo_list.is_empty() {
         lines.push("Todo list:".into());
         for todo in &item.todo_list {
@@ -2340,12 +2355,13 @@ mod tests {
         ensure_agent_home_layout(dir.path()).unwrap();
         rebuild_memory_index(&storage, None).unwrap();
 
-        let brief = brief_with_workspace(
+        let mut brief = brief_with_workspace(
             "default",
             BriefKind::Result,
             "direct result evidence after index rebuild",
             "ws-holon",
         );
+        brief.work_item_id = Some("work-direct-1663".into());
         let brief_ref = format!("brief:{}", brief.id);
         storage.append_brief(&brief).unwrap();
 
@@ -2370,6 +2386,7 @@ mod tests {
             "ws-holon",
         );
         work_item.id = "work-direct-1663".into();
+        work_item.result_brief_id = Some(brief.id.clone());
         work_item.todo_list = vec![TodoItem {
             text: "prove direct work item get".into(),
             state: TodoItemState::InProgress,
@@ -2450,6 +2467,13 @@ mod tests {
                 .unwrap()
                 .content
                 .contains("prove direct work item get")
+        );
+        assert!(
+            get_memory(&storage, "work_item:work-direct-1663", None, None)
+                .unwrap()
+                .unwrap()
+                .content
+                .contains(&format!("Result ref: {brief_ref}"))
         );
         assert!(
             get_memory(&storage, "episode:episode-direct-1663", None, None)

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -113,6 +113,7 @@ struct RunBaseline {
     message_ids: HashSet<String>,
     event_ids: HashSet<String>,
     delivery_summary_ids: HashSet<String>,
+    brief_ids: HashSet<String>,
     turn_index: u64,
     total_input_tokens: u64,
     total_output_tokens: u64,
@@ -472,6 +473,12 @@ fn capture_baseline(
             .into_iter()
             .map(|item| item.id)
             .collect(),
+        brief_ids: runtime
+            .storage()
+            .read_recent_briefs(usize::MAX)?
+            .into_iter()
+            .map(|item| item.id)
+            .collect(),
         turn_index: state.turn_index,
         total_input_tokens: state.total_input_tokens,
         total_output_tokens: state.total_output_tokens,
@@ -745,6 +752,25 @@ async fn build_response(
         None
     };
     let raw_final_text = raw_final_text(&final_state, baseline, final_status);
+    let new_briefs = runtime
+        .storage()
+        .read_recent_briefs(usize::MAX)?
+        .into_iter()
+        .filter(|brief| !baseline.brief_ids.contains(&brief.id))
+        .collect::<Vec<_>>();
+    let new_brief_by_id = new_briefs
+        .iter()
+        .map(|brief| (brief.id.as_str(), brief))
+        .collect::<HashMap<_, _>>();
+    let promoted_completion_report_text = view
+        .new_events
+        .iter()
+        .filter(|event| event.kind == "work_item_completion_report_promoted")
+        .filter_map(|event| event.data["brief_id"].as_str())
+        .filter_map(|id| new_brief_by_id.get(id))
+        .last()
+        .map(|brief| brief.text.trim().to_string())
+        .filter(|text| !text.is_empty());
     let new_delivery_summaries = runtime
         .storage()
         .read_recent_delivery_summaries(usize::MAX)?
@@ -755,7 +781,7 @@ async fn build_response(
         .iter()
         .map(|summary| (summary.id.as_str(), summary))
         .collect::<HashMap<_, _>>();
-    let promoted_completion_report_text = view
+    let legacy_promoted_completion_report_text = view
         .new_events
         .iter()
         .filter(|event| event.kind == "work_item_completion_report_promoted")
@@ -764,12 +790,14 @@ async fn build_response(
         .last()
         .map(|summary| summary.text.trim().to_string())
         .filter(|text| !text.is_empty());
-    let delivery_summary_text = promoted_completion_report_text.or_else(|| {
-        new_delivery_summaries
-            .last()
-            .map(|summary| summary.text.trim().to_string())
-            .filter(|text| !text.is_empty())
-    });
+    let delivery_summary_text = promoted_completion_report_text
+        .or(legacy_promoted_completion_report_text)
+        .or_else(|| {
+            new_delivery_summaries
+                .last()
+                .map(|summary| summary.text.trim().to_string())
+                .filter(|text| !text.is_empty())
+        });
     let final_text = delivery_summary_text
         .or_else(|| raw_final_text.clone())
         .unwrap_or_default();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -86,7 +86,7 @@ use crate::{
         AgentModelState, AgentState, AgentStatus, AgentSummary, AuditEvent, AuthorityClass,
         BriefRecord, CallbackDeliveryMode, CallbackDeliveryPayload, CallbackDeliveryResult,
         CallbackIngressDisposition, CancelWaitingResult, ClosureDecision, ContinuationResolution,
-        ControlAction, DeliverySummaryRecord, ExecCommandBatchItemStatus, ExecCommandBatchResult,
+        ControlAction, ExecCommandBatchItemStatus, ExecCommandBatchResult,
         ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerScope,
         ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
@@ -108,7 +108,6 @@ use turn::LoopControlOptions;
 #[derive(Debug, Clone)]
 pub(super) struct WorkItemCompletionReportPromotion {
     pub(super) record: crate::types::WorkItemRecord,
-    pub(super) delivery_summary_id: String,
     pub(super) brief_id: String,
 }
 
@@ -118,7 +117,7 @@ pub(super) enum WorkItemCompletionReportPromotionOutcome {
     /// user-facing report for terminal delivery.
     Unchanged(crate::types::WorkItemRecord),
     /// Completion promoted the assistant's same-round report into the
-    /// WorkItem's delivery summary and result brief.
+    /// WorkItem's canonical result brief.
     Promoted(WorkItemCompletionReportPromotion),
 }
 
@@ -1055,17 +1054,6 @@ impl RuntimeHandle {
     pub(crate) fn persist_brief_evidence(&self, brief: &BriefRecord) -> Result<()> {
         self.inner.storage.append_brief(brief)?;
         self.inner.runtime_db.evidence().append_brief(brief)
-    }
-
-    pub(crate) fn persist_delivery_summary_evidence(
-        &self,
-        record: &DeliverySummaryRecord,
-    ) -> Result<()> {
-        self.inner.storage.append_delivery_summary(record)?;
-        self.inner
-            .runtime_db
-            .evidence()
-            .append_delivery_summary(record)
     }
 
     pub async fn run(self) -> Result<()> {

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -115,7 +115,6 @@ impl RuntimeHandle {
                             "message_id": message.id.clone(),
                             "reason": "work_item_completion_report_promoted",
                             "work_item_id": &promotion.work_item_id,
-                            "delivery_summary_id": &promotion.delivery_summary_id,
                             "brief_id": &promotion.brief_id,
                         }),
                     ))?;

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -5,10 +5,10 @@ use crate::tool::helpers::truncate_output_to_char_budget;
 use crate::tool::ToolError;
 use crate::types::{
     AgentProfilePreset, BriefKind, BriefRecord, ChildAgentWorkspaceMode, CommandTaskStatusSnapshot,
-    DeliverySummaryRecord, FailureArtifact, FailureArtifactCategory, SpawnAgentModelRequest,
-    SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle,
-    TaskInputResult, TaskKind, TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus,
-    TaskOutputSnapshot, TaskStatusSnapshot, TodoItem, ToolArtifactRef, WorkItemContinuationFrame,
+    FailureArtifact, FailureArtifactCategory, SpawnAgentModelRequest, SpawnAgentModelResolution,
+    SpawnAgentModelResolutionStatus, SpawnAgentResult, TaskHandle, TaskInputResult, TaskKind,
+    TaskListEntry, TaskOutputResult, TaskOutputRetrievalStatus, TaskOutputSnapshot,
+    TaskStatusSnapshot, TodoItem, ToolArtifactRef, WorkItemContinuationFrame,
     WorkItemContinuationReturnPolicy, WorkItemDelegationRecord, WorkItemDelegationState,
     WorkItemPlanStatus, WorkItemReadiness, WorkItemRecord, WorkItemState, CHILD_AGENT_TASK_KIND,
 };
@@ -2572,6 +2572,7 @@ impl RuntimeHandle {
             blocked_by: None,
             recheck_at: None,
             recheck_consumed_at: None,
+            result_brief_id: existing.result_brief_id.clone(),
             result_summary: existing.result_summary.clone(),
             updated_at: Utc::now(),
             ..existing
@@ -2664,45 +2665,34 @@ impl RuntimeHandle {
                 existing,
             ));
         }
-        if existing.result_summary.as_deref() == Some(report_text) {
-            return Ok(WorkItemCompletionReportPromotionOutcome::Unchanged(
-                existing,
-            ));
+        if let Some(result_brief_id) = existing.result_brief_id.as_deref() {
+            if let Some(brief) = self.inner.storage.read_brief_by_id(result_brief_id)? {
+                if brief.text.trim() == report_text {
+                    return Ok(WorkItemCompletionReportPromotionOutcome::Unchanged(
+                        existing,
+                    ));
+                }
+            }
         }
+        let current_turn_id = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.current_turn_id.clone()
+        };
+        let mut brief =
+            BriefRecord::new(agent_id.clone(), BriefKind::Result, report_text, None, None);
+        brief.work_item_id = Some(existing.id.clone());
+        brief.workspace_id = existing.workspace_id.clone();
+        brief.turn_index = source_turn_index;
+        brief.turn_id = current_turn_id;
+        self.persist_brief(&brief).await?;
         let record = WorkItemRecord {
             revision: existing.revision + 1,
-            result_summary: Some(report_text.to_string()),
+            result_brief_id: Some(brief.id.clone()),
             updated_at: Utc::now(),
             ..existing
         };
         self.inner.runtime_db.work_items().upsert(&record, false)?;
         self.inner.storage.append_work_item(&record)?;
-        let evidence = serde_json::json!({
-            "source": "same_round_complete_work_item",
-            "source_turn_index": source_turn_index,
-            "source_round": source_round,
-            "warnings": warnings.clone(),
-        });
-        let current_turn_id = {
-            let guard = self.inner.agent.lock().await;
-            guard.state.current_turn_id.clone()
-        };
-        let mut delivery_summary = DeliverySummaryRecord::new(
-            agent_id.clone(),
-            record.id.clone(),
-            report_text,
-            source_turn_index,
-            Some(evidence.clone()),
-        );
-        delivery_summary.turn_id = current_turn_id.clone();
-        self.persist_delivery_summary_evidence(&delivery_summary)?;
-        let mut brief =
-            BriefRecord::new(agent_id.clone(), BriefKind::Result, report_text, None, None);
-        brief.work_item_id = Some(record.id.clone());
-        brief.workspace_id = record.workspace_id.clone();
-        brief.turn_index = source_turn_index;
-        brief.turn_id = current_turn_id;
-        self.persist_brief(&brief).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_completion_report_promoted",
             serde_json::json!({
@@ -2714,14 +2704,12 @@ impl RuntimeHandle {
                 "text_preview": crate::tool::helpers::truncate_text(report_text, 600),
                 "warnings": warnings.clone(),
                 "warning_count": warnings.len(),
-                "delivery_summary_id": delivery_summary.id.clone(),
                 "brief_id": brief.id.clone(),
             }),
         ))?;
         Ok(WorkItemCompletionReportPromotionOutcome::Promoted(
             WorkItemCompletionReportPromotion {
                 record,
-                delivery_summary_id: delivery_summary.id,
                 brief_id: brief.id,
             },
         ))

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -658,7 +658,11 @@ async fn work_item_query_tools_return_current_open_done_views() {
     );
     assert_eq!(
         completed_payload["work_item"]["completion_report"]["source"].as_str(),
-        Some("work_item_result_summary")
+        Some("result_brief")
+    );
+    assert_eq!(
+        completed_payload["work_item"]["completion_report"]["brief_id"].as_str(),
+        completed.result_brief_id.as_deref()
     );
     assert_eq!(
         completed_payload["work_item"]["completion_report"]["source_turn_index"].as_u64(),
@@ -1994,13 +1998,7 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         .unwrap()
         .unwrap();
     assert_eq!(completed.state, WorkItemState::Completed);
-    assert_eq!(completed.result_summary.as_deref(), Some(report_text));
-    let summary = runtime
-        .storage()
-        .latest_delivery_summary(&work_item.id)
-        .unwrap()
-        .expect("completion report should persist delivery summary");
-    assert_eq!(summary.text, report_text);
+    assert_eq!(completed.result_summary, None);
     let briefs = runtime.recent_briefs(10).await.unwrap();
     let result_briefs = briefs
         .iter()
@@ -2015,7 +2013,16 @@ async fn complete_work_item_promotes_same_round_report_and_binds_evidence() {
         result_briefs[0].work_item_id.as_deref(),
         Some(work_item.id.as_str())
     );
+    assert_eq!(
+        completed.result_brief_id.as_deref(),
+        Some(result_briefs[0].id.as_str())
+    );
     assert_eq!(result_briefs[0].turn_index, Some(1));
+    assert!(runtime
+        .storage()
+        .latest_delivery_summary(&work_item.id)
+        .unwrap()
+        .is_none());
     assert!(
         !briefs.iter().any(|brief| {
             brief.kind == BriefKind::Result
@@ -2467,16 +2474,25 @@ async fn multiple_complete_work_items_in_one_round_do_not_promote_or_short_circu
             .unwrap()
             .unwrap();
         assert_eq!(completed.state, WorkItemState::Completed);
-        assert_eq!(completed.result_summary.as_deref(), Some(report_text));
+        assert_eq!(completed.result_summary, None);
+        let result_brief_id = completed
+            .result_brief_id
+            .as_deref()
+            .expect("completion report should store result brief id");
         assert_eq!(
             runtime
                 .storage()
-                .latest_delivery_summary(work_item_id)
+                .read_brief_by_id(result_brief_id)
                 .unwrap()
-                .expect("completion report should persist delivery summary")
+                .expect("completion result brief should exist")
                 .text,
             report_text
         );
+        assert!(runtime
+            .storage()
+            .latest_delivery_summary(work_item_id)
+            .unwrap()
+            .is_none());
     }
     assert_eq!(
         *provider.calls.lock().await,
@@ -2595,16 +2611,22 @@ async fn repeated_complete_work_item_does_not_overwrite_existing_report() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(
-        completed.result_summary.as_deref(),
-        Some("Original completion report")
-    );
-    let summary = runtime
+    assert_eq!(completed.result_summary, None);
+    let result_brief_id = completed
+        .result_brief_id
+        .as_deref()
+        .expect("original result brief id should remain");
+    let brief = runtime
+        .storage()
+        .read_brief_by_id(result_brief_id)
+        .unwrap()
+        .expect("original result brief should remain");
+    assert_eq!(brief.text, "Original completion report");
+    assert!(runtime
         .storage()
         .latest_delivery_summary(&work_item.id)
         .unwrap()
-        .expect("original delivery summary should remain");
-    assert_eq!(summary.text, "Original completion report");
+        .is_none());
     let transcript = runtime.storage().read_recent_transcript(10).unwrap();
     let tool_results = transcript
         .iter()

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -25,11 +25,12 @@ use crate::{
         ToolCall, ToolError, ToolSpec,
     },
     types::{
-        AdmissionContext, AuditEvent, AuthorityClass, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
-        TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind, TurnRecord,
-        TurnTerminalCheckpointRecord, TurnTerminalKind, TurnTerminalRecord, TurnTerminalSummary,
-        TurnTriggerSummary, WorkItemPlanStatus, WorkItemRecord,
+        AdmissionContext, AuditEvent, AuthorityClass, BriefKind, MessageBody,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+        QueueEntryRecord, QueueEntryStatus, TodoItemState, TokenUsage, TranscriptEntry,
+        TranscriptEntryKind, TurnRecord, TurnTerminalCheckpointRecord, TurnTerminalKind,
+        TurnTerminalRecord, TurnTerminalSummary, TurnTriggerSummary, WorkItemPlanStatus,
+        WorkItemRecord,
     },
 };
 
@@ -62,7 +63,6 @@ pub(super) struct TurnTerminalDelivery {
 #[derive(Debug, Clone)]
 pub(super) struct TurnPromotedCompletionReport {
     pub(super) work_item_id: String,
-    pub(super) delivery_summary_id: String,
     pub(super) brief_id: String,
 }
 
@@ -1507,10 +1507,6 @@ impl RuntimeHandle {
             .inner
             .storage
             .read_recent_tool_executions(TURN_RECORD_SCAN_LIMIT)?;
-        let delivery_summaries = self
-            .inner
-            .storage
-            .read_recent_delivery_summaries(TURN_RECORD_SCAN_LIMIT)?;
         let wait_conditions = self
             .inner
             .storage
@@ -1550,20 +1546,14 @@ impl RuntimeHandle {
             })
             .map(|brief| brief.id.clone())
             .collect();
-        let turn_delivery_summaries = delivery_summaries
+        record.completed_work_item_ids = briefs
             .iter()
-            .filter(|summary| {
-                turn_optional_id_matches(summary.turn_id.as_deref(), turn_id)
-                    || summary.source_turn_index == Some(terminal.turn_index)
+            .filter(|brief| {
+                brief.kind == BriefKind::Result
+                    && (turn_optional_id_matches(brief.turn_id.as_deref(), turn_id)
+                        || brief.turn_index == Some(terminal.turn_index))
             })
-            .collect::<Vec<_>>();
-        record.delivery_summary_ids = turn_delivery_summaries
-            .iter()
-            .map(|summary| summary.id.clone())
-            .collect();
-        record.completed_work_item_ids = turn_delivery_summaries
-            .iter()
-            .map(|summary| summary.work_item_id.clone())
+            .filter_map(|brief| brief.work_item_id.clone())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect();
@@ -3143,7 +3133,6 @@ impl TurnExecution<'_> {
             promoted_completion_reports.extend(completion_promotions.into_iter().map(
                 |promotion| TurnPromotedCompletionReport {
                     work_item_id: promotion.record.id,
-                    delivery_summary_id: promotion.delivery_summary_id,
                     brief_id: promotion.brief_id,
                 },
             ));
@@ -3270,7 +3259,6 @@ impl RuntimeHandle {
                     "work_item_id": work_item_id,
                     "turn_index": turn_index,
                     "round": round,
-                    "delivery_summary_id": promotion.delivery_summary_id.clone(),
                     "brief_id": promotion.brief_id.clone(),
                     "text_preview": truncate_preview(report_text, ROUND_TEXT_PREVIEW_LIMIT),
                 }),

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -33,6 +33,7 @@ pub(crate) enum WorkItemFocusView {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum WorkItemCompletionReportSource {
+    ResultBrief,
     WorkItemResultSummary,
     DeliverySummary,
 }
@@ -41,6 +42,8 @@ pub(crate) enum WorkItemCompletionReportSource {
 pub(crate) struct WorkItemCompletionReportView {
     pub(crate) text: String,
     pub(crate) source: WorkItemCompletionReportSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) brief_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) delivery_summary_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -239,6 +242,17 @@ fn completion_report_for_record(
     if record.state != WorkItemState::Completed {
         return Ok(None);
     }
+    if let Some(brief_id) = record
+        .result_brief_id
+        .as_ref()
+        .filter(|brief_id| !brief_id.trim().is_empty())
+    {
+        if let Some(brief) = runtime.storage().read_brief_by_id(brief_id)? {
+            if !brief.text.trim().is_empty() {
+                return Ok(Some(completion_report_view_from_brief(brief)));
+            }
+        }
+    }
     let cached_delivery_summary = delivery_summaries
         .and_then(|summaries| summaries.get(&record.id))
         .cloned();
@@ -279,9 +293,23 @@ fn completion_report_view(
     WorkItemCompletionReportView {
         text,
         source,
+        brief_id: None,
         delivery_summary_id: delivery_summary.map(|summary| summary.id.clone()),
         source_turn_index: delivery_summary.and_then(|summary| summary.source_turn_index),
         created_at: delivery_summary.map(|summary| summary.created_at),
+    }
+}
+
+fn completion_report_view_from_brief(
+    brief: crate::types::BriefRecord,
+) -> WorkItemCompletionReportView {
+    WorkItemCompletionReportView {
+        text: brief.text,
+        source: WorkItemCompletionReportSource::ResultBrief,
+        brief_id: Some(brief.id),
+        delivery_summary_id: None,
+        source_turn_index: brief.turn_index,
+        created_at: Some(brief.created_at),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3356,6 +3356,8 @@ pub struct WorkItemRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recheck_consumed_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_brief_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result_summary: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -3386,6 +3388,7 @@ impl WorkItemRecord {
             blocked_by: None,
             recheck_at: None,
             recheck_consumed_at: None,
+            result_brief_id: None,
             result_summary: None,
             created_at: now,
             updated_at: now,

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -227,8 +227,7 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
 }
 
 #[tokio::test]
-async fn run_once_prefers_completed_work_item_delivery_summary_over_latest_turn_text() -> Result<()>
-{
+async fn run_once_prefers_completed_work_item_result_brief_over_latest_turn_text() -> Result<()> {
     let home_dir = tempdir()?.keep();
     let workspace_dir = tempdir()?.keep();
     let provider = Arc::new(WorkItemDeliverySummaryProvider::new());
@@ -279,11 +278,23 @@ async fn run_once_prefers_completed_work_item_delivery_summary_over_latest_turn_
     let runtime = host
         .get_public_agent_for_external_ingress("default")
         .await?;
-    let summary = runtime
+    let completed = runtime
+        .latest_work_item(&work_item.id)
+        .await?
+        .expect("completed work item should remain queryable");
+    let result_brief_id = completed
+        .result_brief_id
+        .as_deref()
+        .expect("completed work item should store a result brief id");
+    let result_brief = runtime
+        .storage()
+        .read_brief_by_id(result_brief_id)?
+        .expect("completed work item result brief should exist");
+    assert_eq!(result_brief.text, second.final_text);
+    assert!(runtime
         .storage()
         .latest_delivery_summary(&work_item.id)?
-        .expect("completed work item should persist a delivery summary");
-    assert_eq!(summary.text, second.final_text);
+        .is_none());
     assert_eq!(
         runtime.agent_state().await?.last_turn_token_usage,
         Some(TokenUsage::new(100, 50))


### PR DESCRIPTION
## Summary
- Make WorkItem completion reports use canonical `BriefRecord(kind=Result)` storage via `WorkItemRecord.result_brief_id`.
- Stop the new completion promotion path from writing duplicate `DeliverySummaryRecord` / `result_summary` text while preserving legacy fallback readers.
- Update WorkItem query, run-once/recent-turn context, prompt context, memory projection, and docs to expose or resolve the canonical `brief:<id>` anchor.
- Add/adjust regression coverage for completion promotion, query/context/memory projections, and no duplicate delivery summary writes.

Fixes #1679

## Verification
- `cargo test runtime::tests::work_items`
- `cargo fmt --all -- --check`
- `cargo test --test prompt_context_snapshots`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
