### PR TITLE
fix: normalize ViewImage uncertainty objects

### DIFF
--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -397,7 +397,7 @@ impl RuntimeHandle {
         )?;
         let response = provider
             .complete_turn(ProviderTurnRequest::plain(
-                "You are a vision adapter for a headless agent. Inspect only the provided image and task prompt. Return one JSON object matching visual_observation.v1; do not include markdown, prose, or implementation advice. Required fields: type=\"visual_observation\", schema=\"visual_observation.v1\", summary. Optional fields: ocr, elements, relations, issues, uncertainties, external_sources. Use arrays for optional sections; include visible text in ocr or summary; include bounding boxes when location matters; describe only visible evidence; say when uncertain.",
+                "You are a vision adapter for a headless agent. Inspect only the provided image and task prompt. Return exactly one JSON object and no markdown, prose, or implementation advice. The JSON object must match this shape: {\"type\":\"visual_observation\",\"schema\":\"visual_observation.v1\",\"summary\":\"string\",\"ocr\":[],\"elements\":[],\"relations\":[],\"issues\":[],\"uncertainties\":[],\"external_sources\":[]}. Required fields: type=\"visual_observation\", schema=\"visual_observation.v1\", summary, uncertainties. The uncertainties field must be an array of strings; use [] when there are no caveats. The ocr, elements, relations, issues, and external_sources fields must be arrays of objects; omit them or use [] when empty. Include visible text in ocr or summary; include bounding boxes when location matters; describe only visible evidence; say when uncertain.",
                 vec![ConversationMessage::UserImage {
                     prompt: prompt.to_string(),
                     media_type: media_type.to_string(),

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -286,7 +286,7 @@ fn parse_visual_observation(
         elements: optional_value_array(object.get("elements"), "elements")?,
         relations: optional_value_array(object.get("relations"), "relations")?,
         issues: optional_value_array(object.get("issues"), "issues")?,
-        uncertainties: optional_string_array(object.get("uncertainties"), "uncertainties")?,
+        uncertainties: optional_uncertainties(object.get("uncertainties"))?,
         external_sources: optional_value_array(object.get("external_sources"), "external_sources")?,
     })
 }
@@ -331,21 +331,40 @@ fn optional_value_array(value: Option<&Value>, field: &str) -> Result<Vec<Value>
     }
 }
 
-fn optional_string_array(value: Option<&Value>, field: &str) -> Result<Vec<String>> {
-    match value {
-        Some(Value::Array(values)) => values
-            .iter()
-            .map(|value| {
-                value.as_str().map(ToString::to_string).ok_or_else(|| {
-                    anyhow!("vision adapter response field `{field}` must contain only strings")
+fn optional_uncertainties(value: Option<&Value>) -> Result<Vec<String>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let values = value.as_array().ok_or_else(|| {
+        anyhow!("vision adapter response field `uncertainties` must be an array when present")
+    })?;
+    values
+        .iter()
+        .map(|value| {
+            if let Some(text) = value.as_str() {
+                return Ok(text.to_string());
+            }
+            let Some(object) = value.as_object() else {
+                return Err(anyhow!(
+                    "vision adapter response field `uncertainties` must contain strings or objects with text"
+                ));
+            };
+            ["text", "description", "summary", "message"]
+                .iter()
+                .find_map(|field| object.get(*field).and_then(Value::as_str))
+                .map(ToString::to_string)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "vision adapter response field `uncertainties` object entries must include text"
+                    )
                 })
-            })
-            .collect(),
-        Some(_) => Err(anyhow!(
-            "vision adapter response field `{field}` must be an array when present"
-        )),
-        None => Ok(Vec::new()),
-    }
+        })
+        .filter_map(|result| match result {
+            Ok(text) if text.trim().is_empty() => None,
+            Ok(text) => Some(Ok(text)),
+            Err(error) => Some(Err(error)),
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone)]
@@ -687,6 +706,33 @@ mod tests {
             vec!["small text is unclear".to_string()]
         );
         assert!(observation.elements.is_empty());
