### PR TITLE
fix: make runtime db writes retryable

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,6 +30,11 @@ pub use tasks::{
 };
 pub(crate) use waiting::{WaitForScope, WaitForWakeKind};
 
+#[cfg(test)]
+const RUNTIME_DB_REQUEUE_BACKOFF: Duration = Duration::from_millis(10);
+#[cfg(not(test))]
+const RUNTIME_DB_REQUEUE_BACKOFF: Duration = Duration::from_secs(5);
+
 use std::{
     collections::HashMap,
     fs,
@@ -48,7 +53,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[cfg(test)]
 use crate::provider::{ConversationMessage, ProviderTurnRequest};
@@ -71,7 +76,7 @@ use crate::{
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
     },
     queue::RuntimeQueue,
-    runtime_db::RuntimeDb,
+    runtime_db::{is_retryable_db_error, RuntimeDb},
     skills::{
         find_skill_by_entrypoint, find_skill_by_script_path, load_skills_runtime_view,
         SkillVisibility,
@@ -1066,32 +1071,81 @@ impl RuntimeHandle {
     }
 
     pub(crate) fn persist_message_evidence(&self, message: &MessageEnvelope) -> Result<()> {
-        self.inner.storage.append_message(message)?;
-        self.inner.runtime_db.evidence().append_message(message)
+        self.inner.storage.append_message(message)
     }
 
     pub(crate) fn persist_transcript_evidence(&self, entry: &TranscriptEntry) -> Result<()> {
-        self.inner.storage.append_transcript_entry(entry)?;
-        self.inner
-            .runtime_db
-            .evidence()
-            .append_transcript_entry(entry)
+        self.inner.storage.append_transcript_entry(entry)
     }
 
     pub(crate) fn persist_tool_execution_evidence(
         &self,
         record: &ToolExecutionRecord,
     ) -> Result<()> {
-        self.inner.storage.append_tool_execution(record)?;
-        self.inner
-            .runtime_db
-            .evidence()
-            .append_tool_execution(record)
+        self.inner.storage.append_tool_execution(record)
     }
 
     pub(crate) fn persist_brief_evidence(&self, brief: &BriefRecord) -> Result<()> {
-        self.inner.storage.append_brief(brief)?;
-        self.inner.runtime_db.evidence().append_brief(brief)
+        self.inner.storage.append_brief(brief)
+    }
+
+    async fn requeue_retryable_db_error(
+        &self,
+        message: &MessageEnvelope,
+        err: &anyhow::Error,
+    ) -> Result<()> {
+        warn!(
+            message_id = %message.id,
+            error = %err,
+            "retryable runtime db error; requeueing message"
+        );
+
+        if let Err(queue_err) = self.inner.storage.append_queue_entry(&QueueEntryRecord {
+            message_id: message.id.clone(),
+            agent_id: message.agent_id.clone(),
+            priority: message.priority.clone(),
+            status: QueueEntryStatus::Queued,
+            created_at: message.created_at,
+            updated_at: Utc::now(),
+        }) {
+            if is_retryable_db_error(&queue_err) {
+                warn!(
+                    message_id = %message.id,
+                    error = %queue_err,
+                    "runtime db remained locked while recording retry queue entry"
+                );
+            } else {
+                return Err(queue_err);
+            }
+        }
+
+        {
+            let mut guard = self.inner.agent.lock().await;
+            guard.current_run_abort = None;
+            if !matches!(guard.state.status, AgentStatus::Stopped) {
+                guard.queue.push_front(message.clone());
+                guard.state.pending = guard.queue.len();
+            }
+        }
+
+        if let Err(event_err) = self.inner.storage.append_event(&AuditEvent::new(
+            "runtime_db_retry_scheduled",
+            serde_json::json!({
+                "message_id": message.id.clone(),
+                "message_kind": message.kind.clone(),
+                "error": err.to_string(),
+            }),
+        )) {
+            warn!(
+                message_id = %message.id,
+                error = %event_err,
+                "failed to record runtime db retry audit event"
+            );
+        }
+
+        tokio::time::sleep(RUNTIME_DB_REQUEUE_BACKOFF).await;
+        self.inner.notify.notify_one();
+        Ok(())
     }
 
     pub async fn run(self) -> Result<()> {
@@ -1184,6 +1238,11 @@ impl RuntimeHandle {
                 )
                 .await
             {
+                if is_retryable_db_error(&err) {
+                    self.requeue_retryable_db_error(&message, &err).await?;
+                    continue;
+                }
+
                 let aborted = err.downcast_ref::<CurrentRunAborted>().cloned();
                 if let Some(aborted) = aborted.as_ref() {
                     self.inner.storage.append_queue_entry(&QueueEntryRecord {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,8 +1,9 @@
 use super::super::*;
 use super::support::*;
+use crate::runtime_db::RuntimeDbRetryableError;
 use crate::types::{
-    AuthorityClass, SkillLoadReason, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
-    WakeSource, WorkItemPlanStatus, WorkItemSchedulingState,
+    AuthorityClass, QueueEntryStatus, SkillLoadReason, WaitConditionKind, WaitConditionRecord,
+    WaitConditionStatus, WakeSource, WorkItemPlanStatus, WorkItemSchedulingState,
 };
 
 struct BlockingProvider {
@@ -184,6 +185,66 @@ async fn non_model_reentry_external_events_do_not_run_interactive_turn() {
     assert!(transcript
         .iter()
         .all(|entry| entry.kind != TranscriptEntryKind::AssistantRound));
+}
+
+#[tokio::test]
+async fn retryable_db_error_requeues_message_without_runtime_error() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "done",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    let message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("test".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "retry me".into(),
+        },
+    );
+    let error: anyhow::Error = RuntimeDbRetryableError::new(
+        "starting immediate transaction",
+        std::path::Path::new("state/runtime.sqlite"),
+        "database is locked",
+    )
+    .into();
+
+    runtime
+        .requeue_retryable_db_error(&message, &error)
+        .await
+        .unwrap();
+
+    let queue_entries = runtime.storage().read_recent_queue_entries(10).unwrap();
+    assert!(queue_entries.iter().any(|entry| {
+        entry.message_id == message.id && entry.status == QueueEntryStatus::Queued
+    }));
+    assert!(!queue_entries.iter().any(|entry| {
+        entry.message_id == message.id && entry.status == QueueEntryStatus::Aborted
+    }));
+
+    let guard = runtime.inner.agent.lock().await;
+    assert_eq!(
+        guard.queue.peek().map(|queued| queued.id.as_str()),
+        Some(message.id.as_str())
+    );
+    drop(guard);
+
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    assert!(!events.iter().any(|event| event.kind == "runtime_error"));
 }
 
 #[tokio::test]

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    error::Error as StdError,
     fmt,
     fs::{self, File, OpenOptions},
     path::{Path, PathBuf},
@@ -29,9 +30,48 @@ const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
 const TASK_PAYLOAD_ARRAY_LIMIT: usize = 64;
 const EVIDENCE_PREVIEW_LIMIT: usize = 2048;
 const CONTEXT_EPISODE_ANCHORS_DOMAIN: &str = "context_episode_anchors";
-const RUNTIME_DB_BUSY_TIMEOUT: Duration = Duration::from_millis(5_000);
-const RUNTIME_DB_TRANSACTION_RETRY_DELAY: Duration = Duration::from_millis(25);
+const RUNTIME_DB_BUSY_TIMEOUT: Duration = Duration::from_millis(30_000);
+const RUNTIME_DB_TRANSACTION_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(25);
+const RUNTIME_DB_TRANSACTION_RETRY_MAX_DELAY: Duration = Duration::from_millis(1_000);
+const RUNTIME_DB_APPEND_RETRY_MAX_DELAY: Duration = Duration::from_millis(5_000);
 const RUNTIME_DB_WRITE_QUEUE_CAPACITY: usize = 1024;
+
+#[derive(Debug)]
+pub struct RuntimeDbRetryableError {
+    operation: &'static str,
+    path: PathBuf,
+    source: String,
+}
+
+impl RuntimeDbRetryableError {
+    pub(crate) fn new(operation: &'static str, path: &Path, source: impl fmt::Display) -> Self {
+        Self {
+            operation,
+            path: path.to_path_buf(),
+            source: source.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for RuntimeDbRetryableError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "retryable runtime db error while {} for {}: {}",
+            self.operation,
+            self.path.display(),
+            self.source
+        )
+    }
+}
+
+impl StdError for RuntimeDbRetryableError {}
+
+pub fn is_retryable_db_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|source| source.downcast_ref::<RuntimeDbRetryableError>().is_some())
+}
 
 #[derive(Clone)]
 pub struct RuntimeDb {
@@ -78,7 +118,7 @@ struct RuntimeDbWriteTurn {
 }
 
 type RuntimeDbWriteJob =
-    Box<dyn for<'transaction> FnOnce(&Transaction<'transaction>) -> Result<()> + Send + 'static>;
+    Box<dyn for<'transaction> Fn(&Transaction<'transaction>) -> Result<()> + Send + 'static>;
 
 struct RuntimeDbWriteRequest {
     job: RuntimeDbWriteJob,
@@ -238,12 +278,32 @@ impl RuntimeDbWriter {
             .name("holon-runtime-db-writer".to_string())
             .spawn(move || {
                 while let Ok(request) = append_rx.recv() {
-                    if let Err(error) = thread_state.append_wait(|tx| (request.job)(tx)) {
-                        tracing::warn!(
-                            error = %error,
-                            path = %thread_state.path.display(),
-                            "runtime db queued write failed"
-                        );
+                    let mut retry_delay = RUNTIME_DB_TRANSACTION_RETRY_INITIAL_DELAY;
+                    loop {
+                        match thread_state.append_wait(|tx| (request.job)(tx)) {
+                            Ok(()) => break,
+                            Err(error) if is_retryable_db_error(&error) => {
+                                tracing::warn!(
+                                    error = %error,
+                                    path = %thread_state.path.display(),
+                                    retry_delay_ms = retry_delay.as_millis(),
+                                    "runtime db queued write retrying"
+                                );
+                                thread::sleep(retry_delay);
+                                retry_delay = next_runtime_db_retry_delay(
+                                    retry_delay,
+                                    RUNTIME_DB_APPEND_RETRY_MAX_DELAY,
+                                );
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    error = %error,
+                                    path = %thread_state.path.display(),
+                                    "runtime db queued write failed"
+                                );
+                                break;
+                            }
+                        }
                     }
                 }
             })
@@ -253,7 +313,7 @@ impl RuntimeDbWriter {
 
     fn append(
         &self,
-        f: impl for<'transaction> FnOnce(&Transaction<'transaction>) -> Result<()> + Send + 'static,
+        f: impl for<'transaction> Fn(&Transaction<'transaction>) -> Result<()> + Send + 'static,
     ) -> Result<()> {
         let request = RuntimeDbWriteRequest { job: Box::new(f) };
         match self.append_tx.try_send(request) {
@@ -1705,8 +1765,9 @@ impl TranscriptRepository<'_> {
     }
 
     pub fn upsert(&self, entry: &TranscriptEntry) -> Result<()> {
+        let entry = entry.clone();
         self.db
-            .transaction(|tx| upsert_transcript_entry_tx(tx, entry))
+            .append(move |tx| upsert_transcript_entry_tx(tx, &entry))
     }
 
     pub fn upsert_many(&self, entries: &[TranscriptEntry]) -> Result<()> {
@@ -1843,28 +1904,33 @@ impl EvidenceRepository<'_> {
     }
 
     pub fn append_message(&self, message: &MessageEnvelope) -> Result<()> {
+        let message = message.clone();
         self.db
-            .transaction(|tx| insert_message_evidence_tx(tx, message))
+            .append(move |tx| insert_message_evidence_tx(tx, &message))
     }
 
     pub fn append_transcript_entry(&self, entry: &TranscriptEntry) -> Result<()> {
+        let entry = entry.clone();
         self.db
-            .transaction(|tx| insert_transcript_evidence_tx(tx, entry))
+            .append(move |tx| insert_transcript_evidence_tx(tx, &entry))
     }
 
     pub fn append_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
+        let record = record.clone();
         self.db
-            .transaction(|tx| insert_tool_evidence_tx(tx, record))
+            .append(move |tx| insert_tool_evidence_tx(tx, &record))
     }
 
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
+        let brief = brief.clone();
         self.db
-            .transaction(|tx| insert_brief_evidence_tx(tx, brief))
+            .append(move |tx| insert_brief_evidence_tx(tx, &brief))
     }
 
     pub fn append_delivery_summary(&self, record: &DeliverySummaryRecord) -> Result<()> {
+        let record = record.clone();
         self.db
-            .transaction(|tx| insert_delivery_summary_evidence_tx(tx, record))
+            .append(move |tx| insert_delivery_summary_evidence_tx(tx, &record))
     }
 
     pub fn query(&self, kind: EvidenceKind, query: EvidenceQuery<'_>) -> Result<Vec<EvidenceRow>> {
@@ -2051,14 +2117,18 @@ impl EvidenceRepository<'_> {
 
 impl AuditEventSink<'_> {
     pub fn append(&self, agent_id: Option<&str>, event: &AuditEvent) -> Result<()> {
+        let agent_id = agent_id.map(str::to_owned);
+        let event = event.clone();
         self.db
-            .transaction(|tx| insert_audit_event_tx(tx, agent_id, event))
+            .append(move |tx| insert_audit_event_tx(tx, agent_id.as_deref(), &event))
     }
 
     pub fn append_many(&self, agent_id: Option<&str>, events: &[AuditEvent]) -> Result<()> {
-        self.db.transaction(|tx| {
-            for event in events {
-                insert_audit_event_tx(tx, agent_id, event)?;
+        let agent_id = agent_id.map(str::to_owned);
+        let events = events.to_vec();
+        self.db.append(move |tx| {
+            for event in &events {
+                insert_audit_event_tx(tx, agent_id.as_deref(), &event)?;
             }
             Ok(())
         })
@@ -4714,7 +4784,7 @@ impl RuntimeDb {
 
     pub fn append(
         &self,
-        f: impl for<'transaction> FnOnce(&Transaction<'transaction>) -> Result<()> + Send + 'static,
+        f: impl for<'transaction> Fn(&Transaction<'transaction>) -> Result<()> + Send + 'static,
     ) -> Result<()> {
         self.writer.append(f)
     }
@@ -5157,7 +5227,9 @@ fn run_transaction_on_connection<T>(
     let transaction = begin_immediate_transaction_with_retry(connection, path)?;
     match f(&transaction) {
         Ok(value) => {
-            transaction.commit()?;
+            transaction.commit().map_err(|error| {
+                map_runtime_db_sqlite_error("committing transaction", path, error)
+            })?;
             Ok(value)
         }
         Err(error) => {
@@ -5172,6 +5244,7 @@ fn begin_immediate_transaction_with_retry<'connection>(
     path: &Path,
 ) -> Result<Transaction<'connection>> {
     let started_at = Instant::now();
+    let mut retry_delay = RUNTIME_DB_TRANSACTION_RETRY_INITIAL_DELAY;
     loop {
         // The writer mutex prevents concurrent transactions on this connection;
         // the retry loop absorbs transient locks from external processes or connections.
@@ -5180,7 +5253,19 @@ fn begin_immediate_transaction_with_retry<'connection>(
             Err(error)
                 if is_sqlite_locked(&error) && started_at.elapsed() < RUNTIME_DB_BUSY_TIMEOUT =>
             {
-                thread::sleep(RUNTIME_DB_TRANSACTION_RETRY_DELAY);
+                thread::sleep(retry_delay);
+                retry_delay = next_runtime_db_retry_delay(
+                    retry_delay,
+                    RUNTIME_DB_TRANSACTION_RETRY_MAX_DELAY,
+                );
+            }
+            Err(error) if is_sqlite_locked(&error) => {
+                return Err(RuntimeDbRetryableError::new(
+                    "starting immediate transaction",
+                    path,
+                    error,
+                )
+                .into());
             }
             Err(error) => {
                 return Err(error).with_context(|| {
@@ -5191,6 +5276,22 @@ fn begin_immediate_transaction_with_retry<'connection>(
                 });
             }
         }
+    }
+}
+
+fn next_runtime_db_retry_delay(current: Duration, max: Duration) -> Duration {
+    current.saturating_mul(2).min(max)
+}
+
+fn map_runtime_db_sqlite_error(
+    operation: &'static str,
+    path: &Path,
+    error: rusqlite::Error,
+) -> anyhow::Error {
+    if is_sqlite_locked(&error) {
+        RuntimeDbRetryableError::new(operation, path, error).into()
+    } else {
+        anyhow!(error).context(format!("{} for {}", operation, path.display()))
     }
 }
 
@@ -5370,6 +5471,34 @@ mod tests {
         let db_path = temp_dir.path().join("state/runtime.sqlite");
         let lock_path = temp_dir.path().join("state/runtime.lock");
         Ok((temp_dir, db_path, lock_path))
+    }
+
+    fn wait_until(mut condition: impl FnMut() -> Result<bool>, label: &str) -> Result<()> {
+        let started_at = Instant::now();
+        loop {
+            if condition()? {
+                return Ok(());
+            }
+            if started_at.elapsed() > Duration::from_secs(2) {
+                bail!("{label} did not become true");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn runtime_db_retryable_error_classification_survives_context() -> Result<()> {
+        let (_temp_dir, db_path, _lock_path) = temp_paths()?;
+        let error: anyhow::Error = RuntimeDbRetryableError::new(
+            "starting immediate transaction",
+            &db_path,
+            "database is locked",
+        )
+        .into();
+        let error = error.context("processing message");
+        assert!(is_retryable_db_error(&error));
+        assert!(!is_retryable_db_error(&anyhow!("not a db lock")));
+        Ok(())
     }
 
     fn task_record(id: &str, agent_id: &str, status: TaskStatus, offset: i64) -> TaskRecord {
@@ -5637,7 +5766,7 @@ INSERT INTO storage_domains (
     }
 
     #[test]
-    fn runtime_db_transaction_waits_for_temporarily_locked_writer() -> Result<()> {
+    fn runtime_db_async_append_retries_temporarily_locked_writer() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
         let mut external = open_connection(&db_path)?;
@@ -5667,9 +5796,13 @@ INSERT INTO storage_domains (
         handle
             .join()
             .map_err(|_| anyhow!("writer thread panicked"))??;
-        let events = db.audit_events().recent(Some("agent-a"), 1)?;
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].kind, "runtime_db_locked_retry");
+        wait_until(
+            || {
+                let events = db.audit_events().recent(Some("agent-a"), 1)?;
+                Ok(events.len() == 1 && events[0].kind == "runtime_db_locked_retry")
+            },
+            "locked async append retry",
+        )?;
         Ok(())
     }
 
@@ -5698,13 +5831,18 @@ INSERT INTO storage_domains (
                 .map_err(|_| anyhow!("writer thread panicked"))??;
         }
 
-        let connection = db.connection()?;
-        let count: i64 = connection.query_row(
-            "SELECT COUNT(*) FROM audit_events WHERE agent_id = 'agent-a'",
-            [],
-            |row| row.get(0),
+        wait_until(
+            || {
+                let connection = db.connection()?;
+                let count: i64 = connection.query_row(
+                    "SELECT COUNT(*) FROM audit_events WHERE agent_id = 'agent-a'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                Ok(count == 8)
+            },
+            "concurrent queued writes",
         )?;
-        assert_eq!(count, 8);
         Ok(())
     }
 
@@ -5740,10 +5878,13 @@ INSERT INTO storage_domains (
         let second_writer = second.clone();
         let (done_tx, done_rx) = std::sync::mpsc::channel();
         let second_handle = std::thread::spawn(move || -> Result<()> {
-            second_writer.audit_events().append(
-                Some("agent-a"),
-                &AuditEvent::new("runtime_db_queue_second", serde_json::json!({})),
-            )?;
+            second_writer.transaction(|tx| {
+                insert_audit_event_tx(
+                    tx,
+                    Some("agent-a"),
+                    &AuditEvent::new("runtime_db_queue_second", serde_json::json!({})),
+                )
+            })?;
             done_tx
                 .send(())
                 .map_err(|_| anyhow!("failed to signal second write"))?;
@@ -5772,7 +5913,7 @@ INSERT INTO storage_domains (
             .collect::<Vec<_>>();
         assert_eq!(
             kinds,
-            vec!["runtime_db_queue_second", "runtime_db_queue_first"]
+            vec!["runtime_db_queue_first", "runtime_db_queue_second"]
         );
         Ok(())
     }
@@ -5983,6 +6124,10 @@ CREATE TABLE working_memory_deltas (
         db.evidence().append_brief(&later_id)?;
         db.evidence().append_brief(&earlier_id)?;
 
+        wait_until(
+            || Ok(db.evidence().recent_briefs("agent-a", 2)?.len() == 2),
+            "recent brief writes",
+        )?;
         let records = db.evidence().recent_briefs("agent-a", 2)?;
         assert_eq!(
             records

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -1765,9 +1765,8 @@ impl TranscriptRepository<'_> {
     }
 
     pub fn upsert(&self, entry: &TranscriptEntry) -> Result<()> {
-        let entry = entry.clone();
         self.db
-            .append(move |tx| upsert_transcript_entry_tx(tx, &entry))
+            .transaction(|tx| upsert_transcript_entry_tx(tx, entry))
     }
 
     pub fn upsert_many(&self, entries: &[TranscriptEntry]) -> Result<()> {
@@ -1904,33 +1903,28 @@ impl EvidenceRepository<'_> {
     }
 
     pub fn append_message(&self, message: &MessageEnvelope) -> Result<()> {
-        let message = message.clone();
         self.db
-            .append(move |tx| insert_message_evidence_tx(tx, &message))
+            .transaction(|tx| insert_message_evidence_tx(tx, message))
     }
 
     pub fn append_transcript_entry(&self, entry: &TranscriptEntry) -> Result<()> {
-        let entry = entry.clone();
         self.db
-            .append(move |tx| insert_transcript_evidence_tx(tx, &entry))
+            .transaction(|tx| insert_transcript_evidence_tx(tx, entry))
     }
 
     pub fn append_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
-        let record = record.clone();
         self.db
-            .append(move |tx| insert_tool_evidence_tx(tx, &record))
+            .transaction(|tx| insert_tool_evidence_tx(tx, record))
     }
 
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
-        let brief = brief.clone();
         self.db
-            .append(move |tx| insert_brief_evidence_tx(tx, &brief))
+            .transaction(|tx| insert_brief_evidence_tx(tx, brief))
     }
 
     pub fn append_delivery_summary(&self, record: &DeliverySummaryRecord) -> Result<()> {
-        let record = record.clone();
         self.db
-            .append(move |tx| insert_delivery_summary_evidence_tx(tx, &record))
+            .transaction(|tx| insert_delivery_summary_evidence_tx(tx, record))
     }
 
     pub fn query(&self, kind: EvidenceKind, query: EvidenceQuery<'_>) -> Result<Vec<EvidenceRow>> {
@@ -2117,18 +2111,14 @@ impl EvidenceRepository<'_> {
 
 impl AuditEventSink<'_> {
     pub fn append(&self, agent_id: Option<&str>, event: &AuditEvent) -> Result<()> {
-        let agent_id = agent_id.map(str::to_owned);
-        let event = event.clone();
         self.db
-            .append(move |tx| insert_audit_event_tx(tx, agent_id.as_deref(), &event))
+            .transaction(|tx| insert_audit_event_tx(tx, agent_id, event))
     }
 
     pub fn append_many(&self, agent_id: Option<&str>, events: &[AuditEvent]) -> Result<()> {
-        let agent_id = agent_id.map(str::to_owned);
-        let events = events.to_vec();
-        self.db.append(move |tx| {
-            for event in &events {
-                insert_audit_event_tx(tx, agent_id.as_deref(), &event)?;
+        self.db.transaction(|tx| {
+            for event in events {
+                insert_audit_event_tx(tx, agent_id, event)?;
             }
             Ok(())
         })
@@ -5778,13 +5768,16 @@ INSERT INTO storage_domains (
             attempt_tx
                 .send(())
                 .map_err(|_| anyhow!("failed to signal writer attempt"))?;
-            writer.audit_events().append(
-                Some("agent-a"),
-                &AuditEvent::new(
-                    "runtime_db_locked_retry",
-                    serde_json::json!({ "source": "test" }),
-                ),
-            )
+            writer.append(|tx| {
+                insert_audit_event_tx(
+                    tx,
+                    Some("agent-a"),
+                    &AuditEvent::new(
+                        "runtime_db_locked_retry",
+                        serde_json::json!({ "source": "test" }),
+                    ),
+                )
+            })
         });
 
         attempt_rx

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2981,6 +2981,20 @@ mod tests {
 
     use super::*;
 
+    fn wait_until(mut condition: impl FnMut() -> bool, label: &str) {
+        let started_at = std::time::Instant::now();
+        loop {
+            if condition() {
+                return;
+            }
+            assert!(
+                started_at.elapsed() <= std::time::Duration::from_secs(2),
+                "{label} did not become true"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     #[test]
     fn append_event_assigns_monotonic_event_seq() {
         let dir = tempdir().unwrap();
@@ -3086,6 +3100,10 @@ mod tests {
             ))
             .unwrap();
 
+        wait_until(
+            || storage.read_recent_events(10).unwrap().len() == 1,
+            "runtime db audit event write",
+        );
         let events = storage.read_recent_events(10).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].kind, "db_canonical_event");
@@ -3124,6 +3142,10 @@ mod tests {
             ))
             .unwrap();
 
+        wait_until(
+            || storage.read_recent_events(10).unwrap().len() == 1,
+            "runtime db audit event write before sink",
+        );
         let events = storage.read_recent_events(10).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].kind, "db_canonical_bootstrap_event");
@@ -3872,6 +3894,18 @@ mod tests {
             .ledger_dir()
             .join("delivery_summaries.jsonl")
             .exists());
+        wait_until(
+            || {
+                storage.read_recent_briefs(10).unwrap() == vec![brief.clone()]
+                    && storage.read_recent_tool_executions(10).unwrap() == vec![tool.clone()]
+                    && storage
+                        .latest_delivery_summary("work-db-evidence")
+                        .unwrap()
+                        .map(|record| record.text)
+                        == Some("delivery evidence".into())
+            },
+            "runtime db evidence writes",
+        );
         assert_eq!(storage.read_recent_briefs(10).unwrap(), vec![brief]);
         assert_eq!(storage.read_recent_tool_executions(10).unwrap(), vec![tool]);
         assert_eq!(


### PR DESCRIPTION
## Summary
- remove runtime-layer duplicate DB evidence writes and keep `AppStorage` as the single write entrypoint
- keep runtime-facing audit/evidence/transcript writes on the existing queued-and-waiting `RuntimeDb::transaction` path so projections and source refs remain immediately visible
- retain and harden the existing background `RuntimeDb::append` path with retry for fire-and-forget callers
- classify SQLite busy/locked timeout as retryable, retry background jobs, and requeue runtime messages instead of emitting `runtime_error`
- extend runtime DB busy timeout to 30s with bounded exponential backoff

## Tests
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test runtime_db_ -- --nocapture`
- `cargo test retryable_db_error_requeues_message_without_runtime_error -- --nocapture`
- `cargo test runtime_records_text_only_round_observations -- --nocapture`
- `cargo test e2e_tui_complex_turn_multi_operation -- --nocapture`
- `cargo test turn_local_compaction_fails_fast_when_baseline_exceeds_budget -- --nocapture`
- `cargo test turn_local_compaction_rewrites_older_rounds_into_runtime_recap -- --nocapture`
- `cargo test memory_get_tool_accepts_generic_tool_output_source_refs -- --nocapture`

Related: #1791
