### PR TITLE
[benchmark: minimax-m3] fix: prefer primary model for ViewImage vision selection and add gpt-5.5 codex entry

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -995,7 +995,13 @@ impl RuntimeModelCatalog {
             );
         }
 
-        let mut candidates = self.vision_candidate_models.clone();
+        let mut candidates = Vec::new();
+        candidates.push(primary.clone());
+        for model_ref in &self.vision_candidate_models {
+            if !candidates.iter().any(|existing| existing == model_ref) {
+                candidates.push(model_ref.clone());
+            }
+        }
         for model_ref in chain {
             if !candidates.iter().any(|existing| existing == &model_ref) {
                 candidates.push(model_ref);
@@ -6614,8 +6620,8 @@ mod tests {
             "auto_discovered_vision_model_supports_image_input"
         );
         assert_eq!(selection.candidates.len(), 2);
-        assert!(selection.candidates[0].image_input);
-        assert!(!selection.candidates[1].image_input);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
     }
 
     #[test]
@@ -6687,8 +6693,8 @@ mod tests {
             "auto_discovered_vision_model_supports_image_input"
         );
         assert_eq!(selection.candidates.len(), 2);
-        assert!(selection.candidates[0].image_input);
-        assert!(!selection.candidates[1].image_input);
+        assert!(!selection.candidates[0].image_input);
+        assert!(selection.candidates[1].image_input);
     }
 
     #[test]
@@ -6747,11 +6753,11 @@ mod tests {
         assert_eq!(selection.candidates.len(), 2);
         assert_eq!(
             selection.candidates[0].reason,
-            "model_advertises_image_input"
+            "provider_transport_unsupported_for_view_image_observation"
         );
         assert_eq!(
             selection.candidates[1].reason,
-            "provider_transport_unsupported_for_view_image_observation"
+            "model_advertises_image_input"
         );
     }
 
@@ -6797,6 +6803,36 @@ mod tests {
             .candidates
             .iter()
             .all(|candidate| !candidate.image_input));
+    }
+
+    #[test]
+    fn view_image_vision_selection_prefers_primary_over_other_candidates() {
+        // Primary (openai/gpt-5.4) supports image_input. vision_candidate_models contains
+        // a different image-capable model (anthropic/claude-sonnet-4-6). The primary should
+        // be selected first because it is tried before other candidates.
+        let mut fixture = test_app_config("openai/gpt-5.4", &["anthropic/claude-sonnet-4-6"]);
+        fixture.config.vision_candidate_models = vec![
+            ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),
+            ModelRef::parse("openai/gpt-5.4").unwrap(),
+        ];
+        let catalog = RuntimeModelCatalog::from_config(&fixture.config);
+
+        let selection =
+            catalog.select_view_image_vision_model(&ContextConfig::default(), None, None);
+
+        assert_eq!(
+            selection.selected_mode,
+            crate::types::ViewImageSelectedMode::NativeImageWithObservation
+        );
+        assert_eq!(selection.vision_provider.as_deref(), Some("openai"));
+        assert_eq!(selection.vision_model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(
+            selection.selection_reason,
+            "current_primary_model_supports_image_input"
+        );
+        // Primary appears first in candidates
+        assert_eq!(selection.candidates[0].provider, "openai");
+        assert_eq!(selection.candidates[0].model, "gpt-5.4");
     }
 
     #[test]

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -543,6 +543,25 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             source: ModelMetadataSource::BuiltInCatalog,
         },
         BuiltInModelMetadata {
+            model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.5"),
+            display_name: "GPT-5.5 (Codex)".into(),
+            description: "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.".into(),
+            context_window_tokens: Some(272_000),
+            effective_context_window_percent: 95,
+            auto_compact_token_limit: None,
+            default_max_output_tokens: None,
+            max_output_tokens_upper_limit: None,
+            default_verbosity: Some(ModelVerbosity::Low),
+            tool_output_truncation_estimated_tokens: Some(2_500),
+            capabilities: ModelCapabilityFlags {
+                image_input: true,
+                reasoning_summaries: true,
+                interactive_exec: true,
+                ..ModelCapabilityFlags::default()
+            },
+            source: ModelMetadataSource::BuiltInCatalog,
+        },
+        BuiltInModelMetadata {
             model_ref: ModelRef::new(ProviderId::openai_codex(), "gpt-5.4"),
             display_name: "GPT-5.4 (Codex)".into(),
             description: "Codex runtime defaults mirrored from the local OpenAI Codex model metadata contract.".into(),


### PR DESCRIPTION
## Summary

Fixes holon-run/holon#1730 — prefer the current turn's primary model for ViewImage auto-discovery, and update the openai-codex built-in catalog so its provider preferred model is gpt-5.5.

## Changes

- **src/config.rs** — In `RuntimeModelCatalog::select_view_image_vision_model`, ensure the current turn's primary model is tried first as a vision candidate, before other `vision_candidate_models` entries and the provider fallback chain.
- **src/model_catalog.rs** — Add a `gpt-5.5` entry for the `openai-codex` provider with `image_input` support, placed before `gpt-5.4` so it becomes the provider's preferred model (the iteration uses `or_insert_with`).
- **Tests** — Update existing `view_image_vision_selection_*` assertions to reflect the corrected candidate ordering (primary first), and add a new `view_image_vision_selection_prefers_primary_over_other_candidates` test verifying the primary beats other `vision_candidate_models` entries.

## Verification

- `cargo fmt --all -- --check` — clean
- `RUSTFLAGS="-D warnings" cargo check --all-targets` — clean
- `cargo test --lib view_image` — 27 passed, 0 failed (including the new `prefers_primary_over_other_candidates` test)
- `cargo test --lib` (full lib suite) — 1707 passed, 0 failed, 1 ignored

## Completion

- Production code change is minimal and targeted at the issue's desired behaviors (1) and (2): primary first, then other candidates, while `vision.default` remains the highest-priority override.
- Desired behavior (3) — updating the `openai-codex` provider preferred model to `gpt-5.5` — is achieved by inserting the gpt-5.5 entry before gpt-5.4 in `built_in_entries()` so `preferred_model_for_provider("openai-codex")` returns `gpt-5.5`.
- `vision.default` continues to be checked first and short-circuits the auto-discovery path unchanged.

## Model Tag

[benchmark: minimax-m3] — Holon internal model benchmark, candidate model minimax-m3.