### PR TITLE
feat: select vision model for ViewImage

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -1198,7 +1198,7 @@
       "stability": "stable"
     },
     {
-      "description": "Validate and record durable metadata for a local image file.\n\n`ViewImage` accepts a workspace-relative or absolute image path plus a required\nprompt describing what to inspect. It records provider-neutral evidence such as\nmedia type, byte count, SHA-256, and dimensions when they can be read from the\nfile header.\n\nThis skeleton does not yet call a vision model. Until visual observation\ngeneration is implemented, successful results return `status: \"unavailable\"`\nwith a structured explanation.\n",
+      "description": "Validate and record durable metadata for a local image file.\n\n`ViewImage` accepts a workspace-relative or absolute image path plus a required\nprompt describing what to inspect. It records provider-neutral evidence such as\nmedia type, byte count, SHA-256, and dimensions when they can be read from the\nfile header.\n\n`ViewImage` selects a configured primary or fallback model that advertises\n`image_input` support and includes structured selection diagnostics in the\nresult. If no configured model supports image input, the tool returns a\n`vision_adapter_unavailable` error with the evaluated candidates.\n\nThis skeleton does not yet call the selected vision model. Until provider-native\nvisual observation generation is implemented, successful results return the\nimage metadata, selected mode/provider/model, and an observation placeholder\nexplaining that visual observation generation is not implemented yet.\n",
       "family": "local_environment",
       "freeform_grammar": null,
       "input_schema": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     model_discovery::{discovery_cache_path, load_discovery_cache_at, ModelDiscoveryCacheFile},
     provider::ProviderNativeWebSearchKind,
+    types::{ViewImageSelectedMode, ViewImageVisionCandidate, ViewImageVisionSelection},
     web::{WebProviderKind, WebSearchMode},
 };
 
@@ -942,6 +943,80 @@ impl RuntimeModelCatalog {
                 .then_with(|| left.model_ref.as_string().cmp(&right.model_ref.as_string()))
         });
         models
+    }
+
+    pub fn select_view_image_vision_model(
+        &self,
+        base_context_config: &ContextConfig,
+        model_override: Option<&ModelRef>,
+        pending_fallback_model: Option<&ModelRef>,
+    ) -> ViewImageVisionSelection {
+        let chain = self.provider_chain_for_turn(model_override, pending_fallback_model);
+        let primary = chain
+            .first()
+            .cloned()
+            .unwrap_or_else(|| self.effective_model(model_override));
+        let mut candidates = Vec::new();
+        let mut selected = None;
+
+        for model_ref in &chain {
+            let policy = self.built_in_catalog.resolve_policy(
+                model_ref,
+                &self.model_overrides,
+                &self.discovered_models,
+                self.unknown_model_fallback.as_ref(),
+                base_context_config,
+                self.configured_runtime_max_output_tokens,
+            );
+            let image_input = policy.capabilities.image_input;
+            let reason = if image_input {
+                "model_advertises_image_input"
+            } else {
+                "model_lacks_image_input"
+            };
+            candidates.push(ViewImageVisionCandidate {
+                provider: model_ref.provider.as_str().to_string(),
+                model: model_ref.model.clone(),
+                model_ref: model_ref.as_string(),
+                image_input,
+                reason: reason.to_string(),
+            });
+            if image_input && selected.is_none() {
+                selected = Some(model_ref.clone());
+            }
+        }
+
+        let Some(selected) = selected else {
+            return ViewImageVisionSelection {
+                selected_mode: ViewImageSelectedMode::Unavailable,
+                vision_provider: None,
+                vision_model: None,
+                selection_reason: "no_configured_model_supports_image_input".to_string(),
+                primary_provider: Some(primary.provider.as_str().to_string()),
+                primary_model: Some(primary.model),
+                candidates,
+            };
+        };
+
+        let primary_supports_image = selected == primary;
+        ViewImageVisionSelection {
+            selected_mode: if primary_supports_image {
+                ViewImageSelectedMode::NativeImageWithObservation
+            } else {
+                ViewImageSelectedMode::VisionAdapter
+            },
+            vision_provider: Some(selected.provider.as_str().to_string()),
+            vision_model: Some(selected.model.clone()),
+            selection_reason: if primary_supports_image {
+                "current_primary_model_supports_image_input"
+            } else {
+                "primary_model_lacks_image_input"
+            }
+            .to_string(),
+            primary_provider: Some(primary.provider.as_str().to_string()),
+            primary_model: Some(primary.model),
+            candidates,
+        }
     }
 }
 
@@ -6261,6 +6336,75 @@ mod tests {
             unknown.source,
             crate::model_catalog::ModelMetadataSource::UnknownFallback
         );
+    }
+
+    #[test]
+    fn view_image_vision_selection_uses_primary_when_image_capable() {
+        let fixture = test_app_config("openai/gpt-5.4", &["anthropic/claude-sonnet-4-6"]);
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+        let selection =
+            catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
+
+        assert_eq!(
+            selection.selected_mode,
+            crate::types::ViewImageSelectedMode::NativeImageWithObservation
+        );
+        assert_eq!(selection.vision_provider.as_deref(), Some("openai"));
+        assert_eq!(selection.vision_model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(
+            selection.selection_reason,
+            "current_primary_model_supports_image_input"
+        );
+    }
+
+    #[test]
+    fn view_image_vision_selection_uses_fallback_adapter_when_primary_lacks_image() {
+        let fixture = test_app_config("arcee/trinity-mini", &["openai/gpt-5.4-mini"]);
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+        let selection =
+            catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
+
+        assert_eq!(
+            selection.selected_mode,
+            crate::types::ViewImageSelectedMode::VisionAdapter
+        );
+        assert_eq!(selection.primary_provider.as_deref(), Some("arcee"));
+        assert_eq!(selection.primary_model.as_deref(), Some("trinity-mini"));
+        assert_eq!(selection.vision_provider.as_deref(), Some("openai"));
+        assert_eq!(selection.vision_model.as_deref(), Some("gpt-5.4-mini"));
+        assert_eq!(
+            selection.selection_reason,
+            "primary_model_lacks_image_input"
+        );
+        assert_eq!(selection.candidates.len(), 2);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
+    }
+
+    #[test]
+    fn view_image_vision_selection_reports_unavailable_without_image_capable_model() {
+        let fixture = test_app_config("arcee/trinity-mini", &["arcee/trinity-large-preview"]);
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+        let selection =
+            catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
+
+        assert_eq!(
+            selection.selected_mode,
+            crate::types::ViewImageSelectedMode::Unavailable
+        );
+        assert_eq!(
+            selection.selection_reason,
+            "no_configured_model_supports_image_input"
+        );
+        assert!(selection.vision_provider.is_none());
+        assert_eq!(selection.candidates.len(), 2);
+        assert!(selection
+            .candidates
+            .iter()
+            .all(|candidate| !candidate.image_input));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6432,6 +6432,15 @@ mod tests {
             .models
             .catalog
             .insert(custom_model.as_string(), override_config);
+        let unknown_fallback = ModelRuntimeOverride {
+            capabilities: Some(ModelCapabilityOverride {
+                image_input: Some(false),
+                ..ModelCapabilityOverride::default()
+            }),
+            ..ModelRuntimeOverride::default()
+        };
+        fixture.config.stored_config.model.unknown_fallback = Some(unknown_fallback.clone());
+        fixture.config.validated_unknown_model_fallback = Some(unknown_fallback);
         let catalog = RuntimeModelCatalog::from_config(&fixture.config);
 
         let selection =

--- a/src/config.rs
+++ b/src/config.rs
@@ -931,9 +931,10 @@ impl RuntimeModelCatalog {
                     .or_else(|| {
                         base.and_then(|model| model.tool_output_truncation_estimated_tokens)
                     }),
-                capabilities: base
-                    .map(|model| model.capabilities.clone())
-                    .unwrap_or_default(),
+                capabilities: merged_model_capabilities(
+                    base.map(|model| &model.capabilities),
+                    override_config.capabilities.as_ref(),
+                ),
                 source: crate::model_catalog::ModelMetadataSource::ConfigOverride,
             });
         }
@@ -1033,6 +1034,28 @@ impl Default for RuntimeModelCatalog {
             configured_runtime_max_output_tokens: 8192,
         }
     }
