### PR TITLE
fix: make debug prompt read-only

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -18,28 +18,34 @@ use tracing::warn;
 
 use crate::{
     agent_template::{
-        ensure_agent_home_agents_md_from_template_with_home,
+        discover_agent_templates_catalog, ensure_agent_home_agents_md_from_template_with_home,
         initialize_agent_home_from_template_with_catalog,
         initialize_agent_home_from_template_with_home, initialize_agent_home_without_template,
         seed_builtin_templates_for_home, DEFAULT_AGENT_TEMPLATE_ID,
     },
+    agents_md::load_agents_md,
     callbacks::hash_callback_token,
     config::{AppConfig, RuntimeModelCatalog},
     context::ContextConfig,
     host_registry::RuntimeRegistry,
     ids,
+    prompt::{build_effective_prompt, EffectivePrompt},
     provider::{build_provider_from_config, AgentProvider},
     runtime::{InitialWorkspaceBinding, RuntimeHandle},
     runtime_db::RuntimeDb,
+    skills::{load_skills_runtime_view, SkillVisibility},
     storage::AppStorage,
-    system::WorkspaceAccessMode,
+    system::{ExecutionScopeKind, HostLocalBoundary, WorkspaceAccessMode},
+    tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
     types::{
-        AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint, AgentListEntry,
-        AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState, AgentStatus,
-        AgentSummary, AgentVisibility, AuthorityClass, ChildAgentSummary, ClosureOutcome,
-        ExternalTriggerRecord, OperatorNotificationRecord, RuntimeFailureSummary,
-        SpawnAgentModelResolution, SpawnAgentModelResolutionStatus, TaskRecord, TaskStatus,
-        TranscriptEntry, TranscriptEntryKind, WorkspaceEntry, WorkspaceOccupancyRecord,
+        AdmissionContext, AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint,
+        AgentListEntry, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
+        AgentStatus, AgentSummary, AgentVisibility, AuthorityClass, ChildAgentSummary,
+        ClosureOutcome, ExternalTriggerRecord, MessageBody, MessageDeliverySurface,
+        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
+        RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
+        TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkspaceEntry,
+        WorkspaceOccupancyRecord,
     },
 };
 
@@ -107,6 +113,14 @@ fn stopped_unloaded_agent(agent_id: &str) -> AgentState {
     let mut agent = AgentState::new(agent_id.to_string());
     agent.status = AgentStatus::Stopped;
     agent
+}
+
+fn skill_visibility(identity: &AgentIdentityView) -> SkillVisibility {
+    if identity.kind == AgentKind::Default {
+        SkillVisibility::DefaultAgent
+    } else {
+        SkillVisibility::NonDefaultAgent
+    }
 }
 
 #[derive(Clone)]
@@ -743,6 +757,193 @@ impl RuntimeHost {
         }
         snapshots.sort_by(|left, right| left.agent_id.cmp(&right.agent_id));
         Ok(snapshots)
