### PR TITLE
feat: add message refs for recent turn input

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1496,16 +1496,34 @@ fn message_body_text(body: &MessageBody) -> String {
     }
 }
 
-fn render_recent_turn_input_line(message: &MessageEnvelope) -> String {
+fn render_recent_turn_input_line(
+    message: &MessageEnvelope,
+    mode: RecentTurnProjectionMode,
+) -> String {
+    let message_ref = format!("message:{}", sanitize_inline(&message.id));
     if is_trusted_operator_input(message) {
-        format!(
-            "  - operator input: {}",
-            sanitize_inline(&message_body_text(&message.body))
-        )
+        let body = message_body_text(&message.body);
+        let preview_limit = match mode {
+            RecentTurnProjectionMode::Continuity => usize::MAX,
+            RecentTurnProjectionMode::Nearby => 360,
+            RecentTurnProjectionMode::Older => 180,
+        };
+        let sanitized = sanitize_inline(&body);
+        if matches!(mode, RecentTurnProjectionMode::Continuity)
+            || sanitized.chars().count() <= preview_limit
+        {
+            format!("  - operator input full: {sanitized} message_ref={message_ref}")
+        } else {
+            let preview = truncate_text(&sanitized, preview_limit);
+            format!(
+                "  - operator input preview: {preview} [truncated; full via message_ref={message_ref}]"
+            )
+        }
     } else {
         format!(
-            "  - input: {}",
-            sanitize_inline(&body_preview(&message.body))
+            "  - input: {} message_ref={}",
+            sanitize_inline(&body_preview(&message.body)),
+            message_ref
         )
     }
 }
@@ -2133,7 +2151,7 @@ fn render_turn_record_projection(
         ));
     }
     if let Some(trigger_message) = trigger_message {
-        lines.push(render_recent_turn_input_line(trigger_message));
+        lines.push(render_recent_turn_input_line(trigger_message, mode));
     }
 
     let mut related_briefs = Vec::new();
@@ -3212,7 +3230,8 @@ mod tests {
             .clone();
         assert!(recent_turns.contains("- Turn turn_index 1:"));
         assert!(recent_turns.contains("  - turn_id: turn-db-context"));
-        assert!(recent_turns.contains("  - operator input: Use the database turn spine."));
+        assert!(recent_turns.contains("  - operator input full: Use the database turn spine."));
+        assert!(recent_turns.contains(&format!("message_ref=message:{}", operator.id)));
         assert!(recent_turns.contains("Rendered from DB turn record."));
         assert!(recent_turns.contains("brief_ref=brief:brief-db-context"));
     }
@@ -3503,10 +3522,56 @@ mod tests {
             .content
             .clone();
 
-        assert!(recent_turns.contains("  - operator input: "));
+        assert!(recent_turns.contains("  - operator input full: "));
+        assert!(recent_turns.contains(&format!("message_ref=message:{}", operator.id)));
         assert!(recent_turns.contains(long_tail));
         assert!(!recent_turns.contains("  - operator asked: "));
         assert!(recent_turns.contains("brief_ref=brief:brief-full-operator-input"));
+    }
+
+    #[test]
+    fn older_recent_turn_operator_input_is_previewed_with_message_ref() {
+        let long_tail = "older-operator-tail-hidden-behind-message-ref";
+        let message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: format!("{} {long_tail}", "older operator input. ".repeat(40)),
+            },
+        );
+        let brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "brief anchor remains visible",
+            Some(message.id.clone()),
+            None,
+        );
+        let mut turn = TurnRecord::new("default", "turn-old-message-preview", 1);
+        turn.input_message_ids = vec![message.id.clone()];
+        turn.produced_brief_ids = vec![brief.id.clone()];
+        turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
+
+        let rendered = render_turn_record_projection(
+            &turn,
+            &[message.clone()],
+            &[brief],
+            &[],
+            None,
+            RecentTurnProjectionMode::Older,
+            20_000,
+        )
+        .expect("older turn should render");
+
+        assert!(rendered.contains("operator input preview:"));
+        assert!(rendered.contains(&format!(
+            "[truncated; full via message_ref=message:{}]",
+            message.id
+        )));
+        assert!(!rendered.contains(long_tail));
+        assert!(rendered.contains("brief_ref=brief:"));
     }
 
     #[test]

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -20,8 +20,9 @@ use crate::{
         command_digest, command_output_source_ref, command_preview, command_receipt_source_ref,
     },
     types::{
-        BriefKind, BriefRecord, CommandTaskStatusSnapshot, ContextEpisodeRecord, TaskRecord,
-        TaskStatus, ToolExecutionRecord, TurnRecord, WorkItemRecord, WorkspaceEntry,
+        BriefKind, BriefRecord, CommandTaskStatusSnapshot, ContextEpisodeRecord, MessageBody,
+        MessageEnvelope, TaskRecord, TaskStatus, ToolExecutionRecord, TurnRecord, WorkItemRecord,
+        WorkspaceEntry,
     },
 };
 