+}
+
+fn merged_model_capabilities(
+    base: Option<&crate::model_catalog::ModelCapabilityFlags>,
+    override_config: Option<&crate::model_catalog::ModelCapabilityOverride>,
+) -> crate::model_catalog::ModelCapabilityFlags {
+    let mut capabilities = base.cloned().unwrap_or_default();
+    if let Some(override_config) = override_config {
+        if let Some(value) = override_config.parallel_tool_calls {
+            capabilities.parallel_tool_calls = value;
+        }
+        if let Some(value) = override_config.reasoning_summaries {
+            capabilities.reasoning_summaries = value;
+        }
+        if let Some(value) = override_config.image_input {
+            capabilities.image_input = value;
+        }
+        if let Some(value) = override_config.interactive_exec {
+            capabilities.interactive_exec = value;
+        }
+    }
+    capabilities
 }
 
 impl ControlAuthMode {
@@ -4253,7 +4276,9 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::context::ContextConfig;
-    use crate::model_catalog::{BuiltInModelMetadata, ModelMetadataSource, ModelRuntimeOverride};
+    use crate::model_catalog::{
+        BuiltInModelMetadata, ModelCapabilityOverride, ModelMetadataSource, ModelRuntimeOverride,
+    };
     use crate::model_discovery::{ModelDiscoveryCacheFile, ProviderModelDiscoveryCache};
     use crate::provider::ProviderNativeWebSearchKind;
 
@@ -4997,13 +5022,16 @@ mod tests {
         set_config_key(
             &mut config,
             "models.catalog",
-            r#"{"anthropic/claude-sonnet-4-6":{"prompt_budget_estimated_tokens":32000}}"#,
+            r#"{"anthropic/claude-sonnet-4-6":{"prompt_budget_estimated_tokens":32000,"capabilities":{"image_input":true}}}"#,
         )
         .unwrap();
         assert_eq!(
             get_config_key(&config, "models.catalog").unwrap(),
             json!({
                 "anthropic/claude-sonnet-4-6": {
+                    "capabilities": {
+                        "image_input": true
+                    },
                     "prompt_budget_estimated_tokens": 32_000
                 }
             })
@@ -6374,6 +6402,47 @@ mod tests {
         assert_eq!(selection.primary_model.as_deref(), Some("trinity-mini"));
         assert_eq!(selection.vision_provider.as_deref(), Some("openai"));
         assert_eq!(selection.vision_model.as_deref(), Some("gpt-5.4-mini"));
+        assert_eq!(
+            selection.selection_reason,
+            "primary_model_lacks_image_input"
+        );
+        assert_eq!(selection.candidates.len(), 2);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
+    }
+
+    #[test]
+    fn view_image_vision_selection_uses_configured_custom_fallback_capabilities() {
+        let mut fixture = test_app_config("arcee/trinity-mini", &["custom-openai/my-vision-model"]);
+        let custom_model = ModelRef::parse("custom-openai/my-vision-model").unwrap();
+        let override_config = ModelRuntimeOverride {
+            capabilities: Some(ModelCapabilityOverride {
+                image_input: Some(true),
+                ..ModelCapabilityOverride::default()
+            }),
+            ..ModelRuntimeOverride::default()
+        };
+        fixture
+            .config
+            .validated_model_overrides
+            .insert(custom_model.clone(), override_config.clone());
+        fixture
+            .config
+            .stored_config
+            .models
+            .catalog
+            .insert(custom_model.as_string(), override_config);
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+        let selection =
+            catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
+
+        assert_eq!(
+            selection.selected_mode,
+            crate::types::ViewImageSelectedMode::VisionAdapter
+        );
+        assert_eq!(selection.vision_provider.as_deref(), Some("custom-openai"));
+        assert_eq!(selection.vision_model.as_deref(), Some("my-vision-model"));
         assert_eq!(
             selection.selection_reason,
             "primary_model_lacks_image_input"

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -328,15 +328,15 @@ impl BuiltInModelCatalog {
         let mut capabilities = built_in
             .map(|entry| entry.capabilities.clone())
             .unwrap_or_default();
-        if let Some(override_capabilities) =
-            override_config.and_then(|value| value.capabilities.as_ref())
-        {
-            override_capabilities.apply_to(&mut capabilities);
-        }
         if let Some(fallback_capabilities) =
             fallback_override.and_then(|value| value.capabilities.as_ref())
         {
             fallback_capabilities.apply_to(&mut capabilities);
+        }
+        if let Some(override_capabilities) =
+            override_config.and_then(|value| value.capabilities.as_ref())
+        {
+            override_capabilities.apply_to(&mut capabilities);
         }
 
         ResolvedRuntimeModelPolicy {
@@ -2126,6 +2126,41 @@ mod tests {
         assert_eq!(policy.prompt_budget_estimated_tokens, 64_000);
         assert_eq!(policy.compaction_trigger_estimated_tokens, 48_000);
         assert_eq!(policy.compaction_keep_recent_estimated_tokens, 24_000);
+        assert_eq!(policy.source, ModelMetadataSource::UnknownFallback);
+    }
+
+    #[test]
+    fn model_override_capabilities_take_precedence_over_unknown_fallback() {
+        let catalog = BuiltInModelCatalog::new();
+        let model_ref = ModelRef::new(ProviderId::openai(), "custom-model");
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            model_ref.clone(),
+            ModelRuntimeOverride {
+                capabilities: Some(ModelCapabilityOverride {
+                    image_input: Some(true),
+                    ..ModelCapabilityOverride::default()
+                }),
+                ..ModelRuntimeOverride::default()
+            },
+        );
+
+        let policy = catalog.resolve_policy(
+            &model_ref,
+            &overrides,
+            &HashMap::new(),
+            Some(&ModelRuntimeOverride {
+                capabilities: Some(ModelCapabilityOverride {
+                    image_input: Some(false),
+                    ..ModelCapabilityOverride::default()
+                }),
+                ..ModelRuntimeOverride::default()
+            }),
+            &base_context(),
+            8192,
+        );
+
+        assert!(policy.capabilities.image_input);
         assert_eq!(policy.source, ModelMetadataSource::UnknownFallback);
     }
 

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -38,6 +38,42 @@ pub struct ModelCapabilityFlags {
     pub interactive_exec: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ModelCapabilityOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel_tool_calls: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_summaries: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_input: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interactive_exec: Option<bool>,
+}
+
+impl ModelCapabilityOverride {
+    pub fn is_empty(&self) -> bool {
+        self.parallel_tool_calls.is_none()
+            && self.reasoning_summaries.is_none()
+            && self.image_input.is_none()
+            && self.interactive_exec.is_none()
+    }
+
+    fn apply_to(&self, base: &mut ModelCapabilityFlags) {
+        if let Some(value) = self.parallel_tool_calls {
+            base.parallel_tool_calls = value;
+        }
+        if let Some(value) = self.reasoning_summaries {
+            base.reasoning_summaries = value;
+        }
+        if let Some(value) = self.image_input {
+            base.image_input = value;
+        }
+        if let Some(value) = self.interactive_exec {
+            base.interactive_exec = value;
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BuiltInModelMetadata {
     pub model_ref: ModelRef,
@@ -82,6 +118,8 @@ pub struct ModelRuntimeOverride {
     pub runtime_max_output_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_output_truncation_estimated_tokens: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<ModelCapabilityOverride>,
 }
 
 impl ModelRuntimeOverride {
@@ -96,6 +134,11 @@ impl ModelRuntimeOverride {
             && self.compaction_keep_recent_estimated_tokens.is_none()
             && self.runtime_max_output_tokens.is_none()
             && self.tool_output_truncation_estimated_tokens.is_none()
+            && self
+                .capabilities
+                .as_ref()
+                .map(ModelCapabilityOverride::is_empty)
+                .unwrap_or(true)
     }
 }
 
@@ -282,9 +325,19 @@ impl BuiltInModelCatalog {
             .unwrap_or(DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS);
         let max_output_tokens_upper_limit =
             built_in.and_then(|entry| entry.max_output_tokens_upper_limit);
-        let capabilities = built_in
+        let mut capabilities = built_in
             .map(|entry| entry.capabilities.clone())
             .unwrap_or_default();
+        if let Some(override_capabilities) =
+            override_config.and_then(|value| value.capabilities.as_ref())
+        {
+            override_capabilities.apply_to(&mut capabilities);
+        }
+        if let Some(fallback_capabilities) =
+            fallback_override.and_then(|value| value.capabilities.as_ref())
+        {
+            fallback_capabilities.apply_to(&mut capabilities);
+        }
 
         ResolvedRuntimeModelPolicy {
             model_ref: model_ref.clone(),

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -321,6 +321,17 @@ impl RuntimeHandle {
         self.inner.context_config.read().await.clone()
     }
 
+    pub(crate) async fn current_view_image_vision_selection(
+        &self,
+    ) -> Result<crate::types::ViewImageVisionSelection> {
+        let state = self.agent_state().await?;
+        Ok(self.inner.model_catalog.select_view_image_vision_model(
+            &self.inner.base_context_config,
+            state.model_override.as_ref(),
+            state.pending_fallback_model.as_ref(),
+        ))
+    }
+
     async fn model_config_with_fresh_discovery_cache(&self) -> Option<AppConfig> {
         let Some(reconfig) = self.inner.provider_reconfig.as_ref() else {
             return None;

--- a/src/tool/tool_descriptions/view_image.md
+++ b/src/tool/tool_descriptions/view_image.md
@@ -5,6 +5,12 @@ prompt describing what to inspect. It records provider-neutral evidence such as
 media type, byte count, SHA-256, and dimensions when they can be read from the
 file header.
 
-This skeleton does not yet call a vision model. Until visual observation
-generation is implemented, successful results return `status: "unavailable"`
-with a structured explanation.
+`ViewImage` selects a configured primary or fallback model that advertises
+`image_input` support and includes structured selection diagnostics in the
+result. If no configured model supports image input, the tool returns a
+`vision_adapter_unavailable` error with the evaluated candidates.
+
+This skeleton does not yet call the selected vision model. Until provider-native
+visual observation generation is implemented, successful results return the
+image metadata, selected mode/provider/model, and an observation placeholder
+explaining that visual observation generation is not implemented yet.

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -17,7 +17,8 @@ use crate::{
     tool::{helpers::invalid_tool_input, spec::typed_spec, ToolError},
     types::{
         AuthorityClass, ToolCapabilityFamily, ViewImageGeneratedBy, ViewImageObservation,
-        ViewImageReferenceSize, ViewImageResult, ViewImageSelectedMode, ViewImageVisualReference,
+        ViewImageReferenceSize, ViewImageResult, ViewImageSelectedMode, ViewImageVisionSelection,
+        ViewImageVisualReference,
     },
 };
 
@@ -59,15 +60,20 @@ pub(crate) async fn execute(
         .await?;
     let resolved_path = execution.workspace.resolve_read_path(&path)?;
     let visual_reference = read_visual_reference(&resolved_path)?;
+    let vision_selection = runtime.current_view_image_vision_selection().await?;
+    if vision_selection.selected_mode == ViewImageSelectedMode::Unavailable {
+        return Err(vision_adapter_unavailable(vision_selection));
+    }
     let observation = ViewImageObservation {
         kind: "visual_observation".to_string(),
         schema: "visual_observation.v1".to_string(),
         visual_reference_id: visual_reference.id.clone(),
         prompt,
         generated_by: ViewImageGeneratedBy {
-            mode: ViewImageSelectedMode::Unavailable,
-            provider: None,
-            model: None,
+            mode: vision_selection.selected_mode.clone(),
+            provider: vision_selection.vision_provider.clone(),
+            model: vision_selection.vision_model.clone(),
+            selection_reason: Some(vision_selection.selection_reason.clone()),
         },
         summary:
             "visual observation unavailable: provider-native image observation is not implemented yet"
@@ -83,18 +89,43 @@ pub(crate) async fn execute(
         external_sources: Vec::new(),
     };
     let summary_text = Some(format!(
-        "ViewImage recorded {} ({} bytes); visual observation unavailable",
-        visual_reference.mime, visual_reference.byte_count
+        "ViewImage selected {}/{} for {}; visual observation generation is not implemented yet",
+        vision_selection
+            .vision_provider
+            .as_deref()
+            .unwrap_or("unknown-provider"),
+        vision_selection
+            .vision_model
+            .as_deref()
+            .unwrap_or("unknown-model"),
+        visual_reference.mime
     ));
     serialize_success(
         NAME,
         &ViewImageResult {
             visual_reference,
             observation,
-            selected_mode: ViewImageSelectedMode::Unavailable,
+            selected_mode: vision_selection.selected_mode.clone(),
+            vision_selection,
             summary_text,
         },
     )
+}
+
+fn vision_adapter_unavailable(selection: ViewImageVisionSelection) -> anyhow::Error {
+    ToolError::new(
+        "vision_adapter_unavailable",
+        "ViewImage requires a model with image input support, but no configured provider/model advertises image_input.",
+    )
+    .with_details(json!({
+        "selected_mode": selection.selected_mode,
+        "selection_reason": selection.selection_reason,
+        "primary_provider": selection.primary_provider,
+        "primary_model": selection.primary_model,
+        "candidates": selection.candidates,
+    }))
+    .with_recovery_hint("configure a primary or fallback model whose metadata advertises image_input")
+    .into()
 }
 
 fn read_visual_reference(path: &Path) -> Result<ViewImageVisualReference> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3068,6 +3068,8 @@ pub struct ViewImageGeneratedBy {
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selection_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -3097,8 +3099,34 @@ pub struct ViewImageResult {
     pub visual_reference: ViewImageVisualReference,
     pub observation: ViewImageObservation,
     pub selected_mode: ViewImageSelectedMode,
+    pub vision_selection: ViewImageVisionSelection,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ViewImageVisionCandidate {
+    pub provider: String,
+    pub model: String,
+    pub model_ref: String,
+    pub image_input: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ViewImageVisionSelection {
+    pub selected_mode: ViewImageSelectedMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vision_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vision_model: Option<String>,
+    pub selection_reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<ViewImageVisionCandidate>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- add deterministic ViewImage vision model selection from the configured primary/fallback model chain
- include structured selection diagnostics in ViewImage results and unavailable errors
- cover primary image-capable, fallback adapter, and unavailable selection cases

## Verification
- `cargo fmt --all -- --check`
- `cargo test view_image_vision_selection`
- `cargo test tool::tools::view_image`
- `cargo test tool_schema_inventory_snapshot_matches_generated_inventory -- --exact`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Closes #1703
