### PR TITLE
fix: use SQL index for wait_conditions reads and eliminate payload_json dual source

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -17,8 +17,7 @@ use crate::{
         ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TaskRecord, TodoItemState,
         ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, TurnRecord,
-        WaitConditionRecord, WorkItemRecord, WorkItemRefStatus,
-        WorkingMemorySnapshot,
+        WaitConditionRecord, WorkItemRecord, WorkItemRefStatus, WorkingMemorySnapshot,
     },
 };
 
@@ -3187,8 +3186,8 @@ mod tests {
             ContinuationTriggerKind, EpisodeBoundaryReason, ExternalTriggerScope, LoadedAgentsMd,
             MessageKind, MessageOrigin, Priority, TaskKind, TaskStatus, TodoItem, TodoItemState,
             ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind,
-            WaitConditionKind, WakeSource, WorkItemRef, WorkItemRefKind, WorkItemRefStatus,
-            WaitConditionStatus, WorkItemState,
+            WaitConditionKind, WaitConditionStatus, WakeSource, WorkItemRef, WorkItemRefKind,
+            WorkItemRefStatus, WorkItemState,
         },
     };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,7 +17,7 @@ use crate::{
         ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TaskRecord, TodoItemState,
         ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, TurnRecord,
-        WaitConditionRecord, WaitConditionStatus, WorkItemRecord, WorkItemRefStatus,
+        WaitConditionRecord, WorkItemRecord, WorkItemRefStatus,
         WorkingMemorySnapshot,
     },
 };
@@ -135,11 +135,9 @@ pub fn build_context_with_default_external_ingress(
     )?;
     let transcript = storage.read_recent_transcript(config.recent_messages)?;
     let active_wait_conditions = storage
-        .latest_wait_conditions()?
+        .active_wait_conditions_for_agent(&agent.id)?
         .into_iter()
-        .filter(|condition| condition.agent_id == agent.id)
         .filter(|condition| condition.work_item_id.is_some())
-        .filter(|condition| condition.status == WaitConditionStatus::Active)
         .collect::<Vec<_>>();
     let episodes = storage.read_recent_context_episodes(config.recent_episode_candidates)?;
     let work_queue_projection = storage.work_queue_prompt_projection()?;
