### PR TITLE
feat: add DashScope provider

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -6,7 +6,7 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **47 providers** and **245 models**.
+Holon includes built-in configuration for **49 providers** and **293 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -26,6 +26,8 @@ running Holon.
 | `byteplus` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/v3` | `BYTEPLUS_API_KEY` |
 | `byteplus-coding` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/coding/v3` | `BYTEPLUS_CODING_API_KEY or BYTEPLUS_API_KEY` |
 | `chutes` | OpenAI Chat Completions | `https://llm.chutes.ai/v1` | `CHUTES_API_KEY` |
+| `dashscope` | Anthropic Messages | `https://dashscope.aliyuncs.com/apps/anthropic` | `DASHSCOPE_API_KEY or QWEN_API_KEY` |
+| `dashscope-openai` | OpenAI Chat Completions | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `DASHSCOPE_API_KEY or QWEN_API_KEY` |
 | `deepseek` | Anthropic Messages | `https://api.deepseek.com/anthropic` | `DEEPSEEK_API_KEY` |
 | `deepseek-anthropic` | Anthropic Messages | `https://api.deepseek.com/anthropic` | `DEEPSEEK_API_KEY` |
 | `deepseek-openai` | OpenAI Chat Completions | `https://api.deepseek.com/v1` | `DEEPSEEK_API_KEY` |
@@ -129,6 +131,50 @@ and capabilities.
 | `chutes` | `moonshotai/Kimi-K2.5-TEE` | `chutes/moonshotai/Kimi-K2.5-TEE` | 262144 | 65535 | ✅ | ✅ |
 | `chutes` | `openai/gpt-oss-120b-TEE` | `chutes/openai/gpt-oss-120b-TEE` | 131072 | 65536 | ✅ | — |
 | `chutes` | `zai-org/GLM-4.7-TEE` | `chutes/zai-org/GLM-4.7-TEE` | 202752 | 65535 | ✅ | — |
