### PR TITLE
feat: expose child agent token usage on supervised task status (#1741)

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1452,6 +1452,14 @@ impl RuntimeHost {
                     });
                 }
             }
+            metadata["token_usage"] = serde_json::to_value(crate::types::AgentTokenUsageSummary {
+                total: crate::types::TokenUsage::new(
+                    state.total_input_tokens,
+                    state.total_output_tokens,
+                ),
+                total_model_rounds: state.total_model_rounds,
+                last_turn: state.last_turn_token_usage.clone(),
+            })?;
             let task_detail = Some(metadata);
 
             self.archive_private_agent(child_agent_id).await?;
@@ -1504,6 +1512,15 @@ impl RuntimeHost {
             })
             .unwrap_or_default();
 
+        let token_usage = crate::types::AgentTokenUsageSummary {
+            total: crate::types::TokenUsage::new(
+                state.total_input_tokens,
+                state.total_output_tokens,
+            ),
+            total_model_rounds: state.total_model_rounds,
+            last_turn: state.last_turn_token_usage.clone(),
+        };
+
         Ok(Some(ChildTaskTerminalResult {
             status,
             text,
@@ -1513,6 +1530,7 @@ impl RuntimeHost {
                 "child_visibility": AgentVisibility::Private,
                 "child_ownership": AgentOwnership::ParentSupervised,
                 "child_profile_preset": AgentProfilePreset::PrivateChild,
+                "token_usage": token_usage,
             })),
         }))
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1649,7 +1649,7 @@ pub struct AgentState {
     pub last_runtime_failure: Option<RuntimeFailureSummary>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct TokenUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -1670,7 +1670,7 @@ impl TokenUsage {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AgentTokenUsageSummary {
     pub total: TokenUsage,
     pub total_model_rounds: u64,
@@ -2707,6 +2707,8 @@ pub struct TaskStatusSnapshot {
     pub child_observability: Option<ChildAgentObservabilitySnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub child_supervision: Option<ChildSupervisionProjection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<AgentTokenUsageSummary>,
 }
 
 impl TaskStatusSnapshot {
@@ -2714,6 +2716,8 @@ impl TaskStatusSnapshot {
         let command = CommandTaskStatusSnapshot::from_task_record(task);
         let child_agent_id = task_detail_string(&task.detail, "child_agent_id");
         let child_observability = task_detail_value(&task.detail, "child_observability")
+            .and_then(|value| serde_json::from_value(value.clone()).ok());
+        let token_usage = task_detail_value(&task.detail, "token_usage")
             .and_then(|value| serde_json::from_value(value.clone()).ok());
         let child_supervision = ChildSupervisionProjection::from_task_record(task);
 
@@ -2730,6 +2734,7 @@ impl TaskStatusSnapshot {
             child_agent_id,
             child_observability,
             child_supervision,
+            token_usage,
         }
     }
 }

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -370,6 +370,11 @@ pub async fn subagent_task_status_exposes_live_and_terminal_child_observability(
         .as_ref()
         .and_then(|child| child.last_result_brief.as_deref())
         .is_some_and(|brief| brief.contains("slow child result")));
+    // Verify token usage is exposed on terminal task status for completed child tasks
+    assert!(
+        terminal_snapshot.token_usage.is_some(),
+        "terminal task status should include child agent token usage"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

When a `private_child` agent completes as a supervised task, persist its final `AgentTokenUsageSummary` into the task detail. `TaskStatusSnapshot` now reads `token_usage` from task detail and exposes it via the task status API.

## Changes

- **`src/types.rs`**: Added `token_usage: Option<AgentTokenUsageSummary>` to `TaskStatusSnapshot` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Also added `JsonSchema` derives to `TokenUsage` and `AgentTokenUsageSummary` to support schema generation.
- **`src/host.rs`**: In both `await_child_terminal_result` (active path) and `completed_child_terminal_from_storage` (recovery path), capture the child agent's final token usage from `AgentState` and include it in the task detail JSON under the `"token_usage"` key before archiving the private child.
- **`tests/support/runtime_subagents.rs`**: Added an assertion in `subagent_task_status_exposes_live_and_terminal_child_observability` to verify that the terminal task status includes `token_usage`.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --test runtime_subagents` ✅ (9/9 passed)
- `cargo test --test http_tasks` ✅ (16/16 passed)

## Design Notes

- The snapshot survives child archival/cleanup because it is stored on the task record, not the child agent.
- Public agent status behavior is unchanged.
- Existing `AgentTokenUsageSummary` and `TokenUsage` structs are reused without modification.
