### PR TITLE
fix: stop replaying messages on DB lock retries

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,11 +30,6 @@ pub use tasks::{
 };
 pub(crate) use waiting::{WaitForScope, WaitForWakeKind};
 
-#[cfg(test)]
-const RUNTIME_DB_REQUEUE_BACKOFF: Duration = Duration::from_millis(10);
-#[cfg(not(test))]
-const RUNTIME_DB_REQUEUE_BACKOFF: Duration = Duration::from_secs(5);
-
 use std::{
     collections::HashMap,
     fs,
@@ -53,7 +48,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, RwLock};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 #[cfg(test)]
 use crate::provider::{ConversationMessage, ProviderTurnRequest};
@@ -77,7 +72,7 @@ use crate::{
         ProviderNativeWebSearchKind, ProviderNativeWebSearchRequest,
     },
     queue::RuntimeQueue,
-    runtime_db::{is_retryable_db_error, RuntimeDb},
+    runtime_db::RuntimeDb,
     skills::{
         find_skill_by_entrypoint, find_skill_by_script_path, load_skills_runtime_view,
         SkillVisibility,
@@ -1368,65 +1363,6 @@ impl RuntimeHandle {
         self.inner.storage.append_brief(brief)
     }
 
-    async fn requeue_retryable_db_error(
-        &self,
-        message: &MessageEnvelope,
-        err: &anyhow::Error,
-    ) -> Result<()> {
-        warn!(
-            message_id = %message.id,
-            error = %err,
-            "retryable runtime db error; requeueing message"
-        );
-
-        if let Err(queue_err) = self.inner.storage.append_queue_entry(&QueueEntryRecord {
-            message_id: message.id.clone(),
-            agent_id: message.agent_id.clone(),
-            priority: message.priority.clone(),
-            status: QueueEntryStatus::Queued,
-            created_at: message.created_at,
-            updated_at: Utc::now(),
-        }) {
-            if is_retryable_db_error(&queue_err) {
-                warn!(
-                    message_id = %message.id,
-                    error = %queue_err,
-                    "runtime db remained locked while recording retry queue entry"
-                );
-            } else {
-                return Err(queue_err);
-            }
-        }
-
-        {
-            let mut guard = self.inner.agent.lock().await;
-            guard.current_run_abort = None;
-            if !matches!(guard.state.status, AgentStatus::Stopped) {
-                guard.queue.push_front(message.clone());
-                guard.state.pending = guard.queue.len();
-            }
-        }
-
-        if let Err(event_err) = self.inner.storage.append_event(&AuditEvent::new(
-            "runtime_db_retry_scheduled",
-            serde_json::json!({
-                "message_id": message.id.clone(),
-                "message_kind": message.kind.clone(),
-                "error": err.to_string(),
-            }),
-        )) {
-            warn!(
-                message_id = %message.id,
-                error = %event_err,
-                "failed to record runtime db retry audit event"
-            );
-        }
-
-        tokio::time::sleep(RUNTIME_DB_REQUEUE_BACKOFF).await;
-        self.inner.notify.notify_one();
-        Ok(())
-    }
-
     pub async fn run(self) -> Result<()> {
         self.bootstrap_recovery().await?;
         scheduler_executor::SchedulerDecisionExecutor::new(&self)
@@ -1517,11 +1453,6 @@ impl RuntimeHandle {
                 )
                 .await
             {
-                if is_retryable_db_error(&err) {
-                    self.requeue_retryable_db_error(&message, &err).await?;
-                    continue;
-                }
-
                 let aborted = err.downcast_ref::<CurrentRunAborted>().cloned();
                 if let Some(aborted) = aborted.as_ref() {
                     self.inner.storage.append_queue_entry(&QueueEntryRecord {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,6 +1,5 @@
 use super::super::*;
 use super::support::*;
-use crate::runtime_db::RuntimeDbRetryableError;
 use crate::types::{
     AuthorityClass, QueueEntryStatus, SkillLoadReason, WaitConditionKind, WaitConditionRecord,
     WaitConditionStatus, WakeSource, WorkItemPlanStatus, WorkItemSchedulingState,
@@ -302,66 +301,6 @@ async fn non_model_reentry_external_events_do_not_run_interactive_turn() {
     assert!(transcript
         .iter()
         .all(|entry| entry.kind != TranscriptEntryKind::AssistantRound));
-}
-
-#[tokio::test]
-async fn retryable_db_error_requeues_message_without_runtime_error() {
-    let dir = tempdir().unwrap();
-    let workspace = tempdir().unwrap();
-    let runtime = RuntimeHandle::new(
-        "default",
-        dir.path().to_path_buf(),
-        workspace.path().to_path_buf(),
-        "http://127.0.0.1:7878".into(),
-        Arc::new(CountingProvider {
-            calls: Mutex::new(0),
-            reply: "done",
-        }),
-        "default".into(),
-        context_config(),
-    )
-    .unwrap();
-    let message = MessageEnvelope::new(
-        "default",
-        MessageKind::OperatorPrompt,
-        MessageOrigin::Operator {
-            actor_id: Some("test".into()),
-        },
-        AuthorityClass::OperatorInstruction,
-        Priority::Normal,
-        MessageBody::Text {
-            text: "retry me".into(),
-        },
-    );
-    let error: anyhow::Error = RuntimeDbRetryableError::new(
-        "starting immediate transaction",
-        std::path::Path::new("state/runtime.sqlite"),
-        "database is locked",
-    )
-    .into();
-
-    runtime
-        .requeue_retryable_db_error(&message, &error)
-        .await
-        .unwrap();
-
-    let queue_entries = runtime.storage().read_recent_queue_entries(10).unwrap();
-    assert!(queue_entries.iter().any(|entry| {
-        entry.message_id == message.id && entry.status == QueueEntryStatus::Queued
-    }));
-    assert!(!queue_entries.iter().any(|entry| {
-        entry.message_id == message.id && entry.status == QueueEntryStatus::Aborted
-    }));
-
-    let guard = runtime.inner.agent.lock().await;
-    assert_eq!(
-        guard.queue.peek().map(|queued| queued.id.as_str()),
-        Some(message.id.as_str())
-    );
-    drop(guard);
-
-    let events = runtime.storage().read_recent_events(20).unwrap();
-    assert!(!events.iter().any(|event| event.kind == "runtime_error"));
 }
 
 #[tokio::test]

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -34,6 +34,10 @@ const CONTEXT_EPISODE_ANCHORS_DOMAIN: &str = "context_episode_anchors";
 const RUNTIME_DB_BUSY_TIMEOUT: Duration = Duration::from_millis(30_000);
 const RUNTIME_DB_TRANSACTION_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(25);
 const RUNTIME_DB_TRANSACTION_RETRY_MAX_DELAY: Duration = Duration::from_millis(1_000);
+#[cfg(test)]
+const RUNTIME_DB_BEGIN_RETRY_TIMEOUT: Duration = Duration::from_millis(250);
+#[cfg(not(test))]
+const RUNTIME_DB_BEGIN_RETRY_TIMEOUT: Duration = Duration::from_secs(120);
 const RUNTIME_DB_APPEND_RETRY_MAX_DELAY: Duration = Duration::from_millis(5_000);
 const RUNTIME_DB_WRITE_QUEUE_CAPACITY: usize = 1024;
 
@@ -4838,14 +4842,13 @@ CREATE TABLE IF NOT EXISTS wait_conditions (
 );
 
 CREATE TABLE IF NOT EXISTS queue_entries (
-  message_id TEXT NOT NULL,
+  message_id TEXT PRIMARY KEY,
   agent_id TEXT NOT NULL,
   priority TEXT NOT NULL,
   status TEXT NOT NULL,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  payload_json TEXT NOT NULL,
-  PRIMARY KEY (message_id, status)
+  payload_json TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS timers (
@@ -5799,7 +5802,8 @@ fn begin_immediate_transaction_with_retry<'connection>(
         match Transaction::new_unchecked(connection, TransactionBehavior::Immediate) {
             Ok(transaction) => return Ok((transaction, retry_count, started_at.elapsed())),
             Err(error)
-                if is_sqlite_locked(&error) && started_at.elapsed() < RUNTIME_DB_BUSY_TIMEOUT =>
+                if is_sqlite_locked(&error)
+                    && started_at.elapsed() < RUNTIME_DB_BEGIN_RETRY_TIMEOUT =>
             {
                 retry_count += 1;
                 tracing::trace!(
@@ -7055,6 +7059,45 @@ CREATE TABLE working_memory_deltas (
         assert_eq!(latest.len(), 1);
         assert_eq!(latest[0].message_id, "message-1");
         assert_eq!(latest[0].status, QueueEntryStatus::Dequeued);
+        Ok(())
+    }
+
+    #[test]
+    fn queue_entries_table_uses_message_id_as_current_state_key() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let connection = db.connection()?;
+        let primary_key_columns: Vec<String> = {
+            let mut statement = connection.prepare("PRAGMA table_info(queue_entries)")?;
+            let rows = statement.query_map([], |row| {
+                Ok((row.get::<_, String>(1)?, row.get::<_, i64>(5)?))
+            })?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()?
+                .into_iter()
+                .filter_map(|(name, pk)| (pk > 0).then_some(name))
+                .collect()
+        };
+        assert_eq!(primary_key_columns, vec!["message_id"]);
+
+        let now = Utc::now();
+        let queued = QueueEntryRecord {
+            message_id: "message-current".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        let mut processed = queued.clone();
+        processed.status = QueueEntryStatus::Processed;
+        processed.updated_at = now + chrono::Duration::seconds(1);
+        db.queue_entries().upsert(&queued)?;
+        db.queue_entries().upsert(&processed)?;
+
+        let rows: i64 =
+            connection.query_row("SELECT COUNT(*) FROM queue_entries", [], |row| row.get(0))?;
+        assert_eq!(rows, 1);
+        assert!(db.queue_entries().queued_for_agent("agent-a")?.is_empty());
         Ok(())
     }
 

--- a/tests/support/http_tasks.rs
+++ b/tests/support/http_tasks.rs
@@ -206,20 +206,24 @@ pub async fn tasks_and_state_routes_return_active_latest_tasks_only() -> Result<
         .json()
         .await?;
     let second_id = second["id"].as_str().expect("task id").to_string();
-    create_task("terminal task", "printf done", 1000)
+    let terminal: serde_json::Value = create_task("terminal task", "printf done", 1000)
         .send()
         .await?
-        .error_for_status()?;
+        .json()
+        .await?;
+    let terminal_id = terminal["id"].as_str().expect("task id").to_string();
 
     let runtime = host.default_runtime().await?;
     eventually_async(|| {
         let runtime = runtime.clone();
         let first_id = first_id.clone();
         let second_id = second_id.clone();
+        let terminal_id = terminal_id.clone();
         async move {
             let tasks = runtime.active_tasks(10).await?;
             Ok(tasks.iter().any(|task| task.id == first_id)
-                && tasks.iter().any(|task| task.id == second_id))
+                && tasks.iter().any(|task| task.id == second_id)
+                && tasks.iter().all(|task| task.id != terminal_id))
         }
     })
     .await?;


### PR DESCRIPTION
## Summary

- stop treating retryable runtime DB write failures as a reason to requeue and replay the same message
- keep DB lock handling at the write boundary by extending bounded `BEGIN IMMEDIATE` retry time before surfacing an error
- align the foundation `queue_entries` schema with the current-state table semantics and add a schema/behavior regression test

## Runtime behavior

Before this change, a `database is locked` error from message processing was classified as retryable and `RuntimeHandle::run` pushed the same `MessageEnvelope` back onto the in-memory queue. Under a lock storm, that re-ran the full LLM/tool turn repeatedly for the same message.

After this change, runtime DB begin-lock waits are retried in the DB write layer with a bounded budget. If the write still cannot proceed, the message follows the normal runtime failure path instead of being replayed.

## Verification

- `cargo test runtime_db::tests --lib`
- `cargo test runtime_state --lib`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`

I also ran `cargo clippy --all-targets -- -D warnings`; it currently fails on pre-existing lints across unrelated files on this local toolchain, not on this patch.
