### PR TITLE
fix: slim duplicated audit event payloads

### DIFF
--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -258,7 +258,9 @@ Every stream event should use one canonical envelope.
 - `provenance`
   - provenance fields duplicated for client recovery and indexing
 - `payload`
-  - full standard event payload
+  - bounded event payload for replay, display, and correlation; payloads should
+    reference canonical records instead of copying large message bodies, task
+    details, tool outputs, or full agent state
 
 ### SSE Projection
 
@@ -280,8 +282,10 @@ Important first-party event families currently include:
 ### Message ingress and queue
 
 - `message_admitted`
-- `message_enqueued`
-- `message_processing_started`
+- `message_enqueued` lightweight message lifecycle payload; full message body
+  is read from message storage
+- `message_processing_started` lightweight message lifecycle payload; full
+  message body is read from message storage
 - `continuation_trigger_received`
 - `continuation_resolved`
 
@@ -306,9 +310,12 @@ Important first-party event families currently include:
 
 ### Tasks and timers
 
-- `task_created`
-- `task_status_updated`
-- `task_result_received`
+- `task_created` lightweight task lifecycle payload; full task detail is read
+  from task storage
+- `task_status_updated` lightweight task lifecycle payload; full task detail is
+  read from task storage
+- `task_result_received` lightweight task lifecycle payload; full task output is
+  read from the task output API
 - `task_requeued_after_restart`
 - `timer_created`
 - `timer_fired`
@@ -350,7 +357,8 @@ Important first-party event families currently include:
 
 ### Optional/secondary runtime detail
 
-- `tool_executed`
+- `tool_executed` lightweight tool lifecycle payload with `tool_execution_id`;
+  full tool input/output is read from tool execution storage
 - `tool_execution_failed`
 - `skill_activated`
 - `system_tick_emitted`

--- a/docs/rfcs/operator-display-levels-and-event-presentation.md
+++ b/docs/rfcs/operator-display-levels-and-event-presentation.md
@@ -290,9 +290,11 @@ Examples:
 - `assistant_round_recorded` with tool calls should be merged with the subsequent
   tool or command item instead of producing `Assistant requested tools: ...`
 - `process_execution_requested` and `tool_executed` should become one command or
-  tool lifecycle item
+  tool lifecycle item; `tool_executed` should carry only bounded metadata and a
+  `tool_execution_id` for full output lookup
 - `task_created`, `task_status_updated`, and `task_result_received` should become
-  one task lifecycle item when they refer to the same task
+  one task lifecycle item when they refer to the same task; full task output
+  should be fetched from task APIs, not audit payloads
 - repeated `work_item_written` events should become work item deltas
 - `provider_round_completed` should usually attach telemetry to the nearest
   assistant/tool cycle rather than render as a standalone row
@@ -381,7 +383,8 @@ Policy:
 - `operator_interjection_admitted`: show as operator input in all main levels
 - `message_processing_aborted`: show only when it explains an abort or
   failure
-- all other message plumbing events: hide in main levels; trace only
+- all other message plumbing events: hide in main levels; trace only; message
+  lifecycle payloads carry ids and provenance, not full message bodies
 
 Rationale:
 
@@ -440,6 +443,11 @@ Events:
 - `tool_executed`
 - `tool_execution_failed`
 - `truncated_mutation_tool_call_rejected`
+
+Payload policy:
+
+- `tool_executed` carries command/tool preview, status, duration, summary, and
+  `tool_execution_id`; full tool input/output belongs in `tool_executions`
 
 Policy:
 
@@ -523,6 +531,11 @@ Events:
 - `command_task_runner_failed`
 - `command_task_running_persisted`
 - `command_task_result_enqueue_failed`
+
+Payload policy:
+
+- task lifecycle events carry task id, status, summary, and small terminal
+  metadata; full detail and command output belong in task storage/output APIs
 
 Policy:
 
@@ -655,6 +668,11 @@ Events:
 - `agent_state_changed` (lightweight state sync)
 - `state_changed`
 - `session_state_changed` (legacy replay only)
+
+Payload policy:
+
+- model override events carry model refs and pending/active status only; full
+  model state should be read from state snapshots
 
 Policy:
 

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -3539,6 +3539,95 @@
         "title": "TimerRecord",
         "type": "object"
       },
+      "ToolExecutionRecord": {
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "authority_class": {
+            "enum": [
+              "operator_instruction",
+              "runtime_instruction",
+              "integration_signal",
+              "external_evidence"
+            ],
+            "type": "string"
+          },
+          "completed_at": {
+            "default": null,
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "duration_ms": {
+            "default": 0,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": true,
+          "invocation_surface": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "output": true,
+          "status": {
+            "enum": [
+              "success",
+              "error"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "tool_name": {
+            "type": "string"
+          },
+          "turn_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "turn_index": {
+            "default": 0,
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "work_item_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "tool_name",
+          "created_at",
+          "authority_class",
+          "status",
+          "input",
+          "output",
+          "summary"
+        ],
+        "title": "ToolExecutionRecord",
+        "type": "object"
+      },
       "UninstallSkillRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
@@ -4705,6 +4794,73 @@
         "summary": "Timer detail",
         "tags": [
           "timers"
+        ]
+      }
+    },
+    "/agents/{agent_id}/tool-executions/{tool_execution_id}": {
+      "get": {
+        "description": "Return a persisted tool execution record by id.",
+        "operationId": "agentToolExecution",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tool execution id.",
+            "in": "path",
+            "name": "tool_execution_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolExecutionRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Tool execution detail",
+        "tags": [
+          "tools"
         ]
       }
     },

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,8 +22,8 @@ use crate::{
         ActiveWorkspaceEntry, AgentListEntry, AgentSummary, AuthorityClass, BriefRecord,
         ExternalTriggerStateSnapshot, OperatorNotificationRecord, ResolvedModelAvailability,
         TaskInputResult, TaskOutputResult, TaskRecord, TaskStatusSnapshot, TaskStopResult,
-        TimerRecord, TranscriptEntry, TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord,
-        WorkspaceOccupancyRecord, WorktreeSession,
+        TimerRecord, ToolExecutionRecord, TranscriptEntry, TurnTerminalRecord, WaitingIntentRecord,
+        WorkItemRecord, WorkspaceOccupancyRecord, WorktreeSession,
     },
 };
 
