### PR TITLE
feat: add provider JSON schema response format

### DIFF
--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -346,6 +346,7 @@ mod tests {
             conversation: Vec::new(),
             tools: Vec::new(),
             native_web_search: None,
+            response_format: None,
         };
 
         provider

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -37,6 +37,7 @@ pub struct ProviderTurnRequest {
     pub conversation: Vec<ConversationMessage>,
     pub tools: Vec<ToolSpec>,
     pub native_web_search: Option<ProviderNativeWebSearchRequest>,
+    pub response_format: Option<ProviderResponseFormatRequest>,
 }
 
 impl ProviderTurnRequest {
@@ -50,6 +51,7 @@ impl ProviderTurnRequest {
             conversation,
             tools,
             native_web_search: None,
+            response_format: None,
         }
     }
 }
@@ -140,6 +142,8 @@ pub struct ProviderRequestDiagnostics {
     pub openai_remote_compaction: Option<ProviderOpenAiRemoteCompactionDiagnostics>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub native_web_search: Option<ProviderNativeWebSearchDiagnostics>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ProviderResponseFormatDiagnostics>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -169,6 +173,30 @@ pub struct ProviderNativeWebSearchDiagnostics {
     pub advertised_tool_type: String,
     pub backend_kind: String,
     pub lowered: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProviderResponseFormatRequest {
+    JsonSchema(ProviderJsonSchemaResponseFormat),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderJsonSchemaResponseFormat {
+    pub name: String,
+    pub schema: Value,
+    pub strict: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderResponseFormatDiagnostics {
+    pub requested: bool,
+    pub lowered: bool,
+    pub format_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_reason: Option<String>,
 }
@@ -436,6 +464,7 @@ pub(crate) fn builtin_web_search_probe_turn_request(
         )],
         tools: Vec::new(),
         native_web_search: Some(native_web_search),
+        response_format: None,
     }
 }
 

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -174,6 +174,7 @@ pub fn provider_turn_request_with_prompt_frame() -> ProviderTurnRequest {
         }])],
         tools: Vec::new(),
         native_web_search: None,
+        response_format: None,
     }
 }
 

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -22,7 +22,8 @@ use crate::{
         PromptContentBlock, ProviderBuiltinWebSearchCapability, ProviderCacheUsage,
         ProviderContextManagementPolicy, ProviderNativeWebSearchDiagnostics,
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest, ProviderPromptCapability,
-        ProviderTurnRequest, ProviderTurnResponse,
+        ProviderResponseFormatDiagnostics, ProviderResponseFormatRequest, ProviderTurnRequest,
+        ProviderTurnResponse,
     },
 };
 
@@ -383,6 +384,7 @@ impl AgentProvider for AnthropicProvider {
                 incremental_continuation: None,
                 openai_remote_compaction: None,
                 native_web_search: native_web_search_diagnostics(&request),
+                response_format: response_format_diagnostics(&request),
             }),
         })
     }
@@ -677,6 +679,24 @@ fn native_web_search_diagnostics(
         fallback_reason: (!lowered)
             .then(|| "anthropic transport only supports Anthropic-native web search".into()),
     })