@@ -958,6 +959,7 @@ fn document_for_runtime_ref(
             workspace_profile_document_by_id(storage, workspace_id)
         }
         RuntimeRef::Brief { id } => brief_document_by_id(storage, id),
+        RuntimeRef::Message { id } => message_document_by_id(storage, id),
         RuntimeRef::Turn { id } => turn_document_by_id(storage, id),
         RuntimeRef::Episode { id } => context_episode_document_by_id(storage, id),
         RuntimeRef::WorkItem { id } => work_item_document_by_id(storage, id),
@@ -1128,6 +1130,109 @@ fn brief_document_by_id(storage: &AppStorage, brief_id: &str) -> Result<Option<M
     Ok(brief
         .filter(semantic_brief_is_retrievable)
         .map(|brief| brief_document(storage, brief)))
+}
+
+fn message_document_by_id(
+    storage: &AppStorage,
+    message_id: &str,
+) -> Result<Option<MemoryDocument>> {
+    Ok(storage
+        .read_message_by_id(message_id)?
+        .map(message_document))
+}
+
+fn message_document(message: MessageEnvelope) -> MemoryDocument {
+    let body = message_document_body(&message);
+    let title = format!("Message {}", message.id);
+    MemoryDocument {
+        source_ref: format!("message:{}", message.id),
+        source_kind: "message".into(),
+        scope_kind: "workspace".into(),
+        workspace_id: None,
+        agent_id: message.agent_id.clone(),
+        source_path: None,
+        title,
+        sanitized_excerpt: excerpt(&body),
+        body,
+        metadata: json!({
+            "message_id": message.id,
+            "turn_id": message.turn_id,
+            "message_seq": message.message_seq,
+            "work_item_id": message.work_item_id,
+            "task_id": message.task_id,
+            "governance_surface": "runtime_evidence",
+            "provenance_class": "message_envelope",
+            "trust_class": "runtime_evidence",
+        }),
+        updated_at: message.created_at,
+    }
+}
+
+fn message_document_body(message: &MessageEnvelope) -> String {
+    let mut lines = vec![
+        format!("message_ref: message:{}", message.id),
+        format!("message_id: {}", message.id),
+    ];
+    if let Some(turn_id) = message.turn_id.as_deref() {
+        lines.push(format!("turn_ref: turn:{turn_id}"));
+    }
+    if let Some(message_seq) = message.message_seq {
+        lines.push(format!("message_seq: {message_seq}"));
+    }
+    lines.push(format!("kind: {:?}", message.kind));
+    lines.push(format!("origin: {:?}", message.origin));
+    lines.push(format!("authority_class: {:?}", message.authority_class));
+    lines.push(format!("priority: {:?}", message.priority));
+    if let Some(trigger_kind) = message.trigger_kind {
+        lines.push(format!("trigger_kind: {:?}", trigger_kind));
+    }
+    if let Some(work_item_id) = message.work_item_id.as_deref() {
+        lines.push(format!("work_item_ref: work_item:{work_item_id}"));
+    }
+    if let Some(task_id) = message.task_id.as_deref() {
+        lines.push(format!("task_ref: task:{task_id}"));
+    }
+    if let Some(delivery_surface) = message.delivery_surface {
+        lines.push(format!("delivery_surface: {:?}", delivery_surface));
+    }
+    if let Some(admission_context) = message.admission_context {
+        lines.push(format!("admission_context: {:?}", admission_context));
+    }
+    if !message.source_refs.is_empty() {
+        lines.push(format!(
+            "source_refs: {}",
+            message
+                .source_refs
+                .iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    let body = message_body_text_for_memory(&message.body);
+    lines.push("body:".to_string());
+    lines.push(truncate_multiline(&body, 8_000));
+    lines.join("\n")
+}
+
+fn message_body_text_for_memory(body: &MessageBody) -> String {
+    match body {
+        MessageBody::Text { text } => text.clone(),
+        MessageBody::Json { value } => {
+            serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+        }
+        MessageBody::Brief { text, .. } => text.clone(),
+    }
+}
+
+fn truncate_multiline(value: &str, limit: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(limit).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}\n[truncated]")
+    } else {
+        truncated
+    }
 }
 
 fn context_episode_documents(storage: &AppStorage) -> Result<Vec<MemoryDocument>> {
@@ -1307,13 +1412,23 @@ fn turn_document_body(turn: &TurnRecord) -> String {
     if let Some(trigger) = turn.trigger.as_ref() {
         lines.push(format!("trigger_kind: {:?}", trigger.kind));
         if let Some(message_id) = trigger.message_id.as_deref() {
-            lines.push(format!("trigger_message_id: {message_id}"));
+            lines.push(format!("trigger_message_ref: message:{message_id}"));
         }
     }
     if let Some(work_item_id) = turn.current_work_item_id.as_deref() {
         lines.push(format!("current_work_item_ref: work_item:{work_item_id}"));
     }
-    append_id_list(&mut lines, "input_message_ids", &turn.input_message_ids);
+    if !turn.input_message_ids.is_empty() {
+        lines.push(format!(
+            "input_message_refs: {}",
+            turn.input_message_ids
+                .iter()
+                .take(12)
+                .map(|id| format!("message:{id}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
     if !turn.tool_execution_ids.is_empty() {
         append_id_list(&mut lines, "tool_execution_ids", &turn.tool_execution_ids);
         lines.push(format!(
@@ -2365,6 +2480,23 @@ mod tests {
         let brief_ref = format!("brief:{}", brief.id);
         storage.append_brief(&brief).unwrap();
 
+        let mut message = MessageEnvelope::new(
+            "default",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            MessageBody::Text {
+                text: "direct message source evidence".into(),
+            },
+        );
+        message.id = "msg-direct-1663".into();
+        message.turn_id = Some("turn-direct-1663".into());
+        message.message_seq = Some(7);
+        storage.append_message(&message).unwrap();
+
         storage
             .append_task(&task_record(
                 "task-direct-1663",
@@ -2421,6 +2553,8 @@ mod tests {
 
         let mut turn = TurnRecord::new("default", "turn-direct-1663", 7);
         turn.current_work_item_id = Some("work-direct-1663".into());
+        turn.input_message_ids = vec![message.id.clone()];
+        turn.trigger = Some(crate::types::TurnTriggerSummary::from_message(&message));
         turn.tool_execution_ids = vec!["tool-direct-1663".into()];
         turn.produced_brief_ids = vec![brief.id.clone()];
         storage.append_turn(&turn).unwrap();
@@ -2461,6 +2595,19 @@ mod tests {
             .unwrap()
             .content
             .contains("direct task source evidence"));
+        let message_memory = get_memory(&storage, "message:msg-direct-1663", None, None)
+            .unwrap()
+            .expect("message memory source should be gettable");
+        assert_eq!(message_memory.kind, "message");
+        assert!(message_memory
+            .content
+            .contains("message_ref: message:msg-direct-1663"));
+        assert!(message_memory
+            .content
+            .contains("turn_ref: turn:turn-direct-1663"));
+        assert!(message_memory
+            .content
+            .contains("direct message source evidence"));
         assert!(
             get_memory(&storage, "work_item:work-direct-1663", None, None)
                 .unwrap()
@@ -2494,6 +2641,12 @@ mod tests {
             .contains("current_work_item_ref: work_item:work-direct-1663"));
         assert!(turn_memory
             .content
+            .contains("trigger_message_ref: message:msg-direct-1663"));
+        assert!(turn_memory
+            .content
+            .contains("input_message_refs: message:msg-direct-1663"));
+        assert!(turn_memory
+            .content
             .contains("tool_execution:tool-direct-1663:output"));
         assert!(turn_memory.content.contains(&format!("brief:{}", brief.id)));
         assert!(
@@ -2502,6 +2655,32 @@ mod tests {
                 .unwrap()
                 .content
                 .contains("direct-tool-1663")
+        );
+    }
+
+    #[test]
+    fn memory_get_message_refs_are_scoped_to_current_agent() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+
+        let mut other_agent_message = MessageEnvelope::new(
+            "other-agent",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator { actor_id: None },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            MessageBody::Text {
+                text: "other agent secret message".into(),
+            },
+        );
+        other_agent_message.id = "msg-other-agent-1685".into();
+        storage.append_message(&other_agent_message).unwrap();
+
+        assert!(
+            get_memory(&storage, "message:msg-other-agent-1685", None, None)
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/src/memory/refs.rs
+++ b/src/memory/refs.rs
@@ -9,6 +9,9 @@ pub(crate) enum RuntimeRef {
     Brief {
         id: String,
     },
+    Message {
+        id: String,
+    },
     Turn {
         id: String,
     },
@@ -56,6 +59,7 @@ pub(crate) const ALLOWED_SOURCE_REF_PREFIXES: &[&str] = &[
     "agent_memory:",
     "workspace_profile:",
     "brief:",
+    "message:",
     "turn:",
     "episode:",
     "work_item:",
@@ -99,6 +103,9 @@ impl RuntimeRef {
             "brief" => Ok(Self::Brief {
                 id: suffix.to_string(),
             }),
+            "message" => Ok(Self::Message {
+                id: suffix.to_string(),
+            }),
             "turn" => Ok(Self::Turn {
                 id: suffix.to_string(),
             }),
@@ -124,6 +131,7 @@ impl RuntimeRef {
                 format!("workspace_profile:{workspace_id}")
             }
             Self::Brief { id } => format!("brief:{id}"),
+            Self::Message { id } => format!("message:{id}"),
             Self::Turn { id } => format!("turn:{id}"),
             Self::Episode { id } => format!("episode:{id}"),
             Self::WorkItem { id } => format!("work_item:{id}"),
@@ -232,6 +240,7 @@ mod tests {
             "agent_memory:self",
             "workspace_profile:ws-123",
             "brief:abc",
+            "message:msg_123",
             "turn:turn_123",
             "episode:ep_123",
             "work_item:work_123",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1120,9 +1120,14 @@ impl AppStorage {
                 .messages()
                 .by_id(self.current_agent_id()?.as_deref(), message_id);
         }
+        let current_agent_id = self.current_agent_id()?;
         let mut found = None;
         scan_jsonl_reverse::<MessageEnvelope, _>(&self.messages_path, |message| {
-            if message.id == message_id {
+            if current_agent_id
+                .as_deref()
+                .is_none_or(|agent_id| message.agent_id == agent_id)
+                && message.id == message_id
+            {
                 found = Some(message);
                 return false;
             }

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -393,7 +393,7 @@ fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
     let dir = tempdir()?;
     let storage = AppStorage::new(dir.path())?;
 
-    let previous_operator = MessageEnvelope::new(
+    let mut previous_operator = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
         MessageOrigin::Operator {
@@ -409,6 +409,7 @@ fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
         MessageDeliverySurface::CliPrompt,
         AdmissionContext::LocalProcess,
     );
+    previous_operator.id = "msg_focused_prompt_projection".into();
     storage.append_message(&previous_operator)?;
     let mut result_brief = BriefRecord::new(
         "default",
@@ -462,7 +463,7 @@ Current input relation: current_input is the latest trusted operator input.
 Recent turns:
 - Turn message_seq 1:
   - trigger: trusted operator input
-  - operator input: Run the focused prompt projection test.
+  - operator input full: Run the focused prompt projection test. message_ref=message:msg_focused_prompt_projection
   - produced briefs:
     - Result full:
       Focused prompt projection test passed.
@@ -482,7 +483,7 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
     let dir = tempdir()?;
     let storage = AppStorage::new(dir.path())?;
 
-    let operator_message = MessageEnvelope::new(
+    let mut operator_message = MessageEnvelope::new(
         "default",
         MessageKind::OperatorPrompt,
         MessageOrigin::Operator {
@@ -498,6 +499,7 @@ fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Re
         MessageDeliverySurface::CliPrompt,
         AdmissionContext::LocalProcess,
     );
+    operator_message.id = "msg_runtime_flow_operator".into();
     let mut operator_message_with_turn = operator_message.clone();
     operator_message_with_turn.turn_id = Some("turn_op_test".into());
     storage.append_message(&operator_message_with_turn)?;
@@ -603,7 +605,7 @@ Recent turns:
   - trigger: trusted operator input
   - continues input: message_seq 1
   - continuation trigger: a task-result continuation
-  - operator input: Run cargo test runtime_flow and report back.
+  - operator input full: Run cargo test runtime_flow and report back. message_ref=message:msg_runtime_flow_operator
   - produced briefs:
     - Result full:
       Captured completion report promotion.


### PR DESCRIPTION
## Summary
- add `message:<id>` as a retrievable runtime evidence ref for message envelopes
- expose `trigger_message_ref` and `input_message_refs` from `turn:<id>` documents
- render historical recent-turn trusted operator input with `message_ref` and budgeted previews while preserving full current/continuity input
- keep JSONL message lookup scoped to the current agent

Closes #1685

## Verification
- cargo fmt --all -- --check
- cargo test message -- --nocapture
- cargo test memory_get -- --nocapture
- cargo test older_recent_turn_operator_input_is_previewed_with_message_ref -- --nocapture
- cargo test recent_turns_snapshot -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets