### PR TITLE
fix: slim duplicate runtime payload records

### DIFF
--- a/docs/implementation-decisions/060-index-and-event-payload-disposition.md
+++ b/docs/implementation-decisions/060-index-and-event-payload-disposition.md
@@ -1,0 +1,28 @@
+# Index and event payload disposition
+
+## Decision
+
+Secondary indexes and audit events should not carry full duplicate runtime
+objects when a canonical table or ledger entry already owns the object. Keep
+index/event payloads to stable ids, summaries, and bounded display metadata.
+
+## Disposition
+
+- `message_search_index`: removed the `payload_json` FTS column. The index now
+  stores only ids, filter fields, kind, and searchable body text; query results
+  hydrate from the canonical `messages` table.
+- `work_item_plan_artifact_refreshed`: replaced the full `plan_artifact` copy
+  with artifact path, hash, byte count, update time, and preview completeness.
+  The work item record and plan artifact file remain canonical.
+- `work_item_continuation_*`: replaced full continuation frames in event
+  payloads with continuation summaries. The `work_item_continuations` table
+  remains canonical.
+- `turn_record`: kept the event as an auditable notice with turn ids and
+  relation ids. The `turn_records` spine remains canonical for the full turn
+  projection.
+- `turn_terminal_aborted`: removed the embedded terminal record copy because
+  the terminal record is already persisted through the turn terminal and turn
+  record paths.
+
+Canonical `payload_json` columns remain in object-owner tables where they are
+the durable object representation rather than a secondary duplicate.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -458,6 +458,27 @@ impl RuntimeHandle {
             .storage
             .append_event(&AuditEvent::new("work_item_written", payload))
     }
+
+    pub(crate) fn append_work_item_plan_artifact_refreshed_event(
+        &self,
+        record: &crate::types::WorkItemRecord,
+    ) -> Result<()> {
+        let Some(artifact) = record.plan_artifact.as_ref() else {
+            return Ok(());
+        };
+        self.inner.storage.append_event(&AuditEvent::new(
+            "work_item_plan_artifact_refreshed",
+            serde_json::json!({
+                "work_item_id": record.id,
+                "revision": record.revision,
+                "plan_artifact_path": artifact.path,
+                "plan_artifact_hash": artifact.hash,
+                "plan_artifact_bytes": artifact.bytes,
+                "plan_artifact_updated_at": artifact.updated_at,
+                "preview_complete": artifact.preview_complete,
+            }),
+        ))
+    }
 }
 
 impl RuntimeHandle {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -118,14 +118,7 @@ impl RuntimeHandle {
                 .upsert(&record, current_focus)?;
             self.inner.storage.append_work_item(&record)?;
             if plan_artifact_changed {
-                self.inner.storage.append_event(&AuditEvent::new(
-                    "work_item_plan_artifact_refreshed",
-                    serde_json::json!({
-                        "work_item_id": record.id.clone(),
-                        "revision": record.revision,
-                        "plan_artifact": record.plan_artifact.clone(),
-                    }),
-                ))?;
+                self.append_work_item_plan_artifact_refreshed_event(&record)?;
             }
             self.append_work_item_written_event("turn_end_committed", &record, Value::Null)?;
             record

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2255,8 +2255,7 @@ impl RuntimeHandle {
                 "work_item_continuation_resumed",
                 serde_json::json!({
                     "agent_id": agent_id,
-                    "frame": resolved,
-                    "reason": "explicit_pick",
+                    "continuation": continuation_summary(&resolved, "explicit_pick"),
                 }),
             ))?;
         }
@@ -2274,8 +2273,7 @@ impl RuntimeHandle {
                     "work_item_continuation_cancelled",
                     serde_json::json!({
                         "agent_id": agent_id,
-                        "frame": cancelled,
-                        "reason": "current_focus_reselected",
+                        "continuation": continuation_summary(&cancelled, "current_focus_reselected"),
                     }),
                 ))?;
             }
@@ -2312,8 +2310,7 @@ impl RuntimeHandle {
                     "work_item_continuation_created",
                     serde_json::json!({
                         "agent_id": agent_id,
-                        "frame": frame,
-                        "reason": "pick_work_item",
+                        "continuation": continuation_summary(&frame, "pick_work_item"),
                     }),
                 ))?;
             }