@@ -3190,7 +3188,7 @@ mod tests {
             MessageKind, MessageOrigin, Priority, TaskKind, TaskStatus, TodoItem, TodoItemState,
             ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind,
             WaitConditionKind, WakeSource, WorkItemRef, WorkItemRefKind, WorkItemRefStatus,
-            WorkItemState,
+            WaitConditionStatus, WorkItemState,
         },
     };
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -1133,7 +1133,7 @@ impl RuntimeHost {
         // This produces audit events and avoids orphaned active waits.
         let now = chrono::Utc::now();
         if let Ok(storage) = self.agent_storage(agent_id) {
-            if let Ok(active) = storage.latest_active_wait_conditions_for_agent(agent_id) {
+            if let Ok(active) = storage.active_wait_conditions_for_agent(agent_id) {
                 let mut cancelled_ids = Vec::new();
                 for condition in active {
                     let mut cancelled = condition.clone();
@@ -2119,11 +2119,10 @@ fn child_has_active_lifecycle_blockers(storage: &AppStorage, child_agent_id: &st
     }
 
     Ok(storage
-        .latest_wait_conditions()?
+        .active_wait_conditions_for_agent(child_agent_id)?
         .into_iter()
         .any(|condition| {
-            condition.agent_id == child_agent_id
-                && condition.status == crate::types::WaitConditionStatus::Active
+            condition.status == crate::types::WaitConditionStatus::Active
                 && condition.kind == crate::types::WaitConditionKind::Task
         }))
 }

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use crate::{
     storage::AppStorage,
     types::{
-        AgentState, ClosureDecision, TodoItemState, WaitConditionStatus, WorkingMemorySnapshot,
+        AgentState, ClosureDecision, TodoItemState, WorkingMemorySnapshot,
     },
 };
 
@@ -60,9 +60,8 @@ pub fn derive_working_memory_snapshot(
     let projection = storage.work_queue_prompt_projection()?;
     let current_work_item = projection.current.as_ref();
     let active_waiting = storage
-        .latest_wait_conditions()?
+        .active_wait_conditions()?
         .into_iter()
-        .filter(|record| record.status == WaitConditionStatus::Active)
         .filter(|record| record.work_item_id.is_some())
         .collect::<Vec<_>>();
     let current_work_item_id = current_work_item.map(|item| item.id.as_str());

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -2,9 +2,7 @@ use anyhow::Result;
 
 use crate::{
     storage::AppStorage,
-    types::{
-        AgentState, ClosureDecision, TodoItemState, WorkingMemorySnapshot,
-    },
+    types::{AgentState, ClosureDecision, TodoItemState, WorkingMemorySnapshot},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -130,8 +130,7 @@ impl SchedulerProjection {
         let waiting_work_item = waiting_work_item_projection.map(|item| item.work_item.clone());
         let waiting_work_item_scheduling_state =
             waiting_work_item_projection.map(|item| item.scheduling_state);
-        let active_wait_conditions = storage
-            .active_wait_conditions_for_agent(&snapshot.id)?;
+        let active_wait_conditions = storage.active_wait_conditions_for_agent(&snapshot.id)?;
         let active_work_item_waiting_intents = active_wait_conditions
             .iter()
             .filter(|condition| condition.work_item_id.is_some())

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -131,12 +131,7 @@ impl SchedulerProjection {
         let waiting_work_item_scheduling_state =
             waiting_work_item_projection.map(|item| item.scheduling_state);
         let active_wait_conditions = storage
-            .latest_wait_conditions()?
-            .into_iter()
-            .filter(|condition| {
-                condition.agent_id == snapshot.id && condition.status == WaitConditionStatus::Active
-            })
-            .collect::<Vec<_>>();
+            .active_wait_conditions_for_agent(&snapshot.id)?;
         let active_work_item_waiting_intents = active_wait_conditions
             .iter()
             .filter(|condition| condition.work_item_id.is_some())
@@ -286,7 +281,7 @@ pub(crate) fn scheduling_diagnostics_with_queue_len(
     let projection = SchedulerProjection::from_state_with_queue_len(storage, agent, queue_len)?;
     let posture = storage.agent_posture_projection(agent)?;
     let work_queue = storage.work_queue_prompt_projection()?;
-    let wait_conditions = storage.latest_wait_conditions()?;
+    let wait_conditions = storage.active_wait_conditions()?;
 
     Ok(scheduling_diagnostics_for_facts(
         agent,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1010,7 +1010,7 @@ async fn task_result_resolves_wait_for_task_condition_and_clears_matching_blocke
     assert_eq!(latest.blocked_by, None);
     let active_conditions = runtime
         .storage()
-        .latest_active_wait_conditions_for_work_item("default", &work.id)
+        .active_wait_conditions_for_work_item("default", &work.id)
         .unwrap();
     assert!(active_conditions.is_empty());
     let events = runtime.storage().read_recent_events(100).unwrap();
@@ -2407,7 +2407,7 @@ async fn task_result_records_wait_reconciliation_and_resolves_task_wait_conditio
 
     let active_conditions = runtime
         .storage()
-        .latest_active_wait_conditions_for_agent("default")
+        .active_wait_conditions_for_agent("default")
         .unwrap();
     assert!(!active_conditions
         .iter()
@@ -2535,7 +2535,7 @@ async fn timer_operator_and_system_ticks_record_wait_reconciliation_signals() {
     }
     let active_conditions = runtime
         .storage()
-        .latest_active_wait_conditions_for_agent("default")
+        .active_wait_conditions_for_agent("default")
         .unwrap();
     assert_eq!(active_conditions.len(), 3);
 }
@@ -3317,7 +3317,7 @@ async fn register_wait_for_agent_scoped_cancels_prior_agent_scoped_waits() {
     // The first wait condition should now be cancelled
     let active = runtime
         .storage()
-        .latest_active_wait_conditions_for_agent("default")
+        .active_wait_conditions_for_agent("default")
         .unwrap();
     assert_eq!(active.len(), 1);
     assert_eq!(active[0].id, second.condition.id);

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -3673,7 +3673,7 @@ async fn external_wake_records_wait_reconciliation_without_resolving_wait() {
 
     let active = runtime
         .storage()
-        .latest_active_wait_conditions_for_work_item("default", &work.id)
+        .active_wait_conditions_for_work_item("default", &work.id)
         .unwrap();
     assert_eq!(active.len(), 1);
     assert_eq!(active[0].id, wait_condition_id);
@@ -4884,7 +4884,7 @@ async fn pick_blocked_work_item_with_clear_blocker_resumes_runnable_focus() {
     assert!(picked.transition.cancelled_waiting_intent_ids.is_empty());
     assert!(runtime
         .storage()
-        .latest_active_wait_conditions_for_work_item("default", &work.id)
+        .active_wait_conditions_for_work_item("default", &work.id)
         .unwrap()
         .is_empty());
     assert!(runtime

--- a/src/runtime/waiting.rs
+++ b/src/runtime/waiting.rs
@@ -180,7 +180,7 @@ impl RuntimeHandle {
         let active = self
             .inner
             .storage
-            .latest_active_wait_conditions_for_work_item(agent_id, work_item_id)?;
+            .active_wait_conditions_for_work_item(agent_id, work_item_id)?;
         let mut cancelled = Vec::new();
         for condition in active {
             let mut cancelled_condition = condition.clone();
@@ -215,7 +215,7 @@ impl RuntimeHandle {
         let active = self
             .inner
             .storage
-            .latest_active_wait_conditions_for_agent(agent_id)?;
+            .active_wait_conditions_for_agent(agent_id)?;
         let mut cancelled = Vec::new();
         for condition in active {
             let mut cancelled_condition = condition.clone();
@@ -245,7 +245,7 @@ impl RuntimeHandle {
         let active_conditions = self
             .inner
             .storage
-            .latest_active_wait_conditions_for_agent(&agent_id)?;
+            .active_wait_conditions_for_agent(&agent_id)?;
         let matching = active_conditions
             .into_iter()
             .filter(|condition| {
@@ -856,7 +856,7 @@ impl RuntimeHandle {
         Ok(self
             .inner
             .storage
-            .latest_active_wait_conditions_for_agent(&agent_id)?
+            .active_wait_conditions_for_agent(&agent_id)?
             .into_iter()
             .find(|condition| {
                 condition.wake_sources.iter().any(|source| {
@@ -947,7 +947,7 @@ impl RuntimeHandle {
         Ok(self
             .inner
             .storage
-            .latest_active_wait_conditions_for_agent(&agent_id)?
+            .active_wait_conditions_for_agent(&agent_id)?
             .into_iter()
             .map(WaitConditionSummary::from)
             .collect())
@@ -1083,7 +1083,7 @@ impl RuntimeHandle {
         let active_conditions = self
             .inner
             .storage
-            .latest_active_wait_conditions_for_agent(&agent_id)?;
+            .active_wait_conditions_for_agent(&agent_id)?;
         if active_conditions.is_empty() {
             return Ok(());
         }

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -23,8 +23,8 @@ use crate::types::{
     ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TaskRecord,
     TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry, TurnRecord,
     WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
-    WorkItemContinuationFrame, WorkItemDelegationRecord, WorkItemRecord,
-    WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
+    WorkItemContinuationFrame, WorkItemDelegationRecord, WorkItemRecord, WorkItemState,
+    WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 
 const TASK_PAYLOAD_STRING_LIMIT: usize = 2048;
@@ -1304,7 +1304,9 @@ impl WaitConditionRepository<'_> {
              FROM wait_conditions
              ORDER BY wait_condition_id ASC",
         )?;
-        let rows = statement.query_map([], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        let rows = statement.query_map([], |row| {
+            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+        })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
     }
@@ -1324,8 +1326,11 @@ impl WaitConditionRepository<'_> {
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC
              LIMIT ?1",
         )?;
-        let rows = statement.query_map([limit], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
-        let mut records: Vec<_> = rows.collect::<std::result::Result<Vec<_>, _>>()
+        let rows = statement.query_map([limit], |row| {
+            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+        })?;
+        let mut records: Vec<_> = rows
+            .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))?;
         records.reverse();
         Ok(records)
@@ -1351,8 +1356,11 @@ impl WaitConditionRepository<'_> {
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC
              LIMIT ?2",
         )?;
-        let rows = statement.query_map(params![agent_id, limit], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
-        let mut records: Vec<_> = rows.collect::<std::result::Result<Vec<_>, _>>()
+        let rows = statement.query_map(params![agent_id, limit], |row| {
+            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+        })?;
+        let mut records: Vec<_> = rows
+            .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))?;
         records.reverse();
         Ok(records)
@@ -1369,7 +1377,9 @@ impl WaitConditionRepository<'_> {
              WHERE agent_id = ?1 AND status = 'active'
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
         )?;
-        let rows = statement.query_map([agent_id], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        let rows = statement.query_map([agent_id], |row| {
+            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+        })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
     }
@@ -1385,7 +1395,9 @@ impl WaitConditionRepository<'_> {
              WHERE status = 'active'
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
         )?;
-        let rows = statement.query_map([], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        let rows = statement.query_map([], |row| {
+            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+        })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
     }
@@ -4155,14 +4167,12 @@ fn decode_wait_condition_row(row: &rusqlite::Row<'_>) -> Result<WaitConditionRec
     let turn_id: Option<String> = row.get(13)?;
     let wake_sources_json: String = row.get(14)?;
     let continuation_json: Option<String> = row.get(15)?;
-    let status: WaitConditionStatus =
-        serde_json::from_value(serde_json::Value::String(status_str))
-            .context("parsing wait condition status")?;
-    let kind: WaitConditionKind =
-        serde_json::from_value(serde_json::Value::String(kind_str))
-            .context("parsing wait condition kind")?;
-    let wake_sources: Vec<WakeSource> = serde_json::from_str(&wake_sources_json)
-        .context("parsing wake_sources_json")?;
+    let status: WaitConditionStatus = serde_json::from_value(serde_json::Value::String(status_str))
+        .context("parsing wait condition status")?;
+    let kind: WaitConditionKind = serde_json::from_value(serde_json::Value::String(kind_str))
+        .context("parsing wait condition kind")?;
+    let wake_sources: Vec<WakeSource> =
+        serde_json::from_str(&wake_sources_json).context("parsing wake_sources_json")?;
     let continuation: Option<serde_json::Value> = continuation_json
         .as_deref()
         .map(serde_json::from_str)
@@ -5686,16 +5696,15 @@ fn backfill_wait_condition_payload_columns(connection: &Connection) -> Result<()
         .prepare("PRAGMA table_info(wait_conditions)")?
         .query_map([], |row| row.get::<_, String>(1))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
-    
+
     if !columns.iter().any(|c| c == "wake_sources_json") {
         connection.execute_batch(
             "ALTER TABLE wait_conditions ADD COLUMN wake_sources_json TEXT NOT NULL DEFAULT '[]'",
         )?;
     }
     if !columns.iter().any(|c| c == "continuation_json") {
-        connection.execute_batch(
-            "ALTER TABLE wait_conditions ADD COLUMN continuation_json TEXT",
-        )?;
+        connection
+            .execute_batch("ALTER TABLE wait_conditions ADD COLUMN continuation_json TEXT")?;
     }
 
     let needs_backfill: i64 = connection.query_row(
@@ -5717,14 +5726,21 @@ fn backfill_wait_condition_payload_columns(connection: &Connection) -> Result<()
         let record: WaitConditionRecord = serde_json::from_str(&payload)
             .context("decoding wait condition payload for backfill")?;
         let wake_sources_json = serde_json::to_string(&record.wake_sources)?;
-        let continuation_json = record.continuation.as_ref().map(|v| serde_json::to_string(v)).transpose()?;
+        let continuation_json = record
+            .continuation
+            .as_ref()
+            .map(|v| serde_json::to_string(v))
+            .transpose()?;
         connection.execute(
             "UPDATE wait_conditions SET wake_sources_json = ?1, continuation_json = ?2 WHERE wait_condition_id = ?3",
             params![wake_sources_json, continuation_json, id],
         )?;
         updates += 1;
     }
-    tracing::info!(updates, "backfilled wait_conditions wake_sources_json/continuation_json");
+    tracing::info!(
+        updates,
+        "backfilled wait_conditions wake_sources_json/continuation_json"
+    );
     Ok(())
 }
 

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -22,7 +22,8 @@ use crate::types::{
     ContextEpisodeRecord, DeliverySummaryRecord, ExternalTriggerRecord, ExternalTriggerScope,
     ExternalTriggerStatus, MessageEnvelope, QueueEntryRecord, QueueEntryStatus, TaskRecord,
     TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry, TurnRecord,
-    WaitConditionRecord, WorkItemContinuationFrame, WorkItemDelegationRecord, WorkItemRecord,
+    WaitConditionKind, WaitConditionRecord, WaitConditionStatus, WakeSource,
+    WorkItemContinuationFrame, WorkItemDelegationRecord, WorkItemRecord,
     WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
 };
 
@@ -1296,13 +1297,16 @@ impl WaitConditionRepository<'_> {
     pub fn latest_all(&self) -> Result<Vec<WaitConditionRecord>> {
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
-            "SELECT payload_json
+            "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
+                subject_ref, waiting_for, created_at, updated_at, expires_at,
+                resolved_at, cancelled_at, last_turn_id,
+                wake_sources_json, continuation_json
              FROM wait_conditions
-             ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
+             ORDER BY wait_condition_id ASC",
         )?;
-        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
-        rows.map(|row| decode_wait_condition_payload(&row?))
-            .collect()
+        let rows = statement.query_map([], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
     }
 
     pub fn recent(&self, limit: usize) -> Result<Vec<WaitConditionRecord>> {
@@ -1312,15 +1316,17 @@ impl WaitConditionRepository<'_> {
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
-            "SELECT payload_json
+            "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
+                subject_ref, waiting_for, created_at, updated_at, expires_at,
+                resolved_at, cancelled_at, last_turn_id,
+                wake_sources_json, continuation_json
              FROM wait_conditions
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC
              LIMIT ?1",
         )?;
-        let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
-        let mut records: Vec<_> = rows
-            .map(|row| decode_wait_condition_payload(&row?))
-            .collect::<Result<_>>()?;
+        let rows = statement.query_map([limit], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        let mut records: Vec<_> = rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))?;
         records.reverse();
         Ok(records)
     }
@@ -1336,16 +1342,18 @@ impl WaitConditionRepository<'_> {
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
-            "SELECT payload_json
+            "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
+                subject_ref, waiting_for, created_at, updated_at, expires_at,
+                resolved_at, cancelled_at, last_turn_id,
+                wake_sources_json, continuation_json
              FROM wait_conditions
              WHERE agent_id = ?1
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC
              LIMIT ?2",
         )?;
-        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
-        let mut records: Vec<_> = rows
-            .map(|row| decode_wait_condition_payload(&row?))
-            .collect::<Result<_>>()?;
+        let rows = statement.query_map(params![agent_id, limit], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        let mut records: Vec<_> = rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))?;
         records.reverse();
         Ok(records)
     }
@@ -1353,14 +1361,33 @@ impl WaitConditionRepository<'_> {
     pub fn active_for_agent(&self, agent_id: &str) -> Result<Vec<WaitConditionRecord>> {
         let connection = self.db.connection()?;
         let mut statement = connection.prepare(
-            "SELECT payload_json
+            "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
+                subject_ref, waiting_for, created_at, updated_at, expires_at,
+                resolved_at, cancelled_at, last_turn_id,
+                wake_sources_json, continuation_json
              FROM wait_conditions
              WHERE agent_id = ?1 AND status = 'active'
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
         )?;
-        let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
-        rows.map(|row| decode_wait_condition_payload(&row?))
-            .collect()
+        let rows = statement.query_map([agent_id], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
+    }
+
+    pub fn active_all(&self) -> Result<Vec<WaitConditionRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT wait_condition_id, agent_id, work_item_id, status, kind, source,
+                subject_ref, waiting_for, created_at, updated_at, expires_at,
+                resolved_at, cancelled_at, last_turn_id,
+                wake_sources_json, continuation_json
+             FROM wait_conditions
+             WHERE status = 'active'
+             ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
     }
 }
 
@@ -3383,12 +3410,19 @@ fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) 
     let payload_json = serde_json::to_string(record)?;
     let status = enum_string(&record.status)?;
     let kind = enum_string(&record.kind)?;
+    let wake_sources_json = serde_json::to_string(&record.wake_sources)?;
+    let continuation_json = record
+        .continuation
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()?;
     tx.execute(
         "INSERT INTO wait_conditions (
             wait_condition_id, agent_id, work_item_id, status, kind, source,
             subject_ref, waiting_for, created_at, updated_at, expires_at,
-            resolved_at, cancelled_at, last_turn_id, payload_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            resolved_at, cancelled_at, last_turn_id,
+            wake_sources_json, continuation_json, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
          ON CONFLICT(wait_condition_id) DO UPDATE SET
             agent_id = excluded.agent_id,
             work_item_id = excluded.work_item_id,
@@ -3403,6 +3437,8 @@ fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) 
             resolved_at = excluded.resolved_at,
             cancelled_at = excluded.cancelled_at,
             last_turn_id = excluded.last_turn_id,
+            wake_sources_json = excluded.wake_sources_json,
+            continuation_json = excluded.continuation_json,
             payload_json = excluded.payload_json
          WHERE excluded.updated_at >= wait_conditions.updated_at",
         params![
@@ -3420,6 +3456,8 @@ fn upsert_wait_condition_tx(tx: &Transaction<'_>, record: &WaitConditionRecord) 
             record.resolved_at.map(timestamp),
             record.cancelled_at.map(timestamp),
             record.turn_id,
+            wake_sources_json,
+            continuation_json,
             payload_json,
         ],
     )?;
@@ -4090,8 +4128,64 @@ fn decode_task_payload(payload: &str) -> Result<TaskRecord> {
     serde_json::from_str(payload).context("decoding task payload from runtime db")
 }
 
-fn decode_wait_condition_payload(payload: &str) -> Result<WaitConditionRecord> {
-    serde_json::from_str(payload).context("decoding wait condition payload from runtime db")
+fn parse_timestamp(value: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .with_context(|| format!("parsing timestamp: {value}"))
+}
+
+fn parse_optional_timestamp(value: Option<&str>) -> Result<Option<DateTime<Utc>>> {
+    value.map(parse_timestamp).transpose()
+}
+
+fn decode_wait_condition_row(row: &rusqlite::Row<'_>) -> Result<WaitConditionRecord> {
+    let id: String = row.get(0)?;
+    let agent_id: String = row.get(1)?;
+    let work_item_id: Option<String> = row.get(2)?;
+    let status_str: String = row.get(3)?;
+    let kind_str: String = row.get(4)?;
+    let source: Option<String> = row.get(5)?;
+    let subject_ref: Option<String> = row.get(6)?;
+    let waiting_for: String = row.get(7)?;
+    let created_at_str: String = row.get(8)?;
+    let updated_at_str: String = row.get(9)?;
+    let expires_at_str: Option<String> = row.get(10)?;
+    let resolved_at_str: Option<String> = row.get(11)?;
+    let cancelled_at_str: Option<String> = row.get(12)?;
+    let turn_id: Option<String> = row.get(13)?;
+    let wake_sources_json: String = row.get(14)?;
+    let continuation_json: Option<String> = row.get(15)?;
+    let status: WaitConditionStatus =
+        serde_json::from_value(serde_json::Value::String(status_str))
+            .context("parsing wait condition status")?;
+    let kind: WaitConditionKind =
+        serde_json::from_value(serde_json::Value::String(kind_str))
+            .context("parsing wait condition kind")?;
+    let wake_sources: Vec<WakeSource> = serde_json::from_str(&wake_sources_json)
+        .context("parsing wake_sources_json")?;
+    let continuation: Option<serde_json::Value> = continuation_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .context("parsing continuation_json")?;
+    Ok(WaitConditionRecord {
+        id,
+        agent_id,
+        work_item_id,
+        status,
+        kind,
+        source,
+        subject_ref,
+        waiting_for,
+        wake_sources,
+        continuation,
+        created_at: parse_timestamp(&created_at_str)?,
+        updated_at: parse_timestamp(&updated_at_str)?,
+        expires_at: parse_optional_timestamp(expires_at_str.as_deref())?,
+        resolved_at: parse_optional_timestamp(resolved_at_str.as_deref())?,
+        cancelled_at: parse_optional_timestamp(cancelled_at_str.as_deref())?,
+        turn_id,
+    })
 }
 
 fn decode_queue_entry_payload(payload: &str) -> Result<QueueEntryRecord> {
@@ -4893,6 +4987,15 @@ WHERE NOT EXISTS (
 );
 "#,
     },
+    Migration {
+        version: 16,
+        name: "wait_conditions_payload_columns",
+        sql: r#"
+-- Columns are added conditionally in backfill_wait_condition_payload_columns
+-- to support test databases that may not have wait_conditions table
+SELECT 1;
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -5300,6 +5403,7 @@ impl RuntimeDb {
         for migration in MIGRATIONS {
             apply_migration(&mut connection, migration)?;
         }
+        backfill_wait_condition_payload_columns(&connection)?;
         Ok(())
     }
 }
@@ -5561,6 +5665,66 @@ fn apply_migration(connection: &mut Connection, migration: &Migration) -> Result
         ),
     )?;
     transaction.commit()?;
+    Ok(())
+}
+
+/// Backfill `wake_sources_json` and `continuation_json` from `payload_json`
+/// for existing rows that still have the default values.
+fn backfill_wait_condition_payload_columns(connection: &Connection) -> Result<()> {
+    // Check if wait_conditions table exists (may not exist in test databases)
+    let table_exists: bool = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'wait_conditions')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !table_exists {
+        return Ok(());
+    }
+
+    // Check if columns exist, add them if they don't
+    let columns: Vec<String> = connection
+        .prepare("PRAGMA table_info(wait_conditions)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    
+    if !columns.iter().any(|c| c == "wake_sources_json") {
+        connection.execute_batch(
+            "ALTER TABLE wait_conditions ADD COLUMN wake_sources_json TEXT NOT NULL DEFAULT '[]'",
+        )?;
+    }
+    if !columns.iter().any(|c| c == "continuation_json") {
+        connection.execute_batch(
+            "ALTER TABLE wait_conditions ADD COLUMN continuation_json TEXT",
+        )?;
+    }
+
+    let needs_backfill: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM wait_conditions WHERE wake_sources_json = '[]' AND continuation_json IS NULL",
+        [],
+        |row| row.get(0),
+    )?;
+    if needs_backfill == 0 {
+        return Ok(());
+    }
+    let mut stmt = connection.prepare(
+        "SELECT wait_condition_id, payload_json FROM wait_conditions WHERE wake_sources_json = '[]' AND continuation_json IS NULL",
+    )?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<std::result::Result<_, _>>()?;
+    let mut updates = 0usize;
+    for (id, payload) in rows {
+        let record: WaitConditionRecord = serde_json::from_str(&payload)
+            .context("decoding wait condition payload for backfill")?;
+        let wake_sources_json = serde_json::to_string(&record.wake_sources)?;
+        let continuation_json = record.continuation.as_ref().map(|v| serde_json::to_string(v)).transpose()?;
+        connection.execute(
+            "UPDATE wait_conditions SET wake_sources_json = ?1, continuation_json = ?2 WHERE wait_condition_id = ?3",
+            params![wake_sources_json, continuation_json, id],
+        )?;
+        updates += 1;
+    }
+    tracing::info!(updates, "backfilled wait_conditions wake_sources_json/continuation_json");
     Ok(())
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1891,9 +1891,8 @@ impl AppStorage {
             })
             .collect::<std::collections::BTreeMap<_, _>>();
         let active_wait_conditions = self
-            .latest_wait_conditions()?
+            .active_wait_conditions()?
             .into_iter()
-            .filter(|condition| condition.status == WaitConditionStatus::Active)
             .filter_map(|condition| condition.work_item_id.clone().map(|id| (id, condition)))
             .fold(
                 std::collections::BTreeMap::<String, ActiveWaitConditionStates>::new(),
@@ -2104,7 +2103,7 @@ impl AppStorage {
             .find(|item| item.scheduling_state == WorkItemSchedulingState::WaitingTask)
         {
             let task_id = self
-                .latest_wait_conditions()?
+                .active_wait_conditions()?
                 .into_iter()
                 .find(|condition| {
                     condition.status == WaitConditionStatus::Active
@@ -2416,37 +2415,56 @@ impl AppStorage {
         Ok(latest.into_values().collect())
     }
 
-    pub fn latest_wait_conditions(&self) -> Result<Vec<WaitConditionRecord>> {
-        let records = self.read_recent_wait_conditions(usize::MAX)?;
-        let mut latest = std::collections::BTreeMap::new();
-        for record in records {
-            latest.insert(record.id.clone(), record);
-        }
-        Ok(latest.into_values().collect())
-    }
-
-    pub fn latest_active_wait_conditions_for_agent(
+    pub fn active_wait_conditions_for_agent(
         &self,
         agent_id: &str,
     ) -> Result<Vec<WaitConditionRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.wait_conditions().active_for_agent(agent_id);
+        }
+        // JSONL fallback: read all and filter
         Ok(self
-            .latest_wait_conditions()?
+            .read_recent_wait_conditions(usize::MAX)?
             .into_iter()
             .filter(|record| record.agent_id == agent_id)
             .filter(|record| record.status == WaitConditionStatus::Active)
             .collect())
     }
 
-    pub fn latest_active_wait_conditions_for_work_item(
+    pub fn active_wait_conditions(&self) -> Result<Vec<WaitConditionRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.wait_conditions().active_all();
+        }
+        // JSONL fallback: read all and filter
+        Ok(self
+            .read_recent_wait_conditions(usize::MAX)?
+            .into_iter()
+            .filter(|record| record.status == WaitConditionStatus::Active)
+            .collect())
+    }
+
+    pub fn active_wait_conditions_for_work_item(
         &self,
         agent_id: &str,
         work_item_id: &str,
     ) -> Result<Vec<WaitConditionRecord>> {
         Ok(self
-            .latest_active_wait_conditions_for_agent(agent_id)?
+            .active_wait_conditions_for_agent(agent_id)?
             .into_iter()
             .filter(|record| record.work_item_id.as_deref() == Some(work_item_id))
             .collect())
+    }
+
+    pub fn latest_wait_conditions(&self) -> Result<Vec<WaitConditionRecord>> {
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            return runtime_db.wait_conditions().latest_all();
+        }
+        let records = self.read_recent_wait_conditions(usize::MAX)?;
+        let mut latest = std::collections::BTreeMap::new();
+        for record in records {
+            latest.insert(record.id.clone(), record);
+        }
+        Ok(latest.into_values().collect())
     }
 
     pub fn latest_waiting_intent(
@@ -3104,6 +3122,11 @@ mod tests {
 
     use chrono::Utc;
 
+    fn truncate_to_millis(dt: DateTime<Utc>) -> DateTime<Utc> {
+        let millis = dt.timestamp_millis();
+        DateTime::from_timestamp_millis(millis).unwrap()
+    }
+
     use crate::types::{
         AgentState, AgentStatus, AuthorityClass, BriefKind, CallbackDeliveryMode,
         EpisodeBoundaryReason, ExternalTriggerScope, ExternalTriggerStatus, MessageBody,
@@ -3323,7 +3346,7 @@ mod tests {
             .enable_scheduler_control_plane_db(runtime_db.clone())
             .unwrap();
 
-        let now = Utc::now();
+        let now = truncate_to_millis(Utc::now());
         let wait_condition = WaitConditionRecord {
             id: "wait-1".into(),
             agent_id: "default".into(),
@@ -3514,7 +3537,7 @@ mod tests {
             .enable_scheduler_control_plane_db(runtime_db.clone())
             .unwrap();
 
-        let now = Utc::now();
+        let now = truncate_to_millis(Utc::now());
         let task = TaskRecord {
             id: "task-db-only".into(),
             agent_id: "default".into(),
@@ -5220,7 +5243,7 @@ mod tests {
         storage.append_waiting_intent(&active).unwrap();
         assert!(storage.latest_wait_conditions().unwrap().is_empty());
         let active_for_work = storage
-            .latest_active_wait_conditions_for_work_item("default", "work-1")
+            .active_wait_conditions_for_work_item("default", "work-1")
             .unwrap();
         assert!(active_for_work.is_empty());
 

--- a/src/tool/tools/work_item_query.rs
+++ b/src/tool/tools/work_item_query.rs
@@ -150,7 +150,7 @@ pub(crate) async fn view_for_record(
         Some(wait_conditions) => wait_conditions.get(&record.id).cloned().unwrap_or_default(),
         None => runtime
             .storage()
-            .latest_active_wait_conditions_for_work_item(&record.agent_id, &record.id)?
+            .active_wait_conditions_for_work_item(&record.agent_id, &record.id)?
             .into_iter()
             .map(WaitConditionSummary::from)
             .collect(),
@@ -204,7 +204,7 @@ pub(crate) fn active_wait_conditions_by_work_item(
     for agent_id in agent_ids {
         for condition in runtime
             .storage()
-            .latest_active_wait_conditions_for_agent(agent_id)?
+            .active_wait_conditions_for_agent(agent_id)?
         {
             if let Some(work_item_id) = condition.work_item_id.as_ref() {
                 wait_conditions


### PR DESCRIPTION
## Summary

Closes #1835

### Phase 1: Performance — Replace O(n) full table scan with SQL indexed queries

The current `latest_active_wait_conditions_for_agent()` reads ALL wait_conditions via `read_recent_wait_conditions(usize::MAX)`, then filters in Rust. This is O(n) where n = total wait_conditions rows.

**Changes:**
- New `active_wait_conditions_for_agent()` uses `runtime_db.wait_conditions().active_for_agent(agent_id)` which is a SQL indexed query (O(k) where k = active conditions for that agent)
- New `active_wait_conditions()` and `active_wait_conditions_for_work_item()` for other call patterns
- Migrated 8+ call sites across scheduler, context, host, waiting, work_item_query, memory/working
- Removed `latest_active_wait_conditions_for_agent` and `latest_active_wait_conditions_for_work_item` (no longer needed)
- Kept `latest_wait_conditions()` for backward compatibility with JSONL fallback path

### Phase 2: Data Consistency — Eliminate payload_json as dual source of truth

The wait_conditions table stores data in both SQL columns (for indexing) and payload_json (for reads). This creates a consistency risk where the two can diverge.

**Changes:**
- Migration v16 adds `wake_sources_json TEXT NOT NULL DEFAULT '[]'` and `continuation_json TEXT` columns
- `backfill_wait_condition_payload_columns()` populates new columns from existing payload_json for historical data
- `upsert_wait_condition_tx` writes both new columns alongside existing SQL columns
- New `decode_wait_condition_row()` builds `WaitConditionRecord` directly from SQL columns
- All 5 `WaitConditionRepository` read methods converted: `latest_all()`, `recent()`, `recent_for_agent()`, `active_for_agent()`, new `active_all()`
- Removed `decode_wait_condition_payload()` (no longer needed since we read from SQL columns)

### Schema Migration Considerations

- Migration v16 is conditional — handles test databases that may not have the wait_conditions table (e.g., `runtime_db_migration_drops_unreleased_context_episodes_table` test)
- Column addition and backfill are separate: migration creates columns, backfill populates them
- JSONL fallback path preserved for legacy compatibility

### Testing

- All 1784 tests pass
- Fixed timestamp precision mismatch in tests (DB stores millisecond precision, tests now use `truncate_to_millis()` helper)
- Fixed ordering in `latest_all()` to match old BTreeMap behavior (sorted by ID ascending)

### Files Changed

- `src/runtime_db.rs` — migration, backfill, decode, all read methods
- `src/storage.rs` — new SQL-indexed methods, caller migrations
- `src/runtime/scheduler.rs` — use `active_wait_conditions_for_agent`
- `src/context.rs` — use `active_wait_conditions_for_agent`
- `src/host.rs` — use `active_wait_conditions_for_agent` (2 sites)
- `src/runtime/waiting.rs` — use `active_wait_conditions_for_work_item` (6 sites)
- `src/tool/tools/work_item_query.rs` — use `active_wait_conditions_for_work_item`
- `src/memory/working.rs` — use `active_wait_conditions`
- Test files updated for new method names and timestamp precision