### PR TITLE
feat: add web gui prototype

### DIFF
--- a/web-gui/app/package-lock.json
+++ b/web-gui/app/package-lock.json
@@ -21,7 +21,8 @@
         "@vitejs/plugin-react": "^6.0.2",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -412,6 +413,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
@@ -695,6 +703,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -703,6 +722,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -801,6 +827,129 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -819,6 +968,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -870,6 +1029,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -953,6 +1119,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -973,6 +1146,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -1139,7 +1332,6 @@
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2293,6 +2485,20 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -2316,6 +2522,13 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -2533,6 +2746,13 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2552,6 +2772,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -2606,6 +2840,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2621,6 +2872,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -2857,6 +3118,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zustand": {

--- a/web-gui/app/package.json
+++ b/web-gui/app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host 127.0.0.1",
     "build": "npm run typecheck && vite build",
     "preview": "vite preview --host 127.0.0.1",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json --pretty false && tsc --noEmit -p tsconfig.node.json --pretty false"
   },
   "dependencies": {
@@ -23,6 +24,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
   }
 }

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -216,7 +216,7 @@ export function App() {
           ) : (
             bootstrap.agents.map((agent) => {
               const status = deriveAgentDisplayStatus(agent);
-              const secondary = agentSecondaryStatus(agent);
+              const workSummary = agent.currentWork?.objective;
 
               return (
                 <button
@@ -234,11 +234,11 @@ export function App() {
                         {status.label}
                       </StatusBadge>
                     </span>
-                    <span className="agent-row-meta">
-                      {secondary.map((item, index) => (
-                        <span key={`${item}-${index}`}>{item}</span>
-                      ))}
-                    </span>
+                    {workSummary ? (
+                      <span className="agent-row-meta">
+                        <span>{workSummary}</span>
+                      </span>
+                    ) : null}
                   </span>
                 </button>
               );
@@ -428,11 +428,6 @@ function levelLabel(level: DisplayLevel): string {
   if (level === "info") return "Info";
   if (level === "verbose") return "Verbose";
   return "Debug";
-}
-
-function agentSecondaryStatus(agent: AgentSummary): string[] {
-  const items = [agent.lifecycle, agent.currentWork?.state ?? agent.posture].filter(Boolean);
-  return items.length > 0 ? items : ["unknown"];
 }
 
 function liveStatusLabel(status: string): string {

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -79,6 +79,52 @@ export function App() {
       : selectedAgentDetail?.source === "http" && !selectedAgentDetail.error
         ? "live"
         : "preview";
+  const agentTopControls =
+    route === "agent" ? (
+      <div className="agent-top-controls" aria-label="Agent conversation controls">
+        <div className="agent-stream-controls" aria-label="Agent stream status">
+          <StatusBadge
+            kind="connection"
+            value={selectedAgentSourceStatus}
+            className={`source-chip ${selectedAgentSourceStatus}`}
+          >
+            {selectedAgentSourceStatus}
+          </StatusBadge>
+          <StatusBadge
+            kind="stream"
+            value={selectedAgentLiveStatus}
+            className={`source-chip live-status ${selectedAgentLiveStatus}`}
+            title={selectedAgentLiveTitle}
+          >
+            {liveStatusLabel(selectedAgentLiveStatus)}
+          </StatusBadge>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label={agentDetailLoading ? "Refreshing agent detail" : "Refresh agent detail"}
+            title={agentDetailLoading ? "Refreshing…" : "Refresh agent detail"}
+            disabled={agentDetailLoading}
+            onClick={() => void refreshAgentDetail()}
+          >
+            ↻
+          </Button>
+        </div>
+        <SegmentedControl className="display-level" label="Display level">
+          {(["info", "verbose", "debug"] as const).map((level) => (
+            <SegmentedControlButton
+              active={displayLevel === level}
+              className={displayLevel === level ? "is-active" : ""}
+              key={level}
+              type="button"
+              onClick={() => setDisplayLevel(level, activeAgentId)}
+            >
+              {levelLabel(level)}
+            </SegmentedControlButton>
+          ))}
+        </SegmentedControl>
+      </div>
+    ) : null;
   const isInitialBootstrapping = loading && bootstrap.connection.summary === "Connecting to local runtime…" && !bootstrap.connection.error;
 
   useLayoutEffect(() => {
@@ -238,6 +284,7 @@ export function App() {
               </div>
             </div>
             <div className="top-actions">
+              {agentTopControls}
               <Button
                 type="button"
                 size="icon"
@@ -250,54 +297,6 @@ export function App() {
               </Button>
             </div>
           </div>
-
-          {route === "agent" ? (
-            <div className="agent-top-context" aria-label="Agent conversation context">
-              <div className="agent-top-controls">
-                <div className="agent-stream-controls" aria-label="Agent stream status">
-                  <StatusBadge
-                    kind="connection"
-                    value={selectedAgentSourceStatus}
-                    className={`source-chip ${selectedAgentSourceStatus}`}
-                  >
-                    {selectedAgentSourceStatus}
-                  </StatusBadge>
-                  <StatusBadge
-                    kind="stream"
-                    value={selectedAgentLiveStatus}
-                    className={`source-chip live-status ${selectedAgentLiveStatus}`}
-                    title={selectedAgentLiveTitle}
-                  >
-                    {liveStatusLabel(selectedAgentLiveStatus)}
-                  </StatusBadge>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label={agentDetailLoading ? "Refreshing agent detail" : "Refresh agent detail"}
-                    title={agentDetailLoading ? "Refreshing…" : "Refresh agent detail"}
-                    disabled={agentDetailLoading}
-                    onClick={() => void refreshAgentDetail()}
-                  >
-                    ↻
-                  </Button>
-                </div>
-                <SegmentedControl className="display-level" label="Display level">
-                  {(["info", "verbose", "debug"] as const).map((level) => (
-                    <SegmentedControlButton
-                      active={displayLevel === level}
-                      className={displayLevel === level ? "is-active" : ""}
-                      key={level}
-                      type="button"
-                      onClick={() => setDisplayLevel(level, activeAgentId)}
-                    >
-                      {levelLabel(level)}
-                    </SegmentedControlButton>
-                  ))}
-                </SegmentedControl>
-              </div>
-            </div>
-          ) : null}
         </header>
 
         {route === "dashboard" ? (

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -330,7 +330,10 @@ export function App() {
             onClearModel={() => clearAgentModel(activeAgent.id, displayLevel)}
             onLoadOlderEvents={() => loadOlderAgentEvents(activeAgent.id, displayLevel)}
             onSendPrompt={(text) => sendOperatorPrompt(activeAgent.id, text, displayLevel)}
-            onOpenInspector={() => setInspectorOpen(true)}
+            onOpenInspector={() => {
+              clearInspectorSelection();
+              setInspectorOpen(true);
+            }}
             onInspectActivity={(activity) => inspectActivity(activeAgent.id, activity)}
             selectedActivityId={
               inspectorSelection?.kind === "activity" && inspectorSelection.agentId === activeAgent.id

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 
 import { AgentPage } from "../features/agent/AgentPage";
 import { Button } from "../components/ui/Button";
@@ -14,7 +14,7 @@ import { selectSelectedAgent } from "../runtime/runtime-selectors";
 import { useRuntimeStore } from "../runtime/runtime-store";
 import { useAgentDetail } from "../runtime/useAgentDetail";
 import { useRuntimeDashboard } from "../runtime/useRuntimeDashboard";
-import type { AgentSummary, DisplayLevel, RouteKey } from "../runtime/types";
+import type { AgentSummary, DisplayLevel, RouteKey, RuntimeConnection, RuntimeConnectionConfig } from "../runtime/types";
 import { pushBrowserRoute, routeFromLocation } from "./routes";
 
 const globalRoutes: Array<{ key: RouteKey; label: string; icon: string }> = [
@@ -39,6 +39,7 @@ export function App() {
   const clearInspectorSelection = useRuntimeStore((state) => state.clearInspectorSelection);
   const toggleInspector = useRuntimeStore((state) => state.toggleInspector);
   const toggleNavCollapsed = useRuntimeStore((state) => state.toggleNavCollapsed);
+  const setRuntimeConnection = useRuntimeStore((state) => state.setRuntimeConnection);
   const selectedAgent = useRuntimeStore(selectSelectedAgent);
   const activeAgentId = route === "agent" ? selectedAgent?.id ?? selectedAgentId : undefined;
   const selectedAgentSession = useRuntimeStore((state) =>
@@ -124,7 +125,7 @@ export function App() {
         </SegmentedControl>
       </div>
     ) : null;
-  const isInitialBootstrapping = loading && bootstrap.connection.summary === "Connecting to local runtime…" && !bootstrap.connection.error;
+  const isInitialBootstrapping = loading && bootstrap.agents.length === 0 && !bootstrap.connection.error;
 
   useLayoutEffect(() => {
     const applyBrowserRoute = () => {
@@ -162,7 +163,7 @@ export function App() {
   }
 
   if (isInitialBootstrapping) {
-    return <BootstrappingPage />;
+    return <BootstrappingPage connection={bootstrap.connection} onSetConnection={setRuntimeConnection} />;
   }
 
   return (
@@ -247,13 +248,7 @@ export function App() {
         </section>
 
         <div className="sidebar-bottom">
-          <button className="connection-status" type="button">
-            <span className="runtime-dot" />
-            <span>
-              <strong>{bootstrap.connection.mode}</strong>
-              <small>{bootstrap.connection.summary}</small>
-            </span>
-          </button>
+          <ConnectionSwitcher connection={bootstrap.connection} onSetConnection={setRuntimeConnection} />
         </div>
       </aside>
 
@@ -381,7 +376,13 @@ export function App() {
   );
 }
 
-function BootstrappingPage() {
+function BootstrappingPage({
+  connection,
+  onSetConnection,
+}: {
+  connection: RuntimeConnection;
+  onSetConnection: (config: RuntimeConnectionConfig) => Promise<void>;
+}) {
   return (
     <main className="boot-page" aria-label="Holon is loading">
       <section className="boot-card" role="status" aria-live="polite">
@@ -390,9 +391,93 @@ function BootstrappingPage() {
           <p>Starting Holon Web GUI</p>
           <h1>Preparing runtime data…</h1>
           <span>Loading the runtime handshake and agent roster before rendering the workspace.</span>
+          <ConnectionSwitcher connection={connection} onSetConnection={onSetConnection} compact={false} />
         </div>
       </section>
     </main>
+  );
+}
+
+function ConnectionSwitcher({
+  connection,
+  onSetConnection,
+  compact = true,
+}: {
+  connection: RuntimeConnection;
+  onSetConnection: (config: RuntimeConnectionConfig) => Promise<void>;
+  compact?: boolean;
+}) {
+  const [open, setOpen] = useState(!compact || Boolean(connection.error));
+  const [baseUrl, setBaseUrl] = useState(connection.mode === "remote" ? connection.baseUrl ?? "" : "");
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | undefined>();
+
+  async function applyConnection(config: RuntimeConnectionConfig) {
+    setSaving(true);
+    setFormError(undefined);
+    try {
+      await onSetConnection(config);
+      if (compact) setOpen(false);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className={`connection-switcher ${open ? "is-open" : ""}`}>
+      <button className="connection-status" type="button" onClick={() => setOpen((value) => !value)}>
+        <span className={`runtime-dot ${connection.error ? "error" : ""}`} />
+        <span>
+          <strong>{connection.mode}</strong>
+          <small>{connection.summary}</small>
+        </span>
+      </button>
+      {open ? (
+        <form
+          className="connection-panel"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const trimmedBaseUrl = baseUrl.trim();
+            if (!trimmedBaseUrl) {
+              setFormError("Remote URL is required.");
+              return;
+            }
+            void applyConnection({ mode: "remote", baseUrl: trimmedBaseUrl, token });
+          }}
+        >
+          <label>
+            Remote URL
+            <input
+              value={baseUrl}
+              onChange={(event) => setBaseUrl(event.target.value)}
+              placeholder="http://192.168.1.10:7878"
+              inputMode="url"
+            />
+          </label>
+          <label>
+            Bearer token
+            <input
+              value={token}
+              onChange={(event) => setToken(event.target.value)}
+              placeholder="optional for trusted local networks"
+              type="password"
+            />
+          </label>
+          {formError ? <span className="connection-error">{formError}</span> : null}
+          <div className="connection-actions">
+            <Button type="button" size="sm" variant="secondary" disabled={saving} onClick={() => void applyConnection({ mode: "local" })}>
+              Localhost
+            </Button>
+            <Button type="submit" size="sm" disabled={saving}>
+              {saving ? "Connecting…" : "Use remote"}
+            </Button>
+          </div>
+        </form>
+      ) : null}
+    </div>
   );
 }
 

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -69,7 +69,6 @@ export function App() {
   const activeAgent = selectedAgent ?? selectedAgentDetail?.agent;
   const selectedAgentLiveStatus = selectedAgentSession?.liveStatus ?? "idle";
   const selectedAgentLiveTitle = liveStatusTitle(selectedAgentLiveStatus, selectedAgentSession?.lastStreamActivityAt, selectedAgentSession?.error);
-  const selectedAgentCurrentWork = activeAgent?.currentWork;
   const selectedAgentContext =
     route === "agent" && activeAgent
       ? [activeAgent.lifecycle, activeAgent.posture].filter(Boolean).join(" · ")
@@ -254,21 +253,6 @@ export function App() {
 
           {route === "agent" ? (
             <div className="agent-top-context" aria-label="Agent conversation context">
-              <div className="agent-context-main">
-                <button
-                  className={`work-summary ${selectedAgentCurrentWork ? "has-work" : "is-empty"}`}
-                  type="button"
-                  onClick={() => setInspectorOpen(true)}
-                >
-                  <span className="work-summary-label">Current work</span>
-                  <strong>{selectedAgentCurrentWork?.objective ?? "No active work item"}</strong>
-                  <span className="work-summary-meta">
-                    {selectedAgentCurrentWork
-                      ? `${selectedAgentCurrentWork.state} · ${selectedAgentCurrentWork.id}`
-                      : "Ready for operator input"}
-                  </span>
-                </button>
-              </div>
               <div className="agent-top-controls">
                 <div className="agent-stream-controls" aria-label="Agent stream status">
                   <StatusBadge

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -9,6 +9,7 @@ import { DashboardPage } from "../features/dashboard/DashboardPage";
 import { InspectorPanel } from "../features/inspector/InspectorPanel";
 import { SearchPage } from "../features/search/SearchPage";
 import { SettingsPage } from "../features/settings/SettingsPage";
+import { deriveAgentDisplayStatus } from "../runtime/agent-status";
 import { selectSelectedAgent } from "../runtime/runtime-selectors";
 import { useRuntimeStore } from "../runtime/runtime-store";
 import { useAgentDetail } from "../runtime/useAgentDetail";
@@ -69,10 +70,8 @@ export function App() {
   const activeAgent = selectedAgent ?? selectedAgentDetail?.agent;
   const selectedAgentLiveStatus = selectedAgentSession?.liveStatus ?? "idle";
   const selectedAgentLiveTitle = liveStatusTitle(selectedAgentLiveStatus, selectedAgentSession?.lastStreamActivityAt, selectedAgentSession?.error);
-  const selectedAgentContext =
-    route === "agent" && activeAgent
-      ? [activeAgent.lifecycle, activeAgent.posture].filter(Boolean).join(" · ")
-      : "loading agent";
+  const selectedAgentStatus = route === "agent" && activeAgent ? deriveAgentDisplayStatus(activeAgent) : undefined;
+  const selectedAgentContext = selectedAgentStatus?.label ?? "loading agent";
   const selectedAgentSourceStatus =
     agentDetailLoading && !selectedAgentDetail
       ? "syncing"
@@ -216,7 +215,7 @@ export function App() {
             </div>
           ) : (
             bootstrap.agents.map((agent) => {
-              const status = agentDisplayStatus(agent);
+              const status = deriveAgentDisplayStatus(agent);
               const secondary = agentSecondaryStatus(agent);
 
               return (
@@ -276,7 +275,7 @@ export function App() {
               ) : null}
               <div>
                 <strong>{route === "agent" ? (selectedAgent?.id ?? selectedAgentId) || "Agent" : pageTitle(route)}</strong>
-                <span>
+                <span title={route === "agent" ? selectedAgentStatus?.title : undefined}>
                   {route === "agent"
                     ? selectedAgentContext
                     : pageSubtitle(route, bootstrap.attentionCount, bootstrap.agents.length)}
@@ -431,84 +430,9 @@ function levelLabel(level: DisplayLevel): string {
   return "Debug";
 }
 
-function agentDisplayStatus(agent: AgentSummary): { label: string; title: string; tone: string } {
-  const details = [
-    agent.posture ? `posture: ${agent.posture}` : undefined,
-    agent.lifecycle ? `lifecycle: ${agent.lifecycle}` : undefined,
-    agent.pending > 0 ? `${agent.pending} pending input${agent.pending === 1 ? "" : "s"}` : undefined,
-    agent.activeTaskCount > 0
-      ? `${agent.activeTaskCount} active task${agent.activeTaskCount === 1 ? "" : "s"}`
-      : undefined,
-    agent.waitingCount > 0 ? `${agent.waitingCount} waiting condition${agent.waitingCount === 1 ? "" : "s"}` : undefined,
-  ].filter(Boolean);
-  const title = details.join(" · ") || "No status details";
-
-  if (isStoppedOrArchived(agent.lifecycle) || isStoppedOrArchived(agent.posture)) {
-    return { label: "Stopped", title, tone: "stopped" };
-  }
-
-  if (agent.pending > 0) {
-    return { label: "Needs input", title, tone: "needs-input" };
-  }
-
-  if (agent.activeTaskCount > 0 || agent.currentRunId || isActivePosture(agent.posture)) {
-    return { label: "Running", title, tone: "running" };
-  }
-
-  if (isRunnablePosture(agent.posture)) {
-    return { label: "Runnable", title, tone: "running" };
-  }
-
-  if (agent.waitingCount > 0 || isWaitingPosture(agent.posture)) {
-    return { label: "Waiting", title, tone: "waiting" };
-  }
-
-  if (isBlockedPosture(agent.posture)) {
-    return { label: "Blocked", title, tone: "stopped" };
-  }
-
-  if (isIdlePosture(agent.posture) || isIdlePosture(agent.lifecycle)) {
-    return { label: "Ready", title, tone: "ready" };
-  }
-
-  return { label: "Unknown", title, tone: "muted" };
-}
-
 function agentSecondaryStatus(agent: AgentSummary): string[] {
   const items = [agent.lifecycle, agent.currentWork?.state ?? agent.posture].filter(Boolean);
   return items.length > 0 ? items : ["unknown"];
-}
-
-function normalizeAgentStatus(value?: string | null): string {
-  return (value ?? "").trim().toLowerCase().replace(/[_\s]+/g, "-");
-}
-
-function isStoppedOrArchived(value?: string | null): boolean {
-  const status = normalizeAgentStatus(value);
-  return status === "stopped" || status === "archived";
-}
-
-function isActivePosture(value?: string | null): boolean {
-  const status = normalizeAgentStatus(value);
-  return status === "active-turn" || status === "awake-running" || status === "running";
-}
-
-function isRunnablePosture(value?: string | null): boolean {
-  const status = normalizeAgentStatus(value);
-  return status === "has-queued-input" || status === "has-runnable-work";
-}
-
-function isWaitingPosture(value?: string | null): boolean {
-  return normalizeAgentStatus(value).startsWith("waiting");
-}
-
-function isBlockedPosture(value?: string | null): boolean {
-  return normalizeAgentStatus(value) === "blocked";
-}
-
-function isIdlePosture(value?: string | null): boolean {
-  const status = normalizeAgentStatus(value);
-  return status === "idle" || status === "asleep" || status === "awake-idle" || status === "ready";
 }
 
 function liveStatusLabel(status: string): string {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -780,15 +780,13 @@ function WorkingIndicator({
   return (
     <button className="working-indicator detail" type="button" onClick={onOpenOverview}>
       <div className="working-activity-header">
-        <span className="working-activity-title">
-          <span className="working-activity-dot" aria-hidden="true" />
-          <strong>Working</strong>
-        </span>
+        <span className="working-activity-dot" aria-hidden="true" />
+        <strong>Working</strong>
         {parts.length ? <small>{parts.join(" · ")}</small> : null}
       </div>
       <div className="working-activity-list">
         {activities.map((activity) => (
-          <div className={`working-activity-item ${activity.kind}`} key={activity.id}>
+          <div className={`working-activity-item ${activity.kind} slot-${workingActivitySlot(activity)}`} key={activity.id}>
             <span className="working-activity-icon" aria-label={workingActivityLabel(activity)} title={workingActivityLabel(activity)}>
               {workingActivityIcon(activity)}
             </span>
@@ -800,12 +798,16 @@ function WorkingIndicator({
   );
 }
 
+function workingActivitySlot(activity: AgentTimelineActivity): "assistant" | "action" {
+  return activity.kind === "assistant" ? "assistant" : "action";
+}
+
 function workingActivityLabel(activity: AgentTimelineActivity): string {
-  return activity.kind === "assistant" ? "Assistant" : "Action";
+  return workingActivitySlot(activity) === "assistant" ? "Assistant message" : "Action";
 }
 
 function workingActivityIcon(activity: AgentTimelineActivity): string {
-  return activity.kind === "assistant" ? "✦" : "›";
+  return workingActivitySlot(activity) === "assistant" ? "✦" : "›";
 }
 
 function workingActivityBody(activity: AgentTimelineActivity): string {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -760,7 +760,6 @@ function WorkingIndicator({
   const parts = [
     agent.currentWork?.objective,
     agent.activeTaskCount ? `${agent.activeTaskCount} active task${agent.activeTaskCount === 1 ? "" : "s"}` : undefined,
-    agent.pending ? `${agent.pending} queued` : undefined,
   ].filter(Boolean);
 
   if (displayLevel !== "info" || activities.length === 0) {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -322,6 +322,26 @@ export function AgentPage({
                             <b>Step 2</b>
                             {currentProvider} models
                           </span>
+                          {activeModelOption?.supportsReasoningEffort || currentProviderModels.some((option) => option.supportsReasoningEffort) ? (
+                            <div className="model-picker-reasoning" aria-label="Thinking level">
+                              <span>
+                                <b>Thinking</b>
+                                Choose before selecting a reasoning model
+                              </span>
+                              <div className="reasoning-options">
+                                {["auto", "low", "medium", "high"].map((effort) => (
+                                  <button
+                                    className={selectedReasoningEffort === effort ? "is-active" : ""}
+                                    key={effort}
+                                    type="button"
+                                    onClick={() => setSelectedReasoningEffort(effort)}
+                                  >
+                                    {titleCase(effort)}
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          ) : null}
                           <div className="model-options" role="listbox" aria-label={`${currentProvider} models`}>
                             {currentProviderModels.map((option) => (
                               <button
@@ -346,23 +366,6 @@ export function AgentPage({
                           </div>
                         </div>
                       </div>
-                      {activeModelOption?.supportsReasoningEffort || currentProviderModels.some((option) => option.supportsReasoningEffort) ? (
-                        <div className="model-picker-section" aria-label="Thinking level">
-                          <span>Thinking</span>
-                          <div className="reasoning-options">
-                            {["auto", "low", "medium", "high"].map((effort) => (
-                              <button
-                                className={selectedReasoningEffort === effort ? "is-active" : ""}
-                                key={effort}
-                                type="button"
-                                onClick={() => setSelectedReasoningEffort(effort)}
-                              >
-                                {titleCase(effort)}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                      ) : null}
                       {!modelCatalogLoading && modelCatalog.options.length === 0 ? (
                         <EmptyState
                           className="model-picker-empty"

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -73,7 +73,7 @@ export function AgentPage({
   const preserveScrollRef = useRef<{ height: number; top: number } | null>(null);
   const stickToBottomRef = useRef(true);
   const activeAgent = detail?.agent ?? agent;
-  const sourceTimeline = useMemo(() => detail?.timeline ?? fallbackTimeline(activeAgent), [activeAgent, detail?.timeline]);
+  const sourceTimeline = useMemo(() => timelineWithFallbackBrief(detail?.timeline, activeAgent), [activeAgent, detail?.timeline]);
   const timeline = useMemo(
     () =>
       filterTimelineByDisplayLevel(sourceTimeline, displayLevel, {
@@ -822,6 +822,22 @@ function fallbackTimeline(agent: AgentSummary): AgentTimelineItem[] {
       debug: JSON.stringify(agent, null, 2),
     },
   ];
+}
+
+function timelineWithFallbackBrief(timeline: AgentTimelineItem[] | undefined, agent: AgentSummary): AgentTimelineItem[] {
+  const fallback = fallbackTimeline(agent);
+  if (!timeline?.length) return fallback;
+  const latestBrief = fallback[0];
+  if (!latestBrief) return timeline;
+
+  const hasLatestBrief = timeline.some(
+    (item) => item.kind === "assistant" && normalizeTimelineText(item.body) === normalizeTimelineText(latestBrief.body),
+  );
+  return hasLatestBrief ? timeline : [...timeline, latestBrief];
+}
+
+function normalizeTimelineText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
 }
 
 function hasVisibleBrief(value: string): boolean {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -92,6 +92,8 @@ export function AgentPage({
   const groupedModelOptions = useMemo(() => groupModelOptionsByProvider(modelCatalog.options), [modelCatalog.options]);
   const activeModelOption = useMemo(() => modelCatalog.options.find((option) => option.model === activeAgent.model), [activeAgent.model, modelCatalog.options]);
   const activeModelSupportsReasoning = activeModelOption?.supportsReasoningEffort ?? Boolean(activeAgent.modelReasoningEffort);
+  const activeReasoningBadge = activeModelSupportsReasoning ? (activeAgent.modelReasoningEffort ?? "auto") : undefined;
+  const activeModelTitle = modelButtonTitle(activeAgent.model, activeReasoningBadge, activeAgent.modelSource === "agent_override");
   const currentProvider = selectedProvider ?? activeModelOption?.provider ?? groupedModelOptions[0]?.provider ?? "runtime";
   const currentProviderModels = groupedModelOptions.find((group) => group.provider === currentProvider)?.models ?? [];
 
@@ -264,10 +266,17 @@ export function AgentPage({
               </div>
               <div className="composer-right">
                 <div className="model-picker">
-                  <Button className="model-button" type="button" variant="secondary" aria-expanded={modelPickerOpen} onClick={toggleModelPicker}>
-                    <span>{shortModelLabel(activeAgent.model)}</span>
-                    {activeModelSupportsReasoning ? <small>{activeAgent.modelReasoningEffort ? `thinking ${activeAgent.modelReasoningEffort}` : "thinking auto"}</small> : null}
-                    {activeAgent.modelSource === "agent_override" ? <small>override</small> : null}
+                  <Button
+                    className="model-button"
+                    type="button"
+                    variant="secondary"
+                    aria-expanded={modelPickerOpen}
+                    aria-label={activeModelTitle}
+                    title={activeModelTitle}
+                    onClick={toggleModelPicker}
+                  >
+                    <span className="model-button-label">{shortModelLabel(activeAgent.model)}</span>
+                    {activeReasoningBadge ? <small className="model-button-badge">{activeReasoningBadge}</small> : null}
                     <span aria-hidden="true">⌄</span>
                   </Button>
                   {modelPickerOpen ? (
@@ -395,6 +404,13 @@ export function AgentPage({
 function shortModelLabel(model: string): string {
   const parts = model.split("/");
   return parts[parts.length - 1] || model;
+}
+
+function modelButtonTitle(model: string, reasoningEffort: string | undefined, isModelOverride: boolean): string {
+  const details = [model];
+  if (reasoningEffort) details.push(`reasoning effort: ${reasoningEffort}`);
+  if (isModelOverride) details.push("model override");
+  return details.join(" · ");
 }
 
 function groupModelOptionsByProvider(options: RuntimeModelOption[]): Array<{ provider: string; availableCount: number; models: RuntimeModelOption[] }> {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -295,45 +295,56 @@ export function AgentPage({
                         </span>
                         {changingModel === "runtime-default" ? <em>Saving…</em> : null}
                       </button>
-                      <div className="model-picker-section" aria-label="Providers">
-                        <span>Provider</span>
-                        <div className="model-provider-list">
-                          {groupedModelOptions.map((group) => (
-                            <button
-                              className={`model-provider-option ${group.provider === currentProvider ? "is-active" : ""}`}
-                              key={group.provider}
-                              type="button"
-                              onClick={() => setSelectedProvider(group.provider)}
-                            >
-                              <strong>{group.provider}</strong>
-                              <small>
-                                {group.availableCount}/{group.models.length} available
-                              </small>
-                            </button>
-                          ))}
+                      <div className="model-picker-grid">
+                        <div className="model-picker-section model-picker-providers" aria-label="Providers">
+                          <span>
+                            <b>Step 1</b>
+                            Provider
+                          </span>
+                          <div className="model-provider-list">
+                            {groupedModelOptions.map((group) => (
+                              <button
+                                className={`model-provider-option ${group.provider === currentProvider ? "is-active" : ""}`}
+                                key={group.provider}
+                                type="button"
+                                onClick={() => setSelectedProvider(group.provider)}
+                              >
+                                <strong>{group.provider}</strong>
+                                <small>
+                                  {group.availableCount}/{group.models.length} available
+                                </small>
+                              </button>
+                            ))}
+                          </div>
                         </div>
-                      </div>
-                      <div className="model-options" role="listbox" aria-label="Available models">
-                        {currentProviderModels.map((option) => (
-                          <button
-                            className={`model-option ${option.model === activeAgent.model ? "is-active" : ""}`}
-                            key={option.model}
-                            type="button"
-                            disabled={!option.available || changingModel !== null}
-                            title={option.unavailableReason ?? option.model}
-                            onClick={() => void handleSelectModel(option)}
-                          >
-                            <span>
-                              <strong>{option.displayName}</strong>
-                              <small>{option.model}</small>
-                            </span>
-                            <span className="model-option-meta">
-                              {option.supportsReasoningEffort ? <small>reasoning</small> : null}
-                              {!option.available ? <small>unavailable</small> : null}
-                              {changingModel === option.model ? <em>Saving…</em> : null}
-                            </span>
-                          </button>
-                        ))}
+                        <div className="model-picker-section model-picker-models" aria-label={`${currentProvider} models`}>
+                          <span>
+                            <b>Step 2</b>
+                            {currentProvider} models
+                          </span>
+                          <div className="model-options" role="listbox" aria-label={`${currentProvider} models`}>
+                            {currentProviderModels.map((option) => (
+                              <button
+                                className={`model-option ${option.model === activeAgent.model ? "is-active" : ""}`}
+                                key={option.model}
+                                type="button"
+                                disabled={!option.available || changingModel !== null}
+                                title={option.unavailableReason ?? option.model}
+                                onClick={() => void handleSelectModel(option)}
+                              >
+                                <span>
+                                  <strong>{option.displayName}</strong>
+                                  <small>{option.model}</small>
+                                </span>
+                                <span className="model-option-meta">
+                                  {option.supportsReasoningEffort ? <small>reasoning</small> : null}
+                                  {!option.available ? <small>unavailable</small> : null}
+                                  {changingModel === option.model ? <em>Saving…</em> : null}
+                                </span>
+                              </button>
+                            ))}
+                          </div>
+                        </div>
                       </div>
                       {activeModelOption?.supportsReasoningEffort || currentProviderModels.some((option) => option.supportsReasoningEffort) ? (
                         <div className="model-picker-section" aria-label="Thinking level">

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -3,6 +3,7 @@ import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type FormE
 import { MarkdownContent } from "../../components/MarkdownContent";
 import { Button } from "../../components/ui/Button";
 import { EmptyState } from "../../components/ui/EmptyState";
+import { deriveAgentDisplayStatus } from "../../runtime/agent-status";
 import { debugAgentSessionEvents, filterTimelineByDisplayLevel } from "../../runtime/session-reducer";
 import type {
   AgentDetail,
@@ -447,8 +448,7 @@ function defaultTimelineItemLimit(displayLevel: DisplayLevel): number {
 }
 
 function isAgentWorking(agent: AgentSummary, sendingPrompt: boolean): boolean {
-  const lifecycle = agent.lifecycle.toLowerCase();
-  return sendingPrompt || Boolean(agent.currentRunId) || lifecycle === "awake-running";
+  return sendingPrompt || deriveAgentDisplayStatus(agent).label === "Running";
 }
 
 function collectWorkingActivitiesForCurrentTurn(timeline: AgentTimelineItem[]): AgentTimelineActivity[] {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -469,6 +469,7 @@ function timelineItemToWorkingActivity(item: AgentTimelineItem): AgentTimelineAc
     minDisplayLevel: item.minDisplayLevel,
     sourceIds: item.sourceIds,
     detail: item.detail,
+    rawEvent: item.rawEvent,
     debug: item.debug,
   };
 }
@@ -577,12 +578,21 @@ const TimelineMessage = memo(function TimelineMessage({
 
   const timelineMeta = formatTimelineMeta(item.meta, displayLevel);
   const canInspect = displayLevel !== "info" && canInspectTimelineItem(item);
+  const inspectItem = () => onInspectActivity(timelineItemToWorkingActivity(item));
 
   return (
     <article className={`message ${item.kind}${compactAssistant ? " is-compact" : ""}`}>
       <div className="bubble">
         <TimelineItemContent item={item} />
         <TimelineItemDetail detail={item.detail} />
+      </div>
+      <div className="message-actions" aria-label="Message actions">
+        <button className="message-action" type="button" title="Copy message" onClick={() => copyMessageText(item.body)}>
+          ⧉
+        </button>
+        <button className="message-action" type="button" title="Inspect message" onClick={inspectItem}>
+          ⓘ
+        </button>
       </div>
       {activities.length ? (
         <ActivityTrail
@@ -597,7 +607,7 @@ const TimelineMessage = memo(function TimelineMessage({
         <div className="message-meta">
           {timelineMeta ? <span>{timelineMeta}</span> : null}
           {canInspect ? (
-            <button className="copy-action" type="button" onClick={onOpenInspector}>
+            <button className="copy-action" type="button" onClick={inspectItem}>
               inspect
             </button>
           ) : null}
@@ -606,6 +616,11 @@ const TimelineMessage = memo(function TimelineMessage({
     </article>
   );
 });
+
+function copyMessageText(text: string): void {
+  if (!navigator.clipboard) return;
+  void navigator.clipboard.writeText(text);
+}
 
 function TimelineItemContent({ item }: { item: AgentTimelineItem }) {
   return <MarkdownContent text={item.body} compact={false} />;

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -91,6 +91,7 @@ export function AgentPage({
   const hasHiddenTimelineItems = timeline.length >= visibleTimelineItemLimit && sourceTimeline.length > visibleTimelineItemLimit;
   const groupedModelOptions = useMemo(() => groupModelOptionsByProvider(modelCatalog.options), [modelCatalog.options]);
   const activeModelOption = useMemo(() => modelCatalog.options.find((option) => option.model === activeAgent.model), [activeAgent.model, modelCatalog.options]);
+  const activeModelSupportsReasoning = activeModelOption?.supportsReasoningEffort ?? Boolean(activeAgent.modelReasoningEffort);
   const currentProvider = selectedProvider ?? activeModelOption?.provider ?? groupedModelOptions[0]?.provider ?? "runtime";
   const currentProviderModels = groupedModelOptions.find((group) => group.provider === currentProvider)?.models ?? [];
 
@@ -98,6 +99,7 @@ export function AgentPage({
     setVisibleTimelineItemLimit(defaultTimelineItemLimit(displayLevel));
     setModelPickerOpen(false);
     setSelectedProvider(null);
+    setSelectedReasoningEffort(activeAgent.modelReasoningEffort ?? "auto");
   }, [activeAgent.id, displayLevel]);
 
   useLayoutEffect(() => {
@@ -264,6 +266,7 @@ export function AgentPage({
                 <div className="model-picker">
                   <Button className="model-button" type="button" variant="secondary" aria-expanded={modelPickerOpen} onClick={toggleModelPicker}>
                     <span>{shortModelLabel(activeAgent.model)}</span>
+                    {activeModelSupportsReasoning ? <small>{activeAgent.modelReasoningEffort ? `thinking ${activeAgent.modelReasoningEffort}` : "thinking auto"}</small> : null}
                     {activeAgent.modelSource === "agent_override" ? <small>override</small> : null}
                     <span aria-hidden="true">⌄</span>
                   </Button>
@@ -322,14 +325,14 @@ export function AgentPage({
                             <b>Step 2</b>
                             {currentProvider} models
                           </span>
-                          {activeModelOption?.supportsReasoningEffort || currentProviderModels.some((option) => option.supportsReasoningEffort) ? (
+                          {activeModelSupportsReasoning || currentProviderModels.some((option) => option.supportsReasoningEffort) ? (
                             <div className="model-picker-reasoning" aria-label="Thinking level">
                               <span>
                                 <b>Thinking</b>
                                 Choose before selecting a reasoning model
                               </span>
                               <div className="reasoning-options">
-                                {["auto", "low", "medium", "high"].map((effort) => (
+                                {["auto", "low", "medium", "high", "xhigh"].map((effort) => (
                                   <button
                                     className={selectedReasoningEffort === effort ? "is-active" : ""}
                                     key={effort}

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -231,6 +231,7 @@ export function AgentPage({
                 activities={workingActivities}
                 agent={activeAgent}
                 displayLevel={displayLevel}
+                onInspectActivity={onInspectActivity}
                 onOpenOverview={onOpenInspector}
               />
             ) : null}
@@ -754,11 +755,13 @@ function WorkingIndicator({
   activities,
   agent,
   displayLevel,
+  onInspectActivity,
   onOpenOverview,
 }: {
   activities: AgentTimelineActivity[];
   agent: AgentSummary;
   displayLevel: DisplayLevel;
+  onInspectActivity: (activity: AgentTimelineActivity) => void;
   onOpenOverview: () => void;
 }) {
   const parts = [
@@ -778,23 +781,28 @@ function WorkingIndicator({
   }
 
   return (
-    <button className="working-indicator detail" type="button" onClick={onOpenOverview}>
-      <div className="working-activity-header">
+    <div className="working-indicator detail">
+      <button className="working-activity-header" type="button" onClick={onOpenOverview}>
         <span className="working-activity-dot" aria-hidden="true" />
         <strong>Working</strong>
         {parts.length ? <small>{parts.join(" · ")}</small> : null}
-      </div>
+      </button>
       <div className="working-activity-list">
         {activities.map((activity) => (
-          <div className={`working-activity-item ${activity.kind} slot-${workingActivitySlot(activity)}`} key={activity.id}>
+          <button
+            className={`working-activity-item ${activity.kind} slot-${workingActivitySlot(activity)}`}
+            key={activity.id}
+            type="button"
+            onClick={() => onInspectActivity(activity)}
+          >
             <span className="working-activity-icon" aria-label={workingActivityLabel(activity)} title={workingActivityLabel(activity)}>
               {workingActivityIcon(activity)}
             </span>
             <span>{workingActivityBody(activity)}</span>
-          </div>
+          </button>
         ))}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -811,6 +819,9 @@ function workingActivityIcon(activity: AgentTimelineActivity): string {
 }
 
 function workingActivityBody(activity: AgentTimelineActivity): string {
+  if (workingActivitySlot(activity) === "action") {
+    return trimActivityLine(activity.body || activity.label, 120);
+  }
   const detail = activity.detail?.text
     ?.split("\n")
     .map((line) => line.trim())

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type FormE
 import { MarkdownContent } from "../../components/MarkdownContent";
 import { Button } from "../../components/ui/Button";
 import { EmptyState } from "../../components/ui/EmptyState";
-import { filterTimelineByDisplayLevel } from "../../runtime/session-reducer";
+import { debugAgentSessionEvents, filterTimelineByDisplayLevel } from "../../runtime/session-reducer";
 import type {
   AgentDetail,
   AgentSummary,
@@ -74,12 +74,19 @@ export function AgentPage({
   const stickToBottomRef = useRef(true);
   const activeAgent = detail?.agent ?? agent;
   const sourceTimeline = detail?.timeline ?? [];
+  const sourceEvents = detail?.events ?? [];
   const timeline = useMemo(
-    () =>
-      filterTimelineByDisplayLevel(sourceTimeline, displayLevel, {
+    () => {
+      if (displayLevel === "debug" && sourceEvents.length > 0) {
+        return debugAgentSessionEvents(sourceEvents, {
+          itemLimit: visibleTimelineItemLimit,
+        });
+      }
+      return filterTimelineByDisplayLevel(sourceTimeline, displayLevel, {
         itemLimit: visibleTimelineItemLimit,
-      }),
-    [displayLevel, sourceTimeline, visibleTimelineItemLimit],
+      });
+    },
+    [displayLevel, sourceEvents, sourceTimeline, visibleTimelineItemLimit],
   );
   const isWorking = isAgentWorking(activeAgent, sendingPrompt);
   const workingActivities = useMemo(() => (isWorking ? collectWorkingActivitiesForCurrentTurn(sourceTimeline) : []), [isWorking, sourceTimeline]);
@@ -725,7 +732,7 @@ function ActivityTrail({
             {displayLevel === "debug" ? (
               <div className="activity-meta">
                 <span>{activity.meta}</span>
-                <button className="copy-action" type="button" onClick={onOpenInspector}>
+                <button className="copy-action" type="button" onClick={() => onInspectActivity(activity)}>
                   inspect
                 </button>
               </div>

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -617,7 +617,6 @@ const TimelineMessage = memo(function TimelineMessage({
   }
 
   const timelineMeta = formatTimelineMeta(item.meta, displayLevel);
-  const canInspect = displayLevel !== "info" && canInspectTimelineItem(item);
   const inspectItem = () => onInspectActivity(timelineItemToWorkingActivity(item));
 
   return (
@@ -643,14 +642,9 @@ const TimelineMessage = memo(function TimelineMessage({
           selectedActivityId={selectedActivityId}
         />
       ) : null}
-      {!compactAssistant && (timelineMeta || canInspect) ? (
+      {!compactAssistant && timelineMeta ? (
         <div className="message-meta">
-          {timelineMeta ? <span>{timelineMeta}</span> : null}
-          {canInspect ? (
-            <button className="copy-action" type="button" onClick={inspectItem}>
-              inspect
-            </button>
-          ) : null}
+          <span>{timelineMeta}</span>
         </div>
       ) : null}
     </article>
@@ -686,11 +680,6 @@ function TimelineItemDetail({ detail, compact = false }: { detail?: AgentTimelin
 
 function isRuntimeActivityItem(item: Pick<AgentTimelineItem, "kind">): boolean {
   return item.kind === "tool" || item.kind === "event" || item.kind === "system";
-}
-
-function canInspectTimelineItem(item: AgentTimelineItem): boolean {
-  if (item.kind === "operator" && isSentMessageMeta(item.meta)) return false;
-  return !(item.kind === "assistant" && isLowValueAssistantEventMeta(item.meta));
 }
 
 function ActivityTrail({
@@ -732,9 +721,6 @@ function ActivityTrail({
             {displayLevel === "debug" ? (
               <div className="activity-meta">
                 <span>{activity.meta}</span>
-                <button className="copy-action" type="button" onClick={() => onInspectActivity(activity)}>
-                  inspect
-                </button>
               </div>
             ) : null}
             {displayLevel === "debug" ? <TimelineItemDetail detail={activity.detail} /> : null}
@@ -866,10 +852,6 @@ function formatTimelineMeta(meta: string, displayLevel: DisplayLevel): string {
     .filter((part) => part && !/^event #\d+$/i.test(part));
   if (displayLevel === "verbose") return parts.join(" · ") || meta.split(" · ")[0] || meta;
   return parts[0] || meta;
-}
-
-function isSentMessageMeta(meta: string): boolean {
-  return meta === "Sent" || meta.startsWith("Sent · ");
 }
 
 function isLowValueAssistantEventMeta(meta: string): boolean {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -226,7 +226,14 @@ export function AgentPage({
                 turn={turn}
               />
             ))}
-            {isWorking ? <WorkingIndicator activities={workingActivities} agent={activeAgent} displayLevel={displayLevel} /> : null}
+            {isWorking ? (
+              <WorkingIndicator
+                activities={workingActivities}
+                agent={activeAgent}
+                displayLevel={displayLevel}
+                onOpenOverview={onOpenInspector}
+              />
+            ) : null}
             {timeline.length === 0 ? (
               <EmptyState
                 className="conversation-empty"
@@ -747,49 +754,58 @@ function WorkingIndicator({
   activities,
   agent,
   displayLevel,
+  onOpenOverview,
 }: {
   activities: AgentTimelineActivity[];
   agent: AgentSummary;
   displayLevel: DisplayLevel;
+  onOpenOverview: () => void;
 }) {
-  if (displayLevel !== "info" || activities.length === 0) {
-    const parts = [
-      agent.currentWork?.objective,
-      agent.activeTaskCount ? `${agent.activeTaskCount} active task${agent.activeTaskCount === 1 ? "" : "s"}` : undefined,
-      agent.pending ? `${agent.pending} queued` : undefined,
-    ].filter(Boolean);
+  const parts = [
+    agent.currentWork?.objective,
+    agent.activeTaskCount ? `${agent.activeTaskCount} active task${agent.activeTaskCount === 1 ? "" : "s"}` : undefined,
+    agent.pending ? `${agent.pending} queued` : undefined,
+  ].filter(Boolean);
 
+  if (displayLevel !== "info" || activities.length === 0) {
     return (
-      <div className="working-indicator compact" role="status">
+      <button className="working-indicator compact" type="button" onClick={onOpenOverview}>
         <span className="working-activity-dot" aria-hidden="true" />
         <strong>Working</strong>
         {parts.length ? <span>{parts.join(" · ")}</span> : null}
-      </div>
+      </button>
     );
   }
 
   return (
-    <aside className="working-indicator detail" aria-label="Working activity">
+    <button className="working-indicator detail" type="button" onClick={onOpenOverview}>
       <div className="working-activity-header">
-        <span>Working activity</span>
-        <small>Runtime signals not shown in Info timeline</small>
+        <span className="working-activity-title">
+          <span className="working-activity-dot" aria-hidden="true" />
+          <strong>Working</strong>
+        </span>
+        {parts.length ? <small>{parts.join(" · ")}</small> : null}
       </div>
       <div className="working-activity-list">
         {activities.map((activity) => (
           <div className={`working-activity-item ${activity.kind}`} key={activity.id}>
-            <span className="working-activity-dot" aria-hidden="true" />
-            <strong>{workingActivityLabel(activity)}</strong>
+            <span className="working-activity-icon" aria-label={workingActivityLabel(activity)} title={workingActivityLabel(activity)}>
+              {workingActivityIcon(activity)}
+            </span>
             <span>{workingActivityBody(activity)}</span>
-            <time>{formatDisplayTime(activity.timestamp)}</time>
           </div>
         ))}
       </div>
-    </aside>
+    </button>
   );
 }
 
 function workingActivityLabel(activity: AgentTimelineActivity): string {
   return activity.kind === "assistant" ? "Assistant" : "Action";
+}
+
+function workingActivityIcon(activity: AgentTimelineActivity): string {
+  return activity.kind === "assistant" ? "✦" : "›";
 }
 
 function workingActivityBody(activity: AgentTimelineActivity): string {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -226,10 +226,7 @@ export function AgentPage({
                 turn={turn}
               />
             ))}
-            {displayLevel === "info" && isWorking && workingActivities.length > 0 ? (
-              <WorkingActivityPanel activities={workingActivities} />
-            ) : null}
-            {displayLevel !== "info" && isWorking ? <WorkingStatusMarker agent={activeAgent} /> : null}
+            {isWorking ? <WorkingIndicator activities={workingActivities} agent={activeAgent} displayLevel={displayLevel} /> : null}
             {timeline.length === 0 ? (
               <EmptyState
                 className="conversation-empty"
@@ -746,9 +743,33 @@ function activityIcon(activity: AgentTimelineActivity): string {
   return "·";
 }
 
-function WorkingActivityPanel({ activities }: { activities: AgentTimelineActivity[] }) {
+function WorkingIndicator({
+  activities,
+  agent,
+  displayLevel,
+}: {
+  activities: AgentTimelineActivity[];
+  agent: AgentSummary;
+  displayLevel: DisplayLevel;
+}) {
+  if (displayLevel !== "info" || activities.length === 0) {
+    const parts = [
+      agent.currentWork?.objective,
+      agent.activeTaskCount ? `${agent.activeTaskCount} active task${agent.activeTaskCount === 1 ? "" : "s"}` : undefined,
+      agent.pending ? `${agent.pending} queued` : undefined,
+    ].filter(Boolean);
+
+    return (
+      <div className="working-indicator compact" role="status">
+        <span className="working-activity-dot" aria-hidden="true" />
+        <strong>Working</strong>
+        {parts.length ? <span>{parts.join(" · ")}</span> : null}
+      </div>
+    );
+  }
+
   return (
-    <aside className="working-activity-panel" aria-label="Working activity">
+    <aside className="working-indicator detail" aria-label="Working activity">
       <div className="working-activity-header">
         <span>Working activity</span>
         <small>Runtime signals not shown in Info timeline</small>
@@ -783,22 +804,6 @@ function trimActivityLine(value: string, maxLength: number): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
-}
-
-function WorkingStatusMarker({ agent }: { agent: AgentSummary }) {
-  const parts = [
-    agent.currentWork?.objective,
-    agent.activeTaskCount ? `${agent.activeTaskCount} active task${agent.activeTaskCount === 1 ? "" : "s"}` : undefined,
-    agent.pending ? `${agent.pending} queued` : undefined,
-  ].filter(Boolean);
-
-  return (
-    <div className="working-status-marker" role="status">
-      <span className="working-activity-dot" aria-hidden="true" />
-      <strong>Working</strong>
-      {parts.length ? <span>{parts.join(" · ")}</span> : null}
-    </div>
-  );
 }
 
 function fallbackTimeline(agent: AgentSummary): AgentTimelineItem[] {

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -259,11 +259,6 @@ export function AgentPage({
               </div>
             ) : null}
             <div className="composer-toolbar">
-              <div className="composer-left">
-                <Button type="button" size="icon" variant="ghost" aria-label="Attach">
-                  ＋
-                </Button>
-              </div>
               <div className="composer-right">
                 <div className="model-picker">
                   <Button

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -73,7 +73,7 @@ export function AgentPage({
   const preserveScrollRef = useRef<{ height: number; top: number } | null>(null);
   const stickToBottomRef = useRef(true);
   const activeAgent = detail?.agent ?? agent;
-  const sourceTimeline = useMemo(() => timelineWithFallbackBrief(detail?.timeline, activeAgent), [activeAgent, detail?.timeline]);
+  const sourceTimeline = detail?.timeline ?? [];
   const timeline = useMemo(
     () =>
       filterTimelineByDisplayLevel(sourceTimeline, displayLevel, {
@@ -804,45 +804,6 @@ function trimActivityLine(value: string, maxLength: number): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
-}
-
-function fallbackTimeline(agent: AgentSummary): AgentTimelineItem[] {
-  if (!hasVisibleBrief(agent.lastBrief)) return [];
-
-  return [
-    {
-      id: `${agent.id}-fallback-brief`,
-      kind: "assistant",
-      label: "Latest brief",
-      body: agent.lastBrief,
-      timestamp: agent.lastTurnTime,
-      meta: "brief",
-      minDisplayLevel: "info",
-      sourceIds: [`${agent.id}-fallback-brief`],
-      debug: JSON.stringify(agent, null, 2),
-    },
-  ];
-}
-
-function timelineWithFallbackBrief(timeline: AgentTimelineItem[] | undefined, agent: AgentSummary): AgentTimelineItem[] {
-  const fallback = fallbackTimeline(agent);
-  if (!timeline?.length) return fallback;
-  const latestBrief = fallback[0];
-  if (!latestBrief) return timeline;
-
-  const hasLatestBrief = timeline.some(
-    (item) => item.kind === "assistant" && normalizeTimelineText(item.body) === normalizeTimelineText(latestBrief.body),
-  );
-  return hasLatestBrief ? timeline : [...timeline, latestBrief];
-}
-
-function normalizeTimelineText(value: string): string {
-  return value.replace(/\s+/g, " ").trim();
-}
-
-function hasVisibleBrief(value: string): boolean {
-  const normalized = value.trim().toLowerCase();
-  return Boolean(normalized) && !normalized.startsWith("no recent brief");
 }
 
 function formatDisplayTime(value: string): string {

--- a/web-gui/app/src/features/inspector/InspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/InspectorPanel.tsx
@@ -10,6 +10,15 @@ interface InspectorPanelProps {
   onClose: () => void;
 }
 
+function formatInspectorJson(value: unknown): string {
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
 export function InspectorPanel({ agent, selection, open, onClearSelection, onClose }: InspectorPanelProps) {
   const title = selection?.kind === "activity" ? activityInspectorTitle(selection.activity) : "Session overview";
 
@@ -204,6 +213,7 @@ function WorkItemCard({ workItem, featured = false }: { workItem: NonNullable<Ag
 
 function ActivityDetails({ activity }: { activity: AgentTimelineActivity }) {
   const detail = activity.detail;
+  const rawEventText = formatInspectorJson(activity.rawEvent);
 
   return (
     <div className="inspector-stack">
@@ -246,9 +256,19 @@ function ActivityDetails({ activity }: { activity: AgentTimelineActivity }) {
           className="inspector-empty"
           icon="⌁"
           title="No structured detail"
-          description="This activity has no projected detail yet, so only its timeline summary is available."
+          description="This activity has no projected detail yet. Use the raw event below for the source payload."
         />
       )}
+
+      {rawEventText ? (
+        <section className="context-card inspector-card inspector-detail data">
+          <div className="context-head">
+            <span className="eyebrow">Raw event</span>
+            <strong>Source payload</strong>
+          </div>
+          <pre>{rawEventText}</pre>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/web-gui/app/src/runtime/agent-status.test.ts
+++ b/web-gui/app/src/runtime/agent-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveAgentDisplayStatus } from "./agent-status";
+import type { AgentSummary } from "./types";
+
+const baseAgent: AgentSummary = {
+  id: "agent",
+  badge: "A",
+  profile: "default",
+  lifecycle: "asleep",
+  focusSummary: "",
+  workspace: "",
+  attention: "",
+  model: "",
+  footer: "",
+  subtitle: "",
+  lastBrief: "",
+  lastTurnTime: "",
+  pending: 0,
+  activeTaskCount: 0,
+  waitingCount: 0,
+  posture: "idle",
+  postureReason: "",
+};
+
+function agent(overrides: Partial<AgentSummary>): AgentSummary {
+  return { ...baseAgent, ...overrides };
+}
+
+describe("deriveAgentDisplayStatus", () => {
+  it("treats queued input as ready instead of needing input", () => {
+    expect(deriveAgentDisplayStatus(agent({ pending: 2, posture: "has_queued_input" })).label).toBe("Ready");
+  });
+
+  it("does not infer running from active background tasks alone", () => {
+    expect(deriveAgentDisplayStatus(agent({ activeTaskCount: 1, lifecycle: "asleep", posture: "idle" })).label).toBe("Ready");
+  });
+
+  it("uses explicit runtime turn signals for running", () => {
+    expect(deriveAgentDisplayStatus(agent({ posture: "active_turn" })).label).toBe("Running");
+    expect(deriveAgentDisplayStatus(agent({ lifecycle: "awake-running" })).label).toBe("Running");
+    expect(deriveAgentDisplayStatus(agent({ currentRunId: "run-1" })).label).toBe("Running");
+  });
+
+  it("separates operator input waits from other waits", () => {
+    expect(deriveAgentDisplayStatus(agent({ posture: "waiting_for_operator" })).label).toBe("Waiting for input");
+    expect(deriveAgentDisplayStatus(agent({ posture: "waiting_task" })).label).toBe("Waiting");
+    expect(deriveAgentDisplayStatus(agent({ posture: "blocked" })).label).toBe("Waiting");
+  });
+
+  it("keeps stopped as a top-level terminal state", () => {
+    expect(deriveAgentDisplayStatus(agent({ lifecycle: "stopped", posture: "active_turn" })).label).toBe("Stopped");
+  });
+});

--- a/web-gui/app/src/runtime/agent-status.ts
+++ b/web-gui/app/src/runtime/agent-status.ts
@@ -1,0 +1,63 @@
+import type { AgentSummary } from "./types";
+
+export interface AgentDisplayStatus {
+  label: "Stopped" | "Running" | "Waiting for input" | "Waiting" | "Ready" | "Unknown";
+  title: string;
+  tone: "stopped" | "running" | "needs-input" | "waiting" | "ready" | "muted";
+}
+
+export function deriveAgentDisplayStatus(agent: AgentSummary): AgentDisplayStatus {
+  const lifecycle = normalizeAgentStatus(agent.lifecycle);
+  const posture = normalizeAgentStatus(agent.posture);
+  const details = [
+    agent.posture ? `posture: ${agent.posture}` : undefined,
+    agent.postureReason ? `reason: ${agent.postureReason}` : undefined,
+    agent.lifecycle ? `lifecycle: ${agent.lifecycle}` : undefined,
+    agent.currentRunId ? `run: ${agent.currentRunId}` : undefined,
+    agent.pending > 0 ? `${agent.pending} queued input${agent.pending === 1 ? "" : "s"}` : undefined,
+    agent.activeTaskCount > 0
+      ? `${agent.activeTaskCount} active task${agent.activeTaskCount === 1 ? "" : "s"}`
+      : undefined,
+    agent.waitingCount > 0 ? `${agent.waitingCount} waiting condition${agent.waitingCount === 1 ? "" : "s"}` : undefined,
+  ].filter(Boolean);
+  const title = details.join(" · ") || "No status details";
+
+  if (isStoppedOrArchived(lifecycle) || isStoppedOrArchived(posture)) {
+    return { label: "Stopped", title, tone: "stopped" };
+  }
+
+  if (posture === "active-turn" || lifecycle === "awake-running" || lifecycle === "running" || Boolean(agent.currentRunId)) {
+    return { label: "Running", title, tone: "running" };
+  }
+
+  if (posture === "waiting-for-operator") {
+    return { label: "Waiting for input", title, tone: "needs-input" };
+  }
+
+  if (posture.startsWith("waiting") || posture === "blocked" || agent.waitingCount > 0) {
+    return { label: "Waiting", title, tone: "waiting" };
+  }
+
+  if (
+    posture === "has-queued-input" ||
+    posture === "has-runnable-work" ||
+    posture === "idle" ||
+    lifecycle === "asleep" ||
+    lifecycle === "awake-idle" ||
+    lifecycle === "idle" ||
+    lifecycle === "ready" ||
+    agent.pending > 0
+  ) {
+    return { label: "Ready", title, tone: "ready" };
+  }
+
+  return { label: "Unknown", title, tone: "muted" };
+}
+
+function normalizeAgentStatus(value?: string | null): string {
+  return (value ?? "").trim().toLowerCase().replace(/[_\s]+/g, "-");
+}
+
+function isStoppedOrArchived(status: string): boolean {
+  return status === "stopped" || status === "archived";
+}

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { projectModelOptions } from "./client";
+
+describe("projectModelOptions", () => {
+  it("detects reasoning effort support from runtime available model capabilities", () => {
+    const options = projectModelOptions({
+      available_models: [
+        {
+          model: "openai-codex/gpt-5.5",
+          provider: "openai-codex",
+          capabilities: {
+            reasoning_summaries: true,
+          },
+        },
+      ],
+    });
+
+    expect(options).toEqual([
+      expect.objectContaining({
+        model: "openai-codex/gpt-5.5",
+        provider: "openai-codex",
+        supportsReasoningEffort: true,
+      }),
+    ]);
+  });
+});

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -42,6 +42,7 @@ function disconnectedAgentDetail(agentId: string, error: string): AgentDetail {
       workspace: "unavailable",
       attention: "API disconnected",
       model: "unavailable",
+      modelReasoningEffort: undefined,
       footer: "disconnected",
       subtitle: "Runtime API unavailable",
       lastBrief: "",
@@ -110,6 +111,7 @@ interface AgentListEntryDto {
     source?: "runtime_default" | "agent_override";
     effective_model?: string;
     active_model?: string | null;
+    override_reasoning_effort?: string | null;
   };
   active_workspace_entry?: {
     workspace_id?: string;
@@ -247,6 +249,7 @@ interface AgentModelStateDto {
   source?: "runtime_default" | "agent_override";
   effective_model?: string;
   active_model?: string | null;
+  override_reasoning_effort?: string | null;
 }
 
 interface AgentModelResponseDto {
@@ -739,6 +742,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   const postureReason = state?.agent?.scheduling_posture?.reason ?? entry.scheduling_posture?.reason ?? "posture unavailable";
   const model = state?.agent?.model?.active_model ?? state?.agent?.model?.effective_model ?? entry.model?.active_model ?? entry.model?.effective_model ?? "runtime default";
   const modelSource = state?.agent?.model?.source ?? entry.model?.source;
+  const modelReasoningEffort = state?.agent?.model?.override_reasoning_effort ?? entry.model?.override_reasoning_effort ?? undefined;
   const lifecycle = stringifyLifecycle(state?.agent?.lifecycle ?? entry.lifecycle ?? status);
   const currentRunId = state?.session?.current_run_id ?? entry.current_run_id ?? null;
 
@@ -752,6 +756,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
     attention: attentionLabel(pending, waitingCount),
     model,
     modelSource,
+    modelReasoningEffort: modelReasoningEffort ?? undefined,
     footer: `${lifecycle} · ${posture}`,
     subtitle: `${status} · ${workspace}`,
     lastBrief: brief?.text ?? "",

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -227,8 +227,26 @@ export interface AgentEventPageOptions {
 }
 
 interface RuntimeModelsDto {
-  available_models?: string[];
+  available_models?: Array<string | RuntimeAvailableModelDto>;
   model_availability?: ModelAvailabilityDto[];
+}
+
+interface RuntimeAvailableModelDto {
+  model?: string;
+  provider?: string;
+  display_name?: string;
+  capabilities?: {
+    image_input?: boolean;
+    reasoning_summaries?: boolean;
+  };
+  policy?: {
+    supported_parameters?: string[];
+    capabilities?: {
+      image_input?: boolean;
+      reasoning_summaries?: boolean;
+    };
+  };
+  supported_parameters?: string[];
 }
 
 interface ModelAvailabilityDto {
@@ -241,6 +259,7 @@ interface ModelAvailabilityDto {
     supported_parameters?: string[];
     capabilities?: {
       image_input?: boolean;
+      reasoning_summaries?: boolean;
     };
   };
 }
@@ -838,7 +857,7 @@ function sortableTime(value: string | undefined): number {
   return Number.isNaN(time) ? 0 : time;
 }
 
-function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOption[] {
+export function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOption[] {
   if (response.model_availability?.length) {
     return response.model_availability
       .filter((entry): entry is ModelAvailabilityDto & { model: string } => Boolean(entry.model))
@@ -849,21 +868,36 @@ function projectModelOptions(response: RuntimeModelsDto): RuntimeModelOption[] {
         available: entry.available ?? false,
         unavailableReason: entry.unavailable_reason,
         supportsImageInput: entry.policy?.capabilities?.image_input ?? false,
-        supportsReasoningEffort: entry.policy?.supported_parameters?.includes("reasoning_effort") ?? false,
+        supportsReasoningEffort: supportsReasoningEffort(entry),
       }))
       .sort(compareModelOptions);
   }
 
   return (response.available_models ?? [])
-    .map((model) => ({
-      model,
-      provider: model.split("/")[0] ?? "unknown",
-      displayName: model,
-      available: true,
-      supportsImageInput: false,
-      supportsReasoningEffort: false,
-    }))
+    .map((entry) => {
+      const model = typeof entry === "string" ? entry : entry.model;
+      if (!model) return undefined;
+      return {
+        model,
+        provider: typeof entry === "string" ? (model.split("/")[0] ?? "unknown") : (entry.provider ?? model.split("/")[0] ?? "unknown"),
+        displayName: typeof entry === "string" ? model : (entry.display_name ?? model),
+        available: true,
+        supportsImageInput: typeof entry === "string" ? false : (entry.capabilities?.image_input ?? false),
+        supportsReasoningEffort: typeof entry === "string" ? false : supportsReasoningEffort(entry),
+      };
+    })
+    .filter((entry): entry is RuntimeModelOption => Boolean(entry))
     .sort(compareModelOptions);
+}
+
+function supportsReasoningEffort(entry: ModelAvailabilityDto | RuntimeAvailableModelDto): boolean {
+  return (
+    entry.policy?.supported_parameters?.includes("reasoning_effort") ||
+    ("supported_parameters" in entry && entry.supported_parameters?.includes("reasoning_effort")) ||
+    entry.policy?.capabilities?.reasoning_summaries ||
+    ("capabilities" in entry && entry.capabilities?.reasoning_summaries) ||
+    false
+  );
 }
 
 function compareModelOptions(left: RuntimeModelOption, right: RuntimeModelOption): number {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -19,6 +19,7 @@ import type {
 
 export interface RuntimeClientOptions {
   baseUrl?: string;
+  token?: string;
   fetchImpl?: typeof fetch;
 }
 
@@ -62,15 +63,21 @@ function disconnectedAgentDetail(agentId: string, error: string): AgentDetail {
   };
 }
 
-async function fetchAgentDetail(baseUrl: string, fetchImpl: typeof fetch, agentId: string, displayLevel: DisplayLevel): Promise<AgentDetail> {
+async function fetchAgentDetail(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  agentId: string,
+  displayLevel: DisplayLevel,
+): Promise<AgentDetail> {
   const encodedAgentId = encodeURIComponent(agentId);
   const eventDisplayLevel = displayLevel;
   const [entry, state, events] = await Promise.all([
-    getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS })
+    getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers })
       .then((agents) => agents.find((agent) => agent.identity?.agent_id === agentId))
       .catch(() => undefined),
-    getJson<AgentStateDto>(fetchImpl, baseUrl, `/agents/${encodedAgentId}/state`),
-    fetchAgentEvents(baseUrl, fetchImpl, agentId, { limit: 80, order: "desc", displayLevel: eventDisplayLevel }).catch((): EventPageResponseDto => ({
+    getJson<AgentStateDto>(fetchImpl, baseUrl, `/agents/${encodedAgentId}/state`, { headers }),
+    fetchAgentEvents(baseUrl, fetchImpl, headers, agentId, { limit: 80, order: "desc", displayLevel: eventDisplayLevel }).catch((): EventPageResponseDto => ({
       events: [],
       has_older: false,
     })),
@@ -366,6 +373,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
   const defaultBaseUrl = import.meta.env.DEV ? DEFAULT_DEV_API_BASE : undefined;
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? import.meta.env.VITE_HOLON_API_BASE ?? defaultBaseUrl);
   const fetchImpl = options.fetchImpl ?? fetch;
+  const requestHeaders = authorizationHeaders(options.token);
 
   return {
     async getBootstrap(): Promise<RuntimeBootstrap> {
@@ -374,7 +382,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       }
 
       try {
-        return await fetchRuntimeBootstrap(baseUrl, fetchImpl);
+        return await fetchRuntimeBootstrap(baseUrl, fetchImpl, requestHeaders);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return buildDisconnectedBootstrap(baseUrl, message);
@@ -386,7 +394,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       }
 
       try {
-        return await fetchAgentDetail(baseUrl, fetchImpl, agentId, displayLevel);
+        return await fetchAgentDetail(baseUrl, fetchImpl, requestHeaders, agentId, displayLevel);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return disconnectedAgentDetail(agentId, message);
@@ -396,13 +404,13 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       if (!baseUrl) {
         return { events: [], has_older: false };
       }
-      return fetchAgentEvents(baseUrl, fetchImpl, agentId, options);
+      return fetchAgentEvents(baseUrl, fetchImpl, requestHeaders, agentId, options);
     },
     async getModels(): Promise<RuntimeModelCatalog> {
       if (!baseUrl) {
         return { source: "fixture", options: [] };
       }
-      const response = await getJson<RuntimeModelsDto>(fetchImpl, baseUrl, "/models");
+      const response = await getJson<RuntimeModelsDto>(fetchImpl, baseUrl, "/models", { headers: requestHeaders });
       return {
         source: "http",
         options: projectModelOptions(response),
@@ -412,14 +420,14 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       if (!baseUrl) {
         return { source: "fixture" };
       }
-      const response = await getJson<RuntimeConfigResponseDto>(fetchImpl, baseUrl, "/control/runtime/config");
+      const response = await getJson<RuntimeConfigResponseDto>(fetchImpl, baseUrl, "/control/runtime/config", { headers: requestHeaders });
       return projectRuntimeConfigState(response);
     },
     async updateRuntimeConfig(updates: RuntimeConfigUpdateEntry[]): Promise<RuntimeConfigState> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
-      const response = await patchJson<RuntimeConfigResponseDto>(fetchImpl, baseUrl, "/control/runtime/config", { updates });
+      const response = await patchJson<RuntimeConfigResponseDto>(fetchImpl, baseUrl, "/control/runtime/config", { updates }, requestHeaders);
       return projectRuntimeConfigState(response);
     },
     async search(query: string, options: { agentIds?: string[]; limit?: number } = {}): Promise<SearchResponse> {
@@ -431,18 +439,18 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         agent_ids: options.agentIds,
         limit: options.limit,
         types: ["message"],
-      });
+      }, requestHeaders);
       return projectSearchResponse(response);
     },
     streamAgentEvents(agentId: string, options: AgentEventStreamOptions): AgentEventStreamSubscription | undefined {
       if (!baseUrl) return undefined;
-      return streamAgentEvents(baseUrl, fetchImpl, agentId, options);
+      return streamAgentEvents(baseUrl, fetchImpl, requestHeaders, agentId, options);
     },
     async sendOperatorPrompt(agentId: string, text: string): Promise<void> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
-      await postJson<unknown>(fetchImpl, baseUrl, `/control/agents/${encodeURIComponent(agentId)}/prompt`, { text });
+      await postJson<unknown>(fetchImpl, baseUrl, `/control/agents/${encodeURIComponent(agentId)}/prompt`, { text }, requestHeaders);
     },
     async setAgentModel(agentId: string, model: string, reasoningEffort?: string): Promise<AgentModelStateDto | undefined> {
       if (!baseUrl) {
@@ -453,6 +461,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         baseUrl,
         `/control/agents/${encodeURIComponent(agentId)}/model`,
         { model, reasoning_effort: reasoningEffort, authority_class: "operator_instruction" },
+        requestHeaders,
       );
       return response.model;
     },
@@ -465,6 +474,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         baseUrl,
         `/control/agents/${encodeURIComponent(agentId)}/model/clear`,
         { authority_class: "operator_instruction" },
+        requestHeaders,
       );
       return response.model;
     },
@@ -474,6 +484,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
 async function fetchAgentEvents(
   baseUrl: string,
   fetchImpl: typeof fetch,
+  headers: Record<string, string>,
   agentId: string,
   options: AgentEventPageOptions,
 ): Promise<EventPageResponseDto> {
@@ -485,12 +496,13 @@ async function fetchAgentEvents(
   if (options.displayLevel) query.set("max_level", options.displayLevel);
   const queryString = query.toString();
   const path = `/agents/${encodeURIComponent(agentId)}/events${queryString ? `?${queryString}` : ""}`;
-  return getJson<EventPageResponseDto>(fetchImpl, baseUrl, path);
+  return getJson<EventPageResponseDto>(fetchImpl, baseUrl, path, { headers });
 }
 
 function streamAgentEvents(
   baseUrl: string,
   fetchImpl: typeof fetch,
+  headers: Record<string, string>,
   agentId: string,
   options: AgentEventStreamOptions,
 ): AgentEventStreamSubscription {
@@ -502,7 +514,7 @@ function streamAgentEvents(
   const queryString = query.toString();
   const path = `/agents/${encodedAgentId}/events/stream${queryString ? `?${queryString}` : ""}`;
 
-  void readEventStream(fetchImpl, `${baseUrl}${path}`, controller.signal, options);
+  void readEventStream(fetchImpl, `${baseUrl}${path}`, headers, controller.signal, options);
 
   return {
     close: () => controller.abort(),
@@ -512,12 +524,13 @@ function streamAgentEvents(
 async function readEventStream(
   fetchImpl: typeof fetch,
   url: string,
+  headers: Record<string, string>,
   signal: AbortSignal,
   options: AgentEventStreamOptions,
 ): Promise<void> {
   try {
     const response = await fetchImpl(url, {
-      headers: { Accept: "text/event-stream" },
+      headers: { Accept: "text/event-stream", ...headers },
       signal,
     });
     if (!response.ok) {
@@ -583,10 +596,10 @@ function parseSseEventFrame(frame: string): StreamEventEnvelopeDto | undefined {
   return JSON.parse(dataLines.join("\n")) as StreamEventEnvelopeDto;
 }
 
-async function fetchRuntimeBootstrap(baseUrl: string, fetchImpl: typeof fetch): Promise<RuntimeBootstrap> {
+async function fetchRuntimeBootstrap(baseUrl: string, fetchImpl: typeof fetch, headers: Record<string, string>): Promise<RuntimeBootstrap> {
   const [handshake, agentEntries] = await Promise.all([
-    getJson<{ auth?: { mode?: string } }>(fetchImpl, baseUrl, "/handshake"),
-    getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list"),
+    getJson<{ auth?: { mode?: string } }>(fetchImpl, baseUrl, "/handshake", { headers }),
+    getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { headers }),
   ]);
 
   const agents = agentEntries.map((entry) => projectAgent(entry));
@@ -612,12 +625,12 @@ async function getJson<T>(
   fetchImpl: typeof fetch,
   baseUrl: string,
   path: string,
-  options: { timeoutMs?: number } = {},
+  options: { timeoutMs?: number; headers?: Record<string, string> } = {},
 ): Promise<T> {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
   const response = await fetchImpl(`${baseUrl}${path}`, {
-    headers: { Accept: "application/json" },
+    headers: { Accept: "application/json", ...options.headers },
     signal: controller.signal,
   }).finally(() => window.clearTimeout(timeout));
   if (!response.ok) {
@@ -626,7 +639,13 @@ async function getJson<T>(
   return (await response.json()) as T;
 }
 
-async function postJson<T>(fetchImpl: typeof fetch, baseUrl: string, path: string, body: unknown): Promise<T> {
+async function postJson<T>(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<T> {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
   const response = await fetchImpl(`${baseUrl}${path}`, {
@@ -634,6 +653,7 @@ async function postJson<T>(fetchImpl: typeof fetch, baseUrl: string, path: strin
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
+      ...headers,
     },
     body: JSON.stringify(body),
     signal: controller.signal,
@@ -646,7 +666,13 @@ async function postJson<T>(fetchImpl: typeof fetch, baseUrl: string, path: strin
   return (text ? JSON.parse(text) : undefined) as T;
 }
 
-async function patchJson<T>(fetchImpl: typeof fetch, baseUrl: string, path: string, body: unknown): Promise<T> {
+async function patchJson<T>(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<T> {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
   const response = await fetchImpl(`${baseUrl}${path}`, {
@@ -654,6 +680,7 @@ async function patchJson<T>(fetchImpl: typeof fetch, baseUrl: string, path: stri
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
+      ...headers,
     },
     body: JSON.stringify(body),
     signal: controller.signal,
@@ -977,6 +1004,11 @@ function normalizeBaseUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   return trimmed.replace(/\/+$/, "");
+}
+
+function authorizationHeaders(token: string | undefined): Record<string, string> {
+  const trimmed = token?.trim();
+  return trimmed ? { Authorization: `Bearer ${trimmed}` } : {};
 }
 
 function compactJoin(parts: Array<string | undefined | null>): string {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeConfigState,
   RuntimeConfigSurface,
   RuntimeConnection,
+  RuntimeMessageEnvelope,
   RuntimeModelCatalog,
   RuntimeModelOption,
   SearchResponse,
@@ -363,6 +364,11 @@ interface SearchResultItemDto {
   preview?: string;
 }
 
+interface AgentMessagesBatchGetResponseDto {
+  messages?: RuntimeMessageEnvelope[];
+  missing_message_ids?: string[];
+}
+
 export interface RuntimeConfigUpdateEntry {
   key: string;
   value?: unknown;
@@ -405,6 +411,18 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         return { events: [], has_older: false };
       }
       return fetchAgentEvents(baseUrl, fetchImpl, requestHeaders, agentId, options);
+    },
+    async getAgentMessagesBatch(agentId: string, messageIds: string[]): Promise<AgentMessagesBatchGetResponseDto> {
+      if (!baseUrl || !messageIds.length) {
+        return { messages: [], missing_message_ids: [] };
+      }
+      return postJson<AgentMessagesBatchGetResponseDto>(
+        fetchImpl,
+        baseUrl,
+        `/agents/${encodeURIComponent(agentId)}/messages:batchGet`,
+        { message_ids: messageIds },
+        requestHeaders,
+      );
     },
     async getModels(): Promise<RuntimeModelCatalog> {
       if (!baseUrl) {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -76,7 +76,7 @@ async function fetchAgentDetail(baseUrl: string, fetchImpl: typeof fetch, agentI
   ]);
   const fallbackEntry: AgentListEntryDto = entry ?? { identity: { agent_id: agentId } };
   const agent = projectAgent(fallbackEntry, state, newestBriefFromEvents(events.events ?? []));
-  const timeline = reduceAgentSessionTimeline({ transcript: [], briefs: [], events, eventDisplayLevel });
+  const timeline = reduceAgentSessionTimeline({ events, eventDisplayLevel });
 
   return {
     agent,

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -13,6 +13,7 @@ import type {
   RuntimeBootstrap,
   RuntimeConnectionConfig,
   RuntimeConfigState,
+  RuntimeMessageEnvelope,
   RuntimeModelCatalog,
   SearchResponse,
 } from "./types";
@@ -79,6 +80,8 @@ export interface AgentSessionState {
   detail: AgentDetail | null;
   eventsBySeq: Record<number, unknown>;
   eventSeqs: number[];
+  messagesById: Record<string, RuntimeMessageEnvelope>;
+  missingMessageIds: Record<string, true>;
   newestSeq?: number;
   oldestSeq?: number;
   hasOlder?: boolean;
@@ -190,6 +193,7 @@ const pendingStreamEvents = new Map<string, StreamEventEnvelopeDto[]>();
 const streamFlushTimers = new Map<string, number>();
 const reconnectTimers = new Map<string, number>();
 const staleTimers = new Map<string, number>();
+const messageHydrationInFlight = new Map<string, Set<string>>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 const STREAM_FLUSH_INTERVAL_MS = 100;
@@ -363,6 +367,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     for (const subscription of activeEventStreams.values()) subscription.close();
     activeEventStreams.clear();
     pendingStreamEvents.clear();
+    messageHydrationInFlight.clear();
     for (const timer of streamFlushTimers.values()) window.clearTimeout(timer);
     for (const timer of reconnectTimers.values()) window.clearTimeout(timer);
     for (const timer of staleTimers.values()) window.clearTimeout(timer);
@@ -519,6 +524,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     try {
       const detail = await runtimeClient.getAgentDetail(agentId, displayLevel);
       set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
+      scheduleMessageHydration(get, set, agentId, displayLevel);
     } catch (error) {
       set((state) => ({
         sessionsByAgentId: {
@@ -561,6 +567,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       });
 
       set((state) => mergeEventPageIntoSession(state, agentId, page.events ?? [], page.oldest_seq, page.has_older, displayLevel));
+      scheduleMessageHydration(get, set, agentId, displayLevel);
     } catch (error) {
       set((state) => ({
         sessionsByAgentId: {
@@ -747,6 +754,8 @@ function emptyAgentSession(): AgentSessionState {
     detail: null,
     eventsBySeq: {},
     eventSeqs: [],
+    messagesById: {},
+    missingMessageIds: {},
   };
 }
 
@@ -1013,6 +1022,10 @@ function messageOrigin(payload: unknown): string | undefined {
   return stringField(origin, "kind") ?? stringField(origin, "role") ?? stringField(asRecord(payload), "origin");
 }
 
+function messageIdFromEventPayload(payload: unknown): string | undefined {
+  return stringField(asRecord(payload), "message_id");
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
 }
@@ -1083,6 +1096,7 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
   const pageTimeline = reduceAgentSessionTimeline({
     events: { events: pageEvents },
     eventDisplayLevel: "debug",
+    messagesById: current.messagesById,
   });
   const liveDetailIsNewer = (current.newestSeq ?? 0) > Math.max(detail.eventCursorSeq ?? 0, detail.newestEventSeq ?? 0);
   const agent = liveDetailIsNewer && current.detail ? mergeCachedAgentState(detail.agent, current.detail.agent) : detail.agent;
@@ -1139,6 +1153,7 @@ async function catchUpAgentEvents(
       append: true,
     }),
   );
+  scheduleMessageHydration(get, set, agentId, "debug");
 }
 
 function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEnvelopeDto[]): void {
@@ -1172,6 +1187,7 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
     const liveTimelineDelta = reduceAgentSessionTimeline({
       events: { events: uniqueEvents },
       eventDisplayLevel: "debug",
+      messagesById: current.messagesById,
     });
     const detailEvents = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
     const baseDetail = current.detail ?? createLiveAgentDetail(state.bootstrap.agents.find((agent) => agent.id === agentId));
@@ -1210,6 +1226,50 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
       },
     };
   });
+  scheduleMessageHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
+}
+
+function scheduleMessageHydration(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  displayLevel: DisplayLevel,
+): void {
+  const session = get().sessionsByAgentId[agentId];
+  const messageIds = missingMessageIdsForHydration(session);
+  if (!messageIds.length) return;
+
+  let inFlight = messageHydrationInFlight.get(agentId);
+  if (!inFlight) {
+    inFlight = new Set<string>();
+    messageHydrationInFlight.set(agentId, inFlight);
+  }
+  const requestIds = messageIds.filter((messageId) => !inFlight.has(messageId));
+  if (!requestIds.length) return;
+  requestIds.forEach((messageId) => inFlight.add(messageId));
+
+  void runtimeClient
+    .getAgentMessagesBatch(agentId, requestIds)
+    .then((response) => {
+      set((state) => mergeHydratedMessagesIntoSession(state, agentId, response.messages ?? [], response.missing_message_ids ?? [], displayLevel));
+    })
+    .catch((error) => {
+      set((state) => ({
+        sessionsByAgentId: {
+          ...state.sessionsByAgentId,
+          [agentId]: {
+            ...(state.sessionsByAgentId[agentId] ?? emptyAgentSession()),
+            historyError: error instanceof Error ? error.message : String(error),
+          },
+        },
+      }));
+    })
+    .finally(() => {
+      const current = messageHydrationInFlight.get(agentId);
+      if (!current) return;
+      requestIds.forEach((messageId) => current.delete(messageId));
+      if (!current.size) messageHydrationInFlight.delete(agentId);
+    });
 }
 
 function agentBriefPatchFromEvents(events: StreamEventEnvelopeDto[]): Pick<AgentSummary, "lastBrief" | "lastTurnTime"> | undefined {
@@ -1226,6 +1286,72 @@ function agentBriefPatchFromEvents(events: StreamEventEnvelopeDto[]): Pick<Agent
     };
   }
   return patch;
+}
+
+function missingMessageIdsForHydration(session: AgentSessionState | undefined): string[] {
+  if (!session) return [];
+  const seen = new Set<string>();
+  const missing: string[] = [];
+  for (const eventSeq of session.eventSeqs) {
+    const event = session.eventsBySeq[eventSeq];
+    if (!isStreamEventEnvelope(event) || event.type !== "message_enqueued") continue;
+    const messageId = messageIdFromEventPayload(event.payload);
+    if (!messageId || seen.has(messageId) || session.messagesById[messageId] || session.missingMessageIds[messageId]) continue;
+    seen.add(messageId);
+    missing.push(messageId);
+  }
+  return missing;
+}
+
+function mergeHydratedMessagesIntoSession(
+  state: RuntimeStoreState,
+  agentId: string,
+  messages: RuntimeMessageEnvelope[],
+  missingMessageIds: string[],
+  displayLevel: DisplayLevel,
+): Partial<RuntimeStoreState> {
+  const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
+  const messagesById = { ...current.messagesById };
+  let changed = false;
+  for (const message of messages) {
+    const messageId = typeof message.id === "string" && message.id.trim() ? message.id : undefined;
+    if (!messageId) continue;
+    messagesById[messageId] = message;
+    changed = true;
+  }
+
+  const missingById = { ...current.missingMessageIds };
+  for (const messageId of missingMessageIds) {
+    if (!messageId) continue;
+    missingById[messageId] = true;
+    changed = true;
+  }
+  if (!changed) return {};
+
+  const events = current.eventSeqs.map((eventSeq) => current.eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
+  const timeline = reduceAgentSessionTimeline({
+    events: { events },
+    eventDisplayLevel: displayLevel,
+    messagesById,
+  });
+  const detail = current.detail
+    ? {
+        ...current.detail,
+        timeline,
+      }
+    : current.detail;
+
+  return {
+    sessionsByAgentId: {
+      ...state.sessionsByAgentId,
+      [agentId]: {
+        ...current,
+        detail,
+        messagesById,
+        missingMessageIds: missingById,
+      },
+    },
+  };
 }
 
 function agentRunPatchFromEvents(events: StreamEventEnvelopeDto[]): Pick<AgentSummary, "currentRunId" | "lifecycle"> | undefined {
@@ -1305,6 +1431,7 @@ function mergeEventPageIntoSession(
   const pageTimeline = reduceAgentSessionTimeline({
     events: { events: pageEvents },
     eventDisplayLevel: displayLevel,
+    messagesById: current.messagesById,
   });
   const events = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
   const detail = current.detail

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -1084,7 +1084,8 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
     const baseDetail = current.detail ?? createLiveAgentDetail(state.bootstrap.agents.find((agent) => agent.id === agentId));
     const highestIncomingSeq = highestSeq(eventSeqs) ?? 0;
     const runPatch = agentRunPatchFromEvents(uniqueEvents);
-    const patchedBaseDetail = baseDetail && runPatch ? patchAgentDetailRunState(baseDetail, runPatch) : baseDetail;
+    const briefPatch = agentBriefPatchFromEvents(uniqueEvents);
+    const patchedBaseDetail = patchAgentDetail(baseDetail, runPatch, briefPatch);
     const detail = patchedBaseDetail
       ? {
           ...patchedBaseDetail,
@@ -1097,7 +1098,7 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
 
     return {
       bootstrap: sortBootstrapAgents(
-        runPatch ? patchBootstrapAgentRunState(state.bootstrap, agentId, runPatch) : state.bootstrap,
+        patchBootstrapAgent(state.bootstrap, agentId, runPatch, briefPatch),
         rosterActivityByAgentId,
       ),
       rosterActivityByAgentId,
@@ -1116,6 +1117,22 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
       },
     };
   });
+}
+
+function agentBriefPatchFromEvents(events: StreamEventEnvelopeDto[]): Pick<AgentSummary, "lastBrief" | "lastTurnTime"> | undefined {
+  let patch: Pick<AgentSummary, "lastBrief" | "lastTurnTime"> | undefined;
+  for (const event of events) {
+    if (event.type !== "brief_created") continue;
+    const payload = asRecord(event.payload);
+    const text = stringField(payload, "text");
+    if (!text) continue;
+    const createdAt = stringField(payload, "created_at") ?? event.ts;
+    patch = {
+      lastBrief: text,
+      lastTurnTime: formatTime(createdAt),
+    };
+  }
+  return patch;
 }
 
 function agentRunPatchFromEvents(events: StreamEventEnvelopeDto[]): Pick<AgentSummary, "currentRunId" | "lifecycle"> | undefined {
@@ -1148,26 +1165,31 @@ function runIdFromPayload(payload: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
-function patchBootstrapAgentRunState(
+function patchBootstrapAgent(
   bootstrap: RuntimeBootstrap,
   agentId: string,
-  patch: Pick<AgentSummary, "currentRunId" | "lifecycle">,
+  runPatch: Pick<AgentSummary, "currentRunId" | "lifecycle"> | undefined,
+  briefPatch: Pick<AgentSummary, "lastBrief" | "lastTurnTime"> | undefined,
 ): RuntimeBootstrap {
+  if (!runPatch && !briefPatch) return bootstrap;
   return {
     ...bootstrap,
-    agents: bootstrap.agents.map((agent) => (agent.id === agentId ? { ...agent, ...patch } : agent)),
+    agents: bootstrap.agents.map((agent) => (agent.id === agentId ? { ...agent, ...runPatch, ...briefPatch } : agent)),
   };
 }
 
-function patchAgentDetailRunState(
-  detail: AgentDetail,
-  patch: Pick<AgentSummary, "currentRunId" | "lifecycle">,
-): AgentDetail {
+function patchAgentDetail(
+  detail: AgentDetail | null,
+  runPatch: Pick<AgentSummary, "currentRunId" | "lifecycle"> | undefined,
+  briefPatch: Pick<AgentSummary, "lastBrief" | "lastTurnTime"> | undefined,
+): AgentDetail | null {
+  if (!detail || (!runPatch && !briefPatch)) return detail;
   return {
     ...detail,
     agent: {
       ...detail.agent,
-      ...patch,
+      ...runPatch,
+      ...briefPatch,
     },
   };
 }
@@ -1258,4 +1280,11 @@ function mergeTimeline(existing: AgentTimelineItem[], incoming: AgentTimelineIte
 function sortableTime(value: string): number {
   const timestamp = Date.parse(value);
   return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function formatTime(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(date);
 }

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -986,8 +986,6 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
   const eventSeqs = Array.from(new Set([...current.eventSeqs, ...eventSeqsFromPage(pageEvents)])).sort((left, right) => left - right);
   const events = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
   const pageTimeline = reduceAgentSessionTimeline({
-    transcript: [],
-    briefs: [],
     events: { events: pageEvents },
     eventDisplayLevel: "debug",
   });
@@ -1077,8 +1075,6 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
     };
     const eventSeqs = Array.from(new Set([...current.eventSeqs, ...eventSeqsFromPage(uniqueEvents)])).sort((left, right) => left - right);
     const liveTimelineDelta = reduceAgentSessionTimeline({
-      transcript: [],
-      briefs: [],
       events: { events: uniqueEvents },
       eventDisplayLevel: "debug",
     });
@@ -1190,8 +1186,6 @@ function mergeEventPageIntoSession(
   };
   const eventSeqs = Array.from(new Set([...current.eventSeqs, ...eventSeqsFromPage(pageEvents)])).sort((left, right) => left - right);
   const pageTimeline = reduceAgentSessionTimeline({
-    transcript: [],
-    briefs: [],
     events: { events: pageEvents },
     eventDisplayLevel: displayLevel,
   });

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -557,6 +557,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         updateAgentModelInState(state, agentId, {
           model: modelState?.active_model ?? modelState?.effective_model ?? model,
           modelSource: modelState?.source ?? "agent_override",
+          modelReasoningEffort: modelState?.override_reasoning_effort ?? undefined,
         }),
       );
       await get().refreshAgentDetail(agentId, displayLevel);
@@ -580,6 +581,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         updateAgentModelInState(state, agentId, {
           model: modelState?.active_model ?? modelState?.effective_model ?? "runtime default",
           modelSource: modelState?.source ?? "runtime_default",
+          modelReasoningEffort: modelState?.override_reasoning_effort ?? undefined,
         }),
       );
       await get().refreshAgentDetail(agentId, displayLevel);
@@ -947,7 +949,7 @@ function buildBootstrapMetrics(agents: AgentSummary[]): RuntimeBootstrap["metric
 function updateAgentModelInState(
   state: RuntimeStoreState,
   agentId: string,
-  modelPatch: Pick<AgentSummary, "model"> & Partial<Pick<AgentSummary, "modelSource">>,
+  modelPatch: Pick<AgentSummary, "model"> & Partial<Pick<AgentSummary, "modelSource" | "modelReasoningEffort">>,
 ): Partial<RuntimeStoreState> {
   const session = state.sessionsByAgentId[agentId];
   const detail = session?.detail

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -11,6 +11,7 @@ import type {
   InspectorSelection,
   RouteKey,
   RuntimeBootstrap,
+  RuntimeConnectionConfig,
   RuntimeConfigState,
   RuntimeModelCatalog,
   SearchResponse,
@@ -165,6 +166,7 @@ export interface RuntimeStoreState {
   clearInspectorSelection: () => void;
   toggleInspector: () => void;
   toggleNavCollapsed: () => void;
+  setRuntimeConnection: (config: RuntimeConnectionConfig) => Promise<void>;
   refreshBootstrap: (options?: BootstrapRefreshOptions) => Promise<void>;
   refreshModelCatalog: () => Promise<void>;
   refreshRuntimeConfig: () => Promise<void>;
@@ -179,7 +181,10 @@ export interface RuntimeStoreState {
   stopAgentEventStream: (agentId: string | undefined) => void;
 }
 
-const runtimeClient = createRuntimeClient();
+const RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.runtimeConnection.v1";
+const DISPLAY_LEVEL_STORAGE_KEY = "holon.webGui.displayLevelsByAgentId.v1";
+let runtimeConnectionConfig = readStoredRuntimeConnectionConfig();
+let runtimeClient = createRuntimeClient(runtimeClientOptions(runtimeConnectionConfig));
 const activeEventStreams = new Map<string, AgentEventStreamSubscription>();
 const pendingStreamEvents = new Map<string, StreamEventEnvelopeDto[]>();
 const streamFlushTimers = new Map<string, number>();
@@ -191,7 +196,44 @@ const STREAM_FLUSH_INTERVAL_MS = 100;
 const STREAM_STALE_TIMEOUT_MS = 45_000;
 const STREAM_RECONNECT_BASE_MS = 1_000;
 const STREAM_RECONNECT_MAX_MS = 15_000;
-const DISPLAY_LEVEL_STORAGE_KEY = "holon.webGui.displayLevelsByAgentId.v1";
+
+function runtimeClientOptions(config: RuntimeConnectionConfig) {
+  return config.mode === "remote" ? { baseUrl: config.baseUrl, token: config.token } : {};
+}
+
+function readStoredRuntimeConnectionConfig(): RuntimeConnectionConfig {
+  if (typeof window === "undefined") return { mode: "local" };
+  try {
+    const raw = window.localStorage.getItem(RUNTIME_CONNECTION_STORAGE_KEY);
+    if (!raw) return { mode: "local" };
+    const parsed = JSON.parse(raw) as Partial<RuntimeConnectionConfig>;
+    if (parsed.mode !== "remote") return { mode: "local" };
+    return {
+      mode: "remote",
+      baseUrl: typeof parsed.baseUrl === "string" ? parsed.baseUrl : "",
+      token: typeof parsed.token === "string" ? parsed.token : "",
+    };
+  } catch {
+    return { mode: "local" };
+  }
+}
+
+function writeStoredRuntimeConnectionConfig(config: RuntimeConnectionConfig): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (config.mode === "local") {
+      window.localStorage.removeItem(RUNTIME_CONNECTION_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(RUNTIME_CONNECTION_STORAGE_KEY, JSON.stringify(config));
+  } catch {
+    // Ignore storage failures; the in-memory connection still applies.
+  }
+}
+
+function normalizeConnectionBaseUrl(value: string | undefined): string {
+  return value?.trim().replace(/\/+$/, "") ?? "";
+}
 
 function readStoredDisplayLevels(): Record<string, DisplayLevel> {
   if (typeof window === "undefined") return {};
@@ -235,6 +277,18 @@ const emptyBootstrap: RuntimeBootstrap = {
   agents: [],
 };
 
+function pendingBootstrap(config: RuntimeConnectionConfig): RuntimeBootstrap {
+  return {
+    ...emptyBootstrap,
+    connection: {
+      mode: config.mode,
+      source: "fixture",
+      baseUrl: config.mode === "remote" ? config.baseUrl : undefined,
+      summary: config.mode === "remote" ? "Connecting to remote runtime…" : "Connecting to local runtime…",
+    },
+  };
+}
+
 const emptyModelCatalog: RuntimeModelCatalog = {
   source: "fixture",
   options: [],
@@ -253,7 +307,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   inspectorSelection: undefined,
   navCollapsed: false,
 
-  bootstrap: emptyBootstrap,
+  bootstrap: pendingBootstrap(runtimeConnectionConfig),
   bootstrapLoading: true,
   modelCatalog: emptyModelCatalog,
   modelCatalogLoading: false,
@@ -292,6 +346,45 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   clearInspectorSelection: () => set({ inspectorSelection: undefined }),
   toggleInspector: () => set((state) => ({ inspectorOpen: !state.inspectorOpen })),
   toggleNavCollapsed: () => set((state) => ({ navCollapsed: !state.navCollapsed })),
+
+  setRuntimeConnection: async (config) => {
+    const normalizedConfig: RuntimeConnectionConfig =
+      config.mode === "remote"
+        ? {
+            mode: "remote",
+            baseUrl: normalizeConnectionBaseUrl(config.baseUrl),
+            token: config.token?.trim() || undefined,
+          }
+        : { mode: "local" };
+    runtimeConnectionConfig = normalizedConfig;
+    runtimeClient = createRuntimeClient(runtimeClientOptions(normalizedConfig));
+    writeStoredRuntimeConnectionConfig(normalizedConfig);
+    bootstrapRefreshInFlight = undefined;
+    for (const subscription of activeEventStreams.values()) subscription.close();
+    activeEventStreams.clear();
+    pendingStreamEvents.clear();
+    for (const timer of streamFlushTimers.values()) window.clearTimeout(timer);
+    for (const timer of reconnectTimers.values()) window.clearTimeout(timer);
+    for (const timer of staleTimers.values()) window.clearTimeout(timer);
+    streamFlushTimers.clear();
+    reconnectTimers.clear();
+    staleTimers.clear();
+    set({
+      bootstrap: pendingBootstrap(normalizedConfig),
+      bootstrapLoading: true,
+      bootstrapError: undefined,
+      modelCatalog: emptyModelCatalog,
+      modelCatalogError: undefined,
+      runtimeConfig: emptyRuntimeConfig,
+      runtimeConfigError: undefined,
+      search: null,
+      searchError: undefined,
+      sessionsByAgentId: {},
+      selectedAgentId: "",
+      route: "dashboard",
+    });
+    await get().refreshBootstrap();
+  },
 
   refreshBootstrap: async (options = {}) => {
     if (bootstrapRefreshInFlight) return bootstrapRefreshInFlight;

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -40,6 +40,67 @@ describe("reduceAgentSessionTimeline", () => {
     ]);
   });
 
+  it("hydrates slim operator message events from the message cache", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          {
+            id: "event-1",
+            event_seq: 1,
+            ts: "2026-06-15T10:00:00Z",
+            type: "message_enqueued",
+            payload: {
+              message_id: "msg-1",
+              origin: { kind: "operator" },
+            },
+          },
+        ],
+      },
+      messagesById: {
+        "msg-1": {
+          id: "msg-1",
+          origin: { kind: "operator" },
+          body: { text: "hydrated hello" },
+        },
+      },
+    });
+
+    expect(timeline).toEqual([
+      expect.objectContaining({
+        id: "event-1",
+        kind: "operator",
+        body: "hydrated hello",
+      }),
+    ]);
+  });
+
+  it("keeps slim operator message events visible while hydration is pending", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          {
+            id: "event-1",
+            event_seq: 1,
+            ts: "2026-06-15T10:00:00Z",
+            type: "message_enqueued",
+            payload: {
+              message_id: "msg-1",
+              origin: { kind: "operator" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(timeline).toEqual([
+      expect.objectContaining({
+        id: "event-1",
+        kind: "operator",
+        body: "Loading operator input…",
+      }),
+    ]);
+  });
+
   it("keeps the raw event on projected timeline items", () => {
     const rawEvent = event({
       id: "event-raw",

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -82,7 +82,7 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
-  it("renders work_item_picked objective, id, and reason", () => {
+  it("renders work_item_picked objective and reason without internal ids", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {
         events: [
@@ -137,8 +137,8 @@ describe("reduceAgentSessionTimeline", () => {
         id: "released",
         kind: "system",
         label: "Work item",
-        body: "Released work item focus · work_456 · completed · ready",
-        minDisplayLevel: "verbose",
+        body: "Released work item focus · completed · ready",
+        minDisplayLevel: "debug",
       }),
     );
   });
@@ -168,7 +168,7 @@ describe("reduceAgentSessionTimeline", () => {
         id: "promoted",
         kind: "system",
         label: "Work item",
-        body: "Promoted completion report · work_789 · brief_123 · turn 7 round 2 · Finished the implementation.",
+        body: "Promoted completion report · Finished the implementation.",
       }),
     );
   });
@@ -198,7 +198,7 @@ describe("reduceAgentSessionTimeline", () => {
         id: "candidate-promoted",
         kind: "system",
         label: "Work item",
-        body: "Promoted completion report candidate · work_abc · brief_abc · turn 8 round 1 · Candidate completion text.",
+        body: "Promoted completion report candidate · Candidate completion text.",
       }),
     );
   });

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { SessionEventEnvelope } from "./session-reducer";
 import { reduceAgentSessionTimeline } from "./session-reducer";
 
 describe("reduceAgentSessionTimeline", () => {
@@ -31,4 +32,162 @@ describe("reduceAgentSessionTimeline", () => {
       }),
     ]);
   });
+
+  it("keeps the raw event on projected timeline items", () => {
+    const rawEvent = event({
+      id: "event-raw",
+      event_seq: 2,
+      type: "brief_created",
+      payload: {
+        kind: "result",
+        text: "done",
+      },
+    });
+
+    const timeline = reduceAgentSessionTimeline({ events: { events: [rawEvent] } });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        label: "Result",
+        body: "done",
+        rawEvent,
+      }),
+    );
+  });
+
+  it("hides successful WorkItem mutation tools and keeps failed ones", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("tool-success", "CreateWorkItem"),
+          toolEvent("tool-failed", "UpdateWorkItem", { error: "permission denied" }),
+        ],
+      },
+    });
+
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "tool-failed",
+        kind: "tool",
+        label: "Work item update failed",
+        body: expect.stringContaining("permission denied"),
+      }),
+    );
+  });
+
+  it("renders work_item_picked objective, id, and reason", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "picked",
+            event_seq: 10,
+            type: "work_item_picked",
+            payload: {
+              reason: "next priority",
+              record: {
+                id: "work_123",
+                objective: "Fix timeline",
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "picked",
+        kind: "system",
+        label: "Work item",
+        body: "Picked work item · Fix timeline · next priority",
+        minDisplayLevel: "verbose",
+      }),
+    );
+  });
+
+  it("keeps stale WorkItem reminders at debug level", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "stale",
+            event_seq: 11,
+            type: "work_item_stale_reminder_injected",
+            payload: {
+              record: {
+                id: "work_123",
+                objective: "Fix timeline",
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "stale",
+        kind: "system",
+        label: "Work item",
+        minDisplayLevel: "debug",
+      }),
+    );
+  });
+
+  it("dedupes assistant previews covered by final briefs", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "preview",
+            event_seq: 20,
+            type: "assistant_round_recorded",
+            payload: {
+              text_preview: "Implemented the fix...",
+            },
+          }),
+          event({
+            id: "brief",
+            event_seq: 21,
+            type: "brief_created",
+            payload: {
+              kind: "result",
+              text: "Implemented the fix and verified it.",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "brief",
+        label: "Result",
+        body: "Implemented the fix and verified it.",
+      }),
+    );
+  });
 });
+
+function event(overrides: SessionEventEnvelope): SessionEventEnvelope {
+  return {
+    ts: "2026-06-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function toolEvent(id: string, toolName: string, payload: Record<string, unknown> = {}): SessionEventEnvelope {
+  return event({
+    id,
+    event_seq: Number(id.replace(/\D/g, "")) || undefined,
+    type: "tool_executed",
+    payload: {
+      tool_name: toolName,
+      duration_ms: 11,
+      ...payload,
+    },
+  });
+}

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -150,6 +150,42 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("parses json-string tool errors before rendering failed tool details", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "patch-failed-json",
+            event_seq: 81783,
+            type: "tool_execution_failed",
+            payload: {
+              tool_name: "ApplyPatch",
+              error: JSON.stringify({
+                kind: "ambiguous_context",
+                message: "hunk context matches 8 locations in web-gui/app/src/runtime/session-reducer.ts",
+                details: { candidate_count: 8 },
+              }),
+              error_kind: "ambiguous_context",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        label: "Patch failed",
+        body: "ApplyPatch · hunk context matches 8 locations in web-gui/app/src/runtime/session-reducer.ts",
+        detail: {
+          label: "Error",
+          text: "hunk context matches 8 locations in web-gui/app/src/runtime/session-reducer.ts",
+          tone: "data",
+        },
+      }),
+    );
+  });
+
   it("renders work_item_picked objective and reason without internal ids", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -113,6 +113,96 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("renders focus release details from top-level work item fields", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "released",
+            event_seq: 11,
+            type: "work_item_focus_released",
+            payload: {
+              work_item_id: "work_456",
+              reason: "completed",
+              readiness: "ready",
+              revision: 3,
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "released",
+        kind: "system",
+        label: "Work item",
+        body: "Released work item focus · work_456 · completed · ready",
+        minDisplayLevel: "verbose",
+      }),
+    );
+  });
+
+  it("renders completion report promotion details and preview", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "promoted",
+            event_seq: 12,
+            type: "work_item_completion_report_promoted",
+            payload: {
+              work_item_id: "work_789",
+              brief_id: "brief_123",
+              source_turn_index: 7,
+              source_round: 2,
+              text_preview: "Finished the implementation.",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "promoted",
+        kind: "system",
+        label: "Work item",
+        body: "Promoted completion report · work_789 · brief_123 · turn 7 round 2 · Finished the implementation.",
+      }),
+    );
+  });
+
+  it("renders completion report candidate promotion details and preview", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "candidate-promoted",
+            event_seq: 13,
+            type: "work_item_completion_report_candidate_promoted",
+            payload: {
+              work_item_id: "work_abc",
+              brief_id: "brief_abc",
+              turn_index: 8,
+              round: 1,
+              text_preview: "Candidate completion text.",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "candidate-promoted",
+        kind: "system",
+        label: "Work item",
+        body: "Promoted completion report candidate · work_abc · brief_abc · turn 8 round 1 · Candidate completion text.",
+      }),
+    );
+  });
+
   it("keeps stale WorkItem reminders at debug level", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -121,6 +121,35 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("projects structured tool errors as readable error text instead of raw json", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("patch-failed", "ApplyPatch", {
+            duration_ms: 120,
+            error: {
+              message: "context mismatch near projectApplyPatchTool",
+              diagnostics: [{ path: "src/runtime/session-reducer.ts" }],
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        label: "Patch failed",
+        body: "ApplyPatch · 120ms · context mismatch near projectApplyPatchTool",
+        detail: {
+          label: "Error",
+          text: "context mismatch near projectApplyPatchTool",
+          tone: "data",
+        },
+      }),
+    );
+  });
+
   it("renders work_item_picked objective and reason without internal ids", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -82,6 +82,45 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("projects ViewImage tools with image context instead of duration-only summaries", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("view-image", "ViewImage", {
+            duration_ms: 9700,
+            path: "/Users/jolestar/Desktop/Screenshot.png",
+            view_image_result: {
+              dimensions: { width: 1200, height: 800 },
+              visual_observation: "A browser screenshot showing the conversation timeline.",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        label: "Tool finished",
+        body: "Viewed image · Screenshot.png · 1200×800 · A browser screenshot showing the conversation timeline. · 9.7s",
+      }),
+    );
+  });
+
+  it("falls back to the tool name when a tool has no readable summary", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [toolEvent("opaque-tool", "OpaqueTool", { duration_ms: 9700 })],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        body: "OpaqueTool · 9.7s",
+      }),
+    );
+  });
+
   it("renders work_item_picked objective and reason without internal ids", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -4,6 +4,7 @@ import type { AgentTimelineItem } from "./types";
 import type { SessionEventEnvelope } from "./session-reducer";
 import {
   compactAgentTimelineItems,
+  debugAgentSessionEvents,
   filterTimelineByDisplayLevel,
   mergeAgentTimelineItems,
   reduceAgentSessionTimeline,
@@ -440,6 +441,66 @@ describe("filterTimelineByDisplayLevel", () => {
     );
 
     expect(filtered.map((item) => item.id)).toEqual(["second", "third"]);
+  });
+});
+
+describe("debugAgentSessionEvents", () => {
+  it("projects every identifiable raw event as a debug timeline item", () => {
+    const events = [
+      event({
+        id: "assistant-without-preview",
+        event_seq: 50,
+        type: "assistant_round_recorded",
+        payload: {
+          turn_id: "turn-1",
+        },
+      }),
+      toolEvent("work-item-mutation", "CreateWorkItem", {
+        objective: "Track debug visibility",
+      }),
+      event({
+        type: "no-identity",
+        payload: {
+          text: "missing id and sequence",
+        },
+      }),
+    ];
+
+    const timeline = debugAgentSessionEvents(events);
+
+    expect(timeline.map((item) => item.id)).toEqual(["debug:assistant-without-preview", "debug:work-item-mutation"]);
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        label: "Assistant Round Recorded",
+        meta: "assistant_round_recorded · event #50",
+        detail: expect.objectContaining({
+          label: "Event payload",
+          text: expect.stringContaining('"assistant_round_recorded"'),
+        }),
+        rawEvent: events[0],
+      }),
+    );
+    expect(timeline[1]).toEqual(
+      expect.objectContaining({
+        label: "Tool finished",
+        body: expect.stringContaining("Track debug visibility"),
+        detail: expect.objectContaining({
+          text: expect.stringContaining('"CreateWorkItem"'),
+        }),
+      }),
+    );
+  });
+
+  it("applies item limits to the newest debug events", () => {
+    const timeline = debugAgentSessionEvents(
+      [
+        event({ id: "old", ts: "2026-06-15T10:00:00Z", type: "brief_created", payload: { text: "old" } }),
+        event({ id: "new", ts: "2026-06-15T10:01:00Z", type: "brief_created", payload: { text: "new" } }),
+      ],
+      { itemLimit: 1 },
+    );
+
+    expect(timeline.map((item) => item.id)).toEqual(["debug:new"]);
   });
 });
 

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -474,8 +474,8 @@ describe("debugAgentSessionEvents", () => {
         label: "Assistant Round Recorded",
         meta: "assistant_round_recorded · event #50",
         detail: expect.objectContaining({
-          label: "Event payload",
-          text: expect.stringContaining('"assistant_round_recorded"'),
+          label: "Event details",
+          text: "Turn Id: turn-1",
         }),
         rawEvent: events[0],
       }),
@@ -485,7 +485,8 @@ describe("debugAgentSessionEvents", () => {
         label: "Tool finished",
         body: expect.stringContaining("Track debug visibility"),
         detail: expect.objectContaining({
-          text: expect.stringContaining('"CreateWorkItem"'),
+          label: "Work item change",
+          text: expect.stringContaining("Objective: Track debug visibility"),
         }),
       }),
     );

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -444,7 +444,7 @@ describe("filterTimelineByDisplayLevel", () => {
 });
 
 describe("mergeAgentTimelineItems", () => {
-  it("merges semantic duplicates and combines source ids", () => {
+  it("merges duplicate assistant items by source identity", () => {
     const merged = mergeAgentTimelineItems(
       [
         timelineItem({
@@ -457,7 +457,7 @@ describe("mergeAgentTimelineItems", () => {
       ],
       [
         timelineItem({
-          id: "brief-1",
+          id: "event-1",
           kind: "assistant",
           body: "same answer",
           meta: "brief_created",
@@ -473,6 +473,31 @@ describe("mergeAgentTimelineItems", () => {
         sourceIds: ["brief-1", "event-1"],
       }),
     );
+  });
+
+  it("keeps repeated final briefs with the same text from different events", () => {
+    const merged = mergeAgentTimelineItems(
+      [
+        timelineItem({
+          id: "brief-old",
+          kind: "assistant",
+          body: "Ignored.",
+          meta: "brief_created · event #1",
+          sourceIds: ["brief-old"],
+        }),
+      ],
+      [
+        timelineItem({
+          id: "brief-new",
+          kind: "assistant",
+          body: "Ignored.",
+          meta: "brief_created · event #2",
+          sourceIds: ["brief-new"],
+        }),
+      ],
+    );
+
+    expect(merged.map((item) => item.id)).toEqual(["brief-old", "brief-new"]);
   });
 });
 

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -336,6 +336,33 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("keeps wait condition registrations out of the Info timeline", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "wait-condition",
+            event_seq: 14,
+            type: "wait_condition_registered",
+            payload: {
+              reason: "awaiting external change",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "wait-condition",
+        kind: "system",
+        label: "Waiting",
+        minDisplayLevel: "debug",
+      }),
+    );
+    expect(filterTimelineByDisplayLevel(timeline, "info")).toEqual([]);
+  });
+
   it("dedupes assistant previews covered by final briefs", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import type { AgentTimelineItem } from "./types";
 import type { SessionEventEnvelope } from "./session-reducer";
-import { reduceAgentSessionTimeline } from "./session-reducer";
+import {
+  compactAgentTimelineItems,
+  filterTimelineByDisplayLevel,
+  mergeAgentTimelineItems,
+  reduceAgentSessionTimeline,
+} from "./session-reducer";
 
 describe("reduceAgentSessionTimeline", () => {
   it("projects operator input events into the timeline", () => {
@@ -172,6 +178,105 @@ describe("reduceAgentSessionTimeline", () => {
   });
 });
 
+describe("filterTimelineByDisplayLevel", () => {
+  it("filters items by display level and preserves info-level tool activities", () => {
+    const filtered = filterTimelineByDisplayLevel(
+      [
+        timelineItem({ id: "info", minDisplayLevel: "info" }),
+        timelineItem({ id: "verbose", minDisplayLevel: "verbose" }),
+        timelineItem({ id: "debug", minDisplayLevel: "debug" }),
+        timelineItem({
+          id: "activity-parent",
+          minDisplayLevel: "debug",
+          activities: [
+            {
+              ...timelineItem({ id: "tool-activity", kind: "tool", minDisplayLevel: "verbose" }),
+              meta: "tool_executed · event #1",
+            },
+            {
+              ...timelineItem({ id: "system-activity", kind: "system", minDisplayLevel: "info" }),
+              meta: "brief_created · event #2",
+            },
+          ],
+        }),
+      ],
+      "info",
+    );
+
+    expect(filtered.map((item) => item.id)).toEqual(["info", "activity-parent"]);
+    expect(filtered[1].activities?.map((activity) => activity.id)).toEqual(["tool-activity"]);
+  });
+
+  it("applies explicit item limits after filtering", () => {
+    const filtered = filterTimelineByDisplayLevel(
+      [
+        timelineItem({ id: "first", timestamp: "2026-06-15T10:00:00Z" }),
+        timelineItem({ id: "second", timestamp: "2026-06-15T10:01:00Z" }),
+        timelineItem({ id: "third", timestamp: "2026-06-15T10:02:00Z" }),
+      ],
+      "debug",
+      { itemLimit: 2 },
+    );
+
+    expect(filtered.map((item) => item.id)).toEqual(["second", "third"]);
+  });
+});
+
+describe("mergeAgentTimelineItems", () => {
+  it("merges semantic duplicates and combines source ids", () => {
+    const merged = mergeAgentTimelineItems(
+      [
+        timelineItem({
+          id: "event-1",
+          kind: "assistant",
+          body: "same answer",
+          meta: "brief_created · event #1",
+          sourceIds: ["event-1"],
+        }),
+      ],
+      [
+        timelineItem({
+          id: "brief-1",
+          kind: "assistant",
+          body: "same answer",
+          meta: "brief_created",
+          sourceIds: ["brief-1"],
+        }),
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toEqual(
+      expect.objectContaining({
+        id: "event-1",
+        sourceIds: ["brief-1", "event-1"],
+      }),
+    );
+  });
+});
+
+describe("compactAgentTimelineItems", () => {
+  it("flattens meaningful activities and drops ephemeral runtime activities", () => {
+    const compacted = compactAgentTimelineItems([
+      timelineItem({
+        id: "parent",
+        activities: [
+          {
+            ...timelineItem({ id: "ephemeral-tool", kind: "tool" }),
+            meta: "tool_executed · event #1",
+          },
+          {
+            ...timelineItem({ id: "work-item", kind: "system", label: "Work item" }),
+            meta: "work_item_picked · event #2",
+          },
+        ],
+      }),
+    ]);
+
+    expect(compacted.map((item) => item.id)).toEqual(["parent", "work-item"]);
+  });
+});
+
 function event(overrides: SessionEventEnvelope): SessionEventEnvelope {
   return {
     ts: "2026-06-15T10:00:00Z",
@@ -190,4 +295,18 @@ function toolEvent(id: string, toolName: string, payload: Record<string, unknown
       ...payload,
     },
   });
+}
+
+function timelineItem(overrides: Partial<AgentTimelineItem> = {}): AgentTimelineItem {
+  return {
+    id: "item",
+    kind: "event",
+    label: "Event",
+    body: "body",
+    timestamp: "2026-06-15T10:00:00Z",
+    meta: "event",
+    minDisplayLevel: "info",
+    sourceIds: [overrides.id ?? "item"],
+    ...overrides,
+  };
 }

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { reduceAgentSessionTimeline } from "./session-reducer";
+
+describe("reduceAgentSessionTimeline", () => {
+  it("projects operator input events into the timeline", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          {
+            id: "event-1",
+            event_seq: 1,
+            ts: "2026-06-15T10:00:00Z",
+            type: "message_enqueued",
+            payload: {
+              origin: { kind: "operator" },
+              body: { text: "hello" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(timeline).toEqual([
+      expect.objectContaining({
+        id: "event-1",
+        kind: "operator",
+        label: "Operator input",
+        body: "hello",
+        minDisplayLevel: "info",
+      }),
+    ]);
+  });
+});

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -307,28 +307,31 @@ function item(draft: SessionItemDraft): AgentTimelineItem {
 
 export function compactAgentTimelineItems(items: AgentTimelineItem[]): AgentTimelineItem[] {
   const flattened = flattenTimelineActivities(items);
-  const deduped = flattened.filter((candidate, index) => !isAssistantPreviewDuplicate(candidate, flattened, index));
+  const finalBriefTexts = flattened.filter(isFinalBriefItem).map((item) => normalizeAssistantBriefText(item.body));
+  const deduped = flattened.filter((candidate) => !isAssistantPreviewDuplicate(candidate, finalBriefTexts));
   return deduped.sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
 }
 
-function isAssistantPreviewDuplicate(candidate: AgentTimelineItem, items: AgentTimelineItem[], candidateIndex: number): boolean {
+function isAssistantPreviewDuplicate(candidate: AgentTimelineItem, finalBriefTexts: string[]): boolean {
   if (candidate.kind !== "assistant" || candidate.label !== "Assistant round") return false;
-  const candidateText = normalizeTextKey(candidate.body);
-  if (candidateText.length < 80) return false;
+  const candidateText = normalizeAssistantBriefText(candidate.body);
+  if (!candidateText) return false;
 
-  return items.some((item, index) => {
-    if (index === candidateIndex || item.kind !== "assistant" || item.minDisplayLevel !== "info") return false;
-    return isSameAssistantText(candidateText, normalizeTextKey(item.body));
-  });
+  return finalBriefTexts.some((briefText) => isSameAssistantBriefText(candidateText, briefText));
 }
 
-function isSameAssistantText(left: string, right: string): boolean {
-  if (!left || !right) return false;
-  if (left === right) return true;
+function isFinalBriefItem(item: AgentTimelineItem): boolean {
+  return item.kind === "assistant" && item.minDisplayLevel === "info" && (item.label === "Result" || item.label === "Brief Created");
+}
 
-  const [shorter, longer] = left.length < right.length ? [left, right] : [right, left];
-  if (shorter.length < 160) return false;
-  return longer.startsWith(shorter);
+function isSameAssistantBriefText(previewText: string, briefText: string): boolean {
+  if (!previewText || !briefText) return false;
+  if (previewText === briefText) return true;
+  return briefText.startsWith(previewText);
+}
+
+function normalizeAssistantBriefText(text: string): string {
+  return normalizeTextKey(text).replace(/(?:\s*(?:\.{3}|…))+$/u, "").trim();
 }
 
 function flattenTimelineActivities(items: AgentTimelineItem[]): AgentTimelineItem[] {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -6,24 +6,6 @@ import type {
   DisplayLevel,
 } from "./types";
 
-export interface SessionTranscriptEntry {
-  id?: string;
-  created_at?: string;
-  kind?: string;
-  round?: number | null;
-  stop_reason?: string | null;
-  input_tokens?: number | null;
-  output_tokens?: number | null;
-  data?: unknown;
-}
-
-export interface SessionBriefRecord {
-  id?: string;
-  created_at?: string;
-  text?: string;
-  kind?: string;
-}
-
 export interface SessionEventEnvelope {
   id?: string;
   event_seq?: number;
@@ -33,8 +15,6 @@ export interface SessionEventEnvelope {
 }
 
 export interface ReduceAgentSessionInput {
-  transcript: SessionTranscriptEntry[];
-  briefs: SessionBriefRecord[];
   events: {
     events?: SessionEventEnvelope[];
   };
@@ -77,14 +57,12 @@ const debugRuntimeEvents = new Set([
 const debugOnlyToolNames = new Set(["WaitFor"]);
 
 export function reduceAgentSessionTimeline(input: ReduceAgentSessionInput): AgentTimelineItem[] {
-  const transcriptItems = input.transcript.map(projectTranscriptEntry);
-  const briefItems = input.briefs.map(projectBriefRecord);
   const eventDisplayLevel = input.eventDisplayLevel ?? "debug";
   const eventItems = (input.events.events ?? []).map((event) =>
     projectEventEnvelope(event, eventDisplayLevel, input.includeDebug ?? false),
   );
 
-  const sorted = mergeAgentTimelineItems([], [...transcriptItems, ...briefItems, ...eventItems])
+  const sorted = mergeAgentTimelineItems([], eventItems)
     .filter((item): item is AgentTimelineItem => Boolean(item))
     .sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
 
@@ -128,151 +106,6 @@ export function filterTimelineByDisplayLevel(
     .filter((item) => displayLevelRank[item.minDisplayLevel] <= rank || Boolean(item.activities?.length));
   const limit = options.itemLimit ?? (displayLevel === "info" ? 12 : 160);
   return filtered.slice(-limit);
-}
-
-function projectTranscriptEntry(entry: SessionTranscriptEntry): AgentTimelineItem | undefined {
-  if (!entry.id) return undefined;
-  const kind = entry.kind ?? "transcript";
-  const data = asRecord(entry.data);
-  const timestamp = entry.created_at ?? "";
-
-  if (kind === "incoming_message") {
-    const message = messageEnvelopeProjection(data);
-    if (message?.origin !== "operator") {
-      return item({
-        id: entry.id,
-        kind: "system",
-        label: "Runtime input",
-        body: message?.body || readableText(entry.data) || "Runtime input received.",
-        timestamp,
-        meta: compactJoin([kind, roundMeta(entry.round)]),
-        minDisplayLevel: "verbose",
-        sourceIds: [entry.id],
-        debug: debugJson(entry),
-      });
-    }
-
-    return item({
-      id: entry.id,
-      kind: "operator",
-      label: labelForTranscriptKind(kind),
-      body: message.body || readableText(entry.data) || "Operator input.",
-      timestamp,
-      meta: compactJoin([kind, roundMeta(entry.round)]),
-      minDisplayLevel: "info",
-      sourceIds: [entry.id],
-      debug: debugJson(entry),
-    });
-  }
-
-  if (kind === "continuation_prompt" || kind === "subagent_prompt") {
-    return item({
-      id: entry.id,
-      kind: "system",
-      label: labelForTranscriptKind(kind),
-      body: readableText(entry.data) || labelForTranscriptKind(kind),
-      timestamp,
-      meta: compactJoin([kind, roundMeta(entry.round)]),
-      minDisplayLevel: "verbose",
-      sourceIds: [entry.id],
-      debug: debugJson(entry),
-    });
-  }
-
-  if (kind === "assistant_round") {
-    const text = textFromAssistantBlocks(data?.blocks);
-    const toolNames = toolNamesFromAssistantBlocks(data?.blocks);
-    if (!text && toolNames.length) {
-      return item({
-        id: entry.id,
-        kind: "tool",
-        label: "Assistant requested tools",
-        body: toolNames.join(", "),
-        timestamp,
-        meta: compactJoin([
-          "assistant round",
-          roundMeta(entry.round),
-          entry.stop_reason ?? undefined,
-          `tools: ${toolNames.join(", ")}`,
-        ]),
-        minDisplayLevel: "verbose",
-        sourceIds: [entry.id],
-        debug: debugJson(entry),
-      });
-    }
-    return item({
-      id: entry.id,
-      kind: "assistant",
-      label: "Assistant progress",
-      body: text || summarizeAssistantRound(toolNames),
-      timestamp,
-      meta: compactJoin([
-        "assistant round",
-        roundMeta(entry.round),
-        entry.stop_reason ?? undefined,
-        toolNames.length ? `tools: ${toolNames.join(", ")}` : undefined,
-      ]),
-      minDisplayLevel: "verbose",
-      sourceIds: [entry.id],
-      debug: debugJson(entry),
-    });
-  }
-
-  if (kind === "tool_results") {
-    return item({
-      id: entry.id,
-      kind: "tool",
-      label: "Tool result",
-      body: summarizeToolResults(data?.results),
-      timestamp,
-      meta: compactJoin(["tool results", roundMeta(entry.round)]),
-      minDisplayLevel: "verbose",
-      sourceIds: [entry.id],
-      debug: debugJson(entry),
-    });
-  }
-
-  if (kind === "runtime_failure") {
-    return item({
-      id: entry.id,
-      kind: "system",
-      label: "Runtime failure",
-      body: readableText(entry.data) || "Runtime failure recorded.",
-      timestamp,
-      meta: compactJoin([kind, roundMeta(entry.round)]),
-      minDisplayLevel: "info",
-      sourceIds: [entry.id],
-      debug: debugJson(entry),
-    });
-  }
-
-  return item({
-    id: entry.id,
-    kind: "system",
-    label: labelForTranscriptKind(kind),
-    body: readableText(entry.data) || "Transcript entry recorded.",
-    timestamp,
-    meta: compactJoin([kind, roundMeta(entry.round)]),
-    minDisplayLevel: "debug",
-    sourceIds: [entry.id],
-    debug: debugJson(entry),
-  });
-}
-
-function projectBriefRecord(brief: SessionBriefRecord): AgentTimelineItem | undefined {
-  if (!brief.id && !brief.text) return undefined;
-  const id = brief.id ?? `brief-${brief.created_at ?? brief.text}`;
-  return item({
-    id,
-    kind: "assistant",
-    label: brief.kind === "result" ? "Result" : brief.kind ?? "Brief",
-    body: brief.text ?? "Brief text unavailable.",
-    timestamp: brief.created_at ?? "",
-    meta: compactJoin(["brief", brief.kind]),
-    minDisplayLevel: "info",
-    sourceIds: [id],
-    debug: debugJson(brief),
-  });
 }
 
 function projectEventEnvelope(
@@ -572,32 +405,6 @@ function mergeTimelineActivities(
 
 function mergeSourceIds(sourceIds: string[]): string[] {
   return Array.from(new Set(sourceIds)).slice(0, maxTimelineSourceIds);
-}
-
-function labelForTranscriptKind(kind: string): string {
-  if (kind === "incoming_message") return "Operator input";
-  if (kind === "continuation_prompt") return "Continuation";
-  if (kind === "subagent_prompt") return "Delegation";
-  if (kind === "assistant_round") return "Assistant progress";
-  if (kind === "tool_results") return "Tool results";
-  if (kind === "runtime_failure") return "Runtime failure";
-  return humanizeEventType(kind);
-}
-
-function summarizeAssistantRound(toolNames: string[]): string {
-  if (toolNames.length === 0) return "Assistant round completed.";
-  return `Assistant requested ${toolNames.length} tool call${toolNames.length === 1 ? "" : "s"}: ${toolNames.join(", ")}.`;
-}
-
-function summarizeToolResults(value: unknown): string {
-  if (!Array.isArray(value)) return "Tool results recorded.";
-  const errorCount = value.filter((result) => asRecord(result)?.is_error === true).length;
-  const successCount = value.length - errorCount;
-  return compactJoin([
-    `${value.length} tool result${value.length === 1 ? "" : "s"} recorded`,
-    successCount ? `${successCount} ok` : undefined,
-    errorCount ? `${errorCount} error${errorCount === 1 ? "" : "s"}` : undefined,
-  ]);
 }
 
 function projectToolExecution(
@@ -951,27 +758,6 @@ function readableTextWithoutSummary(value: unknown): string {
   return "";
 }
 
-function textFromAssistantBlocks(value: unknown): string {
-  if (!Array.isArray(value)) return "";
-  return value
-    .map((block) => {
-      const record = asRecord(block);
-      return record?.type === "text" ? stringField(record, "text") : undefined;
-    })
-    .filter((text): text is string => Boolean(text?.trim()))
-    .join("\n\n");
-}
-
-function toolNamesFromAssistantBlocks(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((block) => {
-      const record = asRecord(block);
-      return record?.type === "tool_use" ? stringField(record, "name") : undefined;
-    })
-    .filter((name): name is string => Boolean(name?.trim()));
-}
-
 function toolNamesFromPayload(value: Record<string, unknown> | undefined): string[] {
   const toolNames = arrayField(value, "tool_names");
   if (!toolNames?.length) return [];
@@ -1018,10 +804,6 @@ function numberField(value: Record<string, unknown> | undefined, key: string): n
 function arrayField(value: Record<string, unknown> | undefined, key: string): unknown[] | undefined {
   const candidate = value?.[key];
   return Array.isArray(candidate) ? candidate : undefined;
-}
-
-function roundMeta(round: number | null | undefined): string | undefined {
-  return round == null ? undefined : `round ${round}`;
 }
 
 function humanizeEventType(value: string): string {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -14,6 +14,16 @@ export interface SessionEventEnvelope {
   payload?: unknown;
 }
 
+function projectDebugEvent(
+  eventType: string,
+  payload: Record<string, unknown> | undefined,
+): (Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> & { timestamp?: string }) | undefined {
+  if (eventType === "tool_executed" || eventType === "tool_execution_failed") {
+    return projectToolExecution(eventType, payload, { includeHiddenWorkItemMutations: true });
+  }
+  return projectRuntimeEvent(eventType, payload);
+}
+
 export interface ReduceAgentSessionInput {
   events: {
     events?: SessionEventEnvelope[];
@@ -110,6 +120,14 @@ export function filterTimelineByDisplayLevel(
   return filtered.slice(-limit);
 }
 
+export function debugAgentSessionEvents(events: SessionEventEnvelope[], options: { itemLimit?: number } = {}): AgentTimelineItem[] {
+  const projected = events
+    .filter((event) => event.id || event.event_seq != null)
+    .map((event) => debugEventTimelineItem(event))
+    .sort((left, right) => sortableTime(left.timestamp) - sortableTime(right.timestamp));
+  return projected.slice(-(options.itemLimit ?? 220));
+}
+
 function projectEventEnvelope(
   event: SessionEventEnvelope,
   eventDisplayLevel: DisplayLevel,
@@ -135,6 +153,32 @@ function projectEventEnvelope(
     detail: projection.detail,
     rawEvent: event,
     debug: includeDebug ? debugJson(event) : undefined,
+  });
+}
+
+function debugEventTimelineItem(event: SessionEventEnvelope): AgentTimelineItem {
+  const id = event.id ?? `event-${event.event_seq}`;
+  const payload = asRecord(event.payload);
+  const eventType = event.type ?? "runtime_event";
+  const projection = projectDebugEvent(eventType, payload);
+  const meta = eventMeta(eventType, payload, event.event_seq);
+  const body = projection?.body || readableText(payload) || summarizeDebugEvent(eventType, payload) || humanizeEventType(eventType);
+  return item({
+    id: `debug:${id}`,
+    kind: projection?.kind ?? "event",
+    label: projection?.label ?? humanizeEventType(eventType),
+    body,
+    timestamp: projection?.timestamp ?? event.ts ?? "",
+    meta,
+    minDisplayLevel: "debug",
+    sourceIds: [id],
+    detail: {
+      label: "Event payload",
+      text: debugJson(event),
+      tone: eventType.includes("failed") || eventType.includes("error") ? "data" : (projection?.detail?.tone ?? "data"),
+    },
+    rawEvent: event,
+    debug: debugJson(event),
   });
 }
 
@@ -404,10 +448,11 @@ function mergeSourceIds(sourceIds: string[]): string[] {
 function projectToolExecution(
   eventType: string,
   payload: Record<string, unknown> | undefined,
+  options: { includeHiddenWorkItemMutations?: boolean } = {},
 ): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> | undefined {
   const toolName = stringField(payload, "tool_name") ?? "tool";
   const failed = eventType === "tool_execution_failed" || Boolean(payload?.error);
-  if (!failed && isWorkItemMutationTool(toolName)) return undefined;
+  if (!failed && isWorkItemMutationTool(toolName) && !options.includeHiddenWorkItemMutations) return undefined;
   const projection = projectKnownToolExecution(toolName, payload);
   const label = toolFriendlyLabel(toolName, failed);
   const summary = stringField(payload, "summary");

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -846,12 +846,12 @@ function readableTextWithoutSummary(value: unknown): string {
 
 function toolErrorMessage(payload: Record<string, unknown> | undefined): string | undefined {
   const direct = stringField(payload, "error");
-  if (direct) return direct;
+  if (direct) return structuredErrorMessage(direct) ?? direct;
 
   const error = payload?.error;
   if (typeof error === "string" && error.trim()) return error;
 
-  const errorRecord = asRecord(error);
+  const errorRecord = asRecord(error) ?? asRecord(payload?.tool_error);
   const message = firstStringField(errorRecord, ["message", "summary", "summary_text", "reason", "detail"]);
   if (message) return message;
 
@@ -859,6 +859,18 @@ function toolErrorMessage(payload: Record<string, unknown> | undefined): string 
   if (nested) return nested;
 
   return undefined;
+}
+
+function structuredErrorMessage(value: string): string | undefined {
+  const text = value.trim();
+  if (!text.startsWith("{") && !text.startsWith("[")) return undefined;
+
+  try {
+    const record = asRecord(JSON.parse(text));
+    return firstStringField(record, ["message", "summary", "summary_text", "reason", "detail"]);
+  } catch {
+    return undefined;
+  }
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -416,8 +416,8 @@ function projectToolExecution(
   const exitStatus = numberField(payload, "exit_status") ?? numberField(result, "exit_status");
   const durationMs = numberField(payload, "duration_ms") ?? numberField(result, "duration_ms");
   const error = stringField(payload, "error");
-  const stringPreview = toolStringPreview(toolName, payload, commandPreview);
-  const toolSummary = projection?.body ?? stringPreview ?? summary ?? genericToolDescription(toolName, payload);
+  const stringPreview = toolStringPreview(toolName, payload, commandPreview) || undefined;
+  const toolSummary = projection?.body ?? stringPreview ?? summary ?? genericToolDescription(toolName, payload) ?? toolName;
   const body = compactJoin([
     toolSummary,
     exitStatus == null ? undefined : `exit ${exitStatus}`,
@@ -448,6 +448,7 @@ function projectKnownToolExecution(
   if (toolName === "ApplyPatch") return projectApplyPatchTool(payload);
   if (toolName === "ListWorkItems") return projectListWorkItemsTool(payload);
   if (toolName === "GetWorkItem") return projectGetWorkItemTool(payload);
+  if (toolName === "ViewImage") return projectViewImageTool(payload);
   return undefined;
 }
 
@@ -539,6 +540,28 @@ function projectGetWorkItemTool(payload: Record<string, unknown> | undefined): P
   return {
     body: summary || compactJoin(["Loaded work item", workItemId]) || "Loaded work item",
     detail: { label: "Work item", text: debugJson(result ?? payload ?? {}), tone: "data" },
+  };
+}
+
+function projectViewImageTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.view_image_result) ?? asRecord(payload?.result);
+  const dimensions = asRecord(result?.dimensions);
+  const width = numberField(result, "width") ?? numberField(dimensions, "width");
+  const height = numberField(result, "height") ?? numberField(dimensions, "height");
+  const imagePath = firstStringField(payload, ["path", "image_path"]) ?? firstStringField(result, ["path", "image_path"]);
+  const observation = firstStringField(result, ["visual_observation", "observation", "text_preview"]);
+  const body = compactJoin([
+    "Viewed image",
+    imagePath ? basename(imagePath) : undefined,
+    width != null && height != null ? `${width}×${height}` : undefined,
+    observation ? truncateText(observation, 120) : undefined,
+  ]);
+
+  return {
+    body,
+    detail: observation
+      ? { label: "Visual observation", text: observation, tone: "data" }
+      : { label: "Result", text: debugJson(result ?? payload ?? {}), tone: "data" },
   };
 }
 
@@ -640,6 +663,14 @@ function indentPreview(value: string): string {
     .split("\n")
     .slice(0, 6)
     .join("\n   ");
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
 }
 
 function execCommandPreview(payload: Record<string, unknown> | undefined): string | undefined {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -32,6 +32,7 @@ interface SessionItemDraft {
   minDisplayLevel: DisplayLevel;
   sourceIds: string[];
   detail?: AgentTimelineItemDetail;
+  rawEvent?: unknown;
   debug?: string;
 }
 
@@ -131,6 +132,7 @@ function projectEventEnvelope(
     minDisplayLevel: eventProjectionDisplayLevel(projection.minDisplayLevel, eventDisplayLevel),
     sourceIds: [id],
     detail: projection.detail,
+    rawEvent: event,
     debug: includeDebug ? debugJson(event) : undefined,
   });
 }
@@ -361,6 +363,7 @@ function activityToTimelineItem(activity: AgentTimelineActivity): AgentTimelineI
     minDisplayLevel: activity.minDisplayLevel,
     sourceIds: activity.sourceIds,
     detail: activity.detail,
+    rawEvent: activity.rawEvent,
     debug: activity.debug,
   };
 }

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -42,7 +42,7 @@ const displayLevelRank: Record<DisplayLevel, number> = {
   debug: 2,
 };
 const maxTimelineSourceIds = 200;
-const infoRuntimeEvents = new Set(["brief_created", "wait_condition_registered", "agent_waiting"]);
+const infoRuntimeEvents = new Set(["brief_created", "agent_waiting"]);
 const verboseRuntimeEventPrefixes = ["work_item_"];
 const debugRuntimeEventNames = new Set(["work_item_focus_released", "work_item_stale_reminder_injected"]);
 const debugRuntimeEventPrefixes = ["provider_", "task_"];

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -4,6 +4,7 @@ import type {
   AgentTimelineItemDetail,
   AgentTimelineItemKind,
   DisplayLevel,
+  RuntimeMessageEnvelope,
 } from "./types";
 
 export interface SessionEventEnvelope {
@@ -30,6 +31,7 @@ export interface ReduceAgentSessionInput {
   };
   eventDisplayLevel?: DisplayLevel;
   includeDebug?: boolean;
+  messagesById?: Record<string, RuntimeMessageEnvelope>;
 }
 
 interface SessionItemDraft {
@@ -71,7 +73,7 @@ const debugOnlyToolNames = new Set(["WaitFor"]);
 export function reduceAgentSessionTimeline(input: ReduceAgentSessionInput): AgentTimelineItem[] {
   const eventDisplayLevel = input.eventDisplayLevel ?? "debug";
   const eventItems = (input.events.events ?? []).map((event) =>
-    projectEventEnvelope(event, eventDisplayLevel, input.includeDebug ?? false),
+    projectEventEnvelope(event, eventDisplayLevel, input.includeDebug ?? false, input.messagesById),
   );
 
   const sorted = mergeAgentTimelineItems([], eventItems)
@@ -132,12 +134,13 @@ function projectEventEnvelope(
   event: SessionEventEnvelope,
   eventDisplayLevel: DisplayLevel,
   includeDebug: boolean,
+  messagesById: Record<string, RuntimeMessageEnvelope> | undefined,
 ): AgentTimelineItem | undefined {
   if (!event.id && event.event_seq == null) return undefined;
   const id = event.id ?? `event-${event.event_seq}`;
   const payload = asRecord(event.payload);
   const eventType = event.type ?? "runtime_event";
-  const projection = projectRuntimeEvent(eventType, payload);
+  const projection = projectRuntimeEvent(eventType, payload, messagesById);
   if (!projection) return undefined;
   const meta = eventMeta(eventType, payload, event.event_seq);
 
@@ -219,14 +222,15 @@ function eventProjectionDisplayLevel(level: DisplayLevel, eventDisplayLevel: Dis
 function projectRuntimeEvent(
   eventType: string,
   payload: Record<string, unknown> | undefined,
+  messagesById?: Record<string, RuntimeMessageEnvelope>,
 ): (Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> & { timestamp?: string }) | undefined {
   if (eventType === "message_enqueued") {
-    const message = messageEnvelopeProjection(payload);
+    const message = messageEnvelopeProjection(payload, messagesById);
     if (message?.origin === "operator") {
       return {
         kind: "operator",
         label: "Operator input",
-        body: message.body || "Operator input.",
+        body: message.body || "Loading operator input…",
         minDisplayLevel: "info",
       };
     }
@@ -872,15 +876,27 @@ function systemRuntimeLabel(eventType: string): string {
   return humanizeEventType(eventType);
 }
 
-function messageEnvelopeProjection(payload: Record<string, unknown> | undefined): { origin: "operator" | "runtime"; body: string } | undefined {
+function messageEnvelopeProjection(
+  payload: Record<string, unknown> | undefined,
+  messagesById?: Record<string, RuntimeMessageEnvelope>,
+): { origin: "operator" | "runtime"; body: string } | undefined {
   if (!payload) return undefined;
-  const origin = asRecord(payload.origin);
+  const source = hydratedMessageForPayload(payload, messagesById) ?? payload;
+  const origin = asRecord(source.origin);
   const originKind = stringField(origin, "kind")?.toLowerCase();
-  const body = asRecord(payload.body);
+  const body = asRecord(source.body);
   return {
     origin: originKind === "operator" ? "operator" : "runtime",
     body: messageBodyText(body),
   };
+}
+
+function hydratedMessageForPayload(
+  payload: Record<string, unknown>,
+  messagesById: Record<string, RuntimeMessageEnvelope> | undefined,
+): RuntimeMessageEnvelope | undefined {
+  const messageId = stringField(payload, "message_id");
+  return messageId ? messagesById?.[messageId] : undefined;
 }
 
 function messageBodyText(body: Record<string, unknown> | undefined): string {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -163,6 +163,7 @@ function debugEventTimelineItem(event: SessionEventEnvelope): AgentTimelineItem 
   const projection = projectDebugEvent(eventType, payload);
   const meta = eventMeta(eventType, payload, event.event_seq);
   const body = projection?.body || readableText(payload) || summarizeDebugEvent(eventType, payload) || humanizeEventType(eventType);
+  const detail = debugEventDetail(eventType, payload, projection?.detail);
   return item({
     id: `debug:${id}`,
     kind: projection?.kind ?? "event",
@@ -172,14 +173,31 @@ function debugEventTimelineItem(event: SessionEventEnvelope): AgentTimelineItem 
     meta,
     minDisplayLevel: "debug",
     sourceIds: [id],
-    detail: {
-      label: "Event payload",
-      text: debugJson(event),
-      tone: eventType.includes("failed") || eventType.includes("error") ? "data" : (projection?.detail?.tone ?? "data"),
-    },
+    detail,
     rawEvent: event,
     debug: debugJson(event),
   });
+}
+
+function debugEventDetail(
+  eventType: string,
+  payload: Record<string, unknown> | undefined,
+  projectedDetail: AgentTimelineItemDetail | undefined,
+): AgentTimelineItemDetail | undefined {
+  if (projectedDetail) return projectedDetail;
+
+  const facts = readableEventFacts(payload);
+  if (facts.length) {
+    return {
+      label: "Event details",
+      text: facts.join("\n"),
+      tone: eventType.includes("failed") || eventType.includes("error") ? "data" : "data",
+    };
+  }
+
+  const readable = readableText(payload);
+  if (readable) return { label: "Details", text: readable, tone: "data" };
+  return undefined;
 }
 
 function eventMeta(eventType: string, payload: Record<string, unknown> | undefined, eventSeq: number | undefined): string {
@@ -493,6 +511,7 @@ function projectKnownToolExecution(
   if (toolName === "ApplyPatch") return projectApplyPatchTool(payload);
   if (toolName === "ListWorkItems") return projectListWorkItemsTool(payload);
   if (toolName === "GetWorkItem") return projectGetWorkItemTool(payload);
+  if (isWorkItemMutationTool(toolName)) return projectWorkItemMutationTool(payload);
   if (toolName === "ViewImage") return projectViewImageTool(payload);
   return undefined;
 }
@@ -585,6 +604,17 @@ function projectGetWorkItemTool(payload: Record<string, unknown> | undefined): P
   return {
     body: summary || compactJoin(["Loaded work item", workItemId]) || "Loaded work item",
     detail: { label: "Work item", text: debugJson(result ?? payload ?? {}), tone: "data" },
+  };
+}
+
+function projectWorkItemMutationTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.result);
+  const workItem = asRecord(result?.work_item) ?? asRecord(result) ?? payload;
+  const summary = summarizeWorkItemRecord(workItem);
+  const facts = readableEventFacts(payload);
+  return {
+    body: summary || genericToolDescription(stringField(payload, "tool_name") ?? "WorkItem", payload),
+    detail: facts.length ? { label: "Work item change", text: facts.join("\n"), tone: "data" } : undefined,
   };
 }
 
@@ -887,6 +917,55 @@ function readableTextWithoutSummary(value: unknown): string {
   }
 
   return "";
+}
+
+function readableEventFacts(payload: Record<string, unknown> | undefined): string[] {
+  if (!payload) return [];
+  const facts = new Map<string, string>();
+  collectReadableEventFacts(payload, facts);
+  return Array.from(facts.entries())
+    .map(([key, value]) => `${humanizeEventType(key)}: ${truncateText(value, 240)}`)
+    .slice(0, 12);
+}
+
+function collectReadableEventFacts(value: Record<string, unknown>, facts: Map<string, string>, prefix = "", depth = 0): void {
+  const preferredKeys = [
+    "summary",
+    "summary_text",
+    "text_preview",
+    "output_preview",
+    "stdout_preview",
+    "stderr_preview",
+    "diff_preview",
+    "message",
+    "reason",
+    "status",
+    "priority",
+    "objective",
+    "work_item_id",
+    "task_id",
+    "agent_id",
+    "turn_id",
+    "run_id",
+    "active_model",
+    "stop_reason",
+  ];
+
+  for (const key of preferredKeys) {
+    const factKey = prefix ? `${prefix}_${key}` : key;
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim()) facts.set(factKey, candidate.trim());
+    if (typeof candidate === "number" || typeof candidate === "boolean") facts.set(factKey, String(candidate));
+  }
+
+  if (depth >= 2 || facts.size >= 12) return;
+
+  for (const [key, candidate] of Object.entries(value)) {
+    if (facts.size >= 12) return;
+    const record = asRecord(candidate);
+    if (!record) continue;
+    collectReadableEventFacts(record, facts, prefix ? `${prefix}_${key}` : key, depth + 1);
+  }
 }
 
 function toolErrorMessage(payload: Record<string, unknown> | undefined): string | undefined {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -44,6 +44,7 @@ const displayLevelRank: Record<DisplayLevel, number> = {
 const maxTimelineSourceIds = 200;
 const infoRuntimeEvents = new Set(["brief_created", "wait_condition_registered", "agent_waiting"]);
 const verboseRuntimeEventPrefixes = ["work_item_"];
+const debugRuntimeEventNames = new Set(["work_item_stale_reminder_injected"]);
 const debugRuntimeEventPrefixes = ["provider_", "task_"];
 const debugRuntimeEvents = new Set([
   "message_enqueued",
@@ -260,6 +261,7 @@ function projectRuntimeEvent(
 function runtimeEventDisplayLevel(eventType: string): DisplayLevel {
   if (infoRuntimeEvents.has(eventType)) return "info";
   if (eventType.includes("failed") || eventType.includes("error")) return "info";
+  if (debugRuntimeEventNames.has(eventType)) return "debug";
   if (debugRuntimeEvents.has(eventType)) return "debug";
   if (debugRuntimeEventPrefixes.some((prefix) => eventType.startsWith(prefix))) return "debug";
   if (verboseRuntimeEventPrefixes.some((prefix) => eventType.startsWith(prefix))) return "verbose";
@@ -399,9 +401,10 @@ function mergeSourceIds(sourceIds: string[]): string[] {
 function projectToolExecution(
   eventType: string,
   payload: Record<string, unknown> | undefined,
-): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> {
+): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> | undefined {
   const toolName = stringField(payload, "tool_name") ?? "tool";
   const failed = eventType === "tool_execution_failed" || Boolean(payload?.error);
+  if (!failed && isWorkItemMutationTool(toolName)) return undefined;
   const projection = projectKnownToolExecution(toolName, payload);
   const label = toolFriendlyLabel(toolName, failed);
   const summary = stringField(payload, "summary");
@@ -440,7 +443,13 @@ function projectKnownToolExecution(
   payload: Record<string, unknown> | undefined,
 ): Pick<SessionItemDraft, "body" | "detail"> | undefined {
   if (toolName === "ApplyPatch") return projectApplyPatchTool(payload);
+  if (toolName === "ListWorkItems") return projectListWorkItemsTool(payload);
+  if (toolName === "GetWorkItem") return projectGetWorkItemTool(payload);
   return undefined;
+}
+
+function isWorkItemMutationTool(toolName: string): boolean {
+  return toolName === "CreateWorkItem" || toolName === "UpdateWorkItem" || toolName === "PickWorkItem" || toolName === "CompleteWorkItem";
 }
 
 function toolStringPreview(
@@ -499,6 +508,50 @@ function projectApplyPatchTool(payload: Record<string, unknown> | undefined): Pi
         }
       : undefined,
   };
+}
+
+function projectListWorkItemsTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.list_work_items_result) ?? asRecord(payload?.result);
+  const items = arrayField(result, "work_items") ?? arrayField(result, "items");
+  const total = numberField(result, "total") ?? numberField(result, "total_open") ?? items?.length;
+  const filter = stringField(payload, "filter") ?? stringField(result, "filter");
+  const itemSummaries = summarizeWorkItemRecords(items);
+  return {
+    body: compactJoin([
+      total == null ? "Listed work items" : `${total} work item${total === 1 ? "" : "s"}`,
+      filter ? `filter: ${filter}` : undefined,
+      itemSummaries.length ? itemSummaries.slice(0, 3).join("; ") : undefined,
+    ]),
+    detail: itemSummaries.length
+      ? { label: "Work items", text: itemSummaries.join("\n"), tone: "data" }
+      : { label: "Result", text: debugJson(result ?? payload ?? {}), tone: "data" },
+  };
+}
+
+function projectGetWorkItemTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.get_work_item_result) ?? asRecord(payload?.result);
+  const workItem = asRecord(result?.work_item) ?? asRecord(result);
+  const summary = summarizeWorkItemRecord(workItem);
+  const workItemId = stringField(payload, "work_item_id") ?? stringField(workItem, "id");
+  return {
+    body: summary || compactJoin(["Loaded work item", workItemId]) || "Loaded work item",
+    detail: { label: "Work item", text: debugJson(result ?? payload ?? {}), tone: "data" },
+  };
+}
+
+function summarizeWorkItemRecords(items: unknown[] | undefined): string[] {
+  return (items ?? [])
+    .map(asRecord)
+    .filter((item): item is Record<string, unknown> => Boolean(item))
+    .map(summarizeWorkItemRecord)
+    .filter(Boolean);
+}
+
+function summarizeWorkItemRecord(record: Record<string, unknown> | undefined): string {
+  const id = stringField(record, "id") ?? stringField(record, "work_item_id");
+  const objective = stringField(record, "objective");
+  const lifecycle = stringField(record, "lifecycle") ?? stringField(record, "status");
+  return compactJoin([objective, lifecycle, id]);
 }
 
 function applyPatchDetailText(
@@ -654,6 +707,9 @@ function summarizeWorkItemEvent(eventType: string, payload: Record<string, unkno
   const record = asRecord(payload?.record);
   const objective = stringField(record, "objective");
   const id = stringField(record, "id");
+  if (eventType === "work_item_picked") {
+    return compactJoin(["Picked work item", objective ?? id, stringField(payload, "reason")]);
+  }
   return compactJoin([humanizeEventType(`work_item_${action}`), objective, id]);
 }
 

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -44,7 +44,7 @@ const displayLevelRank: Record<DisplayLevel, number> = {
 const maxTimelineSourceIds = 200;
 const infoRuntimeEvents = new Set(["brief_created", "wait_condition_registered", "agent_waiting"]);
 const verboseRuntimeEventPrefixes = ["work_item_"];
-const debugRuntimeEventNames = new Set(["work_item_stale_reminder_injected"]);
+const debugRuntimeEventNames = new Set(["work_item_focus_released", "work_item_stale_reminder_injected"]);
 const debugRuntimeEventPrefixes = ["provider_", "task_"];
 const debugRuntimeEvents = new Set([
   "message_enqueued",
@@ -709,42 +709,20 @@ function summarizeWorkItemEvent(eventType: string, payload: Record<string, unkno
   const action = stringField(payload, "action") ?? eventType.replace(/^work_item_/, "");
   const record = asRecord(payload?.record);
   const objective = stringField(record, "objective");
-  const id = stringField(record, "id") ?? stringField(payload, "work_item_id");
   const reason = stringField(payload, "reason");
   if (eventType === "work_item_picked") {
-    return compactJoin(["Picked work item", objective ?? id, reason]);
+    return compactJoin(["Picked work item", objective, reason]);
   }
   if (eventType === "work_item_focus_released") {
-    return compactJoin(["Released work item focus", objective ?? id, reason, stringField(payload, "readiness")]);
+    return compactJoin(["Released work item focus", objective, reason, stringField(payload, "readiness")]);
   }
   if (eventType === "work_item_completion_report_promoted") {
-    return compactJoin([
-      "Promoted completion report",
-      objective ?? id,
-      stringField(payload, "brief_id"),
-      sourceTurnRound(payload),
-      stringField(payload, "text_preview"),
-    ]);
+    return compactJoin(["Promoted completion report", objective, stringField(payload, "text_preview")]);
   }
   if (eventType === "work_item_completion_report_candidate_promoted") {
-    return compactJoin([
-      "Promoted completion report candidate",
-      objective ?? id,
-      stringField(payload, "brief_id"),
-      sourceTurnRound(payload),
-      stringField(payload, "text_preview"),
-    ]);
+    return compactJoin(["Promoted completion report candidate", objective, stringField(payload, "text_preview")]);
   }
-  return compactJoin([humanizeEventType(`work_item_${action}`), objective, id]);
-}
-
-function sourceTurnRound(payload: Record<string, unknown> | undefined): string | undefined {
-  const turn = numberField(payload, "source_turn_index") ?? numberField(payload, "turn_index");
-  const round = numberField(payload, "source_round") ?? numberField(payload, "round");
-  if (turn == null && round == null) return undefined;
-  if (turn == null) return `round ${round}`;
-  if (round == null) return `turn ${turn}`;
-  return `turn ${turn} round ${round}`;
+  return compactJoin([humanizeEventType(`work_item_${action}`), objective]);
 }
 
 function summarizeDebugEvent(eventType: string, payload: Record<string, unknown> | undefined): string {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -289,7 +289,7 @@ function timelineDedupeKey(item: AgentTimelineItem): string {
     return `operator:${normalizeTextKey(item.body)}`;
   }
   if (item.kind === "assistant") {
-    return `assistant:${normalizeTextKey(item.body)}`;
+    return `assistant:${item.id}`;
   }
   return `item:${item.id}`;
 }

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -415,7 +415,7 @@ function projectToolExecution(
   const result = asRecord(payload?.exec_command_result);
   const exitStatus = numberField(payload, "exit_status") ?? numberField(result, "exit_status");
   const durationMs = numberField(payload, "duration_ms") ?? numberField(result, "duration_ms");
-  const error = stringField(payload, "error");
+  const error = toolErrorMessage(payload);
   const stringPreview = toolStringPreview(toolName, payload, commandPreview) || undefined;
   const toolSummary = projection?.body ?? stringPreview ?? summary ?? genericToolDescription(toolName, payload) ?? toolName;
   const body = compactJoin([
@@ -425,7 +425,7 @@ function projectToolExecution(
     error,
   ]);
   const outputPreview = commandOutputPreview(payload);
-  const detail = projection?.detail ?? toolExecutionDetail(toolName, payload, commandPreview, outputPreview, toolSummary);
+  const detail = projection?.detail ?? toolExecutionDetail(toolName, payload, commandPreview, outputPreview, toolSummary, failed ? error : undefined);
 
   return {
     kind: "tool",
@@ -610,12 +610,14 @@ function toolExecutionDetail(
   commandPreview: string | undefined,
   outputPreview: string | undefined,
   summary: string | undefined,
+  error: string | undefined,
 ): AgentTimelineItemDetail | undefined {
   if (toolName === "ExecCommandBatch") {
     const batchDetail = commandBatchDetail(payload);
     if (batchDetail) return { label: "Commands", text: batchDetail, tone: "command" };
   }
 
+  if (error) return { label: "Error", text: error, tone: "data" };
   if (commandPreview && outputPreview) return { label: "Output", text: outputPreview, tone: "command" };
   if (commandPreview) {
     return { label: toolName === "ExecCommandBatch" ? "Commands" : "Command", text: commandPreview, tone: "command" };
@@ -840,6 +842,23 @@ function readableTextWithoutSummary(value: unknown): string {
   }
 
   return "";
+}
+
+function toolErrorMessage(payload: Record<string, unknown> | undefined): string | undefined {
+  const direct = stringField(payload, "error");
+  if (direct) return direct;
+
+  const error = payload?.error;
+  if (typeof error === "string" && error.trim()) return error;
+
+  const errorRecord = asRecord(error);
+  const message = firstStringField(errorRecord, ["message", "summary", "summary_text", "reason", "detail"]);
+  if (message) return message;
+
+  const nested = firstStringField(asRecord(errorRecord?.error), ["message", "summary", "summary_text", "reason", "detail"]);
+  if (nested) return nested;
+
+  return undefined;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -709,11 +709,42 @@ function summarizeWorkItemEvent(eventType: string, payload: Record<string, unkno
   const action = stringField(payload, "action") ?? eventType.replace(/^work_item_/, "");
   const record = asRecord(payload?.record);
   const objective = stringField(record, "objective");
-  const id = stringField(record, "id");
+  const id = stringField(record, "id") ?? stringField(payload, "work_item_id");
+  const reason = stringField(payload, "reason");
   if (eventType === "work_item_picked") {
-    return compactJoin(["Picked work item", objective ?? id, stringField(payload, "reason")]);
+    return compactJoin(["Picked work item", objective ?? id, reason]);
+  }
+  if (eventType === "work_item_focus_released") {
+    return compactJoin(["Released work item focus", objective ?? id, reason, stringField(payload, "readiness")]);
+  }
+  if (eventType === "work_item_completion_report_promoted") {
+    return compactJoin([
+      "Promoted completion report",
+      objective ?? id,
+      stringField(payload, "brief_id"),
+      sourceTurnRound(payload),
+      stringField(payload, "text_preview"),
+    ]);
+  }
+  if (eventType === "work_item_completion_report_candidate_promoted") {
+    return compactJoin([
+      "Promoted completion report candidate",
+      objective ?? id,
+      stringField(payload, "brief_id"),
+      sourceTurnRound(payload),
+      stringField(payload, "text_preview"),
+    ]);
   }
   return compactJoin([humanizeEventType(`work_item_${action}`), objective, id]);
+}
+
+function sourceTurnRound(payload: Record<string, unknown> | undefined): string | undefined {
+  const turn = numberField(payload, "source_turn_index") ?? numberField(payload, "turn_index");
+  const round = numberField(payload, "source_round") ?? numberField(payload, "round");
+  if (turn == null && round == null) return undefined;
+  if (turn == null) return `round ${round}`;
+  if (round == null) return `turn ${turn}`;
+  return `turn ${turn} round ${round}`;
 }
 
 function summarizeDebugEvent(eventType: string, payload: Record<string, unknown> | undefined): string {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -118,6 +118,7 @@ function projectEventEnvelope(
   const payload = asRecord(event.payload);
   const eventType = event.type ?? "runtime_event";
   const projection = projectRuntimeEvent(eventType, payload);
+  if (!projection) return undefined;
   const meta = eventMeta(eventType, payload, event.event_seq);
 
   return item({
@@ -153,7 +154,7 @@ function eventProjectionDisplayLevel(level: DisplayLevel, eventDisplayLevel: Dis
 function projectRuntimeEvent(
   eventType: string,
   payload: Record<string, unknown> | undefined,
-): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> & { timestamp?: string } {
+): (Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> & { timestamp?: string }) | undefined {
   if (eventType === "message_enqueued") {
     const message = messageEnvelopeProjection(payload);
     if (message?.origin === "operator") {
@@ -265,7 +266,7 @@ function runtimeEventDisplayLevel(eventType: string): DisplayLevel {
 
 function projectAssistantRoundRecorded(
   payload: Record<string, unknown> | undefined,
-): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> {
+): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> | undefined {
   const textPreview = stringField(payload, "text_preview");
   if (textPreview) {
     return {
@@ -276,22 +277,7 @@ function projectAssistantRoundRecorded(
     };
   }
 
-  const toolNames = toolNamesFromPayload(payload);
-  if (toolNames.length) {
-    return {
-      kind: "tool",
-      label: "Assistant requested tools",
-      body: toolNames.join(", "),
-      minDisplayLevel: toolNames.every(isLowValueToolRequest) ? "debug" : "verbose",
-    };
-  }
-
-  return {
-    kind: "assistant",
-    label: "Assistant round",
-    body: compactJoin(["Assistant round completed without text", cleanStringField(payload, "stop_reason")]),
-    minDisplayLevel: "debug",
-  };
+  return undefined;
 }
 
 function timelineDedupeKey(item: AgentTimelineItem): string {
@@ -444,10 +430,6 @@ function projectToolExecution(
 function toolTimelineDisplayLevel(toolName: string): DisplayLevel {
   if (debugOnlyToolNames.has(toolName)) return "debug";
   return "verbose";
-}
-
-function isLowValueToolRequest(toolName: string): boolean {
-  return toolName === "ExecCommandBatch" || toolName === "WaitFor";
 }
 
 function projectKnownToolExecution(
@@ -756,14 +738,6 @@ function readableTextWithoutSummary(value: unknown): string {
   }
 
   return "";
-}
-
-function toolNamesFromPayload(value: Record<string, unknown> | undefined): string[] {
-  const toolNames = arrayField(value, "tool_names");
-  if (!toolNames?.length) return [];
-  return toolNames
-    .map((name) => (typeof name === "string" ? name.trim() : ""))
-    .filter((name): name is string => Boolean(name));
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -61,6 +61,20 @@ const displayLevelRank: Record<DisplayLevel, number> = {
   debug: 2,
 };
 const maxTimelineSourceIds = 200;
+const infoRuntimeEvents = new Set(["brief_created", "wait_condition_registered", "agent_waiting"]);
+const verboseRuntimeEventPrefixes = ["work_item_"];
+const debugRuntimeEventPrefixes = ["provider_", "task_"];
+const debugRuntimeEvents = new Set([
+  "message_enqueued",
+  "message_processing_started",
+  "turn_local_checkpoint_resume_requested",
+  "turn_local_checkpoint_requested",
+  "turn_local_checkpoint_recorded",
+  "continuation_trigger_received",
+  "continuation_resolved",
+  "closure_decided",
+]);
+const debugOnlyToolNames = new Set(["WaitFor"]);
 
 export function reduceAgentSessionTimeline(input: ReduceAgentSessionInput): AgentTimelineItem[] {
   const transcriptItems = input.transcript.map(projectTranscriptEntry);
@@ -280,7 +294,7 @@ function projectEventEnvelope(
     body: projection.body,
     timestamp: projection.timestamp ?? event.ts ?? "",
     meta,
-    minDisplayLevel: capDisplayLevel(projection.minDisplayLevel, eventDisplayLevel),
+    minDisplayLevel: eventProjectionDisplayLevel(projection.minDisplayLevel, eventDisplayLevel),
     sourceIds: [id],
     detail: projection.detail,
     debug: includeDebug ? debugJson(event) : undefined,
@@ -295,8 +309,11 @@ function eventMeta(eventType: string, payload: Record<string, unknown> | undefin
   return eventRef == null ? eventType : `${eventType} · ${eventRef}`;
 }
 
-function capDisplayLevel(level: DisplayLevel, maxLevel: DisplayLevel): DisplayLevel {
-  void maxLevel;
+function eventProjectionDisplayLevel(level: DisplayLevel, eventDisplayLevel: DisplayLevel): DisplayLevel {
+  // `eventDisplayLevel` describes the API page that supplied the event. It must
+  // not promote or demote a semantic projection: display filtering is applied
+  // later against each item's intrinsic `minDisplayLevel`.
+  void eventDisplayLevel;
   return level;
 }
 
@@ -319,7 +336,7 @@ function projectRuntimeEvent(
       kind: "system",
       label: "Message queued",
       body: message?.body || readableText(payload) || "Runtime message queued.",
-      minDisplayLevel: "debug",
+      minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
   }
 
@@ -329,7 +346,7 @@ function projectRuntimeEvent(
       label: stringField(payload, "kind") === "result" ? "Result" : "Brief Created",
       body: stringField(payload, "text") ?? "Brief text unavailable.",
       timestamp: stringField(payload, "created_at"),
-      minDisplayLevel: "info",
+      minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
   }
 
@@ -347,23 +364,16 @@ function projectRuntimeEvent(
       label: "Started processing",
       body: compactJoin([stringField(payload, "origin") === "operator" ? "Operator input" : undefined, stringField(payload, "run_id")]) ||
         "Agent started processing input.",
-      minDisplayLevel: "debug",
+      minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
   }
 
-  if (
-    eventType === "turn_local_checkpoint_resume_requested" ||
-    eventType === "turn_local_checkpoint_requested" ||
-    eventType === "turn_local_checkpoint_recorded" ||
-    eventType === "continuation_trigger_received" ||
-    eventType === "continuation_resolved" ||
-    eventType === "closure_decided"
-  ) {
+  if (debugRuntimeEvents.has(eventType)) {
     return {
       kind: "system",
       label: systemRuntimeLabel(eventType),
       body: summarizeSystemRuntimeEvent(eventType, payload),
-      minDisplayLevel: "debug",
+      minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
   }
 
@@ -372,7 +382,7 @@ function projectRuntimeEvent(
       kind: "system",
       label: "Work item",
       body: summarizeWorkItemEvent(eventType, payload),
-      minDisplayLevel: "verbose",
+      minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
   }
 
@@ -381,7 +391,7 @@ function projectRuntimeEvent(
       kind: "system",
       label: "Waiting",
       body: readableText(payload) || "Agent is waiting for an external condition.",
-      minDisplayLevel: "info",
+      minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
   }
 
@@ -399,7 +409,7 @@ function projectRuntimeEvent(
       kind: "event",
       label: humanizeEventType(eventType),
       body: summarizeDebugEvent(eventType, payload),
-      minDisplayLevel: "debug",
+      minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
   }
 
@@ -409,6 +419,15 @@ function projectRuntimeEvent(
     body: readableText(payload) || humanizeEventType(eventType),
     minDisplayLevel: "debug",
   };
+}
+
+function runtimeEventDisplayLevel(eventType: string): DisplayLevel {
+  if (infoRuntimeEvents.has(eventType)) return "info";
+  if (eventType.includes("failed") || eventType.includes("error")) return "info";
+  if (debugRuntimeEvents.has(eventType)) return "debug";
+  if (debugRuntimeEventPrefixes.some((prefix) => eventType.startsWith(prefix))) return "debug";
+  if (verboseRuntimeEventPrefixes.some((prefix) => eventType.startsWith(prefix))) return "verbose";
+  return "debug";
 }
 
 function projectAssistantRoundRecorded(
@@ -616,6 +635,7 @@ function projectToolExecution(
 }
 
 function toolTimelineDisplayLevel(toolName: string): DisplayLevel {
+  if (debugOnlyToolNames.has(toolName)) return "debug";
   return "verbose";
 }
 

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -189,6 +189,7 @@ export interface AgentTimelineActivity {
   minDisplayLevel: DisplayLevel;
   sourceIds: string[];
   detail?: AgentTimelineItemDetail;
+  rawEvent?: unknown;
   debug?: string;
 }
 
@@ -209,6 +210,7 @@ export interface AgentTimelineItem {
   sourceIds: string[];
   detail?: AgentTimelineItemDetail;
   activities?: AgentTimelineActivity[];
+  rawEvent?: unknown;
   debug?: string;
 }
 

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -56,6 +56,7 @@ export interface AgentSummary {
   attention: string;
   model: string;
   modelSource?: "runtime_default" | "agent_override";
+  modelReasoningEffort?: string;
   footer: string;
   subtitle: string;
   lastBrief: string;

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -10,6 +10,12 @@ export interface RuntimeConnection {
   error?: string;
 }
 
+export interface RuntimeConnectionConfig {
+  mode: "local" | "remote";
+  baseUrl?: string;
+  token?: string;
+}
+
 export interface WorkItemSummary {
   id: string;
   objective: string;

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -178,6 +178,14 @@ export interface SearchResponse {
   results: SearchResultItem[];
 }
 
+export interface RuntimeMessageEnvelope {
+  id?: string;
+  agent_id?: string;
+  origin?: unknown;
+  body?: unknown;
+  [key: string]: unknown;
+}
+
 export type AgentTimelineItemKind = "operator" | "assistant" | "tool" | "event" | "system";
 
 export interface AgentTimelineItemDetail {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1929,7 +1929,7 @@ code {
   right: 0;
   bottom: calc(100% + 8px);
   z-index: 20;
-  width: min(440px, calc(100vw - 56px));
+  width: min(720px, calc(100vw - 56px));
   max-height: 480px;
   overflow: auto;
   padding: 10px;
@@ -1978,11 +1978,26 @@ code {
   margin-top: 10px;
 }
 
+.model-picker-grid {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.36fr) minmax(260px, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
 .model-picker-section > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   color: var(--faint);
   font-size: 11px;
   font-weight: 760;
   text-transform: uppercase;
+}
+
+.model-picker-section > span b {
+  color: var(--accent);
+  font: inherit;
 }
 
 .model-provider-list,
@@ -1990,6 +2005,10 @@ code {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.model-picker-providers .model-provider-list {
+  display: grid;
 }
 
 .model-provider-option,
@@ -2004,7 +2023,7 @@ code {
 .model-provider-option {
   display: inline-grid;
   gap: 1px;
-  min-width: 96px;
+  min-width: 0;
   padding: 7px 10px;
   text-align: left;
 }
@@ -2029,6 +2048,10 @@ code {
 .reasoning-options button.is-active {
   border-color: var(--accent);
   background: color-mix(in srgb, var(--accent) 10%, var(--surface-soft));
+}
+
+.model-provider-option.is-active {
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .model-option {
@@ -2069,6 +2092,24 @@ code {
 
 .model-picker-empty {
   padding: 12px 4px 4px;
+}
+
+@media (max-width: 640px) {
+  .model-menu {
+    width: min(440px, calc(100vw - 24px));
+  }
+
+  .model-picker-grid {
+    display: block;
+  }
+
+  .model-picker-providers .model-provider-list {
+    display: flex;
+  }
+
+  .model-provider-option {
+    min-width: 96px;
+  }
 }
 
 .settings-inner {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1913,15 +1913,23 @@ code {
   padding-inline: 10px;
 }
 
-.model-button span:first-child {
+.model-button-label {
+  min-width: 0;
+  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.model-button small {
+.model-button-badge {
+  flex: 0 0 auto;
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, transparent);
+  border-radius: 999px;
+  padding: 1px 6px;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
   color: var(--accent);
   font-size: 11px;
+  line-height: 1.35;
 }
 
 .model-menu {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1243,6 +1243,8 @@ code {
 }
 
 .conversation-pane {
+  --conversation-content-max: 980px;
+
   display: grid;
   grid-template-rows: 1fr auto;
   min-height: 0;
@@ -1341,7 +1343,7 @@ code {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr);
   gap: 10px;
-  max-width: min(980px, 100%);
+  max-width: min(var(--conversation-content-max), 100%);
   width: 100%;
   align-self: center;
 }
@@ -1711,8 +1713,9 @@ code {
 
 .working-activity-panel,
 .working-status-marker {
-  width: min(760px, 72%);
-  margin-left: 22px;
+  width: 100%;
+  max-width: min(var(--conversation-content-max), 100%);
+  align-self: center;
   border: 1px solid color-mix(in srgb, var(--line) 68%, transparent);
   border-radius: 14px;
   background:
@@ -1894,7 +1897,8 @@ code {
 }
 
 .composer {
-  margin: 0 28px 18px;
+  width: min(var(--conversation-content-max), calc(100% - 60px));
+  margin: 0 auto 18px;
   border: 1px solid var(--line);
   border-radius: 16px;
   background: var(--surface);

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -424,12 +424,77 @@ button {
   margin-top: auto;
 }
 
+.connection-switcher {
+  display: grid;
+  gap: 8px;
+}
+
 .runtime-dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
   background: var(--success);
   box-shadow: 0 0 0 4px rgba(22, 131, 79, 0.12);
+}
+
+.runtime-dot.error {
+  background: var(--danger);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--danger) 14%, transparent);
+}
+
+.connection-panel {
+  display: grid;
+  gap: 8px;
+  margin: 0 2px 2px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--line-strong) 58%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 84%, var(--sidebar-soft));
+  box-shadow: 0 8px 24px rgba(30, 42, 58, 0.08);
+}
+
+.connection-panel label {
+  display: grid;
+  gap: 5px;
+  color: var(--faint);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.connection-panel input {
+  width: 100%;
+  min-width: 0;
+  padding: 8px 9px;
+  border: 1px solid color-mix(in srgb, var(--line-strong) 64%, transparent);
+  border-radius: 9px;
+  background: var(--surface-soft);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.connection-error {
+  color: var(--danger);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.connection-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.boot-card .connection-switcher {
+  margin-top: 16px;
+}
+
+.boot-card .connection-panel {
+  margin: 0;
 }
 
 .main-shell {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1678,15 +1678,23 @@ code {
   display: grid;
   gap: 10px;
   padding: 12px;
+  cursor: default;
 }
 
 .working-activity-header {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
   display: grid;
   grid-template-columns: auto auto minmax(0, 1fr);
   align-items: center;
   gap: 8px;
   min-width: 0;
+  padding: 0;
   color: var(--faint);
+  text-align: left;
 }
 
 .working-activity-header small {
@@ -1716,8 +1724,27 @@ code {
 }
 
 .working-activity-item {
+  appearance: none;
+  border: 0;
   padding: 7px 0 0;
   border-top: 1px solid color-mix(in srgb, var(--line) 52%, transparent);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.working-activity-header:hover small,
+.working-activity-item:hover span:not(.working-activity-icon),
+.working-activity-header:focus-visible small,
+.working-activity-item:focus-visible span:not(.working-activity-icon) {
+  color: var(--text);
+}
+
+.working-activity-header:focus-visible,
+.working-activity-item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 52%, transparent);
+  outline-offset: 3px;
 }
 
 .working-activity-item.slot-assistant {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1887,13 +1887,12 @@ code {
 .composer-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding: 6px;
   border-top: 1px solid var(--line);
   background: color-mix(in srgb, var(--surface-soft) 46%, transparent);
 }
 
-.composer-left,
 .composer-right {
   display: flex;
   align-items: center;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1405,6 +1405,10 @@ code {
   max-width: min(820px, 78%);
 }
 
+.message:not(.activity-message) {
+  position: relative;
+}
+
 .message.assistant {
   align-self: flex-start;
 }
@@ -1835,6 +1839,46 @@ code {
 .message.activity-message .message-meta {
   margin-left: 12px;
   font-size: 11px;
+}
+
+.message-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.message.operator .message-actions {
+  justify-content: flex-end;
+}
+
+.message:not(.activity-message):hover .message-actions,
+.message:not(.activity-message):focus-within .message-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.message-action {
+  display: inline-grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  box-shadow: var(--shadow-card);
+}
+
+.message-action:hover,
+.message-action:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+  color: var(--accent);
 }
 
 .conversation-empty {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1681,18 +1681,12 @@ code {
 }
 
 .working-activity-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  color: var(--faint);
-}
-
-.working-activity-title {
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
   align-items: center;
   gap: 8px;
   min-width: 0;
+  color: var(--faint);
 }
 
 .working-activity-header small {
@@ -1706,6 +1700,7 @@ code {
 
 .working-activity-list {
   display: grid;
+  grid-template-rows: repeat(2, minmax(0, auto));
   gap: 7px;
 }
 
@@ -1723,6 +1718,14 @@ code {
 .working-activity-item {
   padding: 7px 0 0;
   border-top: 1px solid color-mix(in srgb, var(--line) 52%, transparent);
+}
+
+.working-activity-item.slot-assistant {
+  grid-row: 1;
+}
+
+.working-activity-item.slot-action {
+  grid-row: 2;
 }
 
 .working-indicator.compact {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1659,8 +1659,7 @@ code {
   font-size: 11px;
 }
 
-.working-activity-panel,
-.working-status-marker {
+.working-indicator {
   width: 100%;
   max-width: min(var(--conversation-content-max), 100%);
   align-self: center;
@@ -1671,7 +1670,7 @@ code {
     color-mix(in srgb, var(--surface) 94%, var(--surface-soft));
 }
 
-.working-activity-panel {
+.working-indicator.detail {
   display: grid;
   gap: 10px;
   padding: 12px;
@@ -1703,7 +1702,7 @@ code {
 }
 
 .working-activity-item,
-.working-status-marker {
+.working-indicator.compact {
   display: grid;
   grid-template-columns: auto auto minmax(0, 1fr) auto;
   align-items: center;
@@ -1718,7 +1717,7 @@ code {
   border-top: 1px solid color-mix(in srgb, var(--line) 52%, transparent);
 }
 
-.working-status-marker {
+.working-indicator.compact {
   grid-template-columns: auto auto minmax(0, 1fr);
   padding: 10px 12px;
 }
@@ -1732,7 +1731,7 @@ code {
 }
 
 .working-activity-item strong,
-.working-status-marker strong {
+.working-indicator.compact strong {
   color: var(--faint);
   font-size: 11px;
   font-weight: 780;
@@ -1741,7 +1740,7 @@ code {
 }
 
 .working-activity-item span:not(.working-activity-dot),
-.working-status-marker span:not(.working-activity-dot) {
+.working-indicator.compact span:not(.working-activity-dot) {
   overflow: hidden;
   min-width: 0;
   text-overflow: ellipsis;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1663,11 +1663,15 @@ code {
   width: 100%;
   max-width: min(var(--conversation-content-max), 100%);
   align-self: center;
+  appearance: none;
   border: 1px solid color-mix(in srgb, var(--line) 68%, transparent);
   border-radius: 14px;
   background:
     linear-gradient(90deg, color-mix(in srgb, var(--accent) 9%, transparent), transparent 150px),
     color-mix(in srgb, var(--surface) 94%, var(--surface-soft));
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
 }
 
 .working-indicator.detail {
@@ -1678,22 +1682,26 @@ code {
 
 .working-activity-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
   color: var(--faint);
 }
 
-.working-activity-header span {
-  font-size: 11px;
-  font-weight: 780;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.working-activity-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
 .working-activity-header small {
+  overflow: hidden;
+  min-width: 0;
   color: var(--muted);
   font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .working-activity-list {
@@ -1704,7 +1712,7 @@ code {
 .working-activity-item,
 .working-indicator.compact {
   display: grid;
-  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   gap: 8px;
   min-width: 0;
@@ -1730,26 +1738,34 @@ code {
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 14%, transparent);
 }
 
+.working-activity-title strong,
 .working-activity-item strong,
 .working-indicator.compact strong {
   color: var(--faint);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 780;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
-.working-activity-item span:not(.working-activity-dot),
+.working-activity-icon {
+  display: inline-grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.working-activity-item span:not(.working-activity-icon),
 .working-indicator.compact span:not(.working-activity-dot) {
   overflow: hidden;
   min-width: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.working-activity-item time {
-  color: var(--faint);
-  font-size: 11px;
 }
 
 .message-meta {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1843,15 +1843,21 @@ code {
 
 .message-actions {
   display: flex;
+  position: absolute;
+  top: 6px;
+  right: -34px;
+  z-index: 2;
+  flex-direction: column;
   gap: 6px;
-  margin-top: 6px;
+  margin-top: 0;
   opacity: 0;
   pointer-events: none;
   transition: opacity 120ms ease;
 }
 
 .message.operator .message-actions {
-  justify-content: flex-end;
+  right: auto;
+  left: -34px;
 }
 
 .message:not(.activity-message):hover .message-actions,

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -488,17 +488,12 @@ button {
 
 .agent-top-context {
   align-items: center;
+  justify-content: flex-end;
   min-height: 0;
   padding-block: 6px;
   border-top: 1px solid var(--line);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--surface) 86%, transparent), color-mix(in srgb, var(--surface) 62%, transparent));
-}
-
-.agent-context-main {
-  display: grid;
-  min-width: 0;
-  flex: 1 1 auto;
 }
 
 .agent-top-controls,
@@ -537,64 +532,6 @@ button {
   border-radius: 9px;
   background: var(--surface);
   color: var(--text);
-}
-
-.work-summary {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  min-width: 0;
-  width: 100%;
-  align-items: center;
-  gap: 8px 10px;
-  min-height: 34px;
-  padding: 5px 10px;
-  border: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface) 70%, transparent);
-  color: inherit;
-  text-align: left;
-  transition:
-    border-color 140ms ease,
-    background 140ms ease;
-}
-
-.work-summary:hover {
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--line));
-  background: var(--surface);
-}
-
-.work-summary-label,
-.work-summary-meta {
-  flex: 0 0 auto;
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.work-summary-label {
-  color: var(--faint);
-  font-size: 10px;
-  font-weight: 780;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.work-summary strong {
-  overflow: hidden;
-  min-width: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.work-summary-meta {
-  justify-self: end;
-  overflow: hidden;
-  max-width: 180px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.work-summary.is-empty strong {
-  color: var(--muted);
 }
 
 .display-level {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2011,6 +2011,32 @@ code {
   display: grid;
 }
 
+.model-picker-reasoning {
+  display: grid;
+  gap: 7px;
+  margin: 8px 0;
+  padding: 9px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface-soft) 88%, var(--accent));
+}
+
+.model-picker-reasoning > span {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.model-picker-reasoning > span b {
+  color: var(--accent);
+  font: inherit;
+  text-transform: uppercase;
+}
+
 .model-provider-option,
 .reasoning-options button {
   border: 1px solid var(--line);

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1420,7 +1420,8 @@ code {
 
 .bubble {
   position: relative;
-  max-width: min(820px, 100%);
+  width: 100%;
+  max-width: 100%;
   padding: 2px 0;
   border: 0;
   border-radius: 0;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1432,9 +1432,12 @@ code {
 }
 
 .operator .bubble {
+  width: fit-content;
+  max-width: min(760px, 82%);
   margin-left: auto;
-  border-radius: 0;
-  background: transparent;
+  padding: 8px 12px;
+  border-radius: 14px 14px 4px 14px;
+  background: var(--surface-strong);
   color: var(--text);
 }
 

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1302,6 +1302,8 @@ code {
   flex-direction: column;
   gap: 12px;
   min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   padding: 20px 30px 24px;
   background:
@@ -1830,7 +1832,7 @@ code {
   display: flex;
   position: absolute;
   top: 0;
-  right: -34px;
+  right: 4px;
   z-index: 2;
   flex-direction: column;
   gap: 6px;
@@ -1842,7 +1844,7 @@ code {
 
 .message.operator .message-actions {
   right: auto;
-  left: -34px;
+  left: 4px;
 }
 
 .message:not(.activity-message):hover .message-actions,

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -785,6 +785,14 @@ code {
   padding-left: 1.35em;
 }
 
+.markdown-content ul {
+  list-style-type: disc;
+}
+
+.markdown-content ol {
+  list-style-type: decimal;
+}
+
 .markdown-content li + li {
   margin-top: 0.2em;
 }

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -476,26 +476,16 @@ button {
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
-.topbar-primary,
-.agent-top-context {
+.topbar-primary {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  min-height: 56px;
-  padding: 0 22px;
+  min-height: 58px;
+  padding: 8px 22px;
 }
 
-.agent-top-context {
-  align-items: center;
-  justify-content: flex-end;
-  min-height: 0;
-  padding-block: 6px;
-  border-top: 1px solid var(--line);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--surface) 86%, transparent), color-mix(in srgb, var(--surface) 62%, transparent));
-}
-
+.top-actions,
 .agent-top-controls,
 .agent-stream-controls {
   display: flex;
@@ -504,15 +494,34 @@ button {
   gap: 8px;
 }
 
+.top-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.agent-top-controls {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .top-title {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
+}
+
+.top-title > div {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
 }
 
 .top-title strong,
 .top-title span {
-  display: block;
+  display: inline;
 }
 
 .top-title span {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1402,12 +1402,12 @@ code {
 }
 
 .message {
-  max-width: min(820px, 100%);
+  max-width: 100%;
 }
 
 .message:not(.activity-message) {
   position: relative;
-  width: min(820px, 100%);
+  width: 100%;
   align-self: flex-start;
 }
 
@@ -1420,6 +1420,7 @@ code {
 
 .bubble {
   position: relative;
+  max-width: min(820px, 100%);
   padding: 2px 0;
   border: 0;
   border-radius: 0;
@@ -1428,12 +1429,14 @@ code {
 }
 
 .operator .bubble {
+  margin-left: auto;
   border-radius: 0;
   background: transparent;
   color: var(--text);
 }
 
 .assistant .bubble {
+  margin-right: auto;
   border-radius: 0;
   background: transparent;
 }
@@ -1808,7 +1811,7 @@ code {
 }
 
 .message.operator .message-meta {
-  justify-content: flex-start;
+  justify-content: flex-end;
 }
 
 .message.activity-message .message-meta {
@@ -1828,6 +1831,11 @@ code {
   opacity: 0;
   pointer-events: none;
   transition: opacity 120ms ease;
+}
+
+.message.operator .message-actions {
+  right: auto;
+  left: -34px;
 }
 
 .message:not(.activity-message):hover .message-actions,

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1512,9 +1512,7 @@ code {
   display: grid;
   gap: 4px;
   width: min(760px, 100%);
-  margin: 6px 0 0 18px;
-  padding-left: 12px;
-  border-left: 1px solid color-mix(in srgb, var(--accent) 28%, var(--line));
+  margin: 6px 0 0;
 }
 
 .activity-item {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1402,19 +1402,13 @@ code {
 }
 
 .message {
-  max-width: min(820px, 78%);
+  max-width: min(820px, 100%);
 }
 
 .message:not(.activity-message) {
   position: relative;
-}
-
-.message.assistant {
+  width: min(820px, 100%);
   align-self: flex-start;
-}
-
-.message.operator {
-  align-self: flex-end;
 }
 
 .message.activity-message {
@@ -1426,58 +1420,39 @@ code {
 
 .bubble {
   position: relative;
-  padding: 14px 16px;
-  border: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
-  border-radius: 18px;
-  background: var(--bubble);
-  box-shadow: var(--shadow-card);
+  padding: 2px 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .operator .bubble {
-  border-top-right-radius: 5px;
-  border-color: color-mix(in srgb, var(--accent) 34%, var(--line));
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--accent) 13%, transparent), transparent 140px),
-    var(--surface);
+  border-radius: 0;
+  background: transparent;
   color: var(--text);
 }
 
 .assistant .bubble {
-  border-top-left-radius: 5px;
-  background: var(--surface);
+  border-radius: 0;
+  background: transparent;
 }
 
 .operator .bubble::before,
 .assistant .bubble::before {
-  position: absolute;
-  content: "";
-  top: 12px;
-  bottom: 12px;
-  left: 0;
-  width: 3px;
-  border-radius: 999px;
-  background: var(--line-strong);
-}
-
-.operator .bubble::before {
-  background: var(--accent);
-}
-
-.assistant .bubble::before {
-  background: var(--success);
+  content: none;
 }
 
 .assistant + .assistant {
-  margin-top: -9px;
+  margin-top: -4px;
 }
 
 .message.is-compact {
-  margin-top: -10px;
+  margin-top: -5px;
 }
 
 .message.is-compact .bubble {
-  padding-top: 11px;
-  border-top-left-radius: 17px;
+  padding-top: 0;
 }
 
 .assistant + .activity-message,
@@ -1833,7 +1808,7 @@ code {
 }
 
 .message.operator .message-meta {
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .message.activity-message .message-meta {
@@ -1844,7 +1819,7 @@ code {
 .message-actions {
   display: flex;
   position: absolute;
-  top: 6px;
+  top: 0;
   right: -34px;
   z-index: 2;
   flex-direction: column;
@@ -1853,11 +1828,6 @@ code {
   opacity: 0;
   pointer-events: none;
   transition: opacity 120ms ease;
-}
-
-.message.operator .message-actions {
-  right: auto;
-  left: -34px;
 }
 
 .message:not(.activity-message):hover .message-actions,

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1730,7 +1730,7 @@ code {
   border-top: 1px solid color-mix(in srgb, var(--line) 52%, transparent);
   background: transparent;
   cursor: pointer;
-  font: inherit;
+  font-family: inherit;
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary\n- add the web GUI prototype for Holon runtime sessions\n- support local/remote runtime switching and timeline/session views\n- hydrate slim message events through the new batch message API\n\n## Verification\n- npm test -- --run\n- npm run typecheck\n- npm run build\n\nLatest focused verification was run after the slim message hydration changes.