### PR TITLE
feat: make codex final responses concise

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -951,6 +951,9 @@ impl RuntimeModelCatalog {
                     .or_else(|| base.and_then(|model| model.default_max_output_tokens)),
                 max_output_tokens_upper_limit: base
                     .and_then(|model| model.max_output_tokens_upper_limit),
+                default_verbosity: override_config
+                    .verbosity
+                    .or_else(|| base.and_then(|model| model.default_verbosity)),
                 tool_output_truncation_estimated_tokens: override_config
                     .tool_output_truncation_estimated_tokens
                     .or_else(|| {
@@ -6816,6 +6819,7 @@ mod tests {
                     auto_compact_token_limit: None,
                     default_max_output_tokens: Some(7_777),
                     max_output_tokens_upper_limit: Some(7_777),
+                    default_verbosity: None,
                     tool_output_truncation_estimated_tokens: None,
                     capabilities: Default::default(),
                     source: ModelMetadataSource::RemoteDiscovered,

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -90,6 +90,8 @@ pub struct BuiltInModelMetadata {
     #[serde(default)]
     pub max_output_tokens_upper_limit: Option<u32>,
     #[serde(default)]
+    pub default_verbosity: Option<ModelVerbosity>,
+    #[serde(default)]
     pub tool_output_truncation_estimated_tokens: Option<usize>,
     #[serde(default)]
     pub capabilities: ModelCapabilityFlags,
@@ -117,6 +119,8 @@ pub struct ModelRuntimeOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_max_output_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<ModelVerbosity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_output_truncation_estimated_tokens: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<ModelCapabilityOverride>,
@@ -133,12 +137,31 @@ impl ModelRuntimeOverride {
             && self.compaction_trigger_estimated_tokens.is_none()
             && self.compaction_keep_recent_estimated_tokens.is_none()
             && self.runtime_max_output_tokens.is_none()
+            && self.verbosity.is_none()
             && self.tool_output_truncation_estimated_tokens.is_none()
             && self
                 .capabilities
                 .as_ref()
                 .map(ModelCapabilityOverride::is_empty)
                 .unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelVerbosity {
+    Low,
+    Medium,
+    High,
+}
+
+impl ModelVerbosity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
     }
 }
 
@@ -154,6 +177,8 @@ pub struct ResolvedRuntimeModelPolicy {
     pub compaction_trigger_estimated_tokens: usize,
     pub compaction_keep_recent_estimated_tokens: usize,
     pub runtime_max_output_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<ModelVerbosity>,
     pub tool_output_truncation_estimated_tokens: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_output_tokens_upper_limit: Option<u32>,
@@ -174,6 +199,7 @@ impl Default for ResolvedRuntimeModelPolicy {
             compaction_trigger_estimated_tokens: 2048,
             compaction_keep_recent_estimated_tokens: 768,
             runtime_max_output_tokens: 8192,
+            verbosity: None,
             tool_output_truncation_estimated_tokens:
                 DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS,
             max_output_tokens_upper_limit: None,
@@ -316,6 +342,11 @@ impl BuiltInModelCatalog {
             .or_else(|| built_in.and_then(|entry| entry.default_max_output_tokens))
             .or_else(|| fallback_override.and_then(|value| value.runtime_max_output_tokens))
             .unwrap_or(configured_runtime_max_output_tokens);
+        let verbosity = override_config
+            .and_then(|value| value.verbosity)
+            .or_else(|| built_in.and_then(|entry| entry.default_verbosity))
+            .or_else(|| fallback_override.and_then(|value| value.verbosity))
+            .or_else(|| default_verbosity_for_model(model_ref));
         let tool_output_truncation_estimated_tokens = override_config
             .and_then(|value| value.tool_output_truncation_estimated_tokens)
             .or_else(|| built_in.and_then(|entry| entry.tool_output_truncation_estimated_tokens))
@@ -349,6 +380,7 @@ impl BuiltInModelCatalog {
             compaction_trigger_estimated_tokens,
             compaction_keep_recent_estimated_tokens,
             runtime_max_output_tokens,
+            verbosity,
             tool_output_truncation_estimated_tokens,
             max_output_tokens_upper_limit,
             capabilities,
@@ -422,8 +454,10 @@ fn catalog_model(
     reasoning_summaries: bool,
     image_input: bool,
 ) -> BuiltInModelMetadata {
+    let model_ref = ModelRef::new(provider_id(provider), model);
     BuiltInModelMetadata {
-        model_ref: ModelRef::new(provider_id(provider), model),
+        default_verbosity: default_verbosity_for_model(&model_ref),
+        model_ref,
         display_name: display_name.into(),
         description: format!(
             "Holon built-in runtime metadata for the {provider}/{model} compatible provider model."
@@ -483,6 +517,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: Some(180_000),
             default_max_output_tokens: Some(32_000),
             max_output_tokens_upper_limit: Some(128_000),
+            default_verbosity: None,
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -499,6 +534,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: Some(180_000),
             default_max_output_tokens: Some(32_000),
             max_output_tokens_upper_limit: Some(64_000),
+            default_verbosity: None,
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -515,6 +551,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: None,
             default_max_output_tokens: None,
             max_output_tokens_upper_limit: None,
+            default_verbosity: Some(ModelVerbosity::Low),
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -533,6 +570,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: None,
             default_max_output_tokens: None,
             max_output_tokens_upper_limit: None,
+            default_verbosity: Some(ModelVerbosity::Low),
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -551,6 +589,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: None,
             default_max_output_tokens: None,
             max_output_tokens_upper_limit: None,
+            default_verbosity: Some(ModelVerbosity::Low),
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -569,6 +608,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: None,
             default_max_output_tokens: None,
             max_output_tokens_upper_limit: None,
+            default_verbosity: None,
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -586,6 +626,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: None,
             default_max_output_tokens: None,
             max_output_tokens_upper_limit: None,
+            default_verbosity: None,
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -603,6 +644,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             auto_compact_token_limit: None,
             default_max_output_tokens: None,
             max_output_tokens_upper_limit: None,
+            default_verbosity: None,
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
@@ -614,6 +656,10 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
     ];
     entries.extend(compatible_provider_model_entries());
     entries
+}
+
+fn default_verbosity_for_model(model_ref: &ModelRef) -> Option<ModelVerbosity> {
+    (model_ref.provider == ProviderId::openai_codex()).then_some(ModelVerbosity::Low)
 }
 
 fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -227,6 +227,7 @@ impl OpenRouterModel {
             auto_compact_token_limit: None,
             default_max_output_tokens: None,
             max_output_tokens_upper_limit,
+            default_verbosity: None,
             tool_output_truncation_estimated_tokens: None,
             capabilities: ModelCapabilityFlags {
                 image_input,

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -639,7 +639,7 @@ fn build_system_sections(
         section(
             "reporting_contract",
             PromptStability::Stable,
-            "Prefer durable action over narration. Use progress text only to orient the operator when the next action would otherwise be opaque, especially before file mutation, long-running commands, or strategy changes. Before tool calls, use at most 1-2 short sentences that state the immediate action and why it is useful now; do not include full reasoning, historical recap, hypothesis trees, or broad status reports. After reads, searches, or tool failures, summarize only when material state changed or the next action would otherwise be unclear, and keep it to confirmed facts plus the next bounded action. Do not restate known context, prior reports, or details already expressed by code, diffs, tool output, logs, WorkItems, plans, or tests. Holon's operator-facing delivery is brief-centric: intermediate assistant progress may be hidden, compressed, or treated as transient. Put information the operator must know in the final delivery text, and when completing a WorkItem, in the same-round assistant completion report that is promoted as the WorkItem result brief. Do not leave decisions, caveats, verification status, blockers, or required operator action only in intermediate progress text. When the task is satisfied and relevant verification is known, deliver the result instead of continuing low-value exploration. Final delivery should be concise and user-facing: lead with the outcome, mention changed behavior or relevant files, root cause or rationale when useful, and verification status including skipped or failed checks. Match structure to task complexity; avoid fixed templates, boilerplate, complete process replay, and weak endings such as only saying done.".to_string(),
+            "Prefer durable action over narration. Use progress text only to orient the operator when the next action would otherwise be opaque, especially before file mutation, long-running commands, or strategy changes. Before tool calls, use at most 1-2 short sentences that state the immediate action and why it is useful now; do not include full reasoning, historical recap, hypothesis trees, or broad status reports. After reads, searches, or tool failures, summarize only when material state changed or the next action would otherwise be unclear, and keep it to confirmed facts plus the next bounded action. Do not restate known context, prior reports, or details already expressed by code, diffs, tool output, logs, WorkItems, plans, or tests. Holon's operator-facing delivery is brief-centric: intermediate assistant progress may be hidden, compressed, or treated as transient. Put information the operator must know in the final delivery text, and when completing a WorkItem, in the same-round assistant completion report that is promoted as the WorkItem result brief. Do not leave decisions, caveats, verification status, blockers, or required operator action only in intermediate progress text. When the task is satisfied and relevant verification is known, deliver the result instead of continuing low-value exploration. Final delivery should be concise and user-facing. Lead with the most important conclusion, outcome, or summary. Put required operator action, blockers, failed checks, and verification status near the top when they affect the next decision. Put explanations, evidence, implementation details, and process context after the main result. Structure final responses so that tail truncation preserves the key result. For simple answers, use 1-3 sentences. For small code or config changes, use 2-5 sentences or up to 3 bullets. For medium changes, use up to 6 bullets. Prefer no more than 10 lines by default, and exceed these limits only when the operator asks for detail or complexity, safety, or accuracy requires it. Mention changed behavior or relevant files only when useful. Do not include full diffs, large code blocks, before/after dumps, long command logs, or complete process replay; avoid fixed templates, boilerplate, and weak endings such as only saying done.".to_string(),
         ),
         section(
             "exploration_discipline",
@@ -1761,16 +1761,14 @@ mod tests {
             .find(|section| section.name == "reporting_contract")
             .expect("reporting contract section");
 
-        assert!(section.content.contains("lead with the outcome"));
         assert!(section
             .content
-            .contains("verification status including skipped or failed checks"));
+            .contains("Lead with the most important conclusion"));
+        assert!(section.content.contains("verification status near the top"));
         assert!(section
             .content
-            .contains("Match structure to task complexity"));
-        assert!(section
-            .content
-            .contains("avoid fixed templates, boilerplate, complete process replay"));
+            .contains("tail truncation preserves the key result"));
+        assert!(section.content.contains("fixed templates, boilerplate"));
         assert!(!section
             .content
             .contains("what changed / why / verification"));

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -86,6 +86,7 @@ pub(crate) fn build_candidate(
                 config.runtime_max_output_tokens,
                 &config.home_dir,
                 openai_compaction_policy,
+                resolved_policy.verbosity,
             )?,
         ),
         ProviderTransportKind::OpenAiResponses => {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -286,6 +286,8 @@ pub struct ProviderIncrementalContinuationDiagnostics {
 pub struct ProviderOpenAiRequestControlsDiagnostics {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<String>,
     pub reasoning_sent: bool,
     pub include_reasoning_encrypted_content: bool,
     pub max_output_tokens_sent: bool,

--- a/src/provider/tests/tool_schema.rs
+++ b/src/provider/tests/tool_schema.rs
@@ -2,6 +2,7 @@
 
 use super::support::*;
 use super::*;
+use crate::model_catalog::ModelVerbosity;
 use crate::provider::retry::{ProviderFailureKind, RetryDisposition};
 use crate::provider::transports::OpenAiResponsesTransportContract;
 use crate::tool::{apply_patch::ApplyPatchSurface, tools::apply_patch_tool, ToolSpec};
@@ -235,6 +236,7 @@ fn openai_responses_request_sets_store_false() {
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
         None,
+        None,
     )
     .unwrap();
     assert_eq!(body["store"], Value::Bool(false));
@@ -250,6 +252,7 @@ fn openai_responses_request_lowers_prompt_frame_to_full_request_with_cache_key()
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
+        None,
         None,
     )
     .unwrap();
@@ -272,6 +275,7 @@ fn build_openai_standard_request_includes_max_output_tokens() {
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
         None,
+        None,
     )
     .unwrap();
 
@@ -289,6 +293,7 @@ fn build_openai_codex_streaming_request_omits_max_output_tokens() {
         OpenAiResponsesTransportContract::CodexStreaming,
         ToolSchemaContract::Relaxed,
         None,
+        None,
     )
     .unwrap();
 
@@ -297,6 +302,24 @@ fn build_openai_codex_streaming_request_omits_max_output_tokens() {
     assert!(body.get("reasoning").is_some());
     assert_eq!(body["reasoning"], Value::Null);
     assert_eq!(body["include"], json!([]));
+}
+
+#[test]
+fn build_openai_codex_streaming_request_sends_verbosity() {
+    let request = provider_turn_request();
+    let body = build_openai_responses_request(
+        "gpt-5.4",
+        256,
+        &request,
+        OpenAiResponsesTransportContract::CodexStreaming,
+        ToolSchemaContract::Relaxed,
+        None,
+        Some(ModelVerbosity::Low),
+    )
+    .unwrap();
+
+    assert_eq!(body["stream"], Value::Bool(true));
+    assert_eq!(body["text"], json!({ "verbosity": "low" }));
 }
 
 #[test]
@@ -309,6 +332,7 @@ fn build_openai_codex_streaming_request_sends_supported_reasoning_effort() {
         OpenAiResponsesTransportContract::CodexStreaming,
         ToolSchemaContract::Relaxed,
         Some("low"),
+        None,
     )
     .unwrap();
 
@@ -328,6 +352,7 @@ fn openai_request_uses_function_tool_shape_for_generic_apply_patch() {
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Relaxed,
+        None,
         None,
     )
     .unwrap();
@@ -353,6 +378,7 @@ fn openai_codex_request_uses_custom_codex_dsl_tool_shape_for_apply_patch() {
         &request,
         OpenAiResponsesTransportContract::CodexStreaming,
         ToolSchemaContract::Relaxed,
+        None,
         None,
     )
     .unwrap();
@@ -386,6 +412,7 @@ fn openai_request_payload_validates_full_tool_matrix_in_strict_mode() {
         &request,
         OpenAiResponsesTransportContract::StandardJson,
         ToolSchemaContract::Strict,
+        None,
         None,
     )
     .unwrap();
@@ -458,6 +485,7 @@ fn openai_codex_request_payload_validates_full_tool_matrix_in_strict_mode() {
         OpenAiResponsesTransportContract::CodexStreaming,
         ToolSchemaContract::Strict,
         Some("low"),
+        None,
     )
     .unwrap();
 

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -22,7 +22,7 @@ use crate::{
         ProviderId, ProviderRuntimeConfig,
     },
     context::ContextConfig,
-    model_catalog::BuiltInModelCatalog,
+    model_catalog::{BuiltInModelCatalog, ModelVerbosity},
     provider::{
         builtin_web_search_probe_turn_request, emitted_tool_json_schema,
         http_trace::{ProviderHttpTrace, ProviderHttpTraceRequest},
@@ -73,6 +73,7 @@ pub struct OpenAiCodexProvider {
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
+    verbosity: Option<ModelVerbosity>,
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     compaction_policy: OpenAiCompactionPolicy,
     trace_home_dir: PathBuf,
@@ -317,6 +318,7 @@ impl OpenAiCodexProvider {
             config.runtime_max_output_tokens,
             &config.home_dir,
             openai_compaction_policy_from_config(config, ProviderId::openai_codex(), model),
+            openai_verbosity_from_config(config, ProviderId::openai_codex(), model),
         )
     }
 
@@ -336,6 +338,7 @@ impl OpenAiCodexProvider {
                 model,
                 max_output_tokens,
             ),
+            openai_verbosity_for_model(ProviderId::openai_codex(), model, max_output_tokens),
         )
     }
 
@@ -345,6 +348,7 @@ impl OpenAiCodexProvider {
         max_output_tokens: u32,
         trace_home_dir: &Path,
         compaction_policy: OpenAiCompactionPolicy,
+        verbosity: Option<ModelVerbosity>,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let codex_home = provider_config
@@ -368,6 +372,7 @@ impl OpenAiCodexProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
+            verbosity,
             builtin_web_search: provider_config.builtin_web_search.clone(),
             compaction_policy,
             trace_home_dir: trace_home_dir.to_path_buf(),
@@ -657,6 +662,25 @@ fn openai_compaction_policy_from_config(
     provider: ProviderId,
     model: &str,
 ) -> OpenAiCompactionPolicy {
+    let policy = openai_model_policy_from_config(config, provider, model);
+    OpenAiCompactionPolicy {
+        trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
+    }
+}
+
+fn openai_verbosity_from_config(
+    config: &AppConfig,
+    provider: ProviderId,
+    model: &str,
+) -> Option<ModelVerbosity> {
+    openai_model_policy_from_config(config, provider, model).verbosity
+}
+
+fn openai_model_policy_from_config(
+    config: &AppConfig,
+    provider: ProviderId,
+    model: &str,
+) -> crate::model_catalog::ResolvedRuntimeModelPolicy {
     let base_context_config = ContextConfig {
         recent_messages: config.context_window_messages,
         recent_briefs: config.context_window_briefs,
@@ -669,17 +693,14 @@ fn openai_compaction_policy_from_config(
         max_relevant_episodes: config.max_relevant_episodes,
         ..ContextConfig::default()
     };
-    let policy = BuiltInModelCatalog::default().resolve_policy(
+    BuiltInModelCatalog::default().resolve_policy(
         &ModelRef::new(provider, model),
         &config.validated_model_overrides,
         &config.model_discovery_cache.models(),
         config.validated_unknown_model_fallback.as_ref(),
         &base_context_config,
         config.runtime_max_output_tokens,
-    );
-    OpenAiCompactionPolicy {
-        trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
-    }
+    )
 }
 
 fn openai_compaction_policy_for_model(
@@ -698,6 +719,23 @@ fn openai_compaction_policy_for_model(
     OpenAiCompactionPolicy {
         trigger_input_tokens: policy.compaction_trigger_estimated_tokens as u64,
     }
+}
+
+fn openai_verbosity_for_model(
+    provider: ProviderId,
+    model: &str,
+    max_output_tokens: u32,
+) -> Option<ModelVerbosity> {
+    BuiltInModelCatalog::default()
+        .resolve_policy(
+            &ModelRef::new(provider, model),
+            &Default::default(),
+            &Default::default(),
+            None,
+            &ContextConfig::default(),
+            max_output_tokens,
+        )
+        .verbosity
 }
 
 impl OpenAiChatCompletionsProvider {
@@ -761,6 +799,7 @@ impl AgentProvider for OpenAiProvider {
             &request,
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Relaxed,
+            None,
             None,
         )?;
         let mut plan = plan_openai_responses_request(body, &request, &self.continuation, true)?;
@@ -871,6 +910,7 @@ impl AgentProvider for OpenAiProvider {
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Relaxed,
             None,
+            None,
         )?;
         let headers = self
             .api_key
@@ -931,6 +971,7 @@ impl AgentProvider for OpenAiCodexProvider {
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
             self.reasoning_effort.as_deref(),
+            self.verbosity,
         )?;
         let mut plan = plan_openai_responses_request(body, &request, &self.continuation, false)?;
         let mut sent_diagnostics = plan.diagnostics.clone();
@@ -1081,6 +1122,7 @@ impl AgentProvider for OpenAiCodexProvider {
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
             self.reasoning_effort.as_deref(),
+            self.verbosity,
         )?;
         let headers = openai_codex_headers(&credential, &self.originator);
         let trace = ProviderHttpTrace::from_env(self.trace_home_dir.clone());
@@ -1522,6 +1564,7 @@ pub(crate) fn build_openai_responses_request(
     contract: OpenAiResponsesTransportContract,
     tool_schema_contract: ToolSchemaContract,
     reasoning_effort: Option<&str>,
+    verbosity: Option<ModelVerbosity>,
 ) -> Result<Value> {
     let mut tools = request
         .tools
@@ -1574,6 +1617,9 @@ pub(crate) fn build_openai_responses_request(
         }
         OpenAiResponsesTransportContract::CodexStreaming => {
             body["stream"] = Value::Bool(true);
+            if let Some(verbosity) = verbosity {
+                body["text"] = json!({ "verbosity": verbosity.as_str() });
+            }
             if let Some(reasoning_effort) = reasoning_effort {
                 body["reasoning"] = json!({ "effort": reasoning_effort });
                 body["include"] = json!(["reasoning.encrypted_content"]);
@@ -1611,6 +1657,11 @@ fn openai_request_controls_diagnostics(body: &Value) -> ProviderOpenAiRequestCon
         .and_then(|reasoning| reasoning.get("effort"))
         .and_then(Value::as_str)
         .map(ToString::to_string);
+    let verbosity = body
+        .get("text")
+        .and_then(|text| text.get("verbosity"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
     let include_reasoning_encrypted_content = body
         .get("include")
         .and_then(Value::as_array)
@@ -1624,6 +1675,7 @@ fn openai_request_controls_diagnostics(body: &Value) -> ProviderOpenAiRequestCon
     ProviderOpenAiRequestControlsDiagnostics {
         reasoning_sent: reasoning_effort.is_some(),
         reasoning_effort,
+        verbosity,
         include_reasoning_encrypted_content,
         max_output_tokens_sent,
         max_output_tokens_unsupported: codex_streaming,
@@ -5219,6 +5271,7 @@ mod tests {
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Strict,
             None,
+            None,
         )
         .expect("openai responses request should build");
 
@@ -5258,6 +5311,7 @@ mod tests {
             OpenAiResponsesTransportContract::StandardJson,
             ToolSchemaContract::Strict,
             None,
+            None,
         )
         .expect("openai responses request should build");
 
@@ -5294,6 +5348,7 @@ mod tests {
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
             Some("low"),
+            None,
         )
         .expect("openai codex responses request should build");
 
@@ -5328,6 +5383,7 @@ mod tests {
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
             Some("low"),
+            None,
         )
         .expect("openai codex responses request should build");
         let plan = plan_openai_responses_request(

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -249,6 +249,7 @@ mod tests {
             compaction_trigger_estimated_tokens: 180_000,
             compaction_keep_recent_estimated_tokens: 68_400,
             runtime_max_output_tokens: 32_000,
+            verbosity: None,
             tool_output_truncation_estimated_tokens: 2_500,
             max_output_tokens_upper_limit: Some(128_000),
             capabilities: ModelCapabilityFlags {

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -3055,6 +3055,7 @@ mod tests {
                     compaction_trigger_estimated_tokens: 180_000,
                     compaction_keep_recent_estimated_tokens: 68_400,
                     runtime_max_output_tokens: 32_000,
+                    verbosity: None,
                     tool_output_truncation_estimated_tokens: 2_500,
                     max_output_tokens_upper_limit: Some(128_000),
                     capabilities: crate::model_catalog::ModelCapabilityFlags {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1107,6 +1107,7 @@ mod tests {
                     compaction_trigger_estimated_tokens: 180_000,
                     compaction_keep_recent_estimated_tokens: 68_400,
                     runtime_max_output_tokens: 32_000,
+                    verbosity: None,
                     tool_output_truncation_estimated_tokens: 2_500,
                     max_output_tokens_upper_limit: Some(128_000),
                     capabilities: crate::model_catalog::ModelCapabilityFlags {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -196,6 +196,7 @@ fn sample_agent_summary(agent_id: &str) -> AgentSummary {
                 compaction_trigger_estimated_tokens: 180_000,
                 compaction_keep_recent_estimated_tokens: 68_400,
                 runtime_max_output_tokens: 32_000,
+                verbosity: None,
                 tool_output_truncation_estimated_tokens: 2_500,
                 max_output_tokens_upper_limit: Some(128_000),
                 capabilities: crate::model_catalog::ModelCapabilityFlags {
@@ -277,6 +278,7 @@ fn sample_model_availability(
             compaction_trigger_estimated_tokens: 115_200,
             compaction_keep_recent_estimated_tokens: 43_776,
             runtime_max_output_tokens: 16_000,
+            verbosity: None,
             tool_output_truncation_estimated_tokens: 2_500,
             max_output_tokens_upper_limit: Some(64_000),
             capabilities: crate::model_catalog::ModelCapabilityFlags {


### PR DESCRIPTION
## Summary

- make final response guidance conclusion-first and tail-truncation safe
- add model `verbosity` metadata/override support and default `openai-codex` to `low`
- send `text.verbosity` on openai-codex streaming Responses requests and surface it in diagnostics/UI policy views

## Verification

- `cargo fmt --all -- --check`
- `cargo check --tests -q`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `git diff --check`
