### PR TITLE
feat: add bounded runtime performance diagnostics

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,8 +36,10 @@ Use:
 
 ```bash
 node benchmark/run.mjs validate-manifest --manifest benchmarks/tasks/holon-0015-tool-guidance-registry.yaml
+node benchmark/run.mjs validate-manifest --manifest benchmarks/tasks/holon-1764-runtime-performance-diagnostics.yaml
 node benchmark/run.mjs real --manifest /absolute/path/to/workspace/projects/holon-run/holon/benchmarks/tasks/holon-0050-runtime-result-closure.yaml --runner holon-openai --runner codex-openai --label bench-live-0050
 node benchmark/run.mjs suite --suite benchmarks/suites/openai-phase1.local.yaml --label bench-openai-phase1
+node benchmark/run.mjs suite --suite benchmarks/suites/performance-diagnostics.local.yaml --label bench-perf-diagnostics
 ```
 
 To push benchmark branches and create draft PRs, either:

--- a/benchmarks/suites/performance-diagnostics.local.yaml
+++ b/benchmarks/suites/performance-diagnostics.local.yaml
@@ -1,0 +1,17 @@
+suite_id: performance-diagnostics-local
+label_prefix: perf-diagnostics
+tasks:
+  - ../tasks/holon-1764-runtime-performance-diagnostics.yaml
+runners:
+  - runner_id: holon-openai
+    driver: holon
+    model_ref: openai-codex/gpt-5.3-codex-spark
+  - runner_id: codex-openai
+    driver: codex
+    model: gpt-5.3-codex-spark
+pr:
+  submit_pr: false
+  draft_pr: false
+  push_branch: false
+timeouts:
+  ci_poll_minutes: 30

--- a/benchmarks/tasks/holon-1764-runtime-performance-diagnostics.yaml
+++ b/benchmarks/tasks/holon-1764-runtime-performance-diagnostics.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+task_id: holon-1764-runtime-performance-diagnostics
+repo:
+  name: holon-run/holon
+  local_path: ../..
+issue:
+  number: 1764
+  title: "Add built-in benchmark and diagnostics for runtime query/interface/core performance"
+base:
+  branch: main
+  sha: 82d8d84396708b6b12da7257391f0b20895007c3
+benchmark:
+  mode: live
+task:
+  kind: implementation
+verification:
+  commands:
+    - "cargo test --quiet performance"
+    - "cargo fmt --all -- --check"
+    - "RUSTFLAGS=\"-D warnings\" cargo check --all-targets"
+evaluation:
+  summary: |
+    Add a bounded first-phase performance diagnostics surface for Holon's
+    expensive query/projection, HTTP/control interface, and core runtime module
+    hotspots. The implementation should expose a running-daemon snapshot that
+    operators can inspect from the CLI, and should preserve a path toward
+    broader metrics/benchmark work without introducing a large observability
+    framework.
+  expected_outcome: change_required
+  scope_policy: soft
+  allowed_paths: []
+  forbidden_paths: []
+budget:
+  max_minutes: 120
+  max_operator_followups: 0
+review:
+  mode: none
+metadata:
+  difficulty: medium
+  benchmark_group: performance-diagnostics-2026-06-13

--- a/docs/implementation-decisions/059-bounded-performance-diagnostics.md
+++ b/docs/implementation-decisions/059-bounded-performance-diagnostics.md
@@ -1,0 +1,15 @@
+# 059 Bounded Performance Diagnostics
+
+Holon exposes first-phase runtime performance diagnostics as bounded in-process
+counters, not as a full metrics subsystem.
+
+The counters cover the current investigation hotspots: HTTP JSON response
+construction, `agent_summary` projections, runtime DB connection opens, and
+scheduler poll outcomes. The snapshot is available through the local control
+plane and `holon debug performance`, so operators can inspect a running daemon
+without scraping logs or attaching a profiler.
+
+This deliberately preserves a small runtime boundary. The snapshot shape is
+stable enough for local debugging and benchmark prompts, but it does not yet
+commit Holon to Prometheus/OpenMetrics export, distributed tracing semantics, or
+high-cardinality per-query metrics.

--- a/docs/implementation-decisions/README.md
+++ b/docs/implementation-decisions/README.md
@@ -75,3 +75,4 @@ Current decision notes:
 - [055 Prompt Dump Inventory](./055-prompt-dump-inventory.md)
 - [056 Prompt Cache Workspace Guidance Boundary](./056-prompt-cache-workspace-guidance-boundary.md)
 - [057 OpenAI Codex OAuth Refresh Boundary](./057-openai-codex-oauth-refresh-boundary.md)
+- [059 Bounded Performance Diagnostics](./059-bounded-performance-diagnostics.md)

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -210,6 +210,236 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "PerformanceDiagnosticsSnapshot": {
+        "properties": {
+          "captured_at": {
+            "type": "string"
+          },
+          "db": {
+            "items": {
+              "properties": {
+                "avg_bytes": {
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "avg_ms": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "count": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "max_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "total_bytes": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "total_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "count",
+                "total_ms",
+                "max_ms",
+                "avg_ms"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "http": {
+            "items": {
+              "properties": {
+                "avg_bytes": {
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "avg_ms": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "count": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "max_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "total_bytes": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "total_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "count",
+                "total_ms",
+                "max_ms",
+                "avg_ms"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "process_uptime_ms": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "projections": {
+            "items": {
+              "properties": {
+                "avg_bytes": {
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "avg_ms": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "count": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "max_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "total_bytes": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "total_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "count",
+                "total_ms",
+                "max_ms",
+                "avg_ms"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "scheduler": {
+            "items": {
+              "properties": {
+                "avg_bytes": {
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "avg_ms": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "count": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "max_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "total_bytes": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "total_ms": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "count",
+                "total_ms",
+                "max_ms",
+                "avg_ms"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "captured_at",
+          "process_uptime_ms",
+          "http",
+          "projections",
+          "db",
+          "scheduler"
+        ],
+        "title": "PerformanceDiagnosticsSnapshot",
+        "type": "object"
+      },
       "PickWorkItemRequest": {
         "additionalProperties": false,
         "properties": {
@@ -6371,6 +6601,54 @@
           }
         ],
         "summary": "Update runtime config",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/control/runtime/performance": {
+      "get": {
+        "description": "Return bounded in-process performance diagnostics for HTTP, projections, DB, and scheduler activity.",
+        "operationId": "runtimePerformance",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PerformanceDiagnosticsSnapshot"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Runtime performance diagnostics",
         "tags": [
           "runtime"
         ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -531,6 +531,10 @@ pub enum DebugCommands {
         #[arg(long, default_value_t = 5000)]
         events_limit: usize,
     },
+    Performance {
+        #[arg(long)]
+        json: bool,
+    },
     SchedulerFixture {
         #[arg(long)]
         agent: Option<String>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use crate::{
     config::AppConfig,
     daemon::{RuntimeShutdownResponse, RuntimeStatusResponse},
+    diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
         AttachWorkspaceRequest, ClearAgentModelRequest, ControlPromptRequest, CreateAgentRequest,
         DebugPromptRequest, DetachWorkspaceRequest, ExitWorkspaceRequest,
@@ -387,6 +388,10 @@ impl LocalClient {
 
     pub async fn runtime_config(&self) -> Result<RuntimeConfigReadResponse> {
         self.get_control_json("/control/runtime/config").await
+    }
+
+    pub async fn performance_diagnostics(&self) -> Result<PerformanceDiagnosticsSnapshot> {
+        self.get_control_json("/control/runtime/performance").await
     }
 
     pub async fn update_runtime_config(

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,224 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+static PROCESS_STARTED_AT: OnceLock<Instant> = OnceLock::new();
+
+static HTTP_ALL: MetricAccumulator = MetricAccumulator::new("http.json.all");
+static HTTP_MODELS: MetricAccumulator = MetricAccumulator::new("http.json./models");
+static HTTP_AGENTS_LIST: MetricAccumulator = MetricAccumulator::new("http.json./agents/list");
+static HTTP_AGENT_STATUS: MetricAccumulator =
+    MetricAccumulator::new("http.json./agents/{agent_id}/status");
+static HTTP_AGENT_STATE: MetricAccumulator =
+    MetricAccumulator::new("http.json./agents/{agent_id}/state");
+static HTTP_OTHER: MetricAccumulator = MetricAccumulator::new("http.json.other");
+
+static PROJECTION_AGENT_SUMMARY: MetricAccumulator =
+    MetricAccumulator::new("projection.agent_summary");
+static DB_CONNECTION_OPEN: MetricAccumulator = MetricAccumulator::new("db.connection.open");
+
+static SCHEDULER_POLL_ALL: MetricAccumulator = MetricAccumulator::new("scheduler.poll.all");
+static SCHEDULER_POLL_MESSAGE: MetricAccumulator = MetricAccumulator::new("scheduler.poll.message");
+static SCHEDULER_POLL_IDLE: MetricAccumulator = MetricAccumulator::new("scheduler.poll.idle");
+static SCHEDULER_POLL_STOPPED: MetricAccumulator = MetricAccumulator::new("scheduler.poll.stopped");
+static SCHEDULER_POLL_SHUTDOWN: MetricAccumulator =
+    MetricAccumulator::new("scheduler.poll.shutdown");
+static SCHEDULER_POLL_SKIPPED: MetricAccumulator = MetricAccumulator::new("scheduler.poll.skipped");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerformanceDiagnosticsSnapshot {
+    pub captured_at: String,
+    pub process_uptime_ms: u64,
+    pub http: Vec<MetricSnapshot>,
+    pub projections: Vec<MetricSnapshot>,
+    pub db: Vec<MetricSnapshot>,
+    pub scheduler: Vec<MetricSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricSnapshot {
+    pub name: String,
+    pub count: u64,
+    pub total_ms: u64,
+    pub max_ms: u64,
+    pub avg_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_bytes: Option<f64>,
+}
+
+struct MetricAccumulator {
+    name: &'static str,
+    count: AtomicU64,
+    total_ms: AtomicU64,
+    max_ms: AtomicU64,
+    total_bytes: AtomicU64,
+}
+
+impl MetricAccumulator {
+    const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            count: AtomicU64::new(0),
+            total_ms: AtomicU64::new(0),
+            max_ms: AtomicU64::new(0),
+            total_bytes: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, elapsed: Duration, bytes: Option<usize>) {
+        let elapsed_ms = elapsed.as_millis().min(u128::from(u64::MAX)) as u64;
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.total_ms.fetch_add(elapsed_ms, Ordering::Relaxed);
+        if let Some(bytes) = bytes {
+            self.total_bytes
+                .fetch_add(bytes.min(u64::MAX as usize) as u64, Ordering::Relaxed);
+        }
+        let mut current = self.max_ms.load(Ordering::Relaxed);
+        while elapsed_ms > current {
+            match self.max_ms.compare_exchange_weak(
+                current,
+                elapsed_ms,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(next) => current = next,
+            }
+        }
+    }
+
+    fn snapshot(&'static self, include_bytes: bool) -> MetricSnapshot {
+        let count = self.count.load(Ordering::Relaxed);
+        let total_ms = self.total_ms.load(Ordering::Relaxed);
+        let total_bytes = self.total_bytes.load(Ordering::Relaxed);
+        MetricSnapshot {
+            name: self.name.to_string(),
+            count,
+            total_ms,
+            max_ms: self.max_ms.load(Ordering::Relaxed),
+            avg_ms: average(total_ms, count),
+            total_bytes: include_bytes.then_some(total_bytes),
+            avg_bytes: include_bytes.then_some(average(total_bytes, count)),
+        }
+    }
+}
+
+pub fn record_http_json_response(route: &'static str, elapsed: Duration, bytes: usize) {
+    process_started_at();
+    HTTP_ALL.record(elapsed, Some(bytes));
+    http_route_accumulator(route).record(elapsed, Some(bytes));
+}
+
+pub fn record_agent_summary_projection(elapsed: Duration) {
+    process_started_at();
+    PROJECTION_AGENT_SUMMARY.record(elapsed, None);
+}
+
+pub fn record_runtime_db_connection_open(elapsed: Duration) {
+    process_started_at();
+    DB_CONNECTION_OPEN.record(elapsed, None);
+}
+
+pub fn record_scheduler_poll(outcome: &'static str, elapsed: Duration) {
+    process_started_at();
+    SCHEDULER_POLL_ALL.record(elapsed, None);
+    scheduler_poll_accumulator(outcome).record(elapsed, None);
+}
+
+pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
+    let started_at = process_started_at();
+    PerformanceDiagnosticsSnapshot {
+        captured_at: Utc::now().to_rfc3339(),
+        process_uptime_ms: started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        http: vec![
+            HTTP_ALL.snapshot(true),
+            HTTP_MODELS.snapshot(true),
+            HTTP_AGENTS_LIST.snapshot(true),
+            HTTP_AGENT_STATUS.snapshot(true),
+            HTTP_AGENT_STATE.snapshot(true),
+            HTTP_OTHER.snapshot(true),
+        ],
+        projections: vec![PROJECTION_AGENT_SUMMARY.snapshot(false)],
+        db: vec![DB_CONNECTION_OPEN.snapshot(false)],
+        scheduler: vec![
+            SCHEDULER_POLL_ALL.snapshot(false),
+            SCHEDULER_POLL_MESSAGE.snapshot(false),
+            SCHEDULER_POLL_IDLE.snapshot(false),
+            SCHEDULER_POLL_STOPPED.snapshot(false),
+            SCHEDULER_POLL_SHUTDOWN.snapshot(false),
+            SCHEDULER_POLL_SKIPPED.snapshot(false),
+        ],
+    }
+}
+
+fn http_route_accumulator(route: &'static str) -> &'static MetricAccumulator {
+    match route {
+        "/models" => &HTTP_MODELS,
+        "/agents/list" => &HTTP_AGENTS_LIST,
+        "/agents/{agent_id}/status" => &HTTP_AGENT_STATUS,
+        "/agents/{agent_id}/state" => &HTTP_AGENT_STATE,
+        _ => &HTTP_OTHER,
+    }
+}
+
+fn scheduler_poll_accumulator(outcome: &'static str) -> &'static MetricAccumulator {
+    match outcome {
+        "message" => &SCHEDULER_POLL_MESSAGE,
+        "idle" => &SCHEDULER_POLL_IDLE,
+        "stopped" => &SCHEDULER_POLL_STOPPED,
+        "shutdown" => &SCHEDULER_POLL_SHUTDOWN,
+        _ => &SCHEDULER_POLL_SKIPPED,
+    }
+}
+
+fn process_started_at() -> &'static Instant {
+    PROCESS_STARTED_AT.get_or_init(Instant::now)
+}
+
+fn average(total: u64, count: u64) -> f64 {
+    if count == 0 {
+        0.0
+    } else {
+        total as f64 / count as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_includes_bounded_runtime_hotspot_groups() {
+        record_http_json_response("/agents/{agent_id}/state", Duration::from_millis(7), 1024);
+        record_agent_summary_projection(Duration::from_millis(3));
+        record_runtime_db_connection_open(Duration::from_millis(2));
+        record_scheduler_poll("idle", Duration::from_millis(1));
+
+        let snapshot = performance_snapshot();
+
+        assert!(
+            snapshot
+                .http
+                .iter()
+                .any(|metric| metric.name == "http.json./agents/{agent_id}/state"
+                    && metric.count >= 1)
+        );
+        assert!(snapshot
+            .projections
+            .iter()
+            .any(|metric| metric.name == "projection.agent_summary" && metric.count >= 1));
+        assert!(snapshot
+            .db
+            .iter()
+            .any(|metric| metric.name == "db.connection.open" && metric.count >= 1));
+        assert!(snapshot
+            .scheduler
+            .iter()
+            .any(|metric| metric.name == "scheduler.poll.idle" && metric.count >= 1));
+    }
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -3,6 +3,7 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 static PROCESS_STARTED_AT: OnceLock<Instant> = OnceLock::new();
@@ -28,7 +29,7 @@ static SCHEDULER_POLL_SHUTDOWN: MetricAccumulator =
     MetricAccumulator::new("scheduler.poll.shutdown");
 static SCHEDULER_POLL_SKIPPED: MetricAccumulator = MetricAccumulator::new("scheduler.poll.skipped");
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PerformanceDiagnosticsSnapshot {
     pub captured_at: String,
     pub process_uptime_ms: u64,
@@ -38,7 +39,7 @@ pub struct PerformanceDiagnosticsSnapshot {
     pub scheduler: Vec<MetricSnapshot>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct MetricSnapshot {
     pub name: String,
     pub count: u64,

--- a/src/http.rs
+++ b/src/http.rs
@@ -57,6 +57,7 @@ use crate::{
         graceful_runtime_shutdown, runtime_activity_summary, RuntimeConfigSurface,
         RuntimeServiceHandle,
     },
+    diagnostics,
     host::{PublicAgentError, RuntimeHost},
     ingress::{InboundRequest, WakeDisposition, WakeHint},
     operator_event::{
@@ -297,6 +298,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/control/runtime/readiness", get(runtime_readiness))
         .route("/control/runtime/status", get(runtime_status))
+        .route("/control/runtime/performance", get(runtime_performance))
         .route("/control/runtime/config", get(runtime_config))
         .route("/control/runtime/config", patch(runtime_config_update))
         .route("/control/runtime/shutdown", post(runtime_shutdown))
@@ -421,6 +423,7 @@ fn traced_json<T: Serialize>(
 ) -> Result<AxumResponse, (StatusCode, Json<Value>)> {
     let bytes = serde_json::to_vec(&value).map_err(|err| error_response(err.into()))?;
     let build_elapsed = started_at.elapsed();
+    diagnostics::record_http_json_response(route, build_elapsed, bytes.len());
     if build_elapsed >= HTTP_SLOW_RESPONSE_WARN_AFTER
         || bytes.len() >= HTTP_LARGE_RESPONSE_WARN_BYTES
     {
@@ -939,6 +942,14 @@ pub async fn runtime_readiness(
     ))
 }
 
+pub async fn runtime_performance(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    Ok(Json(diagnostics::performance_snapshot()))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct RuntimeConfigReadResponse {
     pub ok: bool,
@@ -1339,6 +1350,7 @@ pub async fn status(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let started_at = std::time::Instant::now();
     authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     let runtime = state
         .host
@@ -1346,7 +1358,7 @@ pub async fn status(
         .await
         .map_err(agent_access_error)?;
     let agent = runtime.agent_summary().await.map_err(error_response)?;
-    Ok(Json(agent))
+    traced_json("/agents/{agent_id}/status", started_at, agent)
 }
 
 pub async fn state_default(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod client;
 pub mod config;
 pub mod context;
 pub mod daemon;
+pub mod diagnostics;
 pub mod fd_limit;
 pub mod host;
 mod host_registry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1113,6 +1113,18 @@ mod tests {
     }
 
     #[test]
+    fn debug_performance_command_parses_json_flag() {
+        let cli = Cli::parse_from(["holon", "debug", "performance", "--json"]);
+        let Commands::Debug {
+            command: DebugCommands::Performance { json },
+        } = cli.command
+        else {
+            panic!("expected debug performance command");
+        };
+        assert!(json);
+    }
+
+    #[test]
     fn export_scheduler_fixture_writes_replay_harness_shape() {
         let config = test_config();
         let agent_id = "default";
@@ -1490,6 +1502,7 @@ async fn handle_debug_command(config: AppConfig, command: DebugCommands) -> Resu
             limit,
             events_limit,
         } => print_latency_diagnostics(&config, agent, limit, events_limit),
+        DebugCommands::Performance { json } => print_performance_diagnostics(&config, json).await,
         DebugCommands::SchedulerFixture { agent, output } => {
             export_scheduler_fixture(&config, agent, &output)
         }
@@ -1775,6 +1788,41 @@ fn print_latency_diagnostics(
         );
     }
     Ok(())
+}
+
+async fn print_performance_diagnostics(config: &AppConfig, json: bool) -> Result<()> {
+    let client = LocalClient::new(config.clone())?;
+    let snapshot = client.performance_diagnostics().await?;
+    if json {
+        return print_json(&serde_json::to_value(snapshot)?);
+    }
+
+    println!(
+        "process uptime {}",
+        format_duration_ms(snapshot.process_uptime_ms)
+    );
+    print_metric_group("http", &snapshot.http);
+    print_metric_group("projections", &snapshot.projections);
+    print_metric_group("db", &snapshot.db);
+    print_metric_group("scheduler", &snapshot.scheduler);
+    Ok(())
+}
+
+fn print_metric_group(group: &str, metrics: &[holon::diagnostics::MetricSnapshot]) {
+    println!("{group}:");
+    for metric in metrics {
+        if metric.count == 0 {
+            continue;
+        }
+        let bytes = metric
+            .avg_bytes
+            .map(|avg| format!(" avg_bytes={avg:.0}"))
+            .unwrap_or_default();
+        println!(
+            "  {:<36} count={} avg_ms={:.1} max_ms={}{}",
+            metric.name, metric.count, metric.avg_ms, metric.max_ms, bytes
+        );
+    }
 }
 
 fn build_latency_diagnostics(events: &[AuditEvent], limit: usize) -> Vec<TurnLatencyDiagnostics> {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -6,6 +6,7 @@ use schemars::{generate::SchemaSettings, JsonSchema};
 use serde_json::{json, Value};
 
 use crate::{
+    diagnostics::PerformanceDiagnosticsSnapshot,
     http::{
         CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest, PickWorkItemRequest,
         PickWorkItemResponse, RuntimeConfigReadResponse, RuntimeConfigUpdateRequest,
@@ -104,6 +105,7 @@ const ROUTES: &[RouteSpec] = &[
     route("post", "/control/agents/{agent_id}/operator-ingress", "operatorIngress", "control", "Operator ingress", "Deliver an authenticated remote operator prompt.", Some("OperatorIngressRequest"), AuthKind::Control),
     route("get", "/control/runtime/readiness", "runtimeReadiness", "runtime", "Runtime readiness", "Return daemon readiness metadata.", None, AuthKind::Control),
     route("get", "/control/runtime/status", "runtimeStatus", "runtime", "Runtime status", "Return daemon status and runtime activity metadata.", None, AuthKind::Control),
+    route_with_response("get", "/control/runtime/performance", "runtimePerformance", "runtime", "Runtime performance diagnostics", "Return bounded in-process performance diagnostics for HTTP, projections, DB, and scheduler activity.", None, "PerformanceDiagnosticsSnapshot", AuthKind::Control),
     route_with_response("get", "/control/runtime/config", "runtimeConfig", "runtime", "Runtime config", "Return the daemon effective runtime configuration surface.", None, "RuntimeConfigReadResponse", AuthKind::Control),
     route_with_response("patch", "/control/runtime/config", "runtimeConfigUpdate", "runtime", "Update runtime config", "Persist runtime-mutable config updates and classify their effect as restart/reload-required or rejected.", Some("RuntimeConfigUpdateRequest"), "RuntimeConfigUpdateResponse", AuthKind::Control),
     route("post", "/control/runtime/shutdown", "runtimeShutdown", "runtime", "Runtime shutdown", "Request graceful runtime shutdown.", None, AuthKind::Control),
@@ -491,6 +493,10 @@ fn component_schemas() -> Value {
     schemas.insert(
         "RuntimeConfigReadResponse".into(),
         component_schema::<RuntimeConfigReadResponse>(),
+    );
+    schemas.insert(
+        "PerformanceDiagnosticsSnapshot".into(),
+        component_schema::<PerformanceDiagnosticsSnapshot>(),
     );
     schemas.insert(
         "RuntimeConfigUpdateRequest".into(),

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -416,6 +416,7 @@ impl RuntimeHandle {
     }
 
     async fn build_agent_summary(&self) -> Result<AgentSummary> {
+        let started_at = std::time::Instant::now();
         let agent = self.agent_state().await?;
         let active_task_count = self.inner.storage.active_task_count_for_agent(&agent.id)?;
         let model = self.model_state_for(&agent);
@@ -448,7 +449,7 @@ impl RuntimeHandle {
             last_turn: agent.last_turn_token_usage.clone(),
         };
         let active_external_triggers = self.active_external_trigger_summaries().await?;
-        Ok(AgentSummary {
+        let summary = AgentSummary {
             identity,
             lifecycle: crate::types::AgentLifecycleHint::from_status(
                 &agent.id,
@@ -471,7 +472,9 @@ impl RuntimeHandle {
             recent_operator_notifications: self.recent_operator_notifications(10).await?,
             recent_brief_count: self.inner.storage.read_recent_briefs(50)?.len(),
             recent_event_count: self.inner.storage.read_recent_events(100)?.len(),
-        })
+        };
+        crate::diagnostics::record_agent_summary_projection(started_at.elapsed());
+        Ok(summary)
     }
 
     pub async fn agent_list_entry(&self) -> Result<AgentListEntry> {

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -8,6 +8,17 @@ pub(super) enum RunLoopPoll {
     Idle,
 }
 
+impl RunLoopPoll {
+    fn outcome_name(&self) -> &'static str {
+        match self {
+            RunLoopPoll::Shutdown => "shutdown",
+            RunLoopPoll::Stopped(_, _) => "stopped",
+            RunLoopPoll::Message(_) => "message",
+            RunLoopPoll::Idle => "idle",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ShutdownReason {
     DaemonShutdown,
@@ -283,16 +294,32 @@ impl<'a> SchedulerDecisionExecutor<'a> {
     }
 
     pub(super) async fn poll(&self) -> Result<RunLoopPoll> {
+        let started_at = std::time::Instant::now();
         let candidate = {
             let guard = self.runtime.inner.agent.lock().await;
             if self.runtime.inner.shutdown_requested.load(Ordering::SeqCst) {
-                return self.shutdown(guard);
+                let poll = self.shutdown(guard)?;
+                crate::diagnostics::record_scheduler_poll(
+                    poll.outcome_name(),
+                    started_at.elapsed(),
+                );
+                return Ok(poll);
             }
             if guard.state.status == AgentStatus::Stopped {
-                return Ok(RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len()));
+                let poll = RunLoopPoll::Stopped(guard.state.clone(), guard.queue.len());
+                crate::diagnostics::record_scheduler_poll(
+                    poll.outcome_name(),
+                    started_at.elapsed(),
+                );
+                return Ok(poll);
             }
             let Some(message) = guard.queue.peek().cloned() else {
-                return Ok(RunLoopPoll::Idle);
+                let poll = RunLoopPoll::Idle;
+                crate::diagnostics::record_scheduler_poll(
+                    poll.outcome_name(),
+                    started_at.elapsed(),
+                );
+                return Ok(poll);
             };
             QueueCandidate {
                 message,
@@ -301,7 +328,9 @@ impl<'a> SchedulerDecisionExecutor<'a> {
             }
         };
 
-        self.prepare_message(candidate).await
+        let poll = self.prepare_message(candidate).await?;
+        crate::diagnostics::record_scheduler_poll(poll.outcome_name(), started_at.elapsed());
+        Ok(poll)
     }
 
     fn shutdown(

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -4745,6 +4745,7 @@ enum LockMode {
 }
 
 fn open_connection(path: &Path) -> Result<Connection> {
+    let started_at = Instant::now();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("creating runtime db directory {}", parent.display()))?;
@@ -4752,6 +4753,7 @@ fn open_connection(path: &Path) -> Result<Connection> {
     let connection =
         Connection::open(path).with_context(|| format!("opening runtime db {}", path.display()))?;
     configure_connection(&connection)?;
+    crate::diagnostics::record_runtime_db_connection_open(started_at.elapsed());
     Ok(connection)
 }
 

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 58, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 59, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -617,6 +617,23 @@
     "aliases": []
   },
   {
+    "path": "debug.performance",
+    "positionals": [],
+    "flags": [
+      {
+        "long": "json",
+        "short": null,
+        "default_value": null,
+        "possible_values": [
+          "true",
+          "false"
+        ],
+        "required": false
+      }
+    ],
+    "aliases": []
+  },
+  {
     "path": "debug.prompt",
     "positionals": [
       {

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -416,6 +416,22 @@
   },
   {
     "method": "get",
+    "path": "/control/runtime/performance",
+    "handler": "runtime_performance",
+    "operation_id": "runtimePerformance",
+    "tag": "runtime",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/control/runtime/readiness",
     "handler": "runtime_readiness",
     "operation_id": "runtimeReadiness",


### PR DESCRIPTION
## Summary
- add bounded in-process performance diagnostics counters for HTTP JSON responses, agent summary projection, runtime DB connection opens, and scheduler poll outcomes
- expose the snapshot through the local control plane and `holon debug performance [--json]`
- add a benchmark task/suite plus a focused implementation decision note for the first-phase diagnostics boundary

## Verification
- `cargo fmt --all -- --check`
- `cargo test performance -- --nocapture`
- `node benchmark/run.mjs validate-manifest --manifest benchmarks/tasks/holon-1764-runtime-performance-diagnostics.yaml`
- `npm test` in `benchmark/`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

Note: `node benchmark/run.mjs validate-suite ...` is not a lightweight validation command in the current runner; it starts suite execution and timed out locally, so suite parsing is covered by `benchmark` tests instead.