+    }
+
+    #[test]
+    fn normalizes_object_uncertainties_from_vision_adapter() {
+        let observation = parse_visual_observation(
+            r#"{
+                "type": "visual_observation",
+                "schema": "visual_observation.v1",
+                "summary": "A logo is visible.",
+                "uncertainties": [
+                    {"text": "The inner shape may be stylized."},
+                    {"description": "Small text is hard to read."}
+                ]
+            }"#,
+            &test_visual_reference(),
+            "Describe the image.",
+            &test_vision_selection(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            observation.uncertainties,
+            vec![
+                "The inner shape may be stylized.".to_string(),
+                "Small text is hard to read.".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/tests/live_view_image.rs
+++ b/tests/live_view_image.rs
@@ -1,0 +1,129 @@
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use holon::{
+    config::{AppConfig, ProviderId},
+    provider::{
+        build_provider_from_model_chain, ConversationMessage, ModelBlock, ProviderTurnRequest,
+    },
+};
+use serde_json::Value;
+
+fn response_text(blocks: &[ModelBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ModelBlock::Text { text } => Some(text.trim()),
+            _ => None,
+        })
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn parse_observation_json(raw: &str) -> Result<Value> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("vision adapter response was empty");
+    }
+    if let Ok(value) = serde_json::from_str(trimmed) {
+        return Ok(value);
+    }
+    let unfenced = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .and_then(|body| body.strip_suffix("```"))
+        .map(str::trim);
+    if let Some(unfenced) = unfenced {
+        if let Ok(value) = serde_json::from_str(unfenced) {
+            return Ok(value);
+        }
+    }
+    let Some(start) = trimmed.find('{') else {
+        bail!("vision adapter response did not contain JSON");
+    };
+    let Some(end) = trimmed.rfind('}') else {
+        bail!("vision adapter response did not contain a complete JSON object");
+    };
+    serde_json::from_str(&trimmed[start..=end])
+        .map_err(|error| anyhow!("vision adapter returned invalid observation JSON: {error}"))
+}
+
+fn accepted_uncertainty_text(value: &Value) -> Option<&str> {
+    if let Some(text) = value.as_str() {
+        return Some(text);
+    }
+    let object = value.as_object()?;
+    ["text", "description", "summary", "message"]
+        .iter()
+        .find_map(|field| object.get(*field).and_then(Value::as_str))
+}
+
+#[tokio::test]
+#[ignore = "requires configured live vision provider credentials and network access"]
+async fn live_view_image_vision_adapter_returns_visual_observation_json() -> Result<()> {
+    let config = AppConfig::load()?;
+    let model_ref = config
+        .provider_chain()
+        .into_iter()
+        .find(|model| {
+            matches!(
+                model.provider.as_str(),
+                ProviderId::OPENAI | ProviderId::OPENAI_CODEX
+            )
+        })
+        .context("live ViewImage needs a configured OpenAI-compatible vision provider")?;
+    let provider = build_provider_from_model_chain(&config, &[model_ref.clone()])?;
+    let image = std::fs::read("docs/website/assets/logo.png")?;
+    let output = provider
+        .complete_turn(ProviderTurnRequest::plain(
+            "You are a vision adapter for a headless agent. Inspect only the provided image and task prompt. Return exactly one JSON object and no markdown, prose, or implementation advice. The JSON object must match this shape: {\"type\":\"visual_observation\",\"schema\":\"visual_observation.v1\",\"summary\":\"string\",\"ocr\":[],\"elements\":[],\"relations\":[],\"issues\":[],\"uncertainties\":[],\"external_sources\":[]}. Required fields: type=\"visual_observation\", schema=\"visual_observation.v1\", summary, uncertainties. The uncertainties field must be an array of strings; use [] when there are no caveats. The ocr, elements, relations, issues, and external_sources fields must be arrays of objects; omit them or use [] when empty. Include visible text in ocr or summary; include bounding boxes when location matters; describe only visible evidence; say when uncertain.",
+            vec![ConversationMessage::UserImage {
+                prompt: "Describe the visible logo and any text. Return only the required JSON object.".to_string(),
+                media_type: "image/png".to_string(),
+                data_base64: BASE64_STANDARD.encode(image),
+            }],
+            Vec::new(),
+        ))
+        .await?;
+    let text = response_text(&output.blocks);
+    let value = parse_observation_json(&text).with_context(|| {
+        format!(
+            "raw live ViewImage response from {} was {text:?}",
+            model_ref.as_string()
+        )
+    })?;
+    assert_eq!(
+        value.get("type").and_then(Value::as_str),
+        Some("visual_observation"),
+        "raw={text:?}"
+    );
+    assert_eq!(
+        value.get("schema").and_then(Value::as_str),
+        Some("visual_observation.v1"),
+        "raw={text:?}"
+    );
+    assert!(
+        value
+            .get("summary")
+            .and_then(Value::as_str)
+            .is_some_and(|summary| !summary.trim().is_empty()),
+        "raw={text:?}"
+    );
+    let uncertainties = value
+        .get("uncertainties")
+        .and_then(Value::as_array)
+        .context("raw live response must include uncertainties as an array")?;
+    assert!(
+        uncertainties
+            .iter()
+            .all(|entry| accepted_uncertainty_text(entry).is_some()),
+        "uncertainties must be strings or text-bearing objects so ViewImage can normalize them; raw={text:?}"
+    );
+    println!(
+        "live_view_image ref={} input_tokens={} output_tokens={} text={text}",
+        model_ref.as_string(),
+        output.input_tokens,
+        output.output_tokens
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Normalize `uncertainties` entries returned by the ViewImage vision adapter when live models emit objects instead of strings.
- Tighten the vision-adapter prompt to request exactly one JSON object and make `uncertainties` a required `string[]` field.
- Add focused regression coverage for object-shaped uncertainty entries and live ViewImage JSON observation behavior.

## Context

A live vision model returned `uncertainties` as an array of objects even though the internal `visual_observation.v1` shape expects `string[]`. The tool should keep parser-side validation authoritative while tolerating this observed field-level drift by extracting text-like fields from uncertainty objects.

This is a compatibility fix, not a replacement for the provider-level JSON Schema response-format work tracked separately in #1715.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib view_image -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Earlier live verification on this fix also passed:

- `cargo test --test live_view_image live_view_image_vision_adapter_returns_visual_observation_json -- --ignored --nocapture`
