### PR TITLE
feat: expose child agent token usage on supervised task status

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1372,6 +1372,76 @@
                   "null"
                 ]
               },
+              "child_token_usage": {
+                "properties": {
+                  "last_turn": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "total": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": "object"
+                  },
+                  "total_model_rounds": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "total",
+                  "total_model_rounds"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
               "command": {
                 "properties": {
                   "accepts_input": {
@@ -2084,6 +2154,76 @@
               "null"
             ]
           },
+          "child_token_usage": {
+            "properties": {
+              "last_turn": {
+                "properties": {
+                  "input_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "output_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "total_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "input_tokens",
+                  "output_tokens",
+                  "total_tokens"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "total": {
+                "properties": {
+                  "input_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "output_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "total_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "input_tokens",
+                  "output_tokens",
+                  "total_tokens"
+                ],
+                "type": "object"
+              },
+              "total_model_rounds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "total",
+              "total_model_rounds"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "command": {
             "properties": {
               "accepts_input": {
@@ -2475,6 +2615,76 @@
                   "supervision_task_id",
                   "cleanup_owner",
                   "followup_target"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "child_token_usage": {
+                "properties": {
+                  "last_turn": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "total": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": "object"
+                  },
+                  "total_model_rounds": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "total",
+                  "total_model_rounds"
                 ],
                 "type": [
                   "object",

--- a/src/host.rs
+++ b/src/host.rs
@@ -40,12 +40,12 @@ use crate::{
     types::{
         AdmissionContext, AgentIdentityRecord, AgentIdentityView, AgentKind, AgentLifecycleHint,
         AgentListEntry, AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
-        AgentStatus, AgentSummary, AgentVisibility, AuthorityClass, ChildAgentSummary,
-        ClosureOutcome, ExternalTriggerRecord, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
-        RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
-        TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkspaceEntry,
-        WorkspaceOccupancyRecord,
+        AgentStatus, AgentSummary, AgentTokenUsageSummary, AgentVisibility, AuthorityClass,
+        ChildAgentSummary, ClosureOutcome, ExternalTriggerRecord, MessageBody,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin,
+        OperatorNotificationRecord, Priority, RuntimeFailureSummary, SpawnAgentModelResolution,
+        SpawnAgentModelResolutionStatus, TaskRecord, TaskStatus, TokenUsage, TranscriptEntry,
+        TranscriptEntryKind, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -1452,6 +1452,13 @@ impl RuntimeHost {
                     });
                 }
             }
+            let child_token_usage = AgentTokenUsageSummary {
+                total: TokenUsage::new(state.total_input_tokens, state.total_output_tokens),
+                total_model_rounds: state.total_model_rounds,
+                last_turn: state.last_turn_token_usage.clone(),
+            };
+            metadata["child_token_usage"] =
+                serde_json::to_value(&child_token_usage).unwrap_or(Value::Null);
             let task_detail = Some(metadata);
 
             self.archive_private_agent(child_agent_id).await?;
@@ -1504,6 +1511,12 @@ impl RuntimeHost {
             })
             .unwrap_or_default();
 
+        let child_token_usage = AgentTokenUsageSummary {
+            total: TokenUsage::new(state.total_input_tokens, state.total_output_tokens),
+            total_model_rounds: state.total_model_rounds,
+            last_turn: state.last_turn_token_usage.clone(),
+        };
+
         Ok(Some(ChildTaskTerminalResult {
             status,
             text,
@@ -1513,6 +1526,7 @@ impl RuntimeHost {
                 "child_visibility": AgentVisibility::Private,
                 "child_ownership": AgentOwnership::ParentSupervised,
                 "child_profile_preset": AgentProfilePreset::PrivateChild,
+                "child_token_usage": serde_json::to_value(&child_token_usage).unwrap_or(Value::Null),
             })),
         }))
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1649,7 +1649,7 @@ pub struct AgentState {
     pub last_runtime_failure: Option<RuntimeFailureSummary>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub struct TokenUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -1670,7 +1670,7 @@ impl TokenUsage {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub struct AgentTokenUsageSummary {
     pub total: TokenUsage,
     pub total_model_rounds: u64,
@@ -2707,6 +2707,8 @@ pub struct TaskStatusSnapshot {
     pub child_observability: Option<ChildAgentObservabilitySnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_supervision: Option<ChildSupervisionProjection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_token_usage: Option<AgentTokenUsageSummary>,
 }
 
 impl TaskStatusSnapshot {
@@ -2716,6 +2718,8 @@ impl TaskStatusSnapshot {
         let child_observability = task_detail_value(&task.detail, "child_observability")
             .and_then(|value| serde_json::from_value(value.clone()).ok());
         let child_supervision = ChildSupervisionProjection::from_task_record(task);
+        let child_token_usage = task_detail_value(&task.detail, "child_token_usage")
+            .and_then(|value| serde_json::from_value(value.clone()).ok());
 
         Self {
             task_id: task.id.clone(),
@@ -2730,6 +2734,7 @@ impl TaskStatusSnapshot {
             child_agent_id,
             child_observability,
             child_supervision,
+            child_token_usage,
         }
     }
 }
@@ -4776,6 +4781,50 @@ mod tests {
             command.output_path.as_deref(),
             Some("/tmp/command-output.txt")
         );
+    }
+
+    #[test]
+    fn task_status_snapshot_exposes_child_token_usage_from_detail() {
+        let task = TaskRecord {
+            id: "task-child-1".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::ChildAgentTask,
+            status: TaskStatus::Completed,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: Some("child task".into()),
+            detail: Some(serde_json::json!({
+                "child_agent_id": "tmp_child_abc",
+                "child_token_usage": {
+                    "total": {
+                        "input_tokens": 1200,
+                        "output_tokens": 400,
+                        "total_tokens": 1600
+                    },
+                    "total_model_rounds": 3,
+                    "last_turn": {
+                        "input_tokens": 500,
+                        "output_tokens": 150,
+                        "total_tokens": 650
+                    }
+                }
+            })),
+            recovery: None,
+        };
+
+        let snapshot = TaskStatusSnapshot::from_task_record(&task);
+        let usage = snapshot
+            .child_token_usage
+            .expect("child token usage should be present");
+        assert_eq!(usage.total.input_tokens, 1200);
+        assert_eq!(usage.total.output_tokens, 400);
+        assert_eq!(usage.total.total_tokens, 1600);
+        assert_eq!(usage.total_model_rounds, 3);
+        let last = usage.last_turn.expect("last turn usage");
+        assert_eq!(last.input_tokens, 500);
+        assert_eq!(last.output_tokens, 150);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When a `private_child` agent runs as a supervised task, this change captures its final `AgentTokenUsageSummary` into the task detail at terminal result time. `TaskStatusSnapshot` now deserializes `child_token_usage` from task detail, so `TaskStatus` returns it even after child archival/cleanup.

## Changes

- **`src/types.rs`**: Add `JsonSchema` derive to `TokenUsage` and `AgentTokenUsageSummary`; add `child_token_usage` field to `TaskStatusSnapshot`; add unit test
- **`src/host.rs`**: Capture usage in `await_child_terminal_result` (live path) and `completed_child_terminal_from_storage` (recovery path)
- **`docs/website/reference/openapi.json`**: Refreshed OpenAPI snapshot for new schema fields

## Acceptance Criteria

- [x] `TaskStatus` for completed supervised child-agent tasks includes final token usage when available
- [x] Usage snapshot persists in task record after private child archival/cleanup
- [x] Existing public agent status behavior unchanged
- [x] Benchmark/reporting code can recover child token counts from task status alone

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test task_status_snapshot_exposes_child_token_usage_from_detail` ✅
- `cargo test --test openapi_snapshot` ✅
- `cargo test --test tool_schema_inventory_snapshot` ✅

Closes #1741