### PR TITLE
chore: prepare v0.18.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,13 @@ jobs:
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
 
+          ## Changes
+
+          - Add GLM-5.2 model catalog support for BigModel and Z.ai provider configurations.
+          - Improve runtime closeout and persistence by serializing SQLite writes and recording terminal turn records for runtime errors.
+          - Expose private child agent status and child token usage through local control and supervised task status surfaces.
+          - Keep the generated docs search bundle outside the content root and add the agent actor invocation RFC.
+
           ## Install
 
           Homebrew:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -168,14 +168,14 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Current release
 
 The current recommended release is
-[`v0.18.1`](https://github.com/holon-run/holon/releases/tag/v0.18.1).
+[`v0.18.2`](https://github.com/holon-run/holon/releases/tag/v0.18.2).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project will maintain
 compatibility for the CLI, daemon/API semantics, and local persistent storage.
 
 See the full changes in the
-[v0.18.1 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.18.1).
+[v0.18.2 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.18.2).
 
 ## Status and compatibility
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -100,7 +100,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.18.1`](https://github.com/holon-run/holon/releases/tag/v0.18.1).
+[`v0.18.2`](https://github.com/holon-run/holon/releases/tag/v0.18.2).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -3328,7 +3328,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.18.1"
+    "version": "0.18.2"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary

Prepare the Holon v0.18.2 release from current `main`.

## Changes

- Bump crate version from `0.18.1` to `0.18.2`.
- Update README and website current-release links to `v0.18.2`.
- Add v0.18.2 release notes to the release workflow body.

## Verification

- `cargo fmt --all -- --check`
- version/current-release consistency checks
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
