### PR TITLE
chore: prepare v0.18.4 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,10 +111,13 @@ jobs:
 
           ## Changes
 
-          - Add GLM-5.2 model catalog support for BigModel and Z.ai provider configurations.
-          - Improve runtime closeout and persistence by serializing SQLite writes and recording terminal turn records for runtime errors.
-          - Expose private child agent status and child token usage through local control and supervised task status surfaces.
-          - Keep the generated docs search bundle outside the content root and add the agent actor invocation RFC.
+          - Add cross-agent in-app message search for indexed agent messages ([#1787](https://github.com/holon-run/holon/pull/1787)).
+          - Complete runtime settings support in the web GUI ([#1786](https://github.com/holon-run/holon/pull/1786)).
+          - Add configurable API CORS settings for runtime HTTP surfaces ([#1785](https://github.com/holon-run/holon/pull/1785)).
+          - Project the agent_home notes catalog into prompt context ([#1777](https://github.com/holon-run/holon/pull/1777)).
+          - Serialize runtime SQLite writes through the single-writer queue ([#1788](https://github.com/holon-run/holon/pull/1788)).
+          - Unify work item wait state projection across runtime views ([#1780](https://github.com/holon-run/holon/pull/1780)).
+          - Add user-facing guides for onboarding, WebFetch/WebSearch, ViewImage, skills CLI, provider OAuth, and external triggers ([#1782](https://github.com/holon-run/holon/pull/1782)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.18.3"
+version = "0.18.4"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Current release
 
 The current recommended release is
-[`v0.18.3`](https://github.com/holon-run/holon/releases/tag/v0.18.3).
+[`v0.18.4`](https://github.com/holon-run/holon/releases/tag/v0.18.4).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project will maintain
 compatibility for the CLI, daemon/API semantics, and local persistent storage.
 
 See the full changes in the
-[v0.18.3 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.18.3).
+[v0.18.4 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.18.4).
 
 ## Status and compatibility
 

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -3867,7 +3867,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.18.3"
+    "version": "0.18.4"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary
- bump crate and lockfile version to `0.18.4`
- update README current release links to `v0.18.4`
- refresh generated GitHub release notes for changes since `v0.18.3`

## Included changes
- Cross-agent in-app message search: #1787
- Web GUI runtime settings: #1786
- Configurable API CORS: #1785
- agent_home notes catalog prompt projection: #1777
- Runtime SQLite single-writer write queue: #1788
- Work item wait state projection fix: #1780
- User-facing guide updates: #1782

## Verification
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
