### PR TITLE
feat: expose child agent token usage on supervised task status

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1493,6 +1493,76 @@
               "task_id": {
                 "type": "string"
               },
+              "token_usage": {
+                "properties": {
+                  "last_turn": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "total": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": "object"
+                  },
+                  "total_model_rounds": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "total",
+                  "total_model_rounds"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
               "updated_at": {
                 "format": "date-time",
                 "type": "string"
@@ -1830,6 +1900,76 @@
               },
               "task_id": {
                 "type": "string"
+              },
+              "token_usage": {
+                "properties": {
+                  "last_turn": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "total": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": "object"
+                  },
+                  "total_model_rounds": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "total",
+                  "total_model_rounds"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
               }
             },
             "required": [
@@ -2204,6 +2344,76 @@
           },
           "task_id": {
             "type": "string"
+          },
+          "token_usage": {
+            "properties": {
+              "last_turn": {
+                "properties": {
+                  "input_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "output_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "total_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "input_tokens",
+                  "output_tokens",
+                  "total_tokens"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "total": {
+                "properties": {
+                  "input_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "output_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "total_tokens": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "input_tokens",
+                  "output_tokens",
+                  "total_tokens"
+                ],
+                "type": "object"
+              },
+              "total_model_rounds": {
+                "format": "uint64",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "total",
+              "total_model_rounds"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "updated_at": {
             "format": "date-time",
@@ -2601,6 +2811,76 @@
               },
               "task_id": {
                 "type": "string"
+              },
+              "token_usage": {
+                "properties": {
+                  "last_turn": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "total": {
+                    "properties": {
+                      "input_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "output_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "total_tokens": {
+                        "format": "uint64",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "input_tokens",
+                      "output_tokens",
+                      "total_tokens"
+                    ],
+                    "type": "object"
+                  },
+                  "total_model_rounds": {
+                    "format": "uint64",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "total",
+                  "total_model_rounds"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
               },
               "updated_at": {
                 "format": "date-time",

--- a/src/host.rs
+++ b/src/host.rs
@@ -1438,6 +1438,11 @@ impl RuntimeHost {
                 "child_ownership": AgentOwnership::ParentSupervised,
                 "child_profile_preset": AgentProfilePreset::PrivateChild,
                 "child_observability": runtime.child_agent_observability().await?,
+                "token_usage": json!({
+                    "total": crate::types::TokenUsage::new(state.total_input_tokens, state.total_output_tokens),
+                    "last_turn": state.last_turn_token_usage.clone(),
+                    "total_model_rounds": state.total_model_rounds,
+                }),
             });
             if worktree {
                 if let Some(worktree) = state.worktree_session.as_ref() {
@@ -1507,13 +1512,21 @@ impl RuntimeHost {
         Ok(Some(ChildTaskTerminalResult {
             status,
             text,
-            task_detail: Some(json!({
-                "child_agent_id": child_agent_id,
-                "child_kind": AgentKind::Child,
-                "child_visibility": AgentVisibility::Private,
-                "child_ownership": AgentOwnership::ParentSupervised,
-                "child_profile_preset": AgentProfilePreset::PrivateChild,
-            })),
+            task_detail: {
+                let mut detail = json!( {
+                    "child_agent_id": child_agent_id,
+                    "child_kind": AgentKind::Child,
+                    "child_visibility": AgentVisibility::Private,
+                    "child_ownership": AgentOwnership::ParentSupervised,
+                    "child_profile_preset": AgentProfilePreset::PrivateChild,
+                });
+                detail["token_usage"] = json!({
+                    "total": crate::types::TokenUsage::new(state.total_input_tokens, state.total_output_tokens),
+                    "last_turn": state.last_turn_token_usage.clone(),
+                    "total_model_rounds": state.total_model_rounds,
+                });
+                Some(detail)
+            },
         }))
     }
 

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -1635,6 +1635,12 @@ impl RuntimeHandle {
                 }
             });
 
+        let token_usage = task
+            .detail
+            .as_ref()
+            .and_then(|detail| detail.get("token_usage"))
+            .and_then(|value| serde_json::from_value(value.clone()).ok());
+
         Ok(TaskOutputSnapshot {
             task_id: task.id,
             kind: task.kind.as_str().to_string(),
@@ -1648,6 +1654,7 @@ impl RuntimeHandle {
             exit_status,
             failure_artifact,
             child_supervision,
+            token_usage,
         })
     }
 

--- a/src/tool/tools/task_output.rs
+++ b/src/tool/tools/task_output.rs
@@ -131,6 +131,7 @@ mod tests {
                     exit_status: Some(0),
                     failure_artifact: None,
                     child_supervision: None,
+                    token_usage: None,
                 },
             },
         )

--- a/src/types.rs
+++ b/src/types.rs
@@ -1649,7 +1649,7 @@ pub struct AgentState {
     pub last_runtime_failure: Option<RuntimeFailureSummary>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub struct TokenUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -1670,7 +1670,7 @@ impl TokenUsage {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub struct AgentTokenUsageSummary {
     pub total: TokenUsage,
     pub total_model_rounds: u64,
@@ -2707,6 +2707,8 @@ pub struct TaskStatusSnapshot {
     pub child_observability: Option<ChildAgentObservabilitySnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_supervision: Option<ChildSupervisionProjection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<AgentTokenUsageSummary>,
 }
 
 impl TaskStatusSnapshot {
@@ -2716,6 +2718,8 @@ impl TaskStatusSnapshot {
         let child_observability = task_detail_value(&task.detail, "child_observability")
             .and_then(|value| serde_json::from_value(value.clone()).ok());
         let child_supervision = ChildSupervisionProjection::from_task_record(task);
+        let token_usage = task_detail_value(&task.detail, "token_usage")
+            .and_then(|value| serde_json::from_value(value.clone()).ok());
 
         Self {
             task_id: task.id.clone(),
@@ -2730,6 +2734,7 @@ impl TaskStatusSnapshot {
             child_agent_id,
             child_observability,
             child_supervision,
+            token_usage,
         }
     }
 }
@@ -2760,6 +2765,8 @@ pub struct TaskOutputSnapshot {
     pub failure_artifact: Option<FailureArtifact>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_supervision: Option<ChildSupervisionProjection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<AgentTokenUsageSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]


### PR DESCRIPTION
Implements #1741.

## Summary

When a `private_child` agent runs as a supervised task, its final token usage is now captured in the task record's `detail` and exposed through `TaskStatus` / `TaskOutput` APIs.

## Changes

- **`src/host.rs`**: In both `await_child_terminal_result` and `completed_child_terminal_from_storage`, capture the child agent's `token_usage` into `task_detail` before archival. The snapshot includes `total` (input/output tokens), `last_turn`, and `total_model_rounds`.
- **`src/types.rs`**: Add `JsonSchema` derive to `TokenUsage` and `AgentTokenUsageSummary`. Add `token_usage: Option<AgentTokenUsageSummary>` field to `TaskStatusSnapshot` and `TaskOutputSnapshot`, populated from `task_detail[token_usage]`.
- **`src/runtime/tasks.rs`**: Populate `token_usage` in the `task_output_snapshot` helper.
- **`src/tool/tools/task_output.rs`**: Update test fixture.

## Verification

- `cargo fmt --all -- --check` — passed
- `RUSTFLAGS="-D warnings" cargo check --all-targets` — passed
- `cargo test -p holon --lib` — 1708 passed, 0 failed, 1 ignored

## Design Notes

- Token usage persists in `task_detail` JSON, so it survives child agent archival/cleanup.
- Existing public agent status behavior is unchanged.
- The private-agent authority boundary is preserved; only the parent supervisor can see this data via the task API.