### PR TITLE
feat: add GLM-5.2 catalog support

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -6,7 +6,7 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **49 providers** and **302 models**.
+Holon includes built-in configuration for **49 providers** and **308 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
@@ -96,6 +96,7 @@ and capabilities.
 | `bigmodel` | `glm-5` | `bigmodel/glm-5` | 202800 | 131100 | ✅ | — |
 | `bigmodel` | `glm-5-turbo` | `bigmodel/glm-5-turbo` | 202800 | 131100 | ✅ | — |
 | `bigmodel` | `glm-5.1` | `bigmodel/glm-5.1` | 202800 | 131100 | ✅ | — |
+| `bigmodel` | `glm-5.2` | `bigmodel/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `bigmodel` | `glm-5v-turbo` | `bigmodel/glm-5v-turbo` | 202800 | 131100 | ✅ | ✅ |
 | `bigmodel-anthropic` | `glm-4.5` | `bigmodel-anthropic/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `bigmodel-anthropic` | `glm-4.5-air` | `bigmodel-anthropic/glm-4.5-air` | 131072 | 98304 | ✅ | — |
@@ -109,6 +110,7 @@ and capabilities.
 | `bigmodel-anthropic` | `glm-5` | `bigmodel-anthropic/glm-5` | 202800 | 131100 | ✅ | — |
 | `bigmodel-anthropic` | `glm-5-turbo` | `bigmodel-anthropic/glm-5-turbo` | 202800 | 131100 | ✅ | — |
 | `bigmodel-anthropic` | `glm-5.1` | `bigmodel-anthropic/glm-5.1` | 202800 | 131100 | ✅ | — |
+| `bigmodel-anthropic` | `glm-5.2` | `bigmodel-anthropic/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `bigmodel-anthropic` | `glm-5v-turbo` | `bigmodel-anthropic/glm-5v-turbo` | 202800 | 131100 | ✅ | ✅ |
 | `bigmodel-openai` | `glm-4.5` | `bigmodel-openai/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `bigmodel-openai` | `glm-4.5-air` | `bigmodel-openai/glm-4.5-air` | 131072 | 98304 | ✅ | — |
@@ -122,6 +124,7 @@ and capabilities.
 | `bigmodel-openai` | `glm-5` | `bigmodel-openai/glm-5` | 202800 | 131100 | ✅ | — |
 | `bigmodel-openai` | `glm-5-turbo` | `bigmodel-openai/glm-5-turbo` | 202800 | 131100 | ✅ | — |
 | `bigmodel-openai` | `glm-5.1` | `bigmodel-openai/glm-5.1` | 202800 | 131100 | ✅ | — |
+| `bigmodel-openai` | `glm-5.2` | `bigmodel-openai/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `bigmodel-openai` | `glm-5v-turbo` | `bigmodel-openai/glm-5v-turbo` | 202800 | 131100 | ✅ | ✅ |
 | `byteplus` | `moonshotai/kimi-k2.5` | `byteplus/moonshotai/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
 | `byteplus` | `seed-1-8-251228` | `byteplus/seed-1-8-251228` | 256000 | 4096 | — | ✅ |
@@ -350,6 +353,7 @@ and capabilities.
 | `zai` | `glm-5` | `zai/glm-5` | 202800 | 131100 | ✅ | — |
 | `zai` | `glm-5-turbo` | `zai/glm-5-turbo` | 202800 | 131100 | ✅ | — |
 | `zai` | `glm-5.1` | `zai/glm-5.1` | 202800 | 131100 | ✅ | — |
+| `zai` | `glm-5.2` | `zai/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `zai` | `glm-5v-turbo` | `zai/glm-5v-turbo` | 202800 | 131100 | ✅ | ✅ |
 | `zai-anthropic` | `glm-4.5` | `zai-anthropic/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `zai-anthropic` | `glm-4.5-air` | `zai-anthropic/glm-4.5-air` | 131072 | 98304 | ✅ | — |
