### PR TITLE
fix: add brief content source relation

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -91,6 +91,15 @@
                   "kind": {
                     "const": "transcript_entry",
                     "type": "string"
+                  },
+                  "relation": {
+                    "default": "derived_from",
+                    "enum": [
+                      "derived_from",
+                      "finalizes",
+                      "excerpt"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [

--- a/src/context.rs
+++ b/src/context.rs
@@ -3184,10 +3184,10 @@ mod tests {
         storage::AppStorage,
         types::{
             AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
-            AgentVisibility, AuthorityClass, BriefContentSource, BriefKind, BriefRecord,
-            CallbackDeliveryMode, ContextEpisodeRecord, ContinuationTriggerKind,
-            EpisodeBoundaryReason, ExternalTriggerScope, LoadedAgentsMd, MessageKind,
-            MessageOrigin, Priority, TaskKind, TaskStatus, TodoItem, TodoItemState,
+            AgentVisibility, AuthorityClass, BriefContentSource, BriefContentSourceRelation,
+            BriefKind, BriefRecord, CallbackDeliveryMode, ContextEpisodeRecord,
+            ContinuationTriggerKind, EpisodeBoundaryReason, ExternalTriggerScope, LoadedAgentsMd,
+            MessageKind, MessageOrigin, Priority, TaskKind, TaskStatus, TodoItem, TodoItemState,
             ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind,
             WaitConditionKind, WakeSource, WorkItemRef, WorkItemRefKind, WorkItemRefStatus,
             WorkItemState,
@@ -3750,6 +3750,7 @@ mod tests {
         brief.id = "brief-transcript-backed".into();
         brief.content_source = BriefContentSource::TranscriptEntry {
             entry_id: entry.id.clone(),
+            relation: BriefContentSourceRelation::DerivedFrom,
         };
         let mut turn = TurnRecord::new("default", "turn-transcript-backed", 1);
         turn.input_message_ids = vec![message.id.clone()];

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -2905,6 +2905,7 @@ mod tests {
         let mut brief = brief_with_workspace("default", BriefKind::Result, "preview", "ws-holon");
         brief.content_source = BriefContentSource::TranscriptEntry {
             entry_id: entry.id.clone(),
+            relation: crate::types::BriefContentSourceRelation::DerivedFrom,
         };
         let brief_ref = format!("brief:{}", brief.id);
         storage.append_brief(&brief).unwrap();

--- a/src/object_resolver.rs
+++ b/src/object_resolver.rs
@@ -112,7 +112,7 @@ impl<'a> RuntimeObjectResolver<'a> {
     pub fn resolve_brief_content(&self, brief: &BriefRecord) -> Result<String> {
         match &brief.content_source {
             BriefContentSource::Inline => Ok(brief.text.clone()),
-            BriefContentSource::TranscriptEntry { entry_id } => {
+            BriefContentSource::TranscriptEntry { entry_id, .. } => {
                 let Some(entry) = self.resolve_transcript_entry(entry_id)? else {
                     return Ok(brief.text.clone());
                 };
@@ -310,6 +310,7 @@ mod tests {
         let mut brief = BriefRecord::new("agent-a", BriefKind::Result, "preview", None, None);
         brief.content_source = BriefContentSource::TranscriptEntry {
             entry_id: entry.id.clone(),
+            relation: crate::types::BriefContentSourceRelation::DerivedFrom,
         };
         storage.append_brief(&brief).unwrap();
 
@@ -354,6 +355,7 @@ mod tests {
         let mut brief = BriefRecord::new("agent-a", BriefKind::Result, "preview", None, None);
         brief.content_source = BriefContentSource::TranscriptEntry {
             entry_id: "missing".into(),
+            relation: crate::types::BriefContentSourceRelation::DerivedFrom,
         };
         storage.append_brief(&brief).unwrap();
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1188,7 +1188,7 @@ pub(crate) struct BriefTextLookup<'a>(pub(crate) &'a std::collections::BTreeMap<
 impl<'a> BriefTextLookup<'a> {
     pub(crate) fn resolve_for_record(&self, brief: &BriefRecord) -> Option<&str> {
         match brief.content_source {
-            crate::types::BriefContentSource::TranscriptEntry { ref entry_id } => {
+            crate::types::BriefContentSource::TranscriptEntry { ref entry_id, .. } => {
                 self.0.get(entry_id).map(String::as_str)
             }
             crate::types::BriefContentSource::Inline => None,
@@ -1198,7 +1198,7 @@ impl<'a> BriefTextLookup<'a> {
     pub(crate) fn resolve_for_event(&self, event: &ProjectionEventRecord) -> Option<&str> {
         let brief = serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone()).ok()?;
         match brief.content_source {
-            crate::types::BriefContentSource::TranscriptEntry { ref entry_id } => {
+            crate::types::BriefContentSource::TranscriptEntry { ref entry_id, .. } => {
                 self.0.get(entry_id).map(String::as_str)
             }
             crate::types::BriefContentSource::Inline => None,
@@ -3614,6 +3614,7 @@ mod tests {
         let mut brief = BriefRecord::new("default", BriefKind::Result, "preview only", None, None);
         brief.content_source = crate::types::BriefContentSource::TranscriptEntry {
             entry_id: "transcript-entry-1".into(),
+            relation: crate::types::BriefContentSourceRelation::DerivedFrom,
         };
         let event = make_event("brief_created", "Brief: preview only", json!(brief));
         let brief_texts = std::collections::BTreeMap::from([(

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -708,6 +708,7 @@ fn bind_brief_to_assistant_round(brief: &mut BriefRecord, entry_id: Option<&str>
         brief.finalizes_assistant_round_id = Some(entry_id.to_string());
         brief.content_source = crate::types::BriefContentSource::TranscriptEntry {
             entry_id: entry_id.to_string(),
+            relation: crate::types::BriefContentSourceRelation::Finalizes,
         };
     }
 }

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -795,7 +795,7 @@ impl TuiProjection {
                 let brief =
                     serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone()).ok()?;
                 match &brief.content_source {
-                    BriefContentSource::TranscriptEntry { entry_id } => {
+                    BriefContentSource::TranscriptEntry { entry_id, .. } => {
                         if self.brief_text_cache.contains_key(entry_id) {
                             return None;
                         }
@@ -824,7 +824,7 @@ impl TuiProjection {
     pub(crate) fn brief_text_for_event(&self, event: &ProjectionEventRecord) -> Option<&str> {
         let brief = serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone()).ok()?;
         match &brief.content_source {
-            BriefContentSource::TranscriptEntry { entry_id } => {
+            BriefContentSource::TranscriptEntry { entry_id, .. } => {
                 self.brief_text_cache.get(entry_id).map(String::as_str)
             }
             BriefContentSource::Inline => None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3996,16 +3996,50 @@ impl BriefCreatedAuditEvent {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BriefContentSourceRelation {
+    DerivedFrom,
+    Finalizes,
+    Excerpt,
+}
+
+impl Default for BriefContentSourceRelation {
+    fn default() -> Self {
+        Self::DerivedFrom
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum BriefContentSource {
-    TranscriptEntry { entry_id: String },
+    TranscriptEntry {
+        entry_id: String,
+        #[serde(default)]
+        relation: BriefContentSourceRelation,
+    },
     Inline,
 }
 
 impl Default for BriefContentSource {
     fn default() -> Self {
         Self::Inline
+    }
+}
+
+impl BriefContentSource {
+    pub fn transcript_entry_id(&self) -> Option<&str> {
+        match self {
+            Self::TranscriptEntry { entry_id, .. } => Some(entry_id),
+            Self::Inline => None,
+        }
+    }
+
+    pub fn relation(&self) -> Option<BriefContentSourceRelation> {
+        match self {
+            Self::TranscriptEntry { relation, .. } => Some(*relation),
+            Self::Inline => None,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `BriefContentSourceRelation` for transcript-backed briefs (`derived_from`, `finalizes`, `excerpt`)
- write the richer `finalizes` relation when binding completion briefs while preserving `finalizes_assistant_round_id` during migration
- update consumers/tests to tolerate relation-bearing transcript-backed sources

Closes #1818.
Part of #1820.

## Verification
- cargo fmt --all -- --check
- cargo test resolves_transcript_backed_brief_content --lib
- RUSTFLAGS="-D warnings" cargo check --all-targets