### PR TITLE
fix: cancel stale agent-scoped waits on new wait and agent archival

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1129,6 +1129,34 @@ impl RuntimeHost {
                 .await;
             let _ = entry.task.await;
         }
+        // Cancel any active wait conditions before removing the data directory.
+        // This produces audit events and avoids orphaned active waits.
+        let now = chrono::Utc::now();
+        if let Ok(storage) = self.agent_storage(agent_id) {
+            if let Ok(active) = storage.latest_active_wait_conditions_for_agent(agent_id) {
+                let mut cancelled_ids = Vec::new();
+                for condition in active {
+                    let mut cancelled = condition.clone();
+                    cancelled.status = crate::types::WaitConditionStatus::Cancelled;
+                    cancelled.updated_at = now;
+                    cancelled.cancelled_at = Some(now);
+                    if storage.append_wait_condition(&cancelled).is_ok() {
+                        cancelled_ids.push(condition.id);
+                    }
+                }
+                if !cancelled_ids.is_empty() {
+                    let _ = storage.append_event(&crate::types::AuditEvent::new(
+                        "wait_conditions_cancelled",
+                        serde_json::json!({
+                            "agent_id": agent_id,
+                            "reason": "agent_archived",
+                            "wait_condition_ids": cancelled_ids,
+                        }),
+                    ));
+                }
+            }
+        }
+
         let data_dir = self.agent_data_dir(agent_id);
         if data_dir.exists() {
             fs::remove_dir_all(&data_dir)?;

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3235,10 +3235,7 @@ async fn register_wait_for_agent_scoped_cancels_prior_agent_scoped_waits() {
         .await
         .unwrap();
     assert_eq!(second.cancelled_wait_condition_ids.len(), 1);
-    assert_eq!(
-        second.cancelled_wait_condition_ids[0],
-        first.condition.id
-    );
+    assert_eq!(second.cancelled_wait_condition_ids[0], first.condition.id);
 
     // The first wait condition should now be cancelled
     let active = runtime

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3189,3 +3189,71 @@ fn wake_hint_preserved_when_replaced_during_critical_window() {
     let events = runtime.storage().read_recent_events(10).unwrap();
     assert!(events.iter().any(|e| e.kind == "system_tick_emitted"));
 }
+
+#[tokio::test]
+async fn register_wait_for_agent_scoped_cancels_prior_agent_scoped_waits() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(CountingProvider {
+            calls: Mutex::new(0),
+            reply: "unused",
+        }),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    // First agent-scoped wait
+    let first = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "first agent wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(first.cancelled_wait_condition_ids.is_empty());
+
+    // Second agent-scoped wait should cancel the first
+    let second = runtime
+        .register_wait_for(
+            "default",
+            None,
+            WaitForWakeKind::OperatorInput,
+            None,
+            "second agent wait".into(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.cancelled_wait_condition_ids.len(), 1);
+    assert_eq!(
+        second.cancelled_wait_condition_ids[0],
+        first.condition.id
+    );
+
+    // The first wait condition should now be cancelled
+    let active = runtime
+        .storage()
+        .latest_active_wait_conditions_for_agent("default")
+        .unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].id, second.condition.id);
+    assert_eq!(active[0].status, WaitConditionStatus::Active);
+
+    // Verify the first condition was cancelled
+    let all_conditions = runtime.storage().latest_wait_conditions().unwrap();
+    let first_record = all_conditions
+        .iter()
+        .find(|c| c.id == first.condition.id)
+        .unwrap();
+    assert_eq!(first_record.status, WaitConditionStatus::Cancelled);
+}

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -80,7 +80,7 @@ impl RuntimeHandle {
         let (kind, subject_ref, wake_sources) = wait_condition_parts(wake, resource.clone())?;
         let recheck_at = recheck_after_ms.map(|delay| recheck_at_from(now, delay));
         let mut work_item = None;
-        let mut cancelled_wait_condition_ids = Vec::new();
+        let cancelled_wait_condition_ids;
         if let Some(work_item_id) = work_item_id.as_deref() {
             let existing = self.validate_owned_work_item(agent_id, work_item_id)?;
             if existing.state != WorkItemState::Open {
@@ -102,6 +102,12 @@ impl RuntimeHandle {
             self.clear_current_turn_work_item_if_matches(agent_id, &updated, "work_item_waiting")
                 .await?;
             work_item = Some(updated);
+        } else {
+            // Agent-scoped wait: cancel prior active agent-scoped waits,
+            // symmetric with the work-item-scoped branch above.
+            cancelled_wait_condition_ids = self
+                .cancel_active_wait_conditions_for_agent(agent_id, "wait_for_replaced")
+                .await?;
         }
 
         let condition = WaitConditionRecord {
@@ -192,6 +198,40 @@ impl RuntimeHandle {
                 serde_json::json!({
                     "agent_id": agent_id,
                     "work_item_id": work_item_id,
+                    "reason": reason,
+                    "wait_condition_ids": cancelled,
+                }),
+            ))?;
+        }
+        Ok(cancelled)
+    }
+
+    pub(super) async fn cancel_active_wait_conditions_for_agent(
+        &self,
+        agent_id: &str,
+        reason: &str,
+    ) -> Result<Vec<String>> {
+        let now = Utc::now();
+        let active = self
+            .inner
+            .storage
+            .latest_active_wait_conditions_for_agent(agent_id)?;
+        let mut cancelled = Vec::new();
+        for condition in active {
+            let mut cancelled_condition = condition.clone();
+            cancelled_condition.status = WaitConditionStatus::Cancelled;
+            cancelled_condition.updated_at = now;
+            cancelled_condition.cancelled_at = Some(now);
+            self.inner
+                .storage
+                .append_wait_condition(&cancelled_condition)?;
+            cancelled.push(condition.id);
+        }
+        if !cancelled.is_empty() {
+            self.inner.storage.append_event(&AuditEvent::new(
+                "wait_conditions_cancelled",
+                serde_json::json!({
+                    "agent_id": agent_id,
                     "reason": reason,
                     "wait_condition_ids": cancelled,
                 }),


### PR DESCRIPTION
## Summary

Fixes #1808.

Agent-scoped waits (where `work_item_id` is `None`) created in `register_wait_for` did not cancel prior stale agent-scoped waits. The work-item-scoped path already had symmetric cleanup via `cancel_active_wait_conditions_for_work_item`, but the agent-scoped path was completely missing this behavior.

Additionally, `archive_private_agent` did not cancel active wait conditions before removing the agent data directory, potentially leaving orphaned active waits.

## Changes

1. **`src/runtime/waiting.rs`** — Added `cancel_active_wait_conditions_for_agent` method, symmetric with the existing `cancel_active_wait_conditions_for_work_item`. In `register_wait_for`, when a new agent-scoped wait is created (the `else` branch), prior active agent-scoped waits are now cancelled with reason `wait_for_replaced`.

2. **`src/host.rs`** — In `archive_private_agent`, before removing the data directory, cancel all active wait conditions for that agent with reason `agent_archived`, producing proper audit events.

3. **`src/runtime/tests/runtime_state.rs`** — Added `register_wait_for_agent_scoped_cancels_prior_agent_scoped_waits` test verifying that a second agent-scoped wait cancels the first and that the first condition transitions to `Cancelled`.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- All 82 wait-related tests pass ✅
- All 38 scheduler tests pass ✅
- New test passes ✅