@@ -363,6 +367,7 @@ and capabilities.
 | `zai-anthropic` | `glm-5` | `zai-anthropic/glm-5` | 202800 | 131100 | ✅ | — |
 | `zai-anthropic` | `glm-5-turbo` | `zai-anthropic/glm-5-turbo` | 202800 | 131100 | ✅ | — |
 | `zai-anthropic` | `glm-5.1` | `zai-anthropic/glm-5.1` | 202800 | 131100 | ✅ | — |
+| `zai-anthropic` | `glm-5.2` | `zai-anthropic/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `zai-anthropic` | `glm-5v-turbo` | `zai-anthropic/glm-5v-turbo` | 202800 | 131100 | ✅ | ✅ |
 | `zai-openai` | `glm-4.5` | `zai-openai/glm-4.5` | 131072 | 98304 | ✅ | — |
 | `zai-openai` | `glm-4.5-air` | `zai-openai/glm-4.5-air` | 131072 | 98304 | ✅ | — |
@@ -376,4 +381,5 @@ and capabilities.
 | `zai-openai` | `glm-5` | `zai-openai/glm-5` | 202800 | 131100 | ✅ | — |
 | `zai-openai` | `glm-5-turbo` | `zai-openai/glm-5-turbo` | 202800 | 131100 | ✅ | — |
 | `zai-openai` | `glm-5.1` | `zai-openai/glm-5.1` | 202800 | 131100 | ✅ | — |
+| `zai-openai` | `glm-5.2` | `zai-openai/glm-5.2` | 1000000 | 131072 | ✅ | — |
 | `zai-openai` | `glm-5v-turbo` | `zai-openai/glm-5v-turbo` | 202800 | 131100 | ✅ | ✅ |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1993,6 +1993,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             false,
         ),
+        catalog_model("zai", "glm-5.2", "GLM-5.2", 1_000_000, 131_072, true, false),
         catalog_model("zai", "glm-5.1", "GLM-5.1", 202_800, 131_100, true, false),
         catalog_model("zai", "glm-5", "GLM-5", 202_800, 131_100, true, false),
         catalog_model(
@@ -2420,26 +2421,45 @@ mod tests {
             .is_none());
 
         let zai = catalog.resolve_policy(
-            &ModelRef::parse("zai-anthropic/glm-4.7").unwrap(),
+            &ModelRef::parse("zai-anthropic/glm-5.2").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
             8192,
         );
-        assert_eq!(zai.display_name, "GLM-4.7");
+        assert_eq!(zai.display_name, "GLM-5.2");
+        assert_eq!(zai.context_window_tokens, Some(1_000_000));
+        assert_eq!(zai.runtime_max_output_tokens, 131_072);
         assert_eq!(zai.source, ModelMetadataSource::BuiltInCatalog);
 
         let bigmodel = catalog.resolve_policy(
-            &ModelRef::parse("bigmodel-openai/glm-4.7").unwrap(),
+            &ModelRef::parse("bigmodel-openai/glm-5.2").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
             &base_context(),
             8192,
         );
-        assert_eq!(bigmodel.display_name, "GLM-4.7");
+        assert_eq!(bigmodel.display_name, "GLM-5.2");
+        assert_eq!(bigmodel.context_window_tokens, Some(1_000_000));
+        assert_eq!(bigmodel.runtime_max_output_tokens, 131_072);
         assert_eq!(bigmodel.source, ModelMetadataSource::BuiltInCatalog);
+
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("zai").unwrap())
+                .unwrap()
+                .as_string(),
+            "zai/glm-5.2"
+        );
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("bigmodel").unwrap())
+                .unwrap()
+                .as_string(),
+            "bigmodel/glm-5.2"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add GLM-5.2 to the shared Z.ai/BigModel model catalog\n- propagate the model to OpenAI- and Anthropic-compatible provider aliases\n- regenerate the supported model reference docs\n\n## Verification\n- live BigModel Anthropic-compatible probe with glm-5.2\n- live Z.ai Anthropic-compatible context-management probe with glm-5.2\n- live BigModel Anthropic-compatible context-management probe with glm-5.2\n- cargo fmt --all -- --check\n- RUSTFLAGS="-D warnings" cargo check --all-targets