+}
+
+fn response_format_diagnostics(
+    request: &ProviderTurnRequest,
+) -> Option<ProviderResponseFormatDiagnostics> {
+    match request.response_format.as_ref()? {
+        ProviderResponseFormatRequest::JsonSchema(format) => {
+            Some(ProviderResponseFormatDiagnostics {
+                requested: true,
+                lowered: false,
+                format_type: "json_schema".into(),
+                schema_name: Some(format.name.clone()),
+                fallback_reason: Some(
+                    "anthropic transport does not support JSON Schema response format".into(),
+                ),
+            })
+        }
+    }
 }
 
 fn build_context_management_request(
@@ -1853,6 +1873,7 @@ mod tests {
             conversation: vec![ConversationMessage::UserText("Hello".to_string())],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -1901,6 +1922,7 @@ mod tests {
             )],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -1984,6 +2006,7 @@ mod tests {
             ],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -2255,6 +2278,7 @@ mod tests {
             conversation: vec![ConversationMessage::UserText("User message".to_string())],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -2300,6 +2324,7 @@ mod tests {
             conversation: vec![],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         };
 
         let request_payload = anthropic_request_payload_for_test(&request);
@@ -2316,5 +2341,40 @@ mod tests {
             breakpoints.len() <= 10,
             "cache_breakpoints should be bounded to 10 items"
         );
+    }
+
+    #[test]
+    fn response_format_diagnostics_reports_unsupported_json_schema() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("return json".into())],
+            vec![],
+        );
+        request.response_format = Some(ProviderResponseFormatRequest::JsonSchema(
+            crate::provider::ProviderJsonSchemaResponseFormat {
+                name: "answer_v1".into(),
+                strict: true,
+                schema: json!({
+                    "type": "object",
+                    "required": ["answer"],
+                    "properties": {
+                        "answer": { "type": "string" }
+                    }
+                }),
+            },
+        ));
+
+        let diagnostics = response_format_diagnostics(&request)
+            .expect("response format diagnostics should be recorded");
+
+        assert!(diagnostics.requested);
+        assert!(!diagnostics.lowered);
+        assert_eq!(diagnostics.format_type, "json_schema");
+        assert_eq!(diagnostics.schema_name.as_deref(), Some("answer_v1"));
+        assert!(diagnostics
+            .fallback_reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("does not support JSON Schema response format"));
     }
 }

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -405,6 +405,7 @@ fn gemini_response_to_provider_turn_response(
             incremental_continuation: None,
             openai_remote_compaction: None,
             native_web_search: None,
+            response_format: None,
         }),
     })
 }

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -31,6 +31,7 @@ use crate::{
         ProviderNativeWebSearchDiagnostics, ProviderNativeWebSearchKind,
         ProviderNativeWebSearchRequest, ProviderOpenAiRemoteCompactionDiagnostics,
         ProviderOpenAiRequestControlsDiagnostics, ProviderPromptFrame, ProviderRequestDiagnostics,
+        ProviderResponseFormatDiagnostics, ProviderResponseFormatRequest,
         ProviderTransportDiagnostics, ProviderTurnRequest, ProviderTurnResponse,
         ToolSchemaContract,
     },
@@ -1290,6 +1291,7 @@ fn plan_chat_completion_request(
                     None,
                     None,
                     None,
+                    response_format_diagnostics(false, request),
                 ),
             },
         ));
@@ -1318,6 +1320,7 @@ fn plan_chat_completion_request(
                     None,
                     None,
                     None,
+                    response_format_diagnostics(false, request),
                 ),
             },
         ));
@@ -1346,6 +1349,7 @@ fn plan_chat_completion_request(
                     }),
                     None,
                     None,
+                    response_format_diagnostics(false, request),
                 ),
             },
         ));
@@ -1376,6 +1380,7 @@ fn plan_chat_completion_request(
                 }),
                 None,
                 None,
+                response_format_diagnostics(false, request),
             ),
         },
     ));
@@ -1560,6 +1565,9 @@ pub(crate) fn build_openai_responses_request(
     if let Some(cache) = request.prompt_frame.cache.as_ref() {
         body["prompt_cache_key"] = Value::String(cache.prompt_cache_key.clone());
     }
+    if let Some(response_format) = openai_response_format(request) {
+        body["response_format"] = response_format;
+    }
     match contract {
         OpenAiResponsesTransportContract::StandardJson => {
             body["max_output_tokens"] = Value::from(max_output_tokens);
@@ -1576,6 +1584,19 @@ pub(crate) fn build_openai_responses_request(
         }
     }
     Ok(body)
+}
+
+fn openai_response_format(request: &ProviderTurnRequest) -> Option<Value> {
+    match request.response_format.as_ref()? {
+        ProviderResponseFormatRequest::JsonSchema(format) => Some(json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": format.name,
+                "schema": format.schema,
+                "strict": format.strict,
+            }
+        })),
+    }
 }
 
 fn openai_native_web_search_tool(request: &ProviderTurnRequest) -> Option<Value> {
@@ -1647,6 +1668,7 @@ fn plan_openai_responses_request(
                 None,
                 request_controls,
                 native_web_search_diagnostics(request),
+                response_format_diagnostics(true, request),
             ),
         });
     };
@@ -1669,6 +1691,7 @@ fn plan_openai_responses_request(
                 None,
                 request_controls,
                 native_web_search_diagnostics(request),
+                response_format_diagnostics(true, request),
             ),
         });
     };
@@ -1692,6 +1715,7 @@ fn plan_openai_responses_request(
                 }),
                 request_controls,
                 native_web_search_diagnostics(request),
+                response_format_diagnostics(true, request),
             ),
         });
     }
@@ -1720,6 +1744,7 @@ fn plan_openai_responses_request(
                 Some(mismatch),
                 request_controls,
                 native_web_search_diagnostics(request),
+                response_format_diagnostics(true, request),
             ),
         });
     }
@@ -1774,6 +1799,7 @@ fn plan_openai_responses_request(
                 mismatch_kind: None,
             }),
             native_web_search: native_web_search_diagnostics(request),
