### PR TITLE
feat: add runtime object resolver foundation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod memory;
 pub mod model_catalog;
 pub mod model_discovery;
 pub mod notes_catalog;
+pub mod object_resolver;
 pub mod onboarding;
 pub mod onboarding_tui;
 pub mod openapi;

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -14,6 +14,7 @@ use sha2::{Digest, Sha256};
 use crate::{
     agent_template::{agent_memory_operator_path, agent_memory_self_path},
     memory::refs::{RuntimeRef, ToolExecutionRefSelector, ToolOutputSelector},
+    object_resolver::RuntimeObjectResolver,
     runtime_db::{EvidenceKind, RuntimeDb},
     storage::AppStorage,
     tool::helpers::{
@@ -1105,6 +1106,9 @@ fn semantic_brief_is_retrievable(brief: &BriefRecord) -> bool {
 }
 
 fn brief_document(storage: &AppStorage, brief: BriefRecord) -> MemoryDocument {
+    let body = RuntimeObjectResolver::new(storage)
+        .resolve_brief_content(&brief)
+        .unwrap_or_else(|_| brief.text.clone());
     MemoryDocument {
         source_ref: format!("brief:{}", brief.id),
         source_kind: "brief".into(),
@@ -1113,8 +1117,8 @@ fn brief_document(storage: &AppStorage, brief: BriefRecord) -> MemoryDocument {
         agent_id: brief.agent_id,
         source_path: None,
         title: format!("Brief {:?}", brief.kind),
-        sanitized_excerpt: excerpt(&brief.text),
-        body: brief.text,
+        sanitized_excerpt: excerpt(&body),
+        body,
         metadata: json!({
             "work_item_id": brief.work_item_id,
             "related_message_id": brief.related_message_id,
@@ -2339,9 +2343,9 @@ mod tests {
     use crate::{
         agent_template::ensure_agent_home_layout,
         types::{
-            AgentState, BriefKind, ContextEpisodeRecord, EpisodeBoundaryReason, TaskKind,
-            TaskRecord, TaskStatus, TodoItem, TodoItemState, TurnRecord, WorkItemPlanStatus,
-            WorkItemState,
+            AgentState, BriefContentSource, BriefKind, ContextEpisodeRecord, EpisodeBoundaryReason,
+            TaskKind, TaskRecord, TaskStatus, TodoItem, TodoItemState, TranscriptEntry,
+            TranscriptEntryKind, TurnRecord, WorkItemPlanStatus, WorkItemState,
         },
     };
     use serde_json::json;
@@ -2876,6 +2880,39 @@ mod tests {
             .expect("DB-backed runtime evidence should be directly retrievable");
         assert_eq!(memory.content, body);
         assert!(!memory.truncated);
+    }
+
+    #[test]
+    fn memory_get_hydrates_transcript_backed_brief_content() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+
+        let entry = TranscriptEntry::new(
+            "default",
+            TranscriptEntryKind::AssistantRound,
+            Some(1),
+            None,
+            json!({
+                "blocks": [
+                    {"type": "text", "Text": {"text": "full transcript"}},
+                    {"type": "text", "text": "brief body sentinel_4839"}
+                ]
+            }),
+        );
+        storage.append_transcript_entry(&entry).unwrap();
+
+        let mut brief = brief_with_workspace("default", BriefKind::Result, "preview", "ws-holon");
+        brief.content_source = BriefContentSource::TranscriptEntry {
+            entry_id: entry.id.clone(),
+        };
+        let brief_ref = format!("brief:{}", brief.id);
+        storage.append_brief(&brief).unwrap();
+
+        let memory = get_memory(&storage, &brief_ref, None, Some("ws-holon"))
+            .unwrap()
+            .expect("transcript-backed brief should be retrievable");
+        assert_eq!(memory.content, "full transcript brief body sentinel_4839");
     }
 
     #[test]

--- a/src/object_resolver.rs
+++ b/src/object_resolver.rs
@@ -1,0 +1,315 @@
+use anyhow::{bail, Result};
+use serde_json::Value;
+
+use crate::{
+    storage::AppStorage,
+    types::{
+        BriefContentSource, BriefRecord, MessageEnvelope, ToolExecutionRecord, TranscriptEntry,
+        TranscriptEntryKind, TurnRecord,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedRuntimeObject {
+    Message(MessageEnvelope),
+    TranscriptEntry(TranscriptEntry),
+    Brief(ResolvedBrief),
+    Turn(TurnRecord),
+    ToolExecution(ResolvedToolExecution),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedBrief {
+    pub record: BriefRecord,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedToolExecution {
+    pub record: ToolExecutionRecord,
+    pub selector: Option<ToolExecutionSelector>,
+    pub selected: Option<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolExecutionSelector {
+    Input,
+    Output,
+    Summary,
+}
+
+impl ToolExecutionSelector {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "input" => Ok(Self::Input),
+            "output" => Ok(Self::Output),
+            "summary" => Ok(Self::Summary),
+            _ => bail!("unsupported tool_execution selector: {value}"),
+        }
+    }
+}
+
+pub struct RuntimeObjectResolver<'a> {
+    storage: &'a AppStorage,
+}
+
+impl<'a> RuntimeObjectResolver<'a> {
+    pub fn new(storage: &'a AppStorage) -> Self {
+        Self { storage }
+    }
+
+    pub fn resolve_ref(&self, object_ref: &str) -> Result<Option<ResolvedRuntimeObject>> {
+        let Some((kind, rest)) = object_ref.split_once(':') else {
+            bail!("runtime object ref must use kind:id syntax: {object_ref}");
+        };
+        if rest.trim().is_empty() {
+            bail!("runtime object ref is missing id: {object_ref}");
+        }
+
+        match kind {
+            "message" => Ok(self
+                .resolve_message(rest)?
+                .map(ResolvedRuntimeObject::Message)),
+            "transcript" => Ok(self
+                .resolve_transcript_entry(rest)?
+                .map(ResolvedRuntimeObject::TranscriptEntry)),
+            "brief" => Ok(self.resolve_brief(rest)?.map(ResolvedRuntimeObject::Brief)),
+            "turn" => Ok(self.resolve_turn(rest)?.map(ResolvedRuntimeObject::Turn)),
+            "tool_execution" => Ok(self
+                .resolve_tool_execution_ref(rest)?
+                .map(ResolvedRuntimeObject::ToolExecution)),
+            _ => bail!("unsupported runtime object ref kind: {kind}"),
+        }
+    }
+
+    pub fn resolve_message(&self, message_id: &str) -> Result<Option<MessageEnvelope>> {
+        self.storage.read_message_by_id(message_id)
+    }
+
+    pub fn resolve_transcript_entry(&self, entry_id: &str) -> Result<Option<TranscriptEntry>> {
+        self.storage.read_transcript_entry_by_id(entry_id)
+    }
+
+    pub fn resolve_brief(&self, brief_id: &str) -> Result<Option<ResolvedBrief>> {
+        let Some(record) = self.storage.read_brief_by_id(brief_id)? else {
+            return Ok(None);
+        };
+        let content = self.resolve_brief_content(&record)?;
+        Ok(Some(ResolvedBrief { record, content }))
+    }
+
+    pub fn resolve_brief_content(&self, brief: &BriefRecord) -> Result<String> {
+        match &brief.content_source {
+            BriefContentSource::Inline => Ok(brief.text.clone()),
+            BriefContentSource::TranscriptEntry { entry_id } => {
+                let Some(entry) = self.resolve_transcript_entry(entry_id)? else {
+                    return Ok(brief.text.clone());
+                };
+                Ok(transcript_text(&entry).unwrap_or_else(|| brief.text.clone()))
+            }
+        }
+    }
+
+    pub fn resolve_turn(&self, turn_id: &str) -> Result<Option<TurnRecord>> {
+        Ok(self
+            .storage
+            .read_recent_turns(usize::MAX)?
+            .into_iter()
+            .find(|record| record.turn_id == turn_id))
+    }
+
+    pub fn resolve_tool_execution_ref(&self, value: &str) -> Result<Option<ResolvedToolExecution>> {
+        let mut parts = value.splitn(2, ':');
+        let tool_execution_id = parts.next().unwrap_or_default();
+        let selector = parts.next().map(ToolExecutionSelector::parse).transpose()?;
+        self.resolve_tool_execution(tool_execution_id, selector)
+    }
+
+    pub fn resolve_tool_execution(
+        &self,
+        tool_execution_id: &str,
+        selector: Option<ToolExecutionSelector>,
+    ) -> Result<Option<ResolvedToolExecution>> {
+        let Some(record) = self.storage.read_tool_execution_by_id(tool_execution_id)? else {
+            return Ok(None);
+        };
+        let selected = selector.map(|selector| match selector {
+            ToolExecutionSelector::Input => record.input.clone(),
+            ToolExecutionSelector::Output => record.output.clone(),
+            ToolExecutionSelector::Summary => Value::String(record.summary.clone()),
+        });
+        Ok(Some(ResolvedToolExecution {
+            record,
+            selector,
+            selected,
+        }))
+    }
+}
+
+pub fn transcript_text(entry: &TranscriptEntry) -> Option<String> {
+    match entry.kind {
+        TranscriptEntryKind::AssistantRound
+        | TranscriptEntryKind::ToolResults
+        | TranscriptEntryKind::ContinuationPrompt
+        | TranscriptEntryKind::SubagentPrompt
+        | TranscriptEntryKind::SubagentAssistantRound => text_from_blocks(&entry.data),
+        TranscriptEntryKind::IncomingMessage | TranscriptEntryKind::RuntimeFailure => {
+            text_from_message_body(&entry.data).or_else(|| text_from_blocks(&entry.data))
+        }
+    }
+}
+
+fn text_from_blocks(data: &Value) -> Option<String> {
+    let blocks = data.get("blocks")?.as_array()?;
+    let text = blocks
+        .iter()
+        .filter_map(|block| {
+            let kind = block.get("type").and_then(Value::as_str)?;
+            if kind != "text" {
+                return None;
+            }
+            block
+                .get("Text")
+                .and_then(|value| value.get("text"))
+                .or_else(|| block.get("text"))
+                .and_then(Value::as_str)
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!text.trim().is_empty()).then_some(text)
+}
+
+fn text_from_message_body(data: &Value) -> Option<String> {
+    data.get("body")
+        .and_then(|body| {
+            body.get("Text")
+                .and_then(|value| value.get("text"))
+                .or_else(|| body.get("Brief").and_then(|value| value.get("text")))
+                .or_else(|| body.get("text"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_string)
+        .filter(|text| !text.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::{
+        storage::AppStorage,
+        types::{
+            AuthorityClass, BriefKind, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
+            Priority, ToolExecutionStatus,
+        },
+    };
+
+    fn storage() -> (TempDir, AppStorage) {
+        let dir = TempDir::new().unwrap();
+        let storage = AppStorage::new(dir.path()).unwrap();
+        (dir, storage)
+    }
+
+    #[test]
+    fn resolves_canonical_object_refs() {
+        let (_dir, storage) = storage();
+        let message = MessageEnvelope::new(
+            "agent-a",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text { text: "hi".into() },
+        );
+        storage.append_message(&message).unwrap();
+
+        let turn = TurnRecord::new("agent-a", "turn-a", 1);
+        storage.append_turn(&turn).unwrap();
+
+        let tool = ToolExecutionRecord {
+            id: "tool-a".into(),
+            agent_id: "agent-a".into(),
+            work_item_id: None,
+            turn_index: 1,
+            turn_id: Some("turn-a".into()),
+            tool_name: "ExecCommand".into(),
+            created_at: chrono::Utc::now(),
+            completed_at: None,
+            duration_ms: 7,
+            authority_class: AuthorityClass::OperatorInstruction,
+            status: ToolExecutionStatus::Success,
+            input: json!({"cmd": "true"}),
+            output: json!({"exit": 0}),
+            summary: "ok".into(),
+            invocation_surface: None,
+        };
+        storage.append_tool_execution(&tool).unwrap();
+
+        let resolver = RuntimeObjectResolver::new(&storage);
+        assert!(matches!(
+            resolver
+                .resolve_ref(&format!("message:{}", message.id))
+                .unwrap(),
+            Some(ResolvedRuntimeObject::Message(_))
+        ));
+        assert!(matches!(
+            resolver.resolve_ref("turn:turn-a").unwrap(),
+            Some(ResolvedRuntimeObject::Turn(_))
+        ));
+        let Some(ResolvedRuntimeObject::ToolExecution(resolved)) = resolver
+            .resolve_ref("tool_execution:tool-a:summary")
+            .unwrap()
+        else {
+            panic!("expected tool execution");
+        };
+        assert_eq!(resolved.selected, Some(Value::String("ok".into())));
+    }
+
+    #[test]
+    fn resolves_transcript_backed_brief_content() {
+        let (_dir, storage) = storage();
+        let entry = TranscriptEntry::new(
+            "agent-a",
+            TranscriptEntryKind::AssistantRound,
+            Some(1),
+            None,
+            json!({
+                "blocks": [
+                    {"type": "text", "Text": {"text": "full"}},
+                    {"type": "text", "text": "content"}
+                ]
+            }),
+        );
+        storage.append_transcript_entry(&entry).unwrap();
+
+        let mut brief = BriefRecord::new("agent-a", BriefKind::Result, "preview", None, None);
+        brief.content_source = BriefContentSource::TranscriptEntry {
+            entry_id: entry.id.clone(),
+        };
+        storage.append_brief(&brief).unwrap();
+
+        let resolved = RuntimeObjectResolver::new(&storage)
+            .resolve_brief(&brief.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.content, "full content");
+    }
+
+    #[test]
+    fn transcript_backed_brief_falls_back_to_preview_for_legacy_missing_entry() {
+        let (_dir, storage) = storage();
+        let mut brief = BriefRecord::new("agent-a", BriefKind::Result, "preview", None, None);
+        brief.content_source = BriefContentSource::TranscriptEntry {
+            entry_id: "missing".into(),
+        };
+        storage.append_brief(&brief).unwrap();
+
+        let resolved = RuntimeObjectResolver::new(&storage)
+            .resolve_brief(&brief.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.content, "preview");
+    }
+}

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -812,7 +812,7 @@ impl TuiProjection {
     pub(crate) fn hydrate_brief_texts(&mut self, entries: Vec<TranscriptEntry>) -> bool {
         let mut changed = false;
         for entry in entries {
-            if let Some(text) = assistant_round_text_from_entry(&entry) {
+            if let Some(text) = crate::object_resolver::transcript_text(&entry) {
                 // Key by the transcript entry id so multiple briefs sharing
                 // the same transcript entry resolve to the same text.
                 changed |= self.brief_text_cache.insert(entry.id, text).is_none();
@@ -1664,28 +1664,6 @@ fn trim_summary(value: &str) -> String {
         trimmed.push('…');
         trimmed
     }
-}
-
-/// Extract concatenated text blocks from an `AssistantRound` transcript entry.
-/// Returns `None` if the entry is not an assistant round or has no text.
-fn assistant_round_text_from_entry(entry: &TranscriptEntry) -> Option<String> {
-    let blocks = entry.data.get("blocks")?.as_array()?;
-    let text = blocks
-        .iter()
-        .filter_map(|block| {
-            let kind = block.get("type").and_then(Value::as_str)?;
-            if kind != "text" {
-                return None;
-            }
-            block
-                .get("Text")
-                .and_then(|v| v.get("text"))
-                .or_else(|| block.get("text"))
-                .and_then(Value::as_str)
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
-    (!text.trim().is_empty()).then_some(text)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a RuntimeObjectResolver foundation for canonical runtime refs (message, transcript, brief, turn, tool_execution)
- resolve transcript-backed brief content through transcript entries with legacy preview fallback
- route memory brief retrieval and TUI brief hydration through the shared transcript text helper

Closes #1813

## Verification
- cargo fmt --all -- --check
- cargo test object_resolver --lib
- cargo test memory_get_hydrates_transcript_backed_brief_content --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets