### PR TITLE
feat: expose private child agent status through local control APIs (#1742)

### DIFF
--- a/docs/website/reference/model-tool-schema-inventory.json
+++ b/docs/website/reference/model-tool-schema-inventory.json
@@ -65,12 +65,19 @@
       "stability": "stable"
     },
     {
-      "description": "Read the current agent-plane summary, including identity visibility, ownership, profile preset, lifecycle, active work focus, waiting state, and visible child-agent lineage.\n",
+      "description": "Read the current agent-plane summary, including identity visibility, ownership, profile preset, lifecycle, active work focus, waiting state, and visible child-agent lineage.\n\nWhen called without arguments, returns the current agent's summary (unchanged behavior).\nWhen called with `agent_id`, returns the summary of the requested agent through the local trusted control boundary. This allows inspecting private child agents without exposing them to remote/multi-user access.\n\nRemote/multi-user authorization is deferred to future work; the current behavior relies on the local trusted control API boundary.\n",
       "family": "core_agent",
       "freeform_grammar": null,
       "input_schema": {
         "additionalProperties": false,
-        "properties": {},
+        "properties": {
+          "agent_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
         "required": [],
         "type": "object"
       },

--- a/src/host.rs
+++ b/src/host.rs
@@ -316,6 +316,30 @@ impl RuntimeHost {
             .map_err(PublicAgentError::Runtime)
     }
 
+    /// Get an agent for the local control/status API, allowing private child
+    /// agents in addition to public ones. This relies on the current local
+    /// trusted control API boundary rather than hiding `agent_id`.
+    pub async fn get_agent_for_local_status(
+        &self,
+        agent_id: &str,
+    ) -> std::result::Result<RuntimeHandle, PublicAgentError> {
+        let identity = self
+            .agent_identity_record(agent_id)
+            .map_err(PublicAgentError::Runtime)?
+            .ok_or_else(|| PublicAgentError::NotFound {
+                agent_id: agent_id.to_string(),
+            })?;
+        if identity.status != AgentRegistryStatus::Active {
+            return Err(PublicAgentError::Archived {
+                agent_id: agent_id.to_string(),
+            });
+        }
+        // Allow both Public and Private agents through the local status API.
+        self.get_or_create_agent(agent_id)
+            .await
+            .map_err(PublicAgentError::Runtime)
+    }
+
     pub async fn get_public_agent_for_external_ingress(
         &self,
         agent_id: &str,
@@ -607,7 +631,7 @@ impl RuntimeHost {
             .import_legacy(records)
     }
 
-    fn append_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
+    pub(crate) fn append_agent_identity(&self, record: &AgentIdentityRecord) -> Result<()> {
         self.inner.registry.append_agent_identity(record)
     }
 
@@ -1792,6 +1816,16 @@ impl RuntimeHostBridge {
         parent_agent_id: &str,
     ) -> Result<Vec<ChildAgentSummary>> {
         self.host()?.child_agent_summaries(parent_agent_id).await
+    }
+
+    /// Get a full AgentSummary for a given agent_id through the local trusted
+    /// control boundary. This allows private child agent observation.
+    pub(crate) async fn agent_summary_for(
+        &self,
+        agent_id: &str,
+    ) -> Result<crate::types::AgentSummary> {
+        let runtime = self.host()?.get_agent_for_local_status(agent_id).await?;
+        runtime.agent_summary().await
     }
 
     pub(crate) async fn child_observability(
@@ -4110,5 +4144,123 @@ mod tests {
             .to_string()
             .contains("no available providers for configured model chain"));
         assert!(err.to_string().contains("anthropic/claude-sonnet-4-6"));
+    }
+
+    #[tokio::test]
+    async fn get_public_agent_rejects_private_child() {
+        let (_home, host) = test_host();
+
+        let child = AgentIdentityRecord::new(
+            "child_private_1",
+            AgentKind::Child,
+            AgentVisibility::Private,
+            AgentOwnership::ParentSupervised,
+            AgentProfilePreset::PrivateChild,
+            Some(host.config().default_agent_id.clone()),
+            Some("task-1".into()),
+        );
+        host.append_agent_identity(&child).unwrap();
+
+        let err = host
+            .get_public_agent("child_private_1")
+            .await
+            .err()
+            .expect("private child should be rejected by get_public_agent");
+        match err {
+            PublicAgentError::Private { agent_id } => {
+                assert_eq!(agent_id, "child_private_1");
+            }
+            other => panic!("expected Private error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_agent_for_local_status_accepts_private_child() {
+        let (_home, host) = test_host();
+
+        let child = AgentIdentityRecord::new(
+            "child_local_1",
+            AgentKind::Child,
+            AgentVisibility::Private,
+            AgentOwnership::ParentSupervised,
+            AgentProfilePreset::PrivateChild,
+            Some(host.config().default_agent_id.clone()),
+            Some("task-1".into()),
+        );
+        host.append_agent_identity(&child).unwrap();
+
+        let child_storage = host.agent_storage("child_local_1").unwrap();
+        let mut child_state = AgentState::new("child_local_1");
+        child_state.status = AgentStatus::AwakeRunning;
+        child_storage.write_agent(&child_state).unwrap();
+
+        let runtime = host
+            .get_agent_for_local_status("child_local_1")
+            .await
+            .expect("private child should be accessible through local status API");
+        let summary = runtime.agent_summary().await.unwrap();
+        assert_eq!(summary.identity.agent_id, "child_local_1");
+        assert_eq!(summary.identity.visibility, AgentVisibility::Private);
+        assert_eq!(summary.identity.kind, AgentKind::Child);
+    }
+
+    #[tokio::test]
+    async fn get_agent_for_local_status_rejects_archived() {
+        let (_home, host) = test_host();
+
+        let mut child = AgentIdentityRecord::new(
+            "child_archived_1",
+            AgentKind::Child,
+            AgentVisibility::Private,
+            AgentOwnership::ParentSupervised,
+            AgentProfilePreset::PrivateChild,
+            Some(host.config().default_agent_id.clone()),
+            Some("task-1".into()),
+        );
+        child.status = AgentRegistryStatus::Archived;
+        host.append_agent_identity(&child).unwrap();
+
+        let err = host
+            .get_agent_for_local_status("child_archived_1")
+            .await
+            .err()
+            .expect("archived agent should be rejected");
+        match err {
+            PublicAgentError::Archived { agent_id } => {
+                assert_eq!(agent_id, "child_archived_1");
+            }
+            other => panic!("expected Archived error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_agent_for_local_status_rejects_unknown() {
+        let (_home, host) = test_host();
+
+        let err = host
+            .get_agent_for_local_status("nonexistent_agent")
+            .await
+            .err()
+            .expect("unknown agent should be rejected");
+        match err {
+            PublicAgentError::NotFound { agent_id } => {
+                assert_eq!(agent_id, "nonexistent_agent");
+            }
+            other => panic!("expected NotFound error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_agent_for_local_status_accepts_public_agent() {
+        let (_home, host) = test_host();
+
+        let default_id = host.config().default_agent_id.clone();
+        let runtime = host
+            .get_agent_for_local_status(&default_id)
+            .await
+            .expect("public agent should be accessible through local status API");
+        let summary = runtime.agent_summary().await.unwrap();
+        assert_eq!(summary.identity.agent_id, default_id);
+        assert_eq!(summary.identity.visibility, AgentVisibility::Public);
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1342,7 +1342,7 @@ pub async fn status(
     authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
-        .get_public_agent(&agent_id)
+        .get_agent_for_local_status(&agent_id)
         .await
         .map_err(agent_access_error)?;
     let agent = runtime.agent_summary().await.map_err(error_response)?;

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -366,6 +366,23 @@ impl RuntimeHandle {
     }
 
     pub async fn agent_summary(&self) -> Result<AgentSummary> {
+        // Fast path: return current agent summary.
+        self.build_agent_summary().await
+    }
+
+    /// Get a full AgentSummary for a different agent through the host bridge.
+    /// This allows observing private child agents through the local trusted
+    /// control boundary.
+    pub async fn agent_summary_for(&self, agent_id: &str) -> Result<AgentSummary> {
+        let bridge = self
+            .inner
+            .host_bridge
+            .as_ref()
+            .ok_or_else(|| anyhow!("agent_summary_for: no host bridge available"))?;
+        bridge.agent_summary_for(agent_id).await
+    }
+
+    async fn build_agent_summary(&self) -> Result<AgentSummary> {
         let agent = self.agent_state().await?;
         let active_task_count = self.inner.storage.active_task_count_for_agent(&agent.id)?;
         let model = self.model_state_for(&agent);

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -1299,3 +1299,105 @@ fn current_input_summary_extracts_body_from_context_section() {
         "Fix the failing benchmark output."
     );
 }
+
+#[tokio::test]
+async fn agent_get_default_returns_current_agent_summary() {
+    let (_home, _host, runtime) = host_backed_test_runtime().await;
+
+    let result = crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &AuthorityClass::OperatorInstruction,
+        &crate::tool::ToolCall {
+            id: "agent-get-default".into(),
+            name: "AgentGet".into(),
+            input: serde_json::json!({}),
+        },
+    )
+    .await
+    .expect("AgentGet with no args should succeed");
+    assert!(
+        !result.is_error(),
+        "AgentGet default should not be an error"
+    );
+    let envelope = result.envelope;
+    let envelope_str = serde_json::to_string(&envelope).unwrap();
+    assert!(
+        envelope_str.contains("default"),
+        "AgentGet default should contain 'default' agent id"
+    );
+}
+
+#[tokio::test]
+async fn agent_get_with_agent_id_returns_requested_agent() {
+    let (_home, host, runtime) = host_backed_test_runtime().await;
+
+    host.create_named_agent("observer-bot", None).await.unwrap();
+
+    let result = crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &AuthorityClass::OperatorInstruction,
+        &crate::tool::ToolCall {
+            id: "agent-get-target".into(),
+            name: "AgentGet".into(),
+            input: serde_json::json!({ "agent_id": "observer-bot" }),
+        },
+    )
+    .await
+    .expect("AgentGet with agent_id should succeed");
+    assert!(
+        !result.is_error(),
+        "AgentGet with agent_id should not be an error"
+    );
+    let envelope_str = serde_json::to_string(&result.envelope).unwrap();
+    assert!(
+        envelope_str.contains("observer-bot"),
+        "AgentGet result should contain requested agent id"
+    );
+}
+
+#[tokio::test]
+async fn agent_get_with_agent_id_can_access_private_child() {
+    use crate::types::{AgentKind, AgentOwnership, AgentProfilePreset, AgentVisibility};
+
+    let (_home, host, runtime) = host_backed_test_runtime().await;
+
+    let child = crate::types::AgentIdentityRecord::new(
+        "child_agentget_test",
+        AgentKind::Child,
+        AgentVisibility::Private,
+        AgentOwnership::ParentSupervised,
+        AgentProfilePreset::PrivateChild,
+        Some(host.config().default_agent_id.clone()),
+        Some("task-agentget-test".into()),
+    );
+    host.append_agent_identity(&child).unwrap();
+
+    let child_storage = host.agent_storage("child_agentget_test").unwrap();
+    let mut child_state = crate::types::AgentState::new("child_agentget_test");
+    child_state.status = crate::types::AgentStatus::AwakeRunning;
+    child_storage.write_agent(&child_state).unwrap();
+
+    let result = crate::tool::tools::execute_builtin_tool(
+        &runtime,
+        "default",
+        &AuthorityClass::OperatorInstruction,
+        &crate::tool::ToolCall {
+            id: "agent-get-child".into(),
+            name: "AgentGet".into(),
+            input: serde_json::json!({ "agent_id": "child_agentget_test" }),
+        },
+    )
+    .await
+    .expect("AgentGet with private child agent_id should succeed");
+    assert!(
+        !result.is_error(),
+        "AgentGet with private child should not be an error"
+    );
+    let envelope_str = serde_json::to_string(&result.envelope).unwrap();
+    assert!(
+        envelope_str.contains("child_agentget_test"),
+        "AgentGet result should contain child agent id"
+    );
+}

--- a/src/tool/tool_descriptions/agent_get.md
+++ b/src/tool/tool_descriptions/agent_get.md
@@ -1,1 +1,6 @@
 Read the current agent-plane summary, including identity visibility, ownership, profile preset, lifecycle, active work focus, waiting state, and visible child-agent lineage.
+
+When called without arguments, returns the current agent's summary (unchanged behavior).
+When called with `agent_id`, returns the summary of the requested agent through the local trusted control boundary. This allows inspecting private child agents without exposing them to remote/multi-user access.
+
+Remote/multi-user authorization is deferred to future work; the current behavior relies on the local trusted control API boundary.

--- a/src/tool/tools/agent_get.rs
+++ b/src/tool/tools/agent_get.rs
@@ -16,7 +16,10 @@ pub(crate) const NAME: &str = "AgentGet";
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct AgentGetArgs {}
+pub(crate) struct AgentGetArgs {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+}
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
     Ok(BuiltinToolDefinition {
@@ -31,7 +34,17 @@ pub(crate) async fn execute(
     _authority_class: &AuthorityClass,
     input: &Value,
 ) -> Result<crate::tool::ToolResult> {
-    let _args: AgentGetArgs = parse_tool_args(NAME, input)?;
-    let summary = runtime.agent_summary().await?;
+    let args: AgentGetArgs = parse_tool_args(NAME, input)?;
+    let summary = match args.agent_id {
+        None => {
+            // Default behavior: return current agent summary.
+            runtime.agent_summary().await?
+        }
+        Some(requested_id) => {
+            // Requested agent: resolve through the host bridge, which allows
+            // private child agents under the local trusted control boundary.
+            runtime.agent_summary_for(&requested_id).await?
+        }
+    };
     serialize_success(NAME, &AgentGetResult { agent: summary })
 }


### PR DESCRIPTION
## Summary

Implements [issue #1742](https://github.com/holon-run/holon/issues/1742): Expose private child agent status through local control APIs.

Private child agents were previously invisible to the `/agents/{agent_id}/status` HTTP endpoint and the `AgentGet` tool because both filtered on `AgentVisibility::Public`. Under the current simplified trust model, local/operator control API access is trusted, so this change allows private child agent status to be inspected through those surfaces.

## Changes

- **`RuntimeHost::get_agent_for_local_status()`** — New method that resolves an agent by ID, accepting both public and private agents while still rejecting archived/unknown agents. This is the local trusted control boundary equivalent of `get_public_agent()`.
- **`RuntimeHostBridge::agent_summary_for(agent_id)`** — Bridge wrapper that delegates to the host's new method and returns a full `AgentSummary`.
- **`RuntimeHandle::agent_summary_for(agent_id)`** — Tool-accessible method that routes through the host bridge for cross-agent observation.
- **HTTP `/agents/{agent_id}/status`** — Switched from `get_public_agent` to `get_agent_for_local_status`, enabling private child agent status queries.
- **`AgentGet` tool** — Now accepts an optional `agent_id` parameter. Without it, returns the current agent summary (unchanged). With it, returns the requested agent's summary through the local trusted control boundary.
- **Tool description** updated to document the new parameter and local-trust semantics.
- **Tests** covering: public agent rejection by `get_public_agent`, private child acceptance by `get_agent_for_local_status`, archived/unknown rejection, default `AgentGet` behavior, `AgentGet` with explicit `agent_id`, and `AgentGet` accessing private child agents.

## Acceptance Criteria

- [x] `/agents/{agent_id}/status` can return a private child agent summary through the local/operator control API.
- [x] `AgentGet` accepts an optional `agent_id` while preserving current no-argument behavior.
- [x] Behavior documented as relying on the local trusted control API boundary, not on hiding `agent_id`.
- [x] Tests cover public agent status, private child status, and current-agent default `AgentGet` behavior.
- [x] Remote/multi-user authorization is explicitly deferred to future work.

## Verification

```
cargo fmt --all -- --check     # pass
RUSTFLAGS="-D warnings" cargo check --all-targets  # pass
cargo test --lib agent_get -- --nocapture            # 4/4 pass
cargo test --lib get_agent_for_local_status -- --nocapture  # 4/4 pass
cargo test --lib get_public_agent_rejects_private_child -- --nocapture  # 1/1 pass
```