+            response_format: response_format_diagnostics(true, request),
         },
     })
 }
@@ -2031,6 +2057,7 @@ fn incremental_diagnostics(
     mismatch: Option<OpenAiContinuationMismatchDiagnostics>,
     openai_request_controls: Option<ProviderOpenAiRequestControlsDiagnostics>,
     native_web_search: Option<ProviderNativeWebSearchDiagnostics>,
+    response_format: Option<ProviderResponseFormatDiagnostics>,
 ) -> ProviderRequestDiagnostics {
     let mismatch = mismatch.unwrap_or_default();
     ProviderRequestDiagnostics {
@@ -2057,6 +2084,25 @@ fn incremental_diagnostics(
             mismatch_kind: mismatch.mismatch_kind,
         }),
         native_web_search,
+        response_format,
+    }
+}
+
+fn response_format_diagnostics(
+    lowered: bool,
+    request: &ProviderTurnRequest,
+) -> Option<ProviderResponseFormatDiagnostics> {
+    match request.response_format.as_ref()? {
+        ProviderResponseFormatRequest::JsonSchema(format) => {
+            Some(ProviderResponseFormatDiagnostics {
+                requested: true,
+                lowered,
+                format_type: "json_schema".into(),
+                schema_name: Some(format.name.clone()),
+                fallback_reason: (!lowered)
+                    .then(|| "transport does not support JSON Schema response format".into()),
+            })
+        }
     }
 }
 
@@ -4767,8 +4813,8 @@ mod tests {
         ProviderRuntimeConfig, ProviderTransportKind, OPENAI_CODEX_CREDENTIAL_PROFILE,
     };
     use crate::provider::{
-        ConversationMessage, ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
-        ProviderTurnRequest,
+        ConversationMessage, ProviderJsonSchemaResponseFormat, ProviderNativeWebSearchKind,
+        ProviderNativeWebSearchRequest, ProviderResponseFormatRequest, ProviderTurnRequest,
     };
     use base64::Engine;
     use chrono::Utc;
@@ -5186,6 +5232,53 @@ mod tests {
     }
 
     #[test]