+| `dashscope` | `MiniMax-M2.5` | `dashscope/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
+| `dashscope` | `deepseek-v4-flash` | `dashscope/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
+| `dashscope` | `deepseek-v4-pro` | `dashscope/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
+| `dashscope` | `glm-4.7` | `dashscope/glm-4.7` | 202752 | 16384 | — | — |
+| `dashscope` | `glm-5` | `dashscope/glm-5` | 202752 | 16384 | — | — |
+| `dashscope` | `glm-5.1` | `dashscope/glm-5.1` | 202752 | 131072 | ✅ | — |
+| `dashscope` | `kimi-k2.5` | `dashscope/kimi-k2.5` | 262144 | 32768 | — | ✅ |
+| `dashscope` | `kimi-k2.6` | `dashscope/kimi-k2.6` | 262144 | 98304 | ✅ | — |
+| `dashscope` | `mimo-v2.5-pro` | `dashscope/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `dashscope` | `qwen3-coder-flash` | `dashscope/qwen3-coder-flash` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `qwen3-coder-next` | `dashscope/qwen3-coder-next` | 262144 | 65536 | — | — |
+| `dashscope` | `qwen3-coder-plus` | `dashscope/qwen3-coder-plus` | 1000000 | 65536 | — | — |
+| `dashscope` | `qwen3-max-2026-01-23` | `dashscope/qwen3-max-2026-01-23` | 262144 | 65536 | — | — |
+| `dashscope` | `qwen3.5-flash` | `dashscope/qwen3.5-flash` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope` | `qwen3.5-plus` | `dashscope/qwen3.5-plus` | 1000000 | 65536 | — | ✅ |
+| `dashscope` | `qwen3.6-flash` | `dashscope/qwen3.6-flash` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope` | `qwen3.6-plus` | `dashscope/qwen3.6-plus` | 1000000 | 65536 | — | ✅ |
+| `dashscope` | `qwen3.7-max` | `dashscope/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `qwen3.7-max-2026-05-20` | `dashscope/qwen3.7-max-2026-05-20` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `qwen3.7-max-2026-06-08` | `dashscope/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
+| `dashscope` | `qwen3.7-plus` | `dashscope/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope` | `qwen3.7-plus-2026-05-26` | `dashscope/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-openai` | `MiniMax-M2.5` | `dashscope-openai/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
+| `dashscope-openai` | `deepseek-v4-flash` | `dashscope-openai/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
+| `dashscope-openai` | `deepseek-v4-pro` | `dashscope-openai/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
+| `dashscope-openai` | `glm-4.7` | `dashscope-openai/glm-4.7` | 202752 | 16384 | — | — |
+| `dashscope-openai` | `glm-5` | `dashscope-openai/glm-5` | 202752 | 16384 | — | — |
+| `dashscope-openai` | `glm-5.1` | `dashscope-openai/glm-5.1` | 202752 | 131072 | ✅ | — |
+| `dashscope-openai` | `kimi-k2.5` | `dashscope-openai/kimi-k2.5` | 262144 | 32768 | — | ✅ |
+| `dashscope-openai` | `kimi-k2.6` | `dashscope-openai/kimi-k2.6` | 262144 | 98304 | ✅ | — |
+| `dashscope-openai` | `mimo-v2.5-pro` | `dashscope-openai/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `dashscope-openai` | `qwen3-coder-flash` | `dashscope-openai/qwen3-coder-flash` | 1000000 | 65536 | ✅ | — |
+| `dashscope-openai` | `qwen3-coder-next` | `dashscope-openai/qwen3-coder-next` | 262144 | 65536 | — | — |
+| `dashscope-openai` | `qwen3-coder-plus` | `dashscope-openai/qwen3-coder-plus` | 1000000 | 65536 | — | — |
+| `dashscope-openai` | `qwen3-max-2026-01-23` | `dashscope-openai/qwen3-max-2026-01-23` | 262144 | 65536 | — | — |
+| `dashscope-openai` | `qwen3.5-flash` | `dashscope-openai/qwen3.5-flash` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-openai` | `qwen3.5-plus` | `dashscope-openai/qwen3.5-plus` | 1000000 | 65536 | — | ✅ |
+| `dashscope-openai` | `qwen3.6-flash` | `dashscope-openai/qwen3.6-flash` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-openai` | `qwen3.6-plus` | `dashscope-openai/qwen3.6-plus` | 1000000 | 65536 | — | ✅ |
+| `dashscope-openai` | `qwen3.7-max` | `dashscope-openai/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
+| `dashscope-openai` | `qwen3.7-max-2026-05-20` | `dashscope-openai/qwen3.7-max-2026-05-20` | 1000000 | 65536 | ✅ | — |
+| `dashscope-openai` | `qwen3.7-max-2026-06-08` | `dashscope-openai/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
+| `dashscope-openai` | `qwen3.7-plus` | `dashscope-openai/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-openai` | `qwen3.7-plus-2026-05-26` | `dashscope-openai/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
 | `deepseek` | `deepseek-chat` | `deepseek/deepseek-chat` | 131072 | 8192 | — | — |
 | `deepseek` | `deepseek-reasoner` | `deepseek/deepseek-reasoner` | 131072 | 65536 | ✅ | — |
 | `deepseek` | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
@@ -198,15 +244,19 @@ and capabilities.
 | `openrouter` | `openrouter/hunter-alpha` | `openrouter/openrouter/hunter-alpha` | 1048576 | 65536 | ✅ | — |
 | `qianfan` | `deepseek-v3.2` | `qianfan/deepseek-v3.2` | 98304 | 32768 | ✅ | — |
 | `qianfan` | `ernie-5.0-thinking-preview` | `qianfan/ernie-5.0-thinking-preview` | 119000 | 64000 | ✅ | ✅ |
-| `qwen` | `MiniMax-M2.5` | `qwen/MiniMax-M2.5` | 1000000 | 65536 | ✅ | — |
-| `qwen` | `glm-4.7` | `qwen/glm-4.7` | 202752 | 16384 | — | — |
-| `qwen` | `glm-5` | `qwen/glm-5` | 202752 | 16384 | — | — |
-| `qwen` | `kimi-k2.5` | `qwen/kimi-k2.5` | 262144 | 32768 | — | ✅ |
+| `qwen` | `qwen3-coder-flash` | `qwen/qwen3-coder-flash` | 1000000 | 65536 | ✅ | — |
 | `qwen` | `qwen3-coder-next` | `qwen/qwen3-coder-next` | 262144 | 65536 | — | — |
 | `qwen` | `qwen3-coder-plus` | `qwen/qwen3-coder-plus` | 1000000 | 65536 | — | — |
 | `qwen` | `qwen3-max-2026-01-23` | `qwen/qwen3-max-2026-01-23` | 262144 | 65536 | — | — |
+| `qwen` | `qwen3.5-flash` | `qwen/qwen3.5-flash` | 1000000 | 65536 | ✅ | ✅ |
 | `qwen` | `qwen3.5-plus` | `qwen/qwen3.5-plus` | 1000000 | 65536 | — | ✅ |
+| `qwen` | `qwen3.6-flash` | `qwen/qwen3.6-flash` | 1000000 | 65536 | ✅ | ✅ |
 | `qwen` | `qwen3.6-plus` | `qwen/qwen3.6-plus` | 1000000 | 65536 | — | ✅ |
+| `qwen` | `qwen3.7-max` | `qwen/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
+| `qwen` | `qwen3.7-max-2026-05-20` | `qwen/qwen3.7-max-2026-05-20` | 1000000 | 65536 | ✅ | — |
+| `qwen` | `qwen3.7-max-2026-06-08` | `qwen/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
+| `qwen` | `qwen3.7-plus` | `qwen/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `qwen` | `qwen3.7-plus-2026-05-26` | `qwen/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
 | `stepfun` | `step-3.5-flash` | `stepfun/step-3.5-flash` | 262144 | 65536 | ✅ | — |
 | `stepfun-plan` | `step-3.5-flash` | `stepfun-plan/step-3.5-flash` | 262144 | 65536 | ✅ | — |
 | `stepfun-plan` | `step-3.5-flash-2603` | `stepfun-plan/step-3.5-flash-2603` | 262144 | 65536 | ✅ | — |

--- a/src/config.rs
+++ b/src/config.rs
@@ -2721,6 +2721,20 @@ fn built_in_provider_registry_with_settings(
     )?;
     insert_anthropic_compatible_provider(
         &mut registry,
+        "dashscope",
+        "https://dashscope.aliyuncs.com/apps/anthropic",
+        &["DASHSCOPE_API_KEY", "QWEN_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
+        "dashscope-openai",
+        "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        &["DASHSCOPE_API_KEY", "QWEN_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
         "deepseek",
         "https://api.deepseek.com/anthropic",
         &["DEEPSEEK_API_KEY"],
@@ -5463,6 +5477,44 @@ mod tests {
         let qwen = providers.get(&ProviderId::parse("qwen").unwrap()).unwrap();
         assert_eq!(qwen.auth.env.as_deref(), Some("DASHSCOPE_API_KEY"));
         assert_eq!(qwen.credential.as_deref(), Some("dashscope-key"));
+
+        let dashscope = providers
+            .get(&ProviderId::parse("dashscope").unwrap())
+            .unwrap();
+        assert_eq!(
+            dashscope.transport,
+            ProviderTransportKind::AnthropicMessages
+        );
+        assert_eq!(
+            dashscope.base_url,
+            "https://dashscope.aliyuncs.com/apps/anthropic"
+        );
+        assert_eq!(dashscope.auth.env.as_deref(), Some("DASHSCOPE_API_KEY"));
+        assert_eq!(dashscope.credential.as_deref(), Some("dashscope-key"));
+        assert_eq!(
+            dashscope.context_management.cache_strategy,
+            AnthropicCacheStrategy::ClaudeCodePromptCache
+        );
+
+        let dashscope_openai = providers
+            .get(&ProviderId::parse("dashscope-openai").unwrap())
+            .unwrap();
+        assert_eq!(
+            dashscope_openai.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(
+            dashscope_openai.base_url,
+            "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        );
+        assert_eq!(
+            dashscope_openai.auth.env.as_deref(),
+            Some("DASHSCOPE_API_KEY")
+        );
+        assert_eq!(
+            dashscope_openai.credential.as_deref(),
+            Some("dashscope-key")
+        );
 
         let nearai = providers
             .get(&ProviderId::parse("nearai").unwrap())

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1262,6 +1262,51 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "qwen",
+            "qwen3.7-plus",
+            "qwen3.7-plus",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "qwen",
+            "qwen3.7-plus-2026-05-26",
+            "qwen3.7-plus-2026-05-26",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "qwen",
+            "qwen3.7-max",
+            "qwen3.7-max",
+            1_000_000,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
+            "qwen",
+            "qwen3.7-max-2026-06-08",
+            "qwen3.7-max-2026-06-08",
+            1_000_000,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
+            "qwen",
+            "qwen3.7-max-2026-05-20",
+            "qwen3.7-max-2026-05-20",
+            1_000_000,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
+            "qwen",
             "qwen3.5-plus",
             "qwen3.5-plus",
             1_000_000,
@@ -1276,6 +1321,24 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             1_000_000,
             65_536,
             false,
+            true,
+        ),
+        catalog_model(
+            "qwen",
+            "qwen3.6-flash",
+            "qwen3.6-flash",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "qwen",
+            "qwen3.5-flash",
+            "qwen3.5-flash",
+            1_000_000,
+            65_536,
+            true,
             true,
         ),
         catalog_model(
@@ -1307,23 +1370,12 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "qwen",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5",
+            "qwen3-coder-flash",
+            "qwen3-coder-flash",
             1_000_000,
             65_536,
             true,
             false,
-        ),
-        catalog_model("qwen", "glm-5", "glm-5", 202_752, 16_384, false, false),
-        catalog_model("qwen", "glm-4.7", "glm-4.7", 202_752, 16_384, false, false),
-        catalog_model(
-            "qwen",
-            "kimi-k2.5",
-            "kimi-k2.5",
-            262_144,
-            32_768,
-            false,
-            true,
         ),
         catalog_model(
             "stepfun",
@@ -1933,6 +1985,167 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "bigmodel-openai",
         ],
     );
+    extend_catalog_model_aliases_from_source(
+        &mut entries,
+        "qwen",
+        &["dashscope", "dashscope-openai"],
+    );
+    entries.extend([
+        catalog_model(
+            "dashscope",
+            "deepseek-v4-pro",
+            "DeepSeek V4 Pro",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "deepseek-v4-pro",
+            "DeepSeek V4 Pro",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "deepseek-v4-flash",
+            "DeepSeek V4 Flash",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "deepseek-v4-flash",
+            "DeepSeek V4 Flash",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "glm-5.1",
+            "glm-5.1",
+            202_752,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "glm-5.1",
+            "glm-5.1",
+            202_752,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "kimi-k2.6",
+            "kimi-k2.6",
+            262_144,
+            98_304,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "kimi-k2.6",
+            "kimi-k2.6",
+            262_144,
+            98_304,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5",
+            196_608,
+            32_768,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5",
+            196_608,
+            32_768,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "mimo-v2.5-pro",
+            "MiMo V2.5 Pro",
+            1_000_000,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "mimo-v2.5-pro",
+            "MiMo V2.5 Pro",
+            1_000_000,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model("dashscope", "glm-5", "glm-5", 202_752, 16_384, false, false),
+        catalog_model(
+            "dashscope-openai",
+            "glm-5",
+            "glm-5",
+            202_752,
+            16_384,
+            false,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "glm-4.7",
+            "glm-4.7",
+            202_752,
+            16_384,
+            false,
+            false,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "glm-4.7",
+            "glm-4.7",
+            202_752,
+            16_384,
+            false,
+            false,
+        ),
+        catalog_model(
+            "dashscope",
+            "kimi-k2.5",
+            "kimi-k2.5",
+            262_144,
+            32_768,
+            false,
+            true,
+        ),
+        catalog_model(
+            "dashscope-openai",
+            "kimi-k2.5",
+            "kimi-k2.5",
+            262_144,
+            32_768,
+            false,
+            true,
+        ),
+    ]);
     entries
 }
 
@@ -2105,6 +2318,61 @@ mod tests {
         );
         assert_eq!(bigmodel.display_name, "GLM-4.7");
         assert_eq!(bigmodel.source, ModelMetadataSource::BuiltInCatalog);
+    }
+
+    #[test]
+    fn qwen_catalog_is_limited_to_qwen_models_and_dashscope_covers_platform_models() {
+        let catalog = BuiltInModelCatalog::new();
+
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("qwen").unwrap())
+                .unwrap()
+                .as_string(),
+            "qwen/qwen3.7-plus"
+        );
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("dashscope").unwrap())
+                .unwrap()
+                .as_string(),
+            "dashscope/qwen3.7-plus"
+        );
+
+        assert!(catalog
+            .get(&ModelRef::parse("qwen/qwen3.7-plus").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("qwen/qwen3.7-max").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("qwen/MiniMax-M2.5").unwrap())
+            .is_none());
+        assert!(catalog
+            .get(&ModelRef::parse("qwen/glm-5").unwrap())
+            .is_none());
+        assert!(catalog
+            .get(&ModelRef::parse("qwen/kimi-k2.5").unwrap())
+            .is_none());
+
+        assert!(catalog
+            .get(&ModelRef::parse("dashscope/qwen3.7-plus").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("dashscope/MiniMax-M2.5").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("dashscope/glm-5.1").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("dashscope/kimi-k2.6").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("dashscope-openai/qwen3.7-plus").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("dashscope-openai/MiniMax-M2.5").unwrap())
+            .is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add built-in `dashscope` provider using DashScope Anthropic-compatible Messages endpoint by default
- add `dashscope-openai` as the OpenAI-compatible DashScope provider option
- keep `qwen` as a Qwen-only shortcut and add newer Qwen models including `qwen3.7-plus`
- expose DashScope platform catalog entries under both `dashscope/*` and `dashscope-openai/*`
- regenerate the supported models reference

Closes #1710

## Verification
- `cargo run --quiet --bin holon-docgen -- models > docs/website/reference/models.md`
- `cargo fmt --all -- --check`
- `cargo test -q built_in_provider_registry_includes_compatible_provider_defaults`
- `cargo test -q qwen_catalog_is_limited_to_qwen_models_and_dashscope_covers_platform_models`
- `cargo test -q resolves_anthropic_compatible_provider_model_policy`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test -q --lib`
