### PR TITLE
chore: prepare v0.18.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.18.2"
+version = "0.18.3"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -168,14 +168,14 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Current release
 
 The current recommended release is
-[`v0.18.2`](https://github.com/holon-run/holon/releases/tag/v0.18.2).
+[`v0.18.3`](https://github.com/holon-run/holon/releases/tag/v0.18.3).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project will maintain
 compatibility for the CLI, daemon/API semantics, and local persistent storage.
 
 See the full changes in the
-[v0.18.2 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.18.2).
+[v0.18.3 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.18.3).
 
 ## Status and compatibility
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -100,7 +100,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.18.2`](https://github.com/holon-run/holon/releases/tag/v0.18.2).
+[`v0.18.3`](https://github.com/holon-run/holon/releases/tag/v0.18.3).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -3558,7 +3558,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.18.2"
+    "version": "0.18.3"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary
- bump Holon package and lockfile metadata to `0.18.3`
- update the current release references in README docs to `v0.18.3`
- refresh the generated OpenAPI snapshot version to `0.18.3`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test openapi_snapshot`
- `cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
