### PR TITLE
fix: align debug prompt context limits

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -29,7 +29,7 @@ use crate::{
     context::ContextConfig,
     host_registry::RuntimeRegistry,
     ids,
-    prompt::{build_effective_prompt, EffectivePrompt},
+    prompt::{build_effective_prompt_with_apply_patch_surface, EffectivePrompt},
     provider::{build_provider_from_config, AgentProvider},
     runtime::{InitialWorkspaceBinding, RuntimeHandle},
     runtime_db::RuntimeDb,
@@ -905,7 +905,7 @@ impl RuntimeHost {
             .map(|(_, tool)| tool)
             .collect::<Vec<_>>();
         let prompt_tools = provider.prompt_tool_specs(&available_tools);
-        build_effective_prompt(
+        build_effective_prompt_with_apply_patch_surface(
             &storage,
             &state,
             &execution,
@@ -917,6 +917,7 @@ impl RuntimeHost {
             loaded_agents_md,
             &skills,
             &prompt_tools,
+            apply_patch_surface,
             None,
         )
     }
@@ -2149,6 +2150,33 @@ mod tests {
             })
             .count();
         assert_eq!(backups, 0);
+    }
+
+    #[tokio::test]
+    async fn debug_prompt_preview_uses_model_apply_patch_surface_even_when_tools_are_lowered() {
+        let home = tempdir().unwrap();
+        fs::write(
+            home.path().join("config.json"),
+            r#"{"model":{"default":"openai-codex/gpt-5.3-codex-spark"}}"#,
+        )
+        .unwrap();
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("done"))).unwrap();
+        let agent_id = host.config().default_agent_id.clone();
+
+        let prompt = host
+            .preview_agent_prompt(
+                &agent_id,
+                "inspect prompt".into(),
+                AuthorityClass::OperatorInstruction,
+            )
+            .unwrap();
+        let rendered = prompt.render_dump();
+
+        assert!(rendered.contains("Current ApplyPatch surface is Codex DSL freeform"));
+        assert!(rendered.contains("send raw `*** Begin Patch` / `*** End Patch` text directly"));
+        assert!(!rendered.contains("Current ApplyPatch surface is a JSON/function tool"));
     }
 
     fn inherited_model_resolution(provider: &str, model: &str) -> SpawnAgentModelResolution {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1865,6 +1865,7 @@ impl AppStorage {
         let waiting_for_operator = readiness
             .iter()
             .filter(|item| item.candidate_class == WorkItemCandidateClass::WaitingForOperator)
+            .take(3)
             .cloned()
             .collect::<Vec<_>>();
         let blocked = readiness
@@ -6333,6 +6334,39 @@ mod tests {
                 .map(|item| item.work_item.objective.as_str())
                 .collect::<Vec<_>>(),
             vec!["recently completed"]
+        );
+    }
+
+    #[test]
+    fn storage_work_queue_prompt_projection_limits_waiting_for_operator() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        let now = Utc::now();
+
+        for index in 0..5 {
+            let mut waiting = WorkItemRecord::new(
+                "default",
+                format!("operator decision {index}"),
+                WorkItemState::Open,
+            );
+            waiting.plan_status = WorkItemPlanStatus::NeedsInput;
+            waiting.updated_at = now + chrono::Duration::minutes(index);
+            storage.append_work_item(&waiting).unwrap();
+        }
+
+        let projection = storage.work_queue_prompt_projection().unwrap();
+
+        assert_eq!(
+            projection
+                .waiting_for_operator
+                .iter()
+                .map(|item| item.work_item.objective.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "operator decision 4",
+                "operator decision 3",
+                "operator decision 2"
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- pass the model-derived ApplyPatch surface through storage-only debug prompt preview
- cap waiting_for_operator work item prompt candidates to match other bounded groups
- add regression coverage for both paths

## Verification
- cargo fmt --all -- --check
- cargo test debug_prompt_preview_uses_model_apply_patch_surface_even_when_tools_are_lowered --all-targets
- cargo test storage_work_queue_prompt_projection_limits_waiting_for_operator --all-targets
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo run --quiet --bin holon -- debug prompt --agent holon-bench 'test prompt projection' | rg -n "Current ApplyPatch surface|JSON/function tool|Codex DSL freeform"