### PR TITLE
feat: add event watcher SSE fanout

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -7834,6 +7834,44 @@
         ]
       }
     },
+    "/events/stream": {
+      "get": {
+        "description": "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data for all public agents. This live stream uses the in-memory event watcher and does not provide historical replay or a global cursor.",
+        "operationId": "eventsStream",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Server-Sent Events stream. Each data frame contains a StreamEventEnvelope JSON object."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error before stream establishment."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Global event stream",
+        "tags": [
+          "events"
+        ]
+      }
+    },
     "/handshake": {
       "get": {
         "description": "Return auth mode, protocol version, capabilities, and runtime hints.",

--- a/src/host.rs
+++ b/src/host.rs
@@ -34,7 +34,7 @@ use crate::{
     runtime::{InitialWorkspaceBinding, RuntimeHandle},
     runtime_db::RuntimeDb,
     skills::{load_skills_runtime_view, SkillVisibility},
-    storage::AppStorage,
+    storage::{AppStorage, EventBus, PublishedAuditEvent},
     system::{ExecutionScopeKind, HostLocalBoundary, WorkspaceAccessMode},
     tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
     types::{
@@ -100,6 +100,7 @@ impl std::error::Error for PublicAgentError {}
 struct HostInner {
     registry: RuntimeRegistry,
     runtime_db: RuntimeDb,
+    event_bus: EventBus,
     static_provider: Option<Arc<dyn AgentProvider>>,
     agents: RwLock<HashMap<String, AgentEntry>>,
 }
@@ -197,6 +198,7 @@ impl RuntimeHost {
             inner: Arc::new(HostInner {
                 registry,
                 runtime_db,
+                event_bus: EventBus::new(1024),
                 static_provider,
                 agents: RwLock::new(HashMap::new()),
             }),
@@ -219,7 +221,12 @@ impl RuntimeHost {
         let storage =
             AppStorage::new_for_agent(self.agent_data_dir(agent_id), agent_id.to_string())?;
         storage.enable_scheduler_control_plane_db(self.runtime_db().clone())?;
+        storage.enable_event_bus(self.inner.event_bus.clone())?;
         Ok(storage)
+    }
+
+    pub(crate) fn subscribe_events(&self) -> tokio::sync::broadcast::Receiver<PublishedAuditEvent> {
+        self.inner.event_bus.subscribe()
     }
 
     fn agent_storage_read_only(&self, agent_id: &str) -> Result<AppStorage> {
@@ -1611,6 +1618,7 @@ impl RuntimeHost {
                 self.inner.runtime_db.clone(),
                 self.bridge(),
                 RuntimeModelCatalog::from_config(self.config()),
+                self.inner.event_bus.clone(),
             )?
         } else {
             RuntimeHandle::new_reconfigurable_with_host_bridge(
@@ -1623,6 +1631,7 @@ impl RuntimeHost {
                 self.runtime_context_config(),
                 self.inner.runtime_db.clone(),
                 self.bridge(),
+                self.inner.event_bus.clone(),
             )?
         };
         let runtime_task = tokio::spawn({
@@ -3262,6 +3271,7 @@ mod tests {
             host.runtime_context_config(),
             host.runtime_db().clone(),
             bridge,
+            host.inner.event_bus.clone(),
         )
         .unwrap();
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,7 +1,9 @@
-use std::collections::VecDeque;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
+use std::{
+    collections::VecDeque,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 use anyhow::{anyhow, Result};
@@ -69,7 +71,7 @@ use crate::{
     policy::{default_authority_for_origin, validate_message_kind_for_origin},
     runtime::{CurrentRunAbortError, CurrentRunAbortMode, CurrentRunAbortRequest},
     runtime_db::{MessageSearchQuery, MessageSearchRow},
-    storage::{EventLogPageOrder, FileActivityMarker},
+    storage::EventLogPageOrder,
     system::{ExecutionScopeKind, HostLocalBoundary},
     types::{
         ActiveWorkspaceEntry, AdmissionContext, AgentRegistryStatus, AgentSummary, AgentVisibility,
@@ -165,7 +167,6 @@ impl HttpErrorEnvelope {
 const CALLBACK_BODY_LIMIT_BYTES: usize = 256 * 1024;
 const DEFAULT_EVENT_STREAM_WINDOW: usize = 128;
 const MAX_EVENT_STREAM_WINDOW: usize = 512;
-const EVENT_STREAM_POLL_INTERVAL: Duration = Duration::from_millis(250);
 pub(crate) const EVENT_STREAM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 
 impl AppState {
@@ -223,6 +224,7 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/{agent_id}/briefs", get(briefs))
         .route("/agents/{agent_id}/briefs/{brief_id}", get(brief))
         .route("/agents/{agent_id}/state", get(agent_state))
+        .route("/events/stream", get(global_events_stream))
         .route("/agents/{agent_id}/events", get(events))
         .route("/agents/{agent_id}/events/stream", get(events_stream))
         .route(
@@ -826,15 +828,6 @@ struct StreamEventEnvelope {
     event_type: String,
     provenance: EventReplayProvenance,
     payload: Value,
-}
-
-struct EventStreamState {
-    runtime: crate::runtime::RuntimeHandle,
-    runtime_id: String,
-    event_window_limit: usize,
-    event_marker: FileActivityMarker,
-    last_seen_seq: u64,
-    buffered: VecDeque<AuditEvent>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2219,85 +2212,80 @@ pub async fn events_stream(
     if state.require_control_token {
         authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     }
-    let initial_event_marker = runtime
-        .storage()
-        .poll_activity_marker()
-        .map_err(error_response)?
-        .events;
     let events = runtime
         .storage()
         .read_recent_events(event_window_limit.saturating_add(1))
         .map_err(error_response)?;
     let buffered = initial_buffered_events(&events, after_seq)?;
-    let last_seen_seq =
-        after_seq.unwrap_or_else(|| events.last().map_or(0, |event| event.event_seq));
-    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(32);
+    let mut live_rx = runtime
+        .storage()
+        .subscribe_events()
+        .map_err(error_response)?
+        .ok_or_else(|| error_response(anyhow!("event bus unavailable")))?;
+    let (tx, out_rx) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(32);
+    let runtime_id = agent_id.clone();
     tokio::spawn(async move {
-        let mut state = EventStreamState {
-            runtime,
-            runtime_id: agent_id,
-            event_window_limit,
-            event_marker: initial_event_marker,
-            last_seen_seq,
-            buffered,
-        };
+        for event in buffered {
+            if send_stream_event(&tx, &runtime_id, &event).await.is_err() {
+                return;
+            }
+        }
         loop {
-            if let Some(event) = state.buffered.pop_front() {
-                let envelope = stream_event_envelope(&state.runtime_id, &event);
-                state.last_seen_seq = event.event_seq;
-                let payload = serde_json::to_string(&envelope).unwrap_or_else(|_| "{}".to_string());
-                if tx
-                    .send(Ok(Event::default()
-                        .id(envelope.event_seq.to_string())
-                        .event(envelope.event_type)
-                        .data(payload)))
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
-                continue;
-            }
-            let event_marker = match state.runtime.storage().poll_activity_marker() {
-                Ok(marker) => marker.events,
-                Err(err) => {
-                    error!("failed to poll event marker for stream: {err}");
-                    sleep(EVENT_STREAM_POLL_INTERVAL).await;
-                    continue;
-                }
-            };
-            if event_marker == state.event_marker {
-                sleep(EVENT_STREAM_POLL_INTERVAL).await;
-                continue;
-            }
-            let latest_events: Vec<AuditEvent> = match state
-                .runtime
-                .storage()
-                .read_recent_events(state.event_window_limit.saturating_add(1))
-            {
-                Ok(latest_events) => latest_events,
-                Err(err) => {
-                    error!("failed to load events for stream: {err}");
-                    sleep(EVENT_STREAM_POLL_INTERVAL).await;
-                    continue;
-                }
-            };
-            match refresh_buffered_events(&mut state, latest_events) {
-                Ok(()) => {
-                    state.event_marker = event_marker;
-                    if !state.buffered.is_empty() {
-                        continue;
+            match live_rx.recv().await {
+                Ok(published) if published.agent_id.as_deref() == Some(runtime_id.as_str()) => {
+                    if send_stream_event(&tx, &runtime_id, &published.event)
+                        .await
+                        .is_err()
+                    {
+                        break;
                     }
                 }
-                Err(seq) => {
-                    error!("event stream cursor fell out of replay window: {seq}");
-                    break;
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(agent_id = %runtime_id, skipped, "event stream receiver lagged");
                 }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             }
-            sleep(EVENT_STREAM_POLL_INTERVAL).await;
         }
     });
-    let stream = ReceiverStream::new(rx);
+    let stream = ReceiverStream::new(out_rx);
+    let keep_alive = KeepAlive::new()
+        .interval(EVENT_STREAM_HEARTBEAT_INTERVAL)
+        .text("heartbeat");
+    Ok(Sse::new(stream).keep_alive(keep_alive))
+}
+
+pub async fn global_events_stream(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    if state.require_control_token {
+        authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
+    }
+    let mut rx = state.host.subscribe_events();
+    let (tx, rx_out) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(32);
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(published) => {
+                    let Some(agent_id) = published.agent_id.as_deref() else {
+                        continue;
+                    };
+                    if send_stream_event(&tx, agent_id, &published.event)
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(skipped, "global event stream receiver lagged");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+    let stream = ReceiverStream::new(rx_out);
     let keep_alive = KeepAlive::new()
         .interval(EVENT_STREAM_HEARTBEAT_INTERVAL)
         .text("heartbeat");
@@ -2321,25 +2309,6 @@ fn initial_buffered_events(
         events.len()
     };
     Ok(events.iter().skip(start_index).cloned().collect())
-}
-
-fn refresh_buffered_events(
-    state: &mut EventStreamState,
-    latest_events: Vec<AuditEvent>,
-) -> std::result::Result<(), u64> {
-    let start_index = if state.last_seen_seq == 0 {
-        0
-    } else {
-        latest_events
-            .iter()
-            .position(|event| event.event_seq == state.last_seen_seq)
-            .map(|position| position + 1)
-            .ok_or(state.last_seen_seq)?
-    };
-    state
-        .buffered
-        .extend(latest_events.into_iter().skip(start_index));
-    Ok(())
 }
 
 fn oldest_seq(events: &[AuditEvent], order: EventPageOrder) -> Option<u64> {
@@ -2368,6 +2337,23 @@ fn stream_event_envelope(agent_id: &str, event: &AuditEvent) -> StreamEventEnvel
         provenance: event_replay_provenance(&event.data),
         payload: event.data.clone(),
     }
+}
+
+async fn send_stream_event(
+    tx: &tokio::sync::mpsc::Sender<Result<Event, std::convert::Infallible>>,
+    agent_id: &str,
+    event: &AuditEvent,
+) -> std::result::Result<
+    (),
+    tokio::sync::mpsc::error::SendError<Result<Event, std::convert::Infallible>>,
+> {
+    let envelope = stream_event_envelope(agent_id, event);
+    let payload = serde_json::to_string(&envelope).unwrap_or_else(|_| "{}".to_string());
+    tx.send(Ok(Event::default()
+        .id(envelope.event_seq.to_string())
+        .event(envelope.event_type)
+        .data(payload)))
+        .await
 }
 
 async fn event_filter_context(

--- a/src/http.rs
+++ b/src/http.rs
@@ -2212,33 +2212,39 @@ pub async fn events_stream(
     if state.require_control_token {
         authorize_control(&headers, &state).map_err(|err| forbidden(err.to_string()))?;
     }
-    let events = runtime
-        .storage()
-        .read_recent_events(event_window_limit.saturating_add(1))
-        .map_err(error_response)?;
-    let buffered = initial_buffered_events(&events, after_seq)?;
     let mut live_rx = runtime
         .storage()
         .subscribe_events()
         .map_err(error_response)?
         .ok_or_else(|| error_response(anyhow!("event bus unavailable")))?;
+    let events = runtime
+        .storage()
+        .read_recent_events(event_window_limit.saturating_add(1))
+        .map_err(error_response)?;
+    let buffered = initial_buffered_events(&events, after_seq)?;
     let (tx, out_rx) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(32);
     let runtime_id = agent_id.clone();
     tokio::spawn(async move {
+        let mut last_sent_seq = after_seq.unwrap_or(0);
         for event in buffered {
             if send_stream_event(&tx, &runtime_id, &event).await.is_err() {
                 return;
             }
+            last_sent_seq = last_sent_seq.max(event.event_seq);
         }
         loop {
             match live_rx.recv().await {
                 Ok(published) if published.agent_id.as_deref() == Some(runtime_id.as_str()) => {
+                    if published.event.event_seq <= last_sent_seq {
+                        continue;
+                    }
                     if send_stream_event(&tx, &runtime_id, &published.event)
                         .await
                         .is_err()
                     {
                         break;
                     }
+                    last_sent_seq = published.event.event_seq;
                 }
                 Ok(_) => {}
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -70,6 +70,7 @@ const ROUTES: &[RouteSpec] = &[
     aide_route("get", "/agents/{agent_id}/briefs", "agentBriefs", "agents", "Recent briefs", "Return recent user-facing delivery briefs. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route_with_response("get", "/agents/{agent_id}/briefs/{brief_id}", "agentBrief", "agents", "Brief detail", "Return a persisted user-facing delivery brief by id.", None, "BriefRecord", AuthKind::RemoteAccess),
     aide_route("get", "/agents/{agent_id}/state", "agentState", "agents", "Agent state snapshot", "Return the lightweight bootstrap snapshot for an agent. Heavy task, work-item, operator notification, and execution details are available through dedicated routes and events.", None, AuthKind::RemoteAccess),
+    event_stream_route("get", "/events/stream", "eventsStream", "events", "Global event stream", "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data for all public agents. This live stream uses the in-memory event watcher and does not provide historical replay or a global cursor.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/events", "agentEvents", "events", "Agent event page", "Return a bounded page of runtime event envelopes. Query parameters: before_seq, after_seq, limit, order, max_level. Event payloads are included in full; max_level filters event inclusion only. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.", None, AuthKind::RemoteAccess),
     event_stream_route("get", "/agents/{agent_id}/events/stream", "agentEventsStream", "events", "Agent event stream", "Return Server-Sent Events carrying raw StreamEventEnvelope JSON data. Query parameters: after_seq, limit. SSE id is event_seq; SSE event is the audit event kind; missing replay cursors return cursor_not_found before the stream opens. Breaking change: the projection query parameter and StreamEventEnvelope.projection field have been removed.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/messages/{message_id}", "agentMessage", "messages", "Message detail", "Return a persisted message envelope by id for the selected agent.", None, AuthKind::RemoteAccess),
@@ -632,6 +633,7 @@ mod tests {
             .flat_map(|path| path.as_object().into_iter().flat_map(|ops| ops.keys()))
             .count();
         assert!(operation_count >= 40, "expected baseline coverage");
+        assert!(paths["/events/stream"]["get"].is_object());
         assert!(paths["/agents/{agent_id}/events/stream"]["get"].is_object());
         assert!(paths["/callbacks/wake/{callback_token}"]["post"].is_object());
         assert_eq!(

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     queue::RuntimeQueue,
     runtime_db::RuntimeDb,
-    storage::AppStorage,
+    storage::{AppStorage, EventBus},
     system::{LocalSystem, WorkspaceAccessMode, WorkspaceProjectionKind},
     tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
     types::{
@@ -78,6 +78,7 @@ impl RuntimeHandle {
             None,
             None,
             None,
+            None,
         )
     }
 
@@ -92,6 +93,7 @@ impl RuntimeHandle {
         runtime_db: RuntimeDb,
         host_bridge: RuntimeHostBridge,
         model_catalog: RuntimeModelCatalog,
+        event_bus: EventBus,
     ) -> Result<Self> {
         let base_context_config = context_config.clone();
         Self::new_internal(
@@ -111,6 +113,7 @@ impl RuntimeHandle {
             None,
             Some(runtime_db),
             Some(host_bridge),
+            Some(event_bus),
         )
     }
 
@@ -124,6 +127,7 @@ impl RuntimeHandle {
         context_config: ContextConfig,
         runtime_db: RuntimeDb,
         host_bridge: RuntimeHostBridge,
+        event_bus: EventBus,
     ) -> Result<Self> {
         let model_catalog = RuntimeModelCatalog::from_config(&config);
         let model_availability = resolved_model_availability(&config);
@@ -153,6 +157,7 @@ impl RuntimeHandle {
             Some(ProviderReconfigurator { config }),
             Some(runtime_db),
             Some(host_bridge),
+            Some(event_bus),
         )
     }
 
@@ -173,6 +178,7 @@ impl RuntimeHandle {
         provider_reconfig: Option<ProviderReconfigurator>,
         runtime_db: Option<RuntimeDb>,
         host_bridge: Option<RuntimeHostBridge>,
+        event_bus: Option<EventBus>,
     ) -> Result<Self> {
         let mut provider = provider;
         let PreparedRuntimeStorage {
@@ -183,6 +189,9 @@ impl RuntimeHandle {
             active_tasks,
             active_timers,
         } = prepare_runtime_storage(agent_id, data_dir, initial_workspace, runtime_db)?;
+        if let Some(event_bus) = event_bus {
+            storage.enable_event_bus(event_bus)?;
+        }
 
         if let Some(reconfig) = provider_reconfig.as_ref() {
             let chain = model_catalog.provider_chain_for_turn(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
+use tokio::sync::broadcast;
 
 use crate::{
     memory::index::enqueue_memory_index_upsert,
@@ -61,6 +62,32 @@ pub(crate) struct EventLogPage {
     pub(crate) events: Vec<AuditEvent>,
     pub(crate) has_older: bool,
     pub(crate) has_newer: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PublishedAuditEvent {
+    pub(crate) agent_id: Option<String>,
+    pub(crate) event: AuditEvent,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EventBus {
+    tx: broadcast::Sender<PublishedAuditEvent>,
+}
+
+impl EventBus {
+    pub(crate) fn new(capacity: usize) -> Self {
+        let (tx, _rx) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<PublishedAuditEvent> {
+        self.tx.subscribe()
+    }
+
+    fn publish(&self, event: PublishedAuditEvent) {
+        let _ = self.tx.send(event);
+    }
 }
 
 impl WorkQueuePromptProjection {
@@ -221,6 +248,7 @@ pub struct AppStorage {
     transcript_seq_counter: Arc<Mutex<u64>>,
     audit_event_index: Arc<Mutex<Option<AuditEventIndexSink>>>,
     scheduler_control_plane_db: Arc<Mutex<Option<RuntimeDb>>>,
+    event_bus: Arc<Mutex<Option<EventBus>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -356,6 +384,7 @@ impl AppStorage {
             transcript_seq_counter: Arc::new(Mutex::new(transcript_seq_counter)),
             audit_event_index: Arc::new(Mutex::new(None)),
             scheduler_control_plane_db: Arc::new(Mutex::new(None)),
+            event_bus: Arc::new(Mutex::new(None)),
             data_dir,
         })
     }
@@ -421,6 +450,41 @@ impl AppStorage {
             .lock()
             .map_err(|_| anyhow::anyhow!("scheduler control-plane db mutex poisoned"))?;
         *guard = Some(runtime_db);
+        Ok(())
+    }
+
+    pub(crate) fn enable_event_bus(&self, event_bus: EventBus) -> Result<()> {
+        let mut guard = self
+            .event_bus
+            .lock()
+            .map_err(|_| anyhow::anyhow!("event bus mutex poisoned"))?;
+        *guard = Some(event_bus);
+        Ok(())
+    }
+
+    pub(crate) fn subscribe_events(
+        &self,
+    ) -> Result<Option<broadcast::Receiver<PublishedAuditEvent>>> {
+        Ok(self
+            .event_bus
+            .lock()
+            .map_err(|_| anyhow::anyhow!("event bus mutex poisoned"))?
+            .as_ref()
+            .map(EventBus::subscribe))
+    }
+
+    fn publish_event(&self, agent_id: Option<String>, event: &AuditEvent) -> Result<()> {
+        if let Some(event_bus) = self
+            .event_bus
+            .lock()
+            .map_err(|_| anyhow::anyhow!("event bus mutex poisoned"))?
+            .clone()
+        {
+            event_bus.publish(PublishedAuditEvent {
+                agent_id,
+                event: event.clone(),
+            });
+        }
         Ok(())
     }
 
@@ -540,20 +604,22 @@ impl AppStorage {
             .map_err(|_| anyhow::anyhow!("audit event index mutex poisoned"))?
             .clone()
         {
+            let agent_id = sink.agent_id.clone();
             if let Err(error) = sink
                 .runtime_db
                 .audit_events()
-                .append(sink.agent_id.as_deref(), &event)
+                .append(agent_id.as_deref(), &event)
             {
                 tracing::warn!(
                     error = %error,
                     event_id = %event.id,
                     event_kind = %event.kind,
                     event_seq = event.event_seq,
-                    agent_id = sink.agent_id.as_deref().unwrap_or("<global>"),
+                    agent_id = agent_id.as_deref().unwrap_or("<global>"),
                     "failed to enqueue runtime db audit event"
                 );
             }
+            self.publish_event(agent_id, &event)?;
             return Ok(());
         }
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
@@ -572,6 +638,7 @@ impl AppStorage {
                         "failed to enqueue runtime db audit event"
                     );
                 }
+                self.publish_event(agent_id, &event)?;
                 return Ok(());
             }
         }
@@ -580,6 +647,7 @@ impl AppStorage {
         bytes.extend_from_slice(line.as_bytes());
         bytes.push(b'\n');
         append_jsonl_bytes(&self.events_path, &bytes)?;
+        self.publish_event(self.current_agent_id()?, &event)?;
         Ok(())
     }
 

--- a/tests/http_events.rs
+++ b/tests/http_events.rs
@@ -15,6 +15,8 @@ http_async_tests!(
     events_route_supports_cursor_pagination,
     events_route_supports_cursor_replay,
     events_stream_supports_cursor_and_rfc3339_ts,
+    events_stream_receives_live_events_without_polling_replay,
+    global_events_stream_receives_live_agent_events,
     events_route_preserves_replay_provenance,
     events_route_payload_includes_full_fields,
     events_route_max_level_filters_with_bounded_visible_pages,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -68,7 +68,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 66, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 67, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -567,6 +567,23 @@
   },
   {
     "method": "get",
+    "path": "/events/stream",
+    "handler": "global_events_stream",
+    "operation_id": "eventsStream",
+    "tag": "events",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json",
+      "text/event-stream"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/handshake",
     "handler": "handshake",
     "operation_id": "handshake",

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -290,6 +290,51 @@ pub async fn events_stream_supports_cursor_and_rfc3339_ts() -> Result<()> {
     Ok(())
 }
 
+pub async fn events_stream_receives_live_events_without_polling_replay() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    let mut stream = client
+        .get(format!("{base}/agents/default/events/stream"))
+        .send()
+        .await?;
+    runtime.storage().append_event(&AuditEvent::new(
+        "live_test_event",
+        serde_json::json!({ "live": true }),
+    ))?;
+
+    let event = next_sse_event_kind(&mut stream, "live_test_event").await?;
+    assert_eq!(event.data["agent_id"], "default");
+    assert_eq!(event.data["payload"]["live"], true);
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn global_events_stream_receives_live_agent_events() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+
+    let mut stream = client.get(format!("{base}/events/stream")).send().await?;
+    runtime.storage().append_event(&AuditEvent::new(
+        "global_live_test_event",
+        serde_json::json!({ "global": true }),
+    ))?;
+
+    let event = next_sse_event_kind(&mut stream, "global_live_test_event").await?;
+    assert_eq!(event.data["agent_id"], "default");
+    assert_eq!(
+        event.data["event_seq"].as_u64(),
+        Some(event._id.parse::<u64>()?)
+    );
+    assert_eq!(event.data["payload"]["global"], true);
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn events_route_preserves_replay_provenance() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let runtime = host.default_runtime().await?;


### PR DESCRIPTION
## Summary
- add a shared in-memory audit event bus published after durable event append
- switch agent SSE streams from per-connection storage polling to bounded replay plus live watcher subscription
- add live-only global `GET /events/stream` and OpenAPI coverage

Fixes #1810.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo test --test http_events events_stream_receives_live_events_without_polling_replay -- --nocapture`
- `cargo test --test http_events global_events_stream_receives_live_agent_events -- --nocapture`
- `cargo test openapi::tests::generated_openapi_includes_current_http_surface -- --nocapture`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`