### PR TITLE
fix: avoid waiting on background pipe holders

### DIFF
--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -1154,9 +1154,17 @@ async fn collect_remaining_output(running: &mut RunningCommand, captured: &mut C
     };
     // After the main process exits, background children may hold pipe write-ends
     // open indefinitely.  Cap the drain so the agent cannot block forever.
-    let _ = tokio::time::timeout(COLLECT_OUTPUT_DRAIN_TIMEOUT, drain).await;
-    for handle in running.reader_handles.drain(..) {
-        let _ = handle.await;
+    if tokio::time::timeout(COLLECT_OUTPUT_DRAIN_TIMEOUT, drain)
+        .await
+        .is_ok()
+    {
+        for handle in running.reader_handles.drain(..) {
+            let _ = handle.await;
+        }
+    } else {
+        for handle in running.reader_handles.drain(..) {
+            handle.abort();
+        }
     }
 }
 
@@ -1175,9 +1183,17 @@ async fn collect_remaining_output_into_file(
     };
     // After the main process exits, background children may hold pipe write-ends
     // open indefinitely.  Cap the drain so the agent cannot block forever.
-    let _ = tokio::time::timeout(COLLECT_OUTPUT_DRAIN_TIMEOUT, drain).await;
-    for handle in running.reader_handles.drain(..) {
-        let _ = handle.await;
+    if tokio::time::timeout(COLLECT_OUTPUT_DRAIN_TIMEOUT, drain)
+        .await
+        .is_ok()
+    {
+        for handle in running.reader_handles.drain(..) {
+            let _ = handle.await;
+        }
+    } else {
+        for handle in running.reader_handles.drain(..) {
+            handle.abort();
+        }
     }
     Ok(())
 }

--- a/tests/runtime_tasks.rs
+++ b/tests/runtime_tasks.rs
@@ -25,6 +25,7 @@ runtime_async_tests!(
     shell_tools_truncate_large_output_before_provider_reinjection,
     exec_command_reports_nonzero_exit_and_truncates_output,
     exec_command_batch_returns_grouped_item_results,
+    exec_command_batch_does_not_wait_for_background_pipe_holders,
     exec_command_batch_top_level_defaults_apply_to_items,
     exec_command_batch_stop_on_error_skips_later_items,
     exec_command_spawn_failure_returns_shell_recovery_hint,

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -39,7 +39,7 @@ use holon::{
 use serde_json::json;
 use tokio::sync::Mutex;
 
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, timeout, Duration, Instant};
 
 use crate::support::runtime_helpers::{
     aggressive_compaction_config, delegated_prompt_text, git, init_git_repo,
@@ -679,6 +679,57 @@ pub async fn exec_command_batch_returns_grouped_item_results() -> Result<()> {
         runtime.latest_task_records_snapshot()?.is_empty(),
         "batch items should not promote into command_task records"
     );
+    Ok(())
+}
+
+pub async fn exec_command_batch_does_not_wait_for_background_pipe_holders() -> Result<()> {
+    let host =
+        RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ignored")))?;
+    attach_default_workspace(&host).await?;
+    let runtime = host.default_runtime().await?;
+    let registry = ToolRegistry::new(runtime.workspace_root());
+
+    let started = Instant::now();
+    let call = ToolCall {
+        id: "tool-exec-batch-background-pipe".into(),
+        name: "ExecCommandBatch".into(),
+        input: json!({
+            "items": [
+                {
+                    "cmd": "sh -c '(sleep 5) & printf parent_done'",
+                    "login": false,
+                    "yield_time_ms": 10_000,
+                    "max_output_tokens": 256
+                }
+            ]
+        }),
+    };
+    let execute = registry.execute(
+        &runtime,
+        "default",
+        &AuthorityClass::OperatorInstruction,
+        &call,
+    );
+
+    let (result, _) = timeout(Duration::from_secs(3), execute)
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "ExecCommandBatch waited for a background child that only held stdout/stderr open"
+            )
+        })??;
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "ExecCommandBatch should return after the foreground command exits"
+    );
+    let value = parse_tool_result_payload(&result)?;
+    assert_eq!(value["item_count"], 1);
+    assert_eq!(value["completed_count"], 1);
+    assert_eq!(value["items"][0]["status"], "completed");
+    assert!(value["items"][0]["result"]["stdout_preview"]
+        .as_str()
+        .expect("stdout preview")
+        .contains("parent_done"));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- stop waiting forever on command output reader tasks when post-exit pipe draining times out
- add an integration regression test for `ExecCommandBatch` commands that spawn a background process holding stdout/stderr open
- keep existing sleeping-agent command-task reentry behavior covered by the existing test

## Why

`collect_remaining_output()` already capped the final output drain after the foreground command exits, but then unconditionally awaited the stdout/stderr reader tasks. If a background child inherited the pipe write ends, those reader tasks could wait for EOF indefinitely and keep a completed `ExecCommandBatch` item from returning.

## Verification

- `cargo test --test runtime_tasks exec_command_batch_does_not_wait_for_background_pipe_holders -- --nocapture`
- `cargo test --test runtime_tasks background_command_task_result_wakes_sleeping_agent_for_model_reentry -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
