### PR TITLE
[benchmark: kimi-k26] vision candidate priority and built-in model version bump

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -995,7 +995,14 @@ impl RuntimeModelCatalog {
             );
         }
 
-        let mut candidates = self.vision_candidate_models.clone();
+        let mut candidates = vec![];
+        // Primary model gets first priority for auto-discovery
+        if !self.vision_candidate_models.iter().any(|m| m == &primary) {
+            candidates.push(primary.clone());
+        }
+        // Then add explicitly configured vision candidates
+        candidates.extend(self.vision_candidate_models.clone());
+        // Then add the rest of the chain (excluding duplicates)
         for model_ref in chain {
             if !candidates.iter().any(|existing| existing == &model_ref) {
                 candidates.push(model_ref);

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -543,8 +543,8 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             source: ModelMetadataSource::BuiltInCatalog,
         },
         BuiltInModelMetadata {
-            model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.4"),
-            display_name: "GPT-5.4 (Codex)".into(),
+            model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.5"),
+            display_name: "GPT-5.5 (Codex)".into(),
             description: "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.".into(),
             context_window_tokens: Some(272_000),
             effective_context_window_percent: 95,
@@ -2218,7 +2218,7 @@ mod tests {
     fn resolves_built_in_policy_from_known_model() {
         let catalog = BuiltInModelCatalog::new();
         let policy = catalog.resolve_policy(
-            &ModelRef::new(ProviderId::openai_codex(), "gpt-5.4"),
+            &ModelRef::new(ProviderId::openai_codex(), "gpt-5.5"),
             &HashMap::new(),
             &HashMap::new(),
             None,


### PR DESCRIPTION
## Related Issue
- Resolves #1730

## Changes
- In `RuntimeModelCatalog::resolve_vision_candidates`, ensure the primary model is tried first before configured vision candidates and chain fallbacks.
- Update built-in catalog entry for Codex from gpt-5.4 to gpt-5.5 and adjust test expectations accordingly.

## Verification
- `cargo fmt --all -- --check` passed
- `RUSTFLAGS="-D warnings" cargo check --all-targets` passed (no warnings)

## Completeness
- Minimal fix; does not merge automatically.

## Model Label
- kimi-k26