### PR TITLE
fix: refresh Xiaomi MiMo catalog defaults

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -6,7 +6,7 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **49 providers** and **293 models**.
+Holon includes built-in configuration for **49 providers** and **302 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -58,10 +58,10 @@ running Holon.
 | `volcengine` | OpenAI Chat Completions | `https://ark.cn-beijing.volces.com/api/v3` | `VOLCENGINE_API_KEY or ARK_API_KEY` |
 | `volcengine-coding` | OpenAI Chat Completions | `https://ark.cn-beijing.volces.com/api/coding/v3` | `VOLCENGINE_CODING_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
 | `xai` | OpenAI Chat Completions | `https://api.x.ai/v1` | `XAI_API_KEY` |
-| `xiaomi` | Anthropic Messages | `https://api.xiaomimimo.com/anthropic` | `XIAOMI_API_KEY` |
+| `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
 | `xiaomi-anthropic` | Anthropic Messages | `https://api.xiaomimimo.com/anthropic` | `XIAOMI_API_KEY` |
 | `xiaomi-openai` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
-| `xiaomi-token-plan` | Anthropic Messages | `https://token-plan-cn.xiaomimimo.com/anthropic` | `XIAOMI_TOKEN_PLAN_API_KEY` |
+| `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
 | `xiaomi-token-plan-anthropic` | Anthropic Messages | `https://token-plan-cn.xiaomimimo.com/anthropic` | `XIAOMI_TOKEN_PLAN_API_KEY` |
 | `xiaomi-token-plan-openai` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
 | `zai` | Anthropic Messages | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` |
@@ -314,21 +314,30 @@ and capabilities.
 | `xiaomi` | `mimo-v2-flash` | `xiaomi/mimo-v2-flash` | 262144 | 8192 | — | — |
 | `xiaomi` | `mimo-v2-omni` | `xiaomi/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
 | `xiaomi` | `mimo-v2-pro` | `xiaomi/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
+| `xiaomi` | `mimo-v2.5-pro` | `xiaomi/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `xiaomi` | `mimo-v2.5-pro-ultraspeed` | `xiaomi/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
 | `xiaomi-anthropic` | `mimo-v2-flash` | `xiaomi-anthropic/mimo-v2-flash` | 262144 | 8192 | — | — |
 | `xiaomi-anthropic` | `mimo-v2-omni` | `xiaomi-anthropic/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
 | `xiaomi-anthropic` | `mimo-v2-pro` | `xiaomi-anthropic/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
+| `xiaomi-anthropic` | `mimo-v2.5-pro` | `xiaomi-anthropic/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `xiaomi-anthropic` | `mimo-v2.5-pro-ultraspeed` | `xiaomi-anthropic/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
 | `xiaomi-openai` | `mimo-v2-flash` | `xiaomi-openai/mimo-v2-flash` | 262144 | 8192 | — | — |
 | `xiaomi-openai` | `mimo-v2-omni` | `xiaomi-openai/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
 | `xiaomi-openai` | `mimo-v2-pro` | `xiaomi-openai/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
-| `xiaomi-token-plan` | `mimo-v2-flash` | `xiaomi-token-plan/mimo-v2-flash` | 262144 | 8192 | — | — |
+| `xiaomi-openai` | `mimo-v2.5-pro` | `xiaomi-openai/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `xiaomi-openai` | `mimo-v2.5-pro-ultraspeed` | `xiaomi-openai/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
 | `xiaomi-token-plan` | `mimo-v2-omni` | `xiaomi-token-plan/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
 | `xiaomi-token-plan` | `mimo-v2-pro` | `xiaomi-token-plan/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
-| `xiaomi-token-plan-anthropic` | `mimo-v2-flash` | `xiaomi-token-plan-anthropic/mimo-v2-flash` | 262144 | 8192 | — | — |
+| `xiaomi-token-plan` | `mimo-v2.5-pro` | `xiaomi-token-plan/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `xiaomi-token-plan` | `mimo-v2.5-pro-ultraspeed` | `xiaomi-token-plan/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
 | `xiaomi-token-plan-anthropic` | `mimo-v2-omni` | `xiaomi-token-plan-anthropic/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
 | `xiaomi-token-plan-anthropic` | `mimo-v2-pro` | `xiaomi-token-plan-anthropic/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
-| `xiaomi-token-plan-openai` | `mimo-v2-flash` | `xiaomi-token-plan-openai/mimo-v2-flash` | 262144 | 8192 | — | — |
+| `xiaomi-token-plan-anthropic` | `mimo-v2.5-pro` | `xiaomi-token-plan-anthropic/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `xiaomi-token-plan-anthropic` | `mimo-v2.5-pro-ultraspeed` | `xiaomi-token-plan-anthropic/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
 | `xiaomi-token-plan-openai` | `mimo-v2-omni` | `xiaomi-token-plan-openai/mimo-v2-omni` | 262144 | 32000 | ✅ | ✅ |
 | `xiaomi-token-plan-openai` | `mimo-v2-pro` | `xiaomi-token-plan-openai/mimo-v2-pro` | 1048576 | 32000 | ✅ | — |
+| `xiaomi-token-plan-openai` | `mimo-v2.5-pro` | `xiaomi-token-plan-openai/mimo-v2.5-pro` | 1000000 | 131072 | ✅ | — |
+| `xiaomi-token-plan-openai` | `mimo-v2.5-pro-ultraspeed` | `xiaomi-token-plan-openai/mimo-v2.5-pro-ultraspeed` | 1000000 | 131072 | ✅ | — |
 | `zai` | `glm-4.5` | `zai/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5-air` | `zai/glm-4.5-air` | 131072 | 98304 | ✅ | — |
 | `zai` | `glm-4.5-flash` | `zai/glm-4.5-flash` | 131072 | 98304 | ✅ | — |

--- a/src/config.rs
+++ b/src/config.rs
@@ -3020,10 +3020,10 @@ fn built_in_provider_registry_with_settings(
         ],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
+    insert_openai_compatible_provider(
         &mut registry,
         "xiaomi",
-        "https://api.xiaomimimo.com/anthropic",
+        "https://api.xiaomimimo.com/v1",
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
@@ -3041,10 +3041,10 @@ fn built_in_provider_registry_with_settings(
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
+    insert_openai_compatible_provider(
         &mut registry,
         "xiaomi-token-plan",
-        "https://token-plan-cn.xiaomimimo.com/anthropic",
+        "https://token-plan-cn.xiaomimimo.com/v1",
         &["XIAOMI_TOKEN_PLAN_API_KEY"],
         settings_env,
     )?;
@@ -5702,13 +5702,12 @@ mod tests {
         let xiaomi = providers
             .get(&ProviderId::parse("xiaomi").unwrap())
             .unwrap();
-        assert_eq!(xiaomi.transport, ProviderTransportKind::AnthropicMessages);
-        assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/anthropic");
-        assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
         assert_eq!(
-            xiaomi.context_management.cache_strategy,
-            AnthropicCacheStrategy::ClaudeCodePromptCache
+            xiaomi.transport,
+            ProviderTransportKind::OpenAiChatCompletions
         );
+        assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
+        assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
 
         let xiaomi_anthropic = providers
             .get(&ProviderId::parse("xiaomi-anthropic").unwrap())
@@ -5738,19 +5737,15 @@ mod tests {
             .unwrap();
         assert_eq!(
             xiaomi_token_plan.transport,
-            ProviderTransportKind::AnthropicMessages
+            ProviderTransportKind::OpenAiChatCompletions
         );
         assert_eq!(
             xiaomi_token_plan.base_url,
-            "https://token-plan-cn.xiaomimimo.com/anthropic"
+            "https://token-plan-cn.xiaomimimo.com/v1"
         );
         assert_eq!(
             xiaomi_token_plan.credential.as_deref(),
             Some("xiaomi-token-plan-key")
-        );
-        assert_eq!(
-            xiaomi_token_plan.context_management.cache_strategy,
-            AnthropicCacheStrategy::ClaudeCodePromptCache
         );
 
         let xiaomi_token_plan_anthropic = providers
@@ -5879,9 +5874,7 @@ mod tests {
         for provider in [
             "deepseek",
             "deepseek-anthropic",
-            "xiaomi",
             "xiaomi-anthropic",
-            "xiaomi-token-plan",
             "xiaomi-token-plan-anthropic",
             "zai",
             "zai-anthropic",

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1830,6 +1830,24 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "xiaomi",
+            "mimo-v2.5-pro",
+            "Xiaomi MiMo V2.5 Pro",
+            1_000_000,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "xiaomi",
+            "mimo-v2.5-pro-ultraspeed",
+            "Xiaomi MiMo V2.5 Pro UltraSpeed",
+            1_000_000,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "xiaomi",
             "mimo-v2-flash",
             "Xiaomi MiMo V2 Flash",
             262_144,
@@ -1857,11 +1875,20 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "xiaomi-token-plan",
-            "mimo-v2-flash",
-            "Xiaomi MiMo V2 Flash",
-            262_144,
-            8_192,
+            "mimo-v2.5-pro",
+            "Xiaomi MiMo V2.5 Pro",
+            1_000_000,
+            131_072,
+            true,
             false,
+        ),
+        catalog_model(
+            "xiaomi-token-plan",
+            "mimo-v2.5-pro-ultraspeed",
+            "Xiaomi MiMo V2.5 Pro UltraSpeed",
+            1_000_000,
+            131_072,
+            true,
             false,
         ),
         catalog_model(
@@ -2013,12 +2040,12 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
     extend_catalog_model_aliases_from_source(
         &mut entries,
         "xiaomi",
-        &[
-            "xiaomi-anthropic",
-            "xiaomi-openai",
-            "xiaomi-token-plan-anthropic",
-            "xiaomi-token-plan-openai",
-        ],
+        &["xiaomi-anthropic", "xiaomi-openai"],
+    );
+    extend_catalog_model_aliases_from_source(
+        &mut entries,
+        "xiaomi-token-plan",
+        &["xiaomi-token-plan-anthropic", "xiaomi-token-plan-openai"],
     );
     extend_catalog_model_aliases_from_source(
         &mut entries,
@@ -2330,18 +2357,48 @@ mod tests {
         assert_eq!(deepseek_openai.source, ModelMetadataSource::BuiltInCatalog);
 
         let xiaomi = catalog.resolve_policy(
-            &ModelRef::parse("xiaomi-token-plan-openai/mimo-v2-pro").unwrap(),
+            &ModelRef::parse("xiaomi-token-plan-openai/mimo-v2.5-pro").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
             8192,
         );
-        assert_eq!(xiaomi.display_name, "Xiaomi MiMo V2 Pro");
-        assert_eq!(xiaomi.context_window_tokens, Some(1_048_576));
-        assert_eq!(xiaomi.runtime_max_output_tokens, 32_000);
+        assert_eq!(xiaomi.display_name, "Xiaomi MiMo V2.5 Pro");
+        assert_eq!(xiaomi.context_window_tokens, Some(1_000_000));
+        assert_eq!(xiaomi.runtime_max_output_tokens, 131_072);
         assert!(xiaomi.capabilities.reasoning_summaries);
         assert_eq!(xiaomi.source, ModelMetadataSource::BuiltInCatalog);
+
+        let xiaomi_ultraspeed = catalog.resolve_policy(
+            &ModelRef::parse("xiaomi-anthropic/mimo-v2.5-pro-ultraspeed").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(
+            xiaomi_ultraspeed.display_name,
+            "Xiaomi MiMo V2.5 Pro UltraSpeed"
+        );
+        assert_eq!(xiaomi_ultraspeed.context_window_tokens, Some(1_000_000));
+        assert_eq!(xiaomi_ultraspeed.runtime_max_output_tokens, 131_072);
+        assert!(xiaomi_ultraspeed.capabilities.reasoning_summaries);
+        assert_eq!(
+            xiaomi_ultraspeed.source,
+            ModelMetadataSource::BuiltInCatalog
+        );
+
+        assert!(catalog
+            .get(&ModelRef::parse("xiaomi/mimo-v2-pro").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("xiaomi-token-plan/mimo-v2-flash").unwrap())
+            .is_none());
+        assert!(catalog
+            .get(&ModelRef::parse("xiaomi-token-plan-anthropic/mimo-v2-flash").unwrap())
+            .is_none());
 
         let zai = catalog.resolve_policy(
             &ModelRef::parse("zai-anthropic/glm-4.7").unwrap(),


### PR DESCRIPTION
## Summary
- switch `xiaomi` and `xiaomi-token-plan` defaults to OpenAI Chat Completions `/v1` endpoints
- keep `xiaomi-anthropic` and `xiaomi-token-plan-anthropic` as explicit Anthropic endpoint opt-ins
- add MiMo V2.5 Pro / UltraSpeed catalog entries and stop advertising unsupported token-plan Flash entries
- regenerate the supported models reference

Closes #1733
Closes #1553

## Verification
- `cargo run --bin holon-docgen -- models > docs/website/reference/models.md`
- `cargo test model_catalog::tests::resolves_anthropic_compatible_provider_model_policy`
- `cargo test config::tests::built_in_provider_registry_includes_compatible_provider_defaults`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`