### PR TITLE
fix: use db as agent state source

### DIFF
--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -10,6 +10,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     config::AppConfig,
+    runtime_db::RuntimeDb,
     storage::AppStorage,
     types::{AgentRegistryStatus, AgentVisibility, RuntimeFailurePhase, RuntimeFailureSummary},
 };
@@ -272,6 +273,8 @@ pub(crate) fn clear_persisted_daemon_lifecycle_failures(config: &AppConfig) -> R
 
 fn latest_public_runtime_failure(config: &AppConfig) -> Result<Option<RuntimeFailureSummary>> {
     let host_storage = AppStorage::new_global(config.home_dir.join("host"))?;
+    let runtime_db =
+        RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
     let mut latest = None;
     for identity in host_storage
         .latest_agent_identities()?
@@ -285,6 +288,7 @@ fn latest_public_runtime_failure(config: &AppConfig) -> Result<Option<RuntimeFai
             config.agent_root_dir().join(&identity.agent_id),
             identity.agent_id.clone(),
         )?;
+        storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
         let failure = storage
             .read_agent()?
             .and_then(|agent| agent.last_runtime_failure);

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -17,7 +17,13 @@ use crate::config::{provider_registry_for_tests, AppConfig, ModelRef, ProviderId
 use crate::{
     host::RuntimeHost,
     provider::StubProvider,
-    types::{AuthorityClass, CommandTaskSpec, RuntimeFailurePhase, RuntimeFailureSummary},
+    runtime_db::RuntimeDb,
+    storage::AppStorage,
+    types::{
+        AgentIdentityRecord, AgentKind, AgentOwnership, AgentProfilePreset, AgentState,
+        AgentVisibility, AuthorityClass, CommandTaskSpec, RuntimeFailurePhase,
+        RuntimeFailureSummary,
+    },
 };
 use chrono::Utc;
 use std::{
@@ -254,6 +260,39 @@ async fn daemon_status_surfaces_persisted_last_failure_when_runtime_stopped() {
         failure_artifact: None,
     };
     persist_last_runtime_failure(&config, &failure).unwrap();
+    let status = daemon_status(&config).await.unwrap();
+    assert_eq!(status.state, DaemonLifecycleState::Stopped);
+    assert_eq!(status.last_failure, Some(failure));
+}
+
+#[tokio::test]
+async fn daemon_status_surfaces_db_only_public_agent_runtime_failure_when_stopped() {
+    let config = test_config();
+    let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
+    let identity = AgentIdentityRecord::new(
+        "public-agent",
+        AgentKind::Named,
+        AgentVisibility::Public,
+        AgentOwnership::SelfOwned,
+        AgentProfilePreset::PublicNamed,
+        None,
+        None,
+    );
+    host_storage.append_agent_identity(&identity).unwrap();
+    let runtime_db =
+        RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+            .unwrap();
+    let failure = RuntimeFailureSummary {
+        occurred_at: Utc::now(),
+        summary: "public runtime failed".into(),
+        phase: RuntimeFailurePhase::RuntimeTurn,
+        detail_hint: Some("runtime artifact".into()),
+        failure_artifact: None,
+    };
+    let mut agent = AgentState::new("public-agent");
+    agent.last_runtime_failure = Some(failure.clone());
+    runtime_db.agent_states().upsert(&agent).unwrap();
+
     let status = daemon_status(&config).await.unwrap();
     assert_eq!(status.state, DaemonLifecycleState::Stopped);
     assert_eq!(status.last_failure, Some(failure));

--- a/src/host.rs
+++ b/src/host.rs
@@ -215,7 +215,7 @@ impl RuntimeHost {
         &self.inner.runtime_db
     }
 
-    fn agent_storage(&self, agent_id: &str) -> Result<AppStorage> {
+    pub fn agent_storage(&self, agent_id: &str) -> Result<AppStorage> {
         let storage =
             AppStorage::new_for_agent(self.agent_data_dir(agent_id), agent_id.to_string())?;
         storage.enable_scheduler_control_plane_db(self.runtime_db().clone())?;

--- a/src/host.rs
+++ b/src/host.rs
@@ -2628,7 +2628,7 @@ mod tests {
             .expect("unloaded release-bot should still be listed");
         assert_eq!(
             stored_release_bot.scheduling_posture.posture,
-            AgentSchedulingPosture::Unknown
+            AgentSchedulingPosture::Idle
         );
     }
 
@@ -2650,7 +2650,7 @@ mod tests {
         assert!(agent_home.join("notes").is_dir());
         assert!(agent_home.join("work").is_dir());
         assert!(agent_home.join("skills").is_dir());
-        assert!(agent_home.join(".holon/state/agent.json").is_file());
+        assert!(!agent_home.join(".holon/state/agent.json").exists());
         assert!(agent_home.join(".holon/ledger").is_dir());
         assert!(!agent_home.join("agent.json").exists());
         let provenance: crate::agent_template::TemplateProvenanceRecord = serde_json::from_slice(
@@ -3329,7 +3329,7 @@ mod tests {
         );
         host.append_agent_identity(&child).unwrap();
 
-        let child_storage = AppStorage::new(host.agent_data_dir("child_test")).unwrap();
+        let child_storage = host.agent_storage("child_test").unwrap();
         let mut child_state = AgentState::new("child_test");
         child_state.status = AgentStatus::AwakeRunning;
         child_state.pending = 1;
@@ -3388,7 +3388,7 @@ mod tests {
         let (_home, host) = test_host();
         let config = host.config().clone();
         let parent_agent_id = config.default_agent_id.clone();
-        let parent_storage = AppStorage::new(host.agent_data_dir(&parent_agent_id)).unwrap();
+        let parent_storage = host.agent_storage(&parent_agent_id).unwrap();
         parent_storage
             .append_task(&TaskRecord {
                 id: "task-1".into(),
@@ -3419,7 +3419,7 @@ mod tests {
         );
         host.append_agent_identity(&child).unwrap();
 
-        let child_storage = AppStorage::new(host.agent_data_dir("child_test")).unwrap();
+        let child_storage = host.agent_storage("child_test").unwrap();
         let mut child_state = AgentState::new("child_test");
         child_state.status = AgentStatus::AwaitingTask;
         child_storage.write_agent(&child_state).unwrap();
@@ -3464,7 +3464,7 @@ mod tests {
         let (_home, host) = test_host();
         let config = host.config().clone();
         let parent_agent_id = config.default_agent_id.clone();
-        let parent_storage = AppStorage::new(host.agent_data_dir(&parent_agent_id)).unwrap();
+        let parent_storage = host.agent_storage(&parent_agent_id).unwrap();
         parent_storage
             .append_task(&TaskRecord {
                 id: "task-recover-child".into(),
@@ -3502,7 +3502,7 @@ mod tests {
         .with_lineage_parent_agent_id(Some(parent_agent_id.clone()));
         host.append_agent_identity(&child).unwrap();
 
-        let child_storage = AppStorage::new(host.agent_data_dir("child_recover")).unwrap();
+        let child_storage = host.agent_storage("child_recover").unwrap();
         let mut child_state = AgentState::new("child_recover");
         child_state.turn_index = 1;
         child_state.status = AgentStatus::AwakeIdle;
@@ -3842,7 +3842,7 @@ mod tests {
             .expect("host shutdown should be bounded")
             .unwrap();
 
-        let storage = AppStorage::new(host.agent_data_dir(&agent_id)).unwrap();
+        let storage = host.agent_storage(&agent_id).unwrap();
         let persisted = storage.read_agent().unwrap().unwrap();
         assert_eq!(persisted.status, AgentStatus::AwakeIdle);
         assert_eq!(persisted.current_run_id, None);
@@ -3926,7 +3926,8 @@ mod tests {
 
         host.shutdown().await.unwrap();
 
-        let persisted = AppStorage::new(host.agent_data_dir(&agent_id))
+        let persisted = host
+            .agent_storage(&agent_id)
             .unwrap()
             .read_agent()
             .unwrap()

--- a/src/host.rs
+++ b/src/host.rs
@@ -215,6 +215,22 @@ impl RuntimeHost {
         &self.inner.runtime_db
     }
 
+    fn agent_storage(&self, agent_id: &str) -> Result<AppStorage> {
+        let storage =
+            AppStorage::new_for_agent(self.agent_data_dir(agent_id), agent_id.to_string())?;
+        storage.enable_scheduler_control_plane_db(self.runtime_db().clone())?;
+        Ok(storage)
+    }
+
+    fn agent_storage_read_only(&self, agent_id: &str) -> Result<AppStorage> {
+        let storage = AppStorage::open_read_only_for_agent(
+            self.agent_data_dir(agent_id),
+            agent_id.to_string(),
+        )?;
+        storage.enable_scheduler_control_plane_db(self.runtime_db().clone())?;
+        Ok(storage)
+    }
+
     pub(crate) fn bridge(&self) -> RuntimeHostBridge {
         RuntimeHostBridge {
             inner: Arc::downgrade(&self.inner),
@@ -305,7 +321,8 @@ impl RuntimeHost {
         agent_id: &str,
     ) -> std::result::Result<RuntimeHandle, PublicAgentError> {
         self.public_agent_identity(agent_id)?;
-        let state = AppStorage::new_for_agent(self.agent_data_dir(agent_id), agent_id.to_string())
+        let state = self
+            .agent_storage(agent_id)
             .map_err(PublicAgentError::Runtime)?
             .read_agent()
             .map_err(PublicAgentError::Runtime)?
@@ -672,10 +689,7 @@ impl RuntimeHost {
         &self,
         identity: &AgentIdentityRecord,
     ) -> Result<AgentListEntry> {
-        let storage = AppStorage::new_for_agent(
-            self.agent_data_dir(&identity.agent_id),
-            identity.agent_id.clone(),
-        )?;
+        let storage = self.agent_storage(&identity.agent_id)?;
         let agent = match storage.read_agent() {
             Ok(Some(agent)) => agent,
             Ok(None) => stopped_unloaded_agent(&identity.agent_id),
@@ -740,10 +754,7 @@ impl RuntimeHost {
                 });
                 continue;
             }
-            let storage = AppStorage::new_for_agent(
-                self.agent_data_dir(&identity.agent_id),
-                identity.agent_id.clone(),
-            )?;
+            let storage = self.agent_storage(&identity.agent_id)?;
             let state = storage
                 .read_agent()?
                 .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
@@ -815,10 +826,7 @@ impl RuntimeHost {
         text: String,
         authority_class: AuthorityClass,
     ) -> Result<EffectivePrompt> {
-        let storage = AppStorage::open_read_only_for_agent(
-            self.agent_data_dir(&identity.agent_id),
-            identity.agent_id.clone(),
-        )?;
+        let storage = self.agent_storage_read_only(&identity.agent_id)?;
         let state = storage
             .read_agent()?
             .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
@@ -926,10 +934,7 @@ impl RuntimeHost {
         &self,
         identity: &AgentIdentityRecord,
     ) -> Result<Value> {
-        let storage = AppStorage::open_read_only_for_agent(
-            self.agent_data_dir(&identity.agent_id),
-            identity.agent_id.clone(),
-        )?;
+        let storage = self.agent_storage_read_only(&identity.agent_id)?;
         let state = storage
             .read_agent()?
             .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
@@ -957,10 +962,7 @@ impl RuntimeHost {
                 && record.kind == AgentKind::Child
                 && record.parent_agent_id.as_deref() == Some(parent_agent_id)
         }) {
-            let storage = AppStorage::new_for_agent(
-                self.agent_data_dir(&identity.agent_id),
-                identity.agent_id.clone(),
-            )?;
+            let storage = self.agent_storage(&identity.agent_id)?;
             let state = storage
                 .read_agent()?
                 .unwrap_or_else(|| AgentState::new(identity.agent_id.clone()));
@@ -1143,12 +1145,10 @@ impl RuntimeHost {
         let Some(task_id) = identity.delegated_from_task_id.as_deref() else {
             return Ok(true);
         };
-        let parent_data_dir = self.agent_data_dir(parent_agent_id);
-        if !parent_data_dir.exists() {
+        if !self.agent_data_dir(parent_agent_id).exists() {
             return Ok(true);
         }
-        let parent_storage =
-            AppStorage::new_for_agent(parent_data_dir, parent_agent_id.to_string())?;
+        let parent_storage = self.agent_storage(parent_agent_id)?;
         let Some(task) = parent_storage.latest_task_record(task_id)? else {
             return Ok(true);
         };
@@ -1345,10 +1345,7 @@ impl RuntimeHost {
         child_turn_baseline: u64,
         worktree: bool,
     ) -> Result<ChildTaskTerminalResult> {
-        let storage = AppStorage::new_for_agent(
-            self.agent_data_dir(child_agent_id),
-            child_agent_id.to_string(),
-        )?;
+        let storage = self.agent_storage(child_agent_id)?;
         if let Some(result) = self
             .completed_child_terminal_from_storage(&storage, child_agent_id, child_turn_baseline)
             .await?
@@ -1810,10 +1807,7 @@ impl RuntimeHostBridge {
         {
             return Ok(None);
         }
-        let storage = AppStorage::new_for_agent(
-            host.agent_data_dir(child_agent_id),
-            child_agent_id.to_string(),
-        )?;
+        let storage = host.agent_storage(child_agent_id)?;
         let state = storage
             .read_agent()?
             .unwrap_or_else(|| AgentState::new(child_agent_id.to_string()));
@@ -2376,6 +2370,84 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(listed.contains(&"release-bot".to_string()));
         assert!(listed.contains(&host.config().default_agent_id));
+    }
+
+    #[tokio::test]
+    async fn unloaded_list_agent_entries_reads_agent_state_from_db_without_agent_json() {
+        let home = tempdir().unwrap();
+        write_test_model_config(home.path());
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        let identity = AgentIdentityRecord::new(
+            "release-bot",
+            AgentKind::Named,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        runtime_db.agent_identities().upsert(&identity).unwrap();
+        let mut state = AgentState::new("release-bot");
+        state.status = AgentStatus::Asleep;
+        runtime_db.agent_states().upsert(&state).unwrap();
+
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("ok"))).unwrap();
+        assert!(!host
+            .agent_data_dir("release-bot")
+            .join(".holon/state/agent.json")
+            .exists());
+
+        let entry = host
+            .list_agent_entries()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.identity.agent_id == "release-bot")
+            .expect("release-bot should be listed from DB-only state");
+        assert_eq!(entry.status, AgentStatus::Asleep);
+    }
+
+    #[tokio::test]
+    async fn external_ingress_stopped_gate_reads_agent_state_from_db_without_agent_json() {
+        let home = tempdir().unwrap();
+        write_test_model_config(home.path());
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        let identity = AgentIdentityRecord::new(
+            "release-bot",
+            AgentKind::Named,
+            AgentVisibility::Public,
+            AgentOwnership::SelfOwned,
+            AgentProfilePreset::PublicNamed,
+            None,
+            None,
+        );
+        runtime_db.agent_identities().upsert(&identity).unwrap();
+        let mut state = AgentState::new("release-bot");
+        state.status = AgentStatus::Stopped;
+        runtime_db.agent_states().upsert(&state).unwrap();
+
+        let host =
+            RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("ok"))).unwrap();
+        assert!(!host
+            .agent_data_dir("release-bot")
+            .join(".holon/state/agent.json")
+            .exists());
+
+        let error = match host
+            .get_public_agent_for_external_ingress("release-bot")
+            .await
+        {
+            Ok(_) => panic!("stopped DB agent state should reject external ingress"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, PublicAgentError::Stopped { .. }));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,7 +755,10 @@ async fn dump_prompt(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use holon::config::{provider_registry_for_tests, AltScreenMode, ModelRef};
+    use holon::{
+        config::{provider_registry_for_tests, AltScreenMode, ModelRef},
+        runtime_db::RuntimeDb,
+    };
 
     fn test_config() -> AppConfig {
         let home = tempfile::tempdir().unwrap().keep();
@@ -1113,8 +1116,8 @@ mod tests {
     fn export_scheduler_fixture_writes_replay_harness_shape() {
         let config = test_config();
         let agent_id = "default";
-        let agent_home = config.data_dir.join("agents/default");
-        let storage = AppStorage::new_for_agent(&agent_home, agent_id).unwrap();
+        let host = RuntimeHost::new(config.clone()).unwrap();
+        let storage = host.agent_storage(agent_id).unwrap();
         let mut agent = holon::types::AgentState::new("default");
         agent.current_work_item_id = Some("work-1".into());
         storage.write_agent(&agent).unwrap();
@@ -1144,6 +1147,25 @@ mod tests {
         assert!(output.path().join("ledger/messages.jsonl").exists());
         assert!(output.path().join("ledger/tools.jsonl").exists());
         assert!(output.path().join("ledger/transcript.jsonl").exists());
+    }
+
+    #[test]
+    fn export_scheduler_fixture_reads_agent_state_from_runtime_db() {
+        let config = test_config();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        let mut agent = holon::types::AgentState::new("default");
+        agent.current_work_item_id = Some("work-db".into());
+        runtime_db.agent_states().upsert(&agent).unwrap();
+
+        let output = tempfile::tempdir().unwrap();
+        export_scheduler_fixture(&config, None, output.path()).unwrap();
+
+        let agent_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(output.path().join("agent.json")).unwrap())
+                .unwrap();
+        assert_eq!(agent_json["current_work_item_id"].as_str(), Some("work-db"));
     }
 
     #[test]
@@ -1480,8 +1502,9 @@ fn export_scheduler_fixture(
     output: &Path,
 ) -> Result<()> {
     let agent_id = agent.unwrap_or_else(|| config.default_agent_id.clone());
+    let host = RuntimeHost::new(config.clone())?;
     let agent_home = config.data_dir.join("agents").join(&agent_id);
-    let storage = AppStorage::new_for_agent(&agent_home, agent_id.clone())?;
+    let storage = host.agent_storage(&agent_id)?;
     let agent = storage.read_agent()?.with_context(|| {
         format!(
             "agent state not found for {agent_id} in {}",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -344,8 +344,20 @@ struct BuiltinWebSearchSelection {
 #[derive(Debug)]
 struct RuntimeAgent {
     state: AgentState,
+    last_persisted_state: AgentState,
     queue: RuntimeQueue,
     current_run_abort: Option<CurrentRunAbortHandle>,
+}
+
+impl RuntimeAgent {
+    fn persist_state(&mut self, storage: &AppStorage) -> Result<()> {
+        if let Err(error) = storage.write_agent(&self.state) {
+            self.state = self.last_persisted_state.clone();
+            return Err(error);
+        }
+        self.last_persisted_state = self.state.clone();
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -422,6 +434,16 @@ impl CurrentRunAbortSnapshot {
 }
 
 impl RuntimeHandle {
+    pub(crate) async fn update_agent_state<F>(&self, mutate: F) -> Result<AgentState>
+    where
+        F: FnOnce(&mut AgentState) -> Result<()>,
+    {
+        let mut guard = self.inner.agent.lock().await;
+        mutate(&mut guard.state)?;
+        guard.persist_state(&self.inner.storage)?;
+        Ok(guard.state.clone())
+    }
+
     fn build_execution_root_id(
         workspace_id: &str,
         projection_kind: WorkspaceProjectionKind,
@@ -466,7 +488,7 @@ impl RuntimeHandle {
         }
         handle.token.cancel();
         scheduler::apply_stop_projection(&mut guard.state);
-        self.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.inner.storage)?;
         drop(guard);
 
         self.inner.storage.append_event(&AuditEvent::new(
@@ -591,9 +613,11 @@ impl RuntimeHandle {
         if self.inner.provider_reconfig.is_some() {
             self.reconfigure_provider_for_state(&next_state).await?;
         }
-        let mut guard = self.inner.agent.lock().await;
-        guard.state = next_state;
-        self.inner.storage.write_agent(&guard.state)?;
+        self.update_agent_state(|state| {
+            *state = next_state;
+            Ok(())
+        })
+        .await?;
         Ok(())
     }
 
@@ -614,9 +638,11 @@ impl RuntimeHandle {
         if self.inner.provider_reconfig.is_some() {
             self.reconfigure_provider_for_state(&next_state).await?;
         }
-        let mut guard = self.inner.agent.lock().await;
-        guard.state = next_state;
-        self.inner.storage.write_agent(&guard.state)?;
+        self.update_agent_state(|state| {
+            *state = next_state;
+            Ok(())
+        })
+        .await?;
         Ok(())
     }
 
@@ -783,7 +809,7 @@ impl RuntimeHandle {
             guard.state.active_skills.retain(|skill| {
                 matches!(skill.activation_state, SkillActivationState::SessionActive)
             });
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             guard.state.clone()
         };
         self.append_state_changed_events(&state)?;
@@ -845,7 +871,7 @@ impl RuntimeHandle {
                 skill.activation_state = SkillActivationState::SessionActive;
             }
         }
-        self.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.inner.storage)?;
         Ok(())
     }
 
@@ -936,7 +962,7 @@ impl RuntimeHandle {
                 });
             false
         };
-        self.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.inner.storage)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "skill_activated",
             serde_json::json!({
@@ -1001,7 +1027,7 @@ impl RuntimeHandle {
             guard.state.pending = guard.queue.len();
             guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
             guard.state.total_message_count = self.inner.storage.count_messages()?;
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         scheduler_executor::SchedulerDecisionExecutor::new(self)
             .admit_message_wake(&message)
@@ -1211,7 +1237,7 @@ impl RuntimeHandle {
                         scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
                     }
                     guard.current_run_abort = None;
-                    self.inner.storage.write_agent(&guard.state)?;
+                    guard.persist_state(&self.inner.storage)?;
                     guard.state.clone()
                 };
                 self.append_state_changed_events(&failed_state)?;

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -205,6 +205,7 @@ impl RuntimeHandle {
         Ok(Self {
             inner: Arc::new(RuntimeInner {
                 agent: Mutex::new(RuntimeAgent {
+                    last_persisted_state: state.clone(),
                     state,
                     queue,
                     current_run_abort: None,
@@ -550,7 +551,7 @@ fn prepare_runtime_storage(
         }
     }
 
-    let recovered_agent_for_import = storage.read_agent()?;
+    let recovered_agent_for_import = storage.read_legacy_agent_for_import()?;
     if !storage_domain_complete(&runtime_db, "agent_states")? {
         runtime_db
             .agent_states()

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -91,7 +91,7 @@ impl RuntimeHandle {
         ))?;
         let mut guard = self.inner.agent.lock().await;
         guard.state.last_brief_at = Some(bound_brief.created_at);
-        self.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.inner.storage)?;
         Ok(())
     }
 }

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -326,7 +326,7 @@ impl RuntimeHandle {
                 detail_hint: Some("run `holon daemon logs` for details".into()),
                 failure_artifact: Some(failure_artifact),
             });
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         Ok(())
     }

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -59,7 +59,7 @@ impl RuntimeHandle {
                 return Ok(None);
             }
             let work_item_id = guard.state.current_turn_work_item_id.take();
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             (turn_index, work_item_id)
         };
 
@@ -229,7 +229,7 @@ impl RuntimeHandle {
                     == Some(occupancy_id);
                 if should_clear {
                     guard.state.active_workspace_entry = None;
-                    self.inner.storage.write_agent(&guard.state)?;
+                    guard.persist_state(&self.inner.storage)?;
                 }
             }
         }
@@ -642,7 +642,7 @@ impl RuntimeHandle {
             guard.state.model_override = Some(model_override);
             guard.state.model_override_reasoning_effort = reasoning_effort;
             guard.state.pending_fallback_model = None;
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         self.append_audit_event(
             if turn_in_progress {
@@ -675,7 +675,7 @@ impl RuntimeHandle {
             guard.state.model_override = None;
             guard.state.model_override_reasoning_effort = None;
             guard.state.pending_fallback_model = None;
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         self.append_audit_event(
             if turn_in_progress {
@@ -706,7 +706,7 @@ impl RuntimeHandle {
                 .push(workspace.workspace_id.clone());
         }
         self.inner.storage.append_workspace_entry(workspace)?;
-        self.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.inner.storage)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "workspace_attached",
             serde_json::json!({
@@ -769,7 +769,7 @@ impl RuntimeHandle {
                     guard.state.id
                 ));
             }
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             guard.state.id.clone()
         };
 
@@ -923,7 +923,7 @@ impl RuntimeHandle {
             }
             guard.state.active_workspace_entry = Some(entry);
             guard.state.worktree_session = None;
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             self.inner.storage.mark_memory_index_dirty()?;
         }
         if let Some(occupancy_id) = previous_occupancy_id.as_deref() {
@@ -1052,7 +1052,7 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             guard.state.active_workspace_entry = Some(entry.clone());
             guard.state.worktree_session = worktree_session;
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             self.inner.storage.mark_memory_index_dirty()?;
             Ok(())
         }
@@ -1184,7 +1184,7 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             guard.state.active_workspace_entry = Some(entry.clone());
             guard.state.worktree_session = None;
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             self.inner.storage.mark_memory_index_dirty()?;
             Ok(())
         }

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -59,7 +59,7 @@ impl RuntimeHandle {
     ) -> Result<()> {
         let mut guard = self.inner.agent.lock().await;
         guard.state.last_continuation = Some(continuation_resolution.clone());
-        self.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.inner.storage)?;
         Ok(())
     }
 
@@ -250,7 +250,7 @@ impl RuntimeHandle {
                     let mut guard = self.inner.agent.lock().await;
                     if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
                         guard.state.pending_wake_hint = None;
-                        self.inner.storage.write_agent(&guard.state)?;
+                        guard.persist_state(&self.inner.storage)?;
                     }
                     return Ok(false);
                 }
@@ -265,7 +265,7 @@ impl RuntimeHandle {
                 let mut guard = self.inner.agent.lock().await;
                 if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
                     guard.state.pending_wake_hint = None;
-                    self.inner.storage.write_agent(&guard.state)?;
+                    guard.persist_state(&self.inner.storage)?;
                 }
                 Ok(true)
             }
@@ -933,11 +933,8 @@ mod tests {
         persist_test_work_item(test_runtime, &record, true);
         let mut guard = test_runtime.runtime.inner.agent.blocking_lock();
         guard.state.current_work_item_id = Some(record.id.clone());
-        test_runtime
-            .runtime
-            .inner
-            .storage
-            .write_agent(&guard.state)
+        guard
+            .persist_state(&test_runtime.runtime.inner.storage)
             .unwrap();
         record
     }

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -106,7 +106,7 @@ impl RuntimeHandle {
                     if let Some(work_item_id) = message.work_item_id.as_deref() {
                         let mut guard = self.inner.agent.lock().await;
                         guard.state.current_turn_work_item_id = Some(work_item_id.to_string());
-                        self.inner.storage.write_agent(&guard.state)?;
+                        guard.persist_state(&self.inner.storage)?;
                     }
                     self.process_interactive_message(
                         &message,
@@ -159,7 +159,7 @@ impl RuntimeHandle {
                 scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
             }
             if status_mutable || matches!(message.kind, MessageKind::TaskResult) {
-                self.inner.storage.write_agent(&guard.state)?;
+                guard.persist_state(&self.inner.storage)?;
             }
         }
 
@@ -192,7 +192,7 @@ impl RuntimeHandle {
                 &memory_refresh.current_snapshot,
             )?;
             if work_refs_changed || memory_refresh.working_memory_updated || episode_changed {
-                self.inner.storage.write_agent(&guard.state)?;
+                guard.persist_state(&self.inner.storage)?;
             }
         }
         self.inner.storage.append_event(&AuditEvent::new(

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -37,7 +37,7 @@ impl RuntimeHandle {
             let agent_changed =
                 maybe_compact_agent(&self.inner.storage, &mut guard.state, &context_config)?;
             if agent_changed {
-                self.inner.storage.write_agent(&guard.state)?;
+                guard.persist_state(&self.inner.storage)?;
             }
             let state = guard.state.clone();
             drop(guard);

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -140,7 +140,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 format!("occupancy_to_release={occupancy_to_release:?}"),
             ],
         )?;
-        self.runtime.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.runtime.inner.storage)?;
 
         Ok(ControlPostureOutcome {
             requested_action,
@@ -178,7 +178,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         }
 
         if should_write {
-            self.runtime.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.runtime.inner.storage)?;
         }
 
         Ok(ShutdownPostureOutcome {
@@ -194,7 +194,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             queued_messages: guard.queue.len(),
         };
         if apply_bootstrap_recovered_projection(&mut guard.state, facts) {
-            self.runtime.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.runtime.inner.storage)?;
         }
         Ok(guard.state.clone())
     }
@@ -218,7 +218,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 format!("sleeping_until={:?}", guard.state.sleeping_until),
             ],
         )?;
-        self.runtime.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.runtime.inner.storage)?;
         Ok(guard.state.clone())
     }
 
@@ -253,7 +253,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 format!("sleeping_until={:?}", guard.state.sleeping_until),
             ],
         )?;
-        self.runtime.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.runtime.inner.storage)?;
         Ok(Some(guard.state.clone()))
     }
 
@@ -278,7 +278,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 format!("previous_sleeping_until={previous_sleeping_until:?}"),
             ],
         )?;
-        self.runtime.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.runtime.inner.storage)?;
         Ok(Some(guard.state.clone()))
     }
 
@@ -309,7 +309,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
         mut guard: tokio::sync::MutexGuard<'_, RuntimeAgent>,
     ) -> Result<RunLoopPoll> {
         guard.state.current_run_id = None;
-        self.runtime.inner.storage.write_agent(&guard.state)?;
+        guard.persist_state(&self.runtime.inner.storage)?;
         Ok(RunLoopPoll::Shutdown)
     }
 
@@ -375,7 +375,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             if !claimed {
                 let _ = guard.queue.pop_if_next(&candidate.message.id);
                 guard.state.pending = guard.queue.len();
-                self.runtime.inner.storage.write_agent(&guard.state)?;
+                guard.persist_state(&self.runtime.inner.storage)?;
                 return Ok(RunLoopPoll::Idle);
             }
             let message = guard
@@ -392,7 +392,7 @@ impl<'a> SchedulerDecisionExecutor<'a> {
                 reason: Arc::new(StdMutex::new("operator_aborted".into())),
             });
             guard.state.last_wake_reason = Some(format!("{:?}", message.kind));
-            self.runtime.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.runtime.inner.storage)?;
             (message, guard.state.clone())
         };
 

--- a/src/runtime/subagent.rs
+++ b/src/runtime/subagent.rs
@@ -302,7 +302,7 @@ impl RuntimeHandle {
                 response.input_tokens,
                 response.output_tokens,
             ));
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
 
         self.persist_transcript_evidence(&TranscriptEntry {

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -58,7 +58,7 @@ impl RuntimeHandle {
                     scheduler::apply_idle_projection(&mut guard.state, &self.inner.storage)?;
                 }
             }
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         self.inner
             .storage
@@ -127,7 +127,7 @@ impl RuntimeHandle {
             {
                 let mut guard = self.inner.agent.lock().await;
                 guard.state.current_turn_work_item_id = Some(work_item_id);
-                self.inner.storage.write_agent(&guard.state)?;
+                guard.persist_state(&self.inner.storage)?;
             }
             self.process_interactive_message(
                 message,
@@ -361,7 +361,7 @@ mod tests {
             let mut guard = runtime.inner.agent.lock().await;
             guard.state.status = AgentStatus::AwakeRunning;
             guard.state.current_run_id = Some("run-1".into());
-            runtime.inner.storage.write_agent(&guard.state).unwrap();
+            guard.persist_state(&runtime.inner.storage).unwrap();
         }
 
         runtime

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2348,7 +2348,7 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             guard.state.current_work_item_id = Some(record.id.clone());
             guard.state.current_turn_work_item_id = Some(record.id.clone());
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         self.inner
             .runtime_db
@@ -2833,7 +2833,7 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             guard.state.current_work_item_id = Some(suspended.id.clone());
             guard.state.current_turn_work_item_id = Some(suspended.id.clone());
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         self.inner
             .runtime_db
@@ -2904,7 +2904,7 @@ impl RuntimeHandle {
             if release_turn {
                 guard.state.current_turn_work_item_id = None;
             }
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             release_current || release_turn
         };
         if released {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -110,6 +110,41 @@ impl AgentProvider for OperatorInterjectionProbeProvider {
 }
 
 #[tokio::test]
+async fn update_agent_state_rolls_back_memory_when_persist_fails() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let original = runtime.agent_state().await.unwrap();
+    assert_eq!(original.status, AgentStatus::AwakeIdle);
+
+    let error = runtime
+        .update_agent_state(|state| {
+            state.id = "other-agent".into();
+            state.status = AgentStatus::Stopped;
+            Ok(())
+        })
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("cannot write agent state for `other-agent`"));
+
+    let restored = runtime.agent_state().await.unwrap();
+    assert_eq!(restored.id, "default");
+    assert_eq!(restored.status, AgentStatus::AwakeIdle);
+}
+
+#[tokio::test]
 async fn non_model_reentry_external_events_do_not_run_interactive_turn() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -125,7 +125,6 @@ async fn update_agent_state_rolls_back_memory_when_persist_fails() {
     .unwrap();
 
     let original = runtime.agent_state().await.unwrap();
-    assert_eq!(original.status, AgentStatus::AwakeIdle);
 
     let error = runtime
         .update_agent_state(|state| {
@@ -140,8 +139,8 @@ async fn update_agent_state_rolls_back_memory_when_persist_fails() {
         .contains("cannot write agent state for `other-agent`"));
 
     let restored = runtime.agent_state().await.unwrap();
-    assert_eq!(restored.id, "default");
-    assert_eq!(restored.status, AgentStatus::AwakeIdle);
+    assert_eq!(restored.id, original.id);
+    assert_eq!(restored.status, original.status);
 }
 
 #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1529,7 +1529,7 @@ impl RuntimeHandle {
                 duration_ms,
             };
             guard.state.last_turn_terminal = Some(record.clone());
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             record
         };
         self.inner.storage.append_event(&AuditEvent::new(
@@ -1657,7 +1657,7 @@ impl RuntimeHandle {
         {
             let mut guard = self.inner.agent.lock().await;
             guard.state.pending_fallback_model = Some(fallback_model.clone());
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
         let error_text = error.to_string();
         let provider_failure_text = provider_lineage_failure_text(&error_text);
@@ -1782,7 +1782,7 @@ impl RuntimeHandle {
                 duration_ms,
             };
             guard.state.last_turn_terminal = Some(record.clone());
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             record
         };
         self.persist_turn_record(&record).await?;
@@ -1882,7 +1882,7 @@ impl RuntimeHandle {
                 messages.push(message);
             }
             if !messages.is_empty() {
-                if let Err(err) = self.inner.storage.write_agent(&guard.state) {
+                if let Err(err) = guard.persist_state(&self.inner.storage) {
                     for message in messages.iter().rev().cloned() {
                         guard.queue.push_front(message);
                     }
@@ -1931,7 +1931,7 @@ impl RuntimeHandle {
                         guard.queue.push_front(message);
                     }
                     guard.state.pending = guard.queue.len();
-                    let _ = self.inner.storage.write_agent(&guard.state);
+                    let _ = guard.persist_state(&self.inner.storage);
                     return Err(err);
                 }
             }
@@ -2198,7 +2198,7 @@ impl TurnExecution<'_> {
                             let mut guard = runtime.inner.agent.lock().await;
                             if guard.state.pending_fallback_model.is_some() {
                                 guard.state.pending_fallback_model = None;
-                                runtime.inner.storage.write_agent(&guard.state)?;
+                                guard.persist_state(&runtime.inner.storage)?;
                             }
                         }
                         runtime
@@ -2456,7 +2456,7 @@ impl TurnExecution<'_> {
                             let mut guard = runtime.inner.agent.lock().await;
                             if guard.state.pending_fallback_model.is_some() {
                                 guard.state.pending_fallback_model = None;
-                                runtime.inner.storage.write_agent(&guard.state)?;
+                                guard.persist_state(&runtime.inner.storage)?;
                             }
                         }
                         runtime
@@ -2488,7 +2488,7 @@ impl TurnExecution<'_> {
                 guard.state.last_requested_model = model_attempt_state.requested_model.clone();
                 guard.state.last_active_model = model_attempt_state.active_model.clone();
                 guard.state.pending_fallback_model = None;
-                runtime.inner.storage.write_agent(&guard.state)?;
+                guard.persist_state(&runtime.inner.storage)?;
                 (
                     guard.state.turn_index,
                     guard.state.current_run_id.clone(),

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -463,19 +463,19 @@ impl RuntimeHandle {
                 AgentStatus::Stopped => WakeDisposition::Ignored,
                 AgentStatus::AwakeRunning | AgentStatus::AwaitingTask => {
                     guard.state.pending_wake_hint = Some(pending.clone());
-                    self.inner.storage.write_agent(&guard.state)?;
+                    guard.persist_state(&self.inner.storage)?;
                     WakeDisposition::Coalesced
                 }
                 AgentStatus::Booting | AgentStatus::AwakeIdle | AgentStatus::Asleep => {
                     if guard.queue.is_empty() {
                         if guard.state.pending_wake_hint.take().is_some() {
-                            self.inner.storage.write_agent(&guard.state)?;
+                            guard.persist_state(&self.inner.storage)?;
                         }
                         trigger_now = true;
                         WakeDisposition::Triggered
                     } else {
                         guard.state.pending_wake_hint = Some(pending.clone());
-                        self.inner.storage.write_agent(&guard.state)?;
+                        guard.persist_state(&self.inner.storage)?;
                         WakeDisposition::Coalesced
                     }
                 }
@@ -514,7 +514,7 @@ impl RuntimeHandle {
                 let mut guard = self.inner.agent.lock().await;
                 if guard.state.pending_wake_hint.is_none() {
                     guard.state.pending_wake_hint = Some(pending);
-                    self.inner.storage.write_agent(&guard.state)?;
+                    guard.persist_state(&self.inner.storage)?;
                 }
                 return Err(err);
             }
@@ -534,7 +534,7 @@ impl RuntimeHandle {
             let mut guard = self.inner.agent.lock().await;
             if guard.state.pending_wake_hint.as_ref() == Some(&pending) {
                 guard.state.pending_wake_hint = None;
-                self.inner.storage.write_agent(&guard.state)?;
+                guard.persist_state(&self.inner.storage)?;
             }
         }
         Ok(())

--- a/src/runtime/worktree.rs
+++ b/src/runtime/worktree.rs
@@ -211,7 +211,7 @@ impl RuntimeHandle {
                 })),
             });
             guard.state.worktree_session = Some(worktree_session.clone());
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
         }
 
         let boundary = crate::system::HostLocalBoundary::from_parts(
@@ -330,7 +330,7 @@ impl RuntimeHandle {
                     projection_metadata: None,
                 });
             }
-            self.inner.storage.write_agent(&guard.state)?;
+            guard.persist_state(&self.inner.storage)?;
             (session, occupancy_id)
         };
         if let Some(occupancy_id) = occupancy_id.as_deref() {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -367,7 +367,6 @@ impl AppStorage {
     }
 
     pub(crate) fn enable_scheduler_control_plane_db(&self, runtime_db: RuntimeDb) -> Result<()> {
-        self.ensure_writable()?;
         let agent_id = self.current_agent_id()?;
         {
             let mut counter = self
@@ -924,6 +923,7 @@ impl AppStorage {
         }
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             runtime_db.agent_states().upsert(agent)?;
+            return Ok(());
         }
         let content = serde_json::to_vec_pretty(agent)?;
         let tmp_path = self
@@ -943,11 +943,14 @@ impl AppStorage {
     pub fn read_agent(&self) -> Result<Option<AgentState>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             if let Some(agent_id) = self.current_agent_id()? {
-                if let Some(agent) = runtime_db.agent_states().latest(&agent_id)? {
-                    return Ok(Some(agent));
-                }
+                return runtime_db.agent_states().latest(&agent_id);
             }
+            return Ok(None);
         }
+        self.read_agent_file()
+    }
+
+    pub(crate) fn read_legacy_agent_for_import(&self) -> Result<Option<AgentState>> {
         self.read_agent_file()
     }
 
@@ -4402,10 +4405,11 @@ mod tests {
     }
 
     #[test]
-    fn write_agent_with_runtime_db_keeps_legacy_agent_json_export_current() {
+    fn write_agent_with_runtime_db_writes_db_only() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
+        let legacy_before = fs::read_to_string(dir.path().join(".holon/state/agent.json")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -4424,10 +4428,33 @@ mod tests {
         agent.turn_index = 7;
         storage.write_agent(&agent).unwrap();
 
-        let reopened_without_db = AppStorage::new(dir.path()).unwrap();
-        let restored = reopened_without_db.read_agent().unwrap().unwrap();
+        let restored = storage.read_agent().unwrap().unwrap();
         assert_eq!(restored.status, AgentStatus::Stopped);
         assert_eq!(restored.turn_index, 7);
+        assert_eq!(
+            fs::read_to_string(dir.path().join(".holon/state/agent.json")).unwrap(),
+            legacy_before
+        );
+    }
+
+    #[test]
+    fn read_agent_with_runtime_db_does_not_fallback_to_legacy_agent_json() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let mut legacy_agent = AgentState::new("default");
+        legacy_agent.status = AgentStatus::Stopped;
+        storage.write_agent(&legacy_agent).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        runtime_db.agent_states().import_legacy(None).unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db)
+            .unwrap();
+
+        assert_eq!(storage.read_agent().unwrap(), None);
     }
 
     #[test]
@@ -4466,7 +4493,7 @@ mod tests {
         )
         .unwrap();
 
-        let restored = storage.read_agent().unwrap().unwrap();
+        let restored = storage.read_legacy_agent_for_import().unwrap().unwrap();
         assert_eq!(restored.status, AgentStatus::Stopped);
     }
 

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -9,7 +9,6 @@ use holon::{
         AgentProvider, ModelBlock, ProviderTurnRequest, ProviderTurnResponse, StubProvider,
     },
     run_once::{run_once_with_host, RunFinalStatus, RunOnceRequest},
-    storage::AppStorage,
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{AuthorityClass, ControlAction, FailureArtifactCategory, TaskStatus, TokenUsage},
 };
@@ -1290,7 +1289,7 @@ async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
     )?;
 
     let first = run_once_with_host(
-        first_host,
+        first_host.clone(),
         RunOnceRequest {
             agent_id: Some("bench-15".into()),
             create_agent: true,
@@ -1300,9 +1299,11 @@ async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
     .await?;
     assert_eq!(first.agent_id, "bench-15");
 
-    let first_state = AppStorage::new(home_dir.join("agents").join("bench-15"))?
-        .read_agent()?
-        .expect("expected persistent agent state after first run");
+    let first_state = first_host
+        .get_public_agent("bench-15")
+        .await?
+        .agent_state()
+        .await?;
     assert!(first_state.total_message_count > 0);
 
     let second_host =
@@ -1316,7 +1317,7 @@ async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
     assert!(listed_agents.iter().any(|id| id == "bench-15"));
 
     let second = run_once_with_host(
-        second_host,
+        second_host.clone(),
         RunOnceRequest {
             agent_id: Some("bench-15".into()),
             ..run_request("second turn")
@@ -1325,9 +1326,11 @@ async fn run_once_can_target_a_persistent_named_agent_session() -> Result<()> {
     .await?;
     assert_eq!(second.agent_id, "bench-15");
 
-    let second_state = AppStorage::new(home_dir.join("agents").join("bench-15"))?
-        .read_agent()?
-        .expect("expected persistent agent state after second run");
+    let second_state = second_host
+        .get_public_agent("bench-15")
+        .await?
+        .agent_state()
+        .await?;
     assert!(second_state.total_message_count > first_state.total_message_count);
     assert!(home_dir.join("agents").join("bench-15").exists());
     Ok(())
@@ -1390,7 +1393,7 @@ async fn run_once_preserves_existing_workspace_binding_for_persistent_agents() -
         .expect("expected active workspace entry");
 
     let response = run_once_with_host(
-        host,
+        host.clone(),
         RunOnceRequest {
             agent_id: Some("bench-15".into()),
             ..run_request("continue inside existing workspace")
@@ -1399,9 +1402,11 @@ async fn run_once_preserves_existing_workspace_binding_for_persistent_agents() -
     .await?;
     assert_eq!(response.agent_id, "bench-15");
 
-    let resumed_state = AppStorage::new(home_dir.join("agents").join("bench-15"))?
-        .read_agent()?
-        .expect("expected resumed persistent agent state");
+    let resumed_state = host
+        .get_public_agent("bench-15")
+        .await?
+        .agent_state()
+        .await?;
     let resumed_entry = resumed_state
         .active_workspace_entry
         .clone()


### PR DESCRIPTION
## Summary

Fixes #1723.

- stop treating `.holon/state/agent.json` as a runtime agent-state source once the runtime DB is enabled
- keep legacy `agent.json` reads explicit and migration-only
- bind host unloaded/storage read paths to the shared `RuntimeDb`
- centralize runtime `AgentState` persistence through a helper that rolls memory back on DB write failure

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test unloaded_list_agent_entries_reads_agent_state_from_db_without_agent_json -- --nocapture`
- `cargo test external_ingress_stopped_gate_reads_agent_state_from_db_without_agent_json -- --nocapture`
- `cargo test update_agent_state_rolls_back_memory_when_persist_fails -- --nocapture`
- `cargo test write_agent_with_runtime_db_writes_db_only -- --nocapture`
- `cargo test read_agent_with_runtime_db_does_not_fallback_to_legacy_agent_json -- --nocapture`
- `cargo test read_agent_maps_legacy_paused_status_to_stopped -- --nocapture`
