### PR TITLE
fix: canonicalize legacy agent home workspace attachments

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -573,6 +573,25 @@ fn prepare_runtime_storage(
         }
     }
 
+    if workspace::canonicalize_agent_home_bindings(&mut state, storage.data_dir(), &agent_id)? {
+        let workspace = workspace::agent_home_workspace_entry(storage.data_dir(), &agent_id);
+        let known = storage.latest_workspace_entries()?;
+        if !known
+            .iter()
+            .any(|entry| entry.workspace_id == workspace.workspace_id)
+        {
+            storage.append_workspace_entry(&workspace)?;
+        }
+        storage.append_event(&AuditEvent::new(
+            "agent_home_workspace_bindings_migrated",
+            serde_json::json!({
+                "agent_id": agent_id,
+                "workspace_id": workspace.workspace_id,
+                "legacy_workspace_id": crate::types::AGENT_HOME_WORKSPACE_ID,
+            }),
+        ))?;
+    }
+
     if state
         .worktree_session
         .as_ref()

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -722,12 +722,31 @@ impl RuntimeHandle {
         if workspace_id.is_empty() {
             return Err(anyhow!("workspace_id is required"));
         }
-        if workspace_id == AGENT_HOME_WORKSPACE_ID {
-            return Err(anyhow!("AgentHome cannot be detached"));
-        }
 
         let detached_agent_id = {
             let mut guard = self.inner.agent.lock().await;
+            let canonical_agent_home_id = crate::types::agent_home_workspace_id(&guard.state.id);
+            if workspace_id == AGENT_HOME_WORKSPACE_ID {
+                let redundant_legacy_agent_home = guard
+                    .state
+                    .attached_workspaces
+                    .iter()
+                    .any(|id| id == AGENT_HOME_WORKSPACE_ID)
+                    && guard
+                        .state
+                        .attached_workspaces
+                        .iter()
+                        .any(|id| id == &canonical_agent_home_id)
+                    && !guard
+                        .state
+                        .active_workspace_entry
+                        .as_ref()
+                        .is_some_and(|entry| entry.workspace_id == AGENT_HOME_WORKSPACE_ID);
+                if !redundant_legacy_agent_home {
+                    return Err(anyhow!("AgentHome cannot be detached"));
+                }
+            }
+
             if guard
                 .state
                 .active_workspace_entry
@@ -879,6 +898,11 @@ impl RuntimeHandle {
         };
         {
             let mut guard = self.inner.agent.lock().await;
+            workspace::canonicalize_agent_home_bindings(
+                &mut guard.state,
+                self.inner.storage.data_dir(),
+                &state.id,
+            )?;
             if !guard
                 .state
                 .attached_workspaces

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -726,7 +726,7 @@ impl RuntimeHandle {
         let detached_agent_id = {
             let mut guard = self.inner.agent.lock().await;
             let canonical_agent_home_id = crate::types::agent_home_workspace_id(&guard.state.id);
-            if workspace_id == AGENT_HOME_WORKSPACE_ID {
+            if workspace_id == AGENT_HOME_WORKSPACE_ID || workspace_id == canonical_agent_home_id {
                 let redundant_legacy_agent_home = guard
                     .state
                     .attached_workspaces
@@ -742,7 +742,7 @@ impl RuntimeHandle {
                         .active_workspace_entry
                         .as_ref()
                         .is_some_and(|entry| entry.workspace_id == AGENT_HOME_WORKSPACE_ID);
-                if !redundant_legacy_agent_home {
+                if workspace_id != AGENT_HOME_WORKSPACE_ID || !redundant_legacy_agent_home {
                     return Err(anyhow!("AgentHome cannot be detached"));
                 }
             }

--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -147,6 +147,88 @@ async fn agent_home_workspace_ids_are_unique_per_agent_while_alias_remains_local
 }
 
 #[tokio::test]
+async fn runtime_startup_migrates_legacy_agent_home_attachment_alias() {
+    let dir = tempdir().unwrap();
+    let agent_id = "default";
+    let canonical_agent_home_id = crate::types::agent_home_workspace_id(agent_id);
+    let storage = crate::storage::AppStorage::new_for_agent(dir.path(), agent_id).unwrap();
+    let mut state = crate::types::AgentState::new(agent_id);
+    state.attached_workspaces = vec![
+        AGENT_HOME_WORKSPACE_ID.to_string(),
+        canonical_agent_home_id.clone(),
+    ];
+    state.active_workspace_entry = Some(crate::types::ActiveWorkspaceEntry {
+        workspace_id: AGENT_HOME_WORKSPACE_ID.to_string(),
+        workspace_anchor: dir.path().to_path_buf(),
+        execution_root_id: "canonical_root:agent_home".into(),
+        execution_root: dir.path().to_path_buf(),
+        projection_kind: WorkspaceProjectionKind::CanonicalRoot,
+        access_mode: WorkspaceAccessMode::ExclusiveWrite,
+        cwd: dir.path().to_path_buf(),
+        occupancy_id: None,
+        projection_metadata: None,
+    });
+    storage.write_agent(&state).unwrap();
+
+    let runtime = RuntimeHandle::new(
+        agent_id,
+        dir.path().to_path_buf(),
+        InitialWorkspaceBinding::Detached,
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        agent_id.into(),
+        context_config(),
+    )
+    .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+
+    assert_eq!(
+        state.attached_workspaces,
+        vec![canonical_agent_home_id.clone()]
+    );
+    assert_eq!(
+        state
+            .active_workspace_entry
+            .as_ref()
+            .map(|entry| entry.workspace_id.as_str()),
+        Some(canonical_agent_home_id.as_str())
+    );
+    assert!(runtime
+        .all_events()
+        .unwrap()
+        .iter()
+        .any(|event| event.kind == "agent_home_workspace_bindings_migrated"));
+}
+
+#[tokio::test]
+async fn detach_workspace_allows_only_redundant_legacy_agent_home_alias() {
+    let (_home, host, runtime) = host_backed_test_runtime().await;
+    let agent_id = host.config().default_agent_id.as_str();
+    let canonical_agent_home_id = crate::types::agent_home_workspace_id(agent_id);
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.attached_workspaces = vec![
+            AGENT_HOME_WORKSPACE_ID.to_string(),
+            canonical_agent_home_id.clone(),
+        ];
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    runtime
+        .detach_workspace(AGENT_HOME_WORKSPACE_ID)
+        .await
+        .unwrap();
+    let state = runtime.agent_state().await.unwrap();
+
+    assert_eq!(state.attached_workspaces, vec![canonical_agent_home_id]);
+    let err = runtime
+        .detach_workspace(AGENT_HOME_WORKSPACE_ID)
+        .await
+        .expect_err("effective AgentHome should remain protected");
+    assert!(err.to_string().contains("AgentHome cannot be detached"));
+}
+
+#[tokio::test]
 async fn use_workspace_rejects_nonexistent_path() {
     let (_home, _host, runtime) = host_backed_test_runtime().await;
     let nonexistent = runtime.agent_home().join("__holon_test_nonexistent_dir__");

--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -152,6 +152,8 @@ async fn runtime_startup_migrates_legacy_agent_home_attachment_alias() {
     let agent_id = "default";
     let canonical_agent_home_id = crate::types::agent_home_workspace_id(agent_id);
     let storage = crate::storage::AppStorage::new_for_agent(dir.path(), agent_id).unwrap();
+    let preserved_cwd = dir.path().join("notes");
+    std::fs::create_dir_all(&preserved_cwd).unwrap();
     let mut state = crate::types::AgentState::new(agent_id);
     state.attached_workspaces = vec![
         AGENT_HOME_WORKSPACE_ID.to_string(),
@@ -164,7 +166,7 @@ async fn runtime_startup_migrates_legacy_agent_home_attachment_alias() {
         execution_root: dir.path().to_path_buf(),
         projection_kind: WorkspaceProjectionKind::CanonicalRoot,
         access_mode: WorkspaceAccessMode::ExclusiveWrite,
-        cwd: dir.path().to_path_buf(),
+        cwd: preserved_cwd.clone(),
         occupancy_id: None,
         projection_metadata: None,
     });
@@ -192,6 +194,13 @@ async fn runtime_startup_migrates_legacy_agent_home_attachment_alias() {
             .as_ref()
             .map(|entry| entry.workspace_id.as_str()),
         Some(canonical_agent_home_id.as_str())
+    );
+    assert_eq!(
+        state
+            .active_workspace_entry
+            .as_ref()
+            .map(|entry| &entry.cwd),
+        Some(&preserved_cwd)
     );
     assert!(runtime
         .all_events()
@@ -225,6 +234,37 @@ async fn detach_workspace_allows_only_redundant_legacy_agent_home_alias() {
         .detach_workspace(AGENT_HOME_WORKSPACE_ID)
         .await
         .expect_err("effective AgentHome should remain protected");
+    assert!(err.to_string().contains("AgentHome cannot be detached"));
+}
+
+#[tokio::test]
+async fn detach_workspace_rejects_canonical_agent_home_when_inactive() {
+    let (_home, host, runtime) = host_backed_test_runtime().await;
+    let agent_id = host.config().default_agent_id.as_str();
+    let canonical_agent_home_id = crate::types::agent_home_workspace_id(agent_id);
+    let project = tempdir().unwrap();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.attached_workspaces =
+            vec![canonical_agent_home_id.clone(), "ws-project".to_string()];
+        guard.state.active_workspace_entry = Some(crate::types::ActiveWorkspaceEntry {
+            workspace_id: "ws-project".into(),
+            workspace_anchor: project.path().to_path_buf(),
+            execution_root_id: "canonical_root:ws-project".into(),
+            execution_root: project.path().to_path_buf(),
+            projection_kind: WorkspaceProjectionKind::CanonicalRoot,
+            access_mode: WorkspaceAccessMode::ExclusiveWrite,
+            cwd: project.path().to_path_buf(),
+            occupancy_id: None,
+            projection_metadata: None,
+        });
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let err = runtime
+        .detach_workspace(&canonical_agent_home_id)
+        .await
+        .expect_err("canonical AgentHome should remain protected when inactive");
     assert!(err.to_string().contains("AgentHome cannot be detached"));
 }
 

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -58,12 +58,17 @@ pub(crate) fn canonicalize_agent_home_bindings(
         .as_ref()
         .is_some_and(|entry| entry.workspace_id == AGENT_HOME_WORKSPACE_ID)
     {
-        let access_mode = state
-            .active_workspace_entry
-            .as_ref()
+        let previous_entry = state.active_workspace_entry.as_ref();
+        let access_mode = previous_entry
             .map(|entry| entry.access_mode)
             .unwrap_or(WorkspaceAccessMode::ExclusiveWrite);
-        let entry = canonical_agent_home_active_entry(data_dir, agent_id, access_mode)?;
+        let mut entry = canonical_agent_home_active_entry(data_dir, agent_id, access_mode)?;
+        if let Some(previous_cwd) = previous_entry
+            .map(|entry| entry.cwd.as_path())
+            .filter(|cwd| cwd.starts_with(&entry.execution_root))
+        {
+            entry.cwd = previous_cwd.to_path_buf();
+        }
         state.active_workspace_entry = Some(entry);
         state.worktree_session = None;
         changed = true;

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -11,7 +11,10 @@ use crate::{
         EffectiveExecution, ExecutionProfile, ExecutionScopeKind, ExecutionSnapshot,
         WorkspaceAccessMode, WorkspaceProjectionKind, WorkspaceView,
     },
-    types::{agent_home_workspace_id, AgentState, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID},
+    types::{
+        agent_home_workspace_id, ActiveWorkspaceEntry, AgentState, WorkspaceEntry,
+        AGENT_HOME_WORKSPACE_ID,
+    },
 };
 
 pub(crate) fn build_execution_root_id(
@@ -40,6 +43,87 @@ pub(crate) fn agent_home_workspace_entry(data_dir: &Path, agent_id: &str) -> Wor
     entry.workspace_kind = Some("agent_home".into());
     entry.owner_agent_id = Some(agent_id.to_string());
     entry
+}
+
+pub(crate) fn canonicalize_agent_home_bindings(
+    state: &mut AgentState,
+    data_dir: &Path,
+    agent_id: &str,
+) -> Result<bool> {
+    let canonical_id = agent_home_workspace_id(agent_id);
+    let mut changed = false;
+
+    if state
+        .active_workspace_entry
+        .as_ref()
+        .is_some_and(|entry| entry.workspace_id == AGENT_HOME_WORKSPACE_ID)
+    {
+        let access_mode = state
+            .active_workspace_entry
+            .as_ref()
+            .map(|entry| entry.access_mode)
+            .unwrap_or(WorkspaceAccessMode::ExclusiveWrite);
+        let entry = canonical_agent_home_active_entry(data_dir, agent_id, access_mode)?;
+        state.active_workspace_entry = Some(entry);
+        state.worktree_session = None;
+        changed = true;
+    }
+
+    let mut next = Vec::with_capacity(state.attached_workspaces.len().max(1));
+    for workspace_id in &state.attached_workspaces {
+        let next_id = if workspace_id == AGENT_HOME_WORKSPACE_ID {
+            changed = true;
+            canonical_id.as_str()
+        } else {
+            workspace_id.as_str()
+        };
+        if !next.iter().any(|id| id == next_id) {
+            next.push(next_id.to_string());
+        } else {
+            changed = true;
+        }
+    }
+
+    if state
+        .active_workspace_entry
+        .as_ref()
+        .is_some_and(|entry| entry.workspace_id == canonical_id)
+        && !next.iter().any(|id| id == &canonical_id)
+    {
+        next.push(canonical_id);
+        changed = true;
+    }
+
+    if changed {
+        state.attached_workspaces = next;
+    }
+
+    Ok(changed)
+}
+
+pub(crate) fn canonical_agent_home_active_entry(
+    data_dir: &Path,
+    agent_id: &str,
+    access_mode: WorkspaceAccessMode,
+) -> Result<ActiveWorkspaceEntry> {
+    let workspace = agent_home_workspace_entry(data_dir, agent_id);
+    let execution_root = crate::system::workspace::normalize_path(&workspace.workspace_anchor)?;
+    let execution_root_id = build_execution_root_id(
+        &workspace.workspace_id,
+        WorkspaceProjectionKind::CanonicalRoot,
+        &execution_root,
+    )?;
+    Ok(ActiveWorkspaceEntry {
+        workspace_id: workspace.workspace_id,
+        workspace_anchor: workspace.workspace_anchor,
+        execution_root_id,
+        execution_root: execution_root.clone(),
+        projection_kind: WorkspaceProjectionKind::CanonicalRoot,
+        access_mode,
+        cwd: execution_root,
+        occupancy_id: None,
+        projection_metadata: None,
+    })
 }
 
 pub(crate) fn detached_execution_root(storage: &AppStorage) -> PathBuf {


### PR DESCRIPTION
## Summary
- migrate legacy `agent_home` attached workspace bindings to scoped `agent_home:<agent>` on startup
- allow detaching only a redundant legacy `agent_home` alias while keeping effective AgentHome protected
- canonicalize AgentHome bindings when activating AgentHome and add regression coverage

Fixes #1695.

## Verification
- `cargo test legacy_agent_home`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
