### PR TITLE
Fix #1706 cache visual observations for replay

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -95,8 +95,9 @@ use crate::{
         RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
         SkillActivationState, SkillCatalogEntry, SkillLoadReason, SkillsRuntimeView, TaskKind,
         TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
-        TranscriptEntry, TranscriptEntryKind, WaitingIntentRecord, WaitingIntentStatus,
-        WaitingIntentSummary, WaitingReason, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
+        TranscriptEntry, TranscriptEntryKind, ViewImageObservation, WaitingIntentRecord,
+        WaitingIntentStatus, WaitingIntentSummary, WaitingReason, WorkspaceEntry,
+        AGENT_HOME_WORKSPACE_ID,
     },
     web::{WebConfig, WebProviderKind},
 };
@@ -241,6 +242,8 @@ struct RuntimeInner {
     web_config: WebConfig,
     builtin_web_search_probe_cache:
         Mutex<HashMap<BuiltinWebSearchProbeKey, BuiltinWebSearchProbeCacheEntry>>,
+    view_image_observation_cache:
+        Mutex<HashMap<ViewImageObservationCacheKey, ViewImageObservation>>,
     callback_base_url: String,
     tools: ToolRegistry,
     system: Arc<LocalSystem>,
@@ -251,6 +254,14 @@ struct RuntimeInner {
     recovered_timers: Mutex<Option<Vec<TimerRecord>>>,
     suppress_next_continue_active_tick: Mutex<bool>,
     shutdown_requested: AtomicBool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ViewImageObservationCacheKey {
+    pub(crate) visual_reference_id: String,
+    pub(crate) prompt: String,
+    pub(crate) observation_schema: String,
+    pub(crate) generation_policy: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -221,6 +221,7 @@ impl RuntimeHandle {
                 max_tool_output_tokens,
                 web_config,
                 builtin_web_search_probe_cache: Mutex::new(HashMap::new()),
+                view_image_observation_cache: Mutex::new(HashMap::new()),
                 callback_base_url,
                 tools: ToolRegistry::new(PathBuf::new()),
                 system: Arc::new(LocalSystem::new()),
@@ -334,6 +335,30 @@ impl RuntimeHandle {
             state.model_override.as_ref(),
             state.pending_fallback_model.as_ref(),
         ))
+    }
+
+    pub(crate) async fn cached_view_image_observation(
+        &self,
+        key: &crate::runtime::ViewImageObservationCacheKey,
+    ) -> Option<crate::types::ViewImageObservation> {
+        self.inner
+            .view_image_observation_cache
+            .lock()
+            .await
+            .get(key)
+            .cloned()
+    }
+
+    pub(crate) async fn cache_view_image_observation(
+        &self,
+        key: crate::runtime::ViewImageObservationCacheKey,
+        observation: crate::types::ViewImageObservation,
+    ) {
+        self.inner
+            .view_image_observation_cache
+            .lock()
+            .await
+            .insert(key, observation);
     }
 
     pub(crate) async fn generate_view_image_observation(

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -669,6 +669,57 @@ fn summarize_spawn_agent_result(result: &Value) -> Option<String> {
     })
 }
 
+fn summarize_view_image_result(result: &Value) -> Option<String> {
+    let reference = result.get("visual_reference")?;
+    let observation = result.get("observation")?;
+    let reference_id = reference
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let mime = reference
+        .get("mime")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let schema = observation
+        .get("schema")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let prompt = observation
+        .get("prompt")
+        .and_then(Value::as_str)
+        .map(|prompt| truncate_preview(prompt, RECAP_TEXT_PREVIEW_LIMIT));
+    let summary = observation
+        .get("summary")
+        .and_then(Value::as_str)
+        .map(|summary| truncate_preview(summary, RECAP_TEXT_PREVIEW_LIMIT));
+    let ocr = observation
+        .get("ocr")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| entry.get("text").and_then(Value::as_str))
+                .take(3)
+                .map(|text| truncate_preview(text, 80))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut parts = vec![format!(
+        "visual_observation schema={schema} ref={reference_id} mime={mime}"
+    )];
+    if let Some(prompt) = prompt {
+        parts.push(format!("prompt=\"{prompt}\""));
+    }
+    if let Some(summary) = summary {
+        parts.push(format!("summary=\"{summary}\""));
+    }
+    if !ocr.is_empty() {
+        parts.push(format!("ocr=[{}]", ocr.join(" | ")));
+    }
+    Some(parts.join(" "))
+}
+
 fn summarize_tool_result_envelope(envelope: &ToolResultEnvelope) -> String {
     match envelope.status {
         ToolResultStatus::Error => {
@@ -691,6 +742,7 @@ fn summarize_tool_result_envelope(envelope: &ToolResultEnvelope) -> String {
                     "ExecCommand" => Some(summarize_exec_command_result(result)),
                     "TaskOutput" => Some(summarize_task_output_result(result)),
                     "SpawnAgent" => summarize_spawn_agent_result(result),
+                    "ViewImage" => summarize_view_image_result(result),
                     _ => None,
                 })
                 .or_else(|| envelope.summary_text.clone())
@@ -3570,6 +3622,49 @@ mod tests {
         assert!(recap.contains("item=2 cmd_digest="));
         assert!(!recap.contains("cmd_preview="));
         assert!(!recap.contains("turn_batch_hidden_1246"));
+    }
+
+    #[test]
+    fn compacted_round_recap_preserves_view_image_observation_evidence() {
+        let mut round = fixture_round_with_tool(
+            5,
+            "inspect screenshot",
+            "ViewImage",
+            serde_json::json!({
+                "path": "screenshot.png",
+                "prompt": "Read the warning banner."
+            }),
+        );
+        round.tool_result_envelopes = vec![ToolResultEnvelope {
+            tool_name: "ViewImage".to_string(),
+            status: ToolResultStatus::Success,
+            summary_text: Some("generated observation".to_string()),
+            result: Some(serde_json::json!({
+                "visual_reference": {
+                    "id": "vis_warning",
+                    "mime": "image/png"
+                },
+                "observation": {
+                    "schema": "visual_observation.v1",
+                    "prompt": "Read the warning banner.",
+                    "summary": "A red warning banner is visible.",
+                    "ocr": [
+                        {"text": "DEPLOY BLOCKED"},
+                        {"text": "Fix failing checks"}
+                    ]
+                }
+            })),
+            error: None,
+        }];
+
+        let recap = build_compacted_round_recap(&[round], 1_000);
+
+        assert!(recap.contains("ViewImage visual_observation"));
+        assert!(recap.contains("schema=visual_observation.v1"));
+        assert!(recap.contains("ref=vis_warning"));
+        assert!(recap.contains("summary=\"A red warning banner is visible.\""));
+        assert!(recap.contains("ocr=[DEPLOY BLOCKED | Fix failing checks]"));
+        assert!(!recap.contains("generated observation"));
     }
 
     fn fixture_round(round: usize, text: &str) -> TurnRoundRecord {

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use crate::{
-    runtime::RuntimeHandle,
+    runtime::{RuntimeHandle, ViewImageObservationCacheKey},
     system::ExecutionScopeKind,
     tool::{helpers::invalid_tool_input, spec::typed_spec, ToolError, ToolResult},
     types::{
@@ -26,6 +26,8 @@ use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
 pub(crate) const NAME: &str = "ViewImage";
+const VISUAL_OBSERVATION_SCHEMA: &str = "visual_observation.v1";
+const VIEW_IMAGE_OBSERVATION_GENERATION_POLICY: &str = "openai-compatible-image-input.v1";
 const MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
 const MAX_IMAGE_PIXELS: u64 = 50_000_000;
 
@@ -61,7 +63,21 @@ pub(crate) async fn execute(
     let resolved_path = execution.workspace.resolve_read_path(&path)?;
     let image = read_visual_reference(&resolved_path)?;
     let visual_reference = image.visual_reference;
+    let cache_key = observation_cache_key(&visual_reference, &prompt);
     let vision_selection = runtime.current_view_image_vision_selection().await?;
+    if let Some(observation) = runtime.cached_view_image_observation(&cache_key).await {
+        let selected_mode = vision_selection.selected_mode.clone();
+        return serialize_success(
+            NAME,
+            &ViewImageResult {
+                visual_reference,
+                observation,
+                selected_mode,
+                vision_selection,
+                summary_text: Some("ViewImage reused cached visual observation".to_string()),
+            },
+        );
+    }
     if vision_selection.selected_mode == ViewImageSelectedMode::Unavailable {
         return Err(vision_adapter_unavailable(vision_selection));
     }
@@ -76,6 +92,9 @@ pub(crate) async fn execute(
         &vision_selection,
     )
     .map_err(|error| vision_observation_failed(&vision_selection, error))?;
+    runtime
+        .cache_view_image_observation(cache_key, observation.clone())
+        .await;
     let summary_text = Some(format!(
         "ViewImage generated a visual observation with {}/{} for {}",
         vision_selection
@@ -212,6 +231,18 @@ fn vision_observation_failed(
     .into()
 }
 
+fn observation_cache_key(
+    visual_reference: &ViewImageVisualReference,
+    prompt: &str,
+) -> ViewImageObservationCacheKey {
+    ViewImageObservationCacheKey {
+        visual_reference_id: visual_reference.id.clone(),
+        prompt: prompt.to_string(),
+        observation_schema: VISUAL_OBSERVATION_SCHEMA.to_string(),
+        generation_policy: VIEW_IMAGE_OBSERVATION_GENERATION_POLICY.to_string(),
+    }
+}
+
 fn parse_visual_observation(
     raw: &str,
     visual_reference: &ViewImageVisualReference,
@@ -227,9 +258,9 @@ fn parse_visual_observation(
             "vision adapter response `type` must be visual_observation"
         ));
     }
-    if object.get("schema").and_then(Value::as_str) != Some("visual_observation.v1") {
+    if object.get("schema").and_then(Value::as_str) != Some(VISUAL_OBSERVATION_SCHEMA) {
         return Err(anyhow!(
-            "vision adapter response `schema` must be visual_observation.v1"
+            "vision adapter response `schema` must be {VISUAL_OBSERVATION_SCHEMA}"
         ));
     }
     let summary = object
@@ -241,7 +272,7 @@ fn parse_visual_observation(
         .to_string();
     Ok(ViewImageObservation {
         kind: "visual_observation".to_string(),
-        schema: "visual_observation.v1".to_string(),
+        schema: VISUAL_OBSERVATION_SCHEMA.to_string(),
         visual_reference_id: visual_reference.id.clone(),
         prompt: prompt.to_string(),
         generated_by: ViewImageGeneratedBy {
@@ -718,6 +749,18 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("`schema`"));
+    }
+
+    #[test]
+    fn observation_cache_key_includes_schema_and_generation_policy() {
+        let reference = test_visual_reference();
+
+        let key = observation_cache_key(&reference, "What is visible?");
+
+        assert_eq!(key.visual_reference_id, reference.id);
+        assert_eq!(key.prompt, "What is visible?");
+        assert_eq!(key.observation_schema, "visual_observation.v1");
+        assert_eq!(key.generation_policy, "openai-compatible-image-input.v1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1706.

- cache `ViewImage` visual observations by visual reference id, prompt, observation schema, and generation policy
- reuse compatible cached observations before requiring a currently available vision provider, enabling model-switch replay into text-only/non-vision contexts
- preserve structured visual-observation evidence in compacted turn recaps instead of falling back to generic summary text

## Verification

- `cargo test --lib compacted_round_recap_preserves_view_image_observation_evidence`
- `cargo test --lib renders_visual_observation_for_text_only_replay`
- `cargo test --lib observation_cache_key_includes_schema_and_generation_policy`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
