### PR TITLE
feat: cache current runtime projections

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -19,6 +19,10 @@ static HTTP_OTHER: MetricAccumulator = MetricAccumulator::new("http.json.other")
 
 static PROJECTION_AGENT_SUMMARY: MetricAccumulator =
     MetricAccumulator::new("projection.agent_summary");
+static PROJECTION_RUNTIME_CACHE_REBUILD: MetricAccumulator =
+    MetricAccumulator::new("projection.runtime_current_cache.rebuild");
+static PROJECTION_RUNTIME_CACHE_READ: MetricAccumulator =
+    MetricAccumulator::new("projection.runtime_current_cache.read");
 static DB_CONNECTION_OPEN: MetricAccumulator = MetricAccumulator::new("db.connection.open");
 
 static SCHEDULER_POLL_ALL: MetricAccumulator = MetricAccumulator::new("scheduler.poll.all");
@@ -120,6 +124,16 @@ pub fn record_agent_summary_projection(elapsed: Duration) {
     PROJECTION_AGENT_SUMMARY.record(elapsed, None);
 }
 
+pub fn record_runtime_projection_cache_rebuild() {
+    process_started_at();
+    PROJECTION_RUNTIME_CACHE_REBUILD.record(Duration::ZERO, None);
+}
+
+pub fn record_runtime_projection_cache_read() {
+    process_started_at();
+    PROJECTION_RUNTIME_CACHE_READ.record(Duration::ZERO, None);
+}
+
 pub fn record_runtime_db_connection_open(elapsed: Duration) {
     process_started_at();
     DB_CONNECTION_OPEN.record(elapsed, None);
@@ -144,7 +158,11 @@ pub fn performance_snapshot() -> PerformanceDiagnosticsSnapshot {
             HTTP_AGENT_STATE.snapshot(true),
             HTTP_OTHER.snapshot(true),
         ],
-        projections: vec![PROJECTION_AGENT_SUMMARY.snapshot(false)],
+        projections: vec![
+            PROJECTION_AGENT_SUMMARY.snapshot(false),
+            PROJECTION_RUNTIME_CACHE_REBUILD.snapshot(false),
+            PROJECTION_RUNTIME_CACHE_READ.snapshot(false),
+        ],
         db: vec![DB_CONNECTION_OPEN.snapshot(false)],
         scheduler: vec![
             SCHEDULER_POLL_ALL.snapshot(false),
@@ -197,6 +215,8 @@ mod tests {
     fn snapshot_includes_bounded_runtime_hotspot_groups() {
         record_http_json_response("/agents/{agent_id}/state", Duration::from_millis(7), 1024);
         record_agent_summary_projection(Duration::from_millis(3));
+        record_runtime_projection_cache_rebuild();
+        record_runtime_projection_cache_read();
         record_runtime_db_connection_open(Duration::from_millis(2));
         record_scheduler_poll("idle", Duration::from_millis(1));
 
@@ -213,6 +233,12 @@ mod tests {
             .projections
             .iter()
             .any(|metric| metric.name == "projection.agent_summary" && metric.count >= 1));
+        assert!(snapshot.projections.iter().any(|metric| {
+            metric.name == "projection.runtime_current_cache.rebuild" && metric.count >= 1
+        }));
+        assert!(snapshot.projections.iter().any(|metric| {
+            metric.name == "projection.runtime_current_cache.read" && metric.count >= 1
+        }));
         assert!(snapshot
             .db
             .iter()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -235,6 +235,7 @@ pub struct RuntimeHandle {
 
 struct RuntimeInner {
     agent: Mutex<RuntimeAgent>,
+    projection_cache: Mutex<AgentRuntimeProjectionCache>,
     notify: Notify,
     storage: AppStorage,
     runtime_db: RuntimeDb,
@@ -261,6 +262,173 @@ struct RuntimeInner {
     recovered_timers: Mutex<Option<Vec<TimerRecord>>>,
     suppress_next_continue_active_tick: Mutex<bool>,
     shutdown_requested: AtomicBool,
+}
+
+#[derive(Debug, Clone)]
+struct AgentRuntimeProjectionCache {
+    agent_id: String,
+    tasks: HashMap<String, TaskRecord>,
+    work_items: HashMap<String, crate::types::WorkItemRecord>,
+    timers: HashMap<String, TimerRecord>,
+    waiting_intents: HashMap<String, WaitingIntentRecord>,
+    external_triggers: HashMap<String, ExternalTriggerRecord>,
+}
+
+impl AgentRuntimeProjectionCache {
+    fn rebuild(
+        agent_id: String,
+        tasks: Vec<TaskRecord>,
+        work_items: Vec<crate::types::WorkItemRecord>,
+        timers: Vec<TimerRecord>,
+        waiting_intents: Vec<WaitingIntentRecord>,
+        external_triggers: Vec<ExternalTriggerRecord>,
+    ) -> Self {
+        crate::diagnostics::record_runtime_projection_cache_rebuild();
+        let task_agent_id = agent_id.clone();
+        let work_item_agent_id = agent_id.clone();
+        let timer_agent_id = agent_id.clone();
+        let waiting_intent_agent_id = agent_id.clone();
+        let external_trigger_agent_id = agent_id.clone();
+        Self {
+            agent_id,
+            tasks: latest_by(
+                tasks
+                    .into_iter()
+                    .filter(|record| record.agent_id == task_agent_id),
+                |record| record.id.clone(),
+            ),
+            work_items: latest_by(
+                work_items
+                    .into_iter()
+                    .filter(|record| record.agent_id == work_item_agent_id),
+                |record| record.id.clone(),
+            ),
+            timers: latest_by(
+                timers
+                    .into_iter()
+                    .filter(|record| record.agent_id == timer_agent_id),
+                |record| record.id.clone(),
+            ),
+            waiting_intents: latest_by(
+                waiting_intents
+                    .into_iter()
+                    .filter(|record| record.agent_id == waiting_intent_agent_id),
+                |record| record.id.clone(),
+            ),
+            external_triggers: latest_by(
+                external_triggers
+                    .into_iter()
+                    .filter(|record| record.target_agent_id == external_trigger_agent_id),
+                |record| record.external_trigger_id.clone(),
+            ),
+        }
+    }
+
+    fn upsert_task(&mut self, record: TaskRecord) {
+        if record.agent_id == self.agent_id {
+            self.tasks.insert(record.id.clone(), record);
+        }
+    }
+
+    fn upsert_work_item(&mut self, record: crate::types::WorkItemRecord) {
+        if record.agent_id == self.agent_id {
+            self.work_items.insert(record.id.clone(), record);
+        }
+    }
+
+    fn upsert_timer(&mut self, record: TimerRecord) {
+        if record.agent_id == self.agent_id {
+            self.timers.insert(record.id.clone(), record);
+        }
+    }
+
+    fn upsert_waiting_intent(&mut self, record: WaitingIntentRecord) {
+        if record.agent_id == self.agent_id {
+            self.waiting_intents.insert(record.id.clone(), record);
+        }
+    }
+
+    fn upsert_external_trigger(&mut self, record: ExternalTriggerRecord) {
+        if record.target_agent_id == self.agent_id {
+            self.external_triggers
+                .insert(record.external_trigger_id.clone(), record);
+        }
+    }
+
+    fn active_tasks(&self, limit: usize) -> Vec<TaskRecord> {
+        let mut records = self
+            .tasks
+            .values()
+            .filter(|record| {
+                matches!(
+                    record.status,
+                    TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling
+                )
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| right.created_at.cmp(&left.created_at))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        take_limit(records, limit)
+    }
+
+    fn latest_work_items(&self, limit: usize) -> Vec<crate::types::WorkItemRecord> {
+        let mut records = self.work_items.values().cloned().collect::<Vec<_>>();
+        records.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| right.created_at.cmp(&left.created_at))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        take_limit(records, limit)
+    }
+
+    fn recent_timers(&self, limit: usize) -> Vec<TimerRecord> {
+        let mut records = self.timers.values().cloned().collect::<Vec<_>>();
+        records.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        take_limit(records, limit)
+    }
+
+    fn latest_waiting_intents(&self) -> Vec<WaitingIntentRecord> {
+        let mut records = self.waiting_intents.values().cloned().collect::<Vec<_>>();
+        records.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        records
+    }
+
+    fn latest_external_triggers(&self) -> Vec<ExternalTriggerRecord> {
+        let mut records = self.external_triggers.values().cloned().collect::<Vec<_>>();
+        records.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        records
+    }
+}
+
+fn latest_by<T, F>(records: impl IntoIterator<Item = T>, key: F) -> HashMap<String, T>
+where
+    F: Fn(&T) -> String,
+{
+    let mut latest = HashMap::new();
+    for record in records {
+        latest.insert(key(&record), record);
+    }
+    latest
+}
+
+fn take_limit<T>(mut records: Vec<T>, limit: usize) -> Vec<T> {
+    if records.len() > limit {
+        records.truncate(limit);
+    }
+    records
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -441,6 +609,60 @@ impl CurrentRunAbortSnapshot {
 }
 
 impl RuntimeHandle {
+    pub(crate) async fn record_task_projection(&self, record: &TaskRecord) -> Result<()> {
+        self.inner.storage.append_task(record)?;
+        self.inner
+            .projection_cache
+            .lock()
+            .await
+            .upsert_task(record.clone());
+        Ok(())
+    }
+
+    pub(crate) async fn record_work_item_projection(
+        &self,
+        record: &crate::types::WorkItemRecord,
+    ) -> Result<()> {
+        self.inner.storage.append_work_item(record)?;
+        self.inner
+            .projection_cache
+            .lock()
+            .await
+            .upsert_work_item(record.clone());
+        Ok(())
+    }
+
+    pub(crate) async fn record_timer_projection(&self, record: &TimerRecord) -> Result<()> {
+        self.inner.storage.append_timer(record)?;
+        self.inner
+            .projection_cache
+            .lock()
+            .await
+            .upsert_timer(record.clone());
+        Ok(())
+    }
+
+    pub(crate) async fn record_waiting_intent_projection(
+        &self,
+        record: &WaitingIntentRecord,
+    ) -> Result<()> {
+        self.inner.storage.append_waiting_intent(record)?;
+        self.inner
+            .projection_cache
+            .lock()
+            .await
+            .upsert_waiting_intent(record.clone());
+        Ok(())
+    }
+
+    pub(crate) async fn cache_external_trigger_projection(&self, record: &ExternalTriggerRecord) {
+        self.inner
+            .projection_cache
+            .lock()
+            .await
+            .upsert_external_trigger(record.clone());
+    }
+
     pub(crate) fn append_work_item_written_event(
         &self,
         action: &str,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 
 use super::{
-    scheduler_executor, workspace, InitialWorkspaceBinding, RuntimeAgent, RuntimeHandle,
-    RuntimeInner,
+    scheduler_executor, workspace, AgentRuntimeProjectionCache, InitialWorkspaceBinding,
+    RuntimeAgent, RuntimeHandle, RuntimeInner,
 };
 
 #[derive(Debug, Clone)]
@@ -188,6 +188,7 @@ impl RuntimeHandle {
             queue,
             active_tasks,
             active_timers,
+            projection_cache,
         } = prepare_runtime_storage(agent_id, data_dir, initial_workspace, runtime_db)?;
         if let Some(event_bus) = event_bus {
             storage.enable_event_bus(event_bus)?;
@@ -219,6 +220,7 @@ impl RuntimeHandle {
                     queue,
                     current_run_abort: None,
                 }),
+                projection_cache: Mutex::new(projection_cache),
                 notify: Notify::new(),
                 storage,
                 runtime_db,
@@ -511,6 +513,7 @@ struct PreparedRuntimeStorage {
     queue: RuntimeQueue,
     active_tasks: Vec<crate::types::TaskRecord>,
     active_timers: Vec<crate::types::TimerRecord>,
+    projection_cache: AgentRuntimeProjectionCache,
 }
 
 fn prepare_runtime_storage(
@@ -796,6 +799,18 @@ fn prepare_runtime_storage(
         crate::runtime_db::RuntimeDb::expected_storage_domains(),
     )?;
     storage.enable_audit_event_index(runtime_db.clone(), Some(state.id.clone()))?;
+    let projection_cache = AgentRuntimeProjectionCache::rebuild(
+        state.id.clone(),
+        runtime_db.tasks().latest_for_agent(&state.id, usize::MAX)?,
+        runtime_db
+            .work_items()
+            .latest_for_agent(&state.id, usize::MAX)?,
+        runtime_db
+            .timers()
+            .recent_for_agent(&state.id, usize::MAX)?,
+        storage.read_recent_waiting_intents(usize::MAX)?,
+        runtime_db.external_triggers().latest_for_agent(&state.id)?,
+    );
 
     Ok(PreparedRuntimeStorage {
         storage,
@@ -804,6 +819,7 @@ fn prepare_runtime_storage(
         queue,
         active_tasks: snapshot.active_tasks,
         active_timers: snapshot.active_timers,
+        projection_cache,
     })
 }
 

--- a/src/runtime/callback.rs
+++ b/src/runtime/callback.rs
@@ -55,6 +55,7 @@ impl RuntimeHandle {
             revoked.status = ExternalTriggerStatus::Revoked;
             revoked.revoked_at = Some(now);
             self.inner.runtime_db.external_triggers().upsert(&revoked)?;
+            self.cache_external_trigger_projection(&revoked).await;
         }
 
         let external_trigger_id = crate::ids::external_trigger_id();
@@ -79,6 +80,7 @@ impl RuntimeHandle {
             .runtime_db
             .external_triggers()
             .upsert(&descriptor)?;
+        self.cache_external_trigger_projection(&descriptor).await;
         self.inner.storage.append_event(&AuditEvent::new(
             "external_trigger_created",
             serde_json::json!({
@@ -164,7 +166,8 @@ impl RuntimeHandle {
                 }
                 linked_waiting.last_triggered_at = Some(now);
                 linked_waiting.trigger_count += 1;
-                self.inner.storage.append_waiting_intent(&linked_waiting)?;
+                self.record_waiting_intent_projection(&linked_waiting)
+                    .await?;
                 Some(linked_waiting)
             } else {
                 None
@@ -180,6 +183,8 @@ impl RuntimeHandle {
             .runtime_db
             .external_triggers()
             .upsert(&updated_descriptor)?;
+        self.cache_external_trigger_projection(&updated_descriptor)
+            .await;
 
         let updated_descriptor_id = updated_descriptor.external_trigger_id.clone();
         let descriptor_delivery_mode = updated_descriptor.delivery_mode.clone();
@@ -235,6 +240,7 @@ impl RuntimeHandle {
         revoked.status = ExternalTriggerStatus::Revoked;
         revoked.revoked_at = Some(Utc::now());
         self.inner.runtime_db.external_triggers().upsert(&revoked)?;
+        self.cache_external_trigger_projection(&revoked).await;
         self.inner.storage.append_event(&AuditEvent::new(
             "external_trigger_revoked",
             serde_json::json!({

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -116,7 +116,7 @@ impl RuntimeHandle {
                 .runtime_db
                 .work_items()
                 .upsert(&record, current_focus)?;
-            self.inner.storage.append_work_item(&record)?;
+            self.record_work_item_projection(&record).await?;
             if plan_artifact_changed {
                 self.append_work_item_plan_artifact_refreshed_event(&record)?;
             }
@@ -504,11 +504,8 @@ impl RuntimeHandle {
     }
 
     pub async fn active_tasks(&self, limit: usize) -> Result<Vec<TaskRecord>> {
-        let agent_id = self.agent_id().await?;
-        self.inner
-            .runtime_db
-            .tasks()
-            .active_for_agent(&agent_id, limit)
+        crate::diagnostics::record_runtime_projection_cache_read();
+        Ok(self.inner.projection_cache.lock().await.active_tasks(limit))
     }
 
     pub async fn recent_transcript(&self, limit: usize) -> Result<Vec<TranscriptEntry>> {
@@ -582,6 +579,16 @@ impl RuntimeHandle {
         agent_id: &str,
         limit: usize,
     ) -> Result<Vec<crate::types::WorkItemRecord>> {
+        let current_agent_id = self.agent_id().await?;
+        if agent_id == current_agent_id {
+            crate::diagnostics::record_runtime_projection_cache_read();
+            return Ok(self
+                .inner
+                .projection_cache
+                .lock()
+                .await
+                .latest_work_items(limit));
+        }
         self.inner
             .runtime_db
             .work_items()
@@ -656,7 +663,13 @@ impl RuntimeHandle {
     }
 
     pub async fn recent_timers(&self, limit: usize) -> Result<Vec<TimerRecord>> {
-        self.inner.storage.read_recent_timers(limit)
+        crate::diagnostics::record_runtime_projection_cache_read();
+        Ok(self
+            .inner
+            .projection_cache
+            .lock()
+            .await
+            .recent_timers(limit))
     }
 
     pub async fn latest_timer(&self, timer_id: &str) -> Result<Option<TimerRecord>> {

--- a/src/runtime/message_dispatch.rs
+++ b/src/runtime/message_dispatch.rs
@@ -178,8 +178,9 @@ impl RuntimeHandle {
         let final_closure = self.current_closure_decision().await?;
         {
             let mut guard = self.inner.agent.lock().await;
-            let work_refs_changed =
-                self.refresh_current_work_item_refs(&mut guard.state, &message)?;
+            let work_refs_changed = self
+                .refresh_current_work_item_refs(&mut guard.state, &message)
+                .await?;
             let memory_refresh =
                 refresh_working_memory(&self.inner.storage, &mut guard.state, &final_closure)?;
             let episode_changed = refresh_episode_memory(
@@ -207,7 +208,7 @@ impl RuntimeHandle {
         Ok(())
     }
 
-    fn refresh_current_work_item_refs(
+    async fn refresh_current_work_item_refs(
         &self,
         agent: &mut AgentState,
         message: &MessageEnvelope,
@@ -246,7 +247,7 @@ impl RuntimeHandle {
         record.work_refs = merged;
         record.revision = record.revision.saturating_add(1);
         record.updated_at = Utc::now();
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_refs_updated",
             serde_json::json!({

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -50,7 +50,7 @@ impl RuntimeHandle {
         }
 
         self.inner.runtime_db.tasks().upsert(task)?;
-        self.inner.storage.append_task(task)?;
+        self.record_task_projection(task).await?;
         {
             let mut guard = self.inner.agent.lock().await;
             if !matches!(guard.state.status, AgentStatus::Stopped) {

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -2159,7 +2159,7 @@ impl RuntimeHandle {
             .map(|entry| entry.workspace_id)
             .unwrap_or_else(|| crate::types::AGENT_HOME_WORKSPACE_ID.to_string());
         self.inner.runtime_db.work_items().upsert(&record, false)?;
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         self.append_work_item_written_event("created", &record, Value::Null)?;
         self.inner.notify.notify_one();
         Ok(record)
@@ -2488,7 +2488,7 @@ impl RuntimeHandle {
                 .runtime_db
                 .work_items()
                 .upsert(&record, current_focus)?;
-            self.inner.storage.append_work_item(&record)?;
+            self.record_work_item_projection(&record).await?;
             if plan_artifact_changed && record.plan_artifact != existing.plan_artifact {
                 self.append_work_item_plan_artifact_refreshed_event(&record)?;
             }
@@ -2552,7 +2552,7 @@ impl RuntimeHandle {
             .runtime_db
             .work_items()
             .upsert(&record, current_focus)?;
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -2608,7 +2608,7 @@ impl RuntimeHandle {
             &mut record,
         )?;
         self.inner.runtime_db.work_items().upsert(&record, false)?;
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -2709,7 +2709,7 @@ impl RuntimeHandle {
             ..existing
         };
         self.inner.runtime_db.work_items().upsert(&record, false)?;
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "work_item_completion_report_promoted",
             serde_json::json!({

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -96,6 +96,83 @@ fn append_state_changed_events_emits_single_lightweight_agent_event() {
     assert!(payload.get("context_summary").is_none());
 }
 
+#[test]
+fn runtime_projection_cache_rebuilds_current_agent_active_task_projection() {
+    let now = Utc::now();
+    let tasks = vec![
+        TaskRecord {
+            id: "task-old".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now - chrono::Duration::seconds(10),
+            updated_at: now - chrono::Duration::seconds(10),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: None,
+            detail: None,
+            recovery: None,
+        },
+        TaskRecord {
+            id: "task-done".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Completed,
+            created_at: now - chrono::Duration::seconds(5),
+            updated_at: now,
+            parent_message_id: None,
+            work_item_id: None,
+            summary: None,
+            detail: None,
+            recovery: None,
+        },
+        TaskRecord {
+            id: "task-other-agent".into(),
+            agent_id: "other".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Running,
+            created_at: now - chrono::Duration::seconds(4),
+            updated_at: now + chrono::Duration::seconds(4),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: None,
+            detail: None,
+            recovery: None,
+        },
+        TaskRecord {
+            id: "task-new".into(),
+            agent_id: "default".into(),
+            kind: TaskKind::CommandTask,
+            status: TaskStatus::Queued,
+            created_at: now - chrono::Duration::seconds(2),
+            updated_at: now + chrono::Duration::seconds(2),
+            parent_message_id: None,
+            work_item_id: None,
+            summary: None,
+            detail: None,
+            recovery: None,
+        },
+    ];
+
+    let cache = AgentRuntimeProjectionCache::rebuild(
+        "default".into(),
+        tasks,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let active_tasks = cache.active_tasks(10);
+    assert_eq!(
+        active_tasks
+            .iter()
+            .map(|task| task.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-new", "task-old"]
+    );
+}
+
 #[async_trait]
 impl AgentProvider for BlockingProvider {
     async fn complete_turn(&self, _request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -761,22 +761,60 @@ impl RuntimeHandle {
 
     pub async fn latest_waiting_intents(&self) -> Result<Vec<WaitingIntentRecord>> {
         crate::diagnostics::record_runtime_projection_cache_read();
-        Ok(self
+        let cached = {
+            self.inner
+                .projection_cache
+                .lock()
+                .await
+                .latest_waiting_intents()
+        };
+        if !cached.is_empty() {
+            return Ok(cached);
+        }
+        let agent_id = self.agent_id().await?;
+        let mut records = self
             .inner
-            .projection_cache
-            .lock()
-            .await
-            .latest_waiting_intents())
+            .storage
+            .latest_waiting_intents()?
+            .into_iter()
+            .filter(|record| record.agent_id == agent_id)
+            .collect::<Vec<_>>();
+        if !records.is_empty() {
+            let mut cache = self.inner.projection_cache.lock().await;
+            for record in &records {
+                cache.upsert_waiting_intent(record.clone());
+            }
+        }
+        records.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        Ok(records)
     }
 
     pub async fn latest_external_triggers(&self) -> Result<Vec<ExternalTriggerRecord>> {
         crate::diagnostics::record_runtime_projection_cache_read();
-        Ok(self
+        let cached = {
+            self.inner
+                .projection_cache
+                .lock()
+                .await
+                .latest_external_triggers()
+        };
+        if !cached.is_empty() {
+            return Ok(cached);
+        }
+        let agent_id = self.agent_id().await?;
+        let mut records = self
             .inner
-            .projection_cache
-            .lock()
-            .await
-            .latest_external_triggers())
+            .runtime_db
+            .external_triggers()
+            .latest_for_agent(&agent_id)?;
+        if !records.is_empty() {
+            let mut cache = self.inner.projection_cache.lock().await;
+            for record in &records {
+                cache.upsert_external_trigger(record.clone());
+            }
+        }
+        records.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        Ok(records)
     }
 
     pub(super) async fn waiting_intent_work_item_id(

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -315,7 +315,7 @@ impl RuntimeHandle {
             .runtime_db
             .work_items()
             .upsert(&record, current_focus)?;
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -387,7 +387,7 @@ impl RuntimeHandle {
             .runtime_db
             .work_items()
             .upsert(&record, current_focus)?;
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -422,7 +422,8 @@ impl RuntimeHandle {
             .filter(|record| record.scope == WaitingIntentScope::WorkItem)
             .filter(|record| record.work_item_id.as_deref() == Some(existing.id.as_str()))
             .collect::<Vec<_>>();
-        let cancelled_waiting_intent_ids = self.cancel_waiting_records(active_waiting_intents)?;
+        let cancelled_waiting_intent_ids =
+            self.cancel_waiting_records(active_waiting_intents).await?;
 
         let needs_record_write = existing.blocked_by.is_some()
             || existing.recheck_at.is_some()
@@ -455,7 +456,7 @@ impl RuntimeHandle {
             .runtime_db
             .work_items()
             .upsert(&record, current_focus)?;
-        self.inner.storage.append_work_item(&record)?;
+        self.record_work_item_projection(&record).await?;
         if plan_artifact_changed {
             self.append_work_item_plan_artifact_refreshed_event(&record)?;
         }
@@ -604,7 +605,7 @@ impl RuntimeHandle {
             last_fired_at: None,
             fire_count: 0,
         };
-        self.inner.storage.append_timer(&timer)?;
+        self.record_timer_projection(&timer).await?;
         self.inner
             .storage
             .append_event(&AuditEvent::new("timer_created", to_json_value(&timer)))?;
@@ -632,7 +633,7 @@ impl RuntimeHandle {
 
         timer.status = TimerStatus::Cancelled;
         timer.next_fire_at = None;
-        self.inner.storage.append_timer(&timer)?;
+        self.record_timer_projection(&timer).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "timer_cancelled",
             serde_json::json!({
@@ -744,7 +745,7 @@ impl RuntimeHandle {
             timer.status = TimerStatus::Completed;
             timer.next_fire_at = None;
         }
-        self.inner.storage.append_timer(timer)?;
+        self.record_timer_projection(timer).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "timer_fired",
             serde_json::json!({
@@ -759,27 +760,23 @@ impl RuntimeHandle {
     }
 
     pub async fn latest_waiting_intents(&self) -> Result<Vec<WaitingIntentRecord>> {
-        let agent_id = self.agent_id().await?;
-        let mut records = self
+        crate::diagnostics::record_runtime_projection_cache_read();
+        Ok(self
             .inner
-            .storage
-            .latest_waiting_intents()?
-            .into_iter()
-            .filter(|record| record.agent_id == agent_id)
-            .collect::<Vec<_>>();
-        records.sort_by(|left, right| right.created_at.cmp(&left.created_at));
-        Ok(records)
+            .projection_cache
+            .lock()
+            .await
+            .latest_waiting_intents())
     }
 
     pub async fn latest_external_triggers(&self) -> Result<Vec<ExternalTriggerRecord>> {
-        let agent_id = self.agent_id().await?;
-        let mut records = self
+        crate::diagnostics::record_runtime_projection_cache_read();
+        Ok(self
             .inner
-            .runtime_db
-            .external_triggers()
-            .latest_for_agent(&agent_id)?;
-        records.sort_by(|left, right| right.created_at.cmp(&left.created_at));
-        Ok(records)
+            .projection_cache
+            .lock()
+            .await
+            .latest_external_triggers())
     }
 
     pub(super) async fn waiting_intent_work_item_id(
@@ -851,7 +848,7 @@ impl RuntimeHandle {
             let mut updated = waiting.clone();
             updated.status = WaitingIntentStatus::Cancelled;
             updated.cancelled_at = Some(now);
-            self.inner.storage.append_waiting_intent(&updated)?;
+            self.record_waiting_intent_projection(&updated).await?;
             updated
         };
 
@@ -1082,7 +1079,10 @@ impl RuntimeHandle {
         Ok(cancelled)
     }
 
-    fn cancel_waiting_records(&self, waiting: Vec<WaitingIntentRecord>) -> Result<Vec<String>> {
+    async fn cancel_waiting_records(
+        &self,
+        waiting: Vec<WaitingIntentRecord>,
+    ) -> Result<Vec<String>> {
         let now = Utc::now();
         let mut cancelled = Vec::new();
         for record in waiting {
@@ -1092,7 +1092,7 @@ impl RuntimeHandle {
             let mut updated = record;
             updated.status = WaitingIntentStatus::Cancelled;
             updated.cancelled_at = Some(now);
-            self.inner.storage.append_waiting_intent(&updated)?;
+            self.record_waiting_intent_projection(&updated).await?;
             self.inner.storage.append_event(&AuditEvent::new(
                 "waiting_intent_cancelled",
                 serde_json::json!({

--- a/tests/support/http_events.rs
+++ b/tests/support/http_events.rs
@@ -895,8 +895,9 @@ pub async fn events_stream_requires_control_auth_when_configured() -> Result<()>
 }
 
 pub async fn state_snapshot_bounds_large_projection_fields() -> Result<()> {
-    let (host, base, server) = spawn_server().await?;
+    let (host, _base, server) = spawn_server().await?;
     let runtime = host.default_runtime().await?;
+    let config = host.config().clone();
     let now = chrono::Utc::now();
 
     let task = TaskRecord {
@@ -918,6 +919,11 @@ pub async fn state_snapshot_bounds_large_projection_fields() -> Result<()> {
     };
     runtime.storage().append_task(&task)?;
     host.runtime_db().tasks().upsert(&task)?;
+
+    server.abort();
+    let host = RuntimeHost::new_with_provider(config, Arc::new(StubProvider::new("route result")))?;
+    let (base, server) = spawn_server_for_host(host).await?;
+
     let snapshot: serde_json::Value = reqwest::Client::new()
         .get(format!("{base}/agents/default/state"))
         .send()

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -181,32 +181,48 @@ pub async fn create_command_task_route_accepts_command_request() -> Result<()> {
 
 pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
-    let runtime = host.default_runtime().await?;
     let client = reqwest::Client::new();
-    let now = chrono::Utc::now();
-    let task = |id: &str, status: TaskStatus, offset: i64| TaskRecord {
-        id: id.into(),
-        agent_id: "default".into(),
-        kind: TaskKind::CommandTask,
-        status: status.clone(),
-        created_at: now + chrono::Duration::seconds(offset),
-        updated_at: now + chrono::Duration::seconds(offset),
-        parent_message_id: None,
-        work_item_id: None,
-        summary: Some(format!("{id} {status:?}")),
-        detail: None,
-        recovery: None,
+
+    let create_task = |summary: &str, cmd: &str, yield_time_ms: u64| {
+        client
+            .post(format!("{base}/control/agents/default/tasks"))
+            .json(&serde_json::json!({
+                "summary": summary,
+                "cmd": cmd,
+                "login": false,
+                "yield_time_ms": yield_time_ms
+            }))
     };
 
-    for task in [
-        task("task-terminal", TaskStatus::Queued, 0),
-        task("task-running", TaskStatus::Running, 1),
-        task("task-terminal", TaskStatus::Completed, 2),
-        task("task-cancelling", TaskStatus::Cancelling, 3),
-    ] {
-        runtime.storage().append_task(&task)?;
-        host.runtime_db().tasks().upsert(&task)?;
-    }
+    let first: serde_json::Value = create_task("active one", "sleep 30", 1)
+        .send()
+        .await?
+        .json()
+        .await?;
+    let first_id = first["id"].as_str().expect("task id").to_string();
+    let second: serde_json::Value = create_task("active two", "sleep 30", 1)
+        .send()
+        .await?
+        .json()
+        .await?;
+    let second_id = second["id"].as_str().expect("task id").to_string();
+    create_task("terminal task", "printf done", 1000)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let runtime = host.default_runtime().await?;
+    eventually_async(|| {
+        let runtime = runtime.clone();
+        let first_id = first_id.clone();
+        let second_id = second_id.clone();
+        async move {
+            let tasks = runtime.active_tasks(10).await?;
+            Ok(tasks.iter().any(|task| task.id == first_id)
+                && tasks.iter().any(|task| task.id == second_id))
+        }
+    })
+    .await?;
 
     let tasks: serde_json::Value = client
         .get(format!("{base}/agents/default/tasks"))
@@ -220,7 +236,8 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
         .iter()
         .map(|task| task["id"].as_str().unwrap_or_default())
         .collect::<Vec<_>>();
-    assert_eq!(task_ids, vec!["task-cancelling", "task-running"]);
+    assert!(task_ids.contains(&first_id.as_str()));
+    assert!(task_ids.contains(&second_id.as_str()));
 
     let snapshot: serde_json::Value = client
         .get(format!("{base}/agents/default/state"))
@@ -234,7 +251,24 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
         .iter()
         .map(|task| task["id"].as_str().unwrap_or_default())
         .collect::<Vec<_>>();
-    assert_eq!(state_task_ids, vec!["task-cancelling", "task-running"]);
+    assert_eq!(state_task_ids, task_ids);
+
+    client
+        .post(format!(
+            "{base}/control/agents/default/tasks/{first_id}/stop"
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?
+        .error_for_status()?;
+    client
+        .post(format!(
+            "{base}/control/agents/default/tasks/{second_id}/stop"
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await?
+        .error_for_status()?;
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary
- add an in-memory runtime projection cache rebuilt from durable runtime state at bootstrap
- keep task, work item, timer, wait, and external trigger mutation paths synchronized with durable storage
- read current agent state and prompt hot-path projections from the cache and add diagnostics counters

Fixes #1812

## Verification
- cargo fmt --all -- --check
- cargo test --lib diagnostics::tests::snapshot_includes_bounded_runtime_hotspot_groups && cargo test --lib runtime::tests::runtime_state::runtime_projection_cache_rebuilds_current_agent_active_task_projection
- RUSTFLAGS="-D warnings" cargo check --all-targets