+    }
+
+    pub fn preview_public_agent_prompt(
+        &self,
+        agent_id: &str,
+        text: String,
+        authority_class: AuthorityClass,
+    ) -> std::result::Result<EffectivePrompt, PublicAgentError> {
+        let identity = self.public_agent_identity(agent_id)?;
+        self.preview_agent_prompt_from_storage(&identity, text, authority_class)
+            .map_err(PublicAgentError::Runtime)
+    }
+
+    pub fn preview_agent_prompt(
+        &self,
+        agent_id: &str,
+        text: String,
+        authority_class: AuthorityClass,
+    ) -> Result<EffectivePrompt> {
+        self.validate_agent_id(agent_id)?;
+        let identity = if agent_id == self.config().default_agent_id {
+            self.ensure_default_agent_identity()?;
+            self.agent_identity_record(agent_id)?.ok_or_else(|| {
+                anyhow!(
+                    "default agent {} identity missing after initialization",
+                    agent_id
+                )
+            })?
+        } else {
+            self.agent_identity_record(agent_id)?.ok_or_else(|| {
+                anyhow!(
+                    "agent {} not found; create it first with 'holon agent create {}'",
+                    agent_id,
+                    agent_id
+                )
+            })?
+        };
+        if identity.status == AgentRegistryStatus::Archived {
+            return Err(anyhow!("agent {} is archived", agent_id));
+        }
+        self.preview_agent_prompt_from_storage(&identity, text, authority_class)
+    }
+
+    pub fn public_agent_boundary_metadata(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<Value, PublicAgentError> {
+        let identity = self.public_agent_identity(agent_id)?;
+        self.agent_boundary_metadata_from_storage(&identity)
+            .map_err(PublicAgentError::Runtime)
+    }
+
+    fn preview_agent_prompt_from_storage(
+        &self,
+        identity: &AgentIdentityRecord,
+        text: String,
+        authority_class: AuthorityClass,
+    ) -> Result<EffectivePrompt> {
+        let storage = AppStorage::new_for_agent(
+            self.agent_data_dir(&identity.agent_id),
+            identity.agent_id.clone(),
+        )?;
+        let state = storage
+            .read_agent()?
+            .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
+        let identity_view =
+            AgentIdentityView::from_record(identity, &self.config().default_agent_id);
+        let message = MessageEnvelope::new(
+            identity.agent_id.clone(),
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("debug_prompt".into()),
+            },
+            authority_class,
+            Priority::Normal,
+            MessageBody::Text { text },
+        )
+        .with_admission(
+            MessageDeliverySurface::CliPrompt,
+            AdmissionContext::LocalProcess,
+        );
+        let workspace = crate::runtime::workspace::workspace_view_from_state(
+            &state,
+            storage.data_dir().to_path_buf(),
+        )?;
+        let execution = crate::runtime::workspace::build_effective_execution(
+            &storage,
+            ExecutionScopeKind::AgentTurn,
+            state.execution_profile.clone(),
+            workspace,
+            &state.attached_workspaces,
+        )
+        .snapshot();
+        let agent_home = self.agent_data_dir(&identity.agent_id);
+        let loaded_agents_md = load_agents_md(
+            std::env::var_os("HOME").map(PathBuf::from).as_deref(),
+            agent_home.as_path(),
+            crate::runtime::workspace::workspace_anchor_for_state_ref(&state),
+        )?;
+        let mut skills = load_skills_runtime_view(
+            skill_visibility(&identity_view),
+            std::env::var_os("HOME").map(PathBuf::from).as_deref(),
+            agent_home.as_path(),
+            state
+                .active_workspace_entry
+                .as_ref()
+                .map(|entry| entry.workspace_anchor.as_path()),
+            &state.active_skills,
+        )?;
+        skills.agent_templates_catalog = discover_agent_templates_catalog(
+            std::env::var_os("HOME").map(PathBuf::from).as_deref(),
+            agent_home.as_path(),
+        );
+        let model_catalog = RuntimeModelCatalog::from_config(self.config());
+        let model_ref = model_catalog
+            .provider_chain_for_turn(
+                state.model_override.as_ref(),
+                state.pending_fallback_model.as_ref(),
+            )
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| {
+                crate::runtime::agent_model_state_for_catalog(
+                    &model_catalog,
+                    &self.runtime_context_config(),
+                    &state,
+                )
+                .effective_model
+            });
+        let provider = self
+            .inner
+            .static_provider
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| build_provider_from_config(self.config()))?;
+        let apply_patch_surface = ApplyPatchSurface::for_model_ref(&model_ref.as_string());
+        let registry = ToolRegistry::new(execution.execution_root.clone());
+        let available_tools = registry
+            .tool_specs_with_families_for_apply_patch_surface(apply_patch_surface)?
+            .into_iter()
+            .filter(|(family, _)| {
+                identity_view
+                    .profile_preset
+                    .allows_tool_capability_family(*family)
+            })
+            .map(|(_, tool)| tool)
+            .collect::<Vec<_>>();
+        let prompt_tools = provider.prompt_tool_specs(&available_tools);
+        build_effective_prompt(
+            &storage,
+            &state,
+            &execution,
+            &message,
+            &self.runtime_context_config(),
+            &execution.execution_root,
+            agent_home.as_path(),
+            &identity_view,
+            loaded_agents_md,
+            &skills,
+            &prompt_tools,
+            None,
+        )
+    }
+
+    fn agent_boundary_metadata_from_storage(
+        &self,
+        identity: &AgentIdentityRecord,
+    ) -> Result<Value> {
+        let storage = AppStorage::new_for_agent(
+            self.agent_data_dir(&identity.agent_id),
+            identity.agent_id.clone(),
+        )?;
+        let state = storage
+            .read_agent()?
+            .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
+        let workspace = crate::runtime::workspace::workspace_view_from_state(
+            &state,
+            storage.data_dir().to_path_buf(),
+        )?;
+        let execution = crate::runtime::workspace::build_effective_execution(
+            &storage,
+            ExecutionScopeKind::AgentTurn,
+            state.execution_profile.clone(),
+            workspace,
+            &state.attached_workspaces,
+        );
+        Ok(HostLocalBoundary::from_snapshot(&execution.snapshot()).audit_metadata())
     }
 
     pub async fn child_agent_summaries(
@@ -1823,6 +2024,7 @@ mod tests {
     };
 
     use async_trait::async_trait;
+    use chrono::Utc;
     use tempfile::tempdir;
     use tokio::sync::Notify;
 
@@ -1836,8 +2038,8 @@ mod tests {
         types::{
             AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
             AgentSchedulingPosture, AgentStatus, AgentVisibility, AuthorityClass, ControlAction,
-            MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority, TaskRecord,
-            TaskRecoverySpec, TaskStatus, TurnTerminalKind,
+            MessageBody, MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord,
+            QueueEntryStatus, TaskRecord, TaskRecoverySpec, TaskStatus, TurnTerminalKind,
         },
     };
 
@@ -1864,6 +2066,52 @@ mod tests {
         let host =
             RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
         (home, host)
+    }
+
+    #[tokio::test]
+    async fn debug_prompt_preview_is_storage_only_and_leaves_queued_input_unchanged() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+        let storage = AppStorage::new_for_agent(host.agent_data_dir(&agent_id), agent_id.clone())
+            .expect("storage");
+        let mut message = MessageEnvelope::new(
+            &agent_id,
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "queued user input".into(),
+            },
+        );
+        message.turn_id = Some("turn_queued".into());
+        storage.append_message(&message).unwrap();
+        storage
+            .append_queue_entry(&QueueEntryRecord {
+                message_id: message.id.clone(),
+                agent_id: agent_id.clone(),
+                priority: message.priority.clone(),
+                status: QueueEntryStatus::Queued,
+                created_at: message.created_at,
+                updated_at: Utc::now(),
+            })
+            .unwrap();
+
+        let prompt = host
+            .preview_agent_prompt(
+                &agent_id,
+                "inspect prompt".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .unwrap();
+
+        assert!(prompt.render_dump().contains("inspect prompt"));
+        assert!(host.inner.agents.read().await.is_empty());
+        assert_eq!(storage.read_agent().unwrap(), None);
+        let entries = storage.latest_queue_entries().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].message_id, message.id);
+        assert_eq!(entries[0].status, QueueEntryStatus::Queued);
     }
 
     fn inherited_model_resolution(provider: &str, model: &str) -> SpawnAgentModelResolution {

--- a/src/host.rs
+++ b/src/host.rs
@@ -815,7 +815,7 @@ impl RuntimeHost {
         text: String,
         authority_class: AuthorityClass,
     ) -> Result<EffectivePrompt> {
-        let storage = AppStorage::new_for_agent(
+        let storage = AppStorage::open_read_only_for_agent(
             self.agent_data_dir(&identity.agent_id),
             identity.agent_id.clone(),
         )?;
@@ -925,7 +925,7 @@ impl RuntimeHost {
         &self,
         identity: &AgentIdentityRecord,
     ) -> Result<Value> {
-        let storage = AppStorage::new_for_agent(
+        let storage = AppStorage::open_read_only_for_agent(
             self.agent_data_dir(&identity.agent_id),
             identity.agent_id.clone(),
         )?;
@@ -2112,6 +2112,43 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].message_id, message.id);
         assert_eq!(entries[0].status, QueueEntryStatus::Queued);
+    }
+
+    #[tokio::test]
+    async fn debug_prompt_preview_does_not_migrate_legacy_event_ledger() {
+        let (_home, host) = test_host();
+        let agent_id = host.config().default_agent_id.clone();
+        let storage = AppStorage::new_for_agent(host.agent_data_dir(&agent_id), agent_id.clone())
+            .expect("storage");
+        let events_path = storage.data_dir().join(".holon/ledger/events.jsonl");
+        fs::write(
+            &events_path,
+            r#"{"id":"evt_legacy","kind":"test","created_at":"2026-01-01T00:00:00Z"}"#,
+        )
+        .unwrap();
+        let before = fs::read_to_string(&events_path).unwrap();
+
+        let prompt = host
+            .preview_agent_prompt(
+                &agent_id,
+                "inspect prompt".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .unwrap();
+
+        assert!(prompt.render_dump().contains("inspect prompt"));
+        assert_eq!(fs::read_to_string(&events_path).unwrap(), before);
+        let backups = fs::read_dir(events_path.parent().unwrap())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("events.jsonl.bak.")
+            })
+            .count();
+        assert_eq!(backups, 0);
     }
 
     fn inherited_model_resolution(provider: &str, model: &str) -> SpawnAgentModelResolution {

--- a/src/http.rs
+++ b/src/http.rs
@@ -3227,33 +3227,21 @@ pub async fn control_debug_prompt(
         .authority_class
         .clone()
         .unwrap_or(AuthorityClass::OperatorInstruction);
-    let runtime = state
+    let boundary = state
         .host
-        .get_public_agent(&agent_id)
-        .await
+        .public_agent_boundary_metadata(&agent_id)
         .map_err(agent_access_error)?;
-    let boundary = current_boundary_metadata(&runtime)
-        .await
-        .map_err(error_response)?;
-    let dump = runtime
-        .preview_prompt(request.text.clone(), effective_trust.clone())
-        .await
-        .map_err(error_response)?
+    let dump = state
+        .host
+        .preview_public_agent_prompt(&agent_id, request.text.clone(), effective_trust.clone())
+        .map_err(agent_access_error)?
         .render_dump();
-    runtime
-        .append_audit_event(
-            "debug_prompt_requested",
-            json!({
-                "target_agent_id": agent_id,
-                "admission_context": admission_context,
-                "effective_trust": effective_trust,
-                "boundary": boundary,
-            }),
-        )
-        .map_err(error_response)?;
     Ok(Json(json!({
         "ok": true,
         "agent_id": agent_id,
+        "admission_context": admission_context,
+        "effective_trust": effective_trust,
+        "boundary": boundary,
         "dump": dump,
     })))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -747,8 +747,7 @@ async fn dump_prompt(
 ) -> Result<()> {
     let host = RuntimeHost::new(config.clone())?;
     let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
-    let runtime = host.get_or_create_agent(&agent).await?;
-    let prompt = runtime.preview_prompt(text, authority_class).await?;
+    let prompt = host.preview_agent_prompt(&agent, text, authority_class)?;
     println!("{}", prompt.render_dump());
     Ok(())
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,7 +21,7 @@ mod tasks;
 mod test_util;
 mod turn;
 mod waiting;
-mod workspace;
+pub(crate) mod workspace;
 mod worktree;
 
 pub use tasks::{

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -171,6 +171,7 @@ pub struct RecoverySnapshot {
 pub struct AppStorage {
     data_dir: PathBuf,
     agent_id: Option<String>,
+    read_only: bool,
     events_path: PathBuf,
     briefs_path: PathBuf,
     messages_path: PathBuf,
@@ -209,6 +210,12 @@ struct AuditEventIndexSink {
     agent_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StorageOpenMode {
+    ReadWrite,
+    ReadOnly,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileActivityMarker {
     pub exists: bool,
@@ -244,36 +251,62 @@ impl AppStorage {
         Self::new_with_scope(data_dir, Some(agent_id))
     }
 
+    pub fn open_read_only_for_agent(
+        data_dir: impl Into<PathBuf>,
+        agent_id: impl Into<String>,
+    ) -> Result<Self> {
+        let agent_id = agent_id.into();
+        anyhow::ensure!(
+            !agent_id.trim().is_empty(),
+            "agent-scoped storage requires a non-empty agent id"
+        );
+        Self::new_with_scope_options(data_dir, Some(agent_id), StorageOpenMode::ReadOnly)
+    }
+
     pub fn new_global(data_dir: impl Into<PathBuf>) -> Result<Self> {
         Self::new_with_scope(data_dir, None)
     }
 
     fn new_with_scope(data_dir: impl Into<PathBuf>, agent_id: Option<String>) -> Result<Self> {
+        Self::new_with_scope_options(data_dir, agent_id, StorageOpenMode::ReadWrite)
+    }
+
+    fn new_with_scope_options(
+        data_dir: impl Into<PathBuf>,
+        agent_id: Option<String>,
+        mode: StorageOpenMode,
+    ) -> Result<Self> {
         let data_dir = data_dir.into();
-        fs::create_dir_all(&data_dir)
-            .with_context(|| format!("failed to create {}", data_dir.display()))?;
         let runtime_dir = data_dir.join(RUNTIME_DIR);
         let state_dir = runtime_dir.join(RUNTIME_STATE_DIR);
         let ledger_dir = runtime_dir.join(RUNTIME_LEDGER_DIR);
-        for dir in [
-            &state_dir,
-            &ledger_dir,
-            &runtime_dir.join(RUNTIME_INDEXES_DIR),
-            &runtime_dir.join(RUNTIME_CACHE_DIR),
-        ] {
-            fs::create_dir_all(dir)
-                .with_context(|| format!("failed to create {}", dir.display()))?;
+        if mode == StorageOpenMode::ReadWrite {
+            fs::create_dir_all(&data_dir)
+                .with_context(|| format!("failed to create {}", data_dir.display()))?;
+            for dir in [
+                &state_dir,
+                &ledger_dir,
+                &runtime_dir.join(RUNTIME_INDEXES_DIR),
+                &runtime_dir.join(RUNTIME_CACHE_DIR),
+            ] {
+                fs::create_dir_all(dir)
+                    .with_context(|| format!("failed to create {}", dir.display()))?;
+            }
         }
 
         let events_path = ledger_dir.join("events.jsonl");
         let messages_path = ledger_dir.join("messages.jsonl");
         let transcript_path = ledger_dir.join("transcript.jsonl");
-        let event_seq_counter = migrate_events_ledger(&events_path)?;
+        let event_seq_counter = match mode {
+            StorageOpenMode::ReadWrite => migrate_events_ledger(&events_path)?,
+            StorageOpenMode::ReadOnly => read_tail_event_seq(&events_path)?.unwrap_or(0),
+        };
         let message_seq_counter = max_jsonl_u64_field(&messages_path, "message_seq")?;
         let transcript_seq_counter = max_jsonl_u64_field(&transcript_path, "transcript_seq")?;
 
         Ok(Self {
             agent_id,
+            read_only: mode == StorageOpenMode::ReadOnly,
             events_path,
             briefs_path: ledger_dir.join("briefs.jsonl"),
             messages_path,
@@ -308,11 +341,20 @@ impl AppStorage {
         })
     }
 
+    fn ensure_writable(&self) -> Result<()> {
+        anyhow::ensure!(
+            !self.read_only,
+            "cannot write through read-only runtime storage"
+        );
+        Ok(())
+    }
+
     pub(crate) fn enable_audit_event_index(
         &self,
         runtime_db: RuntimeDb,
         agent_id: Option<String>,
     ) -> Result<()> {
+        self.ensure_writable()?;
         let mut guard = self
             .audit_event_index
             .lock()
@@ -325,6 +367,7 @@ impl AppStorage {
     }
 
     pub(crate) fn enable_scheduler_control_plane_db(&self, runtime_db: RuntimeDb) -> Result<()> {
+        self.ensure_writable()?;
         let agent_id = self.current_agent_id()?;
         {
             let mut counter = self
@@ -440,6 +483,7 @@ impl AppStorage {
     }
 
     pub fn append_event(&self, event: &AuditEvent) -> Result<()> {
+        self.ensure_writable()?;
         let _guard = self
             .append_mutex
             .lock()
@@ -448,6 +492,7 @@ impl AppStorage {
     }
 
     fn append_event_with_append_mutex_held(&self, event: &AuditEvent) -> Result<()> {
+        self.ensure_writable()?;
         let mut event = event.clone();
         let mut counter = self
             .event_seq_counter
@@ -743,6 +788,7 @@ impl AppStorage {
     }
 
     fn append_jsonl<T: Serialize>(&self, path: &Path, value: &T) -> Result<()> {
+        self.ensure_writable()?;
         let bytes = jsonl_bytes(value)?;
 
         let _guard = self
@@ -753,6 +799,7 @@ impl AppStorage {
     }
 
     pub fn mark_memory_index_dirty(&self) -> Result<()> {
+        self.ensure_writable()?;
         let agent_id = self.storage_agent_id()?;
         let dirty_path = self.shared_indexes_dir().join(format!(
             "memory.{}.dirty",
@@ -860,6 +907,7 @@ impl AppStorage {
     }
 
     pub fn write_agent(&self, agent: &AgentState) -> Result<()> {
+        self.ensure_writable()?;
         if let Some(storage_agent_id) = self.agent_id.as_deref() {
             anyhow::ensure!(
                 agent.id == storage_agent_id,


### PR DESCRIPTION
## Summary

Closes #1687.

- route CLI `debug prompt` through a storage-only `RuntimeHost` prompt preview path instead of loading/starting a `RuntimeHandle`
- route HTTP `/debug-prompt` through the same read-only host path and remove the debug audit write side effect
- rebuild the prompt inputs from persisted agent state, workspace/execution projection, AGENTS.md, skills, templates, provider tool specs, and boundary metadata without dequeueing messages or mutating agent state
- add regression coverage that queued input remains queued and no runtime/agent state is created by debug prompt preview

## Verification

- `cargo fmt --all -- --check`
- `cargo test debug_prompt_preview_is_storage_only_and_leaves_queued_input_unchanged -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