@@ -2493,14 +2490,7 @@ impl RuntimeHandle {
                 .upsert(&record, current_focus)?;
             self.inner.storage.append_work_item(&record)?;
             if plan_artifact_changed && record.plan_artifact != existing.plan_artifact {
-                self.inner.storage.append_event(&AuditEvent::new(
-                    "work_item_plan_artifact_refreshed",
-                    serde_json::json!({
-                        "work_item_id": record.id.clone(),
-                        "revision": record.revision,
-                        "plan_artifact": record.plan_artifact.clone(),
-                    }),
-                ))?;
+                self.append_work_item_plan_artifact_refreshed_event(&record)?;
             }
             self.append_work_item_written_event(
                 "updated",
@@ -2564,14 +2554,7 @@ impl RuntimeHandle {
             .upsert(&record, current_focus)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_plan_artifact_refreshed",
-                serde_json::json!({
-                    "work_item_id": record.id.clone(),
-                    "revision": record.revision,
-                    "plan_artifact": record.plan_artifact.clone(),
-                }),
-            ))?;
+            self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_recheck_consumed",
@@ -2627,14 +2610,7 @@ impl RuntimeHandle {
         self.inner.runtime_db.work_items().upsert(&record, false)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_plan_artifact_refreshed",
-                serde_json::json!({
-                    "work_item_id": record.id.clone(),
-                    "revision": record.revision,
-                    "plan_artifact": record.plan_artifact.clone(),
-                }),
-            ))?;
+            self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
         {
             self.release_current_work_item_if_matches(&agent_id, &record, "work_item_completed")
@@ -2805,8 +2781,7 @@ impl RuntimeHandle {
                 "work_item_continuation_cancelled",
                 serde_json::json!({
                     "agent_id": agent_id,
-                    "frame": cancelled,
-                    "reason": "suspended_work_item_missing",
+                    "continuation": continuation_summary(&cancelled, "suspended_work_item_missing"),
                 }),
             ))?;
             return Ok(None);
@@ -2820,8 +2795,7 @@ impl RuntimeHandle {
                 "work_item_continuation_cancelled",
                 serde_json::json!({
                     "agent_id": agent_id,
-                    "frame": cancelled,
-                    "reason": "suspended_work_item_not_open",
+                    "continuation": continuation_summary(&cancelled, "suspended_work_item_not_open"),
                     "suspended_work_item_state": suspended.state,
                 }),
             ))?;
@@ -2845,8 +2819,7 @@ impl RuntimeHandle {
             "work_item_continuation_resumed",
             serde_json::json!({
                 "agent_id": agent_id,
-                "frame": resumed,
-                "reason": "active_work_item_completed",
+                "continuation": summary,
                 "completed_work_item_id": completed.id,
                 "resumed_work_item_id": suspended.id,
             }),

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -1273,10 +1273,22 @@ async fn turn_end_refreshes_changed_work_item_plan_artifact_snapshot() {
         committed.plan_artifact.as_ref().unwrap().hash
     );
     let events = runtime.storage().read_recent_events(20).unwrap();
-    assert!(events
+    let refreshed = events
         .iter()
-        .any(|event| event.kind == "work_item_plan_artifact_refreshed"
-            && event.data["work_item_id"].as_str() == Some(work.id.as_str())));
+        .find(|event| {
+            event.kind == "work_item_plan_artifact_refreshed"
+                && event.data["work_item_id"].as_str() == Some(work.id.as_str())
+        })
+        .expect("plan artifact refresh event");
+    assert!(refreshed.data.get("plan_artifact").is_none());
+    assert_eq!(
+        refreshed.data["plan_artifact_hash"].as_str(),
+        Some(committed.plan_artifact.as_ref().unwrap().hash.as_str())
+    );
+    assert_eq!(
+        refreshed.data["preview_complete"].as_bool(),
+        Some(committed.plan_artifact.as_ref().unwrap().preview_complete)
+    );
 }
 
 #[tokio::test]
@@ -5019,6 +5031,21 @@ async fn pick_from_runnable_current_yields_and_complete_resumes_caller() {
             && event.data["reason"].as_str() == Some("continuation_resumed")
             && event.data["work_item_id"].as_str() == Some(current.id.as_str())
     }));
+    let continuation_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.kind.starts_with("work_item_continuation_"))
+        .collect();
+    assert!(continuation_events
+        .iter()
+        .any(|event| event.data["continuation"]["frame_id"].as_str()
+            == Some(created.frame_id.as_str())));
+    assert!(continuation_events
+        .iter()
+        .any(|event| event.data["continuation"]["frame_id"].as_str()
+            == Some(resumed.frame_id.as_str())));
+    assert!(continuation_events
+        .iter()
+        .all(|event| event.data.get("frame").is_none()));
 }
 
 #[tokio::test]

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -1754,7 +1754,19 @@ impl RuntimeHandle {
         self.inner.storage.append_turn(&record)?;
         self.inner.storage.append_event(&AuditEvent::new(
             "turn_record",
-            serde_json::to_value(&record)?,
+            serde_json::json!({
+                "turn_id": record.turn_id,
+                "turn_index": record.turn_index,
+                "agent_id": record.agent_id,
+                "run_id": record.run_id,
+                "current_work_item_id": record.current_work_item_id,
+                "tool_execution_ids": record.tool_execution_ids,
+                "produced_brief_ids": record.produced_brief_ids,
+                "completed_work_item_ids": record.completed_work_item_ids,
+                "waiting_condition_ids": record.waiting_condition_ids,
+                "terminal": record.terminal,
+                "created_at": record.created_at,
+            }),
         ))?;
         Ok(())
     }
@@ -1924,7 +1936,11 @@ impl RuntimeHandle {
             serde_json::json!({
                 "run_id": run_id,
                 "reason": reason,
-                "record": record,
+                "turn_id": record.turn_id.clone(),
+                "turn_index": record.turn_index,
+                "kind": record.kind,
+                "completed_at": record.completed_at,
+                "duration_ms": record.duration_ms,
             }),
         ))?;
         Ok(record)

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -317,14 +317,7 @@ impl RuntimeHandle {
             .upsert(&record, current_focus)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_plan_artifact_refreshed",
-                serde_json::json!({
-                    "work_item_id": record.id.clone(),
-                    "revision": record.revision,
-                    "plan_artifact": record.plan_artifact.clone(),
-                }),
-            ))?;
+            self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
         self.append_work_item_written_event("wait_for_blocked", &record, Value::Null)?;
         Ok(record)
@@ -396,14 +389,7 @@ impl RuntimeHandle {
             .upsert(&record, current_focus)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_plan_artifact_refreshed",
-                serde_json::json!({
-                    "work_item_id": record.id.clone(),
-                    "revision": record.revision,
-                    "plan_artifact": record.plan_artifact.clone(),
-                }),
-            ))?;
+            self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
         self.append_work_item_written_event(
             "wait_for_task_resolved",
@@ -471,14 +457,7 @@ impl RuntimeHandle {
             .upsert(&record, current_focus)?;
         self.inner.storage.append_work_item(&record)?;
         if plan_artifact_changed {
-            self.inner.storage.append_event(&AuditEvent::new(
-                "work_item_plan_artifact_refreshed",
-                serde_json::json!({
-                    "work_item_id": record.id.clone(),
-                    "revision": record.revision,
-                    "plan_artifact": record.plan_artifact.clone(),
-                }),
-            ))?;
+            self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
         self.append_work_item_written_event(
             "pick_blocker_cleared",

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -2783,7 +2783,7 @@ fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<
             payload_json,
         ],
     )?;
-    upsert_message_search_index_tx(tx, message, &kind, &payload_json)?;
+    upsert_message_search_index_tx(tx, message, &kind)?;
     Ok(())
 }
 
@@ -2791,7 +2791,6 @@ fn upsert_message_search_index_tx(
     tx: &Transaction<'_>,
     message: &MessageEnvelope,
     kind: &str,
-    payload_json: &str,
 ) -> Result<()> {
     tx.execute(
         "DELETE FROM message_search_index WHERE evidence_id = ?1",
@@ -2800,8 +2799,8 @@ fn upsert_message_search_index_tx(
     tx.execute(
         "INSERT INTO message_search_index (
             evidence_id, agent_id, turn_id, message_id, task_id, work_item_id,
-            kind, body_text, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            kind, body_text
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             message.id,
             message.agent_id,
@@ -2811,7 +2810,6 @@ fn upsert_message_search_index_tx(
             message.work_item_id,
             kind,
             message_body_search_text(&message.body),
-            payload_json,
         ],
     )?;
     Ok(())
@@ -4871,13 +4869,12 @@ CREATE VIRTUAL TABLE IF NOT EXISTS message_search_index USING fts5(
   task_id UNINDEXED,
   work_item_id UNINDEXED,
   kind,
-  body_text,
-  payload_json
+  body_text
 );
 
 INSERT INTO message_search_index (
   evidence_id, agent_id, turn_id, message_id, task_id, work_item_id,
-  kind, body_text, payload_json
+  kind, body_text
 )
 SELECT
   messages.evidence_id,
@@ -4887,8 +4884,7 @@ SELECT
   messages.task_id,
   messages.work_item_id,
   messages.kind,
-  COALESCE(messages.preview, ''),
-  messages.payload_json
+  COALESCE(messages.preview, '')
 FROM messages
 WHERE NOT EXISTS (
   SELECT 1
@@ -6395,6 +6391,13 @@ CREATE TABLE working_memory_deltas (
     fn message_search_indexes_messages_across_agents() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let columns = db
+            .connection()?
+            .prepare("PRAGMA table_info(message_search_index)")?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        assert!(!columns.iter().any(|column| column == "payload_json"));
+
         let mut first = MessageEnvelope::new(
             "agent-a",
             crate::types::MessageKind::OperatorPrompt,


### PR DESCRIPTION
## Summary
- replace duplicated transcript/tool/work-item payload copies in secondary records/events with canonical refs plus bounded fields
- keep event stream payloads only where they are the delivery surface, and document the payload disposition
- add tests for ref-backed searchable records and slim work-item lifecycle events

Fixes #1817

## Verification
- cargo fmt --all -- --check
- cargo test --lib runtime_db::tests::message_search_indexes_messages_across_agents
- cargo test --lib runtime::tests::work_items::turn_end_refreshes_changed_work_item_plan_artifact_snapshot
- cargo test --lib runtime::tests::work_items::pick_from_runnable_current_yields_and_complete_resumes_caller
- RUSTFLAGS="-D warnings" cargo check --all-targets