### PR TITLE
fix: slim brief and work item audit events

### DIFF
--- a/docs/rfcs/event-stream-interface.md
+++ b/docs/rfcs/event-stream-interface.md
@@ -323,11 +323,15 @@ Important first-party event families currently include:
 
 ### Briefs and operator-visible outcomes
 
-- `brief_created`
+- `brief_created` lightweight brief lifecycle payload with `brief_id`,
+  provenance fields, `kind`, and `text_preview`; full brief text and
+  attachments are read from brief storage/API
 
 ### Work items and planning
 
-- `work_item_written`
+- `work_item_written` lightweight work-item lifecycle payload with
+  `work_item_id`, revision, action, state/readiness, and objective/result
+  previews; full work-item records are read from work-item storage/API
 - `work_item_turn_end_committed`
 - `work_item_turn_end_commit_skipped`
 - `work_plan_snapshot_written`

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -11,6 +11,104 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "BriefRecord": {
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "attachments": {
+            "items": {
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "uri": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "value": true
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "ack",
+              "result",
+              "failure"
+            ],
+            "type": "string"
+          },
+          "related_message_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "related_task_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "turn_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "turn_index": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "work_item_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "workspace_id": {
+            "default": "agent_home",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "kind",
+          "created_at",
+          "text"
+        ],
+        "title": "BriefRecord",
+        "type": "object"
+      },
       "CallbackBody": {
         "description": "Raw callback request body. JSON and text bodies are parsed; other content types are represented internally as base64 JSON."
       },
@@ -4126,6 +4224,73 @@
           "agents"
         ],
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
+      }
+    },
+    "/agents/{agent_id}/briefs/{brief_id}": {
+      "get": {
+        "description": "Return a persisted user-facing delivery brief by id.",
+        "operationId": "agentBrief",
+        "parameters": [
+          {
+            "description": "Agent id.",
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Brief id.",
+            "in": "path",
+            "name": "brief_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BriefRecord"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Brief detail",
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agent_id}/enqueue": {

--- a/src/client.rs
+++ b/src/client.rs
@@ -430,6 +430,11 @@ impl LocalClient {
             .await
     }
 
+    pub async fn agent_brief(&self, agent_id: &str, brief_id: &str) -> Result<BriefRecord> {
+        self.get_json(&format!("/agents/{agent_id}/briefs/{brief_id}"))
+            .await
+    }
+
     pub async fn agent_transcript(
         &self,
         agent_id: &str,

--- a/src/http.rs
+++ b/src/http.rs
@@ -218,6 +218,7 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/{agent_id}/enqueue", post(enqueue))
         .route("/agents/{agent_id}/status", get(status))
         .route("/agents/{agent_id}/briefs", get(briefs))
+        .route("/agents/{agent_id}/briefs/{brief_id}", get(brief))
         .route("/agents/{agent_id}/state", get(agent_state))
         .route("/agents/{agent_id}/events", get(events))
         .route("/agents/{agent_id}/events/stream", get(events_stream))
@@ -1876,6 +1877,28 @@ pub async fn briefs(
         .await
         .map_err(error_response)?;
     Ok(Json(briefs))
+}
+
+pub async fn brief(
+    Path((agent_id, brief_id)): Path<(String, String)>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    let runtime = state
+        .host
+        .get_public_agent(&agent_id)
+        .await
+        .map_err(agent_access_error)?;
+    let Some(brief) = runtime
+        .brief_by_id(&brief_id)
+        .await
+        .map_err(error_response)?
+        .filter(|brief| brief.agent_id == agent_id)
+    else {
+        return Err(not_found(format!("brief {brief_id} not found")));
+    };
+    Ok(Json(brief))
 }
 
 pub async fn transcript_default(

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -13,8 +13,8 @@ use crate::{
         RuntimeConfigUpdateResponse, SearchRequest, SearchResponse, UpdateWorkItemRequest,
     },
     types::{
-        TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult, TimerRecord,
-        ToolExecutionRecord, WorkItemRecord,
+        BriefRecord, TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult,
+        TimerRecord, ToolExecutionRecord, WorkItemRecord,
     },
 };
 
@@ -67,6 +67,7 @@ const ROUTES: &[RouteSpec] = &[
     aide_route("get", "/agents/list", "listAgents", "agents", "List agents", "Return lightweight public agent entries.", None, AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/status", "agentStatus", "agents", "Agent status", "Return the public AgentSummary read model.", None, AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/briefs", "agentBriefs", "agents", "Recent briefs", "Return recent user-facing delivery briefs. Query parameter: limit.", None, AuthKind::RemoteAccess),
+    route_with_response("get", "/agents/{agent_id}/briefs/{brief_id}", "agentBrief", "agents", "Brief detail", "Return a persisted user-facing delivery brief by id.", None, "BriefRecord", AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/state", "agentState", "agents", "Agent state snapshot", "Return the current bootstrap snapshot for an agent.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/events", "agentEvents", "events", "Agent event page", "Return a bounded page of runtime event envelopes. Query parameters: before_seq, after_seq, limit, order, max_level. Event payloads are included in full; max_level filters event inclusion only. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.", None, AuthKind::RemoteAccess),
     event_stream_route("get", "/agents/{agent_id}/events/stream", "agentEventsStream", "events", "Agent event stream", "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data. Query parameters: after_seq, limit. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.", None, AuthKind::RemoteAccess),
@@ -372,6 +373,9 @@ fn path_parameters(path: &str) -> Vec<Value> {
     if path.contains("{work_item_id}") {
         params.push(path_param("work_item_id", "Work item id."));
     }
+    if path.contains("{brief_id}") {
+        params.push(path_param("brief_id", "Brief id."));
+    }
     if path.contains("{timer_id}") {
         params.push(path_param("timer_id", "Timer id."));
     }
@@ -495,6 +499,7 @@ fn component_schemas() -> Value {
         "WorkItemRecord".into(),
         component_schema::<WorkItemRecord>(),
     );
+    schemas.insert("BriefRecord".into(), component_schema::<BriefRecord>());
     schemas.insert("TimerRecord".into(), component_schema::<TimerRecord>());
     schemas.insert(
         "PickWorkItemResponse".into(),

--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::types::{
-    BriefRecord, TaskRecord, TaskStatus, TimerRecord, WaitingIntentRecord, WorkItemRecord,
-    WorkItemState, WorktreeSession,
+    BriefCreatedAuditEvent, BriefRecord, TaskRecord, TaskStatus, TimerRecord, WaitingIntentRecord,
+    WorkItemLifecycleAuditEvent, WorkItemRecord, WorkItemState, WorktreeSession,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -415,11 +415,13 @@ fn brief_visibility(payload: &Value, context: &OperatorPresentationContext) -> O
     if context.awaiting_operator_input {
         return OperatorVisibility::ActionRequired;
     }
-    let Some(brief) = decode_value::<BriefRecord>(payload.clone()) else {
-        return OperatorVisibility::TurnResult;
-    };
-    if brief
-        .work_item_id
+    let work_item_id = decode_value::<BriefRecord>(payload.clone())
+        .and_then(|brief| brief.work_item_id)
+        .or_else(|| {
+            decode_value::<BriefCreatedAuditEvent>(payload.clone())
+                .and_then(|brief| brief.work_item_id)
+        });
+    if work_item_id
         .as_deref()
         .is_some_and(|id| context.completed_work_item_ids.contains(id))
     {
@@ -907,6 +909,7 @@ fn simple_event_text(
 fn brief_text(payload: &Value) -> (String, Option<String>, String) {
     let text = payload
         .get("text")
+        .or_else(|| payload.get("text_preview"))
         .and_then(Value::as_str)
         .map(collapse_whitespace)
         .filter(|text| !text.is_empty())
@@ -1386,29 +1389,46 @@ fn timer_text(
 }
 
 fn work_item_text(payload: &Value, _fallback_summary: &str) -> (String, Option<String>, String) {
-    let Some(record) = payload
+    if let Some(record) = payload
         .get("record")
         .cloned()
         .and_then(decode_value::<WorkItemRecord>)
-    else {
-        return ("Work item updated".into(), None, "Work item updated".into());
-    };
-    let objective = trim_summary(&record.objective);
-    let state = format!("{:?}", record.state);
-    let title = if record.state == WorkItemState::Completed {
+    {
+        return work_item_record_text(
+            &record.objective,
+            record.result_summary.as_deref(),
+            &record.state,
+        );
+    }
+    if let Some(record) = decode_value::<WorkItemLifecycleAuditEvent>(payload.clone()) {
+        return work_item_record_text(
+            &record.objective_preview,
+            record.result_summary_preview.as_deref(),
+            &record.state,
+        );
+    }
+    ("Work item updated".into(), None, "Work item updated".into())
+}
+
+fn work_item_record_text(
+    objective: &str,
+    result_summary: Option<&str>,
+    state: &WorkItemState,
+) -> (String, Option<String>, String) {
+    let objective = trim_summary(objective);
+    let state_label = format!("{:?}", state);
+    let title = if *state == WorkItemState::Completed {
         "Work completed"
     } else {
         "Work item updated"
     };
-    let summary = if record.state == WorkItemState::Completed {
-        record
-            .result_summary
-            .as_deref()
+    let summary = if *state == WorkItemState::Completed {
+        result_summary
             .map(trim_summary)
             .map(|result| format!("Work completed: {result}"))
             .unwrap_or_else(|| format!("Work completed: {objective}"))
     } else {
-        format!("Work item {state}: {objective}")
+        format!("Work item {state_label}: {objective}")
     };
     (title.into(), Some(objective), summary)
 }
@@ -2255,6 +2275,28 @@ mod tests {
     }
 
     #[test]
+    fn brief_created_lightweight_payload_uses_preview_and_work_item_visibility() {
+        let mut context = OperatorPresentationContext::default();
+        context.completed_work_item_ids.insert("wi-1".into());
+        let payload = json!({
+            "brief_id": "brief-1",
+            "agent_id": "default",
+            "workspace_id": "agent_home",
+            "work_item_id": "wi-1",
+            "kind": "result",
+            "created_at": "2026-01-01T00:00:00Z",
+            "text_preview": "completed from preview",
+            "text_len": 22
+        });
+
+        let presentation = present_operator_event("brief_created", &payload, "fallback", &context);
+
+        assert_eq!(presentation.visibility, OperatorVisibility::WorkDone);
+        assert_eq!(presentation.body.as_deref(), Some("completed from preview"));
+        assert_eq!(presentation.summary, "Brief: completed from preview");
+    }
+
+    #[test]
     fn operator_display_mode_parse_accepts_names_and_numeric_aliases() {
         assert_eq!(
             OperatorDisplayMode::parse("3"),
@@ -2452,6 +2494,31 @@ mod tests {
             &context,
             OperatorDisplayMode::Info
         ));
+
+        let lightweight = json!({
+            "agent_id": "default",
+            "work_item_id": "wi-1",
+            "workspace_id": "agent_home",
+            "revision": 3,
+            "action": "completed",
+            "state": "completed",
+            "plan_status": "ready",
+            "readiness": "completed",
+            "updated_at": "2026-01-01T00:00:03Z",
+            "objective_preview": "ship lifecycle display",
+            "objective_len": 22,
+            "result_summary_preview": "merged slim PR"
+        });
+        let lightweight_presentation =
+            present_operator_event("work_item_written", &lightweight, "fallback", &context);
+        assert_eq!(
+            lightweight_presentation.visibility,
+            OperatorVisibility::WorkDone
+        );
+        assert_eq!(
+            lightweight_presentation.summary,
+            "Work completed: merged slim PR"
+        );
 
         let waiting = json!({
             "id": "wait-1",

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -13,8 +13,8 @@ use serde_json::Value;
 use crate::operator_event::OperatorEventCategory;
 use crate::tui::projection::ProjectionEventRecord;
 use crate::types::{
-    BriefKind, BriefRecord, MessageBody, MessageEnvelope, MessageOrigin, WaitingIntentRecord,
-    WaitingIntentScope, WorkItemRecord,
+    BriefCreatedAuditEvent, BriefKind, BriefRecord, MessageBody, MessageEnvelope, MessageOrigin,
+    WaitingIntentRecord, WaitingIntentScope, WorkItemLifecycleAuditEvent, WorkItemRecord,
 };
 
 pub(crate) const LIVE_WORKING_ACTIVITY_DISPLAY_LEVEL: u8 = 4;
@@ -1197,14 +1197,40 @@ fn brief_result_item(event: &ProjectionEventRecord) -> Option<(String, Presentat
                 },
             ))
         }
-        Err(_) => Some((
-            format!("summary:{}", normalize_text_key(&event.summary)),
-            PresentationItem::AssistantResult {
-                brief_id: None,
-                body: event.summary.clone(),
-                outcome: Outcome::Neutral,
-            },
-        )),
+        Err(_) => {
+            if let Ok(brief) =
+                serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone())
+            {
+                if brief.kind == BriefKind::Ack {
+                    return None;
+                }
+                let body = if brief.text_preview.trim().is_empty() {
+                    event.summary.clone()
+                } else {
+                    brief.text_preview
+                };
+                return Some((
+                    format!("id:{}", brief.brief_id),
+                    PresentationItem::AssistantResult {
+                        brief_id: Some(brief.brief_id),
+                        body,
+                        outcome: match brief.kind {
+                            BriefKind::Failure => Outcome::Failure,
+                            BriefKind::Result => Outcome::Success,
+                            BriefKind::Ack => Outcome::Neutral,
+                        },
+                    },
+                ));
+            }
+            Some((
+                format!("summary:{}", normalize_text_key(&event.summary)),
+                PresentationItem::AssistantResult {
+                    brief_id: None,
+                    body: event.summary.clone(),
+                    outcome: Outcome::Neutral,
+                },
+            ))
+        }
     }
 }
 
@@ -1223,16 +1249,23 @@ fn work_item_record(event: &ProjectionEventRecord) -> Option<WorkItemRecord> {
         .and_then(|value| serde_json::from_value(value).ok())
 }
 
+fn work_item_lifecycle_event(event: &ProjectionEventRecord) -> Option<WorkItemLifecycleAuditEvent> {
+    serde_json::from_value(event.payload.clone()).ok()
+}
+
 fn work_item_id_from_event(event: &ProjectionEventRecord) -> Option<String> {
-    work_item_record(event).map(|record| record.id).or_else(|| {
-        event
-            .payload
-            .get("work_item_id")
-            .or_else(|| event.payload.get("current_work_item_id"))
-            .or_else(|| event.payload.get("id"))
-            .and_then(Value::as_str)
-            .map(ToString::to_string)
-    })
+    work_item_record(event)
+        .map(|record| record.id)
+        .or_else(|| work_item_lifecycle_event(event).map(|record| record.work_item_id))
+        .or_else(|| {
+            event
+                .payload
+                .get("work_item_id")
+                .or_else(|| event.payload.get("current_work_item_id"))
+                .or_else(|| event.payload.get("id"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
 }
 
 fn work_item_objective_from_events(
@@ -1243,9 +1276,13 @@ fn work_item_objective_from_events(
         .iter()
         .rev()
         .filter(|event| event.kind == "work_item_written")
-        .filter_map(work_item_record)
-        .find(|record| record.id == work_item_id)
-        .map(|record| record.objective)
+        .find_map(|event| {
+            if let Some(record) = work_item_record(event) {
+                return (record.id == work_item_id).then_some(record.objective);
+            }
+            let record = work_item_lifecycle_event(event)?;
+            (record.work_item_id == work_item_id).then_some(record.objective_preview)
+        })
 }
 
 fn work_item_lifecycle_summary(event: &ProjectionEventRecord) -> String {
@@ -1257,6 +1294,15 @@ fn work_item_lifecycle_summary(event: &ProjectionEventRecord) -> String {
                 .unwrap_or(record.objective);
         }
         return record.objective;
+    }
+    if let Some(record) = work_item_lifecycle_event(event) {
+        if event.payload.get("action").and_then(Value::as_str) == Some("completed") {
+            return record
+                .result_summary_preview
+                .filter(|summary| !summary.trim().is_empty())
+                .unwrap_or(record.objective_preview);
+        }
+        return record.objective_preview;
     }
     event.summary.clone()
 }
@@ -1276,6 +1322,8 @@ fn work_item_bookkeeping_parts(
     let item_id = work_item_id_from_event(event).unwrap_or_else(|| "?".into());
     let summary = if let Some(record) = work_item_record(event) {
         record.objective
+    } else if let Some(record) = work_item_lifecycle_event(event) {
+        record.objective_preview
     } else if item_id != "?" {
         work_item_objective_from_events(&item_id, events).unwrap_or_else(|| event.summary.clone())
     } else {
@@ -1405,11 +1453,19 @@ fn final_brief_texts(events: &[ProjectionEventRecord]) -> Vec<FinalBriefText> {
     events
         .iter()
         .filter(|event| event.kind == "brief_created")
-        .filter_map(|event| serde_json::from_value::<BriefRecord>(event.payload.clone()).ok())
-        .filter(|brief| !brief.text.trim().is_empty())
-        .map(|brief| FinalBriefText {
-            agent_id: brief.agent_id,
-            text: normalized_text(brief.text.as_str()),
+        .filter_map(|event| {
+            if let Ok(brief) = serde_json::from_value::<BriefRecord>(event.payload.clone()) {
+                return (!brief.text.trim().is_empty()).then_some(FinalBriefText {
+                    agent_id: brief.agent_id,
+                    text: normalized_text(brief.text.as_str()),
+                });
+            }
+            let brief =
+                serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone()).ok()?;
+            (!brief.text_preview.trim().is_empty()).then_some(FinalBriefText {
+                agent_id: brief.agent_id,
+                text: normalized_text(brief.text_preview.as_str()),
+            })
         })
         .collect()
 }
@@ -2977,6 +3033,64 @@ mod tests {
     }
 
     #[test]
+    fn reducer_renders_lightweight_work_item_lifecycle_cards() {
+        let created = make_event(
+            "work_item_written",
+            "Work item Open: ship lightweight lifecycle",
+            json!({
+                "agent_id": "default",
+                "work_item_id": "wi-1",
+                "workspace_id": "agent_home",
+                "revision": 1,
+                "action": "created",
+                "state": "open",
+                "plan_status": "draft",
+                "readiness": "runnable",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "objective_preview": "ship lightweight lifecycle",
+                "objective_len": 26
+            }),
+        );
+        let completed = make_event(
+            "work_item_written",
+            "Work completed: merged lightweight PR",
+            json!({
+                "agent_id": "default",
+                "work_item_id": "wi-1",
+                "workspace_id": "agent_home",
+                "revision": 2,
+                "action": "completed",
+                "state": "completed",
+                "plan_status": "ready",
+                "readiness": "completed",
+                "updated_at": "2026-01-01T00:00:01Z",
+                "objective_preview": "ship lightweight lifecycle",
+                "objective_len": 26,
+                "result_summary_preview": "merged lightweight PR"
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[created, completed]);
+
+        assert_eq!(items.len(), 2);
+        match &items[0].item {
+            PresentationItem::WorkItemCard { action, summary } => {
+                assert_eq!(action, "tracking started");
+                assert_eq!(summary, "ship lightweight lifecycle");
+            }
+            other => panic!("expected WorkItemCard, got {:?}", other),
+        }
+        match &items[1].item {
+            PresentationItem::WorkItemCard { action, summary } => {
+                assert_eq!(action, "completed");
+                assert_eq!(summary, "merged lightweight PR");
+            }
+            other => panic!("expected WorkItemCard, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn reducer_renders_work_item_bookkeeping_at_verbose_level() {
         let updated = make_event(
             "work_item_written",
@@ -3356,6 +3470,40 @@ mod tests {
                 assert_eq!(body, "completed the task");
                 assert_eq!(*outcome, Outcome::Success);
                 assert!(!body.contains("Brief:"));
+            }
+            other => panic!("expected AssistantResult, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reducer_brief_created_uses_lightweight_preview() {
+        let event = make_event(
+            "brief_created",
+            "Brief: completed from preview",
+            json!({
+                "brief_id": "brief-1",
+                "agent_id": "default",
+                "workspace_id": "agent_home",
+                "kind": "result",
+                "created_at": "2026-01-01T00:00:00Z",
+                "text_preview": "completed from preview",
+                "text_len": 22
+            }),
+        );
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[event]);
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::AssistantResult {
+                brief_id,
+                body,
+                outcome,
+            } => {
+                assert_eq!(brief_id.as_deref(), Some("brief-1"));
+                assert_eq!(body, "completed from preview");
+                assert_eq!(*outcome, Outcome::Success);
             }
             other => panic!("expected AssistantResult, got {:?}", other),
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -90,10 +90,10 @@ use crate::{
     types::{
         ActiveWorkspaceEntry, AdmissionContext, AgentIdentityView, AgentKind,
         AgentModelOverrideAuditEvent, AgentModelSource, AgentModelState, AgentState,
-        AgentStateChangedEvent, AgentStatus, AgentSummary, AuditEvent, AuthorityClass, BriefRecord,
-        CallbackDeliveryMode, CallbackDeliveryPayload, CallbackDeliveryResult,
-        CallbackIngressDisposition, CancelWaitingResult, ClosureDecision, ContinuationResolution,
-        ControlAction, ExecCommandBatchItemStatus, ExecCommandBatchResult,
+        AgentStateChangedEvent, AgentStatus, AgentSummary, AuditEvent, AuthorityClass,
+        BriefCreatedAuditEvent, BriefRecord, CallbackDeliveryMode, CallbackDeliveryPayload,
+        CallbackDeliveryResult, CallbackIngressDisposition, CancelWaitingResult, ClosureDecision,
+        ContinuationResolution, ControlAction, ExecCommandBatchItemStatus, ExecCommandBatchResult,
         ExternalTriggerCapability, ExternalTriggerRecord, ExternalTriggerScope,
         ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageLifecycleAuditEvent,
@@ -103,7 +103,8 @@ use crate::{
         SkillsRuntimeView, TaskKind, TaskLifecycleAuditEvent, TaskRecord, TaskRecoverySpec,
         TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
         TranscriptEntryKind, ViewImageObservation, WaitingIntentRecord, WaitingIntentStatus,
-        WaitingIntentSummary, WaitingReason, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
+        WaitingIntentSummary, WaitingReason, WorkItemLifecycleAuditEvent, WorkspaceEntry,
+        AGENT_HOME_WORKSPACE_ID,
     },
     web::{WebConfig, WebProviderKind},
 };
@@ -436,6 +437,26 @@ impl CurrentRunAbortSnapshot {
             .lock()
             .map(|reason| reason.clone())
             .unwrap_or_else(|_| "operator_aborted".into())
+    }
+}
+
+impl RuntimeHandle {
+    pub(crate) fn append_work_item_written_event(
+        &self,
+        action: &str,
+        record: &crate::types::WorkItemRecord,
+        extra: Value,
+    ) -> Result<()> {
+        let mut payload =
+            to_json_value(&WorkItemLifecycleAuditEvent::from_work_item(action, record));
+        if let (Some(payload), Some(extra)) = (payload.as_object_mut(), extra.as_object()) {
+            for (key, value) in extra {
+                payload.insert(key.clone(), value.clone());
+            }
+        }
+        self.inner
+            .storage
+            .append_event(&AuditEvent::new("work_item_written", payload))
     }
 }
 

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -12,6 +12,10 @@ impl RuntimeHandle {
         self.inner.storage.read_recent_briefs(limit)
     }
 
+    pub async fn brief_by_id(&self, brief_id: &str) -> Result<Option<BriefRecord>> {
+        self.inner.storage.read_brief_by_id(brief_id)
+    }
+
     pub async fn recent_operator_messages(
         &self,
         limit: usize,
@@ -87,7 +91,7 @@ impl RuntimeHandle {
         self.persist_brief_evidence(&bound_brief)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "brief_created",
-            to_json_value(&bound_brief),
+            to_json_value(&BriefCreatedAuditEvent::from_brief(&bound_brief)),
         ))?;
         let mut guard = self.inner.agent.lock().await;
         guard.state.last_brief_at = Some(bound_brief.created_at);

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -127,13 +127,7 @@ impl RuntimeHandle {
                     }),
                 ))?;
             }
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_written",
-                serde_json::json!({
-                    "action": "turn_end_committed",
-                    "record": record,
-                }),
-            ))?;
+            self.append_work_item_written_event("turn_end_committed", &record, Value::Null)?;
             record
         } else {
             latest

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2160,13 +2160,7 @@ impl RuntimeHandle {
             .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
         self.inner.runtime_db.work_items().upsert(&record, false)?;
         self.inner.storage.append_work_item(&record)?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_written",
-            serde_json::json!({
-                "action": "created",
-                "record": record,
-            }),
-        ))?;
+        self.append_work_item_written_event("created", &record, Value::Null)?;
         self.inner.notify.notify_one();
         Ok(record)
     }
@@ -2508,15 +2502,17 @@ impl RuntimeHandle {
                     }),
                 ))?;
             }
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_written",
+            self.append_work_item_written_event(
+                "updated",
+                &record,
                 serde_json::json!({
-                    "action": "updated",
-                    "record": record,
-                    "previous_objective": previous_objective,
+                    "previous_objective_preview": crate::types::truncate_audit_preview(
+                        &previous_objective,
+                        600
+                    ),
                     "objective_changed": previous_objective != record.objective,
                 }),
-            ))?;
+            )?;
             if let Some(reason) = focus_release_reason {
                 self.release_current_work_item_if_matches(&agent_id, &record, reason)
                     .await?;
@@ -2653,16 +2649,14 @@ impl RuntimeHandle {
         let continuation_resumed = self
             .resume_direct_caller_after_work_item_completed(&agent_id, &record)
             .await?;
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_written",
+        self.append_work_item_written_event(
+            "completed",
+            &record,
             serde_json::json!({
-                "action": "completed",
-                "record": record,
-                "warnings": warnings.clone(),
                 "warning_count": warnings.len(),
                 "continuation_resumed": continuation_resumed.clone(),
             }),
-        ))?;
+        )?;
         self.inner.notify.notify_one();
         Ok(CompletedWorkItem {
             work_item: record,

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -2762,11 +2762,13 @@ async fn complete_work_item_with_unfinished_todos_returns_structured_warning() {
             event.kind == "work_item_written" && event.data["action"].as_str() == Some("completed")
         })
         .expect("completion event should be recorded");
-    assert_eq!(completed_event.data["warning_count"].as_u64(), Some(1));
     assert_eq!(
-        completed_event.data["warnings"][0]["kind"].as_str(),
-        Some("unfinished_todos")
+        completed_event.data["work_item_id"].as_str(),
+        Some(work_item.id.as_str())
     );
+    assert_eq!(completed_event.data["warning_count"].as_u64(), Some(1));
+    assert!(completed_event.data.get("warnings").is_none());
+    assert!(completed_event.data.get("record").is_none());
 }
 
 #[tokio::test]

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -286,13 +286,7 @@ impl RuntimeHandle {
                 }),
             ))?;
         }
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_written",
-            serde_json::json!({
-                "action": "wait_for_blocked",
-                "record": record.clone(),
-            }),
-        ))?;
+        self.append_work_item_written_event("wait_for_blocked", &record, Value::Null)?;
         Ok(record)
     }
 
@@ -371,14 +365,13 @@ impl RuntimeHandle {
                 }),
             ))?;
         }
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_written",
+        self.append_work_item_written_event(
+            "wait_for_task_resolved",
+            &record,
             serde_json::json!({
-                "action": "wait_for_task_resolved",
-                "record": record.clone(),
                 "wait_condition_id": condition.id,
             }),
-        ))?;
+        )?;
         Ok(())
     }
 
@@ -447,16 +440,15 @@ impl RuntimeHandle {
                 }),
             ))?;
         }
-        self.inner.storage.append_event(&AuditEvent::new(
-            "work_item_written",
+        self.append_work_item_written_event(
+            "pick_blocker_cleared",
+            &record,
             serde_json::json!({
-                "action": "pick_blocker_cleared",
-                "record": record.clone(),
                 "reason": reason,
                 "cancelled_wait_condition_ids": cancelled_wait_condition_ids.clone(),
                 "cancelled_waiting_intent_ids": cancelled_waiting_intent_ids.clone(),
             }),
-        ))?;
+        )?;
         self.inner.notify.notify_one();
         Ok(WorkItemBlockerClearance {
             work_item: record,

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -27,9 +27,10 @@ use crate::{
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
         ActiveWorkspaceEntry, AgentModelOverrideAuditEvent, AgentState, AgentStateChangedEvent,
-        AgentSummary, BriefRecord, ClosureDecision, ExternalTriggerStateSnapshot, MessageEnvelope,
-        MessageOrigin, TaskLifecycleAuditEvent, TaskRecord, TimerRecord, TimerStatus,
-        WaitingIntentRecord, WorkItemRecord, WorkItemState, WorktreeSession,
+        AgentSummary, BriefCreatedAuditEvent, BriefRecord, ClosureDecision,
+        ExternalTriggerStateSnapshot, MessageEnvelope, MessageOrigin, TaskLifecycleAuditEvent,
+        TaskRecord, TimerRecord, TimerStatus, WaitingIntentRecord, WorkItemLifecycleAuditEvent,
+        WorkItemRecord, WorkItemState, WorktreeSession,
     },
 };
 
@@ -1341,6 +1342,10 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
             .unwrap_or_else(|| "operator message applied".into()),
         "brief_created" => decode_payload::<BriefRecord>(&event.data.payload)
             .map(|brief| trim_summary(&brief.text))
+            .or_else(|| {
+                decode_payload::<BriefCreatedAuditEvent>(&event.data.payload)
+                    .map(|brief| trim_summary(&brief.text_preview))
+            })
             .unwrap_or_else(|| event.data.event_type.clone()),
         "task_created" | "task_status_updated" | "task_result_received" => {
             decode_payload::<TaskRecord>(&event.data.payload)
@@ -1369,6 +1374,10 @@ fn summarize_event(event: &AgentStreamEvent) -> String {
             .cloned()
             .and_then(decode_value::<WorkItemRecord>)
             .map(|record| format!("{} [{:?}]", record.objective, record.state))
+            .or_else(|| {
+                decode_payload::<WorkItemLifecycleAuditEvent>(&event.data.payload)
+                    .map(|record| format!("{} [{:?}]", record.objective_preview, record.state))
+            })
             .unwrap_or_else(|| event.data.event_type.clone()),
         "waiting_intent_created" => decode_payload::<WaitingIntentRecord>(&event.data.payload)
             .map(|waiting| format!("waiting: {}", trim_summary(&waiting.description)))

--- a/src/types.rs
+++ b/src/types.rs
@@ -979,7 +979,7 @@ pub enum MessageBody {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct BriefAttachment {
     pub kind: String,
     pub name: String,
@@ -3951,6 +3951,102 @@ impl MessageLifecycleAuditEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BriefCreatedAuditEvent {
+    pub brief_id: String,
+    #[serde(alias = "session_id")]
+    pub agent_id: String,
+    pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub kind: BriefKind,
+    pub created_at: DateTime<Utc>,
+    pub text_preview: String,
+    pub text_len: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub related_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub related_task_id: Option<String>,
+}
+
+impl BriefCreatedAuditEvent {
+    pub fn from_brief(brief: &BriefRecord) -> Self {
+        Self {
+            brief_id: brief.id.clone(),
+            agent_id: brief.agent_id.clone(),
+            workspace_id: brief.workspace_id.clone(),
+            work_item_id: brief.work_item_id.clone(),
+            turn_index: brief.turn_index,
+            turn_id: brief.turn_id.clone(),
+            kind: brief.kind,
+            created_at: brief.created_at,
+            text_preview: truncate_audit_preview(&brief.text, 600),
+            text_len: brief.text.chars().count(),
+            related_message_id: brief.related_message_id.clone(),
+            related_task_id: brief.related_task_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkItemLifecycleAuditEvent {
+    #[serde(alias = "session_id")]
+    pub agent_id: String,
+    pub work_item_id: String,
+    pub workspace_id: String,
+    pub revision: u64,
+    pub action: String,
+    pub state: WorkItemState,
+    pub plan_status: WorkItemPlanStatus,
+    pub readiness: WorkItemReadiness,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub objective_preview: String,
+    pub objective_len: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_brief_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_summary_preview: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_by_preview: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recheck_at: Option<DateTime<Utc>>,
+}
+
+impl WorkItemLifecycleAuditEvent {
+    pub fn from_work_item(action: impl Into<String>, record: &WorkItemRecord) -> Self {
+        Self {
+            agent_id: record.agent_id.clone(),
+            work_item_id: record.id.clone(),
+            workspace_id: record.workspace_id.clone(),
+            revision: record.revision,
+            action: action.into(),
+            state: record.state.clone(),
+            plan_status: record.plan_status,
+            readiness: record.readiness(),
+            updated_at: record.updated_at,
+            turn_id: record.turn_id.clone(),
+            objective_preview: truncate_audit_preview(&record.objective, 600),
+            objective_len: record.objective.chars().count(),
+            result_brief_id: record.result_brief_id.clone(),
+            result_summary_preview: record
+                .result_summary
+                .as_deref()
+                .map(|value| truncate_audit_preview(value, 600)),
+            blocked_by_preview: record
+                .blocked_by
+                .as_deref()
+                .map(|value| truncate_audit_preview(value, 600)),
+            recheck_at: record.recheck_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TaskLifecycleAuditEvent {
     pub task_id: String,
     #[serde(alias = "session_id")]
@@ -4090,7 +4186,7 @@ fn detail_i64(detail: Option<&Value>, field: &str) -> Option<i64> {
         .and_then(Value::as_i64)
 }
 
-fn truncate_audit_preview(value: &str, max_chars: usize) -> String {
+pub(crate) fn truncate_audit_preview(value: &str, max_chars: usize) -> String {
     if value.chars().count() <= max_chars {
         return value.to_string();
     }
@@ -4167,7 +4263,7 @@ impl TranscriptEntry {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum BriefKind {
     Ack,
@@ -4189,7 +4285,7 @@ impl BriefKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct BriefRecord {
     pub id: String,
     #[serde(alias = "session_id")]
@@ -5412,6 +5508,75 @@ mod tests {
         assert!(payload.get("metadata").is_none());
         assert!(!payload.to_string().contains("large-message-body"));
         assert!(!payload.to_string().contains("large-message-metadata"));
+    }
+
+    #[test]
+    fn brief_created_audit_event_omits_full_text_and_attachments() {
+        let mut brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "large-brief-text".repeat(1024),
+            Some("msg-1".into()),
+            Some("task-1".into()),
+        );
+        brief.work_item_id = Some("wi-1".into());
+        brief.attachments = Some(vec![BriefAttachment {
+            kind: "json".into(),
+            name: "large".into(),
+            uri: None,
+            value: Some(serde_json::json!({
+                "large_attachment": "large-attachment-value".repeat(1024)
+            })),
+        }]);
+
+        let payload = serde_json::to_value(BriefCreatedAuditEvent::from_brief(&brief)).unwrap();
+
+        assert_eq!(payload["brief_id"], brief.id);
+        assert_eq!(payload["work_item_id"], "wi-1");
+        assert!(payload.get("text").is_none());
+        assert!(payload.get("attachments").is_none());
+        assert!(payload["text_preview"].as_str().unwrap().len() < brief.text.len());
+        assert!(!payload.to_string().contains("large-attachment-value"));
+    }
+
+    #[test]
+    fn work_item_lifecycle_audit_event_omits_full_record_payload() {
+        let mut record = WorkItemRecord::new(
+            "default",
+            "large-work-item-objective".repeat(1024),
+            WorkItemState::Open,
+        );
+        record.plan_artifact = Some(WorkItemPlanArtifact {
+            owner_agent_id: "default".into(),
+            workspace_id: AGENT_HOME_WORKSPACE_ID.into(),
+            workspace_alias: None,
+            relative_path: PathBuf::from("plans/wi.md"),
+            path: PathBuf::from("/tmp/plans/wi.md"),
+            hash: "hash".into(),
+            bytes: 42,
+            updated_at: Utc::now(),
+            preview: "large-plan-preview".repeat(1024),
+            preview_complete: true,
+        });
+        record.todo_list.push(TodoItem {
+            text: "large-todo".repeat(1024),
+            state: TodoItemState::Pending,
+        });
+        record.result_summary = Some("result-summary".into());
+
+        let payload = serde_json::to_value(WorkItemLifecycleAuditEvent::from_work_item(
+            "updated", &record,
+        ))
+        .unwrap();
+
+        assert_eq!(payload["work_item_id"], record.id);
+        assert_eq!(payload["action"], "updated");
+        assert!(payload.get("record").is_none());
+        assert!(payload.get("plan_artifact").is_none());
+        assert!(payload.get("todo_list").is_none());
+        assert!(payload["objective_preview"].as_str().unwrap().len() < record.objective.len());
+        assert!(!payload.to_string().contains("large-plan-preview"));
+        assert!(!payload.to_string().contains("large-todo"));
     }
 
     #[test]

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -14,6 +14,7 @@ macro_rules! http_async_tests {
 http_async_tests!(
     control_prompt_is_open_on_loopback_auto,
     agent_state_route_returns_aggregated_snapshot,
+    agent_brief_route_returns_full_brief_by_id,
     agent_state_route_includes_bootstrap_projection_fields_when_present,
     list_skills_includes_all_agent_skill_roots,
     install_skill_existing_destination_returns_conflict,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 61, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 62, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -55,6 +55,33 @@
   },
   {
     "method": "get",
+    "path": "/agents/{agent_id}/briefs/{brief_id}",
+    "handler": "brief",
+    "operation_id": "agentBrief",
+    "tag": "agents",
+    "parameters": [
+      {
+        "name": "agent_id",
+        "location": "path",
+        "required": true
+      },
+      {
+        "name": "brief_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/agents/{agent_id}/events",
     "handler": "events",
     "operation_id": "agentEvents",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -110,6 +110,48 @@ pub async fn agent_state_route_returns_aggregated_snapshot() -> Result<()> {
     Ok(())
 }
 
+pub async fn agent_brief_route_returns_full_brief_by_id() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{base}/control/agents/default/prompt"))
+        .json(&serde_json::json!({ "text": "brief detail route" }))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+
+    wait_until(|| {
+        Ok(runtime
+            .storage()
+            .read_recent_briefs(10)?
+            .iter()
+            .any(|brief| !brief.text.trim().is_empty()))
+    })
+    .await?;
+    let brief = runtime
+        .storage()
+        .read_recent_briefs(10)?
+        .into_iter()
+        .find(|brief| !brief.text.trim().is_empty())
+        .expect("brief should be persisted");
+
+    let detail = client
+        .get(format!("{base}/agents/default/briefs/{}", brief.id))
+        .send()
+        .await?;
+    assert_eq!(detail.status(), reqwest::StatusCode::OK);
+    let returned: BriefRecord = detail.json().await?;
+
+    assert_eq!(returned.id, brief.id);
+    assert_eq!(returned.agent_id, "default");
+    assert_eq!(returned.text, brief.text);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present() -> Result<()> {
     let mut config = test_config();
     let (host, base, server) = spawn_server_with_config(config.clone()).await?;
@@ -497,6 +539,7 @@ pub async fn remote_tcp_surfaces_require_bearer_token_when_required() -> Result<
         "/agents/default/status",
         "/agents/default/state",
         "/agents/default/briefs",
+        "/agents/default/briefs/brief-test",
         "/agents/default/transcript",
         "/agents/default/tasks",
         "/agents/default/timers",


### PR DESCRIPTION
## Summary

- replace `brief_created` events with lightweight brief lifecycle payloads and add `GET /agents/{agent_id}/briefs/{brief_id}` for full brief hydration
- replace `work_item_written` full-record payloads with locator/status/preview payloads across runtime write paths
- update operator/TUI presentation reducers, OpenAPI docs, route snapshots, and regression tests for the slim event contract

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test audit_event --lib`
- `cargo test lightweight --lib`
- `cargo test complete_work_item_with_unfinished_todos_returns_structured_warning --lib`
- `cargo test --test http_events`
- `cargo test --test http_control agent_brief_route_returns_full_brief_by_id`
- `cargo test --test http_control remote_tcp_surfaces_require_bearer_token_when_required`
- `cargo test --test http_route_snapshot`
- `cargo test --test openapi_snapshot`
