### PR TITLE
feat: add gpt-5.5 built-in model and fix vision model selection priority [benchmark: deepseek-v4-pro]

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -995,10 +995,21 @@ impl RuntimeModelCatalog {
             );
         }
 
-        let mut candidates = self.vision_candidate_models.clone();
-        for model_ref in chain {
-            if !candidates.iter().any(|existing| existing == &model_ref) {
-                candidates.push(model_ref);
+        let mut candidates = Vec::new();
+        // Try the current turn's primary model first when vision.default is absent.
+        if let Some(primary_ref) = chain.first() {
+            candidates.push(primary_ref.clone());
+        }
+        // Then configured vision candidate models (authenticated providers).
+        for model_ref in &self.vision_candidate_models {
+            if !candidates.iter().any(|existing| existing == model_ref) {
+                candidates.push(model_ref.clone());
+            }
+        }
+        // Then remaining chain entries (fallback models).
+        for model_ref in chain.iter().skip(1) {
+            if !candidates.iter().any(|existing| existing == model_ref) {
+                candidates.push(model_ref.clone());
             }
         }
 
@@ -6614,8 +6625,8 @@ mod tests {
             "auto_discovered_vision_model_supports_image_input"
         );
         assert_eq!(selection.candidates.len(), 2);
-        assert!(selection.candidates[0].image_input);
-        assert!(!selection.candidates[1].image_input);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
     }
 
     #[test]
@@ -6687,8 +6698,8 @@ mod tests {
             "auto_discovered_vision_model_supports_image_input"
         );
         assert_eq!(selection.candidates.len(), 2);
-        assert!(selection.candidates[0].image_input);
-        assert!(!selection.candidates[1].image_input);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
     }
 
     #[test]
@@ -6747,11 +6758,11 @@ mod tests {
         assert_eq!(selection.candidates.len(), 2);
         assert_eq!(
             selection.candidates[0].reason,
-            "model_advertises_image_input"
+            "provider_transport_unsupported_for_view_image_observation"
         );
         assert_eq!(
             selection.candidates[1].reason,
-            "provider_transport_unsupported_for_view_image_observation"
+            "model_advertises_image_input"
         );
     }
 

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -543,6 +543,25 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             source: ModelMetadataSource::BuiltInCatalog,
         },
         BuiltInModelMetadata {
+            model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.5"),
+            display_name: "GPT-5.5 (Codex)".into(),
+            description: "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.".into(),
+            context_window_tokens: Some(272_000),
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: Some(ModelVerbosity::Low),
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                reasoning_summaries: true,
+                interactive_exec: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+        },
+        BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.4"),
             display_name: "GPT-5.4 (Codex)".into(),
             description: "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.".into(),


### PR DESCRIPTION
Closes #1730

## Summary
- Add gpt-5.5 built-in model entry with image_input capability
- Fix vision model selection: prioritize current turn primary model over configured vision candidates
- Update test assertions to match new candidate ordering

## Verification
- `cargo fmt --check`: passed
- `RUSTFLAGS="-D warnings" cargo check --all-targets`: passed (45.99s)

## Completion
Implementation is complete: two files modified (config.rs, model_catalog.rs), compilation clean.

## Model
deepseek-v4-pro