+    fn openai_responses_request_lowers_json_schema_response_format() {
+        let mut request = ProviderTurnRequest::plain(
+            "system",
+            vec![ConversationMessage::UserText("return json".into())],
+            vec![],
+        );
+        request.response_format = Some(ProviderResponseFormatRequest::JsonSchema(
+            ProviderJsonSchemaResponseFormat {
+                name: "answer_v1".into(),
+                strict: true,
+                schema: json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["answer"],
+                    "properties": {
+                        "answer": { "type": "string" }
+                    }
+                }),
+            },
+        ));
+
+        let body = build_openai_responses_request(
+            "gpt-test",
+            1024,
+            &request,
+            OpenAiResponsesTransportContract::StandardJson,
+            ToolSchemaContract::Strict,
+            None,
+        )
+        .expect("openai responses request should build");
+
+        assert_eq!(body["response_format"]["type"], json!("json_schema"));
+        assert_eq!(
+            body["response_format"]["json_schema"]["name"],
+            json!("answer_v1")
+        );
+        assert_eq!(
+            body["response_format"]["json_schema"]["strict"],
+            json!(true)
+        );
+        assert_eq!(
+            body["response_format"]["json_schema"]["schema"]["properties"]["answer"]["type"],
+            json!("string")
+        );
+    }
+
+    #[test]
     fn openai_codex_responses_request_lowers_native_web_search_tool() {
         let mut request = ProviderTurnRequest::plain(
             "system",
@@ -5380,6 +5473,7 @@ mod tests {
                 "test",
                 None,
                 0,
+                None,
                 None,
                 None,
                 None,

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1566,7 +1566,7 @@ pub(crate) fn build_openai_responses_request(
         body["prompt_cache_key"] = Value::String(cache.prompt_cache_key.clone());
     }
     if let Some(response_format) = openai_response_format(request) {
-        body["response_format"] = response_format;
+        body["text"]["format"] = response_format;
     }
     match contract {
         OpenAiResponsesTransportContract::StandardJson => {
@@ -1590,11 +1590,9 @@ fn openai_response_format(request: &ProviderTurnRequest) -> Option<Value> {
     match request.response_format.as_ref()? {
         ProviderResponseFormatRequest::JsonSchema(format) => Some(json!({
             "type": "json_schema",
-            "json_schema": {
-                "name": format.name,
-                "schema": format.schema,
-                "strict": format.strict,
-            }
+            "name": format.name,
+            "schema": format.schema,
+            "strict": format.strict,
         })),
     }
 }
@@ -5263,17 +5261,12 @@ mod tests {
         )
         .expect("openai responses request should build");
 
-        assert_eq!(body["response_format"]["type"], json!("json_schema"));
+        assert!(body.get("response_format").is_none());
+        assert_eq!(body["text"]["format"]["type"], json!("json_schema"));
+        assert_eq!(body["text"]["format"]["name"], json!("answer_v1"));
+        assert_eq!(body["text"]["format"]["strict"], json!(true));
         assert_eq!(
-            body["response_format"]["json_schema"]["name"],
-            json!("answer_v1")
-        );
-        assert_eq!(
-            body["response_format"]["json_schema"]["strict"],
-            json!(true)
-        );
-        assert_eq!(
-            body["response_format"]["json_schema"]["schema"]["properties"]["answer"]["type"],
+            body["text"]["format"]["schema"]["properties"]["answer"]["type"],
             json!("string")
         );
     }

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -16,7 +16,8 @@ use crate::{
     model_discovery::{discovery_cache_path, load_discovery_cache_at},
     provider::{
         build_provider_from_model_chain, resolved_model_availability, AgentProvider,
-        ConversationMessage, ModelBlock, ProviderTurnRequest,
+        ConversationMessage, ModelBlock, ProviderJsonSchemaResponseFormat,
+        ProviderResponseFormatRequest, ProviderTurnRequest,
     },
     queue::RuntimeQueue,
     runtime_db::RuntimeDb,
@@ -395,17 +396,17 @@ impl RuntimeHandle {
             &reconfig.config,
             &[ModelRef::parse(&format!("{provider_name}/{model_name}"))?],
         )?;
-        let response = provider
-            .complete_turn(ProviderTurnRequest::plain(
-                "You are a vision adapter for a headless agent. Inspect only the provided image and task prompt. Return exactly one JSON object and no markdown, prose, or implementation advice. The JSON object must match this shape: {\"type\":\"visual_observation\",\"schema\":\"visual_observation.v1\",\"summary\":\"string\",\"ocr\":[],\"elements\":[],\"relations\":[],\"issues\":[],\"uncertainties\":[],\"external_sources\":[]}. Required fields: type=\"visual_observation\", schema=\"visual_observation.v1\", summary, uncertainties. The uncertainties field must be an array of strings; use [] when there are no caveats. The ocr, elements, relations, issues, and external_sources fields must be arrays of objects; omit them or use [] when empty. Include visible text in ocr or summary; include bounding boxes when location matters; describe only visible evidence; say when uncertain.",
-                vec![ConversationMessage::UserImage {
-                    prompt: prompt.to_string(),
-                    media_type: media_type.to_string(),
-                    data_base64: BASE64_STANDARD.encode(bytes),
-                }],
-                Vec::new(),
-            ))
-            .await?;
+        let mut request = ProviderTurnRequest::plain(
+            "You are a vision adapter for a headless agent. Inspect only the provided image and task prompt. Return exactly one JSON object and no markdown, prose, or implementation advice. The JSON object must match this shape: {\"type\":\"visual_observation\",\"schema\":\"visual_observation.v1\",\"summary\":\"string\",\"ocr\":[],\"elements\":[],\"relations\":[],\"issues\":[],\"uncertainties\":[],\"external_sources\":[]}. Required fields: type=\"visual_observation\", schema=\"visual_observation.v1\", summary, uncertainties. The uncertainties field must be an array of strings; use [] when there are no caveats. The ocr, elements, relations, issues, and external_sources fields must be arrays of objects; omit them or use [] when empty. Include visible text in ocr or summary; include bounding boxes when location matters; describe only visible evidence; say when uncertain.",
+            vec![ConversationMessage::UserImage {
+                prompt: prompt.to_string(),
+                media_type: media_type.to_string(),
+                data_base64: BASE64_STANDARD.encode(bytes),
+            }],
+            Vec::new(),
+        );
+        request.response_format = Some(visual_observation_response_format());
+        let response = provider.complete_turn(request).await?;
         let text = response
             .blocks
             .iter()
@@ -802,4 +803,37 @@ fn storage_domain_complete(runtime_db: &RuntimeDb, domain: &str) -> Result<bool>
         .find(|expected| expected.domain == domain)
         .ok_or_else(|| anyhow!("unknown runtime storage domain {domain}"))?;
     runtime_db.storage_domain_is_complete(expected.domain, expected.canonical_source)
+}
+
+fn visual_observation_response_format() -> ProviderResponseFormatRequest {
+    ProviderResponseFormatRequest::JsonSchema(ProviderJsonSchemaResponseFormat {
+        name: "visual_observation_v1".into(),
+        strict: true,
+        schema: serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "type",
+                "schema",
+                "summary",
+                "ocr",
+                "elements",
+                "relations",
+                "issues",
+                "uncertainties",
+                "external_sources"
+            ],
+            "properties": {
+                "type": { "type": "string", "const": "visual_observation" },
+                "schema": { "type": "string", "const": "visual_observation.v1" },
+                "summary": { "type": "string" },
+                "ocr": { "type": "array", "items": { "type": "object" } },
+                "elements": { "type": "array", "items": { "type": "object" } },
+                "relations": { "type": "array", "items": { "type": "object" } },
+                "issues": { "type": "array", "items": { "type": "object" } },
+                "uncertainties": { "type": "array", "items": { "type": "string" } },
+                "external_sources": { "type": "array", "items": { "type": "object" } }
+            }
+        }),
+    })
 }

--- a/src/runtime/provider_turn.rs
+++ b/src/runtime/provider_turn.rs
@@ -66,6 +66,7 @@ pub fn build_provider_turn_request(
         conversation: vec![ConversationMessage::UserBlocks(context_blocks)],
         tools: available_tools,
         native_web_search,
+        response_format: None,
     }
 }
 
