### PR TITLE
fix: slim incoming transcript entries

### DIFF
--- a/src/object_resolver.rs
+++ b/src/object_resolver.rs
@@ -90,6 +90,17 @@ impl<'a> RuntimeObjectResolver<'a> {
         self.storage.read_transcript_entry_by_id(entry_id)
     }
 
+    pub fn resolve_transcript_text(&self, entry: &TranscriptEntry) -> Result<Option<String>> {
+        if entry.kind == TranscriptEntryKind::IncomingMessage {
+            if let Some(message_id) = entry.related_message_id.as_deref() {
+                if let Some(message) = self.resolve_message(message_id)? {
+                    return Ok(message_body_text(&message.body));
+                }
+            }
+        }
+        Ok(transcript_text(entry))
+    }
+
     pub fn resolve_brief(&self, brief_id: &str) -> Result<Option<ResolvedBrief>> {
         let Some(record) = self.storage.read_brief_by_id(brief_id)? else {
             return Ok(None);
@@ -105,7 +116,9 @@ impl<'a> RuntimeObjectResolver<'a> {
                 let Some(entry) = self.resolve_transcript_entry(entry_id)? else {
                     return Ok(brief.text.clone());
                 };
-                Ok(transcript_text(&entry).unwrap_or_else(|| brief.text.clone()))
+                Ok(self
+                    .resolve_transcript_text(&entry)?
+                    .unwrap_or_else(|| brief.text.clone()))
             }
         }
     }
@@ -190,6 +203,16 @@ fn text_from_message_body(data: &Value) -> Option<String> {
         })
         .map(str::to_string)
         .filter(|text| !text.trim().is_empty())
+}
+
+fn message_body_text(body: &crate::types::MessageBody) -> Option<String> {
+    match body {
+        crate::types::MessageBody::Text { text }
+        | crate::types::MessageBody::Brief { text, .. } => {
+            (!text.trim().is_empty()).then(|| text.clone())
+        }
+        crate::types::MessageBody::Json { value } => serde_json::to_string(value).ok(),
+    }
 }
 
 #[cfg(test)]
@@ -295,6 +318,34 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(resolved.content, "full content");
+    }
+
+    #[test]
+    fn resolves_incoming_transcript_text_from_related_message() {
+        let (_dir, storage) = storage();
+        let message = MessageEnvelope::new(
+            "agent-a",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "canonical input".into(),
+            },
+        );
+        storage.append_message(&message).unwrap();
+        let entry = TranscriptEntry::new(
+            "agent-a",
+            TranscriptEntryKind::IncomingMessage,
+            None,
+            Some(message.id.clone()),
+            json!({"delivery_surface": "api"}),
+        );
+
+        let resolved = RuntimeObjectResolver::new(&storage)
+            .resolve_transcript_text(&entry)
+            .unwrap();
+        assert_eq!(resolved.as_deref(), Some("canonical input"));
     }
 
     #[test]

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -267,8 +267,6 @@ impl RuntimeHandle {
             None,
             Some(message.id.clone()),
             serde_json::json!({
-                "kind": message.kind,
-                "origin": message.origin,
                 "authority_class": message.authority_class,
                 "delivery_surface": message.delivery_surface,
                 "admission_context": message.admission_context,
@@ -276,11 +274,8 @@ impl RuntimeHandle {
                 "work_item_id": message.work_item_id.clone(),
                 "task_id": message.task_id.clone(),
                 "source_refs": message.source_refs.clone(),
-                "priority": message.priority,
-                "body": message.body,
-                "metadata": message.metadata,
-                "correlation_id": message.correlation_id,
-                "causation_id": message.causation_id,
+                "correlation_id": message.correlation_id.clone(),
+                "causation_id": message.causation_id.clone(),
             }),
         ))
     }

--- a/tests/support/runtime_waiting.rs
+++ b/tests/support/runtime_waiting.rs
@@ -104,7 +104,9 @@ pub async fn turn_execution_boundary_persists_queue_transcript_and_briefs() -> R
     assert!(transcript.iter().any(|entry| {
         entry.kind == TranscriptEntryKind::IncomingMessage
             && entry.related_message_id.as_deref() == Some(message.id.as_str())
-            && entry.data["body"]["text"].as_str() == Some("exercise the turn boundary")
+            && entry.data["body"].is_null()
+            && entry.data["metadata"].is_null()
+            && entry.data["delivery_surface"].is_null()
     }));
     assert!(transcript.iter().any(|entry| {
         entry.kind == TranscriptEntryKind::AssistantRound && entry.round == Some(1)


### PR DESCRIPTION
## Summary
- store new incoming transcript entries with related_message_id plus bounded provenance instead of copying full message payload/metadata
- resolve incoming transcript content through the referenced MessageEnvelope when rendering/hydrating entries
- preserve legacy copied-payload fallback behavior for historical rows

Fixes #1814

## Verification
- cargo fmt --all -- --check
- cargo test object_resolver --lib
- cargo test turn_execution_boundary_persists_queue_transcript_and_briefs --test runtime_waiting_and_reactivation
- cargo test incoming_transcript_entries_preserve_delivery_surface_and_correlation_metadata --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets