### PR TITLE
feat: add ViewImage tool skeleton

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -1198,6 +1198,36 @@
       "stability": "stable"
     },
     {
+      "description": "Validate and record durable metadata for a local image file.\n\n`ViewImage` accepts a workspace-relative or absolute image path plus a required\nprompt describing what to inspect. It records provider-neutral evidence such as\nmedia type, byte count, SHA-256, and dimensions when they can be read from the\nfile header.\n\nThis skeleton does not yet call a vision model. Until visual observation\ngeneration is implemented, successful results return `status: \"unavailable\"`\nwith a structured explanation.\n",
+      "family": "local_environment",
+      "freeform_grammar": null,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "name": "ViewImage",
+      "related_surfaces": [],
+      "result_envelope": {
+        "canonical": "ToolResultEnvelope",
+        "error_result": "ToolError",
+        "model_rendering": "canonical_json_envelope",
+        "success_result": "tool-specific JSON payload"
+      },
+      "stability": "experimental"
+    },
+    {
       "description": "Fetch a specific http or https URL through Holon's web policy, extract readable text, wrap it as untrusted external content, and return provenance including final URL, status, content type, truncation, and hash.\n",
       "family": "web",
       "freeform_grammar": null,

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -37,11 +37,25 @@ pub(crate) use crate::{
 use super::super::*;
 
 pub(crate) fn context_config() -> ContextConfig {
+    let available_tools =
+        crate::tool::ToolRegistry::new(PathBuf::from("/tmp/holon-test-workspace"))
+            .tool_specs_with_families()
+            .unwrap()
+            .into_iter()
+            .filter(|(family, _)| {
+                AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
+            })
+            .map(|(_, tool)| tool)
+            .collect::<Vec<_>>();
+    let prompt_budget_estimated_tokens =
+        super::super::turn::estimate_tool_specs_tokens(&available_tools) + 4096;
     ContextConfig {
         recent_messages: 8,
         recent_briefs: 8,
         compaction_trigger_messages: 10,
         compaction_keep_recent_messages: 4,
+        prompt_budget_estimated_tokens,
+        turn_projection_min_budget: prompt_budget_estimated_tokens,
         ..ContextConfig::default()
     }
 }

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -673,6 +673,19 @@ async fn turn_local_compaction_fails_fast_when_baseline_exceeds_budget() {
     let provider = Arc::new(BaselineOverBudgetProbeProvider {
         calls: Mutex::new(0),
     });
+    let available_tools = crate::tool::ToolRegistry::new(workspace.path().to_path_buf())
+        .tool_specs_with_families()
+        .unwrap()
+        .into_iter()
+        .filter(|(family, _)| {
+            AgentProfilePreset::PublicNamed.allows_tool_capability_family(*family)
+        })
+        .map(|(_, tool)| tool)
+        .collect::<Vec<_>>();
+    let continuation_effective_budget = 320;
+    let prompt_budget_estimated_tokens = turn::estimate_tool_specs_tokens(&available_tools)
+        + turn::CONTINUATION_BUDGET_SAFETY_MARGIN_TOKENS
+        + continuation_effective_budget;
     let runtime = RuntimeHandle::new(
         "default",
         dir.path().to_path_buf(),
@@ -681,8 +694,11 @@ async fn turn_local_compaction_fails_fast_when_baseline_exceeds_budget() {
         provider.clone(),
         "default".into(),
         ContextConfig {
-            prompt_budget_estimated_tokens: 320,
+            prompt_budget_estimated_tokens,
             compaction_keep_recent_estimated_tokens: 120,
+            turn_projection_budget_ratio: 1.0,
+            turn_projection_min_budget: 0,
+            turn_projection_max_budget: prompt_budget_estimated_tokens,
             ..context_config()
         },
     )

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -355,6 +355,7 @@ mod tests {
             "MemoryGet",
             "ApplyPatch",
             "ExecCommand",
+            "ViewImage",
             "WebFetch",
             "WebSearch",
         ] {
@@ -625,6 +626,7 @@ mod tests {
         assert!(names.iter().all(|name| name != "CancelExternalTrigger"));
         assert!(names.iter().all(|name| name != "TaskList"));
         assert!(names.iter().any(|name| name == "ApplyPatch"));
+        assert!(names.iter().any(|name| name == "ViewImage"));
         assert!(names.iter().any(|name| name == "WebFetch"));
         assert!(names.iter().any(|name| name == "WebSearch"));
         assert!(names.iter().all(|name| name != "CreateTask"));
@@ -672,6 +674,10 @@ mod tests {
         );
         assert_eq!(
             family_for("UseWorkspace"),
+            ToolCapabilityFamily::LocalEnvironment
+        );
+        assert_eq!(
+            family_for("ViewImage"),
             ToolCapabilityFamily::LocalEnvironment
         );
         assert_eq!(family_for("WebFetch"), ToolCapabilityFamily::Web);

--- a/src/tool/tool_descriptions/view_image.md
+++ b/src/tool/tool_descriptions/view_image.md
@@ -1,0 +1,10 @@
+Validate and record durable metadata for a local image file.
+
+`ViewImage` accepts a workspace-relative or absolute image path plus a required
+prompt describing what to inspect. It records provider-neutral evidence such as
+media type, byte count, SHA-256, and dimensions when they can be read from the
+file header.
+
+This skeleton does not yet call a vision model. Until visual observation
+generation is implemented, successful results return `status: "unavailable"`
+with a structured explanation.

--- a/src/tool/tools/mod.rs
+++ b/src/tool/tools/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod task_status;
 pub(crate) mod task_stop;
 pub(crate) mod update_work_item;
 pub(crate) mod use_workspace;
+pub(crate) mod view_image;
 pub(crate) mod wait_for;
 pub(crate) mod web_fetch;
 pub(crate) mod web_search;
@@ -71,6 +72,7 @@ pub(crate) fn builtin_tool_definitions() -> Result<Vec<BuiltinToolDefinition>> {
         exec_command::definition()?,
         exec_command_batch::definition()?,
         use_workspace::definition()?,
+        view_image::definition()?,
         web_fetch::definition()?,
         web_search::definition()?,
     ])
@@ -173,6 +175,9 @@ pub(crate) async fn execute_builtin_tool(
         use_workspace::NAME => {
             use_workspace::execute(runtime, agent_id, authority_class, &call.input).await
         }
+        view_image::NAME => {
+            view_image::execute(runtime, agent_id, authority_class, &call.input).await
+        }
         web_fetch::NAME => {
             web_fetch::execute(runtime, agent_id, authority_class, &call.input).await
         }
@@ -255,6 +260,7 @@ mod tests {
             "TaskStop" => "src/tool/tool_descriptions/task_stop.md",
             "UpdateWorkItem" => "src/tool/tool_descriptions/update_work_item.md",
             "UseWorkspace" => "src/tool/tool_descriptions/use_workspace.md",
+            "ViewImage" => "src/tool/tool_descriptions/view_image.md",
             "WaitFor" => "src/tool/tool_descriptions/wait_for.md",
             "WebFetch" => "src/tool/tool_descriptions/web_fetch.md",
             "WebSearch" => "src/tool/tool_descriptions/web_search.md",

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -1,6 +1,11 @@
-use std::{fs, path::Path};
+use std::{
+    fs::{self, File},
+    io::Read,
+    path::Path,
+};
 
 use anyhow::Result;
+use chrono::Utc;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -11,7 +16,8 @@ use crate::{
     system::ExecutionScopeKind,
     tool::{helpers::invalid_tool_input, spec::typed_spec, ToolError},
     types::{
-        AuthorityClass, ToolCapabilityFamily, ViewImageMetadata, ViewImageResult, ViewImageStatus,
+        AuthorityClass, ToolCapabilityFamily, ViewImageGeneratedBy, ViewImageObservation,
+        ViewImageReferenceSize, ViewImageResult, ViewImageSelectedMode, ViewImageVisualReference,
     },
 };
 
@@ -52,39 +58,57 @@ pub(crate) async fn execute(
         .effective_execution(ExecutionScopeKind::AgentTurn)
         .await?;
     let resolved_path = execution.workspace.resolve_read_path(&path)?;
-    let metadata = read_image_metadata(&resolved_path)?;
-    let observation =
-        "visual observation unavailable: provider-native image observation is not implemented yet"
-            .to_string();
+    let visual_reference = read_visual_reference(&resolved_path)?;
+    let observation = ViewImageObservation {
+        kind: "visual_observation".to_string(),
+        schema: "visual_observation.v1".to_string(),
+        visual_reference_id: visual_reference.id.clone(),
+        prompt,
+        generated_by: ViewImageGeneratedBy {
+            mode: ViewImageSelectedMode::Unavailable,
+            provider: None,
+            model: None,
+        },
+        summary:
+            "visual observation unavailable: provider-native image observation is not implemented yet"
+                .to_string(),
+        ocr: Vec::new(),
+        elements: Vec::new(),
+        relations: Vec::new(),
+        issues: Vec::new(),
+        uncertainties: vec![
+            "ViewImage currently records image metadata only; visual observation generation is not implemented yet."
+                .to_string(),
+        ],
+        external_sources: Vec::new(),
+    };
     let summary_text = Some(format!(
         "ViewImage recorded {} ({} bytes); visual observation unavailable",
-        metadata.media_type, metadata.byte_count
+        visual_reference.mime, visual_reference.byte_count
     ));
     serialize_success(
         NAME,
         &ViewImageResult {
-            status: ViewImageStatus::Unavailable,
-            path,
-            resolved_path,
-            prompt: Some(prompt),
-            metadata,
+            visual_reference,
             observation,
+            selected_mode: ViewImageSelectedMode::Unavailable,
             summary_text,
         },
     )
 }
 
-fn read_image_metadata(path: &Path) -> Result<ViewImageMetadata> {
+fn read_visual_reference(path: &Path) -> Result<ViewImageVisualReference> {
     let file_metadata = fs::metadata(path).map_err(|error| {
-        ToolError::new(
-            "image_read_failed",
-            format!("failed to inspect image file: {error}"),
+        invalid_tool_input(
+            NAME,
+            "ViewImage `path` must refer to a readable local image file",
+            json!({
+                "field": "path",
+                "path": path,
+                "io_error": error.to_string(),
+            }),
+            "provide a readable PNG, JPEG, GIF, or WebP image file path",
         )
-        .with_details(json!({
-            "path": path,
-            "io_error": error.to_string(),
-        }))
-        .with_recovery_hint("provide a readable local image file path")
     })?;
     if !file_metadata.is_file() {
         return Err(invalid_tool_input(
@@ -112,7 +136,7 @@ fn read_image_metadata(path: &Path) -> Result<ViewImageMetadata> {
             "provide a smaller local image file",
         ));
     }
-    let bytes = fs::read(path).map_err(|error| {
+    let mut file = File::open(path).map_err(|error| {
         ToolError::new(
             "image_read_failed",
             format!("failed to read image file: {error}"),
@@ -123,6 +147,34 @@ fn read_image_metadata(path: &Path) -> Result<ViewImageMetadata> {
         }))
         .with_recovery_hint("provide a readable local image file path")
     })?;
+    let mut bytes = Vec::with_capacity(byte_count as usize);
+    file.by_ref()
+        .take(MAX_IMAGE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            ToolError::new(
+                "image_read_failed",
+                format!("failed to read image file: {error}"),
+            )
+            .with_details(json!({
+                "path": path,
+                "io_error": error.to_string(),
+            }))
+            .with_recovery_hint("provide a readable local image file path")
+        })?;
+    if bytes.len() as u64 > MAX_IMAGE_BYTES {
+        return Err(invalid_tool_input(
+            NAME,
+            "ViewImage `path` exceeds the maximum supported image file size",
+            json!({
+                "field": "path",
+                "path": path,
+                "byte_count": bytes.len(),
+                "max_byte_count": MAX_IMAGE_BYTES,
+            }),
+            "provide a smaller local image file",
+        ));
+    }
     let Some(header) = ImageHeader::parse(&bytes) else {
         return Err(invalid_tool_input(
             NAME,
@@ -154,12 +206,19 @@ fn read_image_metadata(path: &Path) -> Result<ViewImageMetadata> {
             ));
         }
     }
-    Ok(ViewImageMetadata {
-        media_type: header.media_type.to_string(),
-        byte_count,
-        sha256: format!("{:x}", Sha256::digest(&bytes)),
-        width: header.width,
-        height: header.height,
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    Ok(ViewImageVisualReference {
+        kind: "visual_reference".to_string(),
+        id: format!("vis_{}", &sha256[..16]),
+        path: path.to_path_buf(),
+        sha256,
+        mime: header.media_type.to_string(),
+        byte_count: bytes.len() as u64,
+        size: ViewImageReferenceSize {
+            width: header.width,
+            height: header.height,
+        },
+        created_at: Utc::now(),
     })
 }
 
@@ -228,11 +287,7 @@ fn parse_webp(bytes: &[u8]) -> Option<ImageHeader> {
             width: Some(read_u24_le(&bytes[24..27]) + 1),
             height: Some(read_u24_le(&bytes[27..30]) + 1),
         }),
-        _ => Some(ImageHeader {
-            media_type: "image/webp",
-            width: None,
-            height: None,
-        }),
+        _ => None,
     }
 }
 
@@ -277,11 +332,7 @@ fn parse_jpeg(bytes: &[u8]) -> Option<ImageHeader> {
         }
         offset += segment_len;
     }
-    Some(ImageHeader {
-        media_type: "image/jpeg",
-        width: None,
-        height: None,
-    })
+    None
 }
 
 fn is_jpeg_sof_marker(marker: u8) -> bool {
@@ -323,19 +374,32 @@ mod tests {
     }
 
     #[test]
-    fn reads_image_metadata() {
+    fn reads_visual_reference() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("image.png");
         let bytes = png_header_bytes(320, 240);
         fs::write(&path, &bytes).unwrap();
 
-        let metadata = read_image_metadata(&path).unwrap();
+        let reference = read_visual_reference(&path).unwrap();
 
-        assert_eq!(metadata.media_type, "image/png");
-        assert_eq!(metadata.byte_count, bytes.len() as u64);
-        assert_eq!(metadata.width, Some(320));
-        assert_eq!(metadata.height, Some(240));
-        assert_eq!(metadata.sha256, format!("{:x}", Sha256::digest(&bytes)));
+        assert_eq!(reference.kind, "visual_reference");
+        assert_eq!(reference.mime, "image/png");
+        assert_eq!(reference.byte_count, bytes.len() as u64);
+        assert_eq!(reference.size.width, Some(320));
+        assert_eq!(reference.size.height, Some(240));
+        assert_eq!(reference.sha256, format!("{:x}", Sha256::digest(&bytes)));
+        assert!(reference.id.starts_with("vis_"));
+    }
+
+    #[test]
+    fn rejects_missing_file_as_invalid_tool_input() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing.png");
+
+        let error = ToolError::from_anyhow(&read_visual_reference(&path).unwrap_err());
+
+        assert_eq!(error.kind, "invalid_tool_input");
+        assert!(error.message.contains("readable local image file"));
     }
 
     #[test]
@@ -344,7 +408,7 @@ mod tests {
         let path = dir.path().join("not-image.txt");
         fs::write(&path, b"hello").unwrap();
 
-        let error = ToolError::from_anyhow(&read_image_metadata(&path).unwrap_err());
+        let error = ToolError::from_anyhow(&read_visual_reference(&path).unwrap_err());
 
         assert_eq!(error.kind, "invalid_tool_input");
         assert!(error.message.contains("supported image file"));
@@ -357,7 +421,7 @@ mod tests {
         let file = File::create(&path).unwrap();
         file.set_len(MAX_IMAGE_BYTES + 1).unwrap();
 
-        let error = ToolError::from_anyhow(&read_image_metadata(&path).unwrap_err());
+        let error = ToolError::from_anyhow(&read_visual_reference(&path).unwrap_err());
 
         assert_eq!(error.kind, "invalid_tool_input");
         assert!(error.message.contains("file size"));
@@ -369,10 +433,25 @@ mod tests {
         let path = dir.path().join("huge.png");
         fs::write(&path, png_header_bytes(100_000, 100_000)).unwrap();
 
-        let error = ToolError::from_anyhow(&read_image_metadata(&path).unwrap_err());
+        let error = ToolError::from_anyhow(&read_visual_reference(&path).unwrap_err());
 
         assert_eq!(error.kind, "invalid_tool_input");
         assert!(error.message.contains("pixel count"));
+    }
+
+    #[test]
+    fn rejects_jpeg_without_sof_dimensions() {
+        let bytes = [0xff, 0xd8, 0xff, 0xd9];
+
+        assert!(ImageHeader::parse(&bytes).is_none());
+    }
+
+    #[test]
+    fn rejects_webp_without_recognized_dimensions() {
+        let mut bytes = b"RIFF\x1e\0\0\0WEBPUNKN".to_vec();
+        bytes.resize(30, 0);
+
+        assert!(ImageHeader::parse(&bytes).is_none());
     }
 
     fn png_header_bytes(width: u32, height: u32) -> Vec<u8> {

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -1,0 +1,385 @@
+use std::{fs, path::Path};
+
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    runtime::RuntimeHandle,
+    system::ExecutionScopeKind,
+    tool::{helpers::invalid_tool_input, spec::typed_spec, ToolError},
+    types::{
+        AuthorityClass, ToolCapabilityFamily, ViewImageMetadata, ViewImageResult, ViewImageStatus,
+    },
+};
+
+use super::{serialize_success, BuiltinToolDefinition};
+use crate::tool::helpers::{parse_tool_args, validate_non_empty};
+
+pub(crate) const NAME: &str = "ViewImage";
+const MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
+const MAX_IMAGE_PIXELS: u64 = 50_000_000;
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ViewImageArgs {
+    pub(crate) path: String,
+    pub(crate) prompt: String,
+}
+
+pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
+    Ok(BuiltinToolDefinition {
+        family: ToolCapabilityFamily::LocalEnvironment,
+        spec: typed_spec::<ViewImageArgs>(
+            NAME,
+            include_str!("../tool_descriptions/view_image.md"),
+        )?,
+    })
+}
+
+pub(crate) async fn execute(
+    runtime: &RuntimeHandle,
+    _agent_id: &str,
+    _authority_class: &AuthorityClass,
+    input: &Value,
+) -> Result<crate::tool::ToolResult> {
+    let args: ViewImageArgs = parse_tool_args(NAME, input)?;
+    let path = validate_non_empty(args.path, NAME, "path")?;
+    let prompt = validate_non_empty(args.prompt, NAME, "prompt")?;
+    let execution = runtime
+        .effective_execution(ExecutionScopeKind::AgentTurn)
+        .await?;
+    let resolved_path = execution.workspace.resolve_read_path(&path)?;
+    let metadata = read_image_metadata(&resolved_path)?;
+    let observation =
+        "visual observation unavailable: provider-native image observation is not implemented yet"
+            .to_string();
+    let summary_text = Some(format!(
+        "ViewImage recorded {} ({} bytes); visual observation unavailable",
+        metadata.media_type, metadata.byte_count
+    ));
+    serialize_success(
+        NAME,
+        &ViewImageResult {
+            status: ViewImageStatus::Unavailable,
+            path,
+            resolved_path,
+            prompt: Some(prompt),
+            metadata,
+            observation,
+            summary_text,
+        },
+    )
+}
+
+fn read_image_metadata(path: &Path) -> Result<ViewImageMetadata> {
+    let file_metadata = fs::metadata(path).map_err(|error| {
+        ToolError::new(
+            "image_read_failed",
+            format!("failed to inspect image file: {error}"),
+        )
+        .with_details(json!({
+            "path": path,
+            "io_error": error.to_string(),
+        }))
+        .with_recovery_hint("provide a readable local image file path")
+    })?;
+    if !file_metadata.is_file() {
+        return Err(invalid_tool_input(
+            NAME,
+            "ViewImage `path` must refer to a regular file",
+            json!({
+                "field": "path",
+                "path": path,
+                "validation_error": "not a regular file",
+            }),
+            "provide a path to a readable PNG, JPEG, GIF, or WebP image file",
+        ));
+    }
+    let byte_count = file_metadata.len();
+    if byte_count > MAX_IMAGE_BYTES {
+        return Err(invalid_tool_input(
+            NAME,
+            "ViewImage `path` exceeds the maximum supported image file size",
+            json!({
+                "field": "path",
+                "path": path,
+                "byte_count": byte_count,
+                "max_byte_count": MAX_IMAGE_BYTES,
+            }),
+            "provide a smaller local image file",
+        ));
+    }
+    let bytes = fs::read(path).map_err(|error| {
+        ToolError::new(
+            "image_read_failed",
+            format!("failed to read image file: {error}"),
+        )
+        .with_details(json!({
+            "path": path,
+            "io_error": error.to_string(),
+        }))
+        .with_recovery_hint("provide a readable local image file path")
+    })?;
+    let Some(header) = ImageHeader::parse(&bytes) else {
+        return Err(invalid_tool_input(
+            NAME,
+            "ViewImage `path` must refer to a supported image file",
+            json!({
+                "field": "path",
+                "path": path,
+                "validation_error": "unsupported image header",
+                "supported_media_types": ["image/png", "image/jpeg", "image/gif", "image/webp"],
+            }),
+            "provide a PNG, JPEG, GIF, or WebP image file",
+        ));
+    };
+    if let (Some(width), Some(height)) = (header.width, header.height) {
+        let pixels = u64::from(width) * u64::from(height);
+        if pixels > MAX_IMAGE_PIXELS {
+            return Err(invalid_tool_input(
+                NAME,
+                "ViewImage `path` exceeds the maximum supported decoded pixel count",
+                json!({
+                    "field": "path",
+                    "path": path,
+                    "width": width,
+                    "height": height,
+                    "pixel_count": pixels,
+                    "max_pixel_count": MAX_IMAGE_PIXELS,
+                }),
+                "provide an image with fewer decoded pixels",
+            ));
+        }
+    }
+    Ok(ViewImageMetadata {
+        media_type: header.media_type.to_string(),
+        byte_count,
+        sha256: format!("{:x}", Sha256::digest(&bytes)),
+        width: header.width,
+        height: header.height,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ImageHeader {
+    media_type: &'static str,
+    width: Option<u32>,
+    height: Option<u32>,
+}
+
+impl ImageHeader {
+    fn parse(bytes: &[u8]) -> Option<Self> {
+        parse_png(bytes)
+            .or_else(|| parse_gif(bytes))
+            .or_else(|| parse_webp(bytes))
+            .or_else(|| parse_jpeg(bytes))
+    }
+}
+
+fn parse_png(bytes: &[u8]) -> Option<ImageHeader> {
+    if bytes.len() < 24 || !bytes.starts_with(b"\x89PNG\r\n\x1a\n") || &bytes[12..16] != b"IHDR" {
+        return None;
+    }
+    Some(ImageHeader {
+        media_type: "image/png",
+        width: Some(u32::from_be_bytes(bytes[16..20].try_into().ok()?)),
+        height: Some(u32::from_be_bytes(bytes[20..24].try_into().ok()?)),
+    })
+}
+
+fn parse_gif(bytes: &[u8]) -> Option<ImageHeader> {
+    if bytes.len() < 10 || !(bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")) {
+        return None;
+    }
+    Some(ImageHeader {
+        media_type: "image/gif",
+        width: Some(u16::from_le_bytes(bytes[6..8].try_into().ok()?) as u32),
+        height: Some(u16::from_le_bytes(bytes[8..10].try_into().ok()?) as u32),
+    })
+}
+
+fn parse_webp(bytes: &[u8]) -> Option<ImageHeader> {
+    if bytes.len() < 30 || !bytes.starts_with(b"RIFF") || &bytes[8..12] != b"WEBP" {
+        return None;
+    }
+    match &bytes[12..16] {
+        b"VP8 " if bytes.len() >= 30 && &bytes[23..26] == b"\x9d\x01\x2a" => {
+            let width = u16::from_le_bytes(bytes[26..28].try_into().ok()?) & 0x3fff;
+            let height = u16::from_le_bytes(bytes[28..30].try_into().ok()?) & 0x3fff;
+            Some(ImageHeader {
+                media_type: "image/webp",
+                width: Some(width as u32),
+                height: Some(height as u32),
+            })
+        }
+        b"VP8L" if bytes.len() >= 25 => {
+            let packed = u32::from_le_bytes(bytes[21..25].try_into().ok()?);
+            Some(ImageHeader {
+                media_type: "image/webp",
+                width: Some((packed & 0x3fff) + 1),
+                height: Some(((packed >> 14) & 0x3fff) + 1),
+            })
+        }
+        b"VP8X" if bytes.len() >= 30 => Some(ImageHeader {
+            media_type: "image/webp",
+            width: Some(read_u24_le(&bytes[24..27]) + 1),
+            height: Some(read_u24_le(&bytes[27..30]) + 1),
+        }),
+        _ => Some(ImageHeader {
+            media_type: "image/webp",
+            width: None,
+            height: None,
+        }),
+    }
+}
+
+fn read_u24_le(bytes: &[u8]) -> u32 {
+    u32::from(bytes[0]) | (u32::from(bytes[1]) << 8) | (u32::from(bytes[2]) << 16)
+}
+
+fn parse_jpeg(bytes: &[u8]) -> Option<ImageHeader> {
+    if bytes.len() < 4 || !bytes.starts_with(&[0xff, 0xd8]) {
+        return None;
+    }
+    let mut offset = 2usize;
+    while offset + 4 <= bytes.len() {
+        while offset < bytes.len() && bytes[offset] == 0xff {
+            offset += 1;
+        }
+        if offset >= bytes.len() {
+            break;
+        }
+        let marker = bytes[offset];
+        offset += 1;
+        if marker == 0xd9 || marker == 0xda {
+            break;
+        }
+        if offset + 2 > bytes.len() {
+            break;
+        }
+        let segment_len = u16::from_be_bytes(bytes[offset..offset + 2].try_into().ok()?) as usize;
+        if segment_len < 2 || offset + segment_len > bytes.len() {
+            break;
+        }
+        if is_jpeg_sof_marker(marker) && segment_len >= 7 {
+            return Some(ImageHeader {
+                media_type: "image/jpeg",
+                height: Some(
+                    u16::from_be_bytes(bytes[offset + 3..offset + 5].try_into().ok()?) as u32,
+                ),
+                width: Some(
+                    u16::from_be_bytes(bytes[offset + 5..offset + 7].try_into().ok()?) as u32,
+                ),
+            });
+        }
+        offset += segment_len;
+    }
+    Some(ImageHeader {
+        media_type: "image/jpeg",
+        width: None,
+        height: None,
+    })
+}
+
+fn is_jpeg_sof_marker(marker: u8) -> bool {
+    matches!(
+        marker,
+        0xc0 | 0xc1 | 0xc2 | 0xc3 | 0xc5 | 0xc6 | 0xc7 | 0xc9 | 0xca | 0xcb | 0xcd | 0xce | 0xcf
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parses_png_header_dimensions() {
+        let bytes = png_header_bytes(640, 480);
+
+        let header = ImageHeader::parse(&bytes).unwrap();
+
+        assert_eq!(header.media_type, "image/png");
+        assert_eq!(header.width, Some(640));
+        assert_eq!(header.height, Some(480));
+    }
+
+    #[test]
+    fn parses_jpeg_sof_dimensions() {
+        let bytes = [
+            0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x00, 0x00, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x01,
+            0x2c, 0x02, 0x80, 0x03, 0x01, 0x11, 0x00,
+        ];
+
+        let header = ImageHeader::parse(&bytes).unwrap();
+
+        assert_eq!(header.media_type, "image/jpeg");
+        assert_eq!(header.width, Some(640));
+        assert_eq!(header.height, Some(300));
+    }
+
+    #[test]
+    fn reads_image_metadata() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("image.png");
+        let bytes = png_header_bytes(320, 240);
+        fs::write(&path, &bytes).unwrap();
+
+        let metadata = read_image_metadata(&path).unwrap();
+
+        assert_eq!(metadata.media_type, "image/png");
+        assert_eq!(metadata.byte_count, bytes.len() as u64);
+        assert_eq!(metadata.width, Some(320));
+        assert_eq!(metadata.height, Some(240));
+        assert_eq!(metadata.sha256, format!("{:x}", Sha256::digest(&bytes)));
+    }
+
+    #[test]
+    fn rejects_non_image_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("not-image.txt");
+        fs::write(&path, b"hello").unwrap();
+
+        let error = ToolError::from_anyhow(&read_image_metadata(&path).unwrap_err());
+
+        assert_eq!(error.kind, "invalid_tool_input");
+        assert!(error.message.contains("supported image file"));
+    }
+
+    #[test]
+    fn rejects_oversized_file_before_reading_contents() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("large.png");
+        let file = File::create(&path).unwrap();
+        file.set_len(MAX_IMAGE_BYTES + 1).unwrap();
+
+        let error = ToolError::from_anyhow(&read_image_metadata(&path).unwrap_err());
+
+        assert_eq!(error.kind, "invalid_tool_input");
+        assert!(error.message.contains("file size"));
+    }
+
+    #[test]
+    fn rejects_oversized_decoded_pixel_count() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("huge.png");
+        fs::write(&path, png_header_bytes(100_000, 100_000)).unwrap();
+
+        let error = ToolError::from_anyhow(&read_image_metadata(&path).unwrap_err());
+
+        assert_eq!(error.kind, "invalid_tool_input");
+        assert!(error.message.contains("pixel count"));
+    }
+
+    fn png_header_bytes(width: u32, height: u32) -> Vec<u8> {
+        let mut bytes = b"\x89PNG\r\n\x1a\n\0\0\0\rIHDR".to_vec();
+        bytes.extend_from_slice(&width.to_be_bytes());
+        bytes.extend_from_slice(&height.to_be_bytes());
+        bytes.extend_from_slice(&[8, 6, 0, 0, 0]);
+        bytes
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -3034,15 +3034,14 @@ pub struct ApplyPatchResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum ViewImageStatus {
+pub enum ViewImageSelectedMode {
     Unavailable,
+    NativeImageWithObservation,
+    VisionAdapter,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-pub struct ViewImageMetadata {
-    pub media_type: String,
-    pub byte_count: u64,
-    pub sha256: String,
+pub struct ViewImageReferenceSize {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub width: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3050,14 +3049,55 @@ pub struct ViewImageMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-pub struct ViewImageResult {
-    pub status: ViewImageStatus,
-    pub path: String,
-    pub resolved_path: PathBuf,
+pub struct ViewImageVisualReference {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub id: String,
+    pub path: PathBuf,
+    pub sha256: String,
+    pub mime: String,
+    pub byte_count: u64,
+    pub size: ViewImageReferenceSize,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ViewImageGeneratedBy {
+    pub mode: ViewImageSelectedMode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub prompt: Option<String>,
-    pub metadata: ViewImageMetadata,
-    pub observation: String,
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ViewImageObservation {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub schema: String,
+    pub visual_reference_id: String,
+    pub prompt: String,
+    pub generated_by: ViewImageGeneratedBy,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ocr: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub elements: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relations: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<Value>,
+    pub uncertainties: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_sources: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ViewImageResult {
+    pub visual_reference: ViewImageVisualReference,
+    pub observation: ViewImageObservation,
+    pub selected_mode: ViewImageSelectedMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_text: Option<String>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3032,6 +3032,35 @@ pub struct ApplyPatchResult {
     pub summary_text: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ViewImageStatus {
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ViewImageMetadata {
+    pub media_type: String,
+    pub byte_count: u64,
+    pub sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ViewImageResult {
+    pub status: ViewImageStatus,
+    pub path: String,
+    pub resolved_path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    pub metadata: ViewImageMetadata,
+    pub observation: String,
+    pub summary_text: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UseWorkspaceResult {
     pub workspace_id: String,


### PR DESCRIPTION
## Summary
- add the `ViewImage` built-in tool skeleton and register it as a local-environment capability
- add durable `ViewImage` result metadata types for image media type, byte count, sha256, and dimensions
- validate local PNG/JPEG/GIF/WebP files with conservative size and decoded-pixel limits, returning `status: "unavailable"` until vision generation is implemented

## Verification
- `cargo fmt --all -- --check`
- `cargo test tool::tools::view_image`
- `cargo test tool::tools::tests::builtin_tool_descriptions_come_from_markdown_files`
- `cargo test tool::dispatch::tests::stable_tool_specs_expose_canonical_coding_tools`
- `cargo test tool::dispatch::tests::stable_tool_specs_include_task_control_and_mutating_tools`
- `cargo test tool::dispatch::tests::stable_tool_specs_cover_expected_capability_families`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #1702
