### PR TITLE
fix: unify work item wait state projection

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -5632,6 +5632,7 @@ mod tests {
                 compaction_keep_recent_messages: 4,
                 ..ContextConfig::default()
             },
+            dir.path(),
         )
         .unwrap();
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,8 +16,8 @@ use crate::{
         ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TaskRecord, TodoItemState,
         ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, TurnRecord,
-        WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus, WorkItemRecord,
-        WorkItemRefStatus, WorkingMemorySnapshot,
+        WaitConditionRecord, WaitConditionStatus, WorkItemRecord, WorkItemRefStatus,
+        WorkingMemorySnapshot,
     },
 };
 
@@ -133,12 +133,12 @@ pub fn build_context_with_default_external_ingress(
         &mut tools,
     )?;
     let transcript = storage.read_recent_transcript(config.recent_messages)?;
-    let active_waiting_intents = storage
-        .latest_waiting_intents()?
+    let active_wait_conditions = storage
+        .latest_wait_conditions()?
         .into_iter()
-        .filter(|intent| intent.agent_id == agent.id)
-        .filter(|intent| intent.scope == WaitingIntentScope::WorkItem)
-        .filter(|intent| intent.status == WaitingIntentStatus::Active)
+        .filter(|condition| condition.agent_id == agent.id)
+        .filter(|condition| condition.work_item_id.is_some())
+        .filter(|condition| condition.status == WaitConditionStatus::Active)
         .collect::<Vec<_>>();
     let episodes = storage.read_recent_context_episodes(config.recent_episode_candidates)?;
     let work_queue_projection = storage.work_queue_prompt_projection()?;
@@ -215,7 +215,7 @@ pub fn build_context_with_default_external_ingress(
             &mut remaining_budget,
             turn_section(
                 "current_work_item",
-                render_current_work_item(work_item, storage.data_dir(), &active_waiting_intents),
+                render_current_work_item(work_item, storage.data_dir(), &active_wait_conditions),
             ),
         );
         if let Some(content) = render_current_work_refs(work_item) {
@@ -225,6 +225,12 @@ pub fn build_context_with_default_external_ingress(
                 turn_section("current_work_refs", content),
             );
         }
+    } else {
+        push_budgeted_section(
+            &mut sections,
+            &mut remaining_budget,
+            turn_section("current_work_item", render_empty_current_work_item()),
+        );
     }
 
     let recent_turn_window_start = recent_turn_window_start(&turn_records);
@@ -1002,7 +1008,7 @@ fn render_message(message: &MessageEnvelope) -> String {
 fn render_current_work_item(
     work_item: &WorkItemRecord,
     agent_home: &std::path::Path,
-    active_waiting_intents: &[WaitingIntentRecord],
+    active_wait_conditions: &[WaitConditionRecord],
 ) -> String {
     let mut lines = vec![
         "Current work item:".to_string(),
@@ -1032,26 +1038,26 @@ fn render_current_work_item(
     if let Some(blocked_by) = work_item.blocked_by.as_deref() {
         lines.push(format!("- Blocked by: {blocked_by}"));
     }
-    let waits = active_waiting_intents
+    let waits = active_wait_conditions
         .iter()
-        .filter(|intent| intent.work_item_id.as_deref() == Some(work_item.id.as_str()))
+        .filter(|condition| condition.work_item_id.as_deref() == Some(work_item.id.as_str()))
         .collect::<Vec<_>>();
     if !waits.is_empty() {
         lines.push("- Active waits:".to_string());
-        lines.extend(waits.into_iter().take(4).map(|intent| {
-            let triggered = intent
-                .last_triggered_at
-                .map(|at| format!(" :: last_triggered_at={at}"))
-                .unwrap_or_default();
-            let resource = intent
-                .resource
+        lines.extend(waits.into_iter().take(4).map(|condition| {
+            let subject = condition
+                .subject_ref
                 .as_deref()
-                .map(|resource| format!(" :: resource={resource}"))
+                .map(|subject| format!(" :: subject_ref={subject}"))
                 .unwrap_or_default();
-            format!("  - {}{resource}{triggered}", intent.description)
+            format!("  - {}{subject}", condition.waiting_for)
         }));
     }
     lines.join("\n")
+}
+
+fn render_empty_current_work_item() -> String {
+    "Current work item: none.\nNo focused WorkItem is attached to this turn.".to_string()
 }
 
 fn render_current_work_refs(work_item: &WorkItemRecord) -> Option<String> {
@@ -3162,8 +3168,8 @@ mod tests {
             ContextEpisodeRecord, ContinuationTriggerKind, EpisodeBoundaryReason,
             ExternalTriggerScope, LoadedAgentsMd, MessageKind, MessageOrigin, Priority, TaskKind,
             TaskStatus, TodoItem, TodoItemState, ToolExecutionRecord, ToolExecutionStatus,
-            TranscriptEntry, TranscriptEntryKind, WaitingIntentRecord, WaitingIntentScope,
-            WaitingIntentStatus, WorkItemRef, WorkItemRefKind, WorkItemRefStatus, WorkItemState,
+            TranscriptEntry, TranscriptEntryKind, WaitConditionKind, WakeSource, WorkItemRef,
+            WorkItemRefKind, WorkItemRefStatus, WorkItemState,
         },
     };
 
@@ -5369,46 +5375,49 @@ mod tests {
             },
         ];
         storage.append_work_item(&active).unwrap();
+        let now = chrono::Utc::now();
         storage
-            .append_waiting_intent(&WaitingIntentRecord {
+            .append_wait_condition(&WaitConditionRecord {
                 id: "wait-current".into(),
                 agent_id: "default".into(),
-                scope: WaitingIntentScope::WorkItem,
                 work_item_id: Some(active.id.clone()),
-                description: "wait for CI webhook".into(),
-                source: "github".into(),
-                resource: Some("pull/1099".into()),
-                condition: Some("ci completed".into()),
-                delivery_mode: CallbackDeliveryMode::EnqueueMessage,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: "cb-current".into(),
-                created_at: chrono::Utc::now(),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pull/1099".into()),
+                waiting_for: "wait for CI webhook".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("cb-current".into()),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
                 cancelled_at: None,
-                last_triggered_at: Some(chrono::Utc::now()),
-                trigger_count: 1,
-                correlation_id: None,
-                causation_id: None,
+                turn_id: None,
             })
             .unwrap();
         storage
-            .append_waiting_intent(&WaitingIntentRecord {
+            .append_wait_condition(&WaitConditionRecord {
                 id: "wait-other-agent".into(),
                 agent_id: "other-agent".into(),
-                scope: WaitingIntentScope::WorkItem,
                 work_item_id: Some(active.id.clone()),
-                description: "other agent wait must not leak".into(),
-                source: "github".into(),
-                resource: Some("pull/other".into()),
-                condition: Some("ci completed".into()),
-                delivery_mode: CallbackDeliveryMode::EnqueueMessage,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: "cb-other".into(),
-                created_at: chrono::Utc::now(),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pull/other".into()),
+                waiting_for: "other agent wait must not leak".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("cb-other".into()),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
                 cancelled_at: None,
-                last_triggered_at: Some(chrono::Utc::now()),
-                trigger_count: 1,
-                correlation_id: None,
-                causation_id: None,
+                turn_id: None,
             })
             .unwrap();
         storage
@@ -5592,6 +5601,52 @@ mod tests {
     }
 
     #[test]
+    fn build_context_includes_empty_current_work_item_section_when_unfocused() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "Continue".to_string(),
+            },
+        );
+        let agent = AgentState::new("default");
+        storage.write_agent(&agent).unwrap();
+
+        let built = build_context(
+            &storage,
+            &agent,
+            &execution_snapshot_for(&agent),
+            &crate::types::SkillsRuntimeView::default(),
+            &current_message,
+            None,
+            &ContextConfig {
+                recent_messages: 4,
+                recent_briefs: 4,
+                compaction_trigger_messages: 10,
+                compaction_keep_recent_messages: 4,
+                ..ContextConfig::default()
+            },
+        )
+        .unwrap();
+
+        let section = built
+            .sections
+            .iter()
+            .find(|section| section.name == "current_work_item")
+            .expect("empty current_work_item section should be present");
+        assert!(section.content.contains("Current work item: none."));
+        assert!(section
+            .content
+            .contains("No focused WorkItem is attached to this turn."));
+    }
+
+    #[test]
     fn build_context_includes_ranked_work_item_candidates_and_completion_reports() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
@@ -5670,25 +5725,43 @@ mod tests {
         storage.append_work_item(&waiting).unwrap();
         storage.append_work_item(&completed).unwrap();
         storage.append_brief(&completion_brief).unwrap();
+        let now = chrono::Utc::now();
         storage
-            .append_waiting_intent(&WaitingIntentRecord {
+            .append_wait_condition(&WaitConditionRecord {
                 id: "wait-triggered".into(),
                 agent_id: "default".into(),
-                scope: WaitingIntentScope::WorkItem,
                 work_item_id: Some(triggered.id.clone()),
-                description: "CI completed".into(),
-                source: "github".into(),
-                resource: Some("pull/1099".into()),
-                condition: Some("ci completed".into()),
-                delivery_mode: CallbackDeliveryMode::EnqueueMessage,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: "cb-triggered".into(),
-                created_at: chrono::Utc::now(),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pull/1099".into()),
+                waiting_for: "ci completed".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("cb-triggered".into()),
+                }],
+                continuation: None,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
                 cancelled_at: None,
-                last_triggered_at: Some(chrono::Utc::now()),
-                trigger_count: 1,
-                correlation_id: None,
-                causation_id: None,
+                turn_id: None,
+            })
+            .unwrap();
+        storage
+            .append_external_trigger(&ExternalTriggerRecord {
+                external_trigger_id: "cb-triggered".into(),
+                target_agent_id: "default".into(),
+                waiting_intent_id: None,
+                scope: ExternalTriggerScope::Agent,
+                delivery_mode: CallbackDeliveryMode::WakeHint,
+                trigger_url: None,
+                token_hash: "token-hash".into(),
+                status: ExternalTriggerStatus::Active,
+                created_at: now,
+                revoked_at: None,
+                last_delivered_at: Some(now),
+                delivery_count: 1,
             })
             .unwrap();
 

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -3,8 +3,7 @@ use anyhow::Result;
 use crate::{
     storage::AppStorage,
     types::{
-        AgentState, ClosureDecision, TodoItemState, WaitingIntentScope, WaitingIntentStatus,
-        WorkingMemorySnapshot,
+        AgentState, ClosureDecision, TodoItemState, WaitConditionStatus, WorkingMemorySnapshot,
     },
 };
 
@@ -61,20 +60,20 @@ pub fn derive_working_memory_snapshot(
     let projection = storage.work_queue_prompt_projection()?;
     let current_work_item = projection.current.as_ref();
     let active_waiting = storage
-        .latest_waiting_intents()?
+        .latest_wait_conditions()?
         .into_iter()
-        .filter(|record| record.status == WaitingIntentStatus::Active)
-        .filter(|record| record.scope == WaitingIntentScope::WorkItem)
+        .filter(|record| record.status == WaitConditionStatus::Active)
+        .filter(|record| record.work_item_id.is_some())
         .collect::<Vec<_>>();
     let current_work_item_id = current_work_item.map(|item| item.id.as_str());
     let waiting_on = active_waiting
         .iter()
         .filter(|record| record.work_item_id.as_deref() == current_work_item_id)
         .map(|record| {
-            if let Some(resource) = record.resource.as_deref() {
-                format!("{} on {}", record.description, resource)
+            if let Some(subject_ref) = record.subject_ref.as_deref() {
+                format!("{} on {}", record.waiting_for, subject_ref)
             } else {
-                record.description.clone()
+                record.waiting_for.clone()
             }
         })
         .chain(current_closure.waiting_reason.map(|reason| {

--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -139,8 +139,11 @@ impl RuntimeHandle {
                 queue_len,
                 work_queue_projection.clone(),
             )?;
-        let trigger =
-            idle_tick_trigger_from_state(pending_wake_hint, work_queue_projection, due_rechecks);
+        let trigger = idle_tick_trigger_from_state(
+            pending_wake_hint,
+            work_queue_projection,
+            due_rechecks.clone(),
+        );
 
         let suppress_continue_active = triggering_continuation
             .is_some_and(|continuation| continuation.model_reentry)
@@ -181,11 +184,13 @@ impl RuntimeHandle {
                             }),
                         ))?;
                     }
+                    self.consume_work_item_rechecks(&due_rechecks).await?;
                     return Ok(false);
                 }
                 scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                 self.emit_system_tick_from_work_queue(&active, "continue_active")
                     .await?;
+                self.consume_work_item_rechecks(&due_rechecks).await?;
                 Ok(true)
             }
             Some(IdleTickTrigger::WorkQueueQueued(queued)) => {
@@ -221,11 +226,13 @@ impl RuntimeHandle {
                             }),
                         ))?;
                     }
+                    self.consume_work_item_rechecks(&due_rechecks).await?;
                     return Ok(false);
                 }
                 scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
                 self.emit_system_tick_from_work_queue(&queued, "queued_available")
                     .await?;
+                self.consume_work_item_rechecks(&due_rechecks).await?;
                 Ok(true)
             }
             Some(IdleTickTrigger::WakeHint(pending)) => {
@@ -252,6 +259,8 @@ impl RuntimeHandle {
                         guard.state.pending_wake_hint = None;
                         guard.persist_state(&self.inner.storage)?;
                     }
+                    drop(guard);
+                    self.consume_work_item_rechecks(&due_rechecks).await?;
                     return Ok(false);
                 }
                 scheduler::append_scheduler_decision(&self.inner.storage, &decision)?;
@@ -267,6 +276,8 @@ impl RuntimeHandle {
                     guard.state.pending_wake_hint = None;
                     guard.persist_state(&self.inner.storage)?;
                 }
+                drop(guard);
+                self.consume_work_item_rechecks(&due_rechecks).await?;
                 Ok(true)
             }
             Some(IdleTickTrigger::BlockedRecheck(items)) => {
@@ -294,7 +305,17 @@ impl RuntimeHandle {
             .inner
             .storage
             .due_blocked_work_item_rechecks(agent_id, chrono::Utc::now())?;
-        for item in due_rechecks {
+        self.consume_work_item_rechecks(&due_rechecks).await
+    }
+
+    async fn consume_work_item_rechecks(
+        &self,
+        work_items: &[crate::types::WorkItemRecord],
+    ) -> Result<()> {
+        if work_items.is_empty() {
+            return Ok(());
+        }
+        for item in work_items {
             let _ = self.consume_work_item_recheck(&item.id).await?;
         }
         Ok(())
@@ -1221,6 +1242,38 @@ mod tests {
     }
 
     #[test]
+    fn pending_wake_hint_consumes_due_blocked_recheck_without_recheck_tick() {
+        let test_runtime = test_runtime();
+        set_agent_idle(&test_runtime);
+
+        set_wake_hint(&test_runtime, "wake-test");
+        let blocked = add_queued_work_item(&test_runtime, "wi-blocked", "blocked-target");
+        block_work_item_with_due_recheck(&test_runtime, &blocked, "waiting for wake");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let emitted = rt
+            .block_on(test_runtime.runtime.maybe_emit_pending_system_tick(None))
+            .unwrap();
+
+        assert!(emitted, "wake hint should still emit a system tick");
+        let ticks = get_emitted_system_ticks(&test_runtime);
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(
+            ticks[0].0, "wake_hint",
+            "wake hint should provide the execution opportunity"
+        );
+
+        let latest = latest_work_item(&test_runtime, "wi-blocked");
+        assert!(
+            latest
+                .recheck_consumed_at
+                .zip(latest.recheck_at)
+                .is_some_and(|(consumed_at, recheck_at)| consumed_at >= recheck_at),
+            "due recheck should be consumed because wake hint already woke the agent"
+        );
+    }
+
+    #[test]
     fn current_work_item_takes_precedence_over_queued_notification() {
         let test_runtime = test_runtime();
         set_agent_idle(&test_runtime);
@@ -1251,7 +1304,7 @@ mod tests {
     }
 
     #[test]
-    fn active_waiting_intent_blocks_work_queue_idle_tick() {
+    fn legacy_waiting_intent_does_not_block_work_queue_idle_tick() {
         let test_runtime = test_runtime();
         set_agent_idle(&test_runtime);
 
@@ -1264,29 +1317,17 @@ mod tests {
             .unwrap();
 
         assert!(
-            !emitted,
-            "active waiting intent should block work-queue self reactivation"
+            emitted,
+            "legacy waiting intents should no longer block work-queue self reactivation"
         );
-        assert!(get_emitted_system_ticks(&test_runtime).is_empty());
-        let events = test_runtime
-            .runtime
-            .inner
-            .storage
-            .read_recent_events(10)
-            .unwrap();
-        let decision = events
-            .iter()
-            .find(|event| event.kind == "scheduler_decision")
-            .expect("blocking decision should be recorded");
+        let ticks = get_emitted_system_ticks(&test_runtime);
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(ticks[0].0, "work_queue");
         assert_eq!(
-            decision.data["decision"].as_str(),
-            Some("WaitForExternalChange")
+            ticks[0].1["reason"].as_str(),
+            Some("continue_active"),
+            "current work item should continue when only a legacy waiting intent exists"
         );
-        assert!(decision.data["evidence"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|value| value.as_str() == Some("work_item_scheduling_state=WaitingExternal")));
     }
 
     #[test]

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -4,9 +4,9 @@ use crate::storage::{AppStorage, WorkQueuePromptProjection};
 use crate::types::{
     AgentPostureProjection, AgentSchedulingPosture, AgentStatus, AuthorityClass,
     ExternalWaitRecoverability, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
-    Priority, TaskRecord, TaskStatus, TimerStatus, TurnTerminalKind, WaitConditionRecord,
-    WaitConditionStatus, WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus,
-    WorkItemRecord, WorkItemSchedulingState, WorkReactivationMode, WorkReactivationSignal,
+    Priority, TaskRecord, TaskStatus, TimerStatus, TurnTerminalKind, WaitConditionKind,
+    WaitConditionRecord, WaitConditionStatus, WorkItemRecord, WorkItemSchedulingState,
+    WorkReactivationMode, WorkReactivationSignal,
 };
 use chrono::{DateTime, Utc};
 
@@ -130,20 +130,29 @@ impl SchedulerProjection {
         let waiting_work_item = waiting_work_item_projection.map(|item| item.work_item.clone());
         let waiting_work_item_scheduling_state =
             waiting_work_item_projection.map(|item| item.scheduling_state);
-        let active_waiting_intents = storage
-            .latest_waiting_intents()?
+        let active_wait_conditions = storage
+            .latest_wait_conditions()?
             .into_iter()
-            .filter(|intent| {
-                intent.agent_id == snapshot.id && intent.status == WaitingIntentStatus::Active
+            .filter(|condition| {
+                condition.agent_id == snapshot.id && condition.status == WaitConditionStatus::Active
             })
             .collect::<Vec<_>>();
-        let active_work_item_waiting_intents = active_waiting_intents
+        let active_work_item_waiting_intents = active_wait_conditions
             .iter()
-            .filter(|intent| intent.scope == WaitingIntentScope::WorkItem)
+            .filter(|condition| condition.work_item_id.is_some())
             .count();
-        let active_agent_waiting_intents = active_waiting_intents
+        let active_agent_waiting_intents = active_wait_conditions
             .iter()
-            .filter(|intent| intent.scope == WaitingIntentScope::Agent)
+            .filter(|condition| condition.work_item_id.is_none())
+            .filter(|condition| {
+                matches!(
+                    condition.kind,
+                    WaitConditionKind::External
+                        | WaitConditionKind::Timer
+                        | WaitConditionKind::System
+                        | WaitConditionKind::Operator
+                )
+            })
             .count();
         let active_timers = storage
             .latest_timer_records()?
@@ -161,7 +170,7 @@ impl SchedulerProjection {
             queued_work_items: queued_runnable_work_items.len(),
             queued_runnable_work_items,
             pending_wake_hint: snapshot.pending_wake_hint,
-            active_waiting_intents: active_waiting_intents.len(),
+            active_waiting_intents: active_wait_conditions.len(),
             active_work_item_waiting_intents,
             active_agent_waiting_intents,
             active_timers,
@@ -232,11 +241,6 @@ impl SchedulerDiagnostic {
         self
     }
 
-    fn waiting_intent_id(mut self, waiting_intent_id: impl Into<String>) -> Self {
-        self.waiting_intent_id = Some(waiting_intent_id.into());
-        self
-    }
-
     fn wait_condition_id(mut self, wait_condition_id: impl Into<String>) -> Self {
         self.wait_condition_id = Some(wait_condition_id.into());
         self
@@ -283,7 +287,6 @@ pub(crate) fn scheduling_diagnostics_with_queue_len(
     let posture = storage.agent_posture_projection(agent)?;
     let work_queue = storage.work_queue_prompt_projection()?;
     let wait_conditions = storage.latest_wait_conditions()?;
-    let waiting_intents = storage.latest_waiting_intents()?;
 
     Ok(scheduling_diagnostics_for_facts(
         agent,
@@ -291,7 +294,6 @@ pub(crate) fn scheduling_diagnostics_with_queue_len(
         &posture,
         &work_queue,
         &wait_conditions,
-        &waiting_intents,
     ))
 }
 
@@ -301,7 +303,6 @@ pub(crate) fn scheduling_diagnostics_for_facts(
     posture: &AgentPostureProjection,
     work_queue: &WorkQueuePromptProjection,
     wait_conditions: &[WaitConditionRecord],
-    waiting_intents: &[WaitingIntentRecord],
 ) -> Vec<SchedulerDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -380,23 +381,6 @@ pub(crate) fn scheduling_diagnostics_for_facts(
             .evidence("blocked_by_present=true")
             .evidence("recheck_at=None")
             .evidence("has_active_waits=false"),
-        );
-    }
-
-    for intent in waiting_intents.iter().filter(|intent| {
-        intent.agent_id == agent.id
-            && intent.status == WaitingIntentStatus::Active
-            && intent.external_trigger_id.trim().is_empty()
-    }) {
-        diagnostics.push(
-            SchedulerDiagnostic::warning(
-                "waiting_intent_without_external_trigger",
-                "active waiting intent has no external trigger id",
-            )
-            .waiting_intent_id(intent.id.clone())
-            .maybe_work_item_id(intent.work_item_id.clone())
-            .evidence(format!("scope={:?}", intent.scope))
-            .evidence("external_trigger_id_empty=true"),
         );
     }
 

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -41,6 +41,7 @@ struct TaskFixture {
 #[derive(Deserialize)]
 struct WaitingIntentFixture {
     id: String,
+    #[allow(dead_code)]
     scope: WaitingIntentScope,
     work_item_id: Option<String>,
 }
@@ -92,6 +93,36 @@ struct ToolExecutionFixture {
     status: ToolExecutionStatus,
     #[serde(default)]
     work_item_id: Option<String>,
+}
+
+fn append_active_external_wait_condition(
+    storage: &AppStorage,
+    id: &str,
+    agent_id: &str,
+    work_item_id: Option<&str>,
+) {
+    storage
+        .append_wait_condition(&WaitConditionRecord {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            work_item_id: work_item_id.map(ToString::to_string),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("test".into()),
+            subject_ref: None,
+            waiting_for: format!("{id} wait"),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some(format!("trigger-{id}")),
+            }],
+            continuation: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            expires_at: None,
+            resolved_at: None,
+            cancelled_at: None,
+            turn_id: None,
+        })
+        .unwrap();
 }
 
 #[derive(Deserialize)]
@@ -277,24 +308,25 @@ fn build_scheduler_fixture(name: &str) -> (tempfile::TempDir, AppStorage, AgentS
     }
     for intent in waiting_intents {
         storage
-            .append_waiting_intent(&WaitingIntentRecord {
+            .append_wait_condition(&WaitConditionRecord {
                 id: intent.id.clone(),
                 agent_id: "default".into(),
-                scope: intent.scope,
                 work_item_id: intent.work_item_id,
-                description: format!("fixture waiting intent {}", intent.id),
-                source: "fixture".into(),
-                resource: None,
-                condition: None,
-                delivery_mode: CallbackDeliveryMode::WakeHint,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: format!("trigger-{}", intent.id),
+                kind: WaitConditionKind::External,
+                source: Some("fixture".into()),
+                subject_ref: None,
+                waiting_for: format!("fixture wait condition {}", intent.id),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some(format!("trigger-{}", intent.id)),
+                }],
+                continuation: None,
+                status: WaitConditionStatus::Active,
                 created_at: Utc::now(),
+                updated_at: Utc::now(),
+                expires_at: None,
+                resolved_at: None,
                 cancelled_at: None,
-                last_triggered_at: None,
-                trigger_count: 0,
-                correlation_id: None,
-                causation_id: None,
+                turn_id: None,
             })
             .unwrap();
     }
@@ -581,33 +613,8 @@ fn scheduler_projection_breaks_down_waiting_intent_scopes() {
     let storage = AppStorage::new(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
-    let now = Utc::now();
-    for (id, scope, work_item_id) in [
-        ("work-wait", WaitingIntentScope::WorkItem, Some("work-1")),
-        ("agent-wait", WaitingIntentScope::Agent, None),
-    ] {
-        storage
-            .append_waiting_intent(&WaitingIntentRecord {
-                id: id.into(),
-                agent_id: "default".into(),
-                scope,
-                work_item_id: work_item_id.map(ToString::to_string),
-                description: format!("{id} description"),
-                source: "test".into(),
-                resource: None,
-                condition: None,
-                delivery_mode: CallbackDeliveryMode::WakeHint,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: format!("trigger-{id}"),
-                created_at: now,
-                cancelled_at: None,
-                last_triggered_at: None,
-                trigger_count: 0,
-                correlation_id: None,
-                causation_id: None,
-            })
-            .unwrap();
-    }
+    append_active_external_wait_condition(&storage, "work-wait", "default", Some("work-1"));
+    append_active_external_wait_condition(&storage, "agent-wait", "default", None);
     agent.pending_wake_hint = None;
     storage.write_agent(&agent).unwrap();
 
@@ -626,27 +633,7 @@ fn scheduler_projection_filters_tasks_waiting_intents_and_timers_by_agent() {
     let now = Utc::now();
 
     for (id, agent_id) in [("wait-current", "default"), ("wait-other", "other")] {
-        storage
-            .append_waiting_intent(&WaitingIntentRecord {
-                id: id.into(),
-                agent_id: agent_id.into(),
-                scope: WaitingIntentScope::Agent,
-                work_item_id: None,
-                description: format!("{id} description"),
-                source: "test".into(),
-                resource: None,
-                condition: None,
-                delivery_mode: CallbackDeliveryMode::WakeHint,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: format!("trigger-{id}"),
-                created_at: now,
-                cancelled_at: None,
-                last_triggered_at: None,
-                trigger_count: 0,
-                correlation_id: None,
-                causation_id: None,
-            })
-            .unwrap();
+        append_active_external_wait_condition(&storage, id, agent_id, None);
     }
     for (id, agent_id) in [("timer-current", "default"), ("timer-other", "other")] {
         storage
@@ -698,27 +685,7 @@ fn idle_boundary_decision_prefers_controlled_status_over_wait_facts() {
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Stopped;
     storage.write_agent(&agent).unwrap();
-    storage
-        .append_waiting_intent(&WaitingIntentRecord {
-            id: "wait-current".into(),
-            agent_id: "default".into(),
-            scope: WaitingIntentScope::Agent,
-            work_item_id: None,
-            description: "wait".into(),
-            source: "test".into(),
-            resource: None,
-            condition: None,
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "trigger-wait-current".into(),
-            created_at: Utc::now(),
-            cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
-        })
-        .unwrap();
+    append_active_external_wait_condition(&storage, "wait-current", "default", None);
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     let decision = scheduler::idle_boundary_decision(&projection, "fixture");
@@ -733,27 +700,7 @@ fn idle_boundary_decision_inspects_wait_facts_while_asleep() {
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Asleep;
     storage.write_agent(&agent).unwrap();
-    storage
-        .append_waiting_intent(&WaitingIntentRecord {
-            id: "wait-current".into(),
-            agent_id: "default".into(),
-            scope: WaitingIntentScope::Agent,
-            work_item_id: None,
-            description: "wait".into(),
-            source: "test".into(),
-            resource: None,
-            condition: None,
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "trigger-wait-current".into(),
-            created_at: Utc::now(),
-            cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
-        })
-        .unwrap();
+    append_active_external_wait_condition(&storage, "wait-current", "default", None);
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     let decision = scheduler::idle_boundary_decision(&projection, "fixture");
@@ -892,27 +839,7 @@ fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts()
     );
     assert_eq!(wake_decision.reason, "wake_hint");
 
-    storage
-        .append_waiting_intent(&WaitingIntentRecord {
-            id: "wait-current".into(),
-            agent_id: "default".into(),
-            scope: WaitingIntentScope::Agent,
-            work_item_id: None,
-            description: "unrelated wait".into(),
-            source: "test".into(),
-            resource: None,
-            condition: None,
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "trigger-wait-current".into(),
-            created_at: Utc::now(),
-            cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
-        })
-        .unwrap();
+    append_active_external_wait_condition(&storage, "wait-current", "default", None);
     let blocked_projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     let work_queue_decision = scheduler::decide_next_action(
         &blocked_projection,
@@ -937,33 +864,12 @@ fn queued_runnable_work_is_not_suppressed_by_unrelated_agent_waiting_intent() {
     let storage = AppStorage::new(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
-    let now = Utc::now();
 
     let mut work_item = WorkItemRecord::new("default", "queued work", WorkItemState::Open);
     work_item.id = "work-queued".into();
     work_item.revision = 4;
     storage.append_work_item(&work_item).unwrap();
-    storage
-        .append_waiting_intent(&WaitingIntentRecord {
-            id: "agent-wait".into(),
-            agent_id: "default".into(),
-            scope: WaitingIntentScope::Agent,
-            work_item_id: None,
-            description: "unrelated external wait".into(),
-            source: "github".into(),
-            resource: None,
-            condition: None,
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "trigger-agent-wait".into(),
-            created_at: now,
-            cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
-        })
-        .unwrap();
+    append_active_external_wait_condition(&storage, "agent-wait", "default", None);
 
     let projection = scheduler::SchedulerProjection::from_state(&storage, &agent).unwrap();
     assert_eq!(projection.active_agent_waiting_intents, 1);
@@ -1054,7 +960,6 @@ fn scheduling_diagnostics_detect_idle_posture_with_runnable_work() {
         &projection,
         &posture,
         &work_queue,
-        &[],
         &[],
     );
 
@@ -1223,30 +1128,8 @@ fn scheduler_diagnostic_append_dedupes_interleaved_recent_events() {
             turn_id: None,
         })
         .unwrap();
-    storage
-        .append_waiting_intent(&WaitingIntentRecord {
-            id: "intent-missing-trigger".into(),
-            agent_id: "default".into(),
-            scope: WaitingIntentScope::Agent,
-            work_item_id: None,
-            description: "fixture waiting intent".into(),
-            source: "github".into(),
-            resource: Some("pr-1".into()),
-            condition: Some("review".into()),
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "".into(),
-            created_at: now,
-            cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
-        })
-        .unwrap();
-
     let appended = scheduler::append_scheduling_diagnostics(&storage, &agent, 0).unwrap();
-    assert!(appended >= 2);
+    assert_eq!(appended, 1);
     assert_eq!(
         scheduler::append_scheduling_diagnostics(&storage, &agent, 0).unwrap(),
         0
@@ -1260,7 +1143,6 @@ fn scheduler_diagnostic_append_dedupes_interleaved_recent_events() {
         .collect::<Vec<_>>();
     assert_eq!(diagnostic_kinds.len(), appended);
     assert!(diagnostic_kinds.contains(&"external_wait_has_weak_recoverability"));
-    assert!(diagnostic_kinds.contains(&"waiting_intent_without_external_trigger"));
 }
 
 #[test]

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -376,24 +376,25 @@ async fn work_queue_projection_derives_scheduling_state_per_work_item() {
     let now = Utc::now();
     runtime
         .storage()
-        .append_waiting_intent(&WaitingIntentRecord {
+        .append_wait_condition(&WaitConditionRecord {
             id: "wait-external".into(),
             agent_id: "default".into(),
-            scope: WaitingIntentScope::WorkItem,
             work_item_id: Some(external.id.clone()),
-            description: "external callback".into(),
-            source: "github".into(),
-            resource: Some("pull_request:1".into()),
-            condition: Some("checks".into()),
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "trigger-external".into(),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pull_request:1".into()),
+            waiting_for: "checks".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-external".into()),
+            }],
+            continuation: None,
             created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
             cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
+            turn_id: None,
         })
         .unwrap();
     runtime
@@ -3523,28 +3524,29 @@ async fn external_wake_records_wait_reconciliation_without_resolving_wait() {
         .await
         .unwrap();
     runtime.pick_work_item(work.id.clone()).await.unwrap();
-    let waiting_id = "wait-ci".to_string();
+    let wait_condition_id = "wait-ci".to_string();
     let trigger_id = "trigger-ci".to_string();
     runtime
         .storage()
-        .append_waiting_intent(&WaitingIntentRecord {
-            id: waiting_id.clone(),
+        .append_wait_condition(&WaitConditionRecord {
+            id: wait_condition_id.clone(),
             agent_id: "default".into(),
-            scope: WaitingIntentScope::WorkItem,
             work_item_id: Some(work.id.clone()),
-            description: "wait for CI".into(),
-            source: "github".into(),
-            resource: Some("holon-run/holon#1292".into()),
-            condition: Some("checks complete".into()),
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: trigger_id.clone(),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("holon-run/holon#1292".into()),
+            waiting_for: "checks complete".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some(trigger_id.clone()),
+            }],
+            continuation: None,
             created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
             cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
+            turn_id: None,
         })
         .unwrap();
     runtime
@@ -3554,7 +3556,7 @@ async fn external_wake_records_wait_reconciliation_without_resolving_wait() {
         .upsert(&ExternalTriggerRecord {
             external_trigger_id: trigger_id.clone(),
             target_agent_id: "default".into(),
-            waiting_intent_id: Some(waiting_id.clone()),
+            waiting_intent_id: None,
             scope: ExternalTriggerScope::Agent,
             delivery_mode: CallbackDeliveryMode::WakeHint,
             trigger_url: Some("http://127.0.0.1:7878/callbacks/wake/ci".into()),
@@ -3605,7 +3607,7 @@ async fn external_wake_records_wait_reconciliation_without_resolving_wait() {
         .iter()
         .find(|event| {
             event.kind == "wait_reconciliation_requested"
-                && event.data["wait_condition_id"] == format!("waiting_intent:{waiting_id}")
+                && event.data["wait_condition_id"] == wait_condition_id
         })
         .expect("external wake should request wait reconciliation");
     assert_eq!(
@@ -3619,13 +3621,12 @@ async fn external_wake_records_wait_reconciliation_without_resolving_wait() {
     );
     assert_eq!(signal.data["waiting_for"].as_str(), Some("checks complete"));
 
-    let waiting = runtime.latest_waiting_intents().await.unwrap();
-    let active = waiting
-        .iter()
-        .find(|record| record.id == waiting_id)
-        .expect("waiting intent should remain visible after wake firing");
-    assert_eq!(active.status, WaitingIntentStatus::Active);
-    assert_eq!(active.trigger_count, 1);
+    let active = runtime
+        .storage()
+        .latest_active_wait_conditions_for_work_item("default", &work.id)
+        .unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].id, wait_condition_id);
 }
 
 #[tokio::test]
@@ -4361,25 +4362,27 @@ async fn current_external_wait_does_not_suppress_queued_runnable_work_item() {
     let queued = WorkItemRecord::new("default", "queued follow-up work", WorkItemState::Open);
     let queued_id = queued.id.clone();
     storage.append_work_item(&queued).unwrap();
+    let now = Utc::now();
     storage
-        .append_waiting_intent(&WaitingIntentRecord {
+        .append_wait_condition(&WaitConditionRecord {
             id: "wait-current".into(),
             agent_id: "default".into(),
-            scope: WaitingIntentScope::WorkItem,
             work_item_id: Some(current_id.clone()),
-            description: "wait for current review".into(),
-            source: "github".into(),
-            resource: Some("pull_request:1".into()),
-            condition: None,
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "trigger-current".into(),
-            created_at: Utc::now(),
+            status: WaitConditionStatus::Active,
+            kind: WaitConditionKind::External,
+            source: Some("github".into()),
+            subject_ref: Some("pull_request:1".into()),
+            waiting_for: "wait for current review".into(),
+            wake_sources: vec![WakeSource::ExternalIngress {
+                external_trigger_id: Some("trigger-current".into()),
+            }],
+            continuation: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+            resolved_at: None,
             cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
+            turn_id: None,
         })
         .unwrap();
     let mut agent = AgentState::new("default");
@@ -4802,30 +4805,6 @@ async fn pick_blocked_work_item_with_clear_blocker_resumes_runnable_focus() {
         WorkItemReadiness::Blocked
     );
 
-    let waiting_intent_id = "legacy-wait-clear-on-pick".to_string();
-    runtime
-        .storage()
-        .append_waiting_intent(&WaitingIntentRecord {
-            id: waiting_intent_id.clone(),
-            agent_id: "default".into(),
-            scope: WaitingIntentScope::WorkItem,
-            work_item_id: Some(work.id.clone()),
-            description: "legacy external wait".into(),
-            source: "github".into(),
-            resource: Some("holon-run/holon#1684".into()),
-            condition: Some("old wait".into()),
-            delivery_mode: CallbackDeliveryMode::WakeHint,
-            status: WaitingIntentStatus::Active,
-            external_trigger_id: "legacy-trigger-clear-on-pick".into(),
-            created_at: Utc::now(),
-            cancelled_at: None,
-            last_triggered_at: None,
-            trigger_count: 0,
-            correlation_id: None,
-            causation_id: None,
-        })
-        .unwrap();
-
     let picked = runtime
         .pick_work_item_with_reason_and_clear_blocker(
             work.id.clone(),
@@ -4852,14 +4831,7 @@ async fn pick_blocked_work_item_with_clear_blocker_resumes_runnable_focus() {
         .transition
         .cancelled_wait_condition_ids
         .contains(&wait.condition.id));
-    assert!(picked
-        .transition
-        .cancelled_wait_condition_ids
-        .contains(&format!("waiting_intent:{waiting_intent_id}")));
-    assert_eq!(
-        picked.transition.cancelled_waiting_intent_ids,
-        vec![waiting_intent_id]
-    );
+    assert!(picked.transition.cancelled_waiting_intent_ids.is_empty());
     assert!(runtime
         .storage()
         .latest_active_wait_conditions_for_work_item("default", &work.id)

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -483,7 +483,10 @@ impl RuntimeHandle {
             created_at: Utc::now(),
         };
         let work_item_id = self
-            .waiting_intent_work_item_id(hint.waiting_intent_id.as_deref())
+            .wake_hint_work_item_id(
+                hint.waiting_intent_id.as_deref(),
+                hint.external_trigger_id.as_deref(),
+            )
             .await?;
 
         let mut trigger_now = false;
@@ -780,6 +783,46 @@ impl RuntimeHandle {
             .storage
             .latest_waiting_intent(&self.agent_id().await?, waiting_intent_id)?
             .and_then(|record| record.work_item_id))
+    }
+
+    async fn wake_hint_work_item_id(
+        &self,
+        waiting_intent_id: Option<&str>,
+        external_trigger_id: Option<&str>,
+    ) -> Result<Option<String>> {
+        if let Some(work_item_id) = self
+            .wait_condition_work_item_id_for_external_trigger(external_trigger_id)
+            .await?
+        {
+            return Ok(Some(work_item_id));
+        }
+        self.waiting_intent_work_item_id(waiting_intent_id).await
+    }
+
+    async fn wait_condition_work_item_id_for_external_trigger(
+        &self,
+        external_trigger_id: Option<&str>,
+    ) -> Result<Option<String>> {
+        let Some(external_trigger_id) = external_trigger_id else {
+            return Ok(None);
+        };
+        let agent_id = self.agent_id().await?;
+        Ok(self
+            .inner
+            .storage
+            .latest_active_wait_conditions_for_agent(&agent_id)?
+            .into_iter()
+            .find(|condition| {
+                condition.wake_sources.iter().any(|source| {
+                    matches!(
+                        source,
+                        WakeSource::ExternalIngress {
+                            external_trigger_id: Some(id)
+                        } if id == external_trigger_id
+                    )
+                })
+            })
+            .and_then(|condition| condition.work_item_id))
     }
 
     pub async fn cancel_waiting(&self, waiting_intent_id: &str) -> Result<CancelWaitingResult> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -109,16 +109,35 @@ struct ActiveWaitConditionStates {
     operator: bool,
     timer: bool,
     system: bool,
+    last_triggered_at: Option<DateTime<Utc>>,
 }
 
 impl ActiveWaitConditionStates {
-    fn record(&mut self, kind: WaitConditionKind) {
-        match kind {
+    fn record(
+        &mut self,
+        condition: &WaitConditionRecord,
+        trigger_delivery_by_id: &std::collections::BTreeMap<String, DateTime<Utc>>,
+    ) {
+        match condition.kind {
             WaitConditionKind::Task => self.task = true,
             WaitConditionKind::External => self.external = true,
             WaitConditionKind::Operator => self.operator = true,
             WaitConditionKind::Timer => self.timer = true,
             WaitConditionKind::System => self.system = true,
+        }
+        for wake_source in &condition.wake_sources {
+            let WakeSource::ExternalIngress {
+                external_trigger_id: Some(external_trigger_id),
+            } = wake_source
+            else {
+                continue;
+            };
+            if let Some(delivered_at) = trigger_delivery_by_id.get(external_trigger_id) {
+                self.last_triggered_at = Some(
+                    self.last_triggered_at
+                        .map_or(*delivered_at, |current| current.max(*delivered_at)),
+                );
+            }
         }
     }
 
@@ -675,35 +694,16 @@ impl AppStorage {
     }
 
     pub fn append_waiting_intent(&self, record: &WaitingIntentRecord) -> Result<()> {
-        let wait_condition = wait_condition_from_waiting_intent(record);
-        let event = external_wait_recoverability_event(&wait_condition);
         let waiting_intent_bytes = jsonl_bytes(record)?;
-        let wait_condition_bytes = jsonl_bytes(&wait_condition)?;
 
-        // Compatibility migration: keep the legacy waiting-intents ledger as the
-        // first durable write, then mirror the same state into the internal wait
-        // condition ledger while holding the storage append mutex so no other
-        // append can observe or interleave with the ordered pair. A filesystem
-        // failure on the second write can still leave the legacy append present;
-        // callers should treat the returned error as a mirror consistency failure,
-        // not proof that the legacy intent was absent.
+        // Compatibility-only legacy ledger. New wait state is recorded through
+        // `append_wait_condition`; legacy waiting intents must not create or
+        // update scheduler-visible wait conditions.
         let _guard = self
             .append_mutex
             .lock()
             .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
-        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
-            runtime_db.wait_conditions().upsert(&wait_condition)?;
-            if let Some(event) = event.as_ref() {
-                self.append_event_with_append_mutex_held(event)?;
-            }
-            return Ok(());
-        }
         append_jsonl_bytes(&self.waiting_intents_path, &waiting_intent_bytes)?;
-        append_jsonl_bytes(&self.wait_conditions_path, &wait_condition_bytes)?;
-        if let Some(event) = event.as_ref() {
-            self.append_event_with_append_mutex_held(event)?;
-        }
         Ok(())
     }
 
@@ -1746,33 +1746,27 @@ impl AppStorage {
             .filter(|item| item.state == WorkItemState::Open)
             .cloned();
 
-        let active_waits = self
-            .latest_waiting_intents()?
+        let trigger_delivery_by_id = self
+            .latest_external_triggers()?
             .into_iter()
-            .filter(|intent| intent.status == WaitingIntentStatus::Active)
-            .filter(|intent| intent.scope == WaitingIntentScope::WorkItem)
-            .filter_map(|intent| intent.work_item_id.map(|id| (id, intent.last_triggered_at)))
-            .fold(
-                std::collections::BTreeMap::<String, Option<DateTime<Utc>>>::new(),
-                |mut acc, (id, triggered_at)| {
-                    let slot = acc.entry(id).or_insert(None);
-                    *slot = match (*slot, triggered_at) {
-                        (Some(left), Some(right)) => Some(left.max(right)),
-                        (None, Some(right)) => Some(right),
-                        (existing, None) => existing,
-                    };
-                    acc
-                },
-            );
+            .filter(|trigger| trigger.status == crate::types::ExternalTriggerStatus::Active)
+            .filter_map(|trigger| {
+                trigger
+                    .last_delivered_at
+                    .map(|delivered_at| (trigger.external_trigger_id, delivered_at))
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
         let active_wait_conditions = self
             .latest_wait_conditions()?
             .into_iter()
             .filter(|condition| condition.status == WaitConditionStatus::Active)
-            .filter_map(|condition| condition.work_item_id.map(|id| (id, condition.kind)))
+            .filter_map(|condition| condition.work_item_id.clone().map(|id| (id, condition)))
             .fold(
                 std::collections::BTreeMap::<String, ActiveWaitConditionStates>::new(),
-                |mut acc, (id, kind)| {
-                    acc.entry(id).or_default().record(kind);
+                |mut acc, (id, condition)| {
+                    acc.entry(id)
+                        .or_default()
+                        .record(&condition, &trigger_delivery_by_id);
                     acc
                 },
             );
@@ -1795,14 +1789,13 @@ impl AppStorage {
             .map(|item| {
                 let is_current = current_work_item_id.as_deref() == Some(item.id.as_str())
                     && item.state == WorkItemState::Open;
-                let last_triggered_at = active_waits.get(&item.id).copied().flatten();
                 let wait_condition = active_wait_conditions.get(&item.id);
                 let wait_condition_state =
                     wait_condition.and_then(ActiveWaitConditionStates::scheduling_state);
-                let has_active_waits =
-                    active_waits.contains_key(&item.id) || wait_condition_state.is_some();
+                let has_active_waits = wait_condition_state.is_some();
                 let has_active_task_waits = active_task_waits.contains(&item.id)
                     || wait_condition.is_some_and(|states| states.task);
+                let last_triggered_at = wait_condition.and_then(|states| states.last_triggered_at);
                 let has_triggered_waits = last_triggered_at.is_some();
                 let yielded = item.state == WorkItemState::Open
                     && active_continuation_suspended_ids.contains(&item.id);
@@ -1811,11 +1804,7 @@ impl AppStorage {
                 } else if has_active_task_waits {
                     item.scheduling_state(Some(WorkItemSchedulingState::WaitingTask))
                 } else {
-                    item.scheduling_state(wait_condition_state.or_else(|| {
-                        active_waits
-                            .contains_key(&item.id)
-                            .then_some(WorkItemSchedulingState::WaitingExternal)
-                    }))
+                    item.scheduling_state(wait_condition_state)
                 };
                 let readiness = readiness_for_scheduling_state(scheduling_state);
                 let candidate_class =
@@ -2734,44 +2723,6 @@ where
     parse_jsonl_match(&prefix, path, &mut matches)
 }
 
-fn wait_condition_from_waiting_intent(record: &WaitingIntentRecord) -> WaitConditionRecord {
-    let updated_at = record
-        .cancelled_at
-        .or(record.last_triggered_at)
-        .unwrap_or(record.created_at);
-    WaitConditionRecord {
-        id: format!("waiting_intent:{}", record.id),
-        agent_id: record.agent_id.clone(),
-        work_item_id: record.work_item_id.clone(),
-        status: match record.status {
-            WaitingIntentStatus::Active => WaitConditionStatus::Active,
-            WaitingIntentStatus::Cancelled => WaitConditionStatus::Cancelled,
-        },
-        kind: WaitConditionKind::External,
-        source: Some(record.source.clone()),
-        subject_ref: record.resource.clone(),
-        waiting_for: record
-            .condition
-            .clone()
-            .unwrap_or_else(|| record.description.clone()),
-        wake_sources: vec![WakeSource::ExternalIngress {
-            external_trigger_id: Some(record.external_trigger_id.clone()),
-        }],
-        continuation: Some(serde_json::json!({
-            "waiting_intent_id": record.id,
-            "external_trigger_id": record.external_trigger_id,
-            "scope": record.scope,
-            "delivery_mode": record.delivery_mode,
-        })),
-        created_at: record.created_at,
-        updated_at,
-        expires_at: None,
-        resolved_at: None,
-        cancelled_at: record.cancelled_at,
-        turn_id: None,
-    }
-}
-
 fn external_wait_recoverability_event(record: &WaitConditionRecord) -> Option<AuditEvent> {
     match record.external_recoverability()? {
         ExternalWaitRecoverability::Weak => Some(AuditEvent::new(
@@ -3024,7 +2975,7 @@ mod tests {
         EpisodeBoundaryReason, ExternalTriggerScope, ExternalTriggerStatus, MessageBody,
         MessageEnvelope, MessageKind, MessageOrigin, Priority, QueueEntryRecord, QueueEntryStatus,
         TaskKind, TaskRecord, TaskRecoverySpec, TaskStatus, TodoItem, TodoItemState,
-        ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, WorkItemPlanStatus,
+        ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, WakeSource, WorkItemPlanStatus,
         WorkItemState,
     };
 
@@ -5063,7 +5014,7 @@ mod tests {
     }
 
     #[test]
-    fn append_waiting_intent_mirrors_internal_wait_condition_ledger() {
+    fn append_waiting_intent_does_not_mirror_internal_wait_condition_ledger() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new(dir.path()).unwrap();
         let now = Utc::now();
@@ -5086,44 +5037,17 @@ mod tests {
             correlation_id: None,
             causation_id: None,
         };
-        let cancelled = WaitingIntentRecord {
-            status: WaitingIntentStatus::Cancelled,
-            cancelled_at: Some(now + chrono::Duration::seconds(10)),
-            ..active.clone()
-        };
 
         storage.append_waiting_intent(&active).unwrap();
-        let mirrored = storage.latest_wait_conditions().unwrap();
-        assert_eq!(mirrored.len(), 1);
-        assert_eq!(mirrored[0].id, "waiting_intent:wait-1");
-        assert_eq!(mirrored[0].status, WaitConditionStatus::Active);
-        assert_eq!(mirrored[0].kind, WaitConditionKind::External);
-        assert_eq!(mirrored[0].source.as_deref(), Some("github"));
-        assert_eq!(mirrored[0].subject_ref.as_deref(), Some("pr-1"));
-        assert_eq!(mirrored[0].waiting_for, "ci passed");
-        assert_eq!(
-            mirrored[0].wake_sources,
-            vec![WakeSource::ExternalIngress {
-                external_trigger_id: Some("trigger-1".into()),
-            }]
-        );
-        assert_eq!(
-            mirrored[0]
-                .continuation
-                .as_ref()
-                .and_then(|value| value.get("waiting_intent_id").and_then(|id| id.as_str())),
-            Some("wait-1")
-        );
-
-        storage.append_waiting_intent(&cancelled).unwrap();
+        assert!(storage.latest_wait_conditions().unwrap().is_empty());
         let active_for_work = storage
             .latest_active_wait_conditions_for_work_item("default", "work-1")
             .unwrap();
         assert!(active_for_work.is_empty());
-        let latest = storage.latest_wait_conditions().unwrap();
-        assert_eq!(latest.len(), 1);
-        assert_eq!(latest[0].status, WaitConditionStatus::Cancelled);
-        assert_eq!(latest[0].cancelled_at, cancelled.cancelled_at);
+
+        let waiting_intents = storage.latest_waiting_intents().unwrap();
+        assert_eq!(waiting_intents.len(), 1);
+        assert_eq!(waiting_intents[0].id, "wait-1");
     }
 
     #[test]
@@ -6288,24 +6212,41 @@ mod tests {
             storage.append_work_item(item).unwrap();
         }
         storage
-            .append_waiting_intent(&WaitingIntentRecord {
+            .append_wait_condition(&WaitConditionRecord {
                 id: "wait-triggered".into(),
                 agent_id: "default".into(),
-                scope: WaitingIntentScope::WorkItem,
                 work_item_id: Some(triggered.id.clone()),
-                description: "triggered wait".into(),
-                source: "test".into(),
-                resource: None,
-                condition: None,
-                delivery_mode: crate::types::CallbackDeliveryMode::WakeHint,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: "trigger-1".into(),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("test".into()),
+                subject_ref: None,
+                waiting_for: "triggered wait".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("trigger-1".into()),
+                }],
+                continuation: None,
                 created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
                 cancelled_at: None,
-                last_triggered_at: Some(now),
-                trigger_count: 1,
-                correlation_id: None,
-                causation_id: None,
+                turn_id: None,
+            })
+            .unwrap();
+        storage
+            .append_external_trigger(&ExternalTriggerRecord {
+                external_trigger_id: "trigger-1".into(),
+                target_agent_id: "default".into(),
+                waiting_intent_id: None,
+                scope: ExternalTriggerScope::Agent,
+                delivery_mode: crate::types::CallbackDeliveryMode::WakeHint,
+                trigger_url: None,
+                token_hash: "token-hash".into(),
+                status: ExternalTriggerStatus::Active,
+                created_at: now,
+                revoked_at: None,
+                last_delivered_at: Some(now),
+                delivery_count: 1,
             })
             .unwrap();
         let mut agent = AgentState::new("default");

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5206,11 +5206,9 @@ mod tests {
             })
             .unwrap();
         let legacy_events = storage.read_recent_events(10).unwrap();
-        let legacy_event = legacy_events
+        assert!(!legacy_events
             .iter()
-            .find(|event| event.data["wait_condition_id"] == "waiting_intent:legacy-weak")
-            .expect("legacy mirror should emit recoverability audit event");
-        assert!(legacy_event.event_seq > emitted[1].event_seq);
+            .any(|event| event.data["wait_condition_id"] == "waiting_intent:legacy-weak"));
     }
 
     #[test]
@@ -5416,24 +5414,26 @@ mod tests {
         external.updated_at = now + chrono::Duration::seconds(1);
         storage.append_work_item(&external).unwrap();
         storage
-            .append_waiting_intent(&WaitingIntentRecord {
-                id: "wait-external".into(),
+            .append_wait_condition(&WaitConditionRecord {
+                id: "external-condition".into(),
                 agent_id: "default".into(),
-                scope: WaitingIntentScope::WorkItem,
                 work_item_id: Some(external.id.clone()),
-                description: "external callback".into(),
-                source: "github".into(),
-                resource: Some("pull_request:1".into()),
-                condition: Some("merged".into()),
-                delivery_mode: CallbackDeliveryMode::WakeHint,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: "trigger-external".into(),
+                status: WaitConditionStatus::Active,
+                kind: WaitConditionKind::External,
+                source: Some("github".into()),
+                subject_ref: Some("pull_request:1".into()),
+                waiting_for: "merged".into(),
+                wake_sources: vec![WakeSource::ExternalIngress {
+                    external_trigger_id: Some("trigger-external".into()),
+                }],
+                continuation: None,
                 created_at: now,
+                updated_at: now,
+                expires_at: None,
+                resolved_at: None,
                 cancelled_at: None,
-                last_triggered_at: None,
-                trigger_count: 0,
-                correlation_id: None,
-                causation_id: None,
+
+                turn_id: None,
             })
             .unwrap();
         assert_eq!(
@@ -5529,11 +5529,14 @@ mod tests {
             |storage: &AppStorage, work_item_id: &str, kind: WaitConditionKind| {
                 let wait_kind = format!("{kind:?}");
                 let wake_sources = match kind {
+                    WaitConditionKind::External => vec![WakeSource::ExternalIngress {
+                        external_trigger_id: Some("trigger-external".into()),
+                    }],
                     WaitConditionKind::Timer => vec![WakeSource::Timer {
                         wake_at: Utc::now() + chrono::Duration::minutes(5),
                     }],
                     WaitConditionKind::System => vec![WakeSource::SystemTick],
-                    _ => unreachable!("helper is only used for timer/system waits"),
+                    _ => unreachable!("helper is only used for external/timer/system waits"),
                 };
                 storage
                     .append_wait_condition(&WaitConditionRecord {
@@ -5542,8 +5545,8 @@ mod tests {
                         work_item_id: Some(work_item_id.into()),
                         status: WaitConditionStatus::Active,
                         kind,
-                        source: None,
-                        subject_ref: None,
+                        source: (wait_kind == "External").then(|| "github".into()),
+                        subject_ref: (wait_kind == "External").then(|| "pull_request:1".into()),
                         waiting_for: wait_kind,
                         wake_sources,
                         continuation: None,
@@ -5616,27 +5619,7 @@ mod tests {
         let mut external = WorkItemRecord::new("default", "external wait", WorkItemState::Open);
         external.blocked_by = Some("github".into());
         storage.append_work_item(&external).unwrap();
-        storage
-            .append_waiting_intent(&WaitingIntentRecord {
-                id: "wait-external".into(),
-                agent_id: "default".into(),
-                scope: WaitingIntentScope::WorkItem,
-                work_item_id: Some(external.id.clone()),
-                description: "external callback".into(),
-                source: "github".into(),
-                resource: Some("pull_request:1".into()),
-                condition: Some("merged".into()),
-                delivery_mode: CallbackDeliveryMode::WakeHint,
-                status: WaitingIntentStatus::Active,
-                external_trigger_id: "trigger-external".into(),
-                created_at: Utc::now(),
-                cancelled_at: None,
-                last_triggered_at: None,
-                trigger_count: 0,
-                correlation_id: None,
-                causation_id: None,
-            })
-            .unwrap();
+        append_wait_condition(&storage, &external.id, WaitConditionKind::External);
         assert_eq!(
             posture_for(&storage, &agent),
             AgentSchedulingPosture::WaitingForExternal

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4012,6 +4012,32 @@ fn chat_text_renders_full_long_brief_events() {
 
 #[test]
 fn chat_text_cache_reuses_unchanged_content_and_replaces_stale_entries() {
+    fn normalize_active_activity_spinners(mut text: Text<'static>) -> Text<'static> {
+        for line in &mut text.lines {
+            let is_active_activity_header = line.spans.len() >= 3
+                && line.spans.get(1).is_some_and(|span| span.content == " ")
+                && line.spans.get(2).is_some_and(|span| {
+                    matches!(
+                        span.content.as_ref(),
+                        "Working"
+                            | "Queued"
+                            | "Continuing"
+                            | "Starting"
+                            | "Waiting task"
+                            | "Waiting external"
+                            | "Waiting"
+                            | "Needs input"
+                            | "Blocked"
+                            | "Delegating"
+                    )
+                });
+            if is_active_activity_header {
+                line.spans[0].content = "*".into();
+            }
+        }
+        text
+    }
+
     let client = LocalClient::new(test_config()).unwrap();
     let mut app = TuiApp::new(
         client,
@@ -4038,7 +4064,10 @@ fn chat_text_cache_reuses_unchanged_content_and_replaces_stale_entries() {
 
     let first = chat_text(&app);
     let second = chat_text(&app);
-    assert_eq!(first.lines, second.lines);
+    assert_eq!(
+        normalize_active_activity_spinners(first).lines,
+        normalize_active_activity_spinners(second).lines
+    );
 
     {
         let cache_ref = app.chat_text_cache.borrow();

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -451,6 +451,10 @@ Agent id: default
 ## execution_environment
 {EXECUTION_ENVIRONMENT}
 
+## current_work_item
+Current work item: none.
+No focused WorkItem is attached to this turn.
+
 ## context_contract
 {CONTEXT_CONTRACT}
 
@@ -790,6 +794,10 @@ Agent id: default
 ## execution_environment
 {EXECUTION_ENVIRONMENT}
 
+## current_work_item
+Current work item: none.
+No focused WorkItem is attached to this turn.
+
 ## context_contract
 {CONTEXT_CONTRACT}
 
@@ -864,6 +872,10 @@ Agent id: default
 ## execution_environment
 {EXECUTION_ENVIRONMENT}
 
+## current_work_item
+Current work item: none.
+No focused WorkItem is attached to this turn.
+
 ## context_contract
 {CONTEXT_CONTRACT}
 
@@ -925,6 +937,10 @@ Agent id: default
 
 ## execution_environment
 {EXECUTION_ENVIRONMENT}
+
+## current_work_item
+Current work item: none.
+No focused WorkItem is attached to this turn.
 
 ## context_contract
 {CONTEXT_CONTRACT}


### PR DESCRIPTION
## Summary
- make `wait_conditions` the scheduler/context wait-state source and keep legacy `waiting_intents` compatibility-only
- preserve external wake provenance by reconciling active wait conditions with delivered external triggers
- always project an explicit empty `current_work_item` section when no WorkItem is focused

Closes #1775.
Closes #1776.
Closes #1779.

## Verification
- cargo fmt --all -- --check
- cargo test runtime::memory_refresh::tests
- cargo test context::tests::build_context_includes_ranked_work_item_candidates_and_completion_reports
- cargo test storage::tests::storage_work_queue_projection_derives_candidate_classes_and_current_todo
- cargo test runtime::tests::scheduler
- cargo test runtime::tests::work_items
- cargo test context::tests
- git diff --check
- RUSTFLAGS="-D warnings" cargo check --all-targets