### PR TITLE
fix: close out runtime errors with terminal records

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1205,6 +1205,7 @@ impl RuntimeHandle {
                     ))?;
                 } else {
                     error!("failed to process message {}: {err:#}", message.id);
+                    self.ensure_runtime_failure_terminal(None, 0).await?;
                     self.inner.storage.append_event(&AuditEvent::new(
                         "runtime_error",
                         serde_json::json!({
@@ -1218,6 +1219,14 @@ impl RuntimeHandle {
                     ))?;
                     self.persist_runtime_failure_artifacts(&message, &err)
                         .await?;
+                    self.inner.storage.append_queue_entry(&QueueEntryRecord {
+                        message_id: message.id.clone(),
+                        agent_id: message.agent_id.clone(),
+                        priority: message.priority.clone(),
+                        status: QueueEntryStatus::Aborted,
+                        created_at: message.created_at,
+                        updated_at: Utc::now(),
+                    })?;
                 }
                 let failed_state = {
                     let mut guard = self.inner.agent.lock().await;

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -1,8 +1,28 @@
 use super::*;
 use crate::provider::ProviderAttemptTimeline;
-use crate::types::{FailureArtifact, FailureArtifactCategory};
+use crate::types::{FailureArtifact, FailureArtifactCategory, TurnTerminalRecord};
 
 impl RuntimeHandle {
+    pub(super) async fn ensure_runtime_failure_terminal(
+        &self,
+        last_assistant_message: Option<String>,
+        duration_ms: u64,
+    ) -> Result<TurnTerminalRecord> {
+        let existing = {
+            let guard = self.inner.agent.lock().await;
+            guard
+                .state
+                .last_turn_terminal
+                .clone()
+                .filter(|terminal| terminal.turn_index == guard.state.turn_index)
+        };
+        if let Some(terminal) = existing {
+            return Ok(terminal);
+        }
+        self.persist_turn_aborted_record("", "runtime_error", last_assistant_message, duration_ms)
+            .await
+    }
+
     fn sanitize_failure_artifact_url(raw: &str) -> String {
         let Ok(mut url) = reqwest::Url::parse(raw) else {
             return raw.to_string();
@@ -289,15 +309,12 @@ impl RuntimeHandle {
             .map(ToString::to_string)
             .filter(|line| !line.trim().is_empty())
             .collect::<Vec<_>>();
-        let brief = brief::make_failure(&message.agent_id, message, failure_text.clone());
+        let terminal = self.ensure_runtime_failure_terminal(None, 0).await?;
+        let mut brief = brief::make_failure(&message.agent_id, message, failure_text.clone());
+        brief.turn_id = Some(terminal.turn_id.clone());
+        brief.turn_index = Some(terminal.turn_index);
         self.persist_brief(&brief).await?;
-        let terminal = {
-            let guard = self.inner.agent.lock().await;
-            guard.state.last_turn_terminal.clone()
-        };
-        if let Some(terminal) = terminal {
-            self.persist_turn_record(&terminal).await?;
-        }
+        self.persist_turn_record(&terminal).await?;
         self.persist_transcript_evidence(&TranscriptEntry::new(
             message.agent_id.clone(),
             TranscriptEntryKind::RuntimeFailure,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1368,6 +1368,81 @@ async fn enqueue_generates_turn_id_for_blank_admitted_turn_id() {
 }
 
 #[tokio::test]
+async fn runtime_error_marks_queue_entry_aborted_and_persists_failed_turn() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(FailingTimelineProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "trigger runtime failure".into(),
+        },
+    );
+    let message_id = message.id.clone();
+    runtime.enqueue(message).await.unwrap();
+
+    let runner = tokio::spawn(runtime.clone().run());
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let queue_entries = runtime.storage().latest_queue_entries().unwrap();
+            if queue_entries.iter().any(|entry| {
+                entry.message_id == message_id && entry.status == QueueEntryStatus::Aborted
+            }) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("runtime error should mark queue entry aborted");
+
+    runtime
+        .control(crate::types::ControlAction::Stop)
+        .await
+        .unwrap();
+    runner.await.unwrap().unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    let terminal = state
+        .last_turn_terminal
+        .as_ref()
+        .expect("runtime error should persist terminal turn");
+    assert_eq!(terminal.kind, TurnTerminalKind::Aborted);
+
+    let briefs = runtime.storage().read_recent_briefs(10).unwrap();
+    let failure_brief = briefs
+        .iter()
+        .find(|brief| brief.kind == BriefKind::Failure)
+        .expect("runtime error should persist failure brief");
+    assert_eq!(failure_brief.turn_index, Some(terminal.turn_index));
+
+    let turns = runtime.storage().read_recent_turns(10).unwrap();
+    let turn = turns
+        .iter()
+        .find(|turn| turn.turn_id == terminal.turn_id)
+        .expect("runtime error should persist turn record");
+    assert_eq!(
+        turn.terminal.as_ref().map(|terminal| terminal.kind),
+        Some(TurnTerminalKind::Aborted)
+    );
+    assert_eq!(turn.produced_brief_ids, vec![failure_brief.id.clone()]);
+}
+
+#[tokio::test]
 async fn enqueue_normalizes_callback_payload_without_operator_elevation() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -1280,3 +1280,82 @@ async fn runtime_failure_artifacts_append_turn_record_after_failure_brief() {
     );
     assert_eq!(turns[0].produced_brief_ids, vec![failure_brief.id.clone()]);
 }
+
+#[tokio::test]
+async fn runtime_failure_artifacts_create_terminal_turn_record_when_missing() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(FailingTimelineProvider),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator { actor_id: None },
+        AuthorityClass::OperatorInstruction,
+        Priority::Next,
+        MessageBody::Text {
+            text: "trigger runtime failure".into(),
+        },
+    );
+    let error = match runtime
+        .run_agent_loop(
+            "default",
+            AuthorityClass::OperatorInstruction,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+    {
+        Ok(_) => panic!("provider failure should abort the turn"),
+        Err(error) => error,
+    };
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.last_turn_terminal = None;
+        runtime.storage().write_agent(&guard.state).unwrap();
+    }
+
+    runtime
+        .persist_runtime_failure_artifacts(&message, &error)
+        .await
+        .unwrap();
+
+    let state = runtime.agent_state().await.unwrap();
+    let terminal = state
+        .last_turn_terminal
+        .as_ref()
+        .expect("runtime failure should synthesize an aborted terminal");
+    assert_eq!(terminal.kind, TurnTerminalKind::Aborted);
+    assert_eq!(terminal.reason.as_deref(), Some("runtime_error"));
+
+    let briefs = runtime.storage().read_recent_briefs(10).unwrap();
+    let failure_brief = briefs
+        .iter()
+        .find(|brief| brief.kind == BriefKind::Failure)
+        .expect("missing runtime failure brief");
+    assert_eq!(failure_brief.turn_index, Some(terminal.turn_index));
+    assert_eq!(
+        failure_brief.turn_id.as_deref(),
+        Some(terminal.turn_id.as_str())
+    );
+
+    let turns = runtime.storage().read_recent_turns(10).unwrap();
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0].turn_id, terminal.turn_id);
+    assert_eq!(
+        turns[0].terminal.as_ref().map(|terminal| terminal.kind),
+        Some(TurnTerminalKind::Aborted)
+    );
+    assert_eq!(turns[0].produced_brief_ids, vec![failure_brief.id.clone()]);
+}

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1755,7 +1755,7 @@ impl RuntimeHandle {
         }))
     }
 
-    async fn persist_turn_aborted_record(
+    pub(super) async fn persist_turn_aborted_record(
         &self,
         run_id: &str,
         reason: &str,


### PR DESCRIPTION
## Summary
- Ensure ordinary runtime errors create a terminal turn record when the normal turn closeout path was skipped.
- Bind runtime failure briefs to that terminal turn id/index and persist the turn record consistently.
- Mark failed queue entries as aborted on ordinary runtime errors, with regression coverage for turn records and queue status.

Fixes #1751

## Verification
- `cargo test runtime_failure_artifacts_create_terminal_turn_record_when_missing`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