@@ -84,6 +85,7 @@ pub fn build_continuation_request(
         conversation,
         tools: available_tools,
         native_web_search,
+        response_format: None,
     }
 }
 

--- a/tests/live_anthropic.rs
+++ b/tests/live_anthropic.rs
@@ -101,6 +101,7 @@ async fn live_anthropic_builtin_web_search_reports_backend() -> Result<()> {
                 backend_kind: capability.backend_kind,
                 max_results: Some(3),
             }),
+            response_format: None,
         })
         .await?;
     let diagnostics = output
@@ -162,6 +163,7 @@ async fn live_provider_accepts_tool_result_continuation_with_runtime_tools() -> 
             ],
             tools,
             native_web_search: None,
+            response_format: None,
         })
         .await?;
     assert!(!output.blocks.is_empty());

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -111,6 +111,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
             ],
             tools: vec![tool.clone()],
             native_web_search: None,
+            response_format: None,
         })
         .await?;
     let tool_use_id = first_output
@@ -143,6 +144,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
             ],
             tools: vec![tool],
             native_web_search: None,
+            response_format: None,
         })
         .await?;
 
@@ -225,6 +227,7 @@ async fn provider_builtin_web_search_reports_backend(
                 backend_kind: capability.backend_kind,
                 max_results: Some(3),
             }),
+            response_format: None,
         })
         .await?;
     let diagnostics = output

--- a/tests/live_codex.rs
+++ b/tests/live_codex.rs
@@ -130,6 +130,7 @@ async fn live_openai_codex_builtin_web_search_reports_backend() -> Result<()> {
             )],
             tools: vec![],
             native_web_search: Some(native_web_search),
+            response_format: None,
         })
         .await?;
     let diagnostics = output
@@ -158,6 +159,7 @@ async fn live_openai_codex_replays_provider_window_after_append_match() -> Resul
             )],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         })
         .await?;
     let first_text = response_text(&first.blocks);
@@ -176,6 +178,7 @@ async fn live_openai_codex_replays_provider_window_after_append_match() -> Resul
             ],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         })
         .await?;
 

--- a/tests/live_llm_baseline.rs
+++ b/tests/live_llm_baseline.rs
@@ -223,6 +223,7 @@ async fn live_llm_baseline_anthropic_prompt_cache_hit() -> Result<()> {
             )],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         })
         .await
         .context("first Anthropic live cache baseline request failed")?;
@@ -234,6 +235,7 @@ async fn live_llm_baseline_anthropic_prompt_cache_hit() -> Result<()> {
             )],
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         })
         .await
         .context("second Anthropic live cache baseline request failed")?;

--- a/tests/live_openai_codex_compact.rs
+++ b/tests/live_openai_codex_compact.rs
@@ -70,6 +70,7 @@ async fn live_openai_codex_remote_compact_route_probe() -> Result<()> {
                 .collect(),
             tools: vec![],
             native_web_search: None,
+            response_format: None,
         })
         .await?;
 


### PR DESCRIPTION
## Summary
- add provider-level JSON Schema response format request/diagnostics
- lower JSON Schema response_format for OpenAI Responses transports
- wire ViewImage visual observation generation to request the visual_observation_v1 schema
- report unsupported response_format diagnostics for non-lowering transports

Closes #1715

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets
- cargo test --lib response_format -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets