### PR TITLE
feat: add cross-agent in-app message search

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1332,6 +1332,131 @@
         "title": "RuntimeConfigUpdateResponse",
         "type": "object"
       },
+      "SearchRequest": {
+        "properties": {
+          "agent_ids": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "limit": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "types": {
+            "default": [],
+            "items": {
+              "enum": [
+                "message"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "SearchRequest",
+        "type": "object"
+      },
+      "SearchResponse": {
+        "properties": {
+          "limit": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "query": {
+            "type": "string"
+          },
+          "results": {
+            "items": {
+              "properties": {
+                "agent_id": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "locator": {
+                  "properties": {
+                    "evidence_id": {
+                      "type": "string"
+                    },
+                    "message_id": {
+                      "type": "string"
+                    },
+                    "task_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "turn_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "work_item_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "evidence_id",
+                    "message_id"
+                  ],
+                  "type": "object"
+                },
+                "preview": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "enum": [
+                    "message"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "agent_id",
+                "locator",
+                "created_at",
+                "kind"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "query",
+          "limit",
+          "results"
+        ],
+        "title": "SearchResponse",
+        "type": "object"
+      },
       "SetAgentModelRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -6952,6 +7077,64 @@
         ]
       }
     },
+    "/search": {
+      "post": {
+        "description": "Search indexed runtime history across visible agents. First version indexes message bodies and returns message result locators.",
+        "operationId": "runtimeSearch",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Search runtime history",
+        "tags": [
+          "search"
+        ]
+      }
+    },
     "/state": {
       "get": {
         "description": "Compatibility alias for the default agent state route.",
@@ -7244,6 +7427,9 @@
     },
     {
       "name": "skills"
+    },
+    {
+      "name": "search"
     },
     {
       "description": "Capability-token callback ingress. Never publish real callback_token values.",

--- a/src/http.rs
+++ b/src/http.rs
@@ -68,6 +68,7 @@ use crate::{
     },
     policy::{default_authority_for_origin, validate_message_kind_for_origin},
     runtime::{CurrentRunAbortError, CurrentRunAbortMode, CurrentRunAbortRequest},
+    runtime_db::{MessageSearchQuery, MessageSearchRow},
     storage::{EventLogPageOrder, FileActivityMarker},
     system::{ExecutionScopeKind, ExecutionSnapshot, HostLocalBoundary},
     types::{
@@ -212,6 +213,7 @@ pub fn router(state: AppState) -> Router {
         .route("/", get(root))
         .route("/handshake", get(handshake))
         .route("/models", get(models_handler))
+        .route("/search", post(search))
         .route("/agents/list", get(list_agent_entries))
         .route("/agents/{agent_id}/enqueue", post(enqueue))
         .route("/agents/{agent_id}/status", get(status))
@@ -479,6 +481,55 @@ fn traced_json<T: Serialize>(
         );
     }
     Ok(([(CONTENT_TYPE, "application/json")], bytes).into_response())
+}
+
+const SEARCH_DEFAULT_LIMIT: usize = 20;
+const SEARCH_MAX_LIMIT: usize = 100;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchItemType {
+    Message,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+pub struct SearchRequest {
+    pub query: String,
+    #[serde(default)]
+    pub agent_ids: Vec<String>,
+    #[serde(default)]
+    pub types: Vec<SearchItemType>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchResponse {
+    pub query: String,
+    pub limit: usize,
+    pub results: Vec<SearchResultItem>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchResultItem {
+    #[serde(rename = "type")]
+    pub result_type: SearchItemType,
+    pub agent_id: String,
+    pub locator: SearchResultLocator,
+    pub created_at: String,
+    pub kind: String,
+    pub preview: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchResultLocator {
+    pub evidence_id: String,
+    pub message_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -893,6 +944,66 @@ pub async fn models_handler(
             "model_availability": model_availability,
         }),
     )
+}
+
+pub async fn search(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<SearchRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let started_at = std::time::Instant::now();
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let query = request.query.trim().to_string();
+    if query.is_empty() {
+        return Err(bad_request("query must not be empty"));
+    }
+    if request
+        .types
+        .iter()
+        .any(|result_type| *result_type != SearchItemType::Message)
+    {
+        return Err(bad_request("only message search is currently supported"));
+    }
+    let limit = request
+        .limit
+        .unwrap_or(SEARCH_DEFAULT_LIMIT)
+        .clamp(1, SEARCH_MAX_LIMIT);
+    let rows = state
+        .host
+        .runtime_db()
+        .messages()
+        .search(MessageSearchQuery {
+            query: query.clone(),
+            agent_ids: request.agent_ids,
+            limit,
+        })
+        .map_err(error_response)?;
+    traced_json(
+        "/search",
+        started_at,
+        SearchResponse {
+            query,
+            limit,
+            results: rows.into_iter().map(search_result_from_message).collect(),
+        },
+    )
+}
+
+fn search_result_from_message(row: MessageSearchRow) -> SearchResultItem {
+    SearchResultItem {
+        result_type: SearchItemType::Message,
+        agent_id: row.agent_id,
+        locator: SearchResultLocator {
+            evidence_id: row.evidence_id,
+            message_id: row.message_id,
+            turn_id: row.turn_id,
+            task_id: row.task_id,
+            work_item_id: row.work_item_id,
+        },
+        created_at: row.created_at,
+        kind: row.kind,
+        preview: row.preview,
+    }
 }
 
 pub async fn handshake(

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -10,7 +10,7 @@ use crate::{
     http::{
         CancelTimerRequest, CompleteWorkItemRequest, CreateTimerRequest, PickWorkItemRequest,
         PickWorkItemResponse, RuntimeConfigReadResponse, RuntimeConfigUpdateRequest,
-        RuntimeConfigUpdateResponse, UpdateWorkItemRequest,
+        RuntimeConfigUpdateResponse, SearchRequest, SearchResponse, UpdateWorkItemRequest,
     },
     types::{
         TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult, TimerRecord,
@@ -82,6 +82,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List skills", "Return installed skills for an agent.", None, AuthKind::RemoteAccess),
+    route_with_response("post", "/search", "runtimeSearch", "search", "Search runtime history", "Search indexed runtime history across visible agents. First version indexes message bodies and returns message result locators.", Some("SearchRequest"), "SearchResponse", AuthKind::RemoteAccess),
     route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
     route("post", "/agents/{agent_id}/enqueue", "enqueueAgent", "ingress", "Enqueue agent message", "Enqueue a public channel/webhook message for the named agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
     route("post", "/webhooks/generic/{agent_id}", "genericWebhook", "ingress", "Generic webhook", "Convert an arbitrary JSON webhook body into a trusted integration message.", Some("GenericJsonPayload"), AuthKind::None),
@@ -259,6 +260,7 @@ fn openapi_value() -> Value {
             { "name": "work-items" },
             { "name": "timers" },
             { "name": "skills" },
+            { "name": "search" },
             { "name": "callbacks", "description": "Capability-token callback ingress. Never publish real callback_token values." },
             { "name": "compat" }
         ],
@@ -525,6 +527,11 @@ fn component_schemas() -> Value {
     schemas.insert(
         "CancelTimerRequest".into(),
         component_schema::<CancelTimerRequest>(),
+    );
+    schemas.insert("SearchRequest".into(), component_schema::<SearchRequest>());
+    schemas.insert(
+        "SearchResponse".into(),
+        component_schema::<SearchResponse>(),
     );
     for name in [
         "EnqueueRequest",

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{
-    ffi::ErrorCode, params, Connection, OptionalExtension, Transaction, TransactionBehavior,
+    ffi::ErrorCode, params, Connection, OptionalExtension, ToSql, Transaction, TransactionBehavior,
 };
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -199,6 +199,26 @@ pub struct EvidenceRow {
 #[derive(Debug, Clone)]
 pub struct EvidencePayloadRow {
     pub payload_json: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MessageSearchQuery {
+    pub query: String,
+    pub agent_ids: Vec<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageSearchRow {
+    pub evidence_id: String,
+    pub agent_id: String,
+    pub turn_id: Option<String>,
+    pub message_id: String,
+    pub task_id: Option<String>,
+    pub work_item_id: Option<String>,
+    pub created_at: String,
+    pub kind: String,
+    pub preview: Option<String>,
 }
 
 impl WorkItemRepository<'_> {
@@ -1365,6 +1385,68 @@ impl MessageRepository<'_> {
             .collect()
     }
 
+    pub fn search(&self, query: MessageSearchQuery) -> Result<Vec<MessageSearchRow>> {
+        if query.limit == 0 {
+            return Ok(Vec::new());
+        }
+        let search_terms = query.query.trim();
+        if search_terms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut clauses = vec!["message_search_index MATCH ?".to_string()];
+        let mut values = Vec::<String>::new();
+        values.push(search_terms.to_string());
+        if !query.agent_ids.is_empty() {
+            let placeholders = std::iter::repeat("?")
+                .take(query.agent_ids.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            clauses.push(format!("messages.agent_id IN ({placeholders})"));
+            values.extend(query.agent_ids);
+        }
+
+        let limit = i64::try_from(query.limit).unwrap_or(i64::MAX);
+        let sql = format!(
+            "SELECT messages.evidence_id,
+                    messages.agent_id,
+                    messages.turn_id,
+                    messages.message_id,
+                    messages.task_id,
+                    messages.work_item_id,
+                    messages.created_at,
+                    messages.kind,
+                    messages.preview
+             FROM message_search_index
+             JOIN messages ON messages.evidence_id = message_search_index.evidence_id
+             WHERE {}
+             ORDER BY bm25(message_search_index), messages.created_at DESC, messages.evidence_id ASC
+             LIMIT {}",
+            clauses.join(" AND "),
+            limit
+        );
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(&sql)?;
+        let params = values
+            .iter()
+            .map(|value| value as &dyn ToSql)
+            .collect::<Vec<_>>();
+        let rows = statement.query_map(params.as_slice(), |row| {
+            Ok(MessageSearchRow {
+                evidence_id: row.get(0)?,
+                agent_id: row.get(1)?,
+                turn_id: row.get(2)?,
+                message_id: row.get(3)?,
+                task_id: row.get(4)?,
+                work_item_id: row.get(5)?,
+                created_at: row.get(6)?,
+                kind: row.get(7)?,
+                preview: row.get(8)?,
+            })
+        })?;
+        rows.map(|row| row.map_err(Into::into)).collect()
+    }
+
     pub fn by_id(
         &self,
         agent_id: Option<&str>,
@@ -2274,6 +2356,7 @@ fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<
     let payload_json = serde_json::to_string(message)?;
     let content_hash = content_hash(&payload_json);
     let kind = enum_string(&message.kind)?;
+    let preview = evidence_preview(&message.body);
     tx.execute(
         "INSERT INTO messages (
             evidence_id, agent_id, turn_id, message_id, message_seq, task_id, work_item_id,
@@ -2304,11 +2387,64 @@ fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<
             kind,
             Option::<String>::None,
             content_hash,
-            evidence_preview(&message.body),
+            preview,
+            payload_json,
+        ],
+    )?;
+    upsert_message_search_index_tx(tx, message, &kind, &payload_json)?;
+    Ok(())
+}
+
+fn upsert_message_search_index_tx(
+    tx: &Transaction<'_>,
+    message: &MessageEnvelope,
+    kind: &str,
+    payload_json: &str,
+) -> Result<()> {
+    tx.execute(
+        "DELETE FROM message_search_index WHERE evidence_id = ?1",
+        params![message.id],
+    )?;
+    tx.execute(
+        "INSERT INTO message_search_index (
+            evidence_id, agent_id, turn_id, message_id, task_id, work_item_id,
+            kind, body_text, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            message.id,
+            message.agent_id,
+            message.turn_id,
+            message.id,
+            message.task_id,
+            message.work_item_id,
+            kind,
+            message_body_search_text(&message.body),
             payload_json,
         ],
     )?;
     Ok(())
+}
+
+fn message_body_search_text(body: &crate::types::MessageBody) -> String {
+    match body {
+        crate::types::MessageBody::Text { text } => text.clone(),
+        crate::types::MessageBody::Json { value } => value.to_string(),
+        crate::types::MessageBody::Brief {
+            title,
+            text,
+            attachments,
+        } => {
+            let mut fields = Vec::new();
+            if let Some(title) = title {
+                fields.push(title.clone());
+            }
+            fields.push(text.clone());
+            if let Some(attachments) = attachments {
+                fields.push(serde_json::to_string(attachments).unwrap_or_default());
+            }
+            fields.join("\n")
+        }
+    }
 }
 
 fn upsert_transcript_entry_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) -> Result<()> {
@@ -4302,6 +4438,44 @@ DROP TABLE IF EXISTS working_memory_deltas;
 DELETE FROM storage_domains WHERE domain = 'working_memory_deltas';
 "#,
     },
+    Migration {
+        version: 15,
+        name: "message_search_index",
+        sql: r#"
+CREATE VIRTUAL TABLE IF NOT EXISTS message_search_index USING fts5(
+  evidence_id UNINDEXED,
+  agent_id UNINDEXED,
+  turn_id UNINDEXED,
+  message_id UNINDEXED,
+  task_id UNINDEXED,
+  work_item_id UNINDEXED,
+  kind,
+  body_text,
+  payload_json
+);
+
+INSERT INTO message_search_index (
+  evidence_id, agent_id, turn_id, message_id, task_id, work_item_id,
+  kind, body_text, payload_json
+)
+SELECT
+  messages.evidence_id,
+  messages.agent_id,
+  messages.turn_id,
+  messages.message_id,
+  messages.task_id,
+  messages.work_item_id,
+  messages.kind,
+  COALESCE(messages.preview, ''),
+  messages.payload_json
+FROM messages
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM message_search_index
+  WHERE message_search_index.evidence_id = messages.evidence_id
+);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -5467,6 +5641,57 @@ CREATE TABLE working_memory_deltas (
                 .collect::<Vec<_>>(),
             vec!["brief-a", "brief-b"]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn message_search_indexes_messages_across_agents() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let mut first = MessageEnvelope::new(
+            "agent-a",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text {
+                text: "find the kestrel runtime note".into(),
+            },
+        );
+        first.id = "msg-search-a".into();
+        let mut second = MessageEnvelope::new(
+            "agent-b",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text {
+                text: "another kestrel message".into(),
+            },
+        );
+        second.id = "msg-search-b".into();
+        db.messages().upsert(&first)?;
+        db.messages().upsert(&second)?;
+
+        let all = db.messages().search(MessageSearchQuery {
+            query: "kestrel".into(),
+            agent_ids: Vec::new(),
+            limit: 10,
+        })?;
+        assert_eq!(all.len(), 2);
+
+        let filtered = db.messages().search(MessageSearchQuery {
+            query: "kestrel".into(),
+            agent_ids: vec!["agent-b".into()],
+            limit: 10,
+        })?;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].agent_id, "agent-b");
+        assert_eq!(filtered[0].message_id, "msg-search-b");
         Ok(())
     }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1389,14 +1389,13 @@ impl MessageRepository<'_> {
         if query.limit == 0 {
             return Ok(Vec::new());
         }
-        let search_terms = query.query.trim();
-        if search_terms.is_empty() {
+        let Some(search_terms) = message_search_match_query(&query.query) else {
             return Ok(Vec::new());
-        }
+        };
 
         let mut clauses = vec!["message_search_index MATCH ?".to_string()];
         let mut values = Vec::<String>::new();
-        values.push(search_terms.to_string());
+        values.push(search_terms);
         if !query.agent_ids.is_empty() {
             let placeholders = std::iter::repeat("?")
                 .take(query.agent_ids.len())
@@ -2444,6 +2443,19 @@ fn message_body_search_text(body: &crate::types::MessageBody) -> String {
             }
             fields.join("\n")
         }
+    }
+}
+
+fn message_search_match_query(query: &str) -> Option<String> {
+    let terms = query
+        .split(|ch: char| !ch.is_alphanumeric())
+        .filter(|term| !term.is_empty())
+        .map(|term| format!("\"{}\"", term))
+        .collect::<Vec<_>>();
+    if terms.is_empty() {
+        None
+    } else {
+        Some(terms.join(" AND "))
     }
 }
 
@@ -4442,6 +4454,22 @@ DELETE FROM storage_domains WHERE domain = 'working_memory_deltas';
         version: 15,
         name: "message_search_index",
         sql: r#"
+CREATE TABLE IF NOT EXISTS messages (
+  evidence_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  turn_id TEXT,
+  message_id TEXT,
+  message_seq INTEGER,
+  task_id TEXT,
+  work_item_id TEXT,
+  created_at TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  content_ref TEXT,
+  content_hash TEXT,
+  preview TEXT,
+  payload_json TEXT NOT NULL
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS message_search_index USING fts5(
   evidence_id UNINDEXED,
   agent_id UNINDEXED,
@@ -5657,7 +5685,9 @@ CREATE TABLE working_memory_deltas (
             crate::types::AuthorityClass::OperatorInstruction,
             crate::types::Priority::Normal,
             crate::types::MessageBody::Text {
-                text: "find the kestrel runtime note".into(),
+                text:
+                    "find the kestrel runtime note for PR #1786 on feature/issue-1783 with foo-bar"
+                        .into(),
             },
         );
         first.id = "msg-search-a".into();
@@ -5692,6 +5722,16 @@ CREATE TABLE working_memory_deltas (
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].agent_id, "agent-b");
         assert_eq!(filtered[0].message_id, "msg-search-b");
+
+        for query in ["PR #1786", "feature/issue-1783", "foo-bar"] {
+            let results = db.messages().search(MessageSearchQuery {
+                query: query.into(),
+                agent_ids: Vec::new(),
+                limit: 10,
+            })?;
+            assert_eq!(results.len(), 1, "query {query:?}");
+            assert_eq!(results[0].message_id, "msg-search-a");
+        }
         Ok(())
     }
 

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 59, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 60, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -1232,6 +1232,22 @@
   },
   {
     "method": "post",
+    "path": "/search",
+    "handler": "search",
+    "operation_id": "runtimeSearch",
+    "tag": "search",
+    "parameters": [],
+    "request_schema": "SearchRequest",
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/webhooks/generic/{agent_id}",
     "handler": "generic_webhook",
     "operation_id": "genericWebhook",


### PR DESCRIPTION
## Summary
- add a top-level `POST /search` in-app search endpoint for cross-agent runtime history queries
- index persisted messages into the runtime database search projection with agent/turn/task/work-item locator metadata
- document the new endpoint in OpenAPI and refresh the HTTP route inventory snapshot

## Scope
- First result type is `message`; requests for other result types are rejected until those projections are indexed.
- Results include `agent_id`, `type`, timestamps, preview text, and locator ids for UI navigation.

Closes #1783

## Verification
- `cargo fmt --all -- --check`
- `cargo test message_search_indexes_messages_across_agents`
- `cargo test --test http_route_snapshot`
- `cargo test --test openapi_snapshot`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
