### PR TITLE
fix: prefer primary model for ViewImage vision selection [benchmark: qwen-37-max]

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -995,7 +995,13 @@ impl RuntimeModelCatalog {
             );
         }
 
-        let mut candidates = self.vision_candidate_models.clone();
+        let mut candidates = Vec::new();
+        candidates.push(primary.clone());
+        for model_ref in &self.vision_candidate_models {
+            if !candidates.iter().any(|existing| existing == model_ref) {
+                candidates.push(model_ref.clone());
+            }
+        }
         for model_ref in chain {
             if !candidates.iter().any(|existing| existing == &model_ref) {
                 candidates.push(model_ref);
@@ -6614,8 +6620,8 @@ mod tests {
             "auto_discovered_vision_model_supports_image_input"
         );
         assert_eq!(selection.candidates.len(), 2);
-        assert!(selection.candidates[0].image_input);
-        assert!(!selection.candidates[1].image_input);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
     }
 
     #[test]
@@ -6687,8 +6693,8 @@ mod tests {
             "auto_discovered_vision_model_supports_image_input"
         );
         assert_eq!(selection.candidates.len(), 2);
-        assert!(selection.candidates[0].image_input);
-        assert!(!selection.candidates[1].image_input);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
     }
 
     #[test]
@@ -6747,11 +6753,11 @@ mod tests {
         assert_eq!(selection.candidates.len(), 2);
         assert_eq!(
             selection.candidates[0].reason,
-            "model_advertises_image_input"
+            "provider_transport_unsupported_for_view_image_observation"
         );
         assert_eq!(
             selection.candidates[1].reason,
-            "provider_transport_unsupported_for_view_image_observation"
+            "model_advertises_image_input"
         );
     }
 
@@ -6797,6 +6803,36 @@ mod tests {
             .candidates
             .iter()
             .all(|candidate| !candidate.image_input));
+    }
+
+    #[test]
+    fn view_image_vision_selection_prefers_primary_over_other_candidates() {
+        // Primary (openai/gpt-5.4) supports image_input. vision_candidate_models contains
+        // a different image-capable model (anthropic/claude-sonnet-4-6). The primary should
+        // be selected first because it is tried before other candidates.
+        let mut fixture = test_app_config("openai/gpt-5.4", &["anthropic/claude-sonnet-4-6"]);
+        fixture.config.vision_candidate_models = vec![
+            ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            ModelRef::parse("openai/gpt-5.4").unwrap(),
+        ];
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+        let selection =
+            catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
+
+        assert_eq!(
+            selection.selected_mode,
+            crate::types::ViewImageSelectedMode::NativeImageWithObservation
+        );
+        assert_eq!(selection.vision_provider.as_deref(), Some("openai"));
+        assert_eq!(selection.vision_model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(
+            selection.selection_reason,
+            "current_primary_model_supports_image_input"
+        );
+        // Primary appears first in candidates
+        assert_eq!(selection.candidates[0].provider, "openai");
+        assert_eq!(selection.candidates[0].model, "gpt-5.4");
     }
 
     #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -543,6 +543,25 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             source: ModelMetadataSource::BuiltInCatalog,
         },
         BuiltInModelMetadata {
+            model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.5"),
+            display_name: "GPT-5.5 (Codex)".into(),
+            description: "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.".into(),
+            context_window_tokens: Some(272_000),
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: Some(ModelVerbosity::Low),
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                reasoning_summaries: true,
+                interactive_exec: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+        },
+        BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.4"),
             display_name: "GPT-5.4 (Codex)".into(),
             description: "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.".into(),


### PR DESCRIPTION
## Summary

This PR fixes ViewImage vision model selection to prefer the current primary model as the first vision candidate, and adds the `openai-codex/gpt-5.5` built-in model entry with `image_input` support.

**Benchmark candidate:** `qwen-37-max`
**Benchmark ID:** `holon-issue-1730-model-benchmark-2026-06-12`

Refs holon-run/holon#1730

## Changes

- **`src/config.rs`**: Ensure the current primary model is added first to the vision candidate list before other `vision_candidate_models` entries, so it is tried first during ViewImage vision selection. Updated existing test assertions to reflect the corrected candidate ordering. Added new test `view_image_vision_selection_prefers_primary_over_other_candidates`.
- **`src/model_catalog.rs`**: Added `openai-codex/gpt-5.5` to the built-in model catalog with `image_input: true`, `reasoning_summaries: true`, and `interactive_exec: true`.

## Verification

- ✅ `cargo fmt --all -- --check` — passed
- ✅ `RUSTFLAGS="-D warnings" cargo check --all-targets` — passed (0 warnings)
- ✅ `cargo test view_image_vision_selection` — 9/9 tests passed

## Note

This is a benchmark candidate PR. Do not merge until the benchmark evaluation is complete. The best attempt will be selected by holon-bench before any merge decision.