### PR TITLE
fix: bound work item prompt projection

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -3028,7 +3028,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1283,13 +1283,13 @@ fn append_candidate_group(
                 lines.push(format!("  - Result ref: brief:{brief_id}"));
             }
             lines.push(format!(
-                "  - Completion report: {}",
-                truncate_text(&report.text.replace('\n', " "), 240)
+                "  - Completion summary: {}",
+                truncate_text(&report.text.replace('\n', " "), 160)
             ));
         }
-        lines.extend(render_work_item_plan_artifact_lines(
-            record, agent_home, "  - ",
-        ));
+        if let Some(plan_ref) = render_work_item_plan_ref(record, agent_home) {
+            lines.push(format!("  - {plan_ref}"));
+        }
     }
     Ok(())
 }
@@ -1387,6 +1387,19 @@ fn render_work_item_plan_artifact_lines(
         );
     }
     lines
+}
+
+fn render_work_item_plan_ref(
+    work_item: &WorkItemRecord,
+    agent_home: &std::path::Path,
+) -> Option<String> {
+    if let Some(artifact) = work_item.plan_artifact.as_ref() {
+        return Some(format!("Plan ref: {}", artifact.path.display()));
+    }
+
+    crate::work_item_plan::ensure_plan_artifact(agent_home, work_item, None)
+        .ok()
+        .map(|artifact| format!("Plan ref: {}", artifact.path.display()))
 }
 
 fn working_memory_is_empty(snapshot: &WorkingMemorySnapshot) -> bool {
@@ -5592,12 +5605,11 @@ mod tests {
             .contains(&format!("Result ref: brief:{}", completion_brief.id)));
         assert!(summary
             .content
-            .contains("Completion report: Promoted completion report only."));
-        assert!(summary.content.contains("Plan artifact:"));
-        assert!(summary.content.contains("Plan preview:"));
-        assert!(summary.content.contains("Verify the queued path."));
-        assert!(summary.content.contains("Plan preview complete: false"));
-        assert!(summary.content.contains("Plan preview complete: true"));
+            .contains("Completion summary: Promoted completion report only."));
+        assert!(summary.content.contains("Plan ref:"));
+        assert!(!summary.content.contains("Plan preview:"));
+        assert!(!summary.content.contains("queued detail"));
+        assert!(!summary.content.contains("Plan preview complete:"));
     }
 
     #[test]

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -1053,8 +1053,7 @@ Current work item:
 Work item candidates by scheduler ranking:
 Blocked work items:
 - [blocked] work_queued :: Review and merge PR #485 :: current_todo=Review expanded snapshot coverage changes :: blocked_by=blocked on active work completion
-  - Plan artifact: $AGENT_HOME/work-items/work_queued/plan.md
-  - Plan preview complete: true
+  - Plan ref: $AGENT_HOME/work-items/work_queued/plan.md
 
 ## context_contract
 {CONTEXT_CONTRACT}

--- a/tests/support/runtime_compaction.rs
+++ b/tests/support/runtime_compaction.rs
@@ -183,7 +183,7 @@ pub async fn preview_prompt_after_compaction_keeps_work_item_plan_and_pending_wo
         .contains("Already shipped shadow-state cleanup"));
     assert!(queued_blocked_section
         .content
-        .contains("Completion report: Promoted cleanup completion report."));
+        .contains("Completion summary: Promoted cleanup completion report."));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- stop inlining plan previews for non-current/completed WorkItem candidates in `queued_blocked_work_items`
- render stable `Plan ref` lines instead, keeping current WorkItem plan previews intact
- shorten completed candidate completion text to a bounded summary

Fixes #1682

## Verification
- cargo fmt --all -- --check
- cargo test build_context_includes_ranked_work_item_candidates_and_completion_reports -- --nocapture
- cargo test --test runtime_compaction runtime_compaction_multi_pass_recovery_preserves_progress_and_artifacts -- --nocapture
- cargo test prompt_context_snapshot_matches_expected -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets