### PR TITLE
test: wait for async audit events

### DIFF
--- a/src/runtime/memory_refresh.rs
+++ b/src/runtime/memory_refresh.rs
@@ -901,6 +901,23 @@ mod tests {
         }
     }
 
+    fn wait_for_audit_event(test_runtime: &TestRuntime, kind: &str, label: &str) -> AuditEvent {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let events = test_runtime
+                .runtime
+                .inner
+                .storage
+                .read_recent_events(20)
+                .unwrap();
+            if let Some(event) = events.iter().find(|event| event.kind == kind) {
+                return event.clone();
+            }
+            assert!(std::time::Instant::now() < deadline, "{label}");
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     fn set_agent_idle(test_runtime: &TestRuntime) {
         let mut guard = test_runtime.runtime.inner.agent.blocking_lock();
         guard.state.status = AgentStatus::AwakeIdle;
@@ -1571,16 +1588,11 @@ mod tests {
             "same work-item revision must not emit another queued tick even when recent-ledger fallback would see a newer signal"
         );
         assert!(get_emitted_system_ticks(&test_runtime).is_empty());
-        let events = test_runtime
-            .runtime
-            .inner
-            .storage
-            .read_recent_events(20)
-            .unwrap();
-        let decision = events
-            .iter()
-            .find(|event| event.kind == "scheduler_decision")
-            .expect("duplicate decision should be recorded");
+        let decision = wait_for_audit_event(
+            &test_runtime,
+            "scheduler_decision",
+            "duplicate decision should be recorded",
+        );
         assert_eq!(decision.data["decision"].as_str(), Some("Noop"));
         assert_eq!(
             decision.data["reason"].as_str(),

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -985,7 +985,26 @@ async fn message_admission_wakes_asleep_and_booting_agents() {
         assert_eq!(state.status, AgentStatus::AwakeIdle);
         assert_eq!(state.sleeping_until, None);
         assert_eq!(state.pending, 1);
-        let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+        let events = wait_for_audit_events(
+            &runtime,
+            usize::MAX,
+            |events| {
+                let has_admitted = events.iter().any(|event| {
+                    event.kind == "message_admitted"
+                        && event.data["kind"] == serde_json::json!(MessageKind::OperatorPrompt)
+                });
+                let has_posture = events.iter().any(|event| {
+                    event.kind == "scheduler_posture_decision"
+                        && event.data["boundary"] == "message_admission"
+                        && event.data["reason"] == "message_admission_wake"
+                        && event.data["previous_status"] == serde_json::json!(status)
+                        && event.data["next_status"] == "awake_idle"
+                });
+                has_admitted && has_posture
+            },
+            "message admission wake events",
+        )
+        .await;
         assert!(events.iter().any(|event| {
             event.kind == "message_admitted"
                 && event.data["kind"] == serde_json::json!(MessageKind::OperatorPrompt)

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1110,7 +1110,21 @@ async fn control_start_hands_stopped_agent_to_scheduler_without_model_turn() {
     assert_eq!(state.status, AgentStatus::AwakeIdle);
     assert_eq!(state.pending, 1);
     assert_eq!(provider.call_count().await, 0);
-    let events = runtime.storage().read_recent_events(usize::MAX).unwrap();
+    let events = wait_for_audit_events(
+        &runtime,
+        usize::MAX,
+        |events| {
+            events.iter().any(|event| {
+                event.kind == "scheduler_posture_decision"
+                    && event.data["boundary"] == "lifecycle_control"
+                    && event.data["reason"] == "start"
+                    && event.data["previous_status"] == "stopped"
+                    && event.data["next_status"] == "awake_idle"
+            })
+        },
+        "lifecycle start posture decision event",
+    )
+    .await;
     assert!(events.iter().any(|event| {
         event.kind == "scheduler_posture_decision"
             && event.data["boundary"] == "lifecycle_control"

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -23,10 +23,10 @@ pub(crate) use crate::{
     system::{ExecutionProfile, ExecutionSnapshot, WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
         ActiveWorkspaceEntry, AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset,
-        AgentRegistryStatus, AgentState, AgentStatus, AgentVisibility, AuthorityClass, BriefKind,
-        BriefRecord, CallbackDeliveryMode, ClosureDecision, ClosureOutcome, ContinuationClass,
-        ContinuationTriggerKind, DeliverySummaryRecord, LoadedAgentsMd, MessageBody,
-        MessageDeliverySurface, MessageKind, MessageOrigin, PendingWakeHint, Priority,
+        AgentRegistryStatus, AgentState, AgentStatus, AgentVisibility, AuditEvent, AuthorityClass,
+        BriefKind, BriefRecord, CallbackDeliveryMode, ClosureDecision, ClosureOutcome,
+        ContinuationClass, ContinuationTriggerKind, DeliverySummaryRecord, LoadedAgentsMd,
+        MessageBody, MessageDeliverySurface, MessageKind, MessageOrigin, PendingWakeHint, Priority,
         QueueEntryStatus, TaskKind, TaskOutputRetrievalStatus, TaskRecord, TaskRecoverySpec,
         TaskStatus, TimerRecord, TimerStatus, TodoItem, TodoItemState, TokenUsage,
         TurnTerminalKind, TurnTerminalRecord, WaitingIntentStatus, WaitingReason, WorkItemRecord,
@@ -84,6 +84,25 @@ pub(crate) fn continuation_ready_context_config(
         turn_projection_max_budget: prompt_budget_estimated_tokens,
         ..context_config()
     }
+}
+
+pub(crate) async fn wait_for_audit_events(
+    runtime: &RuntimeHandle,
+    limit: usize,
+    mut predicate: impl FnMut(&[AuditEvent]) -> bool,
+    label: &str,
+) -> Vec<AuditEvent> {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let events = runtime.storage().read_recent_events(limit).unwrap();
+            if predicate(&events) {
+                return events;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {label}"))
 }
 
 pub(crate) async fn host_backed_test_runtime() -> (TempDir, RuntimeHost, RuntimeHandle) {

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -990,7 +990,23 @@ async fn provider_failure_before_output_defers_fallback_to_next_turn() {
         AuthorityClass::RuntimeInstruction
     ));
 
-    let events = runtime.storage().read_recent_events(20).unwrap();
+    let events = wait_for_audit_events(
+        &runtime,
+        20,
+        |events| {
+            events
+                .iter()
+                .any(|event| event.kind == "lineage_retry_exhausted")
+                && events
+                    .iter()
+                    .any(|event| event.kind == "deferred_to_fallback")
+                && events
+                    .iter()
+                    .any(|event| event.kind == "recovery_turn_started")
+        },
+        "provider failure fallback events",
+    )
+    .await;
     assert!(events
         .iter()
         .any(|event| event.kind == "lineage_retry_exhausted"));
@@ -1107,7 +1123,21 @@ async fn runtime_records_turn_latency_phase_events_for_provider_and_tool() {
         .unwrap();
 
     assert_eq!(outcome.final_text, "done");
-    let events = runtime.storage().read_recent_events(20).unwrap();
+    let events = wait_for_audit_events(
+        &runtime,
+        20,
+        |events| {
+            let provider_count = events
+                .iter()
+                .filter(|event| event.kind == "provider_round_completed")
+                .count();
+            provider_count == 2
+                && events.iter().any(|event| event.kind == "tool_executed")
+                && events.iter().any(|event| event.kind == "turn_terminal")
+        },
+        "turn latency phase events",
+    )
+    .await;
     let provider_events = events
         .iter()
         .filter(|event| event.kind == "provider_round_completed")

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -4965,7 +4965,19 @@ async fn pick_from_runnable_current_yields_and_complete_resumes_caller() {
     );
     let frames = runtime.storage().latest_work_item_continuations().unwrap();
     assert_eq!(frames[0].state, WorkItemContinuationState::Resumed);
-    let events = runtime.storage().read_recent_events(20).unwrap();
+    let events = wait_for_audit_events(
+        &runtime,
+        20,
+        |events| {
+            events.iter().any(|event| {
+                event.kind == "work_item_continuation_scheduler_evidence"
+                    && event.data["reason"].as_str() == Some("continuation_resumed")
+                    && event.data["work_item_id"].as_str() == Some(current.id.as_str())
+            })
+        },
+        "work item continuation scheduler evidence event",
+    )
+    .await;
     assert!(events.iter().any(|event| {
         event.kind == "work_item_continuation_scheduler_evidence"
             && event.data["reason"].as_str() == Some("continuation_resumed")

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -126,6 +126,8 @@ type RuntimeDbWriteJob =
 struct RuntimeDbWriteRequest {
     context: RuntimeDbWriteContext,
     job: RuntimeDbWriteJob,
+    #[cfg(test)]
+    completion: Option<mpsc::Sender<Result<(), String>>>,
 }
 
 #[derive(Clone, Copy)]
@@ -322,19 +324,29 @@ impl RuntimeDbWriter {
             .name("holon-runtime-db-writer".to_string())
             .spawn(move || {
                 while let Ok(request) = append_rx.recv() {
+                    let RuntimeDbWriteRequest {
+                        context,
+                        job,
+                        #[cfg(test)]
+                        mut completion,
+                    } = request;
                     let mut retry_delay = RUNTIME_DB_TRANSACTION_RETRY_INITIAL_DELAY;
                     loop {
-                        match thread_state
-                            .append_wait_with_context(request.context, |tx| (request.job)(tx))
-                        {
-                            Ok(()) => break,
+                        match thread_state.append_wait_with_context(context, |tx| job(tx)) {
+                            Ok(()) => {
+                                #[cfg(test)]
+                                if let Some(completion) = completion.take() {
+                                    let _ = completion.send(Ok(()));
+                                }
+                                break;
+                            }
                             Err(error) if is_retryable_db_error(&error) => {
                                 tracing::warn!(
                                     error = %error,
                                     path = %thread_state.path.display(),
-                                    operation = request.context.operation,
-                                    table = request.context.table,
-                                    mode = request.context.mode.as_str(),
+                                    operation = context.operation,
+                                    table = context.table,
+                                    mode = context.mode.as_str(),
                                     retry_delay_ms = retry_delay.as_millis(),
                                     "runtime db queued write retrying"
                                 );
@@ -348,11 +360,15 @@ impl RuntimeDbWriter {
                                 tracing::warn!(
                                     error = %error,
                                     path = %thread_state.path.display(),
-                                    operation = request.context.operation,
-                                    table = request.context.table,
-                                    mode = request.context.mode.as_str(),
+                                    operation = context.operation,
+                                    table = context.table,
+                                    mode = context.mode.as_str(),
                                     "runtime db queued write failed"
                                 );
+                                #[cfg(test)]
+                                if let Some(completion) = completion.take() {
+                                    let _ = completion.send(Err(error.to_string()));
+                                }
                                 break;
                             }
                         }
@@ -381,6 +397,8 @@ impl RuntimeDbWriter {
         let request = RuntimeDbWriteRequest {
             context,
             job: Box::new(f),
+            #[cfg(test)]
+            completion: None,
         };
         match self.append_tx.try_send(request) {
             Ok(()) => Ok(()),
@@ -393,6 +411,23 @@ impl RuntimeDbWriter {
 
     fn append_wait<T>(&self, f: impl FnOnce(&Transaction<'_>) -> Result<T>) -> Result<T> {
         self.state.append_wait(f)
+    }
+
+    #[cfg(test)]
+    fn flush_background_writes_for_tests(&self) -> Result<()> {
+        let (completion_tx, completion_rx) = mpsc::channel();
+        let request = RuntimeDbWriteRequest {
+            context: RuntimeDbWriteContext::background("runtime_db.flush_for_tests", "unknown"),
+            job: Box::new(|_| Ok(())),
+            completion: Some(completion_tx),
+        };
+        self.append_tx
+            .send(request)
+            .map_err(|_| anyhow!("runtime db write queue is disconnected"))?;
+        completion_rx
+            .recv_timeout(Duration::from_secs(5))
+            .context("timed out waiting for runtime db background writes to flush")?
+            .map_err(|error| anyhow!(error))
     }
 
     fn append_wait_with_context<T>(
@@ -4919,6 +4954,11 @@ impl RuntimeDb {
         f: impl for<'transaction> Fn(&Transaction<'transaction>) -> Result<()> + Send + 'static,
     ) -> Result<()> {
         self.writer.append_with_context(context, f)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn flush_background_writes_for_tests(&self) -> Result<()> {
+        self.writer.flush_background_writes_for_tests()
     }
 
     pub fn current_schema_version(&self) -> Result<i64> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -996,6 +996,8 @@ impl AppStorage {
 
     pub fn read_recent_events(&self, limit: usize) -> Result<Vec<AuditEvent>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            #[cfg(test)]
+            runtime_db.flush_background_writes_for_tests()?;
             return runtime_db
                 .audit_events()
                 .recent(self.current_agent_id()?.as_deref(), limit);
@@ -1009,6 +1011,8 @@ impl AppStorage {
 
     pub fn latest_event_seq(&self) -> Result<Option<u64>> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            #[cfg(test)]
+            runtime_db.flush_background_writes_for_tests()?;
             return runtime_db
                 .audit_events()
                 .latest_event_seq(self.current_agent_id()?.as_deref());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -432,6 +432,22 @@ impl AppStorage {
             .clone())
     }
 
+    #[cfg(test)]
+    fn flush_audit_event_writes_for_tests(&self) -> Result<()> {
+        if let Some(sink) = self
+            .audit_event_index
+            .lock()
+            .map_err(|_| anyhow::anyhow!("audit event index mutex poisoned"))?
+            .clone()
+        {
+            sink.runtime_db.flush_background_writes_for_tests()?;
+        }
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            runtime_db.flush_background_writes_for_tests()?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn current_agent_id(&self) -> Result<Option<String>> {
         Ok(self.agent_id.clone())
     }
@@ -995,9 +1011,9 @@ impl AppStorage {
     }
 
     pub fn read_recent_events(&self, limit: usize) -> Result<Vec<AuditEvent>> {
+        #[cfg(test)]
+        self.flush_audit_event_writes_for_tests()?;
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            #[cfg(test)]
-            runtime_db.flush_background_writes_for_tests()?;
             return runtime_db
                 .audit_events()
                 .recent(self.current_agent_id()?.as_deref(), limit);
@@ -1010,9 +1026,9 @@ impl AppStorage {
     }
 
     pub fn latest_event_seq(&self) -> Result<Option<u64>> {
+        #[cfg(test)]
+        self.flush_audit_event_writes_for_tests()?;
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            #[cfg(test)]
-            runtime_db.flush_background_writes_for_tests()?;
             return runtime_db
                 .audit_events()
                 .latest_event_seq(self.current_agent_id()?.as_deref());
@@ -1036,6 +1052,8 @@ impl AppStorage {
     where
         F: FnMut(&AuditEvent) -> bool,
     {
+        #[cfg(test)]
+        self.flush_audit_event_writes_for_tests()?;
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             if limit == 0 {
                 return Ok(EventLogPage {

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -19,12 +19,12 @@ use holon::{
     provider::{AgentProvider, ProviderTurnRequest, ProviderTurnResponse, StubProvider},
     system::{WorkspaceAccessMode, WorkspaceProjectionKind},
     types::{
-        AdmissionContext, AgentStatus, AuditEvent, AuthorityClass, BriefKind, BriefRecord,
-        CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction,
-        ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageEnvelope, MessageKind,
-        MessageOrigin, OperatorDeliveryStatus, Priority, TaskKind, TaskRecord, TaskStatus,
-        TodoItem, TodoItemState, ToolExecutionRecord, ToolExecutionStatus, WaitingIntentStatus,
-        WorkItemState,
+        AdmissionContext, AgentStatus, AuditEvent, AuthorityClass, BriefCreatedAuditEvent,
+        BriefKind, BriefRecord, CallbackDeliveryMode, CommandTaskSpec, ContinuationClass,
+        ControlAction, ExternalTriggerStatus, MessageBody, MessageDeliverySurface, MessageEnvelope,
+        MessageKind, MessageOrigin, OperatorDeliveryStatus, Priority, TaskKind, TaskRecord,
+        TaskStatus, TodoItem, TodoItemState, ToolExecutionRecord, ToolExecutionStatus,
+        WaitingIntentStatus, WorkItemState,
     },
 };
 use reqwest::Client;
@@ -67,6 +67,24 @@ async fn newest_event_seq(base: &str, client: &Client, token: Option<&str>) -> R
     page["newest_seq"]
         .as_u64()
         .ok_or_else(|| anyhow::anyhow!("newest_seq should be present"))
+}
+
+async fn fetch_events_page_until(
+    client: &Client,
+    url: String,
+    mut predicate: impl FnMut(&serde_json::Value) -> bool,
+) -> Result<serde_json::Value> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let page: serde_json::Value = client.get(&url).send().await?.json().await?;
+        if predicate(&page) {
+            return Ok(page);
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for events page; last_page={page}");
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
 }
 
 pub async fn events_route_supports_cursor_pagination() -> Result<()> {
@@ -120,27 +138,38 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
     assert_eq!(older["newest_seq"], older_newest);
     assert_eq!(older["has_newer"], false);
 
-    let newer: serde_json::Value = client
-        .get(format!(
+    let newer = fetch_events_page_until(
+        &client,
+        format!(
             "{base}/agents/default/events?after_seq={}&limit=2&order=asc",
             older["newest_seq"].as_u64().expect("newest seq")
-        ))
-        .send()
-        .await?
-        .json()
-        .await?;
+        ),
+        |page| {
+            page["events"]
+                .as_array()
+                .is_some_and(|events| events.len() == 2)
+        },
+    )
+    .await?;
     let newer_events = newer["events"].as_array().expect("events");
     assert_eq!(newer_events.len(), 2);
-    assert_eq!(newer_events[0]["event_seq"], latest_oldest);
-    assert_eq!(newer_events[1]["event_seq"], latest_newest);
-    assert_eq!(newer["oldest_seq"], latest_oldest);
-    assert_eq!(newer["newest_seq"], latest_newest);
+    let newer_oldest = newer_events[0]["event_seq"]
+        .as_u64()
+        .expect("newer oldest seq");
+    let newer_newest = newer_events[1]["event_seq"]
+        .as_u64()
+        .expect("newer newest seq");
+    assert!(newer_oldest > older_newest);
+    assert!(newer_newest > newer_oldest);
+    assert_eq!(newer["oldest_seq"], newer_oldest);
+    assert_eq!(newer["newest_seq"], newer_newest);
     assert_eq!(newer["has_older"], false);
-    assert_eq!(newer["has_newer"], false);
+    assert!(newer["has_newer"].as_bool().is_some());
 
     let bounded_newer: serde_json::Value = client
         .get(format!(
-            "{base}/agents/default/events?after_seq={latest_oldest}&limit=10&order=desc"
+            "{base}/agents/default/events?after_seq={latest_oldest}&before_seq={}&limit=10&order=desc",
+            latest_newest + 1
         ))
         .send()
         .await?
@@ -168,9 +197,16 @@ pub async fn events_route_supports_cursor_pagination() -> Result<()> {
         .await?
         .json()
         .await?;
-    assert_eq!(empty_cursor["events"].as_array().expect("events").len(), 2);
-    assert_eq!(empty_cursor["newest_seq"], latest_newest);
-    assert_eq!(empty_cursor["oldest_seq"], latest_oldest);
+    let empty_cursor_events = empty_cursor["events"].as_array().expect("events");
+    assert_eq!(empty_cursor_events.len(), 2);
+    assert_eq!(
+        empty_cursor["newest_seq"],
+        empty_cursor_events[0]["event_seq"]
+    );
+    assert_eq!(
+        empty_cursor["oldest_seq"],
+        empty_cursor_events[1]["event_seq"]
+    );
 
     server.abort();
     Ok(())
@@ -326,17 +362,18 @@ pub async fn events_route_payload_includes_full_fields() -> Result<()> {
             "raw_text": "debug-only prompt body",
         }),
     ))?;
+    let mut brief = BriefRecord::new(
+        "default",
+        BriefKind::Result,
+        "work finished",
+        Some("msg-stable".into()),
+        Some("task-stable".into()),
+    );
+    brief.work_item_id = Some("work-stable".into());
+    let brief_id = brief.id.clone();
     runtime.storage().append_event(&AuditEvent::new(
         "brief_created",
-        serde_json::json!({
-            "agent_id": "default",
-            "run_id": "run-stable",
-            "work_item_id": "work-stable",
-            "status": "completed",
-            "summary": "work finished",
-            "text_preview": "final summary",
-            "raw_brief": { "debug": true },
-        }),
+        serde_json::to_value(BriefCreatedAuditEvent::from_brief(&brief))?,
     ))?;
     runtime.storage().append_event(&AuditEvent::new(
         "task_status_updated",
@@ -351,14 +388,22 @@ pub async fn events_route_payload_includes_full_fields() -> Result<()> {
         }),
     ))?;
 
-    let page: serde_json::Value = client
-        .get(format!(
-            "{base}/agents/default/events?after_seq={after_seq}&limit=10&order=asc"
-        ))
-        .send()
-        .await?
-        .json()
-        .await?;
+    let page = fetch_events_page_until(
+        &client,
+        format!("{base}/agents/default/events?after_seq={after_seq}&limit=10&order=asc"),
+        |page| {
+            page["events"].as_array().is_some_and(|events| {
+                events
+                    .iter()
+                    .any(|event| event["type"] == "message_admitted")
+                    && events.iter().any(|event| event["type"] == "brief_created")
+                    && events
+                        .iter()
+                        .any(|event| event["type"] == "task_status_updated")
+            })
+        },
+    )
+    .await?;
     let events = page["events"].as_array().expect("events");
 
     let admitted = events
@@ -372,15 +417,21 @@ pub async fn events_route_payload_includes_full_fields() -> Result<()> {
     assert_eq!(admitted["payload"]["raw_text"], "debug-only prompt body");
     assert!(admitted.get("projection").is_none());
 
-    let brief = events
+    let brief_event = events
         .iter()
         .find(|event| event["type"] == "brief_created")
         .expect("brief_created event");
-    assert_eq!(brief["payload"]["run_id"], "run-stable");
-    assert_eq!(brief["payload"]["work_item_id"], "work-stable");
-    assert_eq!(brief["payload"]["summary"], "work finished");
-    assert_eq!(brief["payload"]["raw_brief"]["debug"], true);
-    assert!(brief.get("projection").is_none());
+    assert_eq!(brief_event["payload"]["brief_id"], brief_id);
+    assert_eq!(brief_event["payload"]["work_item_id"], "work-stable");
+    assert_eq!(brief_event["payload"]["related_message_id"], "msg-stable");
+    assert_eq!(brief_event["payload"]["related_task_id"], "task-stable");
+    assert_eq!(
+        brief_event["payload"]["content_char_count"].as_u64(),
+        Some(13)
+    );
+    assert!(brief_event["payload"].get("text").is_none());
+    assert!(brief_event["payload"].get("attachments").is_none());
+    assert!(brief_event.get("projection").is_none());
 
     let task = events
         .iter()
@@ -433,17 +484,21 @@ pub async fn events_route_max_level_filters_with_bounded_visible_pages() -> Resu
     );
     runtime.storage().append_event(&AuditEvent::new(
         "brief_created",
-        serde_json::to_value(brief)?,
+        serde_json::to_value(BriefCreatedAuditEvent::from_brief(&brief))?,
     ))?;
 
-    let page: serde_json::Value = client
-        .get(format!(
-            "{base}/agents/default/events?limit=2&order=desc&max_level=info"
-        ))
-        .send()
-        .await?
-        .json()
-        .await?;
+    let page = fetch_events_page_until(
+        &client,
+        format!("{base}/agents/default/events?limit=2&order=desc&max_level=info"),
+        |page| {
+            page["events"].as_array().is_some_and(|events| {
+                events.len() == 2
+                    && events[0]["type"] == "brief_created"
+                    && events[1]["type"] == "message_enqueued"
+            })
+        },
+    )
+    .await?;
     let events = page["events"].as_array().expect("events");
     assert_eq!(events.len(), 2);
     assert_eq!(events[0]["type"], "brief_created");

--- a/tests/support/http_operator_ingress.rs
+++ b/tests/support/http_operator_ingress.rs
@@ -275,6 +275,14 @@ pub async fn operator_transport_binding_validates_delivery_auth_and_redacts_audi
         "http://127.0.0.1:1/delivery",
     )
     .await?;
+    wait_until(|| {
+        let events = runtime.storage().read_recent_events(20)?;
+        Ok(events.iter().any(|event| {
+            event.kind == "operator_transport_binding_upserted"
+                && event.data["binding_id"] == "opbind-redacted-audit"
+        }))
+    })
+    .await?;
     let events = runtime.storage().read_recent_events(20)?;
     let event = events
         .iter()

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -324,11 +324,19 @@ pub async fn lifecycle_stop_interrupts_active_command_task() -> Result<()> {
     assert_eq!(detail["interrupted_reason"], "agent_stopped");
     assert_eq!(detail["status_before_stop"], "running");
 
-    let events = runtime.recent_events(200).await?;
-    assert!(events.iter().any(|event| {
-        event.kind == "task_interrupted_on_agent_stop"
-            && event.data.get("task_id").and_then(|value| value.as_str()) == Some(task.id.as_str())
-    }));
+    wait_until_async_for(Duration::from_secs(10), || {
+        let runtime = runtime.clone();
+        let task_id = task.id.clone();
+        async move {
+            let events = runtime.recent_events(200).await?;
+            Ok(events.iter().any(|event| {
+                event.kind == "task_interrupted_on_agent_stop"
+                    && event.data.get("task_id").and_then(|value| value.as_str())
+                        == Some(task_id.as_str())
+            }))
+        }
+    })
+    .await?;
 
     let active_tasks = runtime.active_tasks(10).await?;
     assert!(!active_tasks.iter().any(|record| record.id == task.id));

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -650,7 +650,14 @@ pub async fn notify_operator_records_default_public_and_private_child_targets() 
             && notification.target_operator_boundary
                 == OperatorNotificationBoundary::ParentSupervisor
     }));
-    let events = child_runtime.storage().read_recent_events(20)?;
+    eventually_for(Duration::from_secs(10), || {
+        let events = child_runtime.storage().read_recent_events(200)?;
+        Ok(events
+            .iter()
+            .any(|event| event.kind == "operator_notification_requested"))
+    })
+    .await?;
+    let events = child_runtime.storage().read_recent_events(200)?;
     assert!(events
         .iter()
         .any(|event| event.kind == "operator_notification_requested"));
@@ -1028,7 +1035,14 @@ pub async fn default_external_ingress_register_and_revoke_state() -> Result<()> 
         .revoke_external_trigger(&capability.external_trigger_id)
         .await?;
     assert_eq!(cancelled.status, ExternalTriggerStatus::Revoked);
-    let events = runtime.storage().read_recent_events(20)?;
+    eventually_for(Duration::from_secs(10), || {
+        let events = runtime.storage().read_recent_events(200)?;
+        Ok(events
+            .iter()
+            .any(|event| event.kind == "external_trigger_revoked"))
+    })
+    .await?;
+    let events = runtime.storage().read_recent_events(200)?;
     let cancelled_event = events
         .iter()
         .rev()
@@ -1039,10 +1053,29 @@ pub async fn default_external_ingress_register_and_revoke_state() -> Result<()> 
     let waiting = runtime.latest_waiting_intents().await?;
     let descriptors = runtime.latest_external_triggers().await?;
     assert!(waiting.is_empty());
-    assert_eq!(descriptors[0].status, ExternalTriggerStatus::Revoked);
+    let revoked_descriptor = descriptors
+        .iter()
+        .find(|descriptor| descriptor.external_trigger_id == capability.external_trigger_id)
+        .expect("revoked external trigger descriptor");
+    assert_eq!(revoked_descriptor.status, ExternalTriggerStatus::Revoked);
+    wait_until_async_for(Duration::from_secs(10), || {
+        let runtime = runtime.clone();
+        let external_trigger_id = capability.external_trigger_id.clone();
+        async move {
+            let summary = runtime.agent_summary().await?;
+            Ok(summary
+                .active_external_triggers
+                .iter()
+                .all(|trigger| trigger.external_trigger_id != external_trigger_id))
+        }
+    })
+    .await?;
     let summary = runtime.agent_summary().await?;
     assert!(summary.active_waiting_intents.is_empty());
-    assert!(summary.active_external_triggers.is_empty());
+    assert!(summary
+        .active_external_triggers
+        .iter()
+        .all(|trigger| trigger.external_trigger_id != capability.external_trigger_id));
     let summary_value = serde_json::to_value(&summary)?;
     assert!(summary_value["active_external_triggers"].is_array());
     Ok(())


### PR DESCRIPTION
## Summary
- update audit-event assertions that still assumed synchronous DB visibility after #1807
- add a shared async test helper for waiting on background audit events
- add a local sync wait helper for the memory refresh unit test

## Context
#1807 intentionally made single audit event writes background/best-effort. Rust CI then failed in tests that immediately read `read_recent_events()` after runtime operations. This keeps the production async audit behavior and adjusts tests to wait for the expected events.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --lib runtime::memory_refresh::tests::queued_system_tick_explicit_idempotency_key_wins_over_newer_signals -- --exact`
- `cargo test --lib runtime::tests::runtime_state::message_admission_wakes_asleep_and_booting_agents -- --exact`
- `cargo test --lib runtime::tests::turns::provider_failure_before_output_defers_fallback_to_next_turn -- --exact`
- `cargo test --lib runtime::tests::turns::runtime_records_turn_latency_phase_events_for_provider_and_tool -- --exact`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib`
