### PR TITLE
fix: add queue_entries table guard to migration 18

### DIFF
--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -5191,6 +5191,20 @@ SELECT 1;
         version: 18,
         name: "queue_entries_current_view",
         sql: r#"
+-- Guard: ensure queue_entries exists for clean databases that never
+-- used the JSONL-based append path. On existing databases with data
+-- this is a no-op.
+CREATE TABLE IF NOT EXISTS queue_entries (
+  message_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  priority TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  entry_index INTEGER NOT NULL DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS queue_entries_current (
   message_id TEXT PRIMARY KEY,
   agent_id TEXT NOT NULL,


### PR DESCRIPTION
## Problem

Migration 18 (`queue_entries_current_view`) assumes `queue_entries` table exists. This breaks on databases where earlier migrations were marked as applied without executing their SQL — specifically the `runtime_db_migration_drops_unreleased_context_episodes_table` test which creates a version-12 database but only sets up tables relevant to that test.

The `runtime_db_migration_drops_unreleased_context_episodes_table` test fails with:
```
Error: no such table: queue_entries
```

## Fix

Add `CREATE TABLE IF NOT EXISTS queue_entries` at the top of migration 18 as a defensive guard. On normal databases (where migration 6 already created the table), this is a no-op.

## Verification

- All 6 `runtime_db_migration` tests pass
- `cargo fmt --all -- --check` clean
- `RUSTFLAGS="-D warnings" cargo check --all-targets` clean
