### PR TITLE
feat: add configurable API CORS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.43", features = ["full"] }
 tokio-stream = "0.1"
 tokio-util = "0.7"
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6.8", features = ["compression-gzip", "trace"] }
+tower-http = { version = "0.6.8", features = ["compression-gzip", "cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 unicode-width = "0.2"

--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ disconnects, the agent continues running in the daemon.
 For more operations, see the [TUI command reference](docs/website/reference/cli.md#terminal-ui)
 and [Daemon management](docs/website/reference/cli.md#daemon-management).
 
+### Remote Web UI access
+
+Browser-based Web UIs that run on another host or port must be allowed by the
+HTTP API CORS configuration. For LAN access, start the daemon on a reachable
+bind address and list the Web UI origin explicitly:
+
+```bash
+holon daemon start --access lan --host 0.0.0.0 --port 7878 --token-file ~/.config/holon/remote.token
+holon config set api.cors.enabled true
+holon config set api.cors.allowed_origins '["http://192.168.1.10:5173"]'
+```
+
+Holon does not enable wildcard browser access by default. If
+`api.cors.allow_credentials` is true, `api.cors.allowed_origins` must list
+specific origins rather than `"*"`.
+
 ## Core concepts
 
 Holon breaks agent work into a few explicit runtime objects:

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -56,6 +56,25 @@ holon config unset model.fallbacks
 
 The `models.catalog` key lets you override runtime metadata for specific provider/model refs. Keys under `model.unknown_fallback.*` control policy for models without built-in metadata.
 
+### HTTP API CORS
+
+CORS is disabled by default. Enable it only for browser-based Web UI origins
+that should call the Holon HTTP/control API. For LAN access, the API must also
+bind to a reachable address such as `0.0.0.0:7878` or a specific LAN IP; a
+`127.0.0.1` bind is not reachable from other devices.
+
+```bash
+holon config set api.cors.enabled true
+holon config set api.cors.allowed_origins '["http://192.168.1.10:5173"]'
+holon config set api.cors.allowed_methods '["GET","POST","PATCH","DELETE","OPTIONS"]'
+holon config set api.cors.allowed_headers '["content-type","authorization"]'
+holon config set api.cors.allow_credentials false
+holon config set api.cors.max_age_seconds 600
+```
+
+Do not combine `api.cors.allow_credentials=true` with
+`api.cors.allowed_origins=["*"]`; Holon rejects that unsafe combination.
+
 ## Credential Management
 
 Credentials are stored securely in `~/.holon/credentials.json`. Use `config credentials` subcommands — **never edit this file directly**.
@@ -202,6 +221,12 @@ TUI debug instrumentation is controlled by environment variables:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `api.cors.enabled` | boolean | `false` | Enable CORS responses on the HTTP/control API |
+| `api.cors.allowed_origins` | string_list | `[]` | Explicit browser origins allowed to call the API |
+| `api.cors.allowed_methods` | string_list | `["GET","POST","PATCH","DELETE","OPTIONS"]` | HTTP methods allowed by CORS preflight |
+| `api.cors.allowed_headers` | string_list | `["content-type","authorization"]` | Request headers allowed by CORS preflight |
+| `api.cors.allow_credentials` | boolean | `false` | Allow credentialed CORS requests; incompatible with wildcard origins |
+| `api.cors.max_age_seconds` | integer | `600` | Browser cache lifetime for preflight responses |
 | `web.fetch.enabled` | boolean | `true` | Enable WebFetch tool |
 | `web.fetch.max_chars` | integer | `20000` | Max characters returned to model |
 | `web.fetch.max_response_bytes` | integer | `750000` | Max response bytes before truncation |

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use axum::http::{HeaderName, HeaderValue, Method};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};
 
@@ -121,6 +122,7 @@ pub struct AppConfig {
     pub max_relevant_episodes: usize,
     pub control_token: Option<String>,
     pub control_auth_mode: ControlAuthMode,
+    pub api_cors: ApiCorsConfigFile,
     pub config_file_path: PathBuf,
     pub stored_config: HolonConfigFile,
     pub web_config: crate::web::WebConfig,
@@ -227,6 +229,8 @@ impl Default for AnthropicCacheStrategy {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct HolonConfigFile {
+    #[serde(default, skip_serializing_if = "ApiConfigFile::is_empty")]
+    pub api: ApiConfigFile,
     #[serde(default, skip_serializing_if = "ModelConfigFile::is_empty")]
     pub model: ModelConfigFile,
     #[serde(default, skip_serializing_if = "ModelsConfigFile::is_empty")]
@@ -241,6 +245,84 @@ pub struct HolonConfigFile {
     pub tui: TuiConfigFile,
     #[serde(default, skip_serializing_if = "WebConfigFile::is_empty")]
     pub web: WebConfigFile,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ApiConfigFile {
+    #[serde(default, skip_serializing_if = "ApiCorsConfigFile::is_empty")]
+    pub cors: ApiCorsConfigFile,
+}
+
+impl ApiConfigFile {
+    pub fn is_empty(&self) -> bool {
+        self.cors.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiCorsConfigFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_origins: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_methods: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_headers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_credentials: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_age_seconds: Option<u64>,
+}
+
+impl Default for ApiCorsConfigFile {
+    fn default() -> Self {
+        Self {
+            enabled: None,
+            allowed_origins: vec![],
+            allowed_methods: default_api_cors_allowed_methods(),
+            allowed_headers: default_api_cors_allowed_headers(),
+            allow_credentials: None,
+            max_age_seconds: Some(600),
+        }
+    }
+}
+
+impl ApiCorsConfigFile {
+    pub fn is_empty(&self) -> bool {
+        self.enabled.is_none()
+            && self.allowed_origins.is_empty()
+            && self.allowed_methods == default_api_cors_allowed_methods()
+            && self.allowed_headers == default_api_cors_allowed_headers()
+            && self.allow_credentials.is_none()
+            && self.max_age_seconds == Some(600)
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or(false)
+    }
+
+    pub fn allow_credentials(&self) -> bool {
+        self.allow_credentials.unwrap_or(false)
+    }
+
+    pub fn max_age_seconds(&self) -> u64 {
+        self.max_age_seconds.unwrap_or(600)
+    }
+}
+
+fn default_api_cors_allowed_methods() -> Vec<String> {
+    ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+fn default_api_cors_allowed_headers() -> Vec<String> {
+    ["content-type", "authorization"]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -569,6 +651,7 @@ impl AppConfig {
         });
         let config_file_path = persisted_config_path(&home_dir);
         let stored_config = load_persisted_config_at(&config_file_path)?;
+        validate_api_cors_config(&stored_config.api.cors)?;
         let credential_store_path = credential_store_path(&home_dir);
         let credential_store =
             if config_uses_credential_profiles(&stored_config) || credential_store_path.exists() {
@@ -721,6 +804,7 @@ impl AppConfig {
             max_relevant_episodes,
             control_token,
             control_auth_mode,
+            api_cors: stored_config.api.cors.clone(),
             config_file_path,
             stored_config,
             web_config,
@@ -1679,6 +1763,48 @@ pub fn provider_config_view(
 pub fn config_schema() -> Vec<ConfigSchemaEntry> {
     vec![
         ConfigSchemaEntry {
+            key: "api.cors.enabled",
+            kind: "boolean",
+            description: "Enable CORS responses on the HTTP/control API. Disabled by default.",
+            default: json!(false),
+            allowed_values: vec!["true", "false"],
+        },
+        ConfigSchemaEntry {
+            key: "api.cors.allowed_origins",
+            kind: "string_list",
+            description: "Allowed browser origins for HTTP/control API CORS. Use explicit origins for LAN Web UI access; wildcard is rejected when credentials are enabled.",
+            default: json!([]),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "api.cors.allowed_methods",
+            kind: "string_list",
+            description: "HTTP methods allowed by CORS preflight responses.",
+            default: json!(default_api_cors_allowed_methods()),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "api.cors.allowed_headers",
+            kind: "string_list",
+            description: "HTTP request headers allowed by CORS preflight responses.",
+            default: json!(default_api_cors_allowed_headers()),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
+            key: "api.cors.allow_credentials",
+            kind: "boolean",
+            description: "Allow credentialed browser CORS requests. Cannot be combined with wildcard origins.",
+            default: json!(false),
+            allowed_values: vec!["true", "false"],
+        },
+        ConfigSchemaEntry {
+            key: "api.cors.max_age_seconds",
+            kind: "positive_integer",
+            description: "Seconds browsers may cache successful CORS preflight responses.",
+            default: json!(600),
+            allowed_values: vec![],
+        },
+        ConfigSchemaEntry {
             key: "model.default",
             kind: "model_ref",
             description: "Explicit default provider/model ref. When unset, the runtime derives one from authenticated providers.",
@@ -2014,6 +2140,27 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
 
 pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
     match key {
+        "api.cors.enabled" => Ok(config
+            .api
+            .cors
+            .enabled
+            .map(Value::Bool)
+            .unwrap_or(Value::Null)),
+        "api.cors.allowed_origins" => Ok(json!(config.api.cors.allowed_origins)),
+        "api.cors.allowed_methods" => Ok(json!(config.api.cors.allowed_methods)),
+        "api.cors.allowed_headers" => Ok(json!(config.api.cors.allowed_headers)),
+        "api.cors.allow_credentials" => Ok(config
+            .api
+            .cors
+            .allow_credentials
+            .map(Value::Bool)
+            .unwrap_or(Value::Null)),
+        "api.cors.max_age_seconds" => Ok(config
+            .api
+            .cors
+            .max_age_seconds
+            .map(|value| json!(value))
+            .unwrap_or(Value::Null)),
         "model.default" => Ok(config
             .model
             .default
@@ -2278,6 +2425,28 @@ pub fn get_config_key(config: &HolonConfigFile, key: &str) -> Result<Value> {
 
 pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) -> Result<()> {
     match key {
+        "api.cors.enabled" => {
+            config.api.cors.enabled = Some(
+                parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
+            );
+        }
+        "api.cors.allowed_origins" => {
+            config.api.cors.allowed_origins = parse_string_list(raw_value)?;
+        }
+        "api.cors.allowed_methods" => {
+            config.api.cors.allowed_methods = parse_string_list(raw_value)?;
+        }
+        "api.cors.allowed_headers" => {
+            config.api.cors.allowed_headers = parse_string_list(raw_value)?;
+        }
+        "api.cors.allow_credentials" => {
+            config.api.cors.allow_credentials = Some(
+                parse_bool_value(raw_value)?.ok_or_else(|| anyhow!("{key} expects a boolean"))?,
+            );
+        }
+        "api.cors.max_age_seconds" => {
+            config.api.cors.max_age_seconds = Some(parse_positive_u64_key(key, raw_value)?);
+        }
         "model.default" => {
             let parsed = ModelRef::parse(raw_value)?;
             config.model.default = Some(parsed.as_string());
@@ -2508,11 +2677,22 @@ pub fn set_config_key(config: &mut HolonConfigFile, key: &str, raw_value: &str) 
         }
         _ => return Err(unknown_config_key(key)),
     }
+    validate_api_cors_config(&config.api.cors)?;
     Ok(())
 }
 
 pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
     match key {
+        "api.cors.enabled" => config.api.cors.enabled = None,
+        "api.cors.allowed_origins" => config.api.cors.allowed_origins.clear(),
+        "api.cors.allowed_methods" => {
+            config.api.cors.allowed_methods = default_api_cors_allowed_methods()
+        }
+        "api.cors.allowed_headers" => {
+            config.api.cors.allowed_headers = default_api_cors_allowed_headers()
+        }
+        "api.cors.allow_credentials" => config.api.cors.allow_credentials = None,
+        "api.cors.max_age_seconds" => config.api.cors.max_age_seconds = Some(600),
         "model.default" => config.model.default = None,
         "model.fallbacks" => config.model.fallbacks.clear(),
         "vision.default" => config.vision.default = None,
@@ -2639,6 +2819,33 @@ pub fn unset_config_key(config: &mut HolonConfigFile, key: &str) -> Result<()> {
             return Ok(());
         }
         _ => return Err(unknown_config_key(key)),
+    }
+    validate_api_cors_config(&config.api.cors)?;
+    Ok(())
+}
+
+pub fn validate_api_cors_config(cors: &ApiCorsConfigFile) -> Result<()> {
+    if cors.allow_credentials() && cors.allowed_origins.iter().any(|origin| origin == "*") {
+        return Err(anyhow!(
+            "api.cors.allow_credentials cannot be true when api.cors.allowed_origins contains wildcard *"
+        ));
+    }
+    for origin in &cors.allowed_origins {
+        if origin != "*" {
+            origin
+                .parse::<HeaderValue>()
+                .with_context(|| format!("invalid api.cors.allowed_origins entry {origin:?}"))?;
+        }
+    }
+    for method in &cors.allowed_methods {
+        method
+            .parse::<Method>()
+            .with_context(|| format!("invalid api.cors.allowed_methods entry {method:?}"))?;
+    }
+    for header in &cors.allowed_headers {
+        header
+            .parse::<HeaderName>()
+            .with_context(|| format!("invalid api.cors.allowed_headers entry {header:?}"))?;
     }
     Ok(())
 }
@@ -4429,8 +4636,9 @@ mod tests {
 
     use super::{
         built_in_provider_doc_entries, built_in_provider_registry_with_settings, config_schema,
-        credential_store_path, default_holon_home, get_config_key, get_config_value,
-        list_credential_profiles_at, load_persisted_config_at, parse_anthropic_cache_strategy,
+        credential_store_path, default_api_cors_allowed_headers, default_api_cors_allowed_methods,
+        default_holon_home, get_config_key, get_config_value, list_credential_profiles_at,
+        load_persisted_config_at, parse_anthropic_cache_strategy,
         parse_anthropic_cache_strategy_env, parse_comma_separated_values, parse_url_value,
         persisted_config_path, provider_registry_for_tests,
         resolve_anthropic_context_management_config, save_persisted_config_at, set_config_key,
@@ -4559,6 +4767,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("control-value".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),
             default_model: ModelRef::parse(default_model).unwrap(),
@@ -4886,6 +5095,97 @@ mod tests {
         assert_eq!(
             get_config_key(&config, "runtime.disable_provider_fallback").unwrap(),
             Value::Null
+        );
+    }
+
+    #[test]
+    fn set_get_and_unset_round_trip_api_cors_config() {
+        let mut config = HolonConfigFile::default();
+        set_config_key(&mut config, "api.cors.enabled", "true").unwrap();
+        set_config_key(
+            &mut config,
+            "api.cors.allowed_origins",
+            r#"["http://192.168.1.10:5173"]"#,
+        )
+        .unwrap();
+        set_config_key(&mut config, "api.cors.allowed_methods", r#"["GET","POST"]"#).unwrap();
+        set_config_key(
+            &mut config,
+            "api.cors.allowed_headers",
+            r#"["content-type","authorization"]"#,
+        )
+        .unwrap();
+        set_config_key(&mut config, "api.cors.allow_credentials", "false").unwrap();
+        set_config_key(&mut config, "api.cors.max_age_seconds", "120").unwrap();
+
+        assert_eq!(
+            get_config_key(&config, "api.cors.enabled").unwrap(),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allowed_origins").unwrap(),
+            json!(["http://192.168.1.10:5173"])
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allowed_methods").unwrap(),
+            json!(["GET", "POST"])
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allowed_headers").unwrap(),
+            json!(["content-type", "authorization"])
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allow_credentials").unwrap(),
+            Value::Bool(false)
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.max_age_seconds").unwrap(),
+            json!(120)
+        );
+
+        unset_config_key(&mut config, "api.cors.enabled").unwrap();
+        unset_config_key(&mut config, "api.cors.allowed_origins").unwrap();
+        unset_config_key(&mut config, "api.cors.allowed_methods").unwrap();
+        unset_config_key(&mut config, "api.cors.allowed_headers").unwrap();
+        unset_config_key(&mut config, "api.cors.allow_credentials").unwrap();
+        unset_config_key(&mut config, "api.cors.max_age_seconds").unwrap();
+        assert_eq!(
+            get_config_key(&config, "api.cors.enabled").unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allowed_origins").unwrap(),
+            json!([])
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allowed_methods").unwrap(),
+            json!(default_api_cors_allowed_methods())
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allowed_headers").unwrap(),
+            json!(default_api_cors_allowed_headers())
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.allow_credentials").unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            get_config_key(&config, "api.cors.max_age_seconds").unwrap(),
+            json!(600)
+        );
+    }
+
+    #[test]
+    fn api_cors_rejects_credentials_with_wildcard_origin() {
+        let mut config = HolonConfigFile::default();
+        set_config_key(&mut config, "api.cors.allowed_origins", r#"["*"]"#).unwrap();
+
+        let error = set_config_key(&mut config, "api.cors.allow_credentials", "true")
+            .expect_err("credentials plus wildcard origin should be rejected");
+
+        assert!(
+            error.to_string().contains("allow_credentials"),
+            "unexpected error: {error:?}"
         );
     }
 

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -75,6 +75,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: crate::config::ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home.path().join("config.json"),
         stored_config: Default::default(),
         default_model: ModelRef {

--- a/src/host.rs
+++ b/src/host.rs
@@ -2316,6 +2316,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("secret".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),
             default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/src/http.rs
+++ b/src/http.rs
@@ -1161,7 +1161,13 @@ fn validate_runtime_config_candidate(
 fn is_runtime_mutable_config_key(key: &str) -> bool {
     matches!(
         key,
-        "model.default"
+        "api.cors.enabled"
+            | "api.cors.allowed_origins"
+            | "api.cors.allowed_methods"
+            | "api.cors.allowed_headers"
+            | "api.cors.allow_credentials"
+            | "api.cors.max_age_seconds"
+            | "model.default"
             | "model.fallbacks"
             | "models.catalog"
             | "model.unknown_fallback"

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,7 +10,7 @@ use axum::{
     extract::{DefaultBodyLimit, MatchedPath, Path, Query, State},
     http::{
         header::{AUTHORIZATION, CONTENT_TYPE},
-        HeaderMap, Request as AxumRequest, Response, StatusCode,
+        HeaderMap, HeaderName, HeaderValue, Method, Request as AxumRequest, Response, StatusCode,
     },
     response::{
         sse::{Event, KeepAlive, Sse},
@@ -27,7 +27,10 @@ use serde_json::{json, Map, Value};
 use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
 use tower_http::{
-    classify::ServerErrorsFailureClass, compression::CompressionLayer, trace::TraceLayer,
+    classify::ServerErrorsFailureClass,
+    compression::CompressionLayer,
+    cors::{AllowOrigin, CorsLayer},
+    trace::TraceLayer,
 };
 use tracing::{error, info, warn, Span};
 
@@ -50,8 +53,8 @@ use tower::ServiceExt;
 use crate::{
     config::{
         credential_store_path, load_credential_store_at, load_persisted_config_at,
-        save_persisted_config_at, set_config_key, unset_config_key, ControlTransportKind,
-        HolonConfigFile, ModelRef,
+        save_persisted_config_at, set_config_key, unset_config_key, ApiCorsConfigFile,
+        ControlTransportKind, HolonConfigFile, ModelRef,
     },
     daemon::{
         graceful_runtime_shutdown, runtime_activity_summary, RuntimeConfigSurface,
@@ -332,6 +335,7 @@ pub fn router(state: AppState) -> Router {
         .route("/transcript", get(transcript_default))
         .route("/worktree-summary", get(worktree_summary_default))
         .fallback(not_found_handler)
+        .layer(api_cors_layer(&state.host.config().api_cors))
         .layer(CompressionLayer::new())
         .layer(
             TraceLayer::new_for_http()
@@ -414,6 +418,46 @@ pub fn router(state: AppState) -> Router {
                 ),
         )
         .with_state(Arc::new(state))
+}
+
+fn api_cors_layer(config: &ApiCorsConfigFile) -> CorsLayer {
+    if !config.enabled() {
+        return CorsLayer::new();
+    }
+
+    let methods = config
+        .allowed_methods
+        .iter()
+        .filter_map(|method| method.parse::<Method>().ok())
+        .collect::<Vec<_>>();
+    let headers = config
+        .allowed_headers
+        .iter()
+        .filter_map(|header| header.parse::<HeaderName>().ok())
+        .collect::<Vec<_>>();
+
+    let allow_origin = if config.allowed_origins.iter().any(|origin| origin == "*") {
+        AllowOrigin::any()
+    } else {
+        AllowOrigin::list(
+            config
+                .allowed_origins
+                .iter()
+                .filter_map(|origin| origin.parse::<HeaderValue>().ok()),
+        )
+    };
+
+    let mut layer = CorsLayer::new()
+        .allow_origin(allow_origin)
+        .allow_methods(methods)
+        .allow_headers(headers)
+        .max_age(Duration::from_secs(config.max_age_seconds()));
+
+    if config.allow_credentials() {
+        layer = layer.allow_credentials(true);
+    }
+
+    layer
 }
 
 fn traced_json<T: Serialize>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -782,6 +782,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("secret".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            api_cors: Default::default(),
             config_file_path: home.join("config.json"),
             stored_config: Default::default(),
             default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1013,6 +1013,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("control-value".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            api_cors: Default::default(),
             config_file_path: home_dir.join("config.json"),
             stored_config: Default::default(),
             default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),

--- a/src/provider/diagnostics.rs
+++ b/src/provider/diagnostics.rs
@@ -474,6 +474,7 @@ mod tests {
             max_relevant_episodes: 3,
             control_token: Some("control-value".into()),
             control_auth_mode: ControlAuthMode::Auto,
+            api_cors: Default::default(),
             config_file_path: home_path.join("config.json"),
             stored_config: Default::default(),
             default_model: ModelRef::parse("openai/gpt-5.4").unwrap(),

--- a/src/provider/tests/support.rs
+++ b/src/provider/tests/support.rs
@@ -288,6 +288,7 @@ pub fn test_config(
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home_path.join("config.json"),
         stored_config: Default::default(),
         default_model: ModelRef::parse(default_model).unwrap(),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -63,6 +63,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: crate::config::ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: temp.join("config.json"),
         stored_config: Default::default(),
         default_model: crate::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -31,6 +31,7 @@ http_async_tests!(
     runtime_status_route_reports_runtime_metadata,
     runtime_readiness_route_omits_activity_summary,
     runtime_config_route_reads_and_updates_persisted_runtime_config,
+    cors_preflight_respects_configured_origin,
     runtime_status_route_reports_waiting_activity_summary,
     runtime_status_route_reports_last_runtime_failure_summary,
     runtime_shutdown_route_requests_shutdown,

--- a/tests/scripted_agent_provider.rs
+++ b/tests/scripted_agent_provider.rs
@@ -35,6 +35,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
         default_model: ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1192,6 +1192,50 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     let persisted = load_persisted_config_at(&config.config_file_path)?;
     assert_eq!(persisted.model.default.as_deref(), Some("openai/gpt-4.1"));
 
+    let valid_cors_response = client
+        .patch(format!("http://{addr}/control/runtime/config"))
+        .bearer_auth("secret")
+        .json(&serde_json::json!({
+            "updates": [
+                { "key": "api.cors.enabled", "value": true },
+                { "key": "api.cors.allowed_origins", "value": ["http://192.168.1.10:5173"] },
+                { "key": "api.cors.allowed_methods", "value": ["GET", "POST"] },
+                { "key": "api.cors.allowed_headers", "value": ["content-type", "authorization"] },
+                { "key": "api.cors.allow_credentials", "value": false },
+                { "key": "api.cors.max_age_seconds", "value": 120 }
+            ]
+        }))
+        .send()
+        .await?;
+    assert!(
+        valid_cors_response.status().is_success(),
+        "valid api.cors update failed: {:?}",
+        valid_cors_response.text().await?
+    );
+    let valid_cors_payload: serde_json::Value = valid_cors_response.json().await?;
+    assert_eq!(valid_cors_payload["changed"], true);
+    assert_eq!(
+        valid_cors_payload["results"][0]["effect"],
+        "accepted_requires_restart"
+    );
+
+    let persisted = load_persisted_config_at(&config.config_file_path)?;
+    assert_eq!(persisted.api.cors.enabled, Some(true));
+    assert_eq!(
+        persisted.api.cors.allowed_origins,
+        vec!["http://192.168.1.10:5173".to_string()]
+    );
+    assert_eq!(
+        persisted.api.cors.allowed_methods,
+        vec!["GET".to_string(), "POST".to_string()]
+    );
+    assert_eq!(
+        persisted.api.cors.allowed_headers,
+        vec!["content-type".to_string(), "authorization".to_string()]
+    );
+    assert_eq!(persisted.api.cors.allow_credentials, Some(false));
+    assert_eq!(persisted.api.cors.max_age_seconds, Some(120));
+
     let valid_web_response = client
         .patch(format!("http://{addr}/control/runtime/config"))
         .bearer_auth("secret")

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use axum::Router;
 use holon::{
     client::LocalClient,
-    config::{load_persisted_config_at, AppConfig, ControlAuthMode},
+    config::{load_persisted_config_at, ApiCorsConfigFile, AppConfig, ControlAuthMode},
     daemon::RuntimeServiceHandle,
     host::RuntimeHost,
     http::{self, AppState},
@@ -1246,6 +1246,73 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
             .map(|provider| provider.kind.as_str()),
         Some("command")
     );
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn cors_preflight_respects_configured_origin() -> Result<()> {
+    let mut config = test_config();
+    config.api_cors = ApiCorsConfigFile {
+        enabled: Some(true),
+        allowed_origins: vec!["http://192.168.1.10:5173".to_string()],
+        allowed_methods: vec!["GET".to_string(), "POST".to_string()],
+        allowed_headers: vec!["content-type".to_string(), "authorization".to_string()],
+        allow_credentials: Some(false),
+        max_age_seconds: Some(600),
+    };
+    std::fs::create_dir_all(&config.workspace_dir)?;
+    init_git_repo(&config.workspace_dir)?;
+    let host = RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    let router: Router = http::router(AppState::for_tcp(host));
+    let listener = TcpListener::bind(&config.http_addr).await?;
+    let addr = connect_addr(listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let client = reqwest::Client::new();
+    let allowed = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("http://{addr}/control/runtime/status"),
+        )
+        .header("origin", "http://192.168.1.10:5173")
+        .header("access-control-request-method", "GET")
+        .header("access-control-request-headers", "authorization")
+        .send()
+        .await?;
+    assert!(allowed.status().is_success());
+    assert_eq!(
+        allowed
+            .headers()
+            .get("access-control-allow-origin")
+            .and_then(|value| value.to_str().ok()),
+        Some("http://192.168.1.10:5173")
+    );
+    assert_eq!(
+        allowed
+            .headers()
+            .get("access-control-max-age")
+            .and_then(|value| value.to_str().ok()),
+        Some("600")
+    );
+
+    let denied = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("http://{addr}/control/runtime/status"),
+        )
+        .header("origin", "http://evil.example")
+        .header("access-control-request-method", "GET")
+        .send()
+        .await?;
+    assert!(denied
+        .headers()
+        .get("access-control-allow-origin")
+        .is_none());
 
     server.abort();
     Ok(())

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -157,6 +157,7 @@ impl TestConfigBuilder {
             max_relevant_episodes: 3,
             control_token: Some("secret".into()),
             control_auth_mode: self.control_auth_mode,
+            api_cors: Default::default(),
             config_file_path: data_dir.join("config.json"),
             stored_config: Default::default(),
             default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -37,6 +37,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -36,6 +36,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/tests/wt203_task_owned_worktree_cleanup.rs
+++ b/tests/wt203_task_owned_worktree_cleanup.rs
@@ -35,6 +35,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -36,6 +36,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -36,6 +36,7 @@ fn test_config() -> AppConfig {
         max_relevant_episodes: 3,
         control_token: Some("secret".into()),
         control_auth_mode: ControlAuthMode::Auto,
+        api_cors: Default::default(),
         config_file_path: home_dir.join("config.json"),
         stored_config: Default::default(),
         default_model: holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap(),


### PR DESCRIPTION
## Summary
- add api.cors.* config keys with validation and runtime config mutation support
- apply a configurable tower-http CORS layer to the HTTP/control API, disabled by default
- document LAN Web UI access and CORS setup

Closes #1784

## Verification
- cargo fmt --all -- --check
- cargo test api_cors
- cargo test --test http_control cors_preflight_respects_configured_origin
- RUSTFLAGS="-D warnings" cargo check --all-targets