@@ -475,6 +475,17 @@ impl LocalClient {
             path.push_str(&format!("&timeout_ms={timeout_ms}"));
         }
         self.get_json(&path).await
+    }
+
+    pub async fn tool_execution(
+        &self,
+        agent_id: &str,
+        tool_execution_id: &str,
+    ) -> Result<ToolExecutionRecord> {
+        self.get_json(&format!(
+            "/agents/{agent_id}/tool-executions/{tool_execution_id}"
+        ))
+        .await
     }
 
     pub async fn task_input(

--- a/src/http.rs
+++ b/src/http.rs
@@ -229,6 +229,10 @@ pub fn router(state: AppState) -> Router {
             get(task_output),
         )
         .route(
+            "/agents/{agent_id}/tool-executions/{tool_execution_id}",
+            get(tool_execution),
+        )
+        .route(
             "/control/agents/{agent_id}/tasks/{task_id}/input",
             post(task_input),
         )
@@ -2324,6 +2328,30 @@ pub async fn task_output(
     Ok(Json(output))
 }
 
+pub async fn tool_execution(
+    Path((agent_id, tool_execution_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let Some(record) = runtime
+        .storage()
+        .read_tool_execution_by_id(&tool_execution_id)
+        .map_err(error_response)?
+        .filter(|record| record.agent_id == agent_id)
+    else {
+        return Err(not_found(format!(
+            "tool execution {tool_execution_id} not found"
+        )));
+    };
+    Ok(Json(record))
+}
+
 pub async fn task_input(
     Path((agent_id, task_id)): Path<(String, String)>,
     State(state): State<Arc<AppState>>,
@@ -3146,33 +3174,15 @@ pub async fn set_agent_model(
     if let Some(reasoning_effort) = request.reasoning_effort.as_deref() {
         validate_reasoning_effort(reasoning_effort)?;
     }
-    let admission_context = control_admission_context(&state);
-    let provided_trust = request.authority_class;
     let model = ModelRef::parse(&request.model).map_err(error_response)?;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
-    let boundary = current_boundary_metadata(&runtime)
-        .await
-        .map_err(error_response)?;
     let model_state = runtime
         .set_model_override(model.clone(), request.reasoning_effort.clone())
         .await
-        .map_err(error_response)?;
-    runtime
-        .append_audit_event(
-            "agent_model_override_requested",
-            json!({
-                "target_agent_id": agent_id,
-                "override_model": model,
-                "admission_context": admission_context,
-                "provided_trust": provided_trust,
-                "boundary": boundary,
-                "model": model_state,
-            }),
-        )
         .map_err(error_response)?;
     Ok(Json(json!({
         "ok": true,
@@ -3194,34 +3204,17 @@ pub async fn clear_agent_model(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Json(request): Json<ClearAgentModelRequest>,
+    Json(_request): Json<ClearAgentModelRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
-    let admission_context = control_admission_context(&state);
-    let provided_trust = request.authority_class;
     let runtime = state
         .host
         .get_public_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
-    let boundary = current_boundary_metadata(&runtime)
-        .await
-        .map_err(error_response)?;
     let model_state = runtime
         .clear_model_override()
         .await
-        .map_err(error_response)?;
-    runtime
-        .append_audit_event(
-            "agent_model_override_clear_requested",
-            json!({
-                "target_agent_id": agent_id,
-                "admission_context": admission_context,
-                "provided_trust": provided_trust,
-                "boundary": boundary,
-                "model": model_state,
-            }),
-        )
         .map_err(error_response)?;
     Ok(Json(json!({
         "ok": true,

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     types::{
         TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult, TimerRecord,
-        WorkItemRecord,
+        ToolExecutionRecord, WorkItemRecord,
     },
 };
 
@@ -74,6 +74,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/tasks", "agentTasks", "tasks", "List active tasks", "Return active task records. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route_with_response("get", "/agents/{agent_id}/tasks/{task_id}", "agentTaskStatus", "tasks", "Task status", "Return a task lifecycle snapshot by id.", None, "TaskStatusSnapshot", AuthKind::RemoteAccess),
     route_with_response("get", "/agents/{agent_id}/tasks/{task_id}/output", "agentTaskOutput", "tasks", "Task output", "Return a task output snapshot. Query parameters: block, timeout_ms.", None, "TaskOutputResult", AuthKind::RemoteAccess),
+    route_with_response("get", "/agents/{agent_id}/tool-executions/{tool_execution_id}", "agentToolExecution", "tools", "Tool execution detail", "Return a persisted tool execution record by id.", None, "ToolExecutionRecord", AuthKind::RemoteAccess),
     route_with_response("post", "/control/agents/{agent_id}/tasks/{task_id}/input", "taskInput", "control", "Task input", "Deliver text input to a managed task.", Some("TaskInputRequest"), "TaskInputResult", AuthKind::Control),
     route_with_response("post", "/control/agents/{agent_id}/tasks/{task_id}/stop", "taskStop", "control", "Task stop", "Request cancellation for a managed task.", Some("TaskStopRequest"), "TaskStopResult", AuthKind::Control),
     route("get", "/agents/{agent_id}/work-items", "agentWorkItems", "work-items", "List work items", "Return latest work item records for the agent. Query parameter: limit.", None, AuthKind::RemoteAccess),
@@ -374,6 +375,9 @@ fn path_parameters(path: &str) -> Vec<Value> {
     if path.contains("{timer_id}") {
         params.push(path_param("timer_id", "Timer id."));
     }
+    if path.contains("{tool_execution_id}") {
+        params.push(path_param("tool_execution_id", "Tool execution id."));
+    }
     if path.contains("{callback_token}") {
         params.push(path_param(
             "callback_token",
@@ -474,6 +478,10 @@ fn component_schemas() -> Value {
     schemas.insert(
         "TaskOutputResult".into(),
         component_schema::<TaskOutputResult>(),
+    );
+    schemas.insert(
+        "ToolExecutionRecord".into(),
+        component_schema::<ToolExecutionRecord>(),
     );
     schemas.insert(
         "TaskInputResult".into(),

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -1060,7 +1060,13 @@ fn agent_body(payload: &Value) -> Option<String> {
 fn model_body(payload: &Value) -> Option<String> {
     first_string_field(
         payload,
-        &["model", "override_model", "requested_model", "active_model"],
+        &[
+            "model",
+            "override_model",
+            "requested_model",
+            "active_model",
+            "effective_model",
+        ],
     )
     .map(|model| format!("model {model}"))
     .or_else(|| agent_body(payload))
@@ -1162,7 +1168,12 @@ fn task_record_text(
             "task_result_received" => "Task result received",
             _ => "Task updated",
         };
-        return (label.into(), None, label.into());
+        let body = task_body(payload);
+        let summary = body
+            .as_deref()
+            .map(|body| format!("{label}: {body}"))
+            .unwrap_or_else(|| label.to_string());
+        return (label.into(), body, summary);
     };
     let summary = task
         .summary

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -2088,9 +2088,15 @@ fn command_status_from_tool_event(event: &ProjectionEventRecord) -> CommandStatu
     if event.kind == "tool_execution_failed" {
         return CommandStatus::Failed;
     }
-    if let Some(disposition) = exec_command_result(event)
-        .and_then(|result| result.get("disposition"))
+    if let Some(disposition) = event
+        .payload
+        .get("exec_command_disposition")
         .and_then(Value::as_str)
+        .or_else(|| {
+            exec_command_result(event)
+                .and_then(|result| result.get("disposition"))
+                .and_then(Value::as_str)
+        })
     {
         return match disposition {
             "promoted_to_task" => CommandStatus::PromotedToTask,
@@ -2109,9 +2115,10 @@ fn command_status_from_tool_event(event: &ProjectionEventRecord) -> CommandStatu
 }
 
 fn command_task_id(event: &ProjectionEventRecord) -> Option<String> {
-    exec_command_result(event)
-        .and_then(|result| result.get("task_handle"))
-        .or_else(|| event.payload.get("task_handle"))
+    event
+        .payload
+        .get("task_handle")
+        .or_else(|| exec_command_result(event).and_then(|result| result.get("task_handle")))
         .and_then(|handle| handle.get("task_id"))
         .and_then(Value::as_str)
         .map(ToString::to_string)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -88,21 +88,22 @@ use crate::{
     },
     tool::{ToolRegistry, ToolResult},
     types::{
-        ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView, AgentKind, AgentModelSource,
-        AgentModelState, AgentState, AgentStateChangedEvent, AgentStatus, AgentSummary, AuditEvent,
-        AuthorityClass, BriefRecord, CallbackDeliveryMode, CallbackDeliveryPayload,
-        CallbackDeliveryResult, CallbackIngressDisposition, CancelWaitingResult, ClosureDecision,
-        ContinuationResolution, ControlAction, ExecCommandBatchItemStatus, ExecCommandBatchResult,
+        ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView, AgentKind,
+        AgentModelOverrideAuditEvent, AgentModelSource, AgentModelState, AgentState,
+        AgentStateChangedEvent, AgentStatus, AgentSummary, AuditEvent, AuthorityClass, BriefRecord,
+        CallbackDeliveryMode, CallbackDeliveryPayload, CallbackDeliveryResult,
+        CallbackIngressDisposition, CancelWaitingResult, ClosureDecision, ContinuationResolution,
+        ControlAction, ExecCommandBatchItemStatus, ExecCommandBatchResult,
         ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerScope,
         ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
-        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, PendingWakeHint,
-        Priority, QueueEntryRecord, QueueEntryStatus, ResolvedModelAvailability,
-        RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
-        SkillActivationState, SkillCatalogEntry, SkillLoadReason, SkillsRuntimeView, TaskKind,
-        TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord,
-        TranscriptEntry, TranscriptEntryKind, ViewImageObservation, WaitingIntentRecord,
-        WaitingIntentStatus, WaitingIntentSummary, WaitingReason, WorkspaceEntry,
-        AGENT_HOME_WORKSPACE_ID,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageLifecycleAuditEvent,
+        MessageOrigin, PendingWakeHint, Priority, QueueEntryRecord, QueueEntryStatus,
+        ResolvedModelAvailability, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
+        SkillActivationSource, SkillActivationState, SkillCatalogEntry, SkillLoadReason,
+        SkillsRuntimeView, TaskKind, TaskLifecycleAuditEvent, TaskRecord, TaskRecoverySpec,
+        TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
+        TranscriptEntryKind, ViewImageObservation, WaitingIntentRecord, WaitingIntentStatus,
+        WaitingIntentSummary, WaitingReason, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
     web::{WebConfig, WebProviderKind},
 };
@@ -1058,7 +1059,7 @@ impl RuntimeHandle {
         ))?;
         self.inner.storage.append_event(&AuditEvent::new(
             "message_enqueued",
-            to_json_value(&message),
+            to_json_value(&MessageLifecycleAuditEvent::from_message(&message)),
         ))?;
         self.inner.notify.notify_one();
         Ok(message)

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -1764,7 +1764,7 @@ mod tests {
         let events = runtime.inner.storage.read_recent_events(20).unwrap();
         assert!(events.iter().any(|event| {
             event.kind == "command_task_terminal_persisted"
-                && event.data["id"].as_str() == Some(task.id.as_str())
+                && event.data["task_id"].as_str() == Some(task.id.as_str())
         }));
     }
 

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -700,11 +700,11 @@ impl RuntimeHandle {
             } else {
                 "agent_model_override_set"
             },
-            serde_json::json!({
-                "agent_id": next_state.id,
-                "model": model_state,
-                "pending_next_turn": turn_in_progress,
-            }),
+            to_json_value(&AgentModelOverrideAuditEvent::from_model_state(
+                next_state.id,
+                &model_state,
+                turn_in_progress,
+            )),
         )?;
         Ok(model_state)
     }
@@ -733,11 +733,11 @@ impl RuntimeHandle {
             } else {
                 "agent_model_override_cleared"
             },
-            serde_json::json!({
-                "agent_id": next_state.id,
-                "model": model_state,
-                "pending_next_turn": turn_in_progress,
-            }),
+            to_json_value(&AgentModelOverrideAuditEvent::from_model_state(
+                next_state.id,
+                &model_state,
+                turn_in_progress,
+            )),
         )?;
         Ok(model_state)
     }

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -78,7 +78,7 @@ impl RuntimeHandle {
         message.normalize_admission_fields();
         self.inner.storage.append_event(&AuditEvent::new(
             "message_processing_started",
-            to_json_value(&message),
+            to_json_value(&MessageLifecycleAuditEvent::from_message(&message)),
         ))?;
         let MessageDispatchPlan {
             prior_closure,

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -60,9 +60,10 @@ impl RuntimeHandle {
             }
             guard.persist_state(&self.inner.storage)?;
         }
-        self.inner
-            .storage
-            .append_event(&AuditEvent::new(transition.event_kind, to_json_value(task)))?;
+        self.inner.storage.append_event(&AuditEvent::new(
+            transition.event_kind,
+            to_json_value(&TaskLifecycleAuditEvent::from_task(task)),
+        ))?;
         Ok(())
     }
 

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -148,7 +148,8 @@ async fn runtime_records_scheduler_decision_before_dequeueing_message() {
     loop {
         let events = runtime.storage().read_recent_events(200).unwrap();
         if events.iter().any(|event| {
-            event.kind == "message_processing_started" && event.data["id"] == message.id.as_str()
+            event.kind == "message_processing_started"
+                && event.data["message_id"] == message.id.as_str()
         }) {
             let decision_index = events
                 .iter()
@@ -162,7 +163,7 @@ async fn runtime_records_scheduler_decision_before_dequeueing_message() {
                 .iter()
                 .position(|event| {
                     event.kind == "message_processing_started"
-                        && event.data["id"] == message.id.as_str()
+                        && event.data["message_id"] == message.id.as_str()
                 })
                 .expect("message processing should start");
             assert!(

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -16,6 +16,7 @@ use crate::{
     runtime::provider_turn::{
         build_continuation_request, build_provider_prompt_frame, build_provider_turn_request,
     },
+    storage::to_json_value,
     tool::{
         helpers::{
             command_cost_diagnostics, command_digest, command_display, command_preview,
@@ -27,10 +28,10 @@ use crate::{
     types::{
         AdmissionContext, AuditEvent, AuthorityClass, BriefKind, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
-        QueueEntryRecord, QueueEntryStatus, TodoItemState, TokenUsage, TranscriptEntry,
-        TranscriptEntryKind, TurnRecord, TurnTerminalCheckpointRecord, TurnTerminalKind,
-        TurnTerminalRecord, TurnTerminalSummary, TurnTriggerSummary, WorkItemPlanStatus,
-        WorkItemRecord,
+        QueueEntryRecord, QueueEntryStatus, TodoItemState, TokenUsage, ToolExecutionAuditEvent,
+        TranscriptEntry, TranscriptEntryKind, TurnRecord, TurnTerminalCheckpointRecord,
+        TurnTerminalKind, TurnTerminalRecord, TurnTerminalSummary, TurnTriggerSummary,
+        WorkItemPlanStatus, WorkItemRecord,
     },
 };
 
@@ -3166,29 +3167,40 @@ impl TurnExecution<'_> {
 
                         runtime.inner.storage.append_event(&AuditEvent::new(
                             "tool_executed",
-                            serde_json::json!({
-                                "tool_call_id": tool_call_id,
-                                "tool_name": tool_name,
-                                "turn_index": turn_index,
-                                "run_id": run_id,
-                                "work_item_id": record.work_item_id.clone(),
-                                "exec_command_cmd": command_preview_field(&call),
-                                "exec_command_display": command_display_field(&call),
-                                "exec_command_batch_items": command_batch_preview_field(&call),
-                                "exec_command_result": exec_command_result_field(&call, &result.envelope),
-                                "apply_patch_result": apply_patch_result_field(&call, &result.envelope),
-                                "tool_result": generic_tool_result_field(&call, &result.envelope),
-                                "exec_command_cost": command_cost_field(
+                            to_json_value(&ToolExecutionAuditEvent {
+                                tool_call_id: tool_call_id.clone(),
+                                tool_execution_id: record.id.clone(),
+                                agent_id: record.agent_id.clone(),
+                                tool_name: tool_name.clone(),
+                                turn_index,
+                                turn_id: record.turn_id.clone(),
+                                run_id,
+                                work_item_id: record.work_item_id.clone(),
+                                status: record.status.clone(),
+                                duration_ms,
+                                summary: record.summary.clone(),
+                                exec_command_cmd: command_preview_field(&call),
+                                exec_command_display: command_display_field(&call),
+                                exec_command_batch_items: command_batch_preview_field(&call),
+                                exec_command_cost: command_cost_field(
                                     &call,
                                     runtime.inner.default_tool_output_tokens,
-                                    runtime.inner.max_tool_output_tokens
+                                    runtime.inner.max_tool_output_tokens,
                                 ),
-                                "status": record.status,
-                                "duration_ms": duration_ms,
-                                "summary": record.summary,
-                                "error": result.tool_error().map(|error| error.render()),
-                                "error_kind": result.tool_error().map(|error| error.kind.clone()),
-                                "tool_error": result.tool_error().cloned(),
+                                exec_command_disposition: exec_command_disposition_field(
+                                    &call,
+                                    &result.envelope,
+                                ),
+                                exit_status: exec_command_exit_status_field(
+                                    &call,
+                                    &result.envelope,
+                                ),
+                                task_handle: exec_command_task_handle_field(
+                                    &call,
+                                    &result.envelope,
+                                ),
+                                error: result.tool_error().map(|error| error.render()),
+                                error_kind: result.tool_error().map(|error| error.kind.clone()),
                             }),
                         ))?;
                         tool_result_envelopes.push(result.envelope.clone());
@@ -3607,26 +3619,33 @@ fn command_batch_preview_field(call: &ToolCall) -> Option<Value> {
     (!previews.is_empty()).then(|| Value::Array(previews))
 }
 
-fn exec_command_result_field(call: &ToolCall, envelope: &ToolResultEnvelope) -> Option<Value> {
+fn exec_command_disposition_field(
+    call: &ToolCall,
+    envelope: &ToolResultEnvelope,
+) -> Option<String> {
     matches!(call.name.as_str(), "ExecCommand" | "ExecCommandBatch")
-        .then(|| envelope.result.clone())
+        .then(|| envelope.result.as_ref())
         .flatten()
+        .and_then(|result| result.get("disposition"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
-fn apply_patch_result_field(call: &ToolCall, envelope: &ToolResultEnvelope) -> Option<Value> {
-    (call.name == "ApplyPatch")
-        .then(|| envelope.result.clone())
+fn exec_command_exit_status_field(call: &ToolCall, envelope: &ToolResultEnvelope) -> Option<i32> {
+    matches!(call.name.as_str(), "ExecCommand" | "ExecCommandBatch")
+        .then(|| envelope.result.as_ref())
         .flatten()
+        .and_then(|result| result.get("exit_status"))
+        .and_then(Value::as_i64)
+        .map(|status| status as i32)
 }
 
-fn generic_tool_result_field(call: &ToolCall, envelope: &ToolResultEnvelope) -> Option<Value> {
-    if matches!(
-        call.name.as_str(),
-        "ExecCommand" | "ExecCommandBatch" | "ApplyPatch"
-    ) {
-        return None;
-    }
-    envelope.result.clone()
+fn exec_command_task_handle_field(call: &ToolCall, envelope: &ToolResultEnvelope) -> Option<Value> {
+    matches!(call.name.as_str(), "ExecCommand" | "ExecCommandBatch")
+        .then(|| envelope.result.as_ref())
+        .flatten()
+        .and_then(|result| result.get("task_handle"))
+        .cloned()
 }
 
 fn command_cost_field(

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -28,8 +28,8 @@ use crate::{
     types::{
         ActiveWorkspaceEntry, AgentModelOverrideAuditEvent, AgentState, AgentStateChangedEvent,
         AgentSummary, BriefRecord, ClosureDecision, ExternalTriggerStateSnapshot, MessageEnvelope,
-        MessageOrigin, TaskRecord, TimerRecord, TimerStatus, WaitingIntentRecord, WorkItemRecord,
-        WorkItemState, WorktreeSession,
+        MessageOrigin, TaskLifecycleAuditEvent, TaskRecord, TimerRecord, TimerStatus,
+        WaitingIntentRecord, WorkItemRecord, WorkItemState, WorktreeSession,
     },
 };
 
@@ -1080,6 +1080,8 @@ impl TuiProjection {
     }
 
     fn apply_model_state_event(&mut self, payload: &Value) -> bool {
+        // Historical audit replay may still contain the full AgentModelState under `model`.
+        // Remove this branch when legacy full-payload audit replay is retired.
         if let Some(model) = payload
             .get("model")
             .cloned()
@@ -1350,19 +1352,13 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
                     )
                 })
                 .or_else(|| {
-                    let summary = event
-                        .data
-                        .payload
-                        .get("summary")
-                        .and_then(Value::as_str)
-                        .or_else(|| event.data.payload.get("task_id").and_then(Value::as_str))?;
-                    let status = event
-                        .data
-                        .payload
-                        .get("status")
-                        .and_then(Value::as_str)
-                        .unwrap_or("unknown");
-                    Some(format!("{summary} [{status}]"))
+                    decode_payload::<TaskLifecycleAuditEvent>(&event.data.payload).map(|task| {
+                        format!(
+                            "{} [{:?}]",
+                            task.summary.as_deref().unwrap_or(task.kind.as_str()),
+                            task.status
+                        )
+                    })
                 })
                 .unwrap_or_else(|| event.data.event_type.clone())
         }
@@ -1523,8 +1519,8 @@ fn trim_summary(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        OperatorDisplayMode, OperatorVisibility, ProjectionEventLane, ProjectionSlice,
-        TuiProjection, EVENT_LOG_LIMIT, TASK_TAIL_LIMIT,
+        summarize_event, OperatorDisplayMode, OperatorVisibility, ProjectionEventLane,
+        ProjectionSlice, TuiProjection, EVENT_LOG_LIMIT, TASK_TAIL_LIMIT,
     };
     use crate::{
         client::{
@@ -1543,10 +1539,11 @@ mod tests {
             ClosureOutcome, ExternalTriggerScope, ExternalTriggerStateSnapshot,
             ExternalTriggerStatus, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
             MessageEnvelope, MessageKind, MessageOrigin, Priority, RuntimePosture,
-            SkillsRuntimeView, TaskRecord, TaskStatus, TimerRecord, TimerStatus, TodoItem,
-            TodoItemState, TokenUsage, TurnTerminalKind, TurnTerminalRecord, WaitingIntentRecord,
-            WaitingIntentScope, WaitingIntentStatus, WaitingIntentSummary, WaitingReason,
-            WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord, WorktreeSession,
+            SkillsRuntimeView, TaskLifecycleAuditEvent, TaskRecord, TaskStatus, TimerRecord,
+            TimerStatus, TodoItem, TodoItemState, TokenUsage, TurnTerminalKind, TurnTerminalRecord,
+            WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus, WaitingIntentSummary,
+            WaitingReason, WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord,
+            WorktreeSession,
         },
     };
     use chrono::Utc;
@@ -2681,6 +2678,24 @@ mod tests {
             .work_items
             .iter()
             .any(|record| record.id == "work-stream" && record.state == WorkItemState::Open));
+    }
+
+    #[test]
+    fn summarize_event_uses_lightweight_task_audit_payload() {
+        let mut task = sample_task();
+        task.id = "task-stream".into();
+        task.status = TaskStatus::Running;
+        task.summary = Some("running stream task".into());
+
+        let event = sample_event(
+            "task_status_updated",
+            serde_json::to_value(TaskLifecycleAuditEvent::from_task(&task)).unwrap(),
+        );
+
+        assert_eq!(
+            summarize_event(&event),
+            "running stream task [Running]".to_string()
+        );
     }
 
     #[test]

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -26,10 +26,10 @@ use crate::{
     presentation::render_live_working_activity_text,
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
-        ActiveWorkspaceEntry, AgentState, AgentStateChangedEvent, AgentSummary, BriefRecord,
-        ClosureDecision, ExternalTriggerStateSnapshot, MessageEnvelope, MessageOrigin, TaskRecord,
-        TimerRecord, TimerStatus, WaitingIntentRecord, WorkItemRecord, WorkItemState,
-        WorktreeSession,
+        ActiveWorkspaceEntry, AgentModelOverrideAuditEvent, AgentState, AgentStateChangedEvent,
+        AgentSummary, BriefRecord, ClosureDecision, ExternalTriggerStateSnapshot, MessageEnvelope,
+        MessageOrigin, TaskRecord, TimerRecord, TimerStatus, WaitingIntentRecord, WorkItemRecord,
+        WorkItemState, WorktreeSession,
     },
 };
 
@@ -1080,14 +1080,25 @@ impl TuiProjection {
     }
 
     fn apply_model_state_event(&mut self, payload: &Value) -> bool {
-        let Some(model) = payload
+        if let Some(model) = payload
             .get("model")
             .cloned()
             .and_then(decode_value::<crate::types::AgentModelState>)
-        else {
+        {
+            self.agent.model = model;
+            return true;
+        }
+
+        let Some(event) = decode_value::<AgentModelOverrideAuditEvent>(payload.clone()) else {
             return false;
         };
-        self.agent.model = model;
+        self.agent.model.source = event.source;
+        self.agent.model.effective_model = event.effective_model;
+        self.agent.model.requested_model = event.requested_model;
+        self.agent.model.active_model = event.active_model;
+        self.agent.model.override_model = event.override_model;
+        self.agent.model.override_reasoning_effort = event.override_reasoning_effort;
+        self.agent.model.fallback_active = event.fallback_active;
         true
     }
 
@@ -1303,6 +1314,14 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
                 crate::types::MessageBody::Json { value } => trim_summary(&value.to_string()),
                 crate::types::MessageBody::Brief { text, .. } => trim_summary(&text),
             })
+            .or_else(|| {
+                event
+                    .data
+                    .payload
+                    .get("message_id")
+                    .and_then(Value::as_str)
+                    .map(|message_id| format!("message queued: {message_id}"))
+            })
             .unwrap_or_else(|| event.data.event_type.clone()),
         "turn_started" => event
             .data
@@ -1329,6 +1348,21 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
                         task.summary.as_deref().unwrap_or(task.kind.as_str()),
                         task.status
                     )
+                })
+                .or_else(|| {
+                    let summary = event
+                        .data
+                        .payload
+                        .get("summary")
+                        .and_then(Value::as_str)
+                        .or_else(|| event.data.payload.get("task_id").and_then(Value::as_str))?;
+                    let status = event
+                        .data
+                        .payload
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown");
+                    Some(format!("{summary} [{status}]"))
                 })
                 .unwrap_or_else(|| event.data.event_type.clone())
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3862,14 +3862,14 @@ pub struct QueueEntryRecord {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolExecutionStatus {
     Success,
     Error,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct ToolExecutionRecord {
     pub id: String,
     #[serde(alias = "session_id")]
@@ -3894,6 +3894,209 @@ pub struct ToolExecutionRecord {
     pub summary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub invocation_surface: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MessageLifecycleAuditEvent {
+    pub message_id: String,
+    #[serde(alias = "session_id")]
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub kind: MessageKind,
+    pub origin: MessageOrigin,
+    pub authority_class: AuthorityClass,
+    pub priority: Priority,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_kind: Option<ContinuationTriggerKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub source_refs: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery_surface: Option<MessageDeliverySurface>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_context: Option<AdmissionContext>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+}
+
+impl MessageLifecycleAuditEvent {
+    pub fn from_message(message: &MessageEnvelope) -> Self {
+        Self {
+            message_id: message.id.clone(),
+            agent_id: message.agent_id.clone(),
+            message_seq: message.message_seq,
+            turn_id: message.turn_id.clone(),
+            kind: message.kind.clone(),
+            origin: message.origin.clone(),
+            authority_class: message.authority_class,
+            priority: message.priority.clone(),
+            trigger_kind: message.trigger_kind,
+            work_item_id: message.work_item_id.clone(),
+            task_id: message.task_id.clone(),
+            source_refs: message.source_refs.clone(),
+            delivery_surface: message.delivery_surface,
+            admission_context: message.admission_context,
+            correlation_id: message.correlation_id.clone(),
+            causation_id: message.causation_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TaskLifecycleAuditEvent {
+    pub task_id: String,
+    #[serde(alias = "session_id")]
+    pub agent_id: String,
+    pub kind: TaskKind,
+    pub status: TaskStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_status: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_summary_preview: Option<String>,
+}
+
+impl TaskLifecycleAuditEvent {
+    pub fn from_task(task: &TaskRecord) -> Self {
+        let detail = task.detail.as_ref();
+        Self {
+            task_id: task.id.clone(),
+            agent_id: task.agent_id.clone(),
+            kind: task.kind.clone(),
+            status: task.status.clone(),
+            created_at: task.created_at,
+            updated_at: task.updated_at,
+            parent_message_id: task.parent_message_id.clone(),
+            work_item_id: task.work_item_id.clone(),
+            summary: task.summary.clone(),
+            task_status: detail_string(detail, "task_status"),
+            exit_status: detail_i64(detail, "exit_status"),
+            error: detail_string(detail, "error").map(|value| truncate_audit_preview(&value, 512)),
+            output_path: detail_string(detail, "output_path"),
+            output_summary_preview: detail_string(detail, "output_summary")
+                .map(|value| truncate_audit_preview(&value, 512)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolExecutionAuditEvent {
+    pub tool_call_id: String,
+    pub tool_execution_id: String,
+    #[serde(alias = "session_id")]
+    pub agent_id: String,
+    pub tool_name: String,
+    pub turn_index: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    pub status: ToolExecutionStatus,
+    pub duration_ms: u64,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_command_cmd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_command_display: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_command_batch_items: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_command_cost: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_command_disposition: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_status: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_handle: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentModelOverrideAuditEvent {
+    #[serde(alias = "session_id")]
+    pub agent_id: String,
+    pub source: AgentModelSource,
+    pub effective_model: ModelRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_model: Option<ModelRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub override_reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub fallback_active: bool,
+    #[serde(default)]
+    pub pending_next_turn: bool,
+}
+
+impl AgentModelOverrideAuditEvent {
+    pub fn from_model_state(
+        agent_id: impl Into<String>,
+        model: &AgentModelState,
+        pending_next_turn: bool,
+    ) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            source: model.source.clone(),
+            effective_model: model.effective_model.clone(),
+            requested_model: model.requested_model.clone(),
+            active_model: model.active_model.clone(),
+            override_model: model.override_model.clone(),
+            override_reasoning_effort: model.override_reasoning_effort.clone(),
+            fallback_active: model.fallback_active,
+            pending_next_turn,
+        }
+    }
+}
+
+fn detail_string(detail: Option<&Value>, field: &str) -> Option<String> {
+    detail
+        .and_then(|value| value.get(field))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn detail_i64(detail: Option<&Value>, field: &str) -> Option<i64> {
+    detail
+        .and_then(|value| value.get(field))
+        .and_then(Value::as_i64)
+}
+
+fn truncate_audit_preview(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut preview = value.chars().take(max_chars).collect::<String>();
+    preview.push_str("...");
+    preview
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -5183,5 +5386,116 @@ mod tests {
         ] {
             assert!(AgentProfilePreset::PublicNamed.allows_tool_capability_family(family));
         }
+    }
+
+    #[test]
+    fn message_lifecycle_audit_event_omits_body_and_metadata() {
+        let mut message = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "large-message-body".repeat(1024),
+            },
+        );
+        message.metadata = Some(serde_json::json!({
+            "large_metadata": "large-message-metadata".repeat(1024)
+        }));
+
+        let payload =
+            serde_json::to_value(MessageLifecycleAuditEvent::from_message(&message)).unwrap();
+
+        assert_eq!(payload["message_id"], message.id);
+        assert!(payload.get("body").is_none());
+        assert!(payload.get("metadata").is_none());
+        assert!(!payload.to_string().contains("large-message-body"));
+        assert!(!payload.to_string().contains("large-message-metadata"));
+    }
+
+    #[test]
+    fn task_lifecycle_audit_event_omits_detail_and_recovery() {
+        let long_output = "large-task-output".repeat(1024);
+        let task = TaskRecord {
+            id: "task-large".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Completed,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            parent_message_id: None,
+            work_item_id: Some("work-1".into()),
+            summary: Some("run command".into()),
+            detail: Some(serde_json::json!({
+                "task_status": "completed",
+                "exit_status": 0,
+                "output_path": "/tmp/task-large.log",
+                "output_summary": long_output,
+                "initial_output": "large-initial-output".repeat(1024)
+            })),
+            recovery: Some(TaskRecoverySpec::CommandTask {
+                summary: "run command".into(),
+                spec: CommandTaskSpec {
+                    cmd: "cargo test".into(),
+                    workdir: None,
+                    shell: None,
+                    login: false,
+                    tty: false,
+                    yield_time_ms: 10_000,
+                    max_output_tokens: None,
+                    accepts_input: false,
+                    terminal_reentry: false,
+                },
+                authority_class: AuthorityClass::OperatorInstruction,
+                promoted_from_exec_command: false,
+            }),
+        };
+
+        let payload = serde_json::to_value(TaskLifecycleAuditEvent::from_task(&task)).unwrap();
+
+        assert_eq!(payload["task_id"], "task-large");
+        assert_eq!(payload["output_path"], "/tmp/task-large.log");
+        assert!(payload.get("detail").is_none());
+        assert!(payload.get("recovery").is_none());
+        assert!(!payload.to_string().contains("large-initial-output"));
+        assert!(payload.to_string().contains("large-task-output"));
+        assert!(
+            payload["output_summary_preview"].as_str().unwrap().len()
+                < "large-task-output".repeat(1024).len()
+        );
+    }
+
+    #[test]
+    fn tool_execution_audit_event_references_canonical_record_without_output() {
+        let payload = serde_json::to_value(ToolExecutionAuditEvent {
+            tool_call_id: "call-1".into(),
+            tool_execution_id: "tool-1".into(),
+            agent_id: "default".into(),
+            tool_name: "ExecCommand".into(),
+            turn_index: 7,
+            turn_id: Some("turn-1".into()),
+            run_id: Some("run-1".into()),
+            work_item_id: Some("work-1".into()),
+            status: ToolExecutionStatus::Success,
+            duration_ms: 42,
+            summary: "command completed".into(),
+            exec_command_cmd: Some("cargo test".into()),
+            exec_command_display: Some("cargo test".into()),
+            exec_command_batch_items: None,
+            exec_command_cost: None,
+            exec_command_disposition: Some("completed".into()),
+            exit_status: Some(0),
+            task_handle: None,
+            error: None,
+            error_kind: None,
+        })
+        .unwrap();
+
+        assert_eq!(payload["tool_execution_id"], "tool-1");
+        assert!(payload.get("output").is_none());
+        assert!(payload.get("tool_result").is_none());
+        assert!(payload.get("exec_command_result").is_none());
+        assert!(payload.get("apply_patch_result").is_none());
     }
 }

--- a/tests/http_events.rs
+++ b/tests/http_events.rs
@@ -19,6 +19,7 @@ http_async_tests!(
     events_route_payload_includes_full_fields,
     events_route_max_level_filters_with_bounded_visible_pages,
     events_stream_includes_tool_payload,
+    tool_execution_route_returns_canonical_output,
     events_stream_includes_assistant_round_payload,
     events_stream_preserves_raw_payload_with_control_auth,
     events_page_cursor_seq_seeds_stream_resume,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 60, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 61, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -291,6 +291,33 @@
   },
   {
     "method": "get",
+    "path": "/agents/{agent_id}/tool-executions/{tool_execution_id}",
+    "handler": "tool_execution",
+    "operation_id": "agentToolExecution",
+    "tag": "tools",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "tool_execution_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/agents/{agent_id}/transcript",
     "handler": "transcript",
     "operation_id": "agentTranscript",

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -23,7 +23,8 @@ use holon::{
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
         ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
         MessageOrigin, OperatorDeliveryStatus, Priority, TaskKind, TaskRecord, TaskStatus,
-        TodoItem, TodoItemState, WaitingIntentStatus, WorkItemState,
+        TodoItem, TodoItemState, ToolExecutionRecord, ToolExecutionStatus, WaitingIntentStatus,
+        WorkItemState,
     },
 };
 use reqwest::Client;
@@ -515,6 +516,56 @@ pub async fn events_stream_includes_tool_payload() -> Result<()> {
         replayed.data["payload"]["artifact_ref"],
         "artifact://test-output"
     );
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn tool_execution_route_returns_canonical_output() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+    let record = ToolExecutionRecord {
+        id: "tool-http-detail".into(),
+        agent_id: "default".into(),
+        work_item_id: Some("work-1".into()),
+        turn_index: 3,
+        turn_id: Some("turn-1".into()),
+        tool_name: "ExecCommand".into(),
+        created_at: chrono::Utc::now(),
+        completed_at: Some(chrono::Utc::now()),
+        duration_ms: 12,
+        authority_class: AuthorityClass::OperatorInstruction,
+        status: ToolExecutionStatus::Success,
+        input: serde_json::json!({"cmd": "printf full-output"}),
+        output: serde_json::json!({
+            "disposition": "completed",
+            "exit_status": 0,
+            "stdout_preview": "full-output".repeat(128)
+        }),
+        summary: "command completed".into(),
+        invocation_surface: None,
+    };
+    runtime.storage().append_tool_execution(&record)?;
+
+    let response = client
+        .get(format!(
+            "{base}/agents/default/tool-executions/tool-http-detail"
+        ))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: ToolExecutionRecord = response.json().await?;
+    assert_eq!(body.id, record.id);
+    assert_eq!(body.output, record.output);
+
+    let missing = client
+        .get(format!(
+            "{base}/agents/default/tool-executions/missing-tool"
+        ))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
 
     server.abort();
     Ok(())

--- a/tests/support/runtime_subagents.rs
+++ b/tests/support/runtime_subagents.rs
@@ -480,7 +480,7 @@ pub async fn subagent_task_failure_propagates_failed_output_to_parent() -> Resul
     let events = runtime.recent_events(20).await?;
     assert!(events.iter().any(|event| {
         event.kind == "task_result_received"
-            && event.data.get("id").and_then(|value| value.as_str()) == Some(task.id.as_str())
+            && event.data.get("task_id").and_then(|value| value.as_str()) == Some(task.id.as_str())
             && event.data.get("status").and_then(|value| value.as_str()) == Some("failed")
     }));
     Ok(())

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -327,7 +327,7 @@ pub async fn lifecycle_stop_interrupts_active_command_task() -> Result<()> {
     let events = runtime.recent_events(200).await?;
     assert!(events.iter().any(|event| {
         event.kind == "task_interrupted_on_agent_stop"
-            && event.data.get("id").and_then(|value| value.as_str()) == Some(task.id.as_str())
+            && event.data.get("task_id").and_then(|value| value.as_str()) == Some(task.id.as_str())
     }));
 
     let active_tasks = runtime.active_tasks(10).await?;
@@ -1892,7 +1892,7 @@ pub async fn command_task_stop_cancels_running_command() -> Result<()> {
     let events = runtime.recent_events(200).await?;
     assert!(events.iter().any(|event| {
         event.kind == "task_result_received"
-            && event.data.get("id").and_then(|value| value.as_str()) == Some(task.id.as_str())
+            && event.data.get("task_id").and_then(|value| value.as_str()) == Some(task.id.as_str())
             && event.data.get("status").and_then(|value| value.as_str()) == Some("cancelled")
     }));
 
@@ -2217,7 +2217,7 @@ pub async fn command_task_runner_failure_marks_task_failed_and_cleans_up() -> Re
     let events = runtime.recent_events(200).await?;
     assert!(events.iter().any(|event| {
         event.kind == "task_result_received"
-            && event.data.get("id").and_then(|value| value.as_str()) == Some(task.id.as_str())
+            && event.data.get("task_id").and_then(|value| value.as_str()) == Some(task.id.as_str())
             && event.data.get("status").and_then(|value| value.as_str()) == Some("failed")
     }));
     Ok(())
@@ -2315,7 +2315,7 @@ pub async fn command_task_nonzero_exit_produces_failed_output_and_runtime_state(
     let events = runtime.recent_events(200).await?;
     assert!(events.iter().any(|event| {
         event.kind == "task_result_received"
-            && event.data.get("id").and_then(|value| value.as_str()) == Some(task.id.as_str())
+            && event.data.get("task_id").and_then(|value| value.as_str()) == Some(task.id.as_str())
             && event.data.get("status").and_then(|value| value.as_str()) == Some("failed")
     }));
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #1793.

This PR stops using selected audit events as duplicate storage for canonical runtime records. The event kinds stay the same, but new payloads are bounded/reference-oriented:

- message lifecycle events carry ids/provenance instead of full `MessageEnvelope` bodies
- task lifecycle events carry task status/summary/terminal metadata instead of full `TaskRecord.detail`
- `tool_executed` carries preview/status/duration plus `tool_execution_id`, while full output remains in `tool_executions`
- model override events no longer embed full `AgentModelState`, and the HTTP duplicate requested/clear-requested audit writes are removed

It also adds `GET /agents/{agent_id}/tool-executions/{tool_execution_id}` so UIs can fetch full tool execution output from canonical storage instead of SSE audit payloads.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test audit_event`
- `cargo test tool_execution_route_returns_canonical_output`
- `cargo test runtime_records_scheduler_decision_before_dequeueing_message`
- `cargo test http_route_snapshot`
- `cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored`
- `cargo test openapi_snapshot`

## Notes

Historical `audit_events` are not migrated or compacted. Consumers keep fallback handling for legacy full payloads.
