### PR TITLE
feat: improve web GUI event timeline and config updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +832,7 @@ version = "0.18.4"
 dependencies = [
  "aide",
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "base64",
@@ -1789,7 +1799,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["json"] }
 base64 = "0.22"
+arc-swap = "1.7"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 crossterm = "0.28"

--- a/docs/rfc-implementation-notes/README.md
+++ b/docs/rfc-implementation-notes/README.md
@@ -15,8 +15,10 @@ would be noisy or misleading if duplicated inside each RFC.
 
 - [control-plane-and-delegation](control-plane-and-delegation.md)
 - [event-and-operator-transport](event-and-operator-transport.md)
+- [event-timeline-projection-audit](event-timeline-projection-audit.md)
 - [memory-and-compaction](memory-and-compaction.md)
 - [policy-and-execution-boundary](policy-and-execution-boundary.md)
+- [projection-query-and-subscription-api](projection-query-and-subscription-api.md)
 - [recent-turns-context-spine](recent-turns-context-spine.md)
 - [runtime-database-storage-migration](runtime-database-storage-migration.md)
 - [runtime-scheduler-contract](runtime-scheduler-contract.md)

--- a/docs/rfc-implementation-notes/event-timeline-projection-audit.md
+++ b/docs/rfc-implementation-notes/event-timeline-projection-audit.md
@@ -1,0 +1,173 @@
+# Event and timeline projection audit
+
+This note records the current state of runtime events as consumed by the local
+TUI and the web GUI timeline. It is intentionally an implementation audit, not a
+new event contract.
+
+Related source:
+
+- `src/tui/projection.rs`
+- `src/presentation.rs`
+- `web-gui/app/src/runtime/session-reducer.ts`
+- `web-gui/app/src/runtime/runtime-store.ts`
+- `docs/rfcs/event-stream-interface.md`
+
+## Current assembly model
+
+The first-party clients consume the same event stream but assemble display state
+independently.
+
+- The TUI keeps a bounded `event_log`, a smaller durable conversation log, and a
+  message cache. It applies state-sync events directly for agent/tasks/timers/
+  work items, and sends non-state-sync events through the presentation reducer.
+- The TUI presentation reducer turns raw events into operator-facing items,
+  deduplicating repeated operator messages, repeated briefs, assistant previews
+  that match final briefs, and command start/finish style updates.
+- The web GUI keeps event pages and live stream deltas in `eventsBySeq`, then
+  rebuilds a per-agent timeline through `reduceAgentSessionTimeline`.
+- The web GUI also keeps a per-agent message cache and hydrates slim
+  `message_enqueued` events through `messages:batchGet`.
+
+The direction is sound: audit events should be lightweight lifecycle facts, and
+large display content should come from message, brief, task-output, or
+presentation storage.
+
+## Event use by family
+
+| Event family | Current TUI use | Current web GUI use | Assessment |
+| --- | --- | --- | --- |
+| `message_enqueued` | Conversation item for operator-origin messages. Slim payloads are hydrated from message storage; old full-message payloads still work. | Timeline operator item when origin is operator. Slim payloads are hydrated through `messages:batchGet`; otherwise the item shows a loading placeholder. | Keep as lifecycle event. Do not carry full text long-term. The event needs stable `message_id`, origin summary, and timestamp/provenance only. |
+| `message_admitted` | Not a primary presentation event. | Falls through to debug runtime event if present. | Mostly audit/debug. It overlaps with `message_enqueued` for UI purposes and should not be promoted into timeline unless it represents a distinct admission failure or trust decision. |
+| `message_processing_started` | Used as an activity boundary/reset signal and debug/status evidence. | Debug event only. | Keep slim. It is useful for run correlation but redundant as a visible timeline item. |
+| `turn_started` | Projection summary and activity boundary/correlation. | Falls through to debug event. | Debug/correlation only. It overlaps with `message_processing_started` for visible display. |
+| `operator_interjection_admitted` | Summarized with `text_preview`. | Falls through to debug unless explicitly projected later. | Keep, but only with preview. It represents a specific interjection state transition rather than ordinary input. |
+| `brief_created` | Conversation result item. Supports both historical full `BriefRecord.text` and slim `BriefCreatedAuditEvent.text_preview`. | Info timeline item, roster activity source, and bootstrap `lastBrief` patch source. Current web code still expects `text` in some paths. | Keep as lifecycle/result event, but payload should remain slim. Web UI should use `text_preview` for list/timeline previews and fetch full brief text from a brief API when needed. |
+| `assistant_round_recorded` / `text_only_round_observed` | Assistant progress preview. Deduplicated when it matches a final `brief_created`. | Verbose assistant preview. Deduplicated when it matches final brief text. | Useful only as progress/debug preview. It duplicates final brief content by design, so it should stay preview-bounded and lower visibility. |
+| `provider_round_completed` | Provider/model progress detail. | Debug event through `provider_` prefix. | Debug/diagnostic only. Avoid carrying large prompt/response content here. |
+| `tool_executed` / `tool_execution_failed` | Main tool/command/action projection. Special cases for commands, `ApplyPatch`, work-item mutations, `ListWorkItems`, sleep, and failures. | Verbose tool item. Special cases for `ApplyPatch`, work-item tools, `ListWorkItems`, `GetWorkItem`, `ViewImage`, command output previews, and errors. | Keep, but payload should contain bounded summaries and artifact refs, not full command output or huge tool results. Some tool result fields duplicate external task/output artifacts and should stay preview-only. |
+| task lifecycle events (`task_created`, `task_status_updated`, `task_result_received`, child/recovery/command-task failures) | TUI updates task state for canonical task events and presents task lifecycle notices for several task events. | Most `task_` events are debug. Active task display comes primarily from agent state/detail, not timeline. | Keep lifecycle events slim. Full command stdout/stderr belongs in task output APIs/artifacts. Visible timeline should usually show only task id, status, summary, and failure reason. |
+| timer/wait/resume events (`timer_created`, `timer_fired`, `wait_condition_registered`, `wait_conditions_*`, `waiting_intent_*`, `callback_delivered`, `continuation_trigger_received`, `continuation_resolved`) | Timers update timer state; fired callback/continuation events can become resume notices; waits can become waiting notices. | `wait_condition_registered` and `agent_waiting` are visible system/waiting items; many others fall through to debug. | Keep. Several events describe different layers of the same wait lifecycle, so only one should be operator-visible by default. Other layers are debug/correlation. |
+| work-item lifecycle events (`work_item_written`, `work_item_picked`, `work_item_focus_released`, continuation/delegation/turn-end/stale-reminder events) | `work_item_written` updates work-item state and selected transitions become cards/bookkeeping. Many work-item lifecycle events become bookkeeping. | `work_item_*` events are verbose or debug; work-item mutation tools are hidden from normal tool timeline unless debug projection asks for them. | Keep `work_item_written` as the canonical state-change event. Many surrounding events duplicate scheduling/bookkeeping and should remain debug/verbose only. Use previews/objective snippets, not full plan or completion bodies. |
+| agent/session state events (`agent_state_changed`, legacy `session_state_changed`, `closure_decided`, `control_applied`, lifecycle shutdown/posture events) | `agent_state_changed` drives TUI state; `closure_decided` updates closure and may present an internal transition. | `closure_decided` is debug; agent detail/bootstrap drives most visible state. | `agent_state_changed` is state sync, not conversation. `session_state_changed` is legacy replay-only and should not be used for new transitions. |
+| workspace/worktree events (`workspace_*`, `worktree_*`, cleanup/metadata events) | Summarized for log/debug; some workspace/worktree enter/exit events have readable summaries. | Fall through to debug unless they match generic error/failure. | Debug/status only. Avoid long paths where an id plus basename/branch is enough; full metadata should be available from workspace/task detail. |
+| scheduler/diagnostic/recovery events (`scheduler_decision`, `scheduler_diagnostic`, retry/lineage/context/compaction events) | Mostly log/debug. | Mostly debug fallthrough. | Keep debug-only. These are important for support but too noisy for timeline. |
+| storage/test/bootstrap events (`db_canonical_*`, `live_event`, `test_event`, `legacy_chat_event`) | Not intended as user timeline items. | Debug fallthrough if exposed. | Internal/debug only; should normally not appear in first-party operator timeline. |
+
+## Repeated or redundant event layers
+
+The following repetitions are expected in the ledger but should not all become
+visible timeline entries:
+
+1. **Input lifecycle duplication**
+   - `message_admitted`, `message_enqueued`, `message_processing_started`, and
+     `turn_started` can all refer to the same operator input.
+   - UI should show at most one operator message, backed by `message_enqueued`
+     plus message hydration.
+   - The other events should remain debug/correlation unless they carry a
+     distinct failure, trust, or queueing decision.
+
+2. **Assistant preview versus final result**
+   - `assistant_round_recorded` and `text_only_round_observed` can contain text
+     that is later repeated by `brief_created`.
+   - Both TUI and web already try to hide assistant previews that match final
+     brief text.
+   - The preview event should keep only `text_preview` and metadata. It should
+     not carry full final-result text.
+
+3. **Tool execution versus command/task artifacts**
+   - `tool_executed` often carries command previews, summaries, output previews,
+     result metadata, and task ids.
+   - Command stdout/stderr and long tool outputs are separately available from
+     task output or tool-output artifacts.
+   - Timeline events should keep bounded previews and stable refs. Long output
+     should not be duplicated in event payloads.
+
+4. **Work item tool calls versus work item lifecycle events**
+   - A `CreateWorkItem`/`UpdateWorkItem`/`PickWorkItem`/`CompleteWorkItem` tool
+     event and a `work_item_written`/`work_item_picked` lifecycle event can
+     describe the same user-visible change.
+   - The web GUI already hides successful work-item mutation tools from normal
+     projection. The TUI presentation reducer also suppresses successful
+     work-item mutation tool events.
+   - The lifecycle event should be the canonical UI source; the tool event is
+     execution evidence and debug detail.
+
+5. **Wait lifecycle layering**
+   - A single wait/resume path can produce wait registration, timer creation,
+     callback delivery, continuation trigger, continuation resolution, and
+     closure changes.
+   - User-facing display should show a concise waiting/resumed item. Lower-level
+     callback/timer/continuation events should remain debug unless something
+     fails.
+
+6. **Agent state sync versus specific lifecycle events**
+   - `agent_state_changed` can repeat facts also visible through closure, task,
+     work-item, and current-run events.
+   - Clients should treat it as a state-sync snapshot/delta source, not as a
+     timeline item.
+
+## Long-field duplication risks
+
+These payload fields are the main duplication risks:
+
+- message bodies in `message_enqueued`;
+- brief full text in `brief_created`;
+- assistant full response text in `assistant_round_recorded` or
+  `text_only_round_observed`;
+- command stdout/stderr and huge command summaries in `tool_executed`;
+- full tool result JSON in `tool_executed`/`tool_execution_failed`;
+- full work-item objectives, plans, completion reports, or todo lists in
+  work-item lifecycle events;
+- full workspace paths and worktree metadata repeated in every workspace event.
+
+The preferred shape is:
+
+- event payload: ids, lifecycle action, timestamps, origin/trust/provenance,
+  short previews, lengths, status, and artifact refs;
+- detail API/storage: full message, full brief, full task output, full work-item
+  record, full tool output, full workspace metadata.
+
+## Client-specific gaps found during the audit
+
+1. The web GUI has message hydration for slim `message_enqueued`, but brief
+   handling is not consistently updated for slim `brief_created`.
+   - `session-reducer.ts` still uses `payload.text` and otherwise renders
+     `Brief text unavailable.`
+   - `runtime-store.ts` and `client.ts` also derive roster/bootstrap last-brief
+     text only from `payload.text`.
+   - These paths should use `text_preview` for preview display and eventually
+     a brief detail API for full text.
+
+2. The web GUI projects many unknown runtime events as debug timeline items.
+   This is useful during development, but the event taxonomy is now large enough
+   that display policy should classify by event family rather than relying on
+   prefix fallthrough.
+
+3. TUI and web implement similar dedupe rules independently:
+   - operator message dedupe;
+   - assistant preview versus final brief dedupe;
+   - work-item mutation tool suppression;
+   - command/tool special casing.
+
+   This is acceptable while the event stream remains raw, but the rules should
+   stay aligned through tests or a shared documented projection policy.
+
+## Recommendations
+
+1. Keep the raw event stream as the canonical replay surface, but treat it as
+   lifecycle/audit data, not a complete display transcript.
+2. Make `message_enqueued`, `brief_created`, task lifecycle, and work-item
+   lifecycle events permanently slim.
+3. Add or stabilize detail APIs for full brief content before requiring UI to
+   display full historical result text from slim events.
+4. Use one visible event per user-facing semantic action:
+   - operator message: `message_enqueued` + message hydration;
+   - assistant final result: `brief_created` + brief hydration when needed;
+   - tool action: `tool_executed`/`tool_execution_failed` with bounded preview;
+   - work-item state change: `work_item_written` / focused lifecycle event;
+   - wait/resume: highest-level wait or resume event, not every timer/callback
+     layer.
+5. Keep duplicated lifecycle layers available in debug mode for recovery and
+   support, but avoid rendering them in the default timeline.
+6. Prefer `*_preview`, `*_len`, ids, and artifact refs over full text fields in
+   audit event payloads.

--- a/docs/rfc-implementation-notes/event-timeline-projection-audit.md
+++ b/docs/rfc-implementation-notes/event-timeline-projection-audit.md
@@ -32,22 +32,28 @@ The direction is sound: audit events should be lightweight lifecycle facts, and
 large display content should come from message, brief, task-output, or
 presentation storage.
 
+Update against the current runtime: the main long-field duplication issues in
+`message_enqueued`, successful `tool_executed`, task lifecycle events, and
+work-item lifecycle events have been addressed in the event payloads. The
+remaining issues are mostly client projection policy, legacy fallback cleanup,
+and full-brief hydration.
+
 ## Event use by family
 
 | Event family | Current TUI use | Current web GUI use | Assessment |
 | --- | --- | --- | --- |
-| `message_enqueued` | Conversation item for operator-origin messages. Slim payloads are hydrated from message storage; old full-message payloads still work. | Timeline operator item when origin is operator. Slim payloads are hydrated through `messages:batchGet`; otherwise the item shows a loading placeholder. | Keep as lifecycle event. Do not carry full text long-term. The event needs stable `message_id`, origin summary, and timestamp/provenance only. |
+| `message_enqueued` | Conversation item for operator-origin messages. Slim payloads are hydrated from message storage; old full-message payloads still work. | Timeline operator item when origin is operator. Slim payloads are hydrated through `messages:batchGet`; otherwise the item shows a loading placeholder. | Long-field issue resolved. Current `MessageLifecycleAuditEvent` carries ids, origin/trust/priority, source refs, delivery/admission metadata, and correlation fields, not message body text. |
 | `message_admitted` | Not a primary presentation event. | Falls through to debug runtime event if present. | Mostly audit/debug. It overlaps with `message_enqueued` for UI purposes and should not be promoted into timeline unless it represents a distinct admission failure or trust decision. |
 | `message_processing_started` | Used as an activity boundary/reset signal and debug/status evidence. | Debug event only. | Keep slim. It is useful for run correlation but redundant as a visible timeline item. |
 | `turn_started` | Projection summary and activity boundary/correlation. | Falls through to debug event. | Debug/correlation only. It overlaps with `message_processing_started` for visible display. |
 | `operator_interjection_admitted` | Summarized with `text_preview`. | Falls through to debug unless explicitly projected later. | Keep, but only with preview. It represents a specific interjection state transition rather than ordinary input. |
-| `brief_created` | Conversation result item. Supports both historical full `BriefRecord.text` and slim `BriefCreatedAuditEvent.text_preview`. | Info timeline item, roster activity source, and bootstrap `lastBrief` patch source. Current web code still expects `text` in some paths. | Keep as lifecycle/result event, but payload should remain slim. Web UI should use `text_preview` for list/timeline previews and fetch full brief text from a brief API when needed. |
+| `brief_created` | Conversation result item. Supports both historical full `BriefRecord.text` and slim `BriefCreatedAuditEvent.text_preview`. | Info timeline item, roster activity source, and bootstrap `lastBrief` patch source. Current web code still expects `text` in some paths. | Runtime payload is now slim: `brief_id`, ids, kind, timestamps, `text_preview`, `text_len`, and related refs. Remaining work is web projection/hydration, not event payload slimming. |
 | `assistant_round_recorded` / `text_only_round_observed` | Assistant progress preview. Deduplicated when it matches a final `brief_created`. | Verbose assistant preview. Deduplicated when it matches final brief text. | Useful only as progress/debug preview. It duplicates final brief content by design, so it should stay preview-bounded and lower visibility. |
 | `provider_round_completed` | Provider/model progress detail. | Debug event through `provider_` prefix. | Debug/diagnostic only. Avoid carrying large prompt/response content here. |
-| `tool_executed` / `tool_execution_failed` | Main tool/command/action projection. Special cases for commands, `ApplyPatch`, work-item mutations, `ListWorkItems`, sleep, and failures. | Verbose tool item. Special cases for `ApplyPatch`, work-item tools, `ListWorkItems`, `GetWorkItem`, `ViewImage`, command output previews, and errors. | Keep, but payload should contain bounded summaries and artifact refs, not full command output or huge tool results. Some tool result fields duplicate external task/output artifacts and should stay preview-only. |
-| task lifecycle events (`task_created`, `task_status_updated`, `task_result_received`, child/recovery/command-task failures) | TUI updates task state for canonical task events and presents task lifecycle notices for several task events. | Most `task_` events are debug. Active task display comes primarily from agent state/detail, not timeline. | Keep lifecycle events slim. Full command stdout/stderr belongs in task output APIs/artifacts. Visible timeline should usually show only task id, status, summary, and failure reason. |
+| `tool_executed` / `tool_execution_failed` | Main tool/command/action projection. Special cases for commands, `ApplyPatch`, work-item mutations, `ListWorkItems`, sleep, and failures. | Verbose tool item. Special cases for `ApplyPatch`, work-item tools, `ListWorkItems`, `GetWorkItem`, `ViewImage`, command output previews, and errors. | Successful `tool_executed` long-field issue resolved. Current `ToolExecutionAuditEvent` keeps execution ids, status, duration, summary, command previews/cost/disposition, exit status, task handle, and bounded error metadata; full tool output/result JSON lives in canonical tool execution evidence. Errors may still carry error detail, which is acceptable as failure evidence unless future error objects become large. |
+| task lifecycle events (`task_created`, `task_status_updated`, `task_result_received`, child/recovery/command-task failures) | TUI presentation can summarize slim task lifecycle events; state-sync compatibility now decodes `TaskLifecycleAuditEvent` in some paths. | Most `task_` events are debug. Active task display comes primarily from agent state/detail, not timeline. | Boundary resolved. Current `TaskLifecycleAuditEvent` is lifecycle metadata plus `output_path` and bounded `output_summary_preview`; full command stdout/stderr belongs in `TaskOutput` and task output artifacts. |
 | timer/wait/resume events (`timer_created`, `timer_fired`, `wait_condition_registered`, `wait_conditions_*`, `waiting_intent_*`, `callback_delivered`, `continuation_trigger_received`, `continuation_resolved`) | Timers update timer state; fired callback/continuation events can become resume notices; waits can become waiting notices. | `wait_condition_registered` and `agent_waiting` are visible system/waiting items; many others fall through to debug. | Keep. Several events describe different layers of the same wait lifecycle, so only one should be operator-visible by default. Other layers are debug/correlation. |
-| work-item lifecycle events (`work_item_written`, `work_item_picked`, `work_item_focus_released`, continuation/delegation/turn-end/stale-reminder events) | `work_item_written` updates work-item state and selected transitions become cards/bookkeeping. Many work-item lifecycle events become bookkeeping. | `work_item_*` events are verbose or debug; work-item mutation tools are hidden from normal tool timeline unless debug projection asks for them. | Keep `work_item_written` as the canonical state-change event. Many surrounding events duplicate scheduling/bookkeeping and should remain debug/verbose only. Use previews/objective snippets, not full plan or completion bodies. |
+| work-item lifecycle events (`work_item_written`, `work_item_picked`, `work_item_focus_released`, continuation/delegation/turn-end/stale-reminder events) | `work_item_written` updates work-item state and selected transitions become cards/bookkeeping. Many work-item lifecycle events become bookkeeping. TUI summaries understand `objective_preview` and `result_summary_preview`. | `work_item_*` events are verbose or debug; work-item mutation tools are hidden from normal tool timeline unless debug projection asks for them. | Long-field issue resolved. Current `WorkItemLifecycleAuditEvent` carries lifecycle metadata, readiness, `objective_preview`/len, result brief id, bounded result/blocker previews, and recheck time; full plans, todo lists, and completion bodies stay in work-item/detail storage or briefs. |
 | agent/session state events (`agent_state_changed`, legacy `session_state_changed`, `closure_decided`, `control_applied`, lifecycle shutdown/posture events) | `agent_state_changed` drives TUI state; `closure_decided` updates closure and may present an internal transition. | `closure_decided` is debug; agent detail/bootstrap drives most visible state. | `agent_state_changed` is state sync, not conversation. `session_state_changed` is legacy replay-only and should not be used for new transitions. |
 | workspace/worktree events (`workspace_*`, `worktree_*`, cleanup/metadata events) | Summarized for log/debug; some workspace/worktree enter/exit events have readable summaries. | Fall through to debug unless they match generic error/failure. | Debug/status only. Avoid long paths where an id plus basename/branch is enough; full metadata should be available from workspace/task detail. |
 | scheduler/diagnostic/recovery events (`scheduler_decision`, `scheduler_diagnostic`, retry/lineage/context/compaction events) | Mostly log/debug. | Mostly debug fallthrough. | Keep debug-only. These are important for support but too noisy for timeline. |
@@ -79,8 +85,9 @@ visible timeline entries:
      result metadata, and task ids.
    - Command stdout/stderr and long tool outputs are separately available from
      task output or tool-output artifacts.
-   - Timeline events should keep bounded previews and stable refs. Long output
-     should not be duplicated in event payloads.
+   - Current successful `tool_executed` events now follow this boundary: they
+     keep bounded summaries/previews and stable refs, while full output/result
+     JSON is stored as tool execution evidence or task output artifacts.
 
 4. **Work item tool calls versus work item lifecycle events**
    - A `CreateWorkItem`/`UpdateWorkItem`/`PickWorkItem`/`CompleteWorkItem` tool
@@ -91,6 +98,9 @@ visible timeline entries:
      work-item mutation tool events.
    - The lifecycle event should be the canonical UI source; the tool event is
      execution evidence and debug detail.
+   - Current lifecycle events use `objective_preview`, `objective_len`,
+     `result_summary_preview`, and `blocked_by_preview` instead of embedding the
+     full work-item record.
 
 5. **Wait lifecycle layering**
    - A single wait/resume path can produce wait registration, timer creation,
@@ -108,17 +118,30 @@ visible timeline entries:
 
 ## Long-field duplication risks
 
-These payload fields are the main duplication risks:
+These payload fields were the main duplication risks. Current status:
 
-- message bodies in `message_enqueued`;
-- brief full text in `brief_created`;
+- `message_enqueued` message bodies: resolved. The event is now
+  `MessageLifecycleAuditEvent` and does not include `body`, `text`, or full
+  message content.
+- `brief_created` full brief text: resolved at runtime payload level. The event
+  is now `BriefCreatedAuditEvent` with `text_preview` and `text_len`; web UI
+  still needs to consistently consume the preview or hydrate full text.
 - assistant full response text in `assistant_round_recorded` or
-  `text_only_round_observed`;
-- command stdout/stderr and huge command summaries in `tool_executed`;
-- full tool result JSON in `tool_executed`/`tool_execution_failed`;
+  `text_only_round_observed`: resolved by using `text_preview` in current
+  projection paths.
+- command stdout/stderr and huge command summaries in successful
+  `tool_executed`: resolved. Full output is not embedded in the event.
+- full tool result JSON in successful `tool_executed`: resolved. Full result
+  evidence is stored under canonical tool execution records, with the event as
+  an index/summary.
+- task output in task lifecycle events: resolved. Lifecycle events keep
+  `output_path` and bounded `output_summary_preview`; full output is fetched
+  through `TaskOutput`/artifacts.
 - full work-item objectives, plans, completion reports, or todo lists in
-  work-item lifecycle events;
-- full workspace paths and worktree metadata repeated in every workspace event.
+  work-item lifecycle events: resolved. Lifecycle events use bounded previews
+  and ids.
+- full workspace paths and worktree metadata repeated in every workspace event:
+  still a general risk to keep watching for workspace/debug events.
 
 The preferred shape is:
 
@@ -138,12 +161,25 @@ The preferred shape is:
    - These paths should use `text_preview` for preview display and eventually
      a brief detail API for full text.
 
-2. The web GUI projects many unknown runtime events as debug timeline items.
+2. Task lifecycle and task output now have the right storage boundary, but
+   clients should keep the distinction explicit:
+   - lifecycle/state views may use `TaskLifecycleAuditEvent`;
+   - output panes should call `TaskOutput` or read artifacts;
+   - `output_path` and bounded `output_summary_preview` are acceptable refs/
+     previews, not a replacement for output hydration.
+
+3. Work-item lifecycle payloads are now preview-bounded, but projection cleanup
+   remains:
+   - prefer `objective_preview`/`result_summary_preview` in TUI/web summaries;
+   - treat old full `WorkItemRecord` payloads as legacy replay fallback only;
+   - keep successful work-item mutation tools hidden in the default timeline.
+
+4. The web GUI projects many unknown runtime events as debug timeline items.
    This is useful during development, but the event taxonomy is now large enough
    that display policy should classify by event family rather than relying on
    prefix fallthrough.
 
-3. TUI and web implement similar dedupe rules independently:
+5. TUI and web implement similar dedupe rules independently:
    - operator message dedupe;
    - assistant preview versus final brief dedupe;
    - work-item mutation tool suppression;
@@ -156,8 +192,9 @@ The preferred shape is:
 
 1. Keep the raw event stream as the canonical replay surface, but treat it as
    lifecycle/audit data, not a complete display transcript.
-2. Make `message_enqueued`, `brief_created`, task lifecycle, and work-item
-   lifecycle events permanently slim.
+2. Keep `message_enqueued`, `brief_created`, successful `tool_executed`, task
+   lifecycle, and work-item lifecycle events permanently slim. The current
+   code already follows this shape for the main duplication risks.
 3. Add or stabilize detail APIs for full brief content before requiring UI to
    display full historical result text from slim events.
 4. Use one visible event per user-facing semantic action:
@@ -170,4 +207,5 @@ The preferred shape is:
 5. Keep duplicated lifecycle layers available in debug mode for recovery and
    support, but avoid rendering them in the default timeline.
 6. Prefer `*_preview`, `*_len`, ids, and artifact refs over full text fields in
-   audit event payloads.
+   audit event payloads. Treat old full-record decoding as legacy replay
+   compatibility, not the new event contract.

--- a/docs/rfc-implementation-notes/projection-query-and-subscription-api.md
+++ b/docs/rfc-implementation-notes/projection-query-and-subscription-api.md
@@ -1,0 +1,475 @@
+# Projection query and subscription API design
+
+This note designs a server-side projection surface for first-party UI clients.
+It complements, but does not replace, the raw event stream described in
+`docs/rfcs/event-stream-interface.md`.
+
+The current TUI and web GUI both reduce raw runtime events into display items.
+That keeps the raw runtime model explicit, but it makes every client own the
+same merge, dedupe, hydration, and visibility policy. A projection API moves the
+default UI path to a shared server-side reducer while preserving raw events for
+audit, replay, diagnostics, and advanced tools.
+
+## Goals
+
+- Provide a default display surface that web and TUI can consume without
+  understanding every runtime event kind.
+- Keep raw events as the canonical ledger and debugging surface.
+- Provide both query and subscription at the same semantic layer, so clients do
+  not have to subscribe to both raw events and projection changes for normal UI.
+- Make long-field boundaries explicit: projection items may include bounded
+  previews and stable refs; full text/output/details still come from detail
+  APIs or artifacts.
+- Centralize display policy for visibility, dedupe, suppression, hydration
+  state, and item replacement.
+
+## Non-goals
+
+- Do not remove `/agents/:id/events` or raw event streaming.
+- Do not make projection items the source of truth for runtime state.
+- Do not require every client to use the same visual renderer. The API provides
+  semantic display items; web and TUI still render them in their native widgets.
+- Do not embed full task output, full tool result JSON, full work-item plans, or
+  full message/brief bodies in projection deltas.
+
+## Layering
+
+```text
+append-only runtime ledger
+        │
+        ├── raw event query/stream
+        │       - audit/debug/replay/developer tooling
+        │       - exact event kind and payload
+        │
+        └── projection reducer
+                │
+                ├── projection query
+                │       - bootstrap, pagination, refresh
+                │
+                └── projection subscription
+                        - item-level deltas / invalidations
+```
+
+Normal UI flow:
+
+```text
+GET projection window
+SUBSCRIBE projection changes for that scope
+hydrate full details only when a user expands or opens an item
+```
+
+Debug/event-inspector flow:
+
+```text
+GET raw event page
+SUBSCRIBE raw events
+```
+
+The key design rule is that a default UI subscribes to projection changes, not
+to raw events. Raw events remain available for trace/debug modes.
+
+## Projection scopes
+
+Projection is scoped because different UI surfaces need different windows and
+different aggregation levels.
+
+Recommended first scopes:
+
+- `agent_timeline`: one agent's operator-facing timeline.
+- `work_item_timeline`: one work item's focused timeline, including related
+  messages, briefs, waits, tasks, and completion events.
+- `task_timeline`: one task's lifecycle and output summary timeline.
+- `agent_roster`: compact per-agent activity/status cards.
+- `work_queue`: current/open/queued/blocked/completed work-item display.
+- `raw_debug_timeline`: optional projection of raw events into debug rows for
+  clients that want a readable event inspector without implementing all labels.
+
+The first implementation can start with `agent_timeline` plus `agent_roster`
+because those cover the current web GUI session view and the TUI conversation
+panel.
+
+## Query API
+
+### Agent timeline
+
+```http
+GET /agents/{agent_id}/projection/timeline?cursor={cursor}&limit=100&direction=backward&level=info
+```
+
+Response:
+
+```json
+{
+  "scope": {
+    "kind": "agent_timeline",
+    "agent_id": "holon-pm"
+  },
+  "revision": "projrev:agent:holon-pm:12345",
+  "source_event_seq": 12345,
+  "items": [],
+  "page": {
+    "start_cursor": "projcur:...",
+    "end_cursor": "projcur:...",
+    "has_more_before": true,
+    "has_more_after": false
+  },
+  "hydration": {
+    "messages": [],
+    "briefs": [],
+    "tasks": [],
+    "work_items": []
+  }
+}
+```
+
+Parameters:
+
+- `cursor`: projection cursor, not raw event id. It identifies an item-window
+  boundary.
+- `limit`: maximum item count.
+- `direction`: `backward` for history pagination, `forward` for catch-up.
+- `level`: `info`, `verbose`, `debug`, or `trace`.
+- `include_open`: optional boolean for appending active mutable items such as
+  in-flight assistant progress or running commands.
+
+### Work item timeline
+
+```http
+GET /work-items/{work_item_id}/projection/timeline?cursor={cursor}&limit=100
+```
+
+This returns the same item shape, scoped to one work item. The reducer includes
+events linked by `work_item_id`, relevant messages/briefs, task/tool events that
+ran under that work item, wait/resume events, and completion result refs.
+
+### Projection detail hydration
+
+Projection items carry refs for full details. Full content should be loaded
+through existing or dedicated detail APIs:
+
+- messages: `messages:batchGet` or equivalent message detail endpoint;
+- briefs: brief detail endpoint by `brief_id`;
+- tasks: `TaskStatus`, `TaskOutput`, and task output artifacts;
+- tool executions: canonical tool execution evidence by `tool_execution_id`;
+- work items: work-item detail endpoint and plan artifact refs.
+
+Projection query may optionally include a bounded `hydration` block for common
+above-the-fold data. This is a convenience cache, not a replacement for detail
+APIs.
+
+## Subscription API
+
+Projection subscriptions use the same scope and visibility semantics as query.
+SSE is sufficient for the first version:
+
+```http
+GET /agents/{agent_id}/projection/timeline/stream?after_revision={revision}&level=info
+```
+
+Events:
+
+```json
+{
+  "type": "projection_delta",
+  "scope": { "kind": "agent_timeline", "agent_id": "holon-pm" },
+  "revision": "projrev:agent:holon-pm:12346",
+  "source_event_seq": 12346,
+  "ops": [
+    { "op": "insert", "after": "item:...", "item": {} },
+    { "op": "replace", "item_id": "item:...", "item": {} },
+    { "op": "remove", "item_id": "item:..." }
+  ]
+}
+```
+
+Other subscription records:
+
+- `projection_invalidated`: the reducer cannot produce a safe delta from the
+  client's `after_revision`; client must refetch the current window.
+- `projection_hydration_available`: optional notice that a previously
+  placeholder item can now be hydrated.
+- `projection_heartbeat`: keepalive, includes latest `source_event_seq`.
+
+The client stores the latest projection `revision`, not just raw event seq.
+`source_event_seq` is still included to correlate projection rows with raw event
+inspection and to know which ledger events are covered.
+
+## Projection item model
+
+A projection item is stable enough for all first-party UIs but not tied to a
+specific visual layout.
+
+```json
+{
+  "id": "pitem:agent:holon-pm:brief:brief_123",
+  "kind": "assistant_result",
+  "title": "Result",
+  "summary": "已完成并提交文档…",
+  "body_preview": "已完成并提交文档…",
+  "body_len": 128,
+  "status": "completed",
+  "visibility": "info",
+  "created_at": "2026-06-16T10:00:00Z",
+  "updated_at": "2026-06-16T10:00:02Z",
+  "refs": {
+    "agent_id": "holon-pm",
+    "brief_id": "brief_123",
+    "message_id": "msg_456",
+    "task_id": null,
+    "work_item_id": null,
+    "tool_execution_id": null,
+    "source_event_ids": ["event_1"],
+    "source_event_seq": 12345
+  },
+  "children": [],
+  "actions": [
+    { "kind": "open_detail", "ref": "brief:brief_123" },
+    { "kind": "show_raw_events", "event_seq": 12345 }
+  ],
+  "debug": {
+    "source_event_kinds": ["brief_created"]
+  }
+}
+```
+
+Required fields:
+
+- `id`: deterministic item id. Related raw events update the same item instead
+  of creating duplicates.
+- `kind`: UI semantic kind, not raw event kind.
+- `summary`: bounded text safe for default lists.
+- `visibility`: minimum level: `info`, `verbose`, `debug`, or `trace`.
+- `refs`: stable ids and raw event correlation.
+
+Recommended item kinds:
+
+- `operator_message`
+- `assistant_progress`
+- `assistant_result`
+- `tool_activity`
+- `command_activity`
+- `file_change`
+- `task_activity`
+- `wait_notice`
+- `resume_notice`
+- `work_item_card`
+- `work_item_bookkeeping`
+- `agent_status`
+- `workspace_activity`
+- `system_alert`
+- `debug_event`
+
+## Event-to-projection policy
+
+The table below is the normative first-pass policy for currently used event
+families. `Default item` is what normal `agent_timeline` should produce.
+`Debug handling` describes how the event remains inspectable.
+
+| Event kind/family | Default projection item | Visibility | Merge/dedupe and hydration policy | Debug handling |
+| --- | --- | --- | --- | --- |
+| `message_enqueued` | `operator_message` for operator-origin messages. | `info` | Use `message_id` as item id. Display hydrated message body or `text_preview`; never require event payload to contain full text. Ignore non-operator messages unless a specific UI scope needs them. | Raw event available; non-operator messages may become `debug_event`. |
+| `message_admitted` | None by default. | `debug` | Admission duplicates `message_enqueued` for normal display. Promote only if admission fails or contains a distinct trust/security decision. | `debug_event` with origin/trust metadata. |
+| `message_processing_started` | None by default; may update active run indicator. | `debug` | Treat as run correlation and activity reset, not a conversation row. | `debug_event`. |
+| `turn_started` / `recovery_turn_started` | None by default; may update active run indicator. | `debug` | Merge with current run state. Do not show alongside operator message. | `debug_event`. |
+| `operator_interjection_admitted` | `operator_message` or `system_alert` depending on payload. | `info` | If it represents a visible interjection, show one concise row using preview. Do not duplicate the original message item. | Raw event preserved. |
+| `brief_created` | `assistant_result`. | `info` | Use `brief_id` as item id. Display `text_preview`; hydrate full markdown only in detail/expanded view. Replace/suppress matching `assistant_progress`. | Raw event preserved with slim payload. |
+| `assistant_round_recorded` / `text_only_round_observed` | `assistant_progress`. | `verbose` | Use bounded preview. If later `brief_created` matches or supersedes it, remove or mark as superseded. Never treat as final result. | `debug_event` at debug level if needed. |
+| `provider_round_completed` | None by default. | `debug` | Provider/model telemetry is not an operator timeline item. It may annotate a surrounding assistant/tool activity in debug view. | `debug_event`. |
+| provider recovery/lineage events (`provider_failed_needs_recovery`, `checkpoint_recorded`, `turn_local_checkpoint_recorded`, `turn_local_compaction_applied`, `working_memory_updated`) | None by default, except failures may become `system_alert`. | `debug` | Keep normal UI result-oriented. Show only actionable or failed recovery facts at info/verbose. | `debug_event`. |
+| successful `tool_executed` | `tool_activity`, `command_activity`, `file_change`, or hidden bookkeeping. | `verbose` | Use `tool_execution_id` as item id. Special-case `ExecCommand`, `ExecCommandBatch`, `ApplyPatch`, image/view tools, and work-item mutation tools. Store refs to full evidence; include only bounded command/result previews. | Full evidence through tool execution detail; raw event as `debug_event`. |
+| `tool_execution_failed` | `system_alert` or failed `tool_activity`. | `info` for failures, `debug` details. | Use bounded error detail as failure evidence. Link `tool_execution_id` and related task/output refs. | Raw event plus tool detail. |
+| `task_created` | Create/update `task_activity`. | `verbose` | Use `task_id` as item id. If task is command-backed, merge with command tool item when `tool_execution_id`/task handle links exist. | `debug_event`. |
+| `task_status_updated` | Replace existing `task_activity`; update active task panels. | `verbose` | Do not append one row per status. Use replace delta to show queued/running/cancelling/completed state. | `debug_event`. |
+| `task_result_received` | Complete `task_activity`; maybe append failure `system_alert`. | `verbose`/`info` on failure | Include `output_summary_preview` and output refs. Full output remains in `TaskOutput`/artifact. | `debug_event`. |
+| command/child task failures (`command_task_runner_failed`, `command_task_result_enqueue_failed`, `supervised_child_task_recovery_failed`) | `system_alert`. | `info` | These are actionable runtime failures. Link task id and recovery refs. | Raw event preserved. |
+| `task_input_delivered` | Update `task_activity` or hide. | `debug`/`verbose` | Show only when useful for interactive task timeline. Do not duplicate operator input text. | `debug_event`. |
+| task worktree events (`task_worktree_metadata_recorded`, `task_worktree_cleanup_failed`, `worktree_created_for_task`) | `workspace_activity` or `system_alert` on failure. | `verbose`/`info` on failure | Keep path/branch previews bounded. Link workspace/worktree detail where available. | `debug_event`. |
+| timers (`timer_created`, `timer_fired`, `timer_fire_failed`) | Usually none; failure becomes `system_alert`. | `debug`/`info` on failure | Timer events feed wait/resume item state. Do not show every timer layer by default. | `debug_event`. |
+| waits (`wait_condition_registered`, `waiting_intent_created`, `wait_conditions_resolved`) | `wait_notice` then `resume_notice`/replace. | `info` | Use wait id/work-item/agent scope as item id. Replace active waiting row when resolved instead of appending every layer. | Raw wait lifecycle visible in debug. |
+| continuation/callback events (`callback_delivered`, `continuation_trigger_received`, `continuation_resolved`) | `resume_notice` if it changes user-visible state. | `info`/`verbose` | Merge into the active wait/resume item. Avoid separate callback, trigger, and resolution rows unless debug. | `debug_event`. |
+| `work_item_written` | `work_item_card` for create/complete/block/unblock or `work_item_bookkeeping` for minor mutations. | `info` for major transitions, `verbose` for bookkeeping | Use `work_item_id` plus transition as item id. Display `objective_preview`/`result_summary_preview`; full plan/todo/result via detail/brief refs. | Raw lifecycle event preserved. |
+| `work_item_picked` / `work_item_focus_released` | Update work queue/current-work panels; optional `work_item_bookkeeping`. | `verbose` | Avoid noisy default rows unless focus change is useful in the timeline scope. | `debug_event`. |
+| work-item delegation/binding/plan events (`work_item_delegation_created`, `work_item_delegation_completed`, `work_item_turn_binding_released`, `work_item_plan_artifact_refreshed`) | `work_item_bookkeeping` or hidden. | `verbose`/`debug` | Show delegation completion if it affects user-facing progress. Hide artifact refresh unless requested. | `debug_event`. |
+| `agent_state_changed` / `state_changed` / legacy `session_state_changed` | Update agent panels, not timeline. | `debug` | Treat as state-sync input for roster/current status. Do not create conversation rows. `session_state_changed` remains legacy replay fallback. | `debug_event`. |
+| `closure_decided` | Update active run status; maybe `system_alert` on failed/interrupted closure. | `verbose`/`info` on abnormal | Normal completion is usually represented by `brief_created`. Avoid duplicate "completed" row. | `debug_event`. |
+| control events (`control_request_admitted`, `control_applied`) | `system_alert` or `agent_status` only when visible to operator. | `verbose`/`debug` | Normal control plumbing is hidden; security/trust outcomes can be visible. | `debug_event`. |
+| operator delivery/mirror events (`operator_delivery_completed`, `operator_notification_mirror_failed`, `target_operator_boundary`) | Usually none; mirror failure becomes `system_alert`. | `debug`/`info` on failure | Delivery success is not a timeline item. | `debug_event`. |
+| workspace/worktree events (`workspace_*`, `worktree_auto_cleanup_failed`, `worktree_created_for_task`) | `workspace_activity` or `system_alert` on failure. | `verbose`/`info` on failure | Use compact names/branches; full metadata by detail refs. | `debug_event`. |
+| scheduler/diagnostic/recovery events (`scheduler_decision`, `scheduler_diagnostic`, lineage/retry/context events) | None by default. | `debug` | Suppress from normal timeline. | `debug_event` / raw event inspector. |
+| storage/test/bootstrap events (`db_canonical_*`, `live_event`, `test_event`, `legacy_chat_event`) | None by default. | `trace` | Internal only unless explicitly viewing raw traces. | Raw trace only. |
+
+Unknown event kinds should not become noisy `info` rows. The reducer should
+default them to `debug_event` with `visibility=debug` and a compact summary.
+This keeps development inspectability without leaking internal vocabulary into
+the normal timeline.
+
+## Reducer semantics
+
+### Deterministic item ids
+
+Projection item ids should be derived from stable runtime ids:
+
+- operator message: `message:{message_id}`;
+- assistant result: `brief:{brief_id}`;
+- tool execution: `tool:{tool_execution_id}`;
+- task: `task:{task_id}`;
+- work item transition: `work-item:{work_item_id}:{transition}:{event_seq}`;
+- active wait: `wait:{wait_id}` or `wait:{agent_id}:{work_item_id}:{kind}`;
+- raw debug fallback: `event:{event_id}`.
+
+Stable ids allow subscriptions to use `replace` instead of append-only noise.
+
+### Replacement and suppression
+
+The reducer should explicitly support:
+
+- `insert`: a new semantic item appears;
+- `replace`: a mutable item changes state, such as running command completion;
+- `remove`: a progress/debug item is superseded by a final result;
+- `annotate`: optional child evidence is attached to an existing item.
+
+Important suppression rules:
+
+- `assistant_progress` is removed or marked superseded when a matching
+  `assistant_result` arrives.
+- successful work-item mutation tools are hidden when the lifecycle event
+  already produced the visible item.
+- task status updates replace one task item, not append a row per status.
+- wait/timer/callback/continuation layers merge into one wait/resume item.
+- normal closure completion is hidden when a final brief exists.
+
+### Visibility
+
+Projection visibility is the minimum level at which an item appears:
+
+- `info`: operator messages, final briefs, failures, waits needing attention,
+  major work-item changes;
+- `verbose`: tools, commands, file changes, task activity, work-item
+  bookkeeping, workspace activity;
+- `debug`: raw runtime internals, state sync, provider telemetry, scheduler and
+  diagnostic events;
+- `trace`: exact raw event pages.
+
+The server may return higher-visibility items when the client asks for
+`level=debug`, but it should not change the meaning of `kind`.
+
+## Web GUI update model
+
+The web GUI should move its default session timeline from:
+
+```text
+event pages + live raw event stream
+  -> session-reducer.ts
+  -> timeline items
+```
+
+to:
+
+```text
+projection query + projection subscription
+  -> projection item store
+  -> React rendering
+```
+
+Recommended web state:
+
+- `projectionItemsById`: normalized item store.
+- `projectionOrderByScope`: ordered item ids per timeline scope.
+- `projectionRevisionByScope`: latest applied revision.
+- `hydrationCache`: message/brief/task/tool/work-item details keyed by refs.
+- `rawEventsBySeq`: retained only for debug/event inspector, not the default
+  timeline reducer.
+
+Web bootstrap:
+
+1. Query `agent_roster` and the selected `agent_timeline`.
+2. Render projection items immediately using previews.
+3. Hydrate visible message/brief details in batch.
+4. Subscribe to the same projection scopes with `after_revision`.
+5. Apply `insert`/`replace`/`remove`; on `projection_invalidated`, refetch the
+   current window.
+
+Web rendering changes:
+
+- `TimelineItem` renders server `kind` directly.
+- Existing special cases for `message_enqueued`, `brief_created`,
+  `tool_executed`, work-item tools, and task events move behind the server
+  projection reducer.
+- The raw event stream remains available behind a debug tab or "show raw
+  events" action from a projection item.
+- Roster `lastBrief` should come from `agent_roster` projection or brief detail,
+  not from assuming `brief_created.payload.text` exists.
+
+## TUI update model
+
+The TUI should keep its renderer and keyboard/display-level behavior, but stop
+needing to classify every raw event for the default conversation view.
+
+TUI bootstrap:
+
+1. Query `agent_timeline` at the configured display level.
+2. Convert projection items into `ConversationCell`s.
+3. Query `work_queue`/`agent_roster` projection scopes for side panels.
+4. Subscribe to projection changes for active scopes.
+
+TUI subscription handling:
+
+- `insert`: append/insert a rendered cell.
+- `replace`: update the existing cell in place when possible.
+- `remove`: hide superseded progress cells.
+- `projection_invalidated`: refetch the visible window and preserve scroll
+  position by item id where possible.
+
+TUI raw event usage after migration:
+
+- debug/trace display level can still open a raw event inspector;
+- state-sync fallback can remain during migration, but the normal conversation
+  should render projection items;
+- existing `src/presentation.rs` reducer can become the first server-side
+  projection reducer implementation, then TUI can consume the API instead of
+  linking equivalent logic directly.
+
+## Migration plan
+
+1. Define the shared projection item schema and scope/revision envelope.
+2. Implement server-side `agent_timeline` query by extracting the existing TUI
+   presentation reducer policy into a reusable runtime projection module.
+3. Add projection subscription that consumes raw event append notifications and
+   emits item deltas for `agent_timeline`.
+4. Move web GUI default timeline to projection query/subscription while keeping
+   raw event pages for debug.
+5. Move TUI conversation panel to projection query/subscription, preserving its
+   renderer and display-level controls.
+6. Add `work_queue` and `agent_roster` projections so side panels no longer
+   infer state from raw event fallthrough.
+7. Keep raw event stream tests and add projection golden tests:
+   - operator message hydration;
+   - brief preview/full hydration;
+   - assistant progress superseded by brief;
+   - command start/result replacement;
+   - task lifecycle replacement;
+   - work-item mutation tool suppression;
+   - wait/timer/callback merge;
+   - unknown event becomes debug-only.
+
+## Open design choices
+
+- Whether projection query should be backed by a persisted projection table or
+  computed from recent events plus current state. The first version can compute
+  on demand; persistence becomes useful once pagination across long history is
+  required.
+- Whether `projection_delta` should support fine-grained child operations or
+  only whole-item replacement. Whole-item replacement is simpler and likely
+  enough for the first version.
+- Whether raw event `max_level` filtering should share the same visibility enum
+  as projection items. The concepts are aligned, but replay authorization and
+  display visibility must stay separate.
+
+## Summary
+
+Projection query/subscription is worthwhile if it is treated as the default UI
+view layer, not as a replacement for raw events. The event ledger remains the
+fact layer. The projection reducer becomes the shared product layer that turns
+events, state, and detail refs into stable display items. Web and TUI then
+subscribe to one semantic surface for normal UI and use raw events only for
+debug, trace, and advanced inspection.

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1601,6 +1601,7 @@
                 "effect": {
                   "enum": [
                     "accepted_requires_restart",
+                    "accepted_reloaded",
                     "rejected"
                   ],
                   "type": "string"

--- a/src/config.rs
+++ b/src/config.rs
@@ -3299,31 +3299,10 @@ fn built_in_provider_registry_with_settings(
         &["DASHSCOPE_API_KEY", "QWEN_API_KEY"],
         settings_env,
     )?;
-    insert_openai_compatible_provider(
-        &mut registry,
-        "dashscope-openai",
-        "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        &["DASHSCOPE_API_KEY", "QWEN_API_KEY"],
-        settings_env,
-    )?;
     insert_anthropic_compatible_provider(
         &mut registry,
         "deepseek",
         "https://api.deepseek.com/anthropic",
-        &["DEEPSEEK_API_KEY"],
-        settings_env,
-    )?;
-    insert_anthropic_compatible_provider(
-        &mut registry,
-        "deepseek-anthropic",
-        "https://api.deepseek.com/anthropic",
-        &["DEEPSEEK_API_KEY"],
-        settings_env,
-    )?;
-    insert_openai_compatible_provider(
-        &mut registry,
-        "deepseek-openai",
-        "https://api.deepseek.com/v1",
         &["DEEPSEEK_API_KEY"],
         settings_env,
     )?;
@@ -3485,41 +3464,6 @@ fn built_in_provider_registry_with_settings(
         &["XIAOMI_API_KEY"],
         settings_env,
     )?;
-    insert_anthropic_compatible_provider(
-        &mut registry,
-        "xiaomi-anthropic",
-        "https://api.xiaomimimo.com/anthropic",
-        &["XIAOMI_API_KEY"],
-        settings_env,
-    )?;
-    insert_openai_compatible_provider(
-        &mut registry,
-        "xiaomi-openai",
-        "https://api.xiaomimimo.com/v1",
-        &["XIAOMI_API_KEY"],
-        settings_env,
-    )?;
-    insert_openai_compatible_provider(
-        &mut registry,
-        "xiaomi-token-plan",
-        "https://token-plan-cn.xiaomimimo.com/v1",
-        &["XIAOMI_TOKEN_PLAN_API_KEY"],
-        settings_env,
-    )?;
-    insert_anthropic_compatible_provider(
-        &mut registry,
-        "xiaomi-token-plan-anthropic",
-        "https://token-plan-cn.xiaomimimo.com/anthropic",
-        &["XIAOMI_TOKEN_PLAN_API_KEY"],
-        settings_env,
-    )?;
-    insert_openai_compatible_provider(
-        &mut registry,
-        "xiaomi-token-plan-openai",
-        "https://token-plan-cn.xiaomimimo.com/v1",
-        &["XIAOMI_TOKEN_PLAN_API_KEY"],
-        settings_env,
-    )?;
     insert_openai_compatible_provider(
         &mut registry,
         "xai",
@@ -3536,36 +3480,8 @@ fn built_in_provider_registry_with_settings(
     )?;
     insert_anthropic_compatible_provider(
         &mut registry,
-        "zai-anthropic",
-        "https://api.z.ai/api/anthropic",
-        &["ZAI_API_KEY"],
-        settings_env,
-    )?;
-    insert_openai_compatible_provider(
-        &mut registry,
-        "zai-openai",
-        "https://api.z.ai/api/paas/v4",
-        &["ZAI_API_KEY"],
-        settings_env,
-    )?;
-    insert_anthropic_compatible_provider(
-        &mut registry,
         "bigmodel",
         "https://open.bigmodel.cn/api/anthropic",
-        &["BIGMODEL_API_KEY"],
-        settings_env,
-    )?;
-    insert_anthropic_compatible_provider(
-        &mut registry,
-        "bigmodel-anthropic",
-        "https://open.bigmodel.cn/api/anthropic",
-        &["BIGMODEL_API_KEY"],
-        settings_env,
-    )?;
-    insert_openai_compatible_provider(
-        &mut registry,
-        "bigmodel-openai",
-        "https://open.bigmodel.cn/api/paas/v4",
         &["BIGMODEL_API_KEY"],
         settings_env,
     )?;
@@ -3614,9 +3530,9 @@ fn insert_anthropic_compatible_provider(
     settings_env: &HashMap<String, String>,
 ) -> Result<()> {
     let builtin_web_search = match provider {
-        "zai" | "zai-anthropic" => Some(zai_builtin_web_search_config()),
-        "bigmodel" | "bigmodel-anthropic" => Some(bigmodel_builtin_web_search_config()),
-        "deepseek" | "deepseek-anthropic" => Some(deepseek_builtin_web_search_config()),
+        "zai" => Some(zai_builtin_web_search_config()),
+        "bigmodel" => Some(bigmodel_builtin_web_search_config()),
+        "deepseek" => Some(deepseek_builtin_web_search_config()),
         _ => None,
     };
     insert_builtin_http_provider_with_context_management(
@@ -5691,16 +5607,14 @@ mod tests {
         assert_eq!(anthropic_search.advertised_tool_type, "web_search_20250305");
         assert_eq!(anthropic_search.backend_kind, "anthropic_web_search");
 
-        let zai = registry
-            .get(&ProviderId::parse("zai-anthropic").unwrap())
-            .unwrap();
+        let zai = registry.get(&ProviderId::parse("zai").unwrap()).unwrap();
         let zai_search = zai.builtin_web_search.as_ref().unwrap();
         assert_eq!(zai_search.kind, ProviderNativeWebSearchKind::Anthropic);
         assert_eq!(zai_search.advertised_tool_type, "web_search_20250305");
         assert_eq!(zai_search.backend_kind, "zai_web_search_prime");
 
         let deepseek = registry
-            .get(&ProviderId::parse("deepseek-anthropic").unwrap())
+            .get(&ProviderId::parse("deepseek").unwrap())
             .unwrap();
         let deepseek_search = deepseek.builtin_web_search.as_ref().unwrap();
         assert_eq!(deepseek_search.kind, ProviderNativeWebSearchKind::Anthropic);
@@ -6174,26 +6088,6 @@ mod tests {
             AnthropicCacheStrategy::ClaudeCodePromptCache
         );
 
-        let dashscope_openai = providers
-            .get(&ProviderId::parse("dashscope-openai").unwrap())
-            .unwrap();
-        assert_eq!(
-            dashscope_openai.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(
-            dashscope_openai.base_url,
-            "https://dashscope.aliyuncs.com/compatible-mode/v1"
-        );
-        assert_eq!(
-            dashscope_openai.auth.env.as_deref(),
-            Some("DASHSCOPE_API_KEY")
-        );
-        assert_eq!(
-            dashscope_openai.credential.as_deref(),
-            Some("dashscope-key")
-        );
-
         let nearai = providers
             .get(&ProviderId::parse("nearai").unwrap())
             .unwrap();
@@ -6220,36 +6114,6 @@ mod tests {
         assert_eq!(deepseek.base_url, "https://api.deepseek.com/anthropic");
         assert_eq!(deepseek.credential.as_deref(), Some("deepseek-key"));
 
-        let deepseek_anthropic = providers
-            .get(&ProviderId::parse("deepseek-anthropic").unwrap())
-            .unwrap();
-        assert_eq!(
-            deepseek_anthropic.transport,
-            ProviderTransportKind::AnthropicMessages
-        );
-        assert_eq!(
-            deepseek_anthropic.base_url,
-            "https://api.deepseek.com/anthropic"
-        );
-        assert_eq!(
-            deepseek_anthropic.credential.as_deref(),
-            Some("deepseek-key")
-        );
-        assert_eq!(
-            deepseek_anthropic.context_management.cache_strategy,
-            AnthropicCacheStrategy::ClaudeCodePromptCache
-        );
-
-        let deepseek_openai = providers
-            .get(&ProviderId::parse("deepseek-openai").unwrap())
-            .unwrap();
-        assert_eq!(
-            deepseek_openai.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(deepseek_openai.base_url, "https://api.deepseek.com/v1");
-        assert_eq!(deepseek_openai.credential.as_deref(), Some("deepseek-key"));
-
         let xiaomi = providers
             .get(&ProviderId::parse("xiaomi").unwrap())
             .unwrap();
@@ -6260,100 +6124,10 @@ mod tests {
         assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
         assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
 
-        let xiaomi_anthropic = providers
-            .get(&ProviderId::parse("xiaomi-anthropic").unwrap())
-            .unwrap();
-        assert_eq!(
-            xiaomi_anthropic.transport,
-            ProviderTransportKind::AnthropicMessages
-        );
-        assert_eq!(
-            xiaomi_anthropic.base_url,
-            "https://api.xiaomimimo.com/anthropic"
-        );
-        assert_eq!(xiaomi_anthropic.credential.as_deref(), Some("xiaomi-key"));
-
-        let xiaomi_openai = providers
-            .get(&ProviderId::parse("xiaomi-openai").unwrap())
-            .unwrap();
-        assert_eq!(
-            xiaomi_openai.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(xiaomi_openai.base_url, "https://api.xiaomimimo.com/v1");
-        assert_eq!(xiaomi_openai.credential.as_deref(), Some("xiaomi-key"));
-
-        let xiaomi_token_plan = providers
-            .get(&ProviderId::parse("xiaomi-token-plan").unwrap())
-            .unwrap();
-        assert_eq!(
-            xiaomi_token_plan.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(
-            xiaomi_token_plan.base_url,
-            "https://token-plan-cn.xiaomimimo.com/v1"
-        );
-        assert_eq!(
-            xiaomi_token_plan.credential.as_deref(),
-            Some("xiaomi-token-plan-key")
-        );
-
-        let xiaomi_token_plan_anthropic = providers
-            .get(&ProviderId::parse("xiaomi-token-plan-anthropic").unwrap())
-            .unwrap();
-        assert_eq!(
-            xiaomi_token_plan_anthropic.transport,
-            ProviderTransportKind::AnthropicMessages
-        );
-        assert_eq!(
-            xiaomi_token_plan_anthropic.base_url,
-            "https://token-plan-cn.xiaomimimo.com/anthropic"
-        );
-        assert_eq!(
-            xiaomi_token_plan_anthropic.credential.as_deref(),
-            Some("xiaomi-token-plan-key")
-        );
-
-        let xiaomi_token_plan_openai = providers
-            .get(&ProviderId::parse("xiaomi-token-plan-openai").unwrap())
-            .unwrap();
-        assert_eq!(
-            xiaomi_token_plan_openai.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(
-            xiaomi_token_plan_openai.base_url,
-            "https://token-plan-cn.xiaomimimo.com/v1"
-        );
-        assert_eq!(
-            xiaomi_token_plan_openai.credential.as_deref(),
-            Some("xiaomi-token-plan-key")
-        );
-
         let zai = providers.get(&ProviderId::parse("zai").unwrap()).unwrap();
         assert_eq!(zai.transport, ProviderTransportKind::AnthropicMessages);
         assert_eq!(zai.base_url, "https://api.z.ai/api/anthropic");
         assert_eq!(zai.credential.as_deref(), Some("zai-key"));
-
-        let zai_anthropic = providers
-            .get(&ProviderId::parse("zai-anthropic").unwrap())
-            .unwrap();
-        assert_eq!(
-            zai_anthropic.transport,
-            ProviderTransportKind::AnthropicMessages
-        );
-        assert_eq!(zai_anthropic.base_url, "https://api.z.ai/api/anthropic");
-
-        let zai_openai = providers
-            .get(&ProviderId::parse("zai-openai").unwrap())
-            .unwrap();
-        assert_eq!(
-            zai_openai.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(zai_openai.base_url, "https://api.z.ai/api/paas/v4");
-        assert_eq!(zai_openai.credential.as_deref(), Some("zai-key"));
 
         let bigmodel = providers
             .get(&ProviderId::parse("bigmodel").unwrap())
@@ -6361,31 +6135,6 @@ mod tests {
         assert_eq!(bigmodel.transport, ProviderTransportKind::AnthropicMessages);
         assert_eq!(bigmodel.base_url, "https://open.bigmodel.cn/api/anthropic");
         assert_eq!(bigmodel.credential.as_deref(), Some("bigmodel-key"));
-
-        let bigmodel_anthropic = providers
-            .get(&ProviderId::parse("bigmodel-anthropic").unwrap())
-            .unwrap();
-        assert_eq!(
-            bigmodel_anthropic.transport,
-            ProviderTransportKind::AnthropicMessages
-        );
-        assert_eq!(
-            bigmodel_anthropic.base_url,
-            "https://open.bigmodel.cn/api/anthropic"
-        );
-
-        let bigmodel_openai = providers
-            .get(&ProviderId::parse("bigmodel-openai").unwrap())
-            .unwrap();
-        assert_eq!(
-            bigmodel_openai.transport,
-            ProviderTransportKind::OpenAiChatCompletions
-        );
-        assert_eq!(
-            bigmodel_openai.base_url,
-            "https://open.bigmodel.cn/api/paas/v4"
-        );
-        assert_eq!(bigmodel_openai.credential.as_deref(), Some("bigmodel-key"));
 
         let minimax = providers
             .get(&ProviderId::parse("minimax").unwrap())
@@ -6424,13 +6173,8 @@ mod tests {
 
         for provider in [
             "deepseek",
-            "deepseek-anthropic",
-            "xiaomi-anthropic",
-            "xiaomi-token-plan-anthropic",
             "zai",
-            "zai-anthropic",
             "bigmodel",
-            "bigmodel-anthropic",
             "minimax",
             "synthetic",
             "vercel-ai-gateway",
@@ -6499,7 +6243,7 @@ mod tests {
         let settings_env = HashMap::new();
 
         let known = super::built_in_provider_default_config_with_settings(
-            &ProviderId::parse("zai-anthropic").unwrap(),
+            &ProviderId::parse("zai").unwrap(),
             &settings_env,
         )
         .unwrap()

--- a/src/host.rs
+++ b/src/host.rs
@@ -214,6 +214,27 @@ impl RuntimeHost {
         self.inner.registry.config()
     }
 
+    /// Hot-reload config for all currently loaded agents.
+    ///
+    /// Re-reads the full config from disk (config file + credentials),
+    /// rebuilds each agent's provider/catalog/model-availability, and atomically swaps
+    /// the config snapshot. In-progress turns are unaffected; the next
+    /// turn picks up the new config.
+    pub async fn reload_all_agents_config(&self) -> Result<()> {
+        let new_config = crate::config::AppConfig::load()
+            .map_err(|e| anyhow!("failed to reload config: {}", e))?;
+        let agent_handles: Vec<RuntimeHandle> = {
+            let agents = self.inner.agents.read().await;
+            agents.values().map(|entry| entry.runtime.clone()).collect()
+        };
+        for runtime in &agent_handles {
+            if let Err(e) = runtime.reload_config(&new_config).await {
+                tracing::warn!(error = %e, "failed to reload config for agent");
+            }
+        }
+        Ok(())
+    }
+
     pub fn runtime_db(&self) -> &RuntimeDb {
         &self.inner.runtime_db
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1196,6 +1196,7 @@ pub struct RuntimeConfigUpdateResult {
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeConfigUpdateEffect {
     AcceptedRequiresRestart,
+    AcceptedReloaded,
     Rejected,
 }
 
@@ -1284,6 +1285,19 @@ pub async fn runtime_config_update(
 
     if changed {
         save_persisted_config_at(&config.config_file_path, &candidate).map_err(error_response)?;
+        // Hot-reload the runtime so the new config takes effect immediately.
+        // The current turn (if any) completes with the old provider; the next
+        // turn picks up the new config automatically.
+        if let Err(e) = state.host.reload_all_agents_config().await {
+            tracing::warn!(error = %e, "config saved but hot-reload failed; restart needed");
+        }
+        // Mark results as reloaded instead of requiring restart.
+        for result in &mut results {
+            if result.effect == RuntimeConfigUpdateEffect::AcceptedRequiresRestart {
+                result.effect = RuntimeConfigUpdateEffect::AcceptedReloaded;
+                result.reason = "applied via hot-reload".into();
+            }
+        }
     }
 
     Ok(Json(RuntimeConfigUpdateResponse {
@@ -1393,6 +1407,10 @@ pub async fn set_credential(
     let kind = CredentialKind::parse(&request.kind).map_err(error_response)?;
     let profile_status = set_credential_profile_at(&path, &profile, kind, request.material)
         .map_err(error_response)?;
+    // Hot-reload so the new credential is available without restart.
+    if let Err(e) = state.host.reload_all_agents_config().await {
+        tracing::warn!(error = %e, "credential saved but hot-reload failed; restart needed");
+    }
     Ok(Json(SetCredentialResponse {
         ok: true,
         profile: profile_status,
@@ -1414,6 +1432,9 @@ pub async fn delete_credential(
     let config = state.host.config();
     let path = credential_store_path(&config.home_dir);
     let profile_status = remove_credential_profile_at(&path, &profile).map_err(error_response)?;
+    if let Err(e) = state.host.reload_all_agents_config().await {
+        tracing::warn!(error = %e, "credential deleted but hot-reload failed; restart needed");
+    }
     Ok(Json(DeleteCredentialResponse {
         ok: true,
         profile: profile_status,

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -479,33 +479,6 @@ fn catalog_model(
     }
 }
 
-fn extend_catalog_model_aliases_from_source(
-    entries: &mut Vec<BuiltInModelMetadata>,
-    source_provider: &str,
-    alias_providers: &[&str],
-) {
-    let source_provider_id = provider_id(source_provider);
-    let source_entries = entries
-        .iter()
-        .filter(|entry| entry.model_ref.provider == source_provider_id)
-        .cloned()
-        .collect::<Vec<_>>();
-
-    for provider in alias_providers {
-        let alias_provider_id = provider_id(provider);
-        for source_entry in &source_entries {
-            let mut alias_entry = source_entry.clone();
-            alias_entry.model_ref =
-                ModelRef::new(alias_provider_id.clone(), &source_entry.model_ref.model);
-            alias_entry.description = format!(
-                "Holon built-in runtime metadata for the {}/{} compatible provider model.",
-                provider, source_entry.model_ref.model
-            );
-            entries.push(alias_entry);
-        }
-    }
-}
-
 fn built_in_entries() -> Vec<BuiltInModelMetadata> {
     let mut entries = vec![
         BuiltInModelMetadata {
@@ -912,42 +885,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "deepseek",
-            "deepseek-reasoner",
-            "DeepSeek Reasoner",
-            131_072,
-            65_536,
-            true,
-            false,
-        ),
-        catalog_model(
-            "deepseek-anthropic",
-            "deepseek-v4-flash",
-            "DeepSeek V4 Flash",
-            1_000_000,
-            384_000,
-            true,
-            false,
-        ),
-        catalog_model(
-            "deepseek-anthropic",
-            "deepseek-v4-pro",
-            "DeepSeek V4 Pro",
-            1_000_000,
-            384_000,
-            true,
-            false,
-        ),
-        catalog_model(
-            "deepseek-anthropic",
-            "deepseek-chat",
-            "DeepSeek Chat",
-            131_072,
-            8_192,
-            false,
-            false,
-        ),
-        catalog_model(
-            "deepseek-anthropic",
             "deepseek-reasoner",
             "DeepSeek Reasoner",
             131_072,
@@ -1994,8 +1931,15 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model("zai", "glm-5.2", "GLM-5.2", 1_000_000, 131_072, true, false),
+        catalog_model(
+            "bigmodel", "glm-5.2", "GLM-5.2", 1_000_000, 131_072, true, false,
+        ),
         catalog_model("zai", "glm-5.1", "GLM-5.1", 202_800, 131_100, true, false),
+        catalog_model(
+            "bigmodel", "glm-5.1", "GLM-5.1", 202_800, 131_100, true, false,
+        ),
         catalog_model("zai", "glm-5", "GLM-5", 202_800, 131_100, true, false),
+        catalog_model("bigmodel", "glm-5", "GLM-5", 202_800, 131_100, true, false),
         catalog_model(
             "zai",
             "glm-5-turbo",
@@ -2056,45 +2000,18 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model("zai", "glm-4.5v", "GLM-4.5V", 64_000, 16_384, true, true),
     ];
-    extend_catalog_model_aliases_from_source(&mut entries, "deepseek", &["deepseek-openai"]);
-    extend_catalog_model_aliases_from_source(
-        &mut entries,
-        "xiaomi",
-        &["xiaomi-anthropic", "xiaomi-openai"],
-    );
-    extend_catalog_model_aliases_from_source(
-        &mut entries,
-        "xiaomi-token-plan",
-        &["xiaomi-token-plan-anthropic", "xiaomi-token-plan-openai"],
-    );
-    extend_catalog_model_aliases_from_source(
-        &mut entries,
-        "zai",
-        &[
-            "zai-anthropic",
-            "zai-openai",
-            "bigmodel",
-            "bigmodel-anthropic",
-            "bigmodel-openai",
-        ],
-    );
-    extend_catalog_model_aliases_from_source(
-        &mut entries,
-        "qwen",
-        &["dashscope", "dashscope-openai"],
-    );
     entries.extend([
         catalog_model(
             "dashscope",
-            "deepseek-v4-pro",
-            "DeepSeek V4 Pro",
+            "qwen3.7-plus",
+            "Qwen3.7 Plus",
             1_000_000,
-            384_000,
+            65_536,
             true,
-            false,
+            true,
         ),
         catalog_model(
-            "dashscope-openai",
+            "dashscope",
             "deepseek-v4-pro",
             "DeepSeek V4 Pro",
             1_000_000,
@@ -2112,25 +2029,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "dashscope-openai",
-            "deepseek-v4-flash",
-            "DeepSeek V4 Flash",
-            1_000_000,
-            384_000,
-            true,
-            false,
-        ),
-        catalog_model(
             "dashscope",
-            "glm-5.1",
-            "glm-5.1",
-            202_752,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-openai",
             "glm-5.1",
             "glm-5.1",
             202_752,
@@ -2148,15 +2047,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "dashscope-openai",
-            "kimi-k2.6",
-            "kimi-k2.6",
-            262_144,
-            98_304,
-            true,
-            false,
-        ),
-        catalog_model(
             "dashscope",
             "MiniMax-M2.5",
             "MiniMax-M2.5",
@@ -2166,25 +2056,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "dashscope-openai",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5",
-            196_608,
-            32_768,
-            true,
-            false,
-        ),
-        catalog_model(
             "dashscope",
-            "mimo-v2.5-pro",
-            "MiMo V2.5 Pro",
-            1_000_000,
-            131_072,
-            true,
-            false,
-        ),
-        catalog_model(
-            "dashscope-openai",
             "mimo-v2.5-pro",
             "MiMo V2.5 Pro",
             1_000_000,
@@ -2194,15 +2066,6 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model("dashscope", "glm-5", "glm-5", 202_752, 16_384, false, false),
         catalog_model(
-            "dashscope-openai",
-            "glm-5",
-            "glm-5",
-            202_752,
-            16_384,
-            false,
-            false,
-        ),
-        catalog_model(
             "dashscope",
             "glm-4.7",
             "glm-4.7",
@@ -2212,25 +2075,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
-            "dashscope-openai",
-            "glm-4.7",
-            "glm-4.7",
-            202_752,
-            16_384,
-            false,
-            false,
-        ),
-        catalog_model(
             "dashscope",
-            "kimi-k2.5",
-            "kimi-k2.5",
-            262_144,
-            32_768,
-            false,
-            true,
-        ),
-        catalog_model(
-            "dashscope-openai",
             "kimi-k2.5",
             "kimi-k2.5",
             262_144,
@@ -2353,7 +2198,7 @@ mod tests {
         let catalog = BuiltInModelCatalog::new();
 
         let deepseek = catalog.resolve_policy(
-            &ModelRef::parse("deepseek-anthropic/deepseek-v4-flash").unwrap(),
+            &ModelRef::parse("deepseek/deepseek-v4-flash").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
@@ -2365,19 +2210,8 @@ mod tests {
         assert_eq!(deepseek.runtime_max_output_tokens, 384_000);
         assert_eq!(deepseek.source, ModelMetadataSource::BuiltInCatalog);
 
-        let deepseek_openai = catalog.resolve_policy(
-            &ModelRef::parse("deepseek-openai/deepseek-v4-flash").unwrap(),
-            &HashMap::new(),
-            &HashMap::new(),
-            None,
-            &base_context(),
-            8192,
-        );
-        assert_eq!(deepseek_openai.display_name, "DeepSeek V4 Flash");
-        assert_eq!(deepseek_openai.source, ModelMetadataSource::BuiltInCatalog);
-
         let xiaomi = catalog.resolve_policy(
-            &ModelRef::parse("xiaomi-token-plan-openai/mimo-v2.5-pro").unwrap(),
+            &ModelRef::parse("xiaomi/mimo-v2.5-pro").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
@@ -2391,7 +2225,7 @@ mod tests {
         assert_eq!(xiaomi.source, ModelMetadataSource::BuiltInCatalog);
 
         let xiaomi_ultraspeed = catalog.resolve_policy(
-            &ModelRef::parse("xiaomi-anthropic/mimo-v2.5-pro-ultraspeed").unwrap(),
+            &ModelRef::parse("xiaomi/mimo-v2.5-pro-ultraspeed").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
@@ -2421,7 +2255,7 @@ mod tests {
             .is_none());
 
         let zai = catalog.resolve_policy(
-            &ModelRef::parse("zai-anthropic/glm-5.2").unwrap(),
+            &ModelRef::parse("zai/glm-5.2").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
@@ -2434,7 +2268,7 @@ mod tests {
         assert_eq!(zai.source, ModelMetadataSource::BuiltInCatalog);
 
         let bigmodel = catalog.resolve_policy(
-            &ModelRef::parse("bigmodel-openai/glm-5.2").unwrap(),
+            &ModelRef::parse("bigmodel/glm-5.2").unwrap(),
             &HashMap::new(),
             &HashMap::new(),
             None,
@@ -2511,10 +2345,10 @@ mod tests {
             .is_some());
         assert!(catalog
             .get(&ModelRef::parse("dashscope-openai/qwen3.7-plus").unwrap())
-            .is_some());
+            .is_none());
         assert!(catalog
             .get(&ModelRef::parse("dashscope-openai/MiniMax-M2.5").unwrap())
-            .is_some());
+            .is_none());
     }
 
     #[test]

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1176,8 +1176,6 @@ mod tests {
             },
         );
         let deepseek = ProviderId::parse("deepseek").unwrap();
-        let deepseek_anthropic = ProviderId::parse("deepseek-anthropic").unwrap();
-        let deepseek_openai = ProviderId::parse("deepseek-openai").unwrap();
         let deepseek_config = ProviderRuntimeConfig {
             id: deepseek.clone(),
             transport: ProviderTransportKind::AnthropicMessages,
@@ -1200,22 +1198,6 @@ mod tests {
         config
             .providers
             .insert(deepseek.clone(), deepseek_config.clone());
-        config.providers.insert(
-            deepseek_anthropic.clone(),
-            ProviderRuntimeConfig {
-                id: deepseek_anthropic.clone(),
-                ..deepseek_config.clone()
-            },
-        );
-        config.providers.insert(
-            deepseek_openai.clone(),
-            ProviderRuntimeConfig {
-                id: deepseek_openai.clone(),
-                transport: ProviderTransportKind::OpenAiChatCompletions,
-                base_url: "https://api.deepseek.com/v1".into(),
-                ..deepseek_config
-            },
-        );
         config.default_model = ModelRef::parse("openai/custom-default").unwrap();
         config.fallback_models = vec![ModelRef::parse("openai/custom-fallback").unwrap()];
         config.validated_model_overrides.insert(
@@ -1245,12 +1227,6 @@ mod tests {
         assert_eq!(custom.credential_profile, "custom-openai");
         assert!(custom.configured);
         assert!(providers.iter().any(|provider| provider.id == deepseek));
-        assert!(!providers
-            .iter()
-            .any(|provider| provider.id == deepseek_anthropic));
-        assert!(!providers
-            .iter()
-            .any(|provider| provider.id == deepseek_openai));
 
         let models = onboarding_model_choices(&config, &ProviderId::openai());
         assert_eq!(models[0].model.as_string(), "openai/custom-default");

--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -198,19 +198,19 @@ mod tests {
         let provider = FallbackProvider {
             candidates: vec![
                 ProviderCandidate {
-                    model_ref: "zai-anthropic/glm-4.7".into(),
-                    provider_name: "zai-anthropic".into(),
+                    model_ref: "zai/glm-4.7".into(),
+                    provider_name: "zai".into(),
                     provider: Arc::new(SearchProvider {
                         capability: Some(search_capability(
-                            "zai-anthropic",
-                            "zai-anthropic/glm-4.7",
+                            "zai",
+                            "zai/glm-4.7",
                             "zai_web_search_prime",
                         )),
                     }),
                 },
                 ProviderCandidate {
-                    model_ref: "deepseek-anthropic/deepseek-chat".into(),
-                    provider_name: "deepseek-anthropic".into(),
+                    model_ref: "deepseek/deepseek-chat".into(),
+                    provider_name: "deepseek".into(),
                     provider: Arc::new(SearchProvider { capability: None }),
                 },
             ],
@@ -219,8 +219,8 @@ mod tests {
         let capability = provider
             .builtin_web_search()
             .expect("active candidate should expose builtin search");
-        assert_eq!(capability.provider_id, "zai-anthropic");
-        assert_eq!(capability.provider_model_ref, "zai-anthropic/glm-4.7");
+        assert_eq!(capability.provider_id, "zai");
+        assert_eq!(capability.provider_model_ref, "zai/glm-4.7");
         assert_eq!(capability.backend_kind, "zai_web_search_prime");
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -42,7 +42,8 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use bootstrap::ProviderReconfigurator;
+use arc_swap::ArcSwap;
+use bootstrap::ConfigSnapshot;
 use chrono::Utc;
 use serde::Serialize;
 use serde_json::Value;
@@ -95,13 +96,12 @@ use crate::{
         ExternalTriggerStatus, ExternalTriggerSummary, LoadedAgentsMd, MessageBody,
         MessageDeliverySurface, MessageEnvelope, MessageKind, MessageLifecycleAuditEvent,
         MessageOrigin, PendingWakeHint, Priority, QueueEntryRecord, QueueEntryStatus,
-        ResolvedModelAvailability, RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture,
-        SkillActivationSource, SkillActivationState, SkillCatalogEntry, SkillLoadReason,
-        SkillsRuntimeView, TaskKind, TaskLifecycleAuditEvent, TaskRecord, TaskRecoverySpec,
-        TaskStatus, TimerRecord, TimerStatus, ToolExecutionRecord, TranscriptEntry,
-        TranscriptEntryKind, ViewImageObservation, WaitingIntentRecord, WaitingIntentStatus,
-        WaitingIntentSummary, WaitingReason, WorkItemLifecycleAuditEvent, WorkspaceEntry,
-        AGENT_HOME_WORKSPACE_ID,
+        RuntimeFailurePhase, RuntimeFailureSummary, RuntimePosture, SkillActivationSource,
+        SkillActivationState, SkillCatalogEntry, SkillLoadReason, SkillsRuntimeView, TaskKind,
+        TaskLifecycleAuditEvent, TaskRecord, TaskRecoverySpec, TaskStatus, TimerRecord,
+        TimerStatus, ToolExecutionRecord, TranscriptEntry, TranscriptEntryKind,
+        ViewImageObservation, WaitingIntentRecord, WaitingIntentStatus, WaitingIntentSummary,
+        WaitingReason, WorkItemLifecycleAuditEvent, WorkspaceEntry, AGENT_HOME_WORKSPACE_ID,
     },
     web::{WebConfig, WebProviderKind},
 };
@@ -238,14 +238,8 @@ struct RuntimeInner {
     storage: AppStorage,
     runtime_db: RuntimeDb,
     provider: RwLock<Arc<dyn AgentProvider>>,
-    provider_reconfig: Option<ProviderReconfigurator>,
-    model_catalog: RuntimeModelCatalog,
-    model_availability: Vec<ResolvedModelAvailability>,
-    base_context_config: ContextConfig,
     context_config: RwLock<ContextConfig>,
-    default_tool_output_tokens: u64,
-    max_tool_output_tokens: u64,
-    web_config: WebConfig,
+    config_snapshot: ArcSwap<ConfigSnapshot>,
     builtin_web_search_probe_cache:
         Mutex<HashMap<BuiltinWebSearchProbeKey, BuiltinWebSearchProbeCacheEntry>>,
     view_image_observation_cache:
@@ -825,8 +819,8 @@ impl RuntimeHandle {
         self.inner.system.clone()
     }
 
-    pub(crate) fn web_config(&self) -> &WebConfig {
-        &self.inner.web_config
+    pub(crate) fn web_config(&self) -> WebConfig {
+        self.inner.config_snapshot.load().web_config.clone()
     }
 
     fn user_home(&self) -> Option<PathBuf> {
@@ -885,7 +879,13 @@ impl RuntimeHandle {
             next_state.model_override = parent_state.model_override.clone();
             next_state
         };
-        if self.inner.provider_reconfig.is_some() {
+        if self
+            .inner
+            .config_snapshot
+            .load()
+            .provider_reconfig
+            .is_some()
+        {
             self.reconfigure_provider_for_state(&next_state).await?;
         }
         self.update_agent_state(|state| {
@@ -910,7 +910,13 @@ impl RuntimeHandle {
             next_state.model_override = parent_state.model_override.clone();
             next_state
         };
-        if self.inner.provider_reconfig.is_some() {
+        if self
+            .inner
+            .config_snapshot
+            .load()
+            .provider_reconfig
+            .is_some()
+        {
             self.reconfigure_provider_for_state(&next_state).await?;
         }
         self.update_agent_state(|state| {

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
+use arc_swap::ArcSwap;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use tokio::sync::{Mutex, Notify, RwLock};
 
@@ -34,6 +35,51 @@ use super::{
     scheduler_executor, workspace, AgentRuntimeProjectionCache, InitialWorkspaceBinding,
     RuntimeAgent, RuntimeHandle, RuntimeInner,
 };
+
+/// Snapshot of config-derived runtime fields that can be hot-swapped at runtime.
+/// Stored behind an `ArcSwap` so that config reloads take effect on the next turn
+/// without disturbing an in-progress turn.
+pub(super) struct ConfigSnapshot {
+    pub model_catalog: RuntimeModelCatalog,
+    pub model_availability: Vec<ResolvedModelAvailability>,
+    pub base_context_config: ContextConfig,
+    pub provider_reconfig: Option<ProviderReconfigurator>,
+    pub default_tool_output_tokens: u64,
+    pub max_tool_output_tokens: u64,
+    pub web_config: crate::web::WebConfig,
+}
+
+impl ConfigSnapshot {
+    /// Build a fresh snapshot from a config, preserving the agent's current model override.
+    pub fn from_config(config: &AppConfig) -> Self {
+        let model_catalog = RuntimeModelCatalog::from_config(config);
+        let model_availability = resolved_model_availability(config);
+        let provider_reconfig = Some(ProviderReconfigurator {
+            config: config.clone(),
+        });
+        let base_context_config = ContextConfig {
+            recent_messages: config.context_window_messages,
+            recent_briefs: config.context_window_briefs,
+            compaction_trigger_messages: config.compaction_trigger_messages,
+            compaction_keep_recent_messages: config.compaction_keep_recent_messages,
+            prompt_budget_estimated_tokens: config.prompt_budget_estimated_tokens,
+            compaction_trigger_estimated_tokens: config.compaction_trigger_estimated_tokens,
+            compaction_keep_recent_estimated_tokens: config.compaction_keep_recent_estimated_tokens,
+            recent_episode_candidates: config.recent_episode_candidates,
+            max_relevant_episodes: config.max_relevant_episodes,
+            ..ContextConfig::default()
+        };
+        Self {
+            model_catalog,
+            model_availability,
+            base_context_config,
+            provider_reconfig,
+            default_tool_output_tokens: config.default_tool_output_tokens as u64,
+            max_tool_output_tokens: config.max_tool_output_tokens as u64,
+            web_config: config.web_config.clone(),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct ProviderReconfigurator {
@@ -180,6 +226,15 @@ impl RuntimeHandle {
         host_bridge: Option<RuntimeHostBridge>,
         event_bus: Option<EventBus>,
     ) -> Result<Self> {
+        let config_snapshot = Arc::new(ConfigSnapshot {
+            model_catalog: model_catalog.clone(),
+            model_availability: model_availability.clone(),
+            base_context_config: base_context_config.clone(),
+            provider_reconfig: provider_reconfig.clone(),
+            default_tool_output_tokens,
+            max_tool_output_tokens,
+            web_config: web_config.clone(),
+        });
         let mut provider = provider;
         let PreparedRuntimeStorage {
             storage,
@@ -194,20 +249,26 @@ impl RuntimeHandle {
             storage.enable_event_bus(event_bus)?;
         }
 
-        if let Some(reconfig) = provider_reconfig.as_ref() {
-            let chain = model_catalog.provider_chain_for_turn(
+        if let Some(reconfig) = config_snapshot.provider_reconfig.as_ref() {
+            let chain = config_snapshot.model_catalog.provider_chain_for_turn(
                 state.model_override.as_ref(),
                 state.pending_fallback_model.as_ref(),
             );
             let mut provider_config = reconfig.config.clone();
-            provider_config.runtime_max_output_tokens = model_catalog
-                .resolved_model_policy(&base_context_config, state.model_override.as_ref())
+            provider_config.runtime_max_output_tokens = config_snapshot
+                .model_catalog
+                .resolved_model_policy(
+                    &config_snapshot.base_context_config,
+                    state.model_override.as_ref(),
+                )
                 .runtime_max_output_tokens;
             provider = build_provider_from_model_chain(&provider_config, &chain)?;
         }
-        let resolved_context_config = if provider_reconfig.is_some() {
-            model_catalog
-                .resolved_context_config(&base_context_config, state.model_override.as_ref())
+        let resolved_context_config = if config_snapshot.provider_reconfig.is_some() {
+            config_snapshot.model_catalog.resolved_context_config(
+                &config_snapshot.base_context_config,
+                state.model_override.as_ref(),
+            )
         } else {
             context_config.clone()
         };
@@ -226,14 +287,8 @@ impl RuntimeHandle {
                 storage,
                 runtime_db,
                 provider: RwLock::new(provider),
-                provider_reconfig,
-                model_catalog,
-                model_availability,
-                base_context_config,
+                config_snapshot: ArcSwap::from(config_snapshot),
                 context_config: RwLock::new(resolved_context_config),
-                default_tool_output_tokens,
-                max_tool_output_tokens,
-                web_config,
                 builtin_web_search_probe_cache: Mutex::new(HashMap::new()),
                 view_image_observation_cache: Mutex::new(HashMap::new()),
                 callback_base_url,
@@ -255,11 +310,8 @@ impl RuntimeHandle {
     }
 
     pub(crate) fn model_state_for(&self, state: &AgentState) -> crate::types::AgentModelState {
-        super::agent_model_state_for_catalog(
-            &self.inner.model_catalog,
-            &self.inner.base_context_config,
-            state,
-        )
+        let snap = self.inner.config_snapshot.load();
+        super::agent_model_state_for_catalog(&snap.model_catalog, &snap.base_context_config, state)
     }
 
     pub(crate) async fn current_apply_patch_surface(&self) -> ApplyPatchSurface {
@@ -278,8 +330,8 @@ impl RuntimeHandle {
     }
 
     fn selected_model_ref_for_state(&self, state: &AgentState) -> Option<ModelRef> {
-        self.inner
-            .model_catalog
+        let snap = self.inner.config_snapshot.load();
+        snap.model_catalog
             .provider_chain_for_turn(
                 state.model_override.as_ref(),
                 state.pending_fallback_model.as_ref(),
@@ -289,19 +341,19 @@ impl RuntimeHandle {
     }
 
     pub(crate) async fn reconfigure_provider_for_state(&self, state: &AgentState) -> Result<()> {
-        let Some(reconfig) = self.inner.provider_reconfig.as_ref() else {
+        let snap = self.inner.config_snapshot.load();
+        let Some(reconfig) = snap.provider_reconfig.as_ref() else {
             return Err(anyhow!(
                 "agent model override is unavailable for runtimes without host-managed provider configuration"
             ));
         };
-        let chain = self.inner.model_catalog.provider_chain_for_turn(
+        let chain = snap.model_catalog.provider_chain_for_turn(
             state.model_override.as_ref(),
             state.pending_fallback_model.as_ref(),
         );
-        let resolved_context_config = self.inner.model_catalog.resolved_context_config(
-            &self.inner.base_context_config,
-            state.model_override.as_ref(),
-        );
+        let resolved_context_config = snap
+            .model_catalog
+            .resolved_context_config(&snap.base_context_config, state.model_override.as_ref());
         let mut provider_config = reconfig.config.clone();
         if let (Some(primary), Some(reasoning_effort)) = (
             chain.first(),
@@ -311,13 +363,9 @@ impl RuntimeHandle {
                 provider.reasoning_effort = Some(reasoning_effort.clone());
             }
         }
-        provider_config.runtime_max_output_tokens = self
-            .inner
+        provider_config.runtime_max_output_tokens = snap
             .model_catalog
-            .resolved_model_policy(
-                &self.inner.base_context_config,
-                state.model_override.as_ref(),
-            )
+            .resolved_model_policy(&snap.base_context_config, state.model_override.as_ref())
             .runtime_max_output_tokens;
         let provider = build_provider_from_model_chain(&provider_config, &chain)?;
         *self.inner.provider.write().await = provider;
@@ -326,7 +374,8 @@ impl RuntimeHandle {
     }
 
     pub(crate) async fn reconfigure_provider_for_current_state(&self) -> Result<()> {
-        if self.inner.provider_reconfig.is_none() {
+        let snap = self.inner.config_snapshot.load();
+        if snap.provider_reconfig.is_none() {
             return Ok(());
         }
         let state = {
@@ -334,6 +383,31 @@ impl RuntimeHandle {
             guard.state.clone()
         };
         self.reconfigure_provider_for_state(&state).await
+    }
+
+    /// Hot-reload config-derived runtime fields from a new `AppConfig`.
+    ///
+    /// Builds a fresh `ConfigSnapshot`, swaps it atomically, then rebuilds
+    /// the provider for the agent's current model-override state. The swap
+    /// is atomic via `ArcSwap`, so an in-progress turn that already loaded
+    /// the old snapshot continues unaffected; the next turn picks up the
+    /// new snapshot automatically.
+    pub(crate) async fn reload_config(&self, config: &AppConfig) -> Result<()> {
+        let new_snapshot = Arc::new(ConfigSnapshot::from_config(config));
+        // Atomically swap the snapshot.
+        self.inner.config_snapshot.store(new_snapshot);
+        // Rebuild provider + context_config for current state.
+        // If this runtime has no provider_reconfig (static provider), skip.
+        let snap = self.inner.config_snapshot.load();
+        if snap.provider_reconfig.is_some() {
+            let state = {
+                let guard = self.inner.agent.lock().await;
+                guard.state.clone()
+            };
+            self.reconfigure_provider_for_state(&state).await?;
+        }
+        tracing::info!("hot-reloaded runtime config (provider/catalog/availability)");
+        Ok(())
     }
 
     pub(crate) async fn current_context_config(&self) -> ContextConfig {
@@ -344,8 +418,9 @@ impl RuntimeHandle {
         &self,
     ) -> Result<crate::types::ViewImageVisionSelection> {
         let state = self.agent_state().await?;
-        Ok(self.inner.model_catalog.select_view_image_vision_model(
-            &self.inner.base_context_config,
+        let snap = self.inner.config_snapshot.load();
+        Ok(snap.model_catalog.select_view_image_vision_model(
+            &snap.base_context_config,
             state.model_override.as_ref(),
             state.pending_fallback_model.as_ref(),
         ))
@@ -393,8 +468,8 @@ impl RuntimeHandle {
             .vision_model
             .as_deref()
             .ok_or_else(|| anyhow!("vision selection did not include a model"))?;
-        if !self
-            .inner
+        let vision_snap = self.inner.config_snapshot.load();
+        if !vision_snap
             .model_catalog
             .provider_supports_view_image_observation(provider_name)
         {
@@ -402,7 +477,8 @@ impl RuntimeHandle {
                 "vision model {provider_name}/{model_name} is not supported by ViewImage observation generation yet"
             ));
         }
-        let reconfig = self.inner.provider_reconfig.as_ref().ok_or_else(|| {
+        let snap = self.inner.config_snapshot.load();
+        let reconfig = snap.provider_reconfig.as_ref().ok_or_else(|| {
             anyhow!("ViewImage observation generation requires host-managed provider configuration")
         })?;
         let provider = build_provider_from_model_chain(
@@ -439,7 +515,8 @@ impl RuntimeHandle {
     }
 
     async fn model_config_with_fresh_discovery_cache(&self) -> Option<AppConfig> {
-        let Some(reconfig) = self.inner.provider_reconfig.as_ref() else {
+        let snap = self.inner.config_snapshot.load();
+        let Some(reconfig) = snap.provider_reconfig.as_ref() else {
             return None;
         };
         let mut config = reconfig.config.clone();
@@ -470,14 +547,16 @@ impl RuntimeHandle {
         if let Some(config) = self.model_config_with_fresh_discovery_cache().await {
             return Ok(RuntimeModelCatalog::from_config(&config).available_models());
         }
-        Ok(self.inner.model_catalog.available_models())
+        let snap = self.inner.config_snapshot.load();
+        Ok(snap.model_catalog.available_models())
     }
 
     pub(crate) async fn model_availability(&self) -> Result<Vec<ResolvedModelAvailability>> {
         if let Some(config) = self.model_config_with_fresh_discovery_cache().await {
             return Ok(resolved_model_availability(&config));
         }
-        Ok(self.inner.model_availability.clone())
+        let snap = self.inner.config_snapshot.load();
+        Ok(snap.model_availability.clone())
     }
 
     pub(crate) async fn model_providers(&self) -> Result<Vec<crate::types::ModelProviderEntry>> {
@@ -500,8 +579,8 @@ impl RuntimeHandle {
     }
 
     async fn provider_config_for_projection(&self) -> Option<AppConfig> {
-        self.inner
-            .provider_reconfig
+        let snap = self.inner.config_snapshot.load();
+        snap.provider_reconfig
             .as_ref()
             .map(|reconfig| reconfig.config.clone())
     }

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -434,10 +434,11 @@ impl RuntimeHandle {
     }
 
     fn apply_command_output_policy(&self, spec: &mut CommandTaskSpec) {
+        let snap = self.inner.config_snapshot.load();
         let effective = effective_tool_output_tokens(
             spec.max_output_tokens,
-            self.inner.default_tool_output_tokens,
-            self.inner.max_tool_output_tokens,
+            snap.default_tool_output_tokens,
+            snap.max_tool_output_tokens,
         );
         spec.max_output_tokens = Some(effective);
     }
@@ -446,10 +447,11 @@ impl RuntimeHandle {
         command_cost_diagnostics(
             &spec.cmd,
             spec.max_output_tokens.unwrap_or_else(|| {
+                let snap = self.inner.config_snapshot.load();
                 effective_tool_output_tokens(
                     None,
-                    self.inner.default_tool_output_tokens,
-                    self.inner.max_tool_output_tokens,
+                    snap.default_tool_output_tokens,
+                    snap.max_tool_output_tokens,
                 )
             }),
         )

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -334,7 +334,8 @@ impl RuntimeHandle {
         BuiltinWebSearchSelectionDiagnostics,
     )> {
         let provider = self.current_provider().await;
-        let native_search_provider = self.web_config().native_search_provider();
+        let web_config = self.web_config();
+        let native_search_provider = web_config.native_search_provider();
         let builtin_capability = provider.builtin_web_search();
         let probe_result = if let Some(capability) = builtin_capability.as_ref() {
             let probe_key = BuiltinWebSearchProbeKey::from_capability(capability);
@@ -347,7 +348,7 @@ impl RuntimeHandle {
             } else if !builtin_web_search_probe_requested(
                 capability,
                 native_search_provider.as_ref(),
-                &self.web_config().search,
+                &web_config.search,
             ) {
                 BuiltinWebSearchProbeCacheEntry {
                     status: BuiltinWebSearchProbeStatus::Skipped,
@@ -357,7 +358,7 @@ impl RuntimeHandle {
                 probe_builtin_web_search_capability(
                     provider.as_ref(),
                     capability,
-                    self.web_config().search.max_results,
+                    web_config.search.max_results,
                 )
                 .await
             }
@@ -372,7 +373,7 @@ impl RuntimeHandle {
             native_web_search_request_for_config(
                 builtin_capability,
                 native_search_provider.as_ref(),
-                &self.web_config().search,
+                &web_config.search,
                 &mut cache,
                 probe_result,
             )

--- a/src/runtime/turn.rs
+++ b/src/runtime/turn.rs
@@ -3071,8 +3071,14 @@ impl TurnExecution<'_> {
                             "exec_command_batch_items": command_batch_preview_field(&call),
                             "exec_command_cost": command_cost_field(
                                 &call,
-                                runtime.inner.default_tool_output_tokens,
-                                runtime.inner.max_tool_output_tokens
+                                {
+                                    let snap = runtime.inner.config_snapshot.load();
+                                    snap.default_tool_output_tokens
+                                },
+                                {
+                                    let snap = runtime.inner.config_snapshot.load();
+                                    snap.max_tool_output_tokens
+                                },
                             ),
                             "error": audit_error,
                             "error_kind": error.kind.clone(),
@@ -3215,8 +3221,12 @@ impl TurnExecution<'_> {
                                 exec_command_batch_items: command_batch_preview_field(&call),
                                 exec_command_cost: command_cost_field(
                                     &call,
-                                    runtime.inner.default_tool_output_tokens,
-                                    runtime.inner.max_tool_output_tokens,
+                                    runtime
+                                        .inner
+                                        .config_snapshot
+                                        .load()
+                                        .default_tool_output_tokens,
+                                    runtime.inner.config_snapshot.load().max_tool_output_tokens,
                                 ),
                                 exec_command_disposition: exec_command_disposition_field(
                                     &call,
@@ -3275,8 +3285,8 @@ impl TurnExecution<'_> {
                                 "exec_command_batch_items": command_batch_preview_field(&call),
                                 "exec_command_cost": command_cost_field(
                                     &call,
-                                    runtime.inner.default_tool_output_tokens,
-                                    runtime.inner.max_tool_output_tokens
+                                    runtime.inner.config_snapshot.load().default_tool_output_tokens,
+                                    runtime.inner.config_snapshot.load().max_tool_output_tokens
                                 ),
                                 "error": audit_error,
                                 "error_kind": error.kind.clone(),

--- a/src/tool/tools/web_fetch.rs
+++ b/src/tool/tools/web_fetch.rs
@@ -39,13 +39,14 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: WebFetchArgs = parse_tool_args(NAME, input)?;
     let url = validate_non_empty(args.url, NAME, "url")?;
+    let web_config = runtime.web_config();
     let result = fetch(
         WebFetchRequest {
             url,
             max_chars: args.max_chars,
             extract_mode: args.extract_mode,
         },
-        &runtime.web_config().fetch,
+        &web_config.fetch,
     )
     .await?;
     serialize_success(NAME, &result)

--- a/src/tool/tools/web_search.rs
+++ b/src/tool/tools/web_search.rs
@@ -41,13 +41,14 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: WebSearchArgs = parse_tool_args(NAME, input)?;
     let query = validate_non_empty(args.query, NAME, "query")?;
+    let web_config = runtime.web_config();
     let result = search(
         WebSearchRequest {
             query,
             max_results: args.max_results,
             provider: args.provider,
         },
-        runtime.web_config(),
+        &web_config,
     )
     .await?;
     serialize_success(NAME, &result)

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -1863,6 +1863,10 @@ fn onboarding_runtime_config_status(
             "Onboarding set runtime default model to {model} via daemon config; restart/reload required: {}",
             result.reason
         ),
+        crate::http::RuntimeConfigUpdateEffect::AcceptedReloaded => format!(
+            "Onboarding set runtime default model to {model} via daemon config; applied via hot-reload: {}",
+            result.reason
+        ),
         crate::http::RuntimeConfigUpdateEffect::Rejected => format!(
             "Onboarding daemon config update rejected for model.default: {}",
             result.reason

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1306,7 +1306,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     assert_eq!(valid_model_payload["changed"], true);
     assert_eq!(
         valid_model_payload["results"][0]["effect"],
-        "accepted_requires_restart"
+        "accepted_reloaded"
     );
 
     let persisted = load_persisted_config_at(&config.config_file_path)?;
@@ -1336,7 +1336,7 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     assert_eq!(valid_cors_payload["changed"], true);
     assert_eq!(
         valid_cors_payload["results"][0]["effect"],
-        "accepted_requires_restart"
+        "accepted_reloaded"
     );
 
     let persisted = load_persisted_config_at(&config.config_file_path)?;

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -6,7 +6,7 @@ import { EmptyState } from "../components/ui/EmptyState";
 import { SegmentedControl, SegmentedControlButton } from "../components/ui/SegmentedControl";
 import { StatusBadge } from "../components/ui/StatusChip";
 import { DashboardPage } from "../features/dashboard/DashboardPage";
-import { InspectorPanel } from "../features/inspector/InspectorPanel";
+import { RightSidePanel } from "../features/right-panel/RightSidePanel";
 import { SearchPage } from "../features/search/SearchPage";
 import { SettingsPage } from "../features/settings/SettingsPage";
 import { deriveAgentDisplayStatus } from "../runtime/agent-status";
@@ -28,16 +28,16 @@ export function App() {
   const route = useRuntimeStore((state) => state.route);
   const selectedAgentId = useRuntimeStore((state) => state.selectedAgentId);
   const displayLevel = useRuntimeStore((state) => state.displayLevel);
-  const inspectorOpen = useRuntimeStore((state) => state.inspectorOpen);
-  const inspectorSelection = useRuntimeStore((state) => state.inspectorSelection);
+  const rightPanelOpen = useRuntimeStore((state) => state.rightPanelOpen);
+  const rightPanelView = useRuntimeStore((state) => state.rightPanelView);
   const navCollapsed = useRuntimeStore((state) => state.navCollapsed);
   const setRoute = useRuntimeStore((state) => state.setRoute);
   const openAgent = useRuntimeStore((state) => state.openAgent);
   const setDisplayLevel = useRuntimeStore((state) => state.setDisplayLevel);
-  const setInspectorOpen = useRuntimeStore((state) => state.setInspectorOpen);
+  const setRightPanelOpen = useRuntimeStore((state) => state.setRightPanelOpen);
   const inspectActivity = useRuntimeStore((state) => state.inspectActivity);
-  const clearInspectorSelection = useRuntimeStore((state) => state.clearInspectorSelection);
-  const toggleInspector = useRuntimeStore((state) => state.toggleInspector);
+  const showAgentOverview = useRuntimeStore((state) => state.showAgentOverview);
+  const toggleRightPanel = useRuntimeStore((state) => state.toggleRightPanel);
   const toggleNavCollapsed = useRuntimeStore((state) => state.toggleNavCollapsed);
   const setRuntimeConnection = useRuntimeStore((state) => state.setRuntimeConnection);
   const selectedAgent = useRuntimeStore(selectSelectedAgent);
@@ -174,7 +174,7 @@ export function App() {
   return (
     <div
       className="app-shell"
-      data-panel={inspectorOpen ? "open" : "closed"}
+      data-panel={rightPanelOpen ? "open" : "closed"}
       data-nav-collapsed={navCollapsed}
     >
       <aside className="sidebar" aria-label="Holon navigation">
@@ -288,9 +288,9 @@ export function App() {
                 type="button"
                 size="icon"
                 variant="ghost"
-                aria-label="Toggle object inspector"
-                title="Toggle object inspector"
-                onClick={toggleInspector}
+                aria-label="Toggle context panel"
+                title="Toggle context panel"
+                onClick={toggleRightPanel}
               >
                 ▭
               </Button>
@@ -329,13 +329,12 @@ export function App() {
             onLoadOlderEvents={() => loadOlderAgentEvents(activeAgent.id, displayLevel)}
             onSendPrompt={(text) => sendOperatorPrompt(activeAgent.id, text, displayLevel)}
             onOpenInspector={() => {
-              clearInspectorSelection();
-              setInspectorOpen(true);
+              showAgentOverview(activeAgent.id);
             }}
             onInspectActivity={(activity) => inspectActivity(activeAgent.id, activity)}
             selectedActivityId={
-              inspectorSelection?.kind === "activity" && inspectorSelection.agentId === activeAgent.id
-                ? inspectorSelection.activity.id
+              rightPanelView?.kind === "activity_inspector" && rightPanelView.agentId === activeAgent.id
+                ? rightPanelView.activity.id
                 : undefined
             }
           />
@@ -374,12 +373,12 @@ export function App() {
       </main>
 
       {selectedAgent ? (
-        <InspectorPanel
+        <RightSidePanel
           agent={selectedAgent}
-          selection={inspectorSelection?.agentId === selectedAgent.id ? inspectorSelection : undefined}
-          open={inspectorOpen}
-          onClearSelection={clearInspectorSelection}
-          onClose={() => setInspectorOpen(false)}
+          view={rightPanelView?.agentId === selectedAgent.id ? rightPanelView : undefined}
+          open={rightPanelOpen}
+          onShowAgentOverview={showAgentOverview}
+          onClose={() => setRightPanelOpen(false)}
         />
       ) : null}
     </div>

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -42,6 +42,7 @@ export function App() {
   const toggleNavCollapsed = useRuntimeStore((state) => state.toggleNavCollapsed);
   const setRuntimeConnection = useRuntimeStore((state) => state.setRuntimeConnection);
   const selectedAgent = useRuntimeStore(selectSelectedAgent);
+  const rosterActivityByAgentId = useRuntimeStore((state) => state.rosterActivityByAgentId);
   const activeAgentId = route === "agent" ? selectedAgent?.id ?? selectedAgentId : undefined;
   const selectedAgentSession = useRuntimeStore((state) =>
     activeAgentId ? state.sessionsByAgentId[activeAgentId] : undefined,
@@ -225,6 +226,7 @@ export function App() {
             bootstrap.agents.map((agent) => {
               const status = deriveAgentDisplayStatus(agent);
               const workSummary = agent.currentWork?.objective;
+              const unreadCount = rosterActivityByAgentId[agent.id]?.unreadCount ?? 0;
 
               return (
                 <button
@@ -238,6 +240,11 @@ export function App() {
                   <span className="agent-row-main">
                     <span className="agent-row-title">
                       <strong>{agent.id}</strong>
+                      {unreadCount > 0 ? (
+                        <span className="agent-row-unread" aria-label={`${unreadCount} unread updates`}>
+                          {formatUnreadCount(unreadCount)}
+                        </span>
+                      ) : null}
                       <StatusBadge className="agent-row-status" kind="agent" value={status.tone} aria-label={status.title} title={status.title}>
                         {status.label}
                       </StatusBadge>
@@ -516,6 +523,10 @@ function MissingAgentPage({ agentId, loading }: { agentId: string; loading: bool
       </div>
     </section>
   );
+}
+
+function formatUnreadCount(count: number): string {
+  return count > 99 ? "99+" : String(count);
 }
 
 function pageTitle(route: RouteKey): string {

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -68,6 +68,7 @@ export function App() {
   const setAgentModel = useRuntimeStore((state) => state.setAgentModel);
   const clearAgentModel = useRuntimeStore((state) => state.clearAgentModel);
   const loadOlderAgentEvents = useRuntimeStore((state) => state.loadOlderAgentEvents);
+  const loadAgentWorkItemDetail = useRuntimeStore((state) => state.loadAgentWorkItemDetail);
   const {
     detail: selectedAgentDetail,
     loading: agentDetailLoading,
@@ -375,8 +376,10 @@ export function App() {
       {selectedAgent ? (
         <RightSidePanel
           agent={selectedAgent}
+          workItemDetailsById={selectedAgentSession?.workItemDetailsById ?? {}}
           view={rightPanelView?.agentId === selectedAgent.id ? rightPanelView : undefined}
           open={rightPanelOpen}
+          onLoadWorkItemDetail={(workItemId) => loadAgentWorkItemDetail(selectedAgent.id, workItemId)}
           onShowAgentOverview={showAgentOverview}
           onClose={() => setRightPanelOpen(false)}
         />

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -423,6 +423,10 @@ function ConnectionSwitcher({
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | undefined>();
 
+  useEffect(() => {
+    if (connection.mode === "remote") setBaseUrl(connection.baseUrl ?? "");
+  }, [connection.baseUrl, connection.mode]);
+
   async function applyConnection(config: RuntimeConnectionConfig) {
     setSaving(true);
     setFormError(undefined);
@@ -455,7 +459,7 @@ function ConnectionSwitcher({
               setFormError("Remote URL is required.");
               return;
             }
-            void applyConnection({ mode: "remote", baseUrl: trimmedBaseUrl, token });
+            void applyConnection({ mode: "remote", baseUrl: trimmedBaseUrl, token: token.trim() || undefined });
           }}
         >
           <label>
@@ -472,7 +476,7 @@ function ConnectionSwitcher({
             <input
               value={token}
               onChange={(event) => setToken(event.target.value)}
-              placeholder="optional for trusted local networks"
+              placeholder={connection.hasToken ? "saved token retained unless replaced" : "optional for trusted local networks"}
               type="password"
             />
           </label>

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -241,13 +241,13 @@ export function App() {
                     <span className="agent-row-title">
                       <strong>{agent.id}</strong>
                       {unreadCount > 0 ? (
-                        <span className="agent-row-unread" aria-label={`${unreadCount} unread updates`}>
+                        <span className="agent-row-unread" aria-label={`${unreadCount} unread updates`} title={`${unreadCount} unread updates`}>
                           {formatUnreadCount(unreadCount)}
                         </span>
                       ) : null}
-                      <StatusBadge className="agent-row-status" kind="agent" value={status.tone} aria-label={status.title} title={status.title}>
-                        {status.label}
-                      </StatusBadge>
+                      <span className={`agent-row-status-dot ${status.tone}`} aria-label={status.title} title={`${status.label} · ${status.title}`}>
+                        {agentStatusIcon(status.tone)}
+                      </span>
                     </span>
                     {workSummary ? (
                       <span className="agent-row-meta">
@@ -527,6 +527,15 @@ function MissingAgentPage({ agentId, loading }: { agentId: string; loading: bool
 
 function formatUnreadCount(count: number): string {
   return count > 99 ? "99+" : String(count);
+}
+
+function agentStatusIcon(tone: string): string {
+  if (tone === "running") return "●";
+  if (tone === "needs-input") return "!";
+  if (tone === "waiting") return "◌";
+  if (tone === "ready") return "✓";
+  if (tone === "stopped") return "×";
+  return "·";
 }
 
 function pageTitle(route: RouteKey): string {

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState, type CSSProperties } from "react";
 
 import { AgentPage } from "../features/agent/AgentPage";
 import { Button } from "../components/ui/Button";
@@ -236,7 +236,7 @@ export function App() {
                   type="button"
                   onClick={() => navigateAgent(agent.id)}
                 >
-                  <span className={`agent-badge ${agent.badgeTone ?? ""}`}>{agent.badge}</span>
+                  <span className={`agent-badge ${agent.badgeTone ?? ""}`} style={agent.badgeHue != null && !agent.badgeTone ? ({ "--badge-hue": `${agent.badgeHue}` } as CSSProperties) : undefined}>{agent.badge}</span>
                   <span className="agent-row-main">
                     <span className="agent-row-title">
                       <strong>{agent.id}</strong>

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -27,7 +27,9 @@ export function App() {
   const { bootstrap, loading, refresh } = useRuntimeDashboard();
   const route = useRuntimeStore((state) => state.route);
   const selectedAgentId = useRuntimeStore((state) => state.selectedAgentId);
-  const displayLevel = useRuntimeStore((state) => state.displayLevel);
+  const displayLevel = useRuntimeStore((state) =>
+    state.displayLevelsByAgentId[selectedAgentId] ?? "info",
+  );
   const rightPanelOpen = useRuntimeStore((state) => state.rightPanelOpen);
   const rightPanelView = useRuntimeStore((state) => state.rightPanelView);
   const navCollapsed = useRuntimeStore((state) => state.navCollapsed);

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -37,6 +37,7 @@ export function App() {
   const setRightPanelOpen = useRuntimeStore((state) => state.setRightPanelOpen);
   const inspectActivity = useRuntimeStore((state) => state.inspectActivity);
   const showAgentOverview = useRuntimeStore((state) => state.showAgentOverview);
+  const showWorkItemDetail = useRuntimeStore((state) => state.showWorkItemDetail);
   const toggleRightPanel = useRuntimeStore((state) => state.toggleRightPanel);
   const toggleNavCollapsed = useRuntimeStore((state) => state.toggleNavCollapsed);
   const setRuntimeConnection = useRuntimeStore((state) => state.setRuntimeConnection);
@@ -380,6 +381,10 @@ export function App() {
           view={rightPanelView?.agentId === selectedAgent.id ? rightPanelView : undefined}
           open={rightPanelOpen}
           onLoadWorkItemDetail={(workItemId) => loadAgentWorkItemDetail(selectedAgent.id, workItemId)}
+          onOpenWorkItemDetail={(workItem) => {
+            showWorkItemDetail(selectedAgent.id, workItem);
+            loadAgentWorkItemDetail(selectedAgent.id, workItem.id);
+          }}
           onShowAgentOverview={showAgentOverview}
           onClose={() => setRightPanelOpen(false)}
         />

--- a/web-gui/app/src/features/agent/AgentPage.test.ts
+++ b/web-gui/app/src/features/agent/AgentPage.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readStoredComposerDraft, storedComposerDraftKey, writeStoredComposerDraft } from "./AgentPage";
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length() {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.items.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}
+
+function installWindow(localStorage: Storage) {
+  vi.stubGlobal("window", {
+    localStorage,
+  });
+}
+
+describe("composer draft storage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("isolates drafts by agent id", () => {
+    installWindow(new MemoryStorage());
+
+    writeStoredComposerDraft("agent-a", "draft for a");
+    writeStoredComposerDraft("agent-b", "draft for b");
+
+    expect(readStoredComposerDraft("agent-a")).toBe("draft for a");
+    expect(readStoredComposerDraft("agent-b")).toBe("draft for b");
+  });
+
+  it("removes the stored draft when the prompt is cleared", () => {
+    const storage = new MemoryStorage();
+    installWindow(storage);
+
+    writeStoredComposerDraft("agent-a", "draft");
+    writeStoredComposerDraft("agent-a", "");
+
+    expect(readStoredComposerDraft("agent-a")).toBe("");
+    expect(storage.getItem(storedComposerDraftKey("agent-a"))).toBeNull();
+  });
+});

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -492,7 +492,7 @@ function isAgentWorking(agent: AgentSummary, sendingPrompt: boolean): boolean {
 function collectWorkingActivitiesForCurrentTurn(timeline: AgentTimelineItem[]): AgentTimelineActivity[] {
   let currentTurnStart = -1;
   for (let index = timeline.length - 1; index >= 0; index -= 1) {
-    if (timeline[index]?.kind === "operator") {
+    if (timeline[index]?.kind === "operator" || isTurnStartedItem(timeline[index]!)) {
       currentTurnStart = index;
       break;
     }
@@ -564,19 +564,33 @@ function groupTimelineTurns(timeline: AgentTimelineItem[]): TimelineTurn[] {
   let current: TimelineTurn | undefined;
 
   for (const item of timeline) {
-    if (!current || item.kind === "operator") {
+    const isTurnBoundary = isTurnStartedItem(item);
+    const isOperatorBoundary = item.kind === "operator";
+    if (!current || isOperatorBoundary || isTurnBoundary) {
+      const triggerLabel = isTurnBoundary ? item.body : undefined;
       current = {
-        id: item.kind === "operator" ? `turn:${item.id}` : `activity:${item.id}`,
-        label: item.kind === "operator" ? "Operator turn" : "Runtime activity",
+        id: isOperatorBoundary || isTurnBoundary ? `turn:${item.id}` : `activity:${item.id}`,
+        label: isOperatorBoundary
+          ? "Operator turn"
+          : isTurnBoundary
+            ? triggerLabel || "Turn"
+            : "Runtime activity",
         timestamp: item.timestamp,
-        items: [],
+        items: isTurnBoundary ? [] : [item],
       };
       turns.push(current);
+      continue;
     }
+    if (isTurnStartedItem(item)) continue;
     current.items.push(item);
   }
 
-  return turns;
+  const nonEmpty = turns.filter((turn) => turn.items.length > 0);
+  return nonEmpty.length === turns.length ? turns : nonEmpty;
+}
+
+function isTurnStartedItem(item: AgentTimelineItem): boolean {
+  return item.meta.startsWith("turn_started");
 }
 
 const TimelineTurnGroup = memo(function TimelineTurnGroup({
@@ -597,7 +611,7 @@ const TimelineTurnGroup = memo(function TimelineTurnGroup({
       <div className="timeline-turn-rail" aria-hidden="true" />
       <div className="timeline-turn-body">
         <div className="timeline-turn-header">
-          <span className="sr-only">{turn.label}</span>
+          <span className="timeline-turn-label">{turn.label}</span>
           <time>{formatDisplayTime(turn.timestamp)}</time>
         </div>
         {turn.items.map((item, index) => (

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -42,6 +42,34 @@ const DEFAULT_VERBOSE_TIMELINE_ITEM_LIMIT = 160;
 const DEFAULT_DEBUG_TIMELINE_ITEM_LIMIT = 220;
 const HISTORY_PAGE_VISIBLE_INCREMENT = 80;
 const TOP_SCROLL_THRESHOLD = 16;
+const COMPOSER_DRAFT_STORAGE_PREFIX = "holon.webGui.composerDraft.v1";
+
+export function storedComposerDraftKey(agentId: string): string {
+  return `${COMPOSER_DRAFT_STORAGE_PREFIX}:${encodeURIComponent(agentId)}`;
+}
+
+export function readStoredComposerDraft(agentId: string): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(storedComposerDraftKey(agentId)) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function writeStoredComposerDraft(agentId: string, prompt: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const key = storedComposerDraftKey(agentId);
+    if (prompt.length > 0) {
+      window.localStorage.setItem(key, prompt);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage failures; the in-memory draft still applies.
+  }
+}
 
 export function AgentPage({
   agent,
@@ -64,7 +92,7 @@ export function AgentPage({
   onInspectActivity,
   selectedActivityId,
 }: AgentPageProps) {
-  const [prompt, setPrompt] = useState("");
+  const [prompt, setPrompt] = useState(() => readStoredComposerDraft(agent.id));
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [changingModel, setChangingModel] = useState<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
@@ -112,6 +140,10 @@ export function AgentPage({
     setSelectedReasoningEffort(activeAgent.modelReasoningEffort ?? "auto");
   }, [activeAgent.id, displayLevel]);
 
+  useEffect(() => {
+    setPrompt(readStoredComposerDraft(activeAgent.id));
+  }, [activeAgent.id]);
+
   useLayoutEffect(() => {
     const list = messageListRef.current;
     if (!list) return;
@@ -132,6 +164,7 @@ export function AgentPage({
     if (!canSendPrompt) return;
     try {
       await onSendPrompt(trimmedPrompt);
+      writeStoredComposerDraft(activeAgent.id, "");
       setPrompt("");
     } catch {
       // Keep the draft in place; runtime-store exposes the user-facing error.
@@ -147,6 +180,11 @@ export function AgentPage({
     if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) return;
     event.preventDefault();
     await sendDraftPrompt();
+  }
+
+  function handlePromptChange(value: string) {
+    setPrompt(value);
+    writeStoredComposerDraft(activeAgent.id, value);
   }
 
   function handleMessageListScroll() {
@@ -263,7 +301,7 @@ export function AgentPage({
               placeholder={`Send operator input to ${activeAgent.id}...`}
               value={prompt}
               disabled={sendingPrompt}
-              onChange={(event) => setPrompt(event.target.value)}
+              onChange={(event) => handlePromptChange(event.target.value)}
               onKeyDown={handleComposerKeyDown}
             />
             {promptError ? (

--- a/web-gui/app/src/features/dashboard/DashboardPage.tsx
+++ b/web-gui/app/src/features/dashboard/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { Button } from "../../components/ui/Button";
 import { Card } from "../../components/ui/Card";
 import { EmptyState } from "../../components/ui/EmptyState";
@@ -95,7 +96,7 @@ export function DashboardPage({ agents, metrics, connection, loading, onRefresh,
               {agents.map((agent) => (
                 <Card className="agent-card" key={agent.id}>
                   <div className="agent-card-head">
-                    <span className={`agent-badge ${agent.badgeTone ?? ""}`}>{agent.badge}</span>
+                    <span className={`agent-badge ${agent.badgeTone ?? ""}`} style={agent.badgeHue != null && !agent.badgeTone ? ({ "--badge-hue": `${agent.badgeHue}` } as CSSProperties) : undefined}>{agent.badge}</span>
                     <div className="agent-card-title">
                       <strong>{agent.id}</strong>
                       <small>{agent.profile}</small>

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
@@ -188,27 +188,29 @@ describe("formatToolExecutionDetail", () => {
 
   it("formats WebSearch tool results with query and structured result list", () => {
     const detail = formatToolExecutionDetail({
-      tool_name: "mcp__web-search-prime__web_search_prime",
+      tool_name: "WebSearch",
       status: "success",
       input: {
-        search_query: "rust async runtime",
-        location: "cn",
-        content_size: "medium",
+        query: "rust async runtime",
+        max_results: 5,
       },
       output: {
         envelope: {
           result: {
+            query: "rust async runtime",
+            provider: "brave",
+            mode: "single",
             results: [
               {
                 title: "Tokio — Async Runtime",
                 url: "https://tokio.rs",
-                siteName: "tokio.rs",
-                summary: "Tokio is an async runtime for writing reliable network applications.",
+                source: "tokio.rs",
+                snippet: "Tokio is an async runtime for writing reliable network applications.",
               },
               {
                 title: "async-std",
                 url: "https://async.rs",
-                summary: "A small and fast async runtime.",
+                snippet: "A small and fast async runtime.",
               },
             ],
           },
@@ -225,19 +227,24 @@ describe("formatToolExecutionDetail", () => {
     expect(detail.text).toContain("2. async-std");
   });
 
-  it("formats WebReader tool results with URL and content preview", () => {
+  it("formats WebFetch tool results with URL and content preview", () => {
     const detail = formatToolExecutionDetail({
-      tool_name: "mcp__web_reader__webReader",
+      tool_name: "WebFetch",
       status: "success",
       input: {
         url: "https://example.com/article",
-        return_format: "markdown",
+        max_chars: 10000,
       },
       output: {
         envelope: {
           result: {
-            title: "Example Article",
-            markdown: "# Example Article\n\nThis is the content of the article.",
+            url: "https://example.com/article",
+            final_url: "https://example.com/article",
+            status: 200,
+            content_type: "text/html",
+            bytes_read: 2048,
+            truncated: false,
+            text: "# Example Article\n\nThis is the content of the article.",
           },
         },
       },
@@ -245,30 +252,7 @@ describe("formatToolExecutionDetail", () => {
 
     expect(detail.tone).toBe("output");
     expect(detail.text).toContain("URL:\nhttps://example.com/article");
-    expect(detail.text).toContain("Title:\nExample Article");
+    expect(detail.text).toContain("Status:\n200");
     expect(detail.text).toContain("Content:\n# Example Article");
-  });
-
-  it("formats AnalyzeImage tool results with image URL and analysis", () => {
-    const detail = formatToolExecutionDetail({
-      tool_name: "mcp__4_5v_mcp__analyze_image",
-      status: "success",
-      input: {
-        imageSource: "https://example.com/image.png",
-        prompt: "Describe the layout of this UI",
-      },
-      output: {
-        envelope: {
-          result: {
-            analysis: "The image shows a three-column layout with a sidebar on the left.",
-          },
-        },
-      },
-    });
-
-    expect(detail.tone).toBe("output");
-    expect(detail.text).toContain("Image:\nhttps://example.com/image.png");
-    expect(detail.text).toContain("Prompt:\nDescribe the layout of this UI");
-    expect(detail.text).toContain("Analysis:\nThe image shows a three-column layout");
   });
 });

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatToolExecutionDetail } from "./InspectorPanel";
+import { formatToolExecutionDetail } from "./ActivityInspectorPanel";
 
 describe("formatToolExecutionDetail", () => {
   it("extracts readable command output from tool execution records", () => {

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
@@ -18,8 +18,28 @@ describe("formatToolExecutionDetail", () => {
       }),
     ).toEqual({
       tone: "output",
-      text: ["Summary:\ncommand completed", "Command:\ncargo test", "Stdout:\ntest result: ok", "Exit:\n0"].join("\n\n"),
+      text: ["Command:\ncargo test", "Stdout:\ntest result: ok", "Result:\ncommand completed", "Exit:\n0"].join("\n\n"),
     });
+  });
+
+  it("shows ApplyPatch input as the full patch when available", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "ApplyPatch",
+      status: "success",
+      summary: "updated files",
+      input: "*** Begin Patch\n*** Update File: app.ts\n@@\n-old\n+new\n*** End Patch\n",
+      output: {
+        envelope: {
+          result: {
+            changed_files: [{ path: "app.ts", action: "M", diff_preview: "@@\n-old\n+new" }],
+          },
+        },
+      },
+    });
+
+    expect(detail.text).toContain("Changed files:\nM · app.ts");
+    expect(detail.text).toContain("Patch:\n*** Begin Patch");
+    expect(detail.text).not.toContain("Patch preview");
   });
 
   it("falls back to result and error fields for legacy records", () => {

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
@@ -109,4 +109,80 @@ describe("formatToolExecutionDetail", () => {
     expect(detail.text).toContain("Batch item 1:\nCommand:\ngit status\n\nStdout:\n## main");
     expect(detail.text).toContain("Batch item 2:\nCommand:\nrg TODO src\n\nStderr:\nno matches");
   });
+
+  it("formats ListTasks as an active task list", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "ListTasks",
+      status: "success",
+      output: {
+        envelope: {
+          result: {
+            total_active: 1,
+            returned: 1,
+            tasks: [
+              {
+                task_id: "task_1",
+                kind: "command_task",
+                status: "running",
+                summary: "Run command: npm run dev",
+                command: { cmd_preview: "npm run dev" },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(detail.text).toContain("Tasks:\nRun command: npm run dev · running · command_task · task_1");
+    expect(detail.text).toContain("Total active:\n1");
+  });
+
+  it("formats ListWorkItems as a readable work item list", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "ListWorkItems",
+      status: "success",
+      input: { filter: "current" },
+      output: {
+        list_work_items_result: {
+          total: 1,
+          returned: 1,
+          work_items: [
+            {
+              id: "work_1",
+              objective: "Improve inspector details",
+              lifecycle: "open",
+              plan_status: "ready",
+              current: true,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(detail.text).toContain("Filter:\ncurrent");
+    expect(detail.text).toContain("Work items:\nImprove inspector details · open · ready · current · work_1");
+  });
+
+  it("formats single work item tool records with state, plan, and todo context", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "GetWorkItem",
+      status: "success",
+      output: {
+        get_work_item_result: {
+          work_item: {
+            id: "work_2",
+            objective: "Track global stream",
+            lifecycle: "open",
+            plan_status: "needs_input",
+            plan_artifact: { path: "/agent/work-items/work_2/plan.md" },
+            todo_list: [{ state: "pending", text: "Decide API shape" }],
+          },
+        },
+      },
+    });
+
+    expect(detail.text).toContain("Objective:\nTrack global stream");
+    expect(detail.text).toContain("State:\nopen · needs_input");
+    expect(detail.text).toContain("Todo:\npending · Decide API shape");
+  });
 });

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.test.ts
@@ -185,4 +185,90 @@ describe("formatToolExecutionDetail", () => {
     expect(detail.text).toContain("State:\nopen · needs_input");
     expect(detail.text).toContain("Todo:\npending · Decide API shape");
   });
+
+  it("formats WebSearch tool results with query and structured result list", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "mcp__web-search-prime__web_search_prime",
+      status: "success",
+      input: {
+        search_query: "rust async runtime",
+        location: "cn",
+        content_size: "medium",
+      },
+      output: {
+        envelope: {
+          result: {
+            results: [
+              {
+                title: "Tokio — Async Runtime",
+                url: "https://tokio.rs",
+                siteName: "tokio.rs",
+                summary: "Tokio is an async runtime for writing reliable network applications.",
+              },
+              {
+                title: "async-std",
+                url: "https://async.rs",
+                summary: "A small and fast async runtime.",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(detail.tone).toBe("output");
+    expect(detail.text).toContain("Query:\nrust async runtime");
+    expect(detail.text).toContain("Results:\n2 found");
+    expect(detail.text).toContain("1. Tokio — Async Runtime");
+    expect(detail.text).toContain("https://tokio.rs");
+    expect(detail.text).toContain("(tokio.rs)");
+    expect(detail.text).toContain("2. async-std");
+  });
+
+  it("formats WebReader tool results with URL and content preview", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "mcp__web_reader__webReader",
+      status: "success",
+      input: {
+        url: "https://example.com/article",
+        return_format: "markdown",
+      },
+      output: {
+        envelope: {
+          result: {
+            title: "Example Article",
+            markdown: "# Example Article\n\nThis is the content of the article.",
+          },
+        },
+      },
+    });
+
+    expect(detail.tone).toBe("output");
+    expect(detail.text).toContain("URL:\nhttps://example.com/article");
+    expect(detail.text).toContain("Title:\nExample Article");
+    expect(detail.text).toContain("Content:\n# Example Article");
+  });
+
+  it("formats AnalyzeImage tool results with image URL and analysis", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "mcp__4_5v_mcp__analyze_image",
+      status: "success",
+      input: {
+        imageSource: "https://example.com/image.png",
+        prompt: "Describe the layout of this UI",
+      },
+      output: {
+        envelope: {
+          result: {
+            analysis: "The image shows a three-column layout with a sidebar on the left.",
+          },
+        },
+      },
+    });
+
+    expect(detail.tone).toBe("output");
+    expect(detail.text).toContain("Image:\nhttps://example.com/image.png");
+    expect(detail.text).toContain("Prompt:\nDescribe the layout of this UI");
+    expect(detail.text).toContain("Analysis:\nThe image shows a three-column layout");
+  });
 });

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -101,6 +101,7 @@ function formatKnownToolExecutionDetail(record: RuntimeToolExecutionRecord): { t
   if (record.tool_name === "ApplyPatch") return formatApplyPatchToolExecution(record);
   if (record.tool_name === "ExecCommand") return formatExecCommandToolExecution(record);
   if (record.tool_name === "ExecCommandBatch") return formatExecCommandBatchToolExecution(record);
+  if (record.tool_name === "ListTasks") return formatListTasksToolExecution(record);
   if (record.tool_name === "WaitFor") return formatWaitForToolExecution(record);
   if (record.tool_name === "ViewImage") return formatViewImageToolExecution(record);
   if (isWorkItemTool(record.tool_name)) return formatWorkItemToolExecution(record);
@@ -158,6 +159,24 @@ function formatExecCommandBatchToolExecution(record: RuntimeToolExecutionRecord)
   return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
 }
 
+function formatListTasksToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "list_tasks_result") ?? (isRecord(output) ? output : undefined);
+  const tasks = arrayRecords(result?.tasks ?? result?.active_tasks);
+  const taskLines = tasks.map(formatTaskRecord).filter(Boolean);
+  const total = result?.total_active ?? result?.total ?? tasks.length;
+  const returned = result?.returned ?? tasks.length;
+  const lines = [
+    labelledText("Summary", record.summary),
+    labelledText("Tasks", taskLines.join("\n")),
+    labelledText("Total active", total),
+    labelledText("Returned", returned),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
 function formatWaitForToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
   const input = isRecord(record.input) ? record.input : record;
   const lines = [
@@ -188,22 +207,15 @@ function formatViewImageToolExecution(record: RuntimeToolExecutionRecord): { tex
 
 function formatWorkItemToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
   const output = unwrapToolOutput(record.output ?? record.result);
-  const result = asResultRecord(output, `${uncapitalize(record.tool_name ?? "")}_result`) ?? (isRecord(output) ? output : undefined);
+  const result = workItemToolResultRecord(output, record.tool_name) ?? (isRecord(output) ? output : undefined);
   if (record.tool_name === "ListWorkItems") {
     const items = arrayRecords(result?.work_items ?? result?.items);
-    const itemLines = items
-      .map((item) =>
-        compactMeta([
-          textField(item.objective) || textField(item.objective_preview),
-          textField(item.lifecycle) || textField(item.state) || textField(item.status),
-          textField(item.plan_status),
-          textField(item.id) || textField(item.work_item_id),
-        ]),
-      )
-      .filter(Boolean);
+    const itemLines = items.map(formatWorkItemRecord).filter(Boolean);
     const lines = [
+      labelledText("Filter", nestedValue(record.input, ["filter"]) ?? result?.filter),
       labelledText("Work items", itemLines.join("\n")),
       labelledText("Total", result?.total ?? result?.total_open ?? items.length),
+      labelledText("Returned", result?.returned ?? items.length),
       labelledText("Result", record.summary || result?.summary_text),
       labelledText("Error", record.error),
     ].filter(Boolean);
@@ -211,10 +223,14 @@ function formatWorkItemToolExecution(record: RuntimeToolExecutionRecord): { text
   }
 
   const workItem = isRecord(result?.work_item) ? result.work_item : result;
+  const planArtifact = isRecord(workItem?.plan_artifact) ? workItem.plan_artifact : undefined;
   const lines = [
     labelledText("Objective", nestedValue(workItem, ["objective", "objective_preview"]) ?? nestedValue(record.input, ["objective"])),
     labelledText("Work item", nestedValue(workItem, ["id", "work_item_id"]) ?? nestedValue(record.input, ["work_item_id"])),
-    labelledText("State", compactMeta([textField(workItem?.lifecycle), textField(workItem?.plan_status), textField(workItem?.readiness)])),
+    labelledText("State", compactMeta([textField(workItem?.lifecycle), textField(workItem?.state), textField(workItem?.plan_status), textField(workItem?.readiness)])),
+    labelledText("Focus", truthyText(workItem?.current) || truthyText(workItem?.current_focus)),
+    labelledText("Plan", nestedValue(planArtifact, ["path"]) ?? nestedValue(workItem, ["plan_path"])),
+    labelledText("Todo", formatTodoItems(arrayRecords(workItem?.todo_list))),
     labelledText("Result", record.summary || result?.summary_text),
     labelledText("Error", record.error),
   ].filter(Boolean);
@@ -241,6 +257,39 @@ function formatBatchToolOutput(input: unknown, output: unknown): string[] {
       return lines.length ? `Batch item ${item.index ?? index + 1}:\n${lines.join("\n\n")}` : "";
     })
     .filter(Boolean);
+}
+
+function formatWorkItemRecord(item: Record<string, unknown>): string {
+  const status = compactMeta([
+    textField(item.lifecycle) || textField(item.state) || textField(item.status),
+    textField(item.plan_status),
+    textField(item.readiness),
+    truthyText(item.current) || truthyText(item.current_focus),
+  ]);
+  return compactMeta([
+    textField(item.objective) || textField(item.objective_preview) || textField(item.title),
+    status,
+    textField(item.id) || textField(item.work_item_id),
+  ]);
+}
+
+function formatTaskRecord(task: Record<string, unknown>): string {
+  const command = isRecord(task.command) ? commandText(task.command) || textField(task.command.cmd_preview) : "";
+  const retrieval = isRecord(task.retrieval) ? textField(task.retrieval.status) || textField(task.retrieval.output) : "";
+  return compactMeta([
+    textField(task.summary) || command || textField(task.kind),
+    textField(task.status),
+    textField(task.kind),
+    textField(task.task_id) || textField(task.id),
+    retrieval,
+  ]);
+}
+
+function formatTodoItems(items: Record<string, unknown>[]): string {
+  return items
+    .map((item) => compactMeta([textField(item.state), textField(item.text) || textField(item.title)]))
+    .filter(Boolean)
+    .join("\n");
 }
 
 function labelledText(label: string, value: unknown): string {
@@ -291,13 +340,29 @@ function isWorkItemTool(toolName: string | undefined): boolean {
   return Boolean(toolName && ["ListWorkItems", "GetWorkItem", "CreateWorkItem", "UpdateWorkItem", "PickWorkItem", "CompleteWorkItem"].includes(toolName));
 }
 
-function uncapitalize(value: string): string {
-  return value ? `${value[0].toLowerCase()}${value.slice(1)}` : value;
+function workItemToolResultRecord(output: unknown, toolName: string | undefined): Record<string, unknown> | undefined {
+  if (!isRecord(output)) return undefined;
+  const resultKeyByTool: Record<string, string> = {
+    ListWorkItems: "list_work_items_result",
+    GetWorkItem: "get_work_item_result",
+    CreateWorkItem: "create_work_item_result",
+    UpdateWorkItem: "update_work_item_result",
+    PickWorkItem: "pick_work_item_result",
+    CompleteWorkItem: "complete_work_item_result",
+  };
+  const resultKey = toolName ? resultKeyByTool[toolName] : undefined;
+  if (resultKey && isRecord(output[resultKey])) return output[resultKey] as Record<string, unknown>;
+  if (isRecord(output.result)) return output.result;
+  return undefined;
 }
 
 function scalarText(value: unknown): string {
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return "";
+}
+
+function truthyText(value: unknown): string {
+  return value === true ? "current" : "";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -105,8 +105,24 @@ function formatKnownToolExecutionDetail(record: RuntimeToolExecutionRecord): { t
   if (record.tool_name === "WaitFor") return formatWaitForToolExecution(record);
   if (record.tool_name === "ViewImage") return formatViewImageToolExecution(record);
   if (isWorkItemTool(record.tool_name)) return formatWorkItemToolExecution(record);
+  if (isWebSearchTool(record.tool_name)) return formatWebSearchToolExecution(record);
+  if (isWebReaderTool(record.tool_name)) return formatWebReaderToolExecution(record);
+  if (isAnalyzeImageTool(record.tool_name)) return formatAnalyzeImageToolExecution(record);
   return undefined;
 }
+
+function isWebSearchTool(toolName: string | undefined): boolean {
+  return toolName === "mcp__web-search-prime__web_search_prime" || toolName === "WebSearch";
+}
+
+function isWebReaderTool(toolName: string | undefined): boolean {
+  return toolName === "mcp__web_reader__webReader";
+}
+
+function isAnalyzeImageTool(toolName: string | undefined): boolean {
+  return toolName === "mcp__4_5v_mcp__analyze_image";
+}
+
 
 function formatApplyPatchToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
   const output = unwrapToolOutput(record.output ?? record.result);
@@ -203,6 +219,106 @@ function formatViewImageToolExecution(record: RuntimeToolExecutionRecord): { tex
     labelledText("Error", record.error),
   ].filter(Boolean);
   return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatWebSearchToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const results = extractInspectorSearchResults(output);
+  const query = nestedValue(input, ["search_query", "query", "q"]);
+  const location = nestedValue(input, ["location"]);
+  const resultLines = results.slice(0, 15).map((item, index) => {
+    const title = nestedValue(item, ["title", "name"]);
+    const url = nestedValue(item, ["url", "link", "href"]);
+    const siteName = nestedValue(item, ["siteName", "site_name", "websiteName", "website_name"]);
+    const summary = nestedValue(item, ["summary", "snippet", "description"]);
+    return labelledText(
+      `${index + 1}. ${title ?? "Untitled"}`,
+      [url, siteName ? `(${siteName})` : undefined, typeof summary === "string" ? truncateInspectorText(summary, 300) : undefined]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  });
+  const lines = [
+    labelledText("Query", query),
+    labelledText("Location", location),
+    labelledText("Content size", nestedValue(input, ["content_size"])),
+    labelledText("Recency", nestedValue(input, ["search_recency_filter"])),
+    labelledText("Domain filter", nestedValue(input, ["search_domain_filter"])),
+    labelledText("Results", `${results.length} found`),
+    ...resultLines,
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: results.length ? "output" : "data" };
+}
+
+function formatWebReaderToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const url = nestedValue(input, ["url"]);
+  const title = nestedText(output, ["title", "pageTitle"]);
+  const contentPreview = extractInspectorMarkdownPreview(output, 2000);
+  const lines = [
+    labelledText("URL", url),
+    labelledText("Title", title),
+    labelledText("Format", nestedValue(input, ["return_format"])),
+    labelledText("Images", nestedValue(input, ["retain_images"])),
+    labelledText("Content", contentPreview),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: contentPreview ? "output" : "data" };
+}
+
+function formatAnalyzeImageToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const lines = [
+    labelledText("Image", nestedValue(input, ["imageSource", "image_source", "url"])),
+    labelledText("Prompt", nestedValue(input, ["prompt"])),
+    labelledText("Analysis", nestedText(output, ["analysis", "result", "text", "content", "description"])),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function extractInspectorSearchResults(value: unknown): Record<string, unknown>[] {
+  const record = isRecord(value) ? value : undefined;
+  if (!record) return [];
+  for (const key of ["results", "search_results", "data", "items"]) {
+    const candidate = record[key];
+    if (Array.isArray(candidate)) {
+      return candidate.filter((item): item is Record<string, unknown> => isRecord(item));
+    }
+  }
+  return [];
+}
+
+function extractInspectorMarkdownPreview(value: unknown, maxChars: number): string | undefined {
+  const record = isRecord(value) ? value : undefined;
+  if (!record) return undefined;
+  for (const key of ["markdown", "content", "text"]) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return truncateInspectorText(candidate, maxChars);
+    }
+  }
+  const content = record.content;
+  if (Array.isArray(content)) {
+    const text = content
+      .map((item) => (isRecord(item) ? item.text : undefined))
+      .filter((text): text is string => typeof text === "string")
+      .join("\n");
+    return text.trim() ? truncateInspectorText(text, maxChars) : undefined;
+  }
+  return undefined;
+}
+
+function truncateInspectorText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  const truncated = value.slice(0, maxChars - 1);
+  const lastNewline = truncated.lastIndexOf("\n");
+  const cutPoint = lastNewline > maxChars * 0.6 ? lastNewline : truncated.length;
+  return `${truncated.slice(0, cutPoint)}…`;
 }
 
 function formatWorkItemToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -8,6 +8,10 @@ import type {
   RuntimeToolExecutionRecord,
 } from "../../runtime/types";
 
+function hasHydratedDetail(detailState: InspectorActivityDetailState | undefined): boolean {
+  return Boolean(detailState?.toolExecution || detailState?.taskOutput);
+}
+
 function HydratedActivityDetails({ detailState }: { detailState?: InspectorActivityDetailState }) {
   if (!detailState) return null;
   if (detailState.loading) {
@@ -64,6 +68,9 @@ function ToolExecutionDetail({ record }: { record: RuntimeToolExecutionRecord })
 }
 
 export function formatToolExecutionDetail(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const knownToolDetail = formatKnownToolExecutionDetail(record);
+  if (knownToolDetail) return knownToolDetail;
+
   const output = unwrapToolOutput(record.output ?? record.result);
   const batchItemSections = formatBatchToolOutput(record.input, output);
   const lines = [
@@ -88,6 +95,130 @@ function unwrapToolOutput(value: unknown): unknown {
   const envelope = isRecord(value) ? value.envelope : undefined;
   const result = isRecord(envelope) ? envelope.result : undefined;
   return result ?? value;
+}
+
+function formatKnownToolExecutionDetail(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } | undefined {
+  if (record.tool_name === "ApplyPatch") return formatApplyPatchToolExecution(record);
+  if (record.tool_name === "ExecCommand") return formatExecCommandToolExecution(record);
+  if (record.tool_name === "ExecCommandBatch") return formatExecCommandBatchToolExecution(record);
+  if (record.tool_name === "WaitFor") return formatWaitForToolExecution(record);
+  if (record.tool_name === "ViewImage") return formatViewImageToolExecution(record);
+  if (isWorkItemTool(record.tool_name)) return formatWorkItemToolExecution(record);
+  return undefined;
+}
+
+function formatApplyPatchToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "apply_patch_result");
+  const changedFiles = arrayRecords(result?.changed_files);
+  const changedPaths = stringArray(result?.changed_paths);
+  const diagnostics = arrayRecords(result?.diagnostics)
+    .map((diagnostic) => compactMeta([textField(diagnostic.level), textField(diagnostic.message)]))
+    .filter(Boolean);
+  const fileSummaries = changedFiles.map((file) => compactMeta([textField(file.action), textField(file.path) || "unknown path"]));
+  const patchText = patchInputText(record.input) || textField(record.patch) || textField(result?.patch);
+  const diffPreview = textField(result?.diff_preview) || changedFiles.map((file) => textField(file.diff_preview)).filter(Boolean).join("\n\n");
+  const lines = [
+    labelledText("Summary", record.summary || result?.summary_text),
+    labelledText("Changed files", fileSummaries.length ? fileSummaries.join("\n") : changedPaths.join("\n")),
+    labelledText("Diagnostics", diagnostics.join("\n")),
+    labelledText(patchText ? "Patch" : "Patch preview", patchText || diffPreview),
+    labelledText("Result", result?.summary_text),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatExecCommandToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const lines = [
+    labelledText("Command", commandText(record.input) || textField(record.cmd_preview)),
+    labelledText("Stdout", nestedText(output, ["stdout", "stdout_preview", "output", "output_preview", "combined_output_preview"])),
+    labelledText("Stderr", nestedText(output, ["stderr", "stderr_preview"])),
+    labelledText("Initial output", nestedText(output, ["initial_output_preview"])),
+    labelledText("Result", nestedText(output, ["summary", "summary_text", "result_summary", "result_summary_preview"]) || record.summary),
+    labelledText("Error", record.error ?? nestedValue(output, ["error"])),
+    labelledText("Exit", nestedValue(output, ["exit_status", "status", "disposition"])),
+  ].filter(Boolean);
+
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatExecCommandBatchToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const batchItemSections = formatBatchToolOutput(record.input, output);
+  const lines = [
+    labelledText("Summary", record.summary),
+    labelledText("Result", nestedText(output, ["summary", "summary_text", "result_summary", "result_summary_preview"])),
+    labelledText("Error", record.error ?? nestedValue(output, ["error"])),
+    ...batchItemSections,
+  ].filter(Boolean);
+
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatWaitForToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const input = isRecord(record.input) ? record.input : record;
+  const lines = [
+    labelledText("Reason", input.reason),
+    labelledText("Wake", input.wake),
+    labelledText("Resource", input.resource),
+    labelledText("Recheck after", input.recheck_after_ms),
+    labelledText("Result", record.summary),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: "data" };
+}
+
+function formatViewImageToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "view_image_result");
+  const dimensions = isRecord(result?.dimensions) ? result.dimensions : undefined;
+  const width = nestedValue(result, ["width"]) ?? nestedValue(dimensions, ["width"]);
+  const height = nestedValue(result, ["height"]) ?? nestedValue(dimensions, ["height"]);
+  const lines = [
+    labelledText("Path", nestedValue(record.input, ["path", "image_path"]) ?? nestedValue(result, ["path", "image_path"])),
+    labelledText("Dimensions", width != null && height != null ? `${width}×${height}` : ""),
+    labelledText("Observation", nestedText(result, ["visual_observation", "observation", "text_preview"])),
+    labelledText("Result", result?.summary_text || record.summary),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatWorkItemToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, `${uncapitalize(record.tool_name ?? "")}_result`) ?? (isRecord(output) ? output : undefined);
+  if (record.tool_name === "ListWorkItems") {
+    const items = arrayRecords(result?.work_items ?? result?.items);
+    const itemLines = items
+      .map((item) =>
+        compactMeta([
+          textField(item.objective) || textField(item.objective_preview),
+          textField(item.lifecycle) || textField(item.state) || textField(item.status),
+          textField(item.plan_status),
+          textField(item.id) || textField(item.work_item_id),
+        ]),
+      )
+      .filter(Boolean);
+    const lines = [
+      labelledText("Work items", itemLines.join("\n")),
+      labelledText("Total", result?.total ?? result?.total_open ?? items.length),
+      labelledText("Result", record.summary || result?.summary_text),
+      labelledText("Error", record.error),
+    ].filter(Boolean);
+    return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+  }
+
+  const workItem = isRecord(result?.work_item) ? result.work_item : result;
+  const lines = [
+    labelledText("Objective", nestedValue(workItem, ["objective", "objective_preview"]) ?? nestedValue(record.input, ["objective"])),
+    labelledText("Work item", nestedValue(workItem, ["id", "work_item_id"]) ?? nestedValue(record.input, ["work_item_id"])),
+    labelledText("State", compactMeta([textField(workItem?.lifecycle), textField(workItem?.plan_status), textField(workItem?.readiness)])),
+    labelledText("Result", record.summary || result?.summary_text),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
 }
 
 function formatBatchToolOutput(input: unknown, output: unknown): string[] {
@@ -135,6 +266,33 @@ function nestedValue(value: unknown, keys: string[]): unknown {
     if (field != null && (!isBlankString(field))) return field;
   }
   return undefined;
+}
+
+function asResultRecord(output: unknown, key: string): Record<string, unknown> | undefined {
+  if (!isRecord(output)) return undefined;
+  return (isRecord(output[key]) ? output[key] : output) as Record<string, unknown>;
+}
+
+function arrayRecords(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function patchInputText(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (!isRecord(input)) return "";
+  return textField(input.patch) || textField(input.input) || textField(input.freeform);
+}
+
+function isWorkItemTool(toolName: string | undefined): boolean {
+  return Boolean(toolName && ["ListWorkItems", "GetWorkItem", "CreateWorkItem", "UpdateWorkItem", "PickWorkItem", "CompleteWorkItem"].includes(toolName));
+}
+
+function uncapitalize(value: string): string {
+  return value ? `${value[0].toLowerCase()}${value.slice(1)}` : value;
 }
 
 function scalarText(value: unknown): string {
@@ -191,6 +349,9 @@ function formatInspectorJson(value: unknown): string {
 export function ActivityInspectorPanel({ activity, detailState }: { activity: AgentTimelineActivity; detailState?: InspectorActivityDetailState }) {
   const detail = activity.detail;
   const rawEventText = formatInspectorJson(activity.rawEvent);
+  const hydratedDetail = hasHydratedDetail(detailState);
+  const showTimelineDetail = Boolean(detail && !hydratedDetail);
+  const structuredDetail = showTimelineDetail || Boolean(detail) || hydratedDetail;
 
   return (
     <div className="inspector-stack">
@@ -220,7 +381,7 @@ export function ActivityInspectorPanel({ activity, detailState }: { activity: Ag
         </dl>
       </section>
 
-      {detail ? (
+      {showTimelineDetail && detail ? (
         <section className={`context-card inspector-card inspector-detail ${detail.tone ?? "data"}`}>
           <div className="context-head">
             <span className="eyebrow">{detailLabel(detail.tone)}</span>
@@ -228,25 +389,22 @@ export function ActivityInspectorPanel({ activity, detailState }: { activity: Ag
           </div>
           <pre>{detail.text}</pre>
         </section>
-      ) : (
+      ) : !hydratedDetail ? (
         <EmptyState
           className="inspector-empty"
           icon="⌁"
           title="No structured detail"
           description="This activity has no projected detail yet. Use the raw event below for the source payload."
         />
-      )}
+      ) : null}
 
       <HydratedActivityDetails detailState={detailState} />
 
       {rawEventText ? (
-        <section className="context-card inspector-card inspector-detail data">
-          <div className="context-head">
-            <span className="eyebrow">Raw event</span>
-            <strong>Source payload</strong>
-          </div>
+        <details className="context-card inspector-card inspector-raw-detail" open={!structuredDetail}>
+          <summary>Raw event</summary>
           <pre>{rawEventText}</pre>
-        </section>
+        </details>
       ) : null}
     </div>
   );
@@ -260,7 +418,7 @@ export function activityInspectorTitle(activity: AgentTimelineActivity): string 
 }
 
 function detailLabel(tone?: AgentTimelineItemDetail["tone"]): string {
-  if (tone === "command") return "Command output";
+  if (tone === "command") return "Command";
   if (tone === "diff") return "Patch diff";
   if (tone === "output") return "Output";
   return "Result";

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -1,22 +1,12 @@
 import { EmptyState } from "../../components/ui/EmptyState";
 import { StatusBadge } from "../../components/ui/StatusChip";
 import type {
-  AgentSummary,
   AgentTimelineActivity,
   AgentTimelineItemDetail,
   InspectorActivityDetailState,
-  InspectorSelection,
   RuntimeTaskOutputResult,
   RuntimeToolExecutionRecord,
 } from "../../runtime/types";
-
-interface InspectorPanelProps {
-  agent: AgentSummary;
-  selection?: InspectorSelection;
-  open: boolean;
-  onClearSelection: () => void;
-  onClose: () => void;
-}
 
 function HydratedActivityDetails({ detailState }: { detailState?: InspectorActivityDetailState }) {
   if (!detailState) return null;
@@ -198,203 +188,7 @@ function formatInspectorJson(value: unknown): string {
   }
 }
 
-export function InspectorPanel({ agent, selection, open, onClearSelection, onClose }: InspectorPanelProps) {
-  const title = selection?.kind === "activity" ? activityInspectorTitle(selection.activity) : "Session overview";
-
-  return (
-    <aside className="side-panel" aria-label="Object side panel" hidden={!open}>
-      <div className="panel-header">
-        <div>
-          <span className="eyebrow">Inspector</span>
-          <strong>{title}</strong>
-        </div>
-        <div className="panel-actions">
-          {selection ? (
-            <button type="button" aria-label="Show session overview" onClick={onClearSelection}>
-              Overview
-            </button>
-          ) : null}
-          <button type="button" aria-label="Close side panel" onClick={onClose}>
-            ×
-          </button>
-        </div>
-      </div>
-      <div className="panel-body">
-        {selection?.kind === "activity" ? (
-          <ActivityDetails activity={selection.activity} detailState={selection.detailState} />
-        ) : (
-          <SessionOverview agent={agent} />
-        )}
-      </div>
-    </aside>
-  );
-}
-
-function SessionOverview({ agent }: { agent: AgentSummary }) {
-  const workspace = agent.workspaceSummary;
-  const openWorkItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
-  const currentWorkItems = openWorkItems.filter((item) => item.current);
-  const otherWorkItems = openWorkItems.filter((item) => !item.current);
-
-  return (
-    <div className="inspector-stack">
-      <section className="context-card inspector-card">
-        <div className="context-head">
-          <span className="eyebrow">Agent</span>
-          <StatusBadge className="state-chip" kind="agent" value={agent.posture || agent.lifecycle} />
-        </div>
-        <h2>{agent.id}</h2>
-        <dl className="inspector-facts">
-          <div>
-            <dt>Lifecycle</dt>
-            <dd>{agent.lifecycle}</dd>
-          </div>
-          <div>
-            <dt>Model</dt>
-            <dd>{agent.model}</dd>
-          </div>
-          <div>
-            <dt>Focus</dt>
-            <dd>{agent.focusSummary}</dd>
-          </div>
-        </dl>
-      </section>
-
-      <section className="context-card inspector-card">
-        <div className="context-head">
-          <span className="eyebrow">Workspace</span>
-          <StatusBadge className="state-chip" kind="connection" value={agent.workspace === "not bound" ? "unbound" : "active"} />
-        </div>
-        <h2>{workspace?.name ?? agent.workspace}</h2>
-        <dl className="inspector-facts">
-          <div>
-            <dt>Name</dt>
-            <dd>{workspace?.name ?? (agent.workspace === "not bound" ? "No active workspace" : agent.workspace)}</dd>
-          </div>
-          <div>
-            <dt>Anchor</dt>
-            <dd>{workspace?.anchor ?? "—"}</dd>
-          </div>
-          <div>
-            <dt>ID</dt>
-            <dd>{workspace?.id ?? "—"}</dd>
-          </div>
-        </dl>
-      </section>
-
-      <section className="context-card inspector-card">
-        <div className="context-head">
-          <span className="eyebrow">{workspace?.worktree ? "Worktree / Execution" : "Execution"}</span>
-          <StatusBadge className="state-chip" kind="connection" value={workspace?.worktree ? "worktree" : "root"} />
-        </div>
-        <h2>{workspace?.worktree?.branch ?? "Current root"}</h2>
-        <dl className="inspector-facts">
-          {workspace?.worktree ? (
-            <>
-              <div>
-                <dt>Branch</dt>
-                <dd>{workspace.worktree.branch ?? "—"}</dd>
-              </div>
-              <div>
-                <dt>Worktree</dt>
-                <dd>{workspace.worktree.path ?? "—"}</dd>
-              </div>
-            </>
-          ) : null}
-          <div>
-            <dt>Root</dt>
-            <dd>{workspace?.executionRoot ?? workspace?.anchor ?? "—"}</dd>
-          </div>
-          <div>
-            <dt>Cwd</dt>
-            <dd>{workspace?.cwd ?? "—"}</dd>
-          </div>
-        </dl>
-      </section>
-
-      <section className="context-card inspector-card">
-        <div className="context-head">
-          <span className="eyebrow">Tasks</span>
-          <StatusBadge className="state-chip" kind="connection" value={agent.activeTaskCount ? "active" : "idle"} />
-        </div>
-        <h2>{agent.activeTaskCount} active</h2>
-        {agent.tasks?.length ? (
-          <ul className="inspector-list">
-            {agent.tasks.map((task) => (
-              <li key={task.id}>
-                <div className="inspector-list-head">
-                  <strong>{task.summary}</strong>
-                  <StatusBadge className="state-chip" kind="connection" value={task.status} />
-                </div>
-                <small>{compactMeta([task.kind, task.command, task.workdir])}</small>
-                <code>{task.id}</code>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <dl className="inspector-facts">
-            <div>
-              <dt>Queued</dt>
-              <dd>{agent.pending}</dd>
-            </div>
-            <div>
-              <dt>Waiting</dt>
-              <dd>{agent.waitingCount}</dd>
-            </div>
-            <div>
-              <dt>Attention</dt>
-              <dd>{agent.attention}</dd>
-            </div>
-          </dl>
-        )}
-      </section>
-
-      {openWorkItems.length ? (
-        <section className="context-card current-work inspector-card">
-          <div className="context-head">
-            <span className="eyebrow">Open work items</span>
-            <StatusBadge className="state-chip" kind="work" value={`${openWorkItems.length} open`} />
-          </div>
-          {currentWorkItems.map((workItem) => (
-            <WorkItemCard key={workItem.id} workItem={workItem} featured />
-          ))}
-          {otherWorkItems.length ? (
-            <details className="inspector-details-list">
-              <summary>{otherWorkItems.length} other open</summary>
-              <div className="inspector-nested-stack">
-                {otherWorkItems.map((workItem) => (
-                  <WorkItemCard key={workItem.id} workItem={workItem} />
-                ))}
-              </div>
-            </details>
-          ) : null}
-        </section>
-      ) : (
-        <EmptyState
-          className="inspector-empty"
-          icon="◎"
-          title="No current work item"
-          description="Select a timeline activity to inspect tool output, or continue the conversation from the main pane."
-        />
-      )}
-    </div>
-  );
-}
-
-function WorkItemCard({ workItem, featured = false }: { workItem: NonNullable<AgentSummary["workItems"]>[number]; featured?: boolean }) {
-  return (
-    <article className={`inspector-list-item${featured ? " featured" : ""}`}>
-      <div className="inspector-list-head">
-        <strong>{workItem.objective}</strong>
-        <StatusBadge className="state-chip" kind="work" value={workItem.state} />
-      </div>
-      <small>{compactMeta([workItem.current ? "current" : undefined, workItem.planStatus])}</small>
-      <code>{workItem.id}</code>
-    </article>
-  );
-}
-
-function ActivityDetails({ activity, detailState }: { activity: AgentTimelineActivity; detailState?: InspectorActivityDetailState }) {
+export function ActivityInspectorPanel({ activity, detailState }: { activity: AgentTimelineActivity; detailState?: InspectorActivityDetailState }) {
   const detail = activity.detail;
   const rawEventText = formatInspectorJson(activity.rawEvent);
 
@@ -458,7 +252,7 @@ function ActivityDetails({ activity, detailState }: { activity: AgentTimelineAct
   );
 }
 
-function activityInspectorTitle(activity: AgentTimelineActivity): string {
+export function activityInspectorTitle(activity: AgentTimelineActivity): string {
   if (activity.detail?.tone === "command") return "Command";
   if (activity.detail?.tone === "diff") return "Patch";
   if (activity.detail?.tone === "output") return "Output";

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -109,6 +109,10 @@ function formatKnownToolExecutionDetail(record: RuntimeToolExecutionRecord): { t
   if (isWebFetchTool(record.tool_name)) return formatWebFetchToolExecution(record);
   if (record.tool_name === "MemorySearch") return formatMemorySearchToolExecution(record);
   if (record.tool_name === "MemoryGet") return formatMemoryGetToolExecution(record);
+  if (record.tool_name === "TaskOutput") return formatTaskOutputToolExecution(record);
+  if (record.tool_name === "TaskStatus") return formatTaskStatusToolExecution(record);
+  if (record.tool_name === "TaskStop") return formatTaskStopToolExecution(record);
+  if (record.tool_name === "TaskInput") return formatTaskInputToolExecution(record);
   return undefined;
 }
 
@@ -187,6 +191,68 @@ function formatListTasksToolExecution(record: RuntimeToolExecutionRecord): { tex
     labelledText("Error", record.error),
   ].filter(Boolean);
 
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatTaskOutputToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "task_output_result") ?? (isRecord(output) ? output : undefined);
+  const task = isRecord(result?.task) ? result.task : isRecord(result?.task_record) ? result.task_record : undefined;
+  const taskId = nestedValue(task, ["task_id", "id"]) ?? nestedValue(record.input, ["task_id"]);
+  const status = nestedValue(task, ["status"]) ?? nestedValue(result, ["status", "retrieval_status"]);
+  const exitStatus = nestedValue(task, ["exit_status"]) ?? nestedValue(result, ["exit_status"]);
+  const outputText = nestedText(result, ["output_preview", "output", "stdout", "stderr", "combined_output_preview"]);
+  const truncated = nestedValue(result, ["output_truncated", "truncated"]) === true;
+  const lines = [
+    labelledText("Task ID", taskId),
+    labelledText("Status", status),
+    labelledText("Exit", exitStatus),
+    labelledText("Summary", nestedValue(task, ["summary"]) ?? nestedValue(result, ["summary", "result_summary"])),
+    outputText ? labelledText(truncated ? "Output (truncated)" : "Output", outputText) : "",
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatTaskStatusToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "task_status_result") ?? (isRecord(output) ? output : undefined);
+  const taskId = nestedValue(result, ["task_id", "id"]) ?? nestedValue(record.input, ["task_id"]);
+  const lines = [
+    labelledText("Task ID", taskId),
+    labelledText("Status", nestedValue(result, ["status"])),
+    labelledText("Kind", nestedValue(result, ["kind"])),
+    labelledText("Summary", nestedValue(result, ["summary"])),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatTaskStopToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "task_stop_result") ?? (isRecord(output) ? output : undefined);
+  const taskId = nestedValue(result, ["task_id", "id"]) ?? nestedValue(record.input, ["task_id"]);
+  const lines = [
+    labelledText("Task ID", taskId),
+    labelledText("Status", nestedValue(result, ["status"])),
+    labelledText("Summary", record.summary),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
+}
+
+function formatTaskInputToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const result = asResultRecord(output, "task_input_result") ?? (isRecord(output) ? output : undefined);
+  const taskId = nestedValue(result, ["task_id", "id"]) ?? nestedValue(record.input, ["task_id"]);
+  const input = nestedValue(record.input, ["input"]) ?? nestedValue(result, ["input"]);
+  const lines = [
+    labelledText("Task ID", taskId),
+    labelledText("Input", input),
+    labelledText("Status", nestedValue(result, ["status"])),
+    labelledText("Summary", record.summary),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
   return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
 }
 

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -199,13 +199,17 @@ function formatTaskOutputToolExecution(record: RuntimeToolExecutionRecord): { te
   const result = asResultRecord(output, "task_output_result") ?? (isRecord(output) ? output : undefined);
   const task = isRecord(result?.task) ? result.task : isRecord(result?.task_record) ? result.task_record : undefined;
   const taskId = nestedValue(task, ["task_id", "id"]) ?? nestedValue(record.input, ["task_id"]);
-  const status = nestedValue(task, ["status"]) ?? nestedValue(result, ["status", "retrieval_status"]);
+  const status = nestedValue(task, ["status"]) ?? nestedValue(result, ["status"]);
+  const retrievalStatus = nestedValue(result, ["retrieval_status"]);
   const exitStatus = nestedValue(task, ["exit_status"]) ?? nestedValue(result, ["exit_status"]);
-  const outputText = nestedText(result, ["output_preview", "output", "stdout", "stderr", "combined_output_preview"]);
-  const truncated = nestedValue(result, ["output_truncated", "truncated"]) === true;
+  const outputText =
+    nestedText(task, ["output_preview", "output", "stdout", "stderr", "combined_output_preview"]) ??
+    nestedText(result, ["output_preview", "output", "stdout", "stderr", "combined_output_preview"]);
+  const truncated = nestedValue(task, ["output_truncated"]) === true || nestedValue(result, ["output_truncated", "truncated"]) === true;
   const lines = [
     labelledText("Task ID", taskId),
     labelledText("Status", status),
+    labelledText("Retrieval", retrievalStatus),
     labelledText("Exit", exitStatus),
     labelledText("Summary", nestedValue(task, ["summary"]) ?? nestedValue(result, ["summary", "result_summary"])),
     outputText ? labelledText(truncated ? "Output (truncated)" : "Output", outputText) : "",

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -107,6 +107,8 @@ function formatKnownToolExecutionDetail(record: RuntimeToolExecutionRecord): { t
   if (isWorkItemTool(record.tool_name)) return formatWorkItemToolExecution(record);
   if (isWebSearchTool(record.tool_name)) return formatWebSearchToolExecution(record);
   if (isWebFetchTool(record.tool_name)) return formatWebFetchToolExecution(record);
+  if (record.tool_name === "MemorySearch") return formatMemorySearchToolExecution(record);
+  if (record.tool_name === "MemoryGet") return formatMemoryGetToolExecution(record);
   return undefined;
 }
 
@@ -264,6 +266,47 @@ function formatWebFetchToolExecution(record: RuntimeToolExecutionRecord): { text
     labelledText("Status", status),
     labelledText("Content-Type", contentType),
     labelledText("Bytes read", bytesRead),
+    truncated ? labelledText("Truncated", "yes") : "",
+    labelledText("Content", contentPreview),
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: contentPreview ? "output" : "data" };
+}
+
+function formatMemorySearchToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const results = arrayRecords(nestedValue(output, ["results"]));
+  const query = nestedValue(output, ["query"]) ?? nestedValue(input, ["query"]);
+  const resultLines = results.slice(0, 15).map((item, index) => {
+    const sourceRef = nestedValue(item, ["source_ref"]);
+    const preview = nestedValue(item, ["preview"]);
+    const score = nestedValue(item, ["score"]);
+    return labelledText(
+      `${index + 1}. ${sourceRef ?? "Unknown source"}`,
+      [typeof score === "string" ? `score: ${score}` : undefined, typeof preview === "string" ? truncateInspectorText(preview, 300) : undefined]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  });
+  const lines = [
+    labelledText("Query", query),
+    labelledText("Results", `${results.length} found`),
+    ...resultLines,
+    labelledText("Error", record.error),
+  ].filter(Boolean);
+  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: results.length ? "output" : "data" };
+}
+
+function formatMemoryGetToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const input = isRecord(record.input) ? record.input : {};
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const sourceRef = nestedValue(output, ["source_ref"]) ?? nestedValue(input, ["source_ref"]);
+  const content = nestedText(output, ["content"]);
+  const contentPreview = typeof content === "string" && content.trim() ? truncateInspectorText(content, 2000) : undefined;
+  const truncated = nestedValue(output, ["truncated"]);
+  const lines = [
+    labelledText("Source ref", sourceRef),
     truncated ? labelledText("Truncated", "yes") : "",
     labelledText("Content", contentPreview),
     labelledText("Error", record.error),

--- a/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/ActivityInspectorPanel.tsx
@@ -106,21 +106,16 @@ function formatKnownToolExecutionDetail(record: RuntimeToolExecutionRecord): { t
   if (record.tool_name === "ViewImage") return formatViewImageToolExecution(record);
   if (isWorkItemTool(record.tool_name)) return formatWorkItemToolExecution(record);
   if (isWebSearchTool(record.tool_name)) return formatWebSearchToolExecution(record);
-  if (isWebReaderTool(record.tool_name)) return formatWebReaderToolExecution(record);
-  if (isAnalyzeImageTool(record.tool_name)) return formatAnalyzeImageToolExecution(record);
+  if (isWebFetchTool(record.tool_name)) return formatWebFetchToolExecution(record);
   return undefined;
 }
 
 function isWebSearchTool(toolName: string | undefined): boolean {
-  return toolName === "mcp__web-search-prime__web_search_prime" || toolName === "WebSearch";
+  return toolName === "WebSearch";
 }
 
-function isWebReaderTool(toolName: string | undefined): boolean {
-  return toolName === "mcp__web_reader__webReader";
-}
-
-function isAnalyzeImageTool(toolName: string | undefined): boolean {
-  return toolName === "mcp__4_5v_mcp__analyze_image";
+function isWebFetchTool(toolName: string | undefined): boolean {
+  return toolName === "WebFetch";
 }
 
 
@@ -224,27 +219,27 @@ function formatViewImageToolExecution(record: RuntimeToolExecutionRecord): { tex
 function formatWebSearchToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
   const input = isRecord(record.input) ? record.input : {};
   const output = unwrapToolOutput(record.output ?? record.result);
-  const results = extractInspectorSearchResults(output);
-  const query = nestedValue(input, ["search_query", "query", "q"]);
-  const location = nestedValue(input, ["location"]);
+  const results = arrayRecords(nestedValue(output, ["results"]));
+  const query = nestedValue(output, ["query"]) ?? nestedValue(input, ["query", "search_query", "q"]);
+  const provider = nestedValue(output, ["provider"]);
+  const mode = nestedValue(output, ["mode"]);
   const resultLines = results.slice(0, 15).map((item, index) => {
-    const title = nestedValue(item, ["title", "name"]);
-    const url = nestedValue(item, ["url", "link", "href"]);
-    const siteName = nestedValue(item, ["siteName", "site_name", "websiteName", "website_name"]);
-    const summary = nestedValue(item, ["summary", "snippet", "description"]);
+    const title = nestedValue(item, ["title"]);
+    const url = nestedValue(item, ["url"]);
+    const source = nestedValue(item, ["source"]);
+    const snippet = nestedValue(item, ["snippet"]);
+    const publishedAt = nestedValue(item, ["published_at"]);
     return labelledText(
       `${index + 1}. ${title ?? "Untitled"}`,
-      [url, siteName ? `(${siteName})` : undefined, typeof summary === "string" ? truncateInspectorText(summary, 300) : undefined]
+      [url, source ? `(${source})` : undefined, publishedAt ? String(publishedAt) : undefined, typeof snippet === "string" ? truncateInspectorText(snippet, 300) : undefined]
         .filter(Boolean)
         .join("\n"),
     );
   });
   const lines = [
     labelledText("Query", query),
-    labelledText("Location", location),
-    labelledText("Content size", nestedValue(input, ["content_size"])),
-    labelledText("Recency", nestedValue(input, ["search_recency_filter"])),
-    labelledText("Domain filter", nestedValue(input, ["search_domain_filter"])),
+    labelledText("Provider", provider),
+    labelledText("Mode", mode),
     labelledText("Results", `${results.length} found`),
     ...resultLines,
     labelledText("Error", record.error),
@@ -252,65 +247,28 @@ function formatWebSearchToolExecution(record: RuntimeToolExecutionRecord): { tex
   return { text: lines.join("\n\n") || formatInspectorJson(record), tone: results.length ? "output" : "data" };
 }
 
-function formatWebReaderToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+function formatWebFetchToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
   const input = isRecord(record.input) ? record.input : {};
   const output = unwrapToolOutput(record.output ?? record.result);
-  const url = nestedValue(input, ["url"]);
-  const title = nestedText(output, ["title", "pageTitle"]);
-  const contentPreview = extractInspectorMarkdownPreview(output, 2000);
+  const url = nestedValue(output, ["url"]) ?? nestedValue(input, ["url"]);
+  const finalUrl = nestedValue(output, ["final_url"]);
+  const status = nestedValue(output, ["status"]);
+  const contentType = nestedValue(output, ["content_type"]);
+  const bytesRead = nestedValue(output, ["bytes_read"]);
+  const truncated = nestedValue(output, ["truncated"]);
+  const text = nestedText(output, ["text"]);
+  const contentPreview = typeof text === "string" && text.trim() ? truncateInspectorText(text, 2000) : undefined;
   const lines = [
     labelledText("URL", url),
-    labelledText("Title", title),
-    labelledText("Format", nestedValue(input, ["return_format"])),
-    labelledText("Images", nestedValue(input, ["retain_images"])),
+    finalUrl && finalUrl !== url ? labelledText("Final URL", finalUrl) : "",
+    labelledText("Status", status),
+    labelledText("Content-Type", contentType),
+    labelledText("Bytes read", bytesRead),
+    truncated ? labelledText("Truncated", "yes") : "",
     labelledText("Content", contentPreview),
     labelledText("Error", record.error),
   ].filter(Boolean);
   return { text: lines.join("\n\n") || formatInspectorJson(record), tone: contentPreview ? "output" : "data" };
-}
-
-function formatAnalyzeImageToolExecution(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
-  const input = isRecord(record.input) ? record.input : {};
-  const output = unwrapToolOutput(record.output ?? record.result);
-  const lines = [
-    labelledText("Image", nestedValue(input, ["imageSource", "image_source", "url"])),
-    labelledText("Prompt", nestedValue(input, ["prompt"])),
-    labelledText("Analysis", nestedText(output, ["analysis", "result", "text", "content", "description"])),
-    labelledText("Error", record.error),
-  ].filter(Boolean);
-  return { text: lines.join("\n\n") || formatInspectorJson(record), tone: lines.length ? "output" : "data" };
-}
-
-function extractInspectorSearchResults(value: unknown): Record<string, unknown>[] {
-  const record = isRecord(value) ? value : undefined;
-  if (!record) return [];
-  for (const key of ["results", "search_results", "data", "items"]) {
-    const candidate = record[key];
-    if (Array.isArray(candidate)) {
-      return candidate.filter((item): item is Record<string, unknown> => isRecord(item));
-    }
-  }
-  return [];
-}
-
-function extractInspectorMarkdownPreview(value: unknown, maxChars: number): string | undefined {
-  const record = isRecord(value) ? value : undefined;
-  if (!record) return undefined;
-  for (const key of ["markdown", "content", "text"]) {
-    const candidate = record[key];
-    if (typeof candidate === "string" && candidate.trim()) {
-      return truncateInspectorText(candidate, maxChars);
-    }
-  }
-  const content = record.content;
-  if (Array.isArray(content)) {
-    const text = content
-      .map((item) => (isRecord(item) ? item.text : undefined))
-      .filter((text): text is string => typeof text === "string")
-      .join("\n");
-    return text.trim() ? truncateInspectorText(text, maxChars) : undefined;
-  }
-  return undefined;
 }
 
 function truncateInspectorText(value: string, maxChars: number): string {

--- a/web-gui/app/src/features/inspector/InspectorPanel.test.ts
+++ b/web-gui/app/src/features/inspector/InspectorPanel.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { formatToolExecutionDetail } from "./InspectorPanel";
+
+describe("formatToolExecutionDetail", () => {
+  it("extracts readable command output from tool execution records", () => {
+    expect(
+      formatToolExecutionDetail({
+        tool_name: "ExecCommand",
+        status: "success",
+        summary: "command completed",
+        input: { cmd: "cargo test" },
+        output: {
+          exit_status: 0,
+          stdout_preview: "test result: ok",
+          stderr_preview: "",
+        },
+      }),
+    ).toEqual({
+      tone: "output",
+      text: ["Summary:\ncommand completed", "Command:\ncargo test", "Stdout:\ntest result: ok", "Exit:\n0"].join("\n\n"),
+    });
+  });
+
+  it("falls back to result and error fields for legacy records", () => {
+    expect(
+      formatToolExecutionDetail({
+        tool_name: "ExecCommand",
+        status: "error",
+        result: {
+          stderr: "failed",
+        },
+        error: "command exploded",
+      }).text,
+    ).toContain("Stderr:\nfailed");
+  });
+});

--- a/web-gui/app/src/features/inspector/InspectorPanel.test.ts
+++ b/web-gui/app/src/features/inspector/InspectorPanel.test.ts
@@ -34,4 +34,59 @@ describe("formatToolExecutionDetail", () => {
       }).text,
     ).toContain("Stderr:\nfailed");
   });
+
+  it("extracts command output from tool result envelopes", () => {
+    expect(
+      formatToolExecutionDetail({
+        tool_name: "ExecCommand",
+        status: "success",
+        input: { cmd: "npm test" },
+        output: {
+          envelope: {
+            result: {
+              exit_status: 0,
+              stdout_preview: "tests passed",
+              summary_text: "command exited with status 0",
+            },
+          },
+        },
+      }).text,
+    ).toContain("Stdout:\ntests passed");
+  });
+
+  it("extracts command output from batch item result envelopes", () => {
+    const detail = formatToolExecutionDetail({
+      tool_name: "ExecCommandBatch",
+      status: "success",
+      input: {
+        items: [{ cmd: "git status" }, { cmd: "rg TODO src" }],
+      },
+      output: {
+        envelope: {
+          result: {
+            items: [
+              {
+                index: 1,
+                result: {
+                  exit_status: 0,
+                  stdout_preview: "## main",
+                },
+              },
+              {
+                cmd: "rg TODO src",
+                index: 2,
+                result: {
+                  exit_status: 1,
+                  stderr_preview: "no matches",
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(detail.text).toContain("Batch item 1:\nCommand:\ngit status\n\nStdout:\n## main");
+    expect(detail.text).toContain("Batch item 2:\nCommand:\nrg TODO src\n\nStderr:\nno matches");
+  });
 });

--- a/web-gui/app/src/features/inspector/InspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/InspectorPanel.tsx
@@ -1,6 +1,14 @@
 import { EmptyState } from "../../components/ui/EmptyState";
 import { StatusBadge } from "../../components/ui/StatusChip";
-import type { AgentSummary, AgentTimelineActivity, AgentTimelineItemDetail, InspectorSelection } from "../../runtime/types";
+import type {
+  AgentSummary,
+  AgentTimelineActivity,
+  AgentTimelineItemDetail,
+  InspectorActivityDetailState,
+  InspectorSelection,
+  RuntimeTaskOutputResult,
+  RuntimeToolExecutionRecord,
+} from "../../runtime/types";
 
 interface InspectorPanelProps {
   agent: AgentSummary;
@@ -8,6 +16,79 @@ interface InspectorPanelProps {
   open: boolean;
   onClearSelection: () => void;
   onClose: () => void;
+}
+
+function HydratedActivityDetails({ detailState }: { detailState?: InspectorActivityDetailState }) {
+  if (!detailState) return null;
+  if (detailState.loading) {
+    return (
+      <section className="context-card inspector-card inspector-detail data">
+        <div className="context-head">
+          <span className="eyebrow">Full detail</span>
+          <strong>Loading…</strong>
+        </div>
+        <pre>Fetching full tool/task detail from the runtime API.</pre>
+      </section>
+    );
+  }
+  if (detailState.error) {
+    return (
+      <section className="context-card inspector-card inspector-detail data">
+        <div className="context-head">
+          <span className="eyebrow">Full detail</span>
+          <strong>Unavailable</strong>
+        </div>
+        <pre>{detailState.error}</pre>
+      </section>
+    );
+  }
+  return (
+    <>
+      {detailState.toolExecution ? <ToolExecutionDetail record={detailState.toolExecution} /> : null}
+      {detailState.taskOutput ? <TaskOutputDetail output={detailState.taskOutput} /> : null}
+    </>
+  );
+}
+
+function ToolExecutionDetail({ record }: { record: RuntimeToolExecutionRecord }) {
+  return (
+    <section className="context-card inspector-card inspector-detail data">
+      <div className="context-head">
+        <span className="eyebrow">Tool execution</span>
+        <strong>{compactMeta([record.tool_name, record.status])}</strong>
+      </div>
+      <pre>{formatInspectorJson(record)}</pre>
+    </section>
+  );
+}
+
+function TaskOutputDetail({ output }: { output: RuntimeTaskOutputResult }) {
+  const text = taskOutputText(output) || formatInspectorJson(output);
+  return (
+    <section className="context-card inspector-card inspector-detail output">
+      <div className="context-head">
+        <span className="eyebrow">Task output</span>
+        <strong>{compactMeta([output.task?.status ?? output.status, output.retrieval_status])}</strong>
+      </div>
+      <pre>{text}</pre>
+    </section>
+  );
+}
+
+function taskOutputText(output: RuntimeTaskOutputResult): string {
+  return [
+    textField(output.task?.result_summary),
+    textField(output.task?.output_preview),
+    textField(output.output),
+    textField(output.stdout),
+    textField(output.stderr),
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function textField(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
 function formatInspectorJson(value: unknown): string {
@@ -41,7 +122,11 @@ export function InspectorPanel({ agent, selection, open, onClearSelection, onClo
         </div>
       </div>
       <div className="panel-body">
-        {selection?.kind === "activity" ? <ActivityDetails activity={selection.activity} /> : <SessionOverview agent={agent} />}
+        {selection?.kind === "activity" ? (
+          <ActivityDetails activity={selection.activity} detailState={selection.detailState} />
+        ) : (
+          <SessionOverview agent={agent} />
+        )}
       </div>
     </aside>
   );
@@ -211,7 +296,7 @@ function WorkItemCard({ workItem, featured = false }: { workItem: NonNullable<Ag
   );
 }
 
-function ActivityDetails({ activity }: { activity: AgentTimelineActivity }) {
+function ActivityDetails({ activity, detailState }: { activity: AgentTimelineActivity; detailState?: InspectorActivityDetailState }) {
   const detail = activity.detail;
   const rawEventText = formatInspectorJson(activity.rawEvent);
 
@@ -259,6 +344,8 @@ function ActivityDetails({ activity }: { activity: AgentTimelineActivity }) {
           description="This activity has no projected detail yet. Use the raw event below for the source payload."
         />
       )}
+
+      <HydratedActivityDetails detailState={detailState} />
 
       {rawEventText ? (
         <section className="context-card inspector-card inspector-detail data">

--- a/web-gui/app/src/features/inspector/InspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/InspectorPanel.tsx
@@ -51,15 +51,83 @@ function HydratedActivityDetails({ detailState }: { detailState?: InspectorActiv
 }
 
 function ToolExecutionDetail({ record }: { record: RuntimeToolExecutionRecord }) {
+  const detail = formatToolExecutionDetail(record);
+  const rawText = formatInspectorJson(record);
+
   return (
-    <section className="context-card inspector-card inspector-detail data">
-      <div className="context-head">
-        <span className="eyebrow">Tool execution</span>
-        <strong>{compactMeta([record.tool_name, record.status])}</strong>
-      </div>
-      <pre>{formatInspectorJson(record)}</pre>
-    </section>
+    <>
+      <section className={`context-card inspector-card inspector-detail ${detail.tone}`}>
+        <div className="context-head">
+          <span className="eyebrow">Tool execution</span>
+          <strong>{compactMeta([record.tool_name, record.status])}</strong>
+        </div>
+        <pre>{detail.text}</pre>
+      </section>
+      {rawText ? (
+        <details className="context-card inspector-card inspector-raw-detail">
+          <summary>Raw tool execution JSON</summary>
+          <pre>{rawText}</pre>
+        </details>
+      ) : null}
+    </>
   );
+}
+
+export function formatToolExecutionDetail(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
+  const output = record.output ?? record.result;
+  const lines = [
+    labelledText("Summary", record.summary),
+    labelledText("Command", commandText(record.input)),
+    labelledText("Stdout", nestedText(output, ["stdout", "stdout_preview", "output", "output_preview", "combined_output_preview"])),
+    labelledText("Stderr", nestedText(output, ["stderr", "stderr_preview"])),
+    labelledText("Initial output", nestedText(output, ["initial_output_preview"])),
+    labelledText("Result", nestedText(output, ["summary", "summary_text", "result_summary", "result_summary_preview"])),
+    labelledText("Error", record.error ?? nestedValue(output, ["error"])),
+    labelledText("Exit", nestedValue(output, ["exit_status", "status", "disposition"])),
+  ].filter(Boolean);
+
+  return {
+    text: lines.join("\n\n") || formatInspectorJson(record),
+    tone: lines.length ? "output" : "data",
+  };
+}
+
+function labelledText(label: string, value: unknown): string {
+  const text = textField(value) || scalarText(value);
+  return text ? `${label}:\n${text}` : "";
+}
+
+function commandText(input: unknown): string {
+  const value = nestedValue(input, ["cmd", "command", "cmd_preview"]);
+  if (typeof value === "string") return value;
+  return "";
+}
+
+function nestedText(value: unknown, keys: string[]): string {
+  const found = nestedValue(value, keys);
+  return textField(found) || scalarText(found);
+}
+
+function nestedValue(value: unknown, keys: string[]): unknown {
+  if (!isRecord(value)) return undefined;
+  for (const key of keys) {
+    const field = value[key];
+    if (field != null && (!isBlankString(field))) return field;
+  }
+  return undefined;
+}
+
+function scalarText(value: unknown): string {
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function isBlankString(value: unknown): boolean {
+  return typeof value === "string" && value.trim() === "";
 }
 
 function TaskOutputDetail({ output }: { output: RuntimeTaskOutputResult }) {

--- a/web-gui/app/src/features/inspector/InspectorPanel.tsx
+++ b/web-gui/app/src/features/inspector/InspectorPanel.tsx
@@ -74,22 +74,52 @@ function ToolExecutionDetail({ record }: { record: RuntimeToolExecutionRecord })
 }
 
 export function formatToolExecutionDetail(record: RuntimeToolExecutionRecord): { text: string; tone: "output" | "data" } {
-  const output = record.output ?? record.result;
+  const output = unwrapToolOutput(record.output ?? record.result);
+  const batchItemSections = formatBatchToolOutput(record.input, output);
   const lines = [
     labelledText("Summary", record.summary),
-    labelledText("Command", commandText(record.input)),
+    batchItemSections.length ? "" : labelledText("Command", commandText(record.input)),
     labelledText("Stdout", nestedText(output, ["stdout", "stdout_preview", "output", "output_preview", "combined_output_preview"])),
     labelledText("Stderr", nestedText(output, ["stderr", "stderr_preview"])),
     labelledText("Initial output", nestedText(output, ["initial_output_preview"])),
     labelledText("Result", nestedText(output, ["summary", "summary_text", "result_summary", "result_summary_preview"])),
     labelledText("Error", record.error ?? nestedValue(output, ["error"])),
     labelledText("Exit", nestedValue(output, ["exit_status", "status", "disposition"])),
+    ...batchItemSections,
   ].filter(Boolean);
 
   return {
     text: lines.join("\n\n") || formatInspectorJson(record),
     tone: lines.length ? "output" : "data",
   };
+}
+
+function unwrapToolOutput(value: unknown): unknown {
+  const envelope = isRecord(value) ? value.envelope : undefined;
+  const result = isRecord(envelope) ? envelope.result : undefined;
+  return result ?? value;
+}
+
+function formatBatchToolOutput(input: unknown, output: unknown): string[] {
+  if (!isRecord(output) || !Array.isArray(output.items)) return [];
+  const inputItems = isRecord(input) && Array.isArray(input.items) ? input.items : [];
+
+  return output.items
+    .map((item, index) => {
+      if (!isRecord(item)) return "";
+      const result = isRecord(item.result) ? item.result : item;
+      const command = textField(item.cmd) || commandText(inputItems[index]);
+      const lines = [
+        labelledText("Command", command),
+        labelledText("Stdout", nestedText(result, ["stdout", "stdout_preview", "output", "output_preview", "combined_output_preview"])),
+        labelledText("Stderr", nestedText(result, ["stderr", "stderr_preview"])),
+        labelledText("Result", nestedText(result, ["summary", "summary_text", "result_summary", "result_summary_preview"])),
+        labelledText("Error", nestedValue(result, ["error"])),
+        labelledText("Exit", nestedValue(result, ["exit_status", "status", "disposition"])),
+      ].filter(Boolean);
+      return lines.length ? `Batch item ${item.index ?? index + 1}:\n${lines.join("\n\n")}` : "";
+    })
+    .filter(Boolean);
 }
 
 function labelledText(label: string, value: unknown): string {

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -1,28 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
-
 import { EmptyState } from "../../components/ui/EmptyState";
 import { StatusBadge } from "../../components/ui/StatusChip";
 import type { AgentSummary, WorkItemDetailState, WorkItemSummary } from "../../runtime/types";
 
 interface AgentOverviewPanelProps {
   agent: AgentSummary;
-  workItemDetailsById: Record<string, WorkItemDetailState>;
   onLoadWorkItemDetail: (workItemId: string) => void;
+  onOpenWorkItemDetail: (workItem: WorkItemSummary) => void;
 }
 
-export function AgentOverviewPanel({ agent, workItemDetailsById, onLoadWorkItemDetail }: AgentOverviewPanelProps) {
+export function AgentOverviewPanel({ agent, onLoadWorkItemDetail, onOpenWorkItemDetail }: AgentOverviewPanelProps) {
   const workspace = agent.workspaceSummary;
   const workItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
-  const [selectedWorkItemId, setSelectedWorkItemId] = useState<string | undefined>(workItems[0]?.id);
   const currentWorkItems = workItems.filter((item) => item.current);
   const openWorkItems = workItems.filter((item) => !item.current && item.state !== "completed");
   const completedWorkItems = workItems.filter((item) => item.state === "completed");
-  const selectedWorkItemSummary = useMemo(
-    () => workItems.find((item) => item.id === selectedWorkItemId) ?? workItems[0],
-    [selectedWorkItemId, workItems],
-  );
-  const selectedWorkItemDetail = selectedWorkItemSummary ? workItemDetailsById[selectedWorkItemSummary.id] : undefined;
-  const selectedWorkItem = selectedWorkItemDetail?.workItem ?? selectedWorkItemSummary;
   const currentWorkLabel = currentWorkItems[0]?.objective ?? agent.currentWork?.objective ?? "No current work item";
   const workspaceName = workspace?.name ?? agent.workspace;
   const workspaceRoot = workspace?.cwd ?? workspace?.executionRoot ?? workspace?.worktree?.path ?? workspace?.anchor;
@@ -30,25 +21,9 @@ export function AgentOverviewPanel({ agent, workItemDetailsById, onLoadWorkItemD
   const showCwd = Boolean(workspace?.cwd && workspace.cwd !== workspace.executionRoot);
   const hasActiveTasks = agent.activeTaskCount > 0 || Boolean(agent.tasks?.length);
 
-  useEffect(() => {
-    if (!workItems.length) {
-      setSelectedWorkItemId(undefined);
-      return;
-    }
-    if (selectedWorkItemId && workItems.some((item) => item.id === selectedWorkItemId)) return;
-    setSelectedWorkItemId(workItems[0]?.id);
-  }, [selectedWorkItemId, workItems]);
-
-  useEffect(() => {
-    if (!selectedWorkItemSummary || selectedWorkItemDetail?.workItem || selectedWorkItemDetail?.loading) return;
-    onLoadWorkItemDetail(selectedWorkItemSummary.id);
-  }, [onLoadWorkItemDetail, selectedWorkItemDetail?.loading, selectedWorkItemDetail?.workItem, selectedWorkItemSummary]);
-
   const selectWorkItem = (workItem: WorkItemSummary) => {
-    setSelectedWorkItemId(workItem.id);
-    if (!workItemDetailsById[workItem.id]?.workItem) {
-      onLoadWorkItemDetail(workItem.id);
-    }
+    onOpenWorkItemDetail(workItem);
+    onLoadWorkItemDetail(workItem.id);
   };
 
   return (
@@ -173,22 +148,21 @@ export function AgentOverviewPanel({ agent, workItemDetailsById, onLoadWorkItemD
             <StatusBadge className="state-chip" kind="work" value={`${openWorkItems.length + currentWorkItems.length} open`} />
           </div>
           {currentWorkItems.map((workItem) => (
-            <WorkItemCard key={workItem.id} workItem={workItem} featured selected={workItem.id === selectedWorkItem?.id} onSelect={selectWorkItem} />
+            <WorkItemCard key={workItem.id} workItem={workItem} featured onSelect={selectWorkItem} />
           ))}
           {openWorkItems.length ? (
             <div className="inspector-nested-stack">
               {openWorkItems.map((workItem) => (
-                <WorkItemCard key={workItem.id} workItem={workItem} selected={workItem.id === selectedWorkItem?.id} onSelect={selectWorkItem} />
+                <WorkItemCard key={workItem.id} workItem={workItem} onSelect={selectWorkItem} />
               ))}
             </div>
           ) : null}
-          {selectedWorkItem ? <WorkItemDetailPanel workItem={selectedWorkItem} detailState={selectedWorkItemDetail} /> : null}
           {completedWorkItems.length ? (
             <details className="inspector-details-list">
               <summary>{completedWorkItems.length} completed</summary>
               <div className="inspector-nested-stack">
                 {completedWorkItems.map((workItem) => (
-                  <WorkItemCard key={workItem.id} workItem={workItem} selected={workItem.id === selectedWorkItem?.id} onSelect={selectWorkItem} />
+                  <WorkItemCard key={workItem.id} workItem={workItem} onSelect={selectWorkItem} />
                 ))}
               </div>
             </details>
@@ -209,19 +183,16 @@ export function AgentOverviewPanel({ agent, workItemDetailsById, onLoadWorkItemD
 function WorkItemCard({
   workItem,
   featured = false,
-  selected = false,
   onSelect,
 }: {
   workItem: WorkItemSummary;
   featured?: boolean;
-  selected?: boolean;
   onSelect: (workItem: WorkItemSummary) => void;
 }) {
   return (
     <button
       type="button"
-      className={`inspector-list-item work-item-button${featured ? " featured" : ""}${selected ? " selected" : ""}`}
-      aria-pressed={selected}
+      className={`inspector-list-item work-item-button${featured ? " featured" : ""}`}
       onClick={() => onSelect(workItem)}
     >
       <div className="inspector-list-head">
@@ -234,7 +205,7 @@ function WorkItemCard({
   );
 }
 
-function WorkItemDetailPanel({ workItem, detailState }: { workItem: WorkItemSummary; detailState?: WorkItemDetailState }) {
+export function WorkItemDetailPanel({ workItem, detailState }: { workItem: WorkItemSummary; detailState?: WorkItemDetailState }) {
   const loading = detailState?.loading && !detailState.workItem;
   const plan = workItem.planArtifact;
   return (

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -4,9 +4,10 @@ import type { AgentSummary } from "../../runtime/types";
 
 export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
   const workspace = agent.workspaceSummary;
-  const openWorkItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
-  const currentWorkItems = openWorkItems.filter((item) => item.current);
-  const otherWorkItems = openWorkItems.filter((item) => !item.current);
+  const workItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
+  const currentWorkItems = workItems.filter((item) => item.current);
+  const openWorkItems = workItems.filter((item) => !item.current && item.state !== "completed");
+  const completedWorkItems = workItems.filter((item) => item.state === "completed");
   const currentWorkLabel = currentWorkItems[0]?.objective ?? agent.currentWork?.objective ?? "No current work item";
   const workspaceName = workspace?.name ?? agent.workspace;
   const workspaceRoot = workspace?.cwd ?? workspace?.executionRoot ?? workspace?.worktree?.path ?? workspace?.anchor;
@@ -129,20 +130,27 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
         </section>
       ) : null}
 
-      {openWorkItems.length ? (
+      {workItems.length ? (
         <section className="context-card current-work inspector-card">
           <div className="context-head">
-            <span className="eyebrow">Open work items</span>
-            <StatusBadge className="state-chip" kind="work" value={`${openWorkItems.length} open`} />
+            <span className="eyebrow">Work items</span>
+            <StatusBadge className="state-chip" kind="work" value={`${openWorkItems.length + currentWorkItems.length} open`} />
           </div>
           {currentWorkItems.map((workItem) => (
             <WorkItemCard key={workItem.id} workItem={workItem} featured />
           ))}
-          {otherWorkItems.length ? (
+          {openWorkItems.length ? (
+            <div className="inspector-nested-stack">
+              {openWorkItems.map((workItem) => (
+                <WorkItemCard key={workItem.id} workItem={workItem} />
+              ))}
+            </div>
+          ) : null}
+          {completedWorkItems.length ? (
             <details className="inspector-details-list">
-              <summary>{otherWorkItems.length} other open</summary>
+              <summary>{completedWorkItems.length} completed</summary>
               <div className="inspector-nested-stack">
-                {otherWorkItems.map((workItem) => (
+                {completedWorkItems.map((workItem) => (
                   <WorkItemCard key={workItem.id} workItem={workItem} />
                 ))}
               </div>

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -276,8 +276,8 @@ export function WorkItemDetailPanel({ workItem, detailState }: { workItem: WorkI
         </section>
       ) : null}
       {workItem.workRefs?.length ? (
-        <section className="work-item-detail-section">
-          <h3>Refs</h3>
+        <details className="work-item-detail-section work-item-detail-refs">
+          <summary>Refs</summary>
           <ul className="inspector-list">
             {workItem.workRefs.map((ref) => (
               <li key={`${ref.kind}-${ref.ref}`}>
@@ -290,7 +290,7 @@ export function WorkItemDetailPanel({ workItem, detailState }: { workItem: WorkI
               </li>
             ))}
           </ul>
-        </section>
+        </details>
       ) : null}
     </article>
   );

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -7,6 +7,7 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
   const openWorkItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
   const currentWorkItems = openWorkItems.filter((item) => item.current);
   const otherWorkItems = openWorkItems.filter((item) => !item.current);
+  const currentWorkLabel = currentWorkItems[0]?.objective ?? agent.currentWork?.objective ?? "No current work item";
 
   return (
     <div className="inspector-stack">
@@ -26,15 +27,19 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
             <dd>{agent.model}</dd>
           </div>
           <div>
-            <dt>Focus</dt>
-            <dd>{agent.focusSummary}</dd>
+            <dt>Current work</dt>
+            <dd>{currentWorkLabel}</dd>
+          </div>
+          <div>
+            <dt>Scheduling</dt>
+            <dd>{compactMeta([agent.posture, agent.postureReason])}</dd>
           </div>
         </dl>
       </section>
 
       <section className="context-card inspector-card">
         <div className="context-head">
-          <span className="eyebrow">Workspace</span>
+          <span className="eyebrow">Workspace context</span>
           <StatusBadge className="state-chip" kind="connection" value={agent.workspace === "not bound" ? "unbound" : "active"} />
         </div>
         <h2>{workspace?.name ?? agent.workspace}</h2>
@@ -51,36 +56,38 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
             <dt>ID</dt>
             <dd>{workspace?.id ?? "—"}</dd>
           </div>
-        </dl>
-      </section>
-
-      <section className="context-card inspector-card">
-        <div className="context-head">
-          <span className="eyebrow">{workspace?.worktree ? "Worktree / Execution" : "Execution"}</span>
-          <StatusBadge className="state-chip" kind="connection" value={workspace?.worktree ? "worktree" : "root"} />
-        </div>
-        <h2>{workspace?.worktree?.branch ?? "Current root"}</h2>
-        <dl className="inspector-facts">
-          {workspace?.worktree ? (
-            <>
-              <div>
-                <dt>Branch</dt>
-                <dd>{workspace.worktree.branch ?? "—"}</dd>
-              </div>
-              <div>
-                <dt>Worktree</dt>
-                <dd>{workspace.worktree.path ?? "—"}</dd>
-              </div>
-            </>
-          ) : null}
           <div>
-            <dt>Root</dt>
+            <dt>Projection</dt>
+            <dd>{compactMeta([workspace?.projectionKind, workspace?.accessMode])}</dd>
+          </div>
+          <div>
+            <dt>Execution root</dt>
             <dd>{workspace?.executionRoot ?? workspace?.anchor ?? "—"}</dd>
           </div>
           <div>
             <dt>Cwd</dt>
             <dd>{workspace?.cwd ?? "—"}</dd>
           </div>
+          {workspace?.worktree ? (
+            <>
+              <div>
+                <dt>Managed branch</dt>
+                <dd>{workspace.worktree.branch ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Worktree</dt>
+                <dd>{workspace.worktree.path ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Original branch</dt>
+                <dd>{workspace.worktree.originalBranch ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Original cwd</dt>
+                <dd>{workspace.worktree.originalCwd ?? "—"}</dd>
+              </div>
+            </>
+          ) : null}
         </dl>
       </section>
 

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -1,0 +1,172 @@
+import { EmptyState } from "../../components/ui/EmptyState";
+import { StatusBadge } from "../../components/ui/StatusChip";
+import type { AgentSummary } from "../../runtime/types";
+
+export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
+  const workspace = agent.workspaceSummary;
+  const openWorkItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
+  const currentWorkItems = openWorkItems.filter((item) => item.current);
+  const otherWorkItems = openWorkItems.filter((item) => !item.current);
+
+  return (
+    <div className="inspector-stack">
+      <section className="context-card inspector-card">
+        <div className="context-head">
+          <span className="eyebrow">Agent</span>
+          <StatusBadge className="state-chip" kind="agent" value={agent.posture || agent.lifecycle} />
+        </div>
+        <h2>{agent.id}</h2>
+        <dl className="inspector-facts">
+          <div>
+            <dt>Lifecycle</dt>
+            <dd>{agent.lifecycle}</dd>
+          </div>
+          <div>
+            <dt>Model</dt>
+            <dd>{agent.model}</dd>
+          </div>
+          <div>
+            <dt>Focus</dt>
+            <dd>{agent.focusSummary}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="context-card inspector-card">
+        <div className="context-head">
+          <span className="eyebrow">Workspace</span>
+          <StatusBadge className="state-chip" kind="connection" value={agent.workspace === "not bound" ? "unbound" : "active"} />
+        </div>
+        <h2>{workspace?.name ?? agent.workspace}</h2>
+        <dl className="inspector-facts">
+          <div>
+            <dt>Name</dt>
+            <dd>{workspace?.name ?? (agent.workspace === "not bound" ? "No active workspace" : agent.workspace)}</dd>
+          </div>
+          <div>
+            <dt>Anchor</dt>
+            <dd>{workspace?.anchor ?? "—"}</dd>
+          </div>
+          <div>
+            <dt>ID</dt>
+            <dd>{workspace?.id ?? "—"}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="context-card inspector-card">
+        <div className="context-head">
+          <span className="eyebrow">{workspace?.worktree ? "Worktree / Execution" : "Execution"}</span>
+          <StatusBadge className="state-chip" kind="connection" value={workspace?.worktree ? "worktree" : "root"} />
+        </div>
+        <h2>{workspace?.worktree?.branch ?? "Current root"}</h2>
+        <dl className="inspector-facts">
+          {workspace?.worktree ? (
+            <>
+              <div>
+                <dt>Branch</dt>
+                <dd>{workspace.worktree.branch ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Worktree</dt>
+                <dd>{workspace.worktree.path ?? "—"}</dd>
+              </div>
+            </>
+          ) : null}
+          <div>
+            <dt>Root</dt>
+            <dd>{workspace?.executionRoot ?? workspace?.anchor ?? "—"}</dd>
+          </div>
+          <div>
+            <dt>Cwd</dt>
+            <dd>{workspace?.cwd ?? "—"}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="context-card inspector-card">
+        <div className="context-head">
+          <span className="eyebrow">Tasks</span>
+          <StatusBadge className="state-chip" kind="connection" value={agent.activeTaskCount ? "active" : "idle"} />
+        </div>
+        <h2>{agent.activeTaskCount} active</h2>
+        {agent.tasks?.length ? (
+          <ul className="inspector-list">
+            {agent.tasks.map((task) => (
+              <li key={task.id}>
+                <div className="inspector-list-head">
+                  <strong>{task.summary}</strong>
+                  <StatusBadge className="state-chip" kind="connection" value={task.status} />
+                </div>
+                <small>{compactMeta([task.kind, task.command, task.workdir])}</small>
+                <code>{task.id}</code>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <dl className="inspector-facts">
+            <div>
+              <dt>Queued</dt>
+              <dd>{agent.pending}</dd>
+            </div>
+            <div>
+              <dt>Waiting</dt>
+              <dd>{agent.waitingCount}</dd>
+            </div>
+            <div>
+              <dt>Attention</dt>
+              <dd>{agent.attention}</dd>
+            </div>
+          </dl>
+        )}
+      </section>
+
+      {openWorkItems.length ? (
+        <section className="context-card current-work inspector-card">
+          <div className="context-head">
+            <span className="eyebrow">Open work items</span>
+            <StatusBadge className="state-chip" kind="work" value={`${openWorkItems.length} open`} />
+          </div>
+          {currentWorkItems.map((workItem) => (
+            <WorkItemCard key={workItem.id} workItem={workItem} featured />
+          ))}
+          {otherWorkItems.length ? (
+            <details className="inspector-details-list">
+              <summary>{otherWorkItems.length} other open</summary>
+              <div className="inspector-nested-stack">
+                {otherWorkItems.map((workItem) => (
+                  <WorkItemCard key={workItem.id} workItem={workItem} />
+                ))}
+              </div>
+            </details>
+          ) : null}
+        </section>
+      ) : (
+        <EmptyState
+          className="inspector-empty"
+          icon="◎"
+          title="No current work item"
+          description="Select a timeline activity to inspect tool output, or continue the conversation from the main pane."
+        />
+      )}
+    </div>
+  );
+}
+
+function WorkItemCard({ workItem, featured = false }: { workItem: NonNullable<AgentSummary["workItems"]>[number]; featured?: boolean }) {
+  return (
+    <article className={`inspector-list-item${featured ? " featured" : ""}`}>
+      <div className="inspector-list-head">
+        <strong>{workItem.objective}</strong>
+        <StatusBadge className="state-chip" kind="work" value={workItem.state} />
+      </div>
+      <small>{compactMeta([workItem.current ? "current" : undefined, workItem.planStatus])}</small>
+      <code>{workItem.id}</code>
+    </article>
+  );
+}
+
+function compactMeta(parts: Array<string | undefined>): string {
+  return parts.filter(Boolean).join(" · ") || "—";
+}
+

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -10,7 +10,6 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
   const currentWorkLabel = currentWorkItems[0]?.objective ?? agent.currentWork?.objective ?? "No current work item";
   const workspaceName = workspace?.name ?? agent.workspace;
   const workspaceRoot = workspace?.cwd ?? workspace?.executionRoot ?? workspace?.worktree?.path ?? workspace?.anchor;
-  const branchLabel = workspace?.worktree?.branch ?? workspace?.worktree?.originalBranch;
   const modeLabel = workspace?.worktree ? "Managed worktree" : workspace?.projectionKind;
 
   return (
@@ -53,8 +52,8 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
             <dd>{workspaceRoot ?? (agent.workspace === "not bound" ? "No active workspace" : "—")}</dd>
           </div>
           <div>
-            <dt>Branch</dt>
-            <dd>{branchLabel ?? "—"}</dd>
+            <dt>Anchor</dt>
+            <dd>{workspace?.anchor ?? "—"}</dd>
           </div>
           <div>
             <dt>Mode</dt>
@@ -72,10 +71,6 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
               <div>
                 <dt>ID</dt>
                 <dd>{workspace.id}</dd>
-              </div>
-              <div>
-                <dt>Anchor</dt>
-                <dd>{workspace.anchor}</dd>
               </div>
               <div>
                 <dt>Projection</dt>

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -11,6 +11,7 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
   const workspaceName = workspace?.name ?? agent.workspace;
   const workspaceRoot = workspace?.cwd ?? workspace?.executionRoot ?? workspace?.worktree?.path ?? workspace?.anchor;
   const modeLabel = workspace?.worktree ? "Managed worktree" : workspace?.projectionKind;
+  const showCwd = Boolean(workspace?.cwd && workspace.cwd !== workspace.executionRoot);
 
   return (
     <div className="inspector-stack">
@@ -80,10 +81,12 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
                 <dt>Execution root</dt>
                 <dd>{workspace.executionRoot ?? "—"}</dd>
               </div>
-              <div>
-                <dt>Cwd</dt>
-                <dd>{workspace.cwd ?? "—"}</dd>
-              </div>
+              {showCwd ? (
+                <div>
+                  <dt>Cwd</dt>
+                  <dd>{workspace.cwd}</dd>
+                </div>
+              ) : null}
               {workspace.worktree ? (
                 <>
                   <div>
@@ -93,10 +96,6 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
                   <div>
                     <dt>Original branch</dt>
                     <dd>{workspace.worktree.originalBranch ?? "—"}</dd>
-                  </div>
-                  <div>
-                    <dt>Original cwd</dt>
-                    <dd>{workspace.worktree.originalCwd ?? "—"}</dd>
                   </div>
                 </>
               ) : null}

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -12,6 +12,7 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
   const workspaceRoot = workspace?.cwd ?? workspace?.executionRoot ?? workspace?.worktree?.path ?? workspace?.anchor;
   const modeLabel = workspace?.worktree ? "Managed worktree" : workspace?.projectionKind;
   const showCwd = Boolean(workspace?.cwd && workspace.cwd !== workspace.executionRoot);
+  const hasActiveTasks = agent.activeTaskCount > 0 || Boolean(agent.tasks?.length);
 
   return (
     <div className="inspector-stack">
@@ -104,42 +105,29 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
         ) : null}
       </section>
 
-      <section className="context-card inspector-card">
-        <div className="context-head">
-          <span className="eyebrow">Tasks</span>
-          <StatusBadge className="state-chip" kind="connection" value={agent.activeTaskCount ? "active" : "idle"} />
-        </div>
-        <h2>{agent.activeTaskCount} active</h2>
-        {agent.tasks?.length ? (
-          <ul className="inspector-list">
-            {agent.tasks.map((task) => (
-              <li key={task.id}>
-                <div className="inspector-list-head">
-                  <strong>{task.summary}</strong>
-                  <StatusBadge className="state-chip" kind="connection" value={task.status} />
-                </div>
-                <small>{compactMeta([task.kind, task.command, task.workdir])}</small>
-                <code>{task.id}</code>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <dl className="inspector-facts">
-            <div>
-              <dt>Queued</dt>
-              <dd>{agent.pending}</dd>
-            </div>
-            <div>
-              <dt>Waiting</dt>
-              <dd>{agent.waitingCount}</dd>
-            </div>
-            <div>
-              <dt>Attention</dt>
-              <dd>{agent.attention}</dd>
-            </div>
-          </dl>
-        )}
-      </section>
+      {hasActiveTasks ? (
+        <section className="context-card inspector-card">
+          <div className="context-head">
+            <span className="eyebrow">Tasks</span>
+            <StatusBadge className="state-chip" kind="connection" value="active" />
+          </div>
+          <h2>{agent.activeTaskCount} active</h2>
+          {agent.tasks?.length ? (
+            <ul className="inspector-list">
+              {agent.tasks.map((task) => (
+                <li key={task.id}>
+                  <div className="inspector-list-head">
+                    <strong>{task.summary}</strong>
+                    <StatusBadge className="state-chip" kind="connection" value={task.status} />
+                  </div>
+                  <small>{compactMeta([task.kind, task.command, task.workdir])}</small>
+                  <code>{task.id}</code>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      ) : null}
 
       {openWorkItems.length ? (
         <section className="context-card current-work inspector-card">

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -8,6 +8,10 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
   const currentWorkItems = openWorkItems.filter((item) => item.current);
   const otherWorkItems = openWorkItems.filter((item) => !item.current);
   const currentWorkLabel = currentWorkItems[0]?.objective ?? agent.currentWork?.objective ?? "No current work item";
+  const workspaceName = workspace?.name ?? agent.workspace;
+  const workspaceRoot = workspace?.cwd ?? workspace?.executionRoot ?? workspace?.worktree?.path ?? workspace?.anchor;
+  const branchLabel = workspace?.worktree?.branch ?? workspace?.worktree?.originalBranch;
+  const modeLabel = workspace?.worktree ? "Managed worktree" : workspace?.projectionKind;
 
   return (
     <div className="inspector-stack">
@@ -39,56 +43,71 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
 
       <section className="context-card inspector-card">
         <div className="context-head">
-          <span className="eyebrow">Workspace context</span>
+          <span className="eyebrow">Workspace</span>
           <StatusBadge className="state-chip" kind="connection" value={agent.workspace === "not bound" ? "unbound" : "active"} />
         </div>
-        <h2>{workspace?.name ?? agent.workspace}</h2>
+        <h2>{workspaceName}</h2>
         <dl className="inspector-facts">
           <div>
-            <dt>Name</dt>
-            <dd>{workspace?.name ?? (agent.workspace === "not bound" ? "No active workspace" : agent.workspace)}</dd>
+            <dt>Working directory</dt>
+            <dd>{workspaceRoot ?? (agent.workspace === "not bound" ? "No active workspace" : "—")}</dd>
           </div>
           <div>
-            <dt>Anchor</dt>
-            <dd>{workspace?.anchor ?? "—"}</dd>
+            <dt>Branch</dt>
+            <dd>{branchLabel ?? "—"}</dd>
           </div>
           <div>
-            <dt>ID</dt>
-            <dd>{workspace?.id ?? "—"}</dd>
+            <dt>Mode</dt>
+            <dd>{compactMeta([modeLabel, workspace?.accessMode])}</dd>
           </div>
-          <div>
-            <dt>Projection</dt>
-            <dd>{compactMeta([workspace?.projectionKind, workspace?.accessMode])}</dd>
-          </div>
-          <div>
-            <dt>Execution root</dt>
-            <dd>{workspace?.executionRoot ?? workspace?.anchor ?? "—"}</dd>
-          </div>
-          <div>
-            <dt>Cwd</dt>
-            <dd>{workspace?.cwd ?? "—"}</dd>
-          </div>
-          {workspace?.worktree ? (
-            <>
-              <div>
-                <dt>Managed branch</dt>
-                <dd>{workspace.worktree.branch ?? "—"}</dd>
-              </div>
-              <div>
-                <dt>Worktree</dt>
-                <dd>{workspace.worktree.path ?? "—"}</dd>
-              </div>
-              <div>
-                <dt>Original branch</dt>
-                <dd>{workspace.worktree.originalBranch ?? "—"}</dd>
-              </div>
-              <div>
-                <dt>Original cwd</dt>
-                <dd>{workspace.worktree.originalCwd ?? "—"}</dd>
-              </div>
-            </>
-          ) : null}
         </dl>
+        {workspace ? (
+          <details className="inspector-details-list workspace-technical-details">
+            <summary>Technical details</summary>
+            <dl className="inspector-facts">
+              <div>
+                <dt>Name</dt>
+                <dd>{workspace.name}</dd>
+              </div>
+              <div>
+                <dt>ID</dt>
+                <dd>{workspace.id}</dd>
+              </div>
+              <div>
+                <dt>Anchor</dt>
+                <dd>{workspace.anchor}</dd>
+              </div>
+              <div>
+                <dt>Projection</dt>
+                <dd>{compactMeta([workspace.projectionKind, workspace.accessMode])}</dd>
+              </div>
+              <div>
+                <dt>Execution root</dt>
+                <dd>{workspace.executionRoot ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Cwd</dt>
+                <dd>{workspace.cwd ?? "—"}</dd>
+              </div>
+              {workspace.worktree ? (
+                <>
+                  <div>
+                    <dt>Worktree</dt>
+                    <dd>{workspace.worktree.path ?? "—"}</dd>
+                  </div>
+                  <div>
+                    <dt>Original branch</dt>
+                    <dd>{workspace.worktree.originalBranch ?? "—"}</dd>
+                  </div>
+                  <div>
+                    <dt>Original cwd</dt>
+                    <dd>{workspace.worktree.originalCwd ?? "—"}</dd>
+                  </div>
+                </>
+              ) : null}
+            </dl>
+          </details>
+        ) : null}
       </section>
 
       <section className="context-card inspector-card">

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -1,19 +1,55 @@
+import { useEffect, useMemo, useState } from "react";
+
 import { EmptyState } from "../../components/ui/EmptyState";
 import { StatusBadge } from "../../components/ui/StatusChip";
-import type { AgentSummary } from "../../runtime/types";
+import type { AgentSummary, WorkItemDetailState, WorkItemSummary } from "../../runtime/types";
 
-export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
+interface AgentOverviewPanelProps {
+  agent: AgentSummary;
+  workItemDetailsById: Record<string, WorkItemDetailState>;
+  onLoadWorkItemDetail: (workItemId: string) => void;
+}
+
+export function AgentOverviewPanel({ agent, workItemDetailsById, onLoadWorkItemDetail }: AgentOverviewPanelProps) {
   const workspace = agent.workspaceSummary;
   const workItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
+  const [selectedWorkItemId, setSelectedWorkItemId] = useState<string | undefined>(workItems[0]?.id);
   const currentWorkItems = workItems.filter((item) => item.current);
   const openWorkItems = workItems.filter((item) => !item.current && item.state !== "completed");
   const completedWorkItems = workItems.filter((item) => item.state === "completed");
+  const selectedWorkItemSummary = useMemo(
+    () => workItems.find((item) => item.id === selectedWorkItemId) ?? workItems[0],
+    [selectedWorkItemId, workItems],
+  );
+  const selectedWorkItemDetail = selectedWorkItemSummary ? workItemDetailsById[selectedWorkItemSummary.id] : undefined;
+  const selectedWorkItem = selectedWorkItemDetail?.workItem ?? selectedWorkItemSummary;
   const currentWorkLabel = currentWorkItems[0]?.objective ?? agent.currentWork?.objective ?? "No current work item";
   const workspaceName = workspace?.name ?? agent.workspace;
   const workspaceRoot = workspace?.cwd ?? workspace?.executionRoot ?? workspace?.worktree?.path ?? workspace?.anchor;
   const modeLabel = workspace?.worktree ? "Managed worktree" : workspace?.projectionKind;
   const showCwd = Boolean(workspace?.cwd && workspace.cwd !== workspace.executionRoot);
   const hasActiveTasks = agent.activeTaskCount > 0 || Boolean(agent.tasks?.length);
+
+  useEffect(() => {
+    if (!workItems.length) {
+      setSelectedWorkItemId(undefined);
+      return;
+    }
+    if (selectedWorkItemId && workItems.some((item) => item.id === selectedWorkItemId)) return;
+    setSelectedWorkItemId(workItems[0]?.id);
+  }, [selectedWorkItemId, workItems]);
+
+  useEffect(() => {
+    if (!selectedWorkItemSummary || selectedWorkItemDetail?.workItem || selectedWorkItemDetail?.loading) return;
+    onLoadWorkItemDetail(selectedWorkItemSummary.id);
+  }, [onLoadWorkItemDetail, selectedWorkItemDetail?.loading, selectedWorkItemDetail?.workItem, selectedWorkItemSummary]);
+
+  const selectWorkItem = (workItem: WorkItemSummary) => {
+    setSelectedWorkItemId(workItem.id);
+    if (!workItemDetailsById[workItem.id]?.workItem) {
+      onLoadWorkItemDetail(workItem.id);
+    }
+  };
 
   return (
     <div className="inspector-stack">
@@ -137,21 +173,22 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
             <StatusBadge className="state-chip" kind="work" value={`${openWorkItems.length + currentWorkItems.length} open`} />
           </div>
           {currentWorkItems.map((workItem) => (
-            <WorkItemCard key={workItem.id} workItem={workItem} featured />
+            <WorkItemCard key={workItem.id} workItem={workItem} featured selected={workItem.id === selectedWorkItem?.id} onSelect={selectWorkItem} />
           ))}
           {openWorkItems.length ? (
             <div className="inspector-nested-stack">
               {openWorkItems.map((workItem) => (
-                <WorkItemCard key={workItem.id} workItem={workItem} />
+                <WorkItemCard key={workItem.id} workItem={workItem} selected={workItem.id === selectedWorkItem?.id} onSelect={selectWorkItem} />
               ))}
             </div>
           ) : null}
+          {selectedWorkItem ? <WorkItemDetailPanel workItem={selectedWorkItem} detailState={selectedWorkItemDetail} /> : null}
           {completedWorkItems.length ? (
             <details className="inspector-details-list">
               <summary>{completedWorkItems.length} completed</summary>
               <div className="inspector-nested-stack">
                 {completedWorkItems.map((workItem) => (
-                  <WorkItemCard key={workItem.id} workItem={workItem} />
+                  <WorkItemCard key={workItem.id} workItem={workItem} selected={workItem.id === selectedWorkItem?.id} onSelect={selectWorkItem} />
                 ))}
               </div>
             </details>
@@ -169,17 +206,128 @@ export function AgentOverviewPanel({ agent }: { agent: AgentSummary }) {
   );
 }
 
-function WorkItemCard({ workItem, featured = false }: { workItem: NonNullable<AgentSummary["workItems"]>[number]; featured?: boolean }) {
+function WorkItemCard({
+  workItem,
+  featured = false,
+  selected = false,
+  onSelect,
+}: {
+  workItem: WorkItemSummary;
+  featured?: boolean;
+  selected?: boolean;
+  onSelect: (workItem: WorkItemSummary) => void;
+}) {
   return (
-    <article className={`inspector-list-item${featured ? " featured" : ""}`}>
+    <button
+      type="button"
+      className={`inspector-list-item work-item-button${featured ? " featured" : ""}${selected ? " selected" : ""}`}
+      aria-pressed={selected}
+      onClick={() => onSelect(workItem)}
+    >
       <div className="inspector-list-head">
         <strong>{workItem.objective}</strong>
         <StatusBadge className="state-chip" kind="work" value={workItem.state} />
       </div>
       <small>{compactMeta([workItem.current ? "current" : undefined, workItem.planStatus])}</small>
       <code>{workItem.id}</code>
+    </button>
+  );
+}
+
+function WorkItemDetailPanel({ workItem, detailState }: { workItem: WorkItemSummary; detailState?: WorkItemDetailState }) {
+  const loading = detailState?.loading && !detailState.workItem;
+  const plan = workItem.planArtifact;
+  return (
+    <article className="work-item-detail inspector-list-item featured">
+      <div className="inspector-list-head">
+        <strong>Details</strong>
+        {loading ? <StatusBadge className="state-chip" kind="connection" value="loading" /> : null}
+      </div>
+      {detailState?.error ? <p className="inspector-error">{detailState.error}</p> : null}
+      <dl className="inspector-facts">
+        <div>
+          <dt>Objective</dt>
+          <dd>{workItem.objective}</dd>
+        </div>
+        <div>
+          <dt>Work item</dt>
+          <dd>{workItem.id}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>{compactMeta([workItem.current ? "current" : undefined, workItem.state, workItem.planStatus])}</dd>
+        </div>
+        {workItem.revision != null ? (
+          <div>
+            <dt>Revision</dt>
+            <dd>{workItem.revision}</dd>
+          </div>
+        ) : null}
+        {workItem.blockedBy ? (
+          <div>
+            <dt>Blocked by</dt>
+            <dd>{workItem.blockedBy}</dd>
+          </div>
+        ) : null}
+        {workItem.resultSummary ? (
+          <div>
+            <dt>Result</dt>
+            <dd>{workItem.resultSummary}</dd>
+          </div>
+        ) : null}
+        {workItem.updatedAt ? (
+          <div>
+            <dt>Updated</dt>
+            <dd>{formatDateTime(workItem.updatedAt)}</dd>
+          </div>
+        ) : null}
+      </dl>
+      {plan?.preview || plan?.path ? (
+        <section className="work-item-detail-section">
+          <h3>Plan</h3>
+          {plan.path ? <code>{plan.path}</code> : null}
+          {plan.preview ? <pre>{plan.preview}</pre> : null}
+        </section>
+      ) : null}
+      {workItem.todoList?.length ? (
+        <section className="work-item-detail-section">
+          <h3>Todo</h3>
+          <ul className="inspector-list">
+            {workItem.todoList.map((item, index) => (
+              <li key={`${item.state}-${index}`}>
+                <div className="inspector-list-head">
+                  <strong>{item.text}</strong>
+                  <StatusBadge className="state-chip" kind="work" value={item.state} />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {workItem.workRefs?.length ? (
+        <section className="work-item-detail-section">
+          <h3>Refs</h3>
+          <ul className="inspector-list">
+            {workItem.workRefs.map((ref) => (
+              <li key={`${ref.kind}-${ref.ref}`}>
+                <div className="inspector-list-head">
+                  <strong>{ref.title ?? ref.ref}</strong>
+                  <StatusBadge className="state-chip" kind="connection" value={ref.status ?? ref.kind} />
+                </div>
+                <small>{compactMeta([ref.kind, ref.reason])}</small>
+                <code>{ref.ref}</code>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
     </article>
   );
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 
 function compactMeta(parts: Array<string | undefined>): string {

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -1,0 +1,44 @@
+import type { AgentSummary, RightPanelView } from "../../runtime/types";
+import { ActivityInspectorPanel, activityInspectorTitle } from "../inspector/ActivityInspectorPanel";
+import { AgentOverviewPanel } from "./AgentOverviewPanel";
+
+interface RightSidePanelProps {
+  agent: AgentSummary;
+  view?: RightPanelView;
+  open: boolean;
+  onShowAgentOverview: () => void;
+  onClose: () => void;
+}
+
+export function RightSidePanel({ agent, view, open, onShowAgentOverview, onClose }: RightSidePanelProps) {
+  const activeView = view?.agentId === agent.id ? view : { kind: "agent_overview" as const, agentId: agent.id };
+  const title = activeView.kind === "activity_inspector" ? activityInspectorTitle(activeView.activity) : "Agent overview";
+
+  return (
+    <aside className="side-panel" aria-label="Context side panel" hidden={!open}>
+      <div className="panel-header">
+        <div>
+          <span className="eyebrow">Context panel</span>
+          <strong>{title}</strong>
+        </div>
+        <div className="panel-actions">
+          {activeView.kind !== "agent_overview" ? (
+            <button type="button" aria-label="Show agent overview" onClick={onShowAgentOverview}>
+              Agent Overview
+            </button>
+          ) : null}
+          <button type="button" aria-label="Close side panel" onClick={onClose}>
+            ×
+          </button>
+        </div>
+      </div>
+      <div className="panel-body">
+        {activeView.kind === "activity_inspector" ? (
+          <ActivityInspectorPanel activity={activeView.activity} detailState={activeView.detailState} />
+        ) : (
+          <AgentOverviewPanel agent={agent} />
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -1,16 +1,18 @@
-import type { AgentSummary, RightPanelView } from "../../runtime/types";
+import type { AgentSummary, RightPanelView, WorkItemDetailState } from "../../runtime/types";
 import { ActivityInspectorPanel, activityInspectorTitle } from "../inspector/ActivityInspectorPanel";
 import { AgentOverviewPanel } from "./AgentOverviewPanel";
 
 interface RightSidePanelProps {
   agent: AgentSummary;
+  workItemDetailsById?: Record<string, WorkItemDetailState>;
   view?: RightPanelView;
   open: boolean;
+  onLoadWorkItemDetail: (workItemId: string) => void;
   onShowAgentOverview: () => void;
   onClose: () => void;
 }
 
-export function RightSidePanel({ agent, view, open, onShowAgentOverview, onClose }: RightSidePanelProps) {
+export function RightSidePanel({ agent, workItemDetailsById = {}, view, open, onLoadWorkItemDetail, onShowAgentOverview, onClose }: RightSidePanelProps) {
   const activeView = view?.agentId === agent.id ? view : { kind: "agent_overview" as const, agentId: agent.id };
   const title = activeView.kind === "activity_inspector" ? activityInspectorTitle(activeView.activity) : "Agent overview";
 
@@ -36,7 +38,7 @@ export function RightSidePanel({ agent, view, open, onShowAgentOverview, onClose
         {activeView.kind === "activity_inspector" ? (
           <ActivityInspectorPanel activity={activeView.activity} detailState={activeView.detailState} />
         ) : (
-          <AgentOverviewPanel agent={agent} />
+          <AgentOverviewPanel agent={agent} workItemDetailsById={workItemDetailsById} onLoadWorkItemDetail={onLoadWorkItemDetail} />
         )}
       </div>
     </aside>

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -1,6 +1,6 @@
-import type { AgentSummary, RightPanelView, WorkItemDetailState } from "../../runtime/types";
+import type { AgentSummary, RightPanelView, WorkItemDetailState, WorkItemSummary } from "../../runtime/types";
 import { ActivityInspectorPanel, activityInspectorTitle } from "../inspector/ActivityInspectorPanel";
-import { AgentOverviewPanel } from "./AgentOverviewPanel";
+import { AgentOverviewPanel, WorkItemDetailPanel } from "./AgentOverviewPanel";
 
 interface RightSidePanelProps {
   agent: AgentSummary;
@@ -8,13 +8,30 @@ interface RightSidePanelProps {
   view?: RightPanelView;
   open: boolean;
   onLoadWorkItemDetail: (workItemId: string) => void;
+  onOpenWorkItemDetail: (workItem: WorkItemSummary) => void;
   onShowAgentOverview: () => void;
   onClose: () => void;
 }
 
-export function RightSidePanel({ agent, workItemDetailsById = {}, view, open, onLoadWorkItemDetail, onShowAgentOverview, onClose }: RightSidePanelProps) {
+export function RightSidePanel({
+  agent,
+  workItemDetailsById = {},
+  view,
+  open,
+  onLoadWorkItemDetail,
+  onOpenWorkItemDetail,
+  onShowAgentOverview,
+  onClose,
+}: RightSidePanelProps) {
   const activeView = view?.agentId === agent.id ? view : { kind: "agent_overview" as const, agentId: agent.id };
-  const title = activeView.kind === "activity_inspector" ? activityInspectorTitle(activeView.activity) : "Agent overview";
+  const title =
+    activeView.kind === "activity_inspector"
+      ? activityInspectorTitle(activeView.activity)
+      : activeView.kind === "work_item_detail"
+        ? "Work item detail"
+        : "Agent overview";
+  const detailState = activeView.kind === "work_item_detail" ? workItemDetailsById[activeView.workItem.id] : undefined;
+  const detailWorkItem = activeView.kind === "work_item_detail" ? detailState?.workItem ?? activeView.workItem : undefined;
 
   return (
     <aside className="side-panel" aria-label="Context side panel" hidden={!open}>
@@ -37,8 +54,12 @@ export function RightSidePanel({ agent, workItemDetailsById = {}, view, open, on
       <div className="panel-body">
         {activeView.kind === "activity_inspector" ? (
           <ActivityInspectorPanel activity={activeView.activity} detailState={activeView.detailState} />
+        ) : activeView.kind === "work_item_detail" && detailWorkItem ? (
+          <div className="inspector-stack">
+            <WorkItemDetailPanel workItem={detailWorkItem} detailState={detailState} />
+          </div>
         ) : (
-          <AgentOverviewPanel agent={agent} workItemDetailsById={workItemDetailsById} onLoadWorkItemDetail={onLoadWorkItemDetail} />
+          <AgentOverviewPanel agent={agent} onLoadWorkItemDetail={onLoadWorkItemDetail} onOpenWorkItemDetail={onOpenWorkItemDetail} />
         )}
       </div>
     </aside>

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -189,7 +189,7 @@ export function SettingsPage({
       rejected.length
         ? `${rejected.length} setting${rejected.length === 1 ? "" : "s"} rejected.`
         : result.changed
-          ? "Saved to config.json. Restart the daemon for these runtime defaults to take effect."
+          ? "Saved to config.json. Changes applied via hot-reload."
           : "No runtime config changes were persisted.",
     );
   }
@@ -211,7 +211,7 @@ export function SettingsPage({
       rejected.length
         ? `${rejected.length} search setting${rejected.length === 1 ? "" : "s"} rejected.`
         : result.changed
-          ? "Saved search settings to config.json. Restart the daemon for routing changes to take effect."
+          ? "Saved search settings to config.json. Changes applied via hot-reload."
           : "No search config changes were persisted.",
     );
   }
@@ -226,7 +226,7 @@ export function SettingsPage({
       rejected.length
         ? `${rejected.length} vision setting${rejected.length === 1 ? "" : "s"} rejected.`
         : result.changed
-          ? "Saved Vision default to config.json. Restart the daemon for ViewImage selection to take effect."
+          ? "Saved Vision default to config.json. Changes applied via hot-reload."
           : "No Vision config changes were persisted.",
     );
   }
@@ -267,7 +267,7 @@ export function SettingsPage({
       rejected.length
         ? `${rejected.length} provider setting${rejected.length === 1 ? "" : "s"} rejected.`
         : result.changed
-          ? `Saved ${providerId} provider settings to config.json. Restart the daemon for credential changes to take effect.`
+          ? `Saved ${providerId} provider settings to config.json. Changes applied via hot-reload.`
           : "No provider config changes were persisted.",
     );
   }
@@ -280,7 +280,7 @@ export function SettingsPage({
           <h1>Settings</h1>
           <p>
             Configure common runtime defaults from the Web GUI. Saved model defaults are persisted to config.json
-            and take effect after the daemon is restarted.
+            and take effect immediately via hot-reload.
           </p>
           <div className="settings-quickstart" aria-label="Settings overview">
             <div>
@@ -293,7 +293,7 @@ export function SettingsPage({
               <strong>
                 {configuredProviderCount}/{surface?.providers.length ?? 0} ready
               </strong>
-              <small>Credential changes may require daemon restart.</small>
+              <small>Credential changes apply via hot-reload.</small>
             </div>
             <div>
               <span>Web search</span>

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -307,43 +307,12 @@ export function SettingsPage({
         </Card>
 
         <div className="settings-grid">
-          <Card className="settings-card">
-            <div className="settings-card-head">
-              <div>
-                <span className="eyebrow">Connection</span>
-                <h2>Runtime API</h2>
-              </div>
-              <StatusChip className={`source-chip ${connection.source === "http" ? "live" : "preview"}`} tone={connection.source === "http" ? "live" : "preview"}>
-                {connection.source === "http" ? "live" : "preview"}
-              </StatusChip>
-            </div>
-            <dl className="settings-list">
-              <div>
-                <dt>Mode</dt>
-                <dd>{connection.mode}</dd>
-              </div>
-              <div>
-                <dt>API base</dt>
-                <dd>{connection.baseUrl ?? "not configured"}</dd>
-              </div>
-              <div>
-                <dt>Status</dt>
-                <dd>{connection.summary}</dd>
-              </div>
-              {connection.error ? (
-                <div>
-                  <dt>Error</dt>
-                  <dd className="settings-error">{connection.error}</dd>
-                </div>
-              ) : null}
-            </dl>
-          </Card>
-
+          {/* ── Model & Vision ── */}
           <Card className="settings-card">
             <div className="settings-card-head">
               <div>
                 <span className="eyebrow">Runtime defaults</span>
-                <h2>Model posture</h2>
+                <h2>Model &amp; Vision</h2>
               </div>
               <Button type="button" variant="secondary" disabled={runtimeConfigLoading} onClick={() => void onRefreshRuntimeConfig()}>
                 {runtimeConfigLoading ? "Refreshing…" : "Refresh"}
@@ -363,44 +332,63 @@ export function SettingsPage({
                   void saveRuntimeConfig();
                 }}
               >
-                <p className="settings-muted">
-                  These defaults are written to config.json. Active agents keep their current runtime state until the daemon is restarted or an agent-level override is changed.
-                </p>
                 <label>
                   <span>Default model</span>
                   <input list="available-models" value={modelDefault} onChange={(event) => setModelDefault(event.target.value)} />
+                  <datalist id="available-models">
+                    {availableModels.map((model) => (
+                      <option key={model.model} value={model.model}>
+                        {model.displayName}
+                      </option>
+                    ))}
+                  </datalist>
                 </label>
-                <label>
-                  <span>Fallback models</span>
-                  <input value={modelFallbacks} onChange={(event) => setModelFallbacks(event.target.value)} placeholder="provider/model, provider/model" />
-                </label>
-                <div className="settings-form-row">
+                <details className="settings-advanced">
+                  <summary>Advanced</summary>
                   <label>
-                    <span>Max output tokens</span>
-                    <input inputMode="numeric" value={runtimeMaxOutputTokens} onChange={(event) => setRuntimeMaxOutputTokens(event.target.value)} />
+                    <span>Vision default model</span>
+                    <input list="vision-models" value={visionDefault} onChange={(event) => setVisionDefault(event.target.value)} placeholder="provider/model or empty for auto" />
+                    <datalist id="vision-models">
+                      {visionModels.map((model) => (
+                        <option key={model.model} value={model.model}>
+                          {model.displayName}
+                        </option>
+                      ))}
+                    </datalist>
                   </label>
                   <label>
-                    <span>Default tool output tokens</span>
-                    <input inputMode="numeric" value={defaultToolOutputTokens} onChange={(event) => setDefaultToolOutputTokens(event.target.value)} />
+                    <span>Fallback models</span>
+                    <input value={modelFallbacks} onChange={(event) => setModelFallbacks(event.target.value)} placeholder="provider/model, provider/model" />
                   </label>
-                  <label>
-                    <span>Max tool output tokens</span>
-                    <input inputMode="numeric" value={maxToolOutputTokens} onChange={(event) => setMaxToolOutputTokens(event.target.value)} />
+                  <div className="settings-form-row">
+                    <label>
+                      <span>Max output tokens</span>
+                      <input inputMode="numeric" value={runtimeMaxOutputTokens} onChange={(event) => setRuntimeMaxOutputTokens(event.target.value)} />
+                    </label>
+                    <label>
+                      <span>Default tool output tokens</span>
+                      <input inputMode="numeric" value={defaultToolOutputTokens} onChange={(event) => setDefaultToolOutputTokens(event.target.value)} />
+                    </label>
+                    <label>
+                      <span>Max tool output tokens</span>
+                      <input inputMode="numeric" value={maxToolOutputTokens} onChange={(event) => setMaxToolOutputTokens(event.target.value)} />
+                    </label>
+                  </div>
+                  <label className="settings-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={disableProviderFallback}
+                      onChange={(event) => setDisableProviderFallback(event.target.checked)}
+                    />
+                    <span>Disable provider fallback</span>
                   </label>
-                </div>
-                <label className="settings-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={disableProviderFallback}
-                    onChange={(event) => setDisableProviderFallback(event.target.checked)}
-                  />
-                  <span>Disable provider fallback</span>
-                </label>
+                </details>
                 <div className="settings-actions">
                   <Button type="submit" disabled={runtimeConfigSaving || runtimeConfigLoading}>
-                    {runtimeConfigSaving ? "Saving…" : "Save runtime defaults"}
+                    {runtimeConfigSaving ? "Saving…" : "Save"}
                   </Button>
                   {saveMessage ? <span>{saveMessage}</span> : null}
+                  {visionSaveMessage ? <span>{visionSaveMessage}</span> : null}
                 </div>
                 {rejectedResults.length ? (
                   <div className="settings-error-banner">
@@ -411,13 +399,6 @@ export function SettingsPage({
                     ))}
                   </div>
                 ) : null}
-                <datalist id="available-models">
-                  {availableModels.map((model) => (
-                    <option key={model.model} value={model.model}>
-                      {model.displayName}
-                    </option>
-                  ))}
-                </datalist>
               </form>
             )}
             <dl className="settings-list compact">
@@ -436,64 +417,7 @@ export function SettingsPage({
             </dl>
           </Card>
 
-          <Card className="settings-card">
-            <div className="settings-card-head">
-              <div>
-                <span className="eyebrow">Runtime defaults</span>
-                <h2>Vision / ImageView</h2>
-              </div>
-            </div>
-            {!surface ? (
-              <div className="settings-callout">
-                <strong>Vision config unavailable</strong>
-                <span>Connect to a live runtime and refresh this page to edit ViewImage defaults.</span>
-              </div>
-            ) : (
-              <form
-                className="settings-form"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  void saveVisionConfig();
-                }}
-              >
-                <p className="settings-muted">
-                  ViewImage uses <code>vision.default</code> when set. Leave it empty to let Holon auto-discover a configured model with image input support.
-                </p>
-                <label>
-                  <span>Vision default model</span>
-                  <input list="vision-models" value={visionDefault} onChange={(event) => setVisionDefault(event.target.value)} placeholder="provider/model or empty for auto" />
-                </label>
-                <dl className="settings-list compact settings-inline-summary">
-                  <div>
-                    <dt>Selection mode</dt>
-                    <dd>{visionDefault ? "explicit vision.default" : "auto-discover image-capable model"}</dd>
-                  </div>
-                  <div>
-                    <dt>Provider credential</dt>
-                    <dd>{visionDefault ? (visionProviderReady ? "ready" : "missing or unknown") : "checked during auto-discovery"}</dd>
-                  </div>
-                  <div>
-                    <dt>Image-capable models</dt>
-                    <dd>{visionModels.length ? visionModels.map((model) => model.model).join(", ") : "none reported by model catalog"}</dd>
-                  </div>
-                </dl>
-                <div className="settings-actions">
-                  <Button type="submit" disabled={runtimeConfigSaving || runtimeConfigLoading}>
-                    {runtimeConfigSaving ? "Saving…" : "Save vision settings"}
-                  </Button>
-                  {visionSaveMessage ? <span>{visionSaveMessage}</span> : null}
-                </div>
-                <datalist id="vision-models">
-                  {visionModels.map((model) => (
-                    <option key={model.model} value={model.model}>
-                      {model.displayName}
-                    </option>
-                  ))}
-                </datalist>
-              </form>
-            )}
-          </Card>
-
+          {/* ── Web search ── */}
           <Card className="settings-card">
             <div className="settings-card-head">
               <div>
@@ -514,124 +438,168 @@ export function SettingsPage({
                   void saveSearchConfig();
                 }}
               >
-                <p className="settings-muted">
-                  Search routing controls whether Holon can call provider-native search and which external search providers are attempted first.
-                </p>
                 <label className="settings-checkbox">
                   <input type="checkbox" checked={searchEnabled} onChange={(event) => setSearchEnabled(event.target.checked)} />
                   <span>Enable WebSearch</span>
                 </label>
-                <label className="settings-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={searchBuiltinProviderEnabled}
-                    onChange={(event) => setSearchBuiltinProviderEnabled(event.target.checked)}
-                  />
-                  <span>Allow provider-native search when available</span>
+                <label>
+                  <span>Default provider</span>
+                  <input list="web-search-providers" value={searchProvider} onChange={(event) => setSearchProvider(event.target.value)} />
+                  <datalist id="web-search-providers">
+                    <option value="auto">auto</option>
+                    <option value="duckduckgo">duckduckgo</option>
+                    {surface.webSearchProviders.map((provider) => (
+                      <option key={provider.id} value={provider.id}>
+                        {provider.kind}
+                      </option>
+                    ))}
+                  </datalist>
                 </label>
-                <div className="settings-form-row">
-                  <label>
-                    <span>Default provider</span>
-                    <input list="web-search-providers" value={searchProvider} onChange={(event) => setSearchProvider(event.target.value)} />
+                <details className="settings-advanced">
+                  <summary>Advanced</summary>
+                  <label className="settings-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={searchBuiltinProviderEnabled}
+                      onChange={(event) => setSearchBuiltinProviderEnabled(event.target.checked)}
+                    />
+                    <span>Allow provider-native search when available</span>
                   </label>
-                  <label>
-                    <span>Mode</span>
-                    <select value={searchMode} onChange={(event) => setSearchMode(event.target.value as "single" | "fallback" | "aggregate")}>
-                      <option value="single">single</option>
-                      <option value="fallback">fallback</option>
-                      <option value="aggregate">aggregate</option>
-                    </select>
-                  </label>
-                  <label>
-                    <span>Provider order</span>
-                    <input value={searchProviders} onChange={(event) => setSearchProviders(event.target.value)} placeholder="duckduckgo, brave" />
-                  </label>
-                </div>
-                <div className="settings-form-row">
-                  <label>
-                    <span>Max results</span>
-                    <input inputMode="numeric" value={searchMaxResults} onChange={(event) => setSearchMaxResults(event.target.value)} />
-                  </label>
-                  <label>
-                    <span>Max provider attempts</span>
-                    <input inputMode="numeric" value={searchMaxProviderAttempts} onChange={(event) => setSearchMaxProviderAttempts(event.target.value)} />
-                  </label>
-                  <label>
-                    <span>Configured providers</span>
-                    <input readOnly value={surface.webSearchProviders.map((provider) => provider.id).join(", ") || "duckduckgo builtin"} />
-                  </label>
-                </div>
+                  <div className="settings-form-row">
+                    <label>
+                      <span>Mode</span>
+                      <select value={searchMode} onChange={(event) => setSearchMode(event.target.value as "single" | "fallback" | "aggregate")}>
+                        <option value="single">single</option>
+                        <option value="fallback">fallback</option>
+                        <option value="aggregate">aggregate</option>
+                      </select>
+                    </label>
+                    <label>
+                      <span>Provider order</span>
+                      <input value={searchProviders} onChange={(event) => setSearchProviders(event.target.value)} placeholder="duckduckgo, brave" />
+                    </label>
+                    <label>
+                      <span>Max results</span>
+                      <input inputMode="numeric" value={searchMaxResults} onChange={(event) => setSearchMaxResults(event.target.value)} />
+                    </label>
+                  </div>
+                  <div className="settings-form-row">
+                    <label>
+                      <span>Max provider attempts</span>
+                      <input inputMode="numeric" value={searchMaxProviderAttempts} onChange={(event) => setSearchMaxProviderAttempts(event.target.value)} />
+                    </label>
+                    <label>
+                      <span>Configured providers</span>
+                      <input readOnly value={surface.webSearchProviders.map((provider) => provider.id).join(", ") || "duckduckgo builtin"} />
+                    </label>
+                  </div>
+                </details>
                 <div className="settings-actions">
                   <Button type="submit" disabled={runtimeConfigSaving || runtimeConfigLoading}>
-                    {runtimeConfigSaving ? "Saving…" : "Save search settings"}
+                    {runtimeConfigSaving ? "Saving…" : "Save"}
                   </Button>
                   {searchSaveMessage ? <span>{searchSaveMessage}</span> : null}
                 </div>
-                <dl className="settings-list compact settings-inline-summary">
-                  <div>
-                    <dt>Current route</dt>
-                    <dd>
-                      {searchProvider || "auto"} · {searchMode}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>Provider list</dt>
-                    <dd>{searchProviders || "runtime default"}</dd>
-                  </div>
-                </dl>
-                <datalist id="web-search-providers">
-                  <option value="auto">auto</option>
-                  <option value="duckduckgo">duckduckgo</option>
-                  {surface.webSearchProviders.map((provider) => (
-                    <option key={provider.id} value={provider.id}>
-                      {provider.kind}
-                    </option>
-                  ))}
-                </datalist>
               </form>
             )}
           </Card>
+        </div>
 
-          <Card className="settings-card">
-            <div className="settings-card-head">
-              <div>
-                <span className="eyebrow">Provider accounts</span>
-                <h2>Model providers</h2>
-              </div>
+        {/* ── Model providers ── */}
+        <Card className="settings-card">
+          <div className="settings-card-head">
+            <div>
+              <span className="eyebrow">Provider accounts</span>
+              <h2>Model providers</h2>
             </div>
-            {!surface ? (
-              <div className="settings-callout">
-                <strong>Provider config unavailable</strong>
-                <span>Connect to a live runtime and refresh this page to edit model provider credentials.</span>
-              </div>
-            ) : (
-              <div className="settings-provider-list">
-                <p className="settings-muted">
-                  Configure one provider account and its credential profile. Transport is determined automatically by the runtime.
-                </p>
-                {surface.providers.map((provider) => {
-                  const draft = providerDrafts[provider.id];
-                  if (!draft) return null;
-                  return (
-                    <form
-                      className="settings-provider-editor"
-                      key={provider.id}
-                      onSubmit={(event) => {
-                        event.preventDefault();
-                        void saveProviderConfig(provider.id);
-                      }}
-                    >
-                      <header>
-                        <div>
-                          <strong>{provider.id}</strong>
-                          <small>
-                            {provider.transport} · {provider.credentialSource}/{provider.credentialKind}
-                          </small>
+          </div>
+          {!surface ? (
+            <div className="settings-callout">
+              <strong>Provider config unavailable</strong>
+              <span>Connect to a live runtime and refresh this page to edit model provider credentials.</span>
+            </div>
+          ) : (
+            <div className="settings-provider-list">
+              <p className="settings-muted">
+                Configure each provider account. Enter the API key in the primary section; expand Advanced for transport and credential details.
+              </p>
+              {surface.providers.map((provider) => {
+                const draft = providerDrafts[provider.id];
+                if (!draft) return null;
+                return (
+                  <form
+                    className="settings-provider-editor"
+                    key={provider.id}
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      void saveProviderConfig(provider.id);
+                    }}
+                  >
+                    <header>
+                      <div>
+                        <strong>{provider.id}</strong>
+                        <small>
+                          {provider.transport} · {provider.credentialSource}/{provider.credentialKind}
+                        </small>
+                      </div>
+                      <StatusChip className={`settings-status ${provider.credentialConfigured ? "available" : "unavailable"}`} tone={provider.credentialConfigured ? "success" : "error"}>
+                        {provider.credentialConfigured ? "credential ready" : "credential missing"}
+                      </StatusChip>
+                    </header>
+                    {/* Primary: API Key management */}
+                    {draft.credentialSource === "credential_profile" && draft.credentialProfile ? (
+                      <div className="settings-api-key-section">
+                        <div className="settings-api-key-header">
+                          <span>API Key for &quot;{draft.credentialProfile}&quot;</span>
+                          <StatusChip
+                            className={`settings-status ${isCredentialProfileConfigured(draft.credentialProfile) ? "available" : "unavailable"}`}
+                            tone={isCredentialProfileConfigured(draft.credentialProfile) ? "success" : "error"}
+                          >
+                            {isCredentialProfileConfigured(draft.credentialProfile) ? "key set" : "no key"}
+                          </StatusChip>
                         </div>
-                        <StatusChip className={`settings-status ${provider.credentialConfigured ? "available" : "unavailable"}`} tone={provider.credentialConfigured ? "success" : "error"}>
-                          {provider.credentialConfigured ? "credential ready" : "credential missing"}
-                        </StatusChip>
-                      </header>
+                        <div className="settings-form-row">
+                          <label>
+                            <span>API Key{credentialStoreLoading ? " (loading…)" : ""}</span>
+                            <input
+                              type="password"
+                              placeholder="Paste API key for this credential profile"
+                              value={apiKeyDrafts[provider.id] ?? ""}
+                              onChange={(event) => setApiKeyDrafts((prev) => ({ ...prev, [provider.id]: event.target.value }))}
+                            />
+                          </label>
+                        </div>
+                        <div className="settings-actions">
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            disabled={!apiKeyDrafts[provider.id]?.trim()}
+                            onClick={() => void saveApiKey(provider.id, draft.credentialProfile!, draft.credentialKind)}
+                          >
+                            Save API Key
+                          </Button>
+                          {isCredentialProfileConfigured(draft.credentialProfile) ? (
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              onClick={() => void removeApiKey(provider.id, draft.credentialProfile!)}
+                            >
+                              Remove Key
+                            </Button>
+                          ) : null}
+                          {credentialMessages[provider.id] ? (
+                            <span className="settings-save-message">{credentialMessages[provider.id]}</span>
+                          ) : null}
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="settings-hint">
+                        Credential source is <code>{draft.credentialSource}</code>. Switch to <code>credential_profile</code> in Advanced to manage API keys from the web UI.
+                      </p>
+                    )}
+                    {/* Advanced: full provider config */}
+                    <details className="settings-advanced">
+                      <summary>Advanced</summary>
                       <div className="settings-form-row">
                         <label>
                           <span>Transport <small className="settings-muted">(read-only)</small></span>
@@ -678,74 +646,29 @@ export function SettingsPage({
                           <span>Credential profile</span>
                           <input value={draft.credentialProfile ?? ""} onChange={(event) => updateProviderDraft(provider.id, { credentialProfile: event.target.value })} />
                         </label>
-                        {draft.credentialSource === "credential_profile" ? (
-                          <p className="settings-hint">Auto-named <code>{provider.id}:default</code> if left empty. Multiple providers can share one profile; use different names (e.g. <code>{provider.id}:work</code>) for separate keys.</p>
-                        ) : null}
                       </div>
+                      {draft.credentialSource === "credential_profile" ? (
+                        <p className="settings-hint">Auto-named <code>{provider.id}:default</code> if left empty. Multiple providers can share one profile; use different names (e.g. <code>{provider.id}:work</code>) for separate keys.</p>
+                      ) : null}
                       <label>
                         <span>External credential provider</span>
                         <input value={draft.credentialExternal ?? ""} onChange={(event) => updateProviderDraft(provider.id, { credentialExternal: event.target.value })} />
                       </label>
-                      {draft.credentialSource === "credential_profile" && draft.credentialProfile ? (
-                        <div className="settings-api-key-section">
-                          <div className="settings-api-key-header">
-                            <span>API Key for &quot;{draft.credentialProfile}&quot;</span>
-                            <StatusChip
-                              className={`settings-status ${isCredentialProfileConfigured(draft.credentialProfile) ? "available" : "unavailable"}`}
-                              tone={isCredentialProfileConfigured(draft.credentialProfile) ? "success" : "error"}
-                            >
-                              {isCredentialProfileConfigured(draft.credentialProfile) ? "key set" : "no key"}
-                            </StatusChip>
-                          </div>
-                          <div className="settings-form-row">
-                            <label>
-                              <span>API Key{credentialStoreLoading ? " (loading…)" : ""}</span>
-                              <input
-                                type="password"
-                                placeholder="Paste API key for this credential profile"
-                                value={apiKeyDrafts[provider.id] ?? ""}
-                                onChange={(event) => setApiKeyDrafts((prev) => ({ ...prev, [provider.id]: event.target.value }))}
-                              />
-                            </label>
-                          </div>
-                          <div className="settings-actions">
-                            <Button
-                              type="button"
-                              variant="secondary"
-                              disabled={!apiKeyDrafts[provider.id]?.trim()}
-                              onClick={() => void saveApiKey(provider.id, draft.credentialProfile!, draft.credentialKind)}
-                            >
-                              Save API Key
-                            </Button>
-                            {isCredentialProfileConfigured(draft.credentialProfile) ? (
-                              <Button
-                                type="button"
-                                variant="secondary"
-                                onClick={() => void removeApiKey(provider.id, draft.credentialProfile!)}
-                              >
-                                Remove Key
-                              </Button>
-                            ) : null}
-                          </div>
-                          {credentialMessages[provider.id] ? (
-                            <span className="settings-save-message">{credentialMessages[provider.id]}</span>
-                          ) : null}
-                        </div>
-                      ) : null}
-                      <div className="settings-actions">
-                        <Button type="submit" disabled={runtimeConfigSaving || runtimeConfigLoading}>
-                          {runtimeConfigSaving ? "Saving…" : `Save ${provider.id}`}
-                        </Button>
-                      </div>
-                    </form>
-                  );
-                })}
-                {providerSaveMessage ? <span className="settings-save-message">{providerSaveMessage}</span> : null}
-              </div>
-            )}
-          </Card>
-        </div>
+                    </details>
+                    <div className="settings-actions">
+                      <Button type="submit" disabled={runtimeConfigSaving || runtimeConfigLoading}>
+                        {runtimeConfigSaving ? "Saving…" : `Save ${provider.id}`}
+                      </Button>
+                    </div>
+                  </form>
+                );
+              })}
+              {providerSaveMessage ? <span className="settings-save-message">{providerSaveMessage}</span> : null}
+            </div>
+          )}
+        </Card>
 
+        {/* ── Model catalog diagnostics ── */}
         <Card className="settings-card settings-models">
           <div className="settings-card-head">
             <div>

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -90,6 +90,10 @@ export function SettingsPage({
   const [credentialMessages, setCredentialMessages] = useState<Record<string, string>>({});
   const availableModels = useMemo(() => modelCatalog.options.filter((model) => model.available), [modelCatalog.options]);
   const visionModels = useMemo(() => modelCatalog.options.filter((model) => model.available && model.supportsImageInput), [modelCatalog.options]);
+  const providersWithModels = useMemo(
+    () => new Set(modelCatalog.options.map((m) => m.provider)),
+    [modelCatalog.options],
+  );
 
   useEffect(() => {
     if (!surface) return;
@@ -546,6 +550,11 @@ export function SettingsPage({
                         {provider.credentialConfigured ? "credential ready" : "credential missing"}
                       </StatusChip>
                     </header>
+                    {provider.credentialConfigured && !providersWithModels.has(provider.id) ? (
+                      <p className="settings-provider-hint">
+                        No models in catalog for this provider — it will not appear in the model selector. Add model entries under <strong>Model overrides</strong> or configure model discovery to make its models available.
+                      </p>
+                    ) : null}
                     {/* Primary: API Key management */}
                     {draft.credentialSource === "credential_profile" && draft.credentialProfile ? (
                       <div className="settings-api-key-section">

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -651,7 +651,14 @@ export function SettingsPage({
                         </label>
                         <label>
                           <span>Credential source</span>
-                          <select value={draft.credentialSource} onChange={(event) => updateProviderDraft(provider.id, { credentialSource: event.target.value })}>
+                          <select value={draft.credentialSource} onChange={(event) => {
+                            const source = event.target.value;
+                            if (source === "credential_profile" && !draft.credentialProfile?.trim()) {
+                              updateProviderDraft(provider.id, { credentialSource: source, credentialProfile: `${provider.id}:default` });
+                            } else {
+                              updateProviderDraft(provider.id, { credentialSource: source });
+                            }
+                          }}>
                             {credentialSources.map((source) => (
                               <option key={source} value={source}>
                                 {source}
@@ -679,6 +686,9 @@ export function SettingsPage({
                           <span>Credential profile</span>
                           <input value={draft.credentialProfile ?? ""} onChange={(event) => updateProviderDraft(provider.id, { credentialProfile: event.target.value })} />
                         </label>
+                        {draft.credentialSource === "credential_profile" ? (
+                          <p className="settings-hint">Auto-named <code>{provider.id}:default</code> if left empty. Multiple providers can share one profile; use different names (e.g. <code>{provider.id}:work</code>) for separate keys.</p>
+                        ) : null}
                       </div>
                       <label>
                         <span>External credential provider</span>

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -42,7 +42,6 @@ type ProviderDraft = Pick<
   "transport" | "baseUrl" | "credentialSource" | "credentialKind" | "credentialEnv" | "credentialProfile" | "credentialExternal"
 >;
 
-const providerTransports = ["openai_codex_responses", "openai_responses", "openai_chat_completions", "anthropic_messages", "gemini_generate_content"];
 const credentialSources = ["env", "credential_profile", "external_cli", "credential_process", "none"];
 const credentialKinds = ["api_key", "bearer_token", "oauth", "session_token", "aws_sdk", "none"];
 
@@ -251,7 +250,6 @@ export function SettingsPage({
     if (!draft) return;
     setProviderSaveMessage(undefined);
     const result = await onUpdateRuntimeConfig([
-      { key: `providers.${providerId}.transport`, value: draft.transport },
       { key: `providers.${providerId}.base_url`, value: draft.baseUrl.trim() },
       { key: `providers.${providerId}.auth.source`, value: draft.credentialSource },
       { key: `providers.${providerId}.auth.kind`, value: draft.credentialKind },
@@ -265,7 +263,7 @@ export function SettingsPage({
       rejected.length
         ? `${rejected.length} provider setting${rejected.length === 1 ? "" : "s"} rejected.`
         : result.changed
-          ? `Saved ${providerId} provider settings to config.json. Restart the daemon for transport or credential changes to take effect.`
+          ? `Saved ${providerId} provider settings to config.json. Restart the daemon for credential changes to take effect.`
           : "No provider config changes were persisted.",
     );
   }
@@ -291,7 +289,7 @@ export function SettingsPage({
               <strong>
                 {configuredProviderCount}/{surface?.providers.length ?? 0} ready
               </strong>
-              <small>Credentials and transports may require daemon restart.</small>
+              <small>Credential changes may require daemon restart.</small>
             </div>
             <div>
               <span>Web search</span>
@@ -604,12 +602,12 @@ export function SettingsPage({
             {!surface ? (
               <div className="settings-callout">
                 <strong>Provider config unavailable</strong>
-                <span>Connect to a live runtime and refresh this page to edit model provider transports and credentials.</span>
+                <span>Connect to a live runtime and refresh this page to edit model provider credentials.</span>
               </div>
             ) : (
               <div className="settings-provider-list">
                 <p className="settings-muted">
-                  Configure one provider account/profile, then choose the transport under it. The same credential profile can be reused across transports.
+                  Configure one provider account and its credential profile. Transport is determined automatically by the runtime.
                 </p>
                 {surface.providers.map((provider) => {
                   const draft = providerDrafts[provider.id];
@@ -636,14 +634,8 @@ export function SettingsPage({
                       </header>
                       <div className="settings-form-row">
                         <label>
-                          <span>Transport</span>
-                          <select value={draft.transport} onChange={(event) => updateProviderDraft(provider.id, { transport: event.target.value })}>
-                            {providerTransports.map((transport) => (
-                              <option key={transport} value={transport}>
-                                {transport}
-                              </option>
-                            ))}
-                          </select>
+                          <span>Transport <small className="settings-muted">(read-only)</small></span>
+                          <input value={provider.transport} readOnly disabled />
                         </label>
                         <label>
                           <span>Base URL</span>

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -142,4 +142,45 @@ describe("createRuntimeClient", () => {
     ]);
     expect(seen).toEqual(["http://example.test:7878/agents/agent%2Fone/work-items?limit=25"]);
   });
+
+  it("fetches agent work item details from the scoped detail endpoint", async () => {
+    const seen: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.endsWith("/agents/agent%2Fone/work-items/work%2Fdetail")) {
+        return Response.json({
+          id: "work/detail",
+          objective: "Inspect details",
+          state: "open",
+          plan_status: "ready",
+          revision: 7,
+          plan_artifact: { path: "/agent/work-items/work-detail/plan.md", preview: "1. Ship it" },
+          todo_list: [{ text: "verify", state: "pending" }],
+          result_summary: "not done yet",
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.getAgentWorkItem("agent/one", "work/detail")).resolves.toEqual(
+      expect.objectContaining({
+        id: "work/detail",
+        objective: "Inspect details",
+        state: "open",
+        planStatus: "ready",
+        revision: 7,
+        planArtifact: expect.objectContaining({ path: "/agent/work-items/work-detail/plan.md", preview: "1. Ship it" }),
+        todoList: [{ text: "verify", state: "pending" }],
+        resultSummary: "not done yet",
+      }),
+    );
+    expect(seen).toEqual(["http://example.test:7878/agents/agent%2Fone/work-items/work%2Fdetail"]);
+  });
 });

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -115,4 +115,31 @@ describe("createRuntimeClient", () => {
     );
     expect(seen).toEqual(["http://example.test:7878/agents/agent%2Fone/tasks/task%2F42/output?block=false"]);
   });
+
+  it("fetches agent work items from the scoped work-items endpoint", async () => {
+    const seen: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.endsWith("/agents/agent%2Fone/work-items?limit=25")) {
+        return Response.json([
+          { id: "work-current", objective: "Current", state: "open", plan_status: "ready" },
+          { id: "work-done", objective: "Done", state: "completed" },
+        ]);
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.getAgentWorkItems("agent/one", { limit: 25 })).resolves.toEqual([
+      expect.objectContaining({ id: "work-current", objective: "Current", state: "open", planStatus: "ready" }),
+      expect.objectContaining({ id: "work-done", objective: "Done", state: "completed" }),
+    ]);
+    expect(seen).toEqual(["http://example.test:7878/agents/agent%2Fone/work-items?limit=25"]);
+  });
 });

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { projectModelOptions } from "./client";
+import { createRuntimeClient, projectModelOptions } from "./client";
 
 describe("projectModelOptions", () => {
   it("detects reasoning effort support from runtime available model capabilities", () => {
@@ -23,5 +23,38 @@ describe("projectModelOptions", () => {
         supportsReasoningEffort: true,
       }),
     ]);
+  });
+});
+
+describe("createRuntimeClient", () => {
+  it("preserves the configured remote connection mode even when the runtime auth mode is local", async () => {
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/handshake")) {
+        return Response.json({ auth: { mode: "local" } });
+      }
+      if (url.endsWith("/agents/list")) {
+        return Response.json([]);
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      token: "secret-token",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const bootstrap = await client.getBootstrap();
+
+    expect(bootstrap.connection).toEqual(
+      expect.objectContaining({
+        mode: "remote",
+        source: "http",
+        baseUrl: "http://example.test:7878",
+        hasToken: true,
+      }),
+    );
   });
 });

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -57,4 +57,62 @@ describe("createRuntimeClient", () => {
       }),
     );
   });
+
+  it("fetches full tool execution detail for inspector hydration", async () => {
+    const seen: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.endsWith("/agents/agent%2Fone/tool-executions/tool%2F42")) {
+        return Response.json({ id: "tool/42", tool_name: "ExecCommand", result: { stdout: "full output" } });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.getToolExecution("agent/one", "tool/42")).resolves.toEqual(
+      expect.objectContaining({
+        id: "tool/42",
+        result: expect.objectContaining({ stdout: "full output" }),
+      }),
+    );
+    expect(seen).toEqual(["http://example.test:7878/agents/agent%2Fone/tool-executions/tool%2F42"]);
+  });
+
+  it("fetches task output without blocking for inspector hydration", async () => {
+    const seen: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.endsWith("/agents/agent%2Fone/tasks/task%2F42/output?block=false")) {
+        return Response.json({
+          retrieval_status: "success",
+          task: { task_id: "task/42", status: "completed", output_preview: "full task output" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.getTaskOutput("agent/one", "task/42")).resolves.toEqual(
+      expect.objectContaining({
+        retrieval_status: "success",
+        task: expect.objectContaining({
+          status: "completed",
+          output_preview: "full task output",
+        }),
+      }),
+    );
+    expect(seen).toEqual(["http://example.test:7878/agents/agent%2Fone/tasks/task%2F42/output?block=false"]);
+  });
 });

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -413,7 +413,7 @@ interface RuntimeProviderSummaryDto {
 
 interface RuntimeConfigUpdateResultDto {
   key?: string;
-  effect?: "accepted_requires_restart" | "rejected";
+  effect?: "accepted_requires_restart" | "accepted_reloaded" | "rejected";
   reason?: string;
 }
 

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -191,9 +191,37 @@ interface AgentStateDto {
 
 interface WorkItemDto {
   id?: string;
+  agent_id?: string;
+  revision?: number;
   objective?: string;
   state?: string;
   plan_status?: string;
+  plan_artifact?: {
+    path?: string;
+    relative_path?: string;
+    workspace_alias?: string;
+    preview?: string;
+    preview_complete?: boolean;
+    updated_at?: string;
+  };
+  todo_list?: Array<{
+    text?: string;
+    state?: string;
+  }>;
+  work_refs?: Array<{
+    kind?: string;
+    ref?: string;
+    title?: string;
+    reason?: string;
+    status?: string;
+    last_seen_at?: string;
+  }>;
+  blocked_by?: string;
+  recheck_at?: string;
+  result_brief_id?: string;
+  result_summary?: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 interface AgentWorkspaceDto {
@@ -459,6 +487,13 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       const workItems = await fetchAgentWorkItems(baseUrl, fetchImpl, requestHeaders, agentId, options);
       return projectWorkItems(workItems);
     },
+    async getAgentWorkItem(agentId: string, workItemId: string): Promise<WorkItemSummary | undefined> {
+      if (!baseUrl || !workItemId) {
+        return undefined;
+      }
+      const workItem = await fetchAgentWorkItem(baseUrl, fetchImpl, requestHeaders, agentId, workItemId);
+      return projectWorkItem(workItem);
+    },
     async getAgentEvents(agentId: string, options: AgentEventPageOptions = {}): Promise<EventPageResponseDto> {
       if (!baseUrl) {
         return { events: [], has_older: false };
@@ -658,6 +693,21 @@ async function fetchAgentWorkItems(
     fetchImpl,
     baseUrl,
     `/agents/${encodeURIComponent(agentId)}/work-items${queryString ? `?${queryString}` : ""}`,
+    { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers },
+  );
+}
+
+async function fetchAgentWorkItem(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  agentId: string,
+  workItemId: string,
+): Promise<WorkItemDto> {
+  return getJson<WorkItemDto>(
+    fetchImpl,
+    baseUrl,
+    `/agents/${encodeURIComponent(agentId)}/work-items/${encodeURIComponent(workItemId)}`,
     { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers },
   );
 }
@@ -1275,19 +1325,59 @@ function projectWorkItems(
   return selectWorkItems(workItems);
 }
 
+function projectWorkItem(workItem: WorkItemDto | undefined, currentWorkItemId?: string | null): WorkItemSummary | undefined {
+  if (!workItem?.id) return undefined;
+  const planArtifact = workItem.plan_artifact;
+  return {
+    id: workItem.id,
+    objective: workItem.objective ?? workItem.id,
+    state: workItem.state ?? "unknown",
+    planStatus: workItem.plan_status,
+    current: workItem.id === currentWorkItemId,
+    revision: workItem.revision,
+    createdAt: workItem.created_at,
+    updatedAt: workItem.updated_at,
+    blockedBy: workItem.blocked_by,
+    recheckAt: workItem.recheck_at,
+    resultBriefId: workItem.result_brief_id,
+    resultSummary: workItem.result_summary,
+    planArtifact: planArtifact
+      ? {
+          path: planArtifact.path,
+          relativePath: planArtifact.relative_path,
+          workspaceAlias: planArtifact.workspace_alias,
+          preview: planArtifact.preview,
+          previewComplete: planArtifact.preview_complete,
+          updatedAt: planArtifact.updated_at,
+        }
+      : undefined,
+    todoList: (workItem.todo_list ?? [])
+      .filter((item) => item.text)
+      .map((item) => ({
+        text: item.text ?? "",
+        state: item.state ?? "unknown",
+      })),
+    workRefs: (workItem.work_refs ?? [])
+      .filter((item) => item.ref)
+      .map((item) => ({
+        kind: item.kind ?? "other",
+        ref: item.ref ?? "",
+        title: item.title,
+        reason: item.reason,
+        status: item.status,
+        lastSeenAt: item.last_seen_at,
+      })),
+  };
+}
+
 function selectWorkItems(
   workItems: Array<{ id?: string; objective?: string; state?: string; plan_status?: string }>,
   currentWorkItemId?: string | null,
 ): WorkItemSummary[] {
   return workItems
     .filter((item) => item.id)
-    .map((item) => ({
-      id: item.id ?? "unknown-work-item",
-      objective: item.objective ?? item.id ?? "Work item",
-      state: item.state ?? "unknown",
-      planStatus: item.plan_status,
-      current: item.id === currentWorkItemId,
-    }))
+    .map((item) => projectWorkItem(item as WorkItemDto, currentWorkItemId))
+    .filter((item): item is WorkItemSummary => Boolean(item))
     .sort((left, right) => {
       if (left.current !== right.current) return left.current ? -1 : 1;
       return left.objective.localeCompare(right.objective);

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1,5 +1,5 @@
 import { agentDetailFixtures } from "./fixtures";
-import { reduceAgentSessionTimeline, transcriptEntryIdForPayload } from "./session-reducer";
+import { briefIdForPayload, reduceAgentSessionTimeline, transcriptEntryIdForPayload } from "./session-reducer";
 import type {
   AgentDetail,
   AgentSummary,
@@ -10,6 +10,7 @@ import type {
   RuntimeConfigState,
   RuntimeConfigSurface,
   RuntimeConnection,
+  RuntimeBriefRecord,
   RuntimeMessageEnvelope,
   RuntimeModelCatalog,
   RuntimeModelOption,
@@ -89,18 +90,20 @@ async function fetchAgentDetail(
   ]);
   const fallbackEntry: AgentListEntryDto = entry ?? { identity: { agent_id: agentId } };
   const transcriptEntriesById = await fetchTranscriptEntriesForEvents(baseUrl, fetchImpl, headers, agentId, events.events ?? []);
+  const briefRecordsById = await fetchBriefRecordsForEvents(baseUrl, fetchImpl, headers, agentId, events.events ?? [], transcriptEntriesById);
   const agent = projectAgent(
     fallbackEntry,
     state,
-    newestBriefFromEvents(events.events ?? [], transcriptEntriesById),
+    newestBriefFromEvents(events.events ?? [], transcriptEntriesById, briefRecordsById),
   );
-  const timeline = reduceAgentSessionTimeline({ events, eventDisplayLevel, transcriptEntriesById });
+  const timeline = reduceAgentSessionTimeline({ events, eventDisplayLevel, transcriptEntriesById, briefRecordsById });
 
   return {
     agent,
     source: "http",
     timeline,
     events: events.events ?? [],
+    briefRecordsById,
     eventCursorSeq: events.cursor_seq,
     newestEventSeq: events.newest_seq,
     oldestEventSeq: events.oldest_seq,
@@ -188,12 +191,7 @@ interface AgentWorkspaceDto {
     } | null;
 }
 
-interface BriefRecordDto {
-  id?: string;
-  created_at?: string;
-  text?: string;
-  kind?: string;
-}
+type BriefRecordDto = RuntimeBriefRecord;
 
 export interface EventPageResponseDto {
   events?: EventEnvelopeDto[];
@@ -469,6 +467,12 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         requestHeaders,
       );
     },
+    async getAgentBriefsById(agentId: string, briefIds: string[]): Promise<Record<string, RuntimeBriefRecord>> {
+      if (!baseUrl || !briefIds.length) {
+        return {};
+      }
+      return fetchBriefRecordsById(baseUrl, fetchImpl, requestHeaders, agentId, briefIds);
+    },
     async getModels(): Promise<RuntimeModelCatalog> {
       if (!baseUrl) {
         return { source: "fixture", options: [] };
@@ -619,6 +623,47 @@ async function fetchTranscriptEntriesForEvents(
     headers,
   ).catch((): AgentTranscriptEntriesBatchGetResponseDto => ({ entries: [], missing_entry_ids: entryIds }));
   return Object.fromEntries((response.entries ?? []).flatMap((entry) => (entry.id ? [[entry.id, entry]] : [])));
+}
+
+async function fetchBriefRecordsForEvents(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  agentId: string,
+  events: EventEnvelopeDto[],
+  transcriptEntriesById: Record<string, RuntimeTranscriptEntry>,
+): Promise<Record<string, RuntimeBriefRecord>> {
+  const briefIds = Array.from(
+    new Set(
+      events
+        .filter((event) => event.type === "brief_created")
+        .filter((event) => {
+          const payload = asRecord(event.payload);
+          const entryId = transcriptEntryIdForPayload(payload);
+          return !((entryId ? transcriptEntryText(transcriptEntriesById[entryId]) : undefined) ?? stringValue(payload?.text));
+        })
+        .map((event) => briefIdForPayload(asRecord(event.payload)))
+        .filter((briefId): briefId is string => Boolean(briefId)),
+    ),
+  );
+  if (!briefIds.length) return {};
+  return fetchBriefRecordsById(baseUrl, fetchImpl, headers, agentId, briefIds);
+}
+
+async function fetchBriefRecordsById(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  agentId: string,
+  briefIds: string[],
+): Promise<Record<string, RuntimeBriefRecord>> {
+  const records = await Promise.all(
+    briefIds.map(async (briefId): Promise<RuntimeBriefRecord | undefined> => {
+      const path = `/agents/${encodeURIComponent(agentId)}/briefs/${encodeURIComponent(briefId)}`;
+      return getJson<RuntimeBriefRecord>(fetchImpl, baseUrl, path, { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers }).catch(() => undefined);
+    }),
+  );
+  return Object.fromEntries(records.flatMap((record) => (record?.id ? [[record.id, record]] : [])));
 }
 
 function streamAgentEvents(
@@ -1048,13 +1093,16 @@ function projectTasks(tasks: NonNullable<AgentStateDto["tasks"]>): TaskSummary[]
 function newestBriefFromEvents(
   events: EventEnvelopeDto[],
   transcriptEntriesById: Record<string, RuntimeTranscriptEntry> = {},
+  briefRecordsById: Record<string, RuntimeBriefRecord> = {},
 ): BriefRecordDto | undefined {
   return events
     .filter((event) => event.type === "brief_created")
     .map((event) => {
       const payload = event.payload && typeof event.payload === "object" ? (event.payload as Record<string, unknown>) : {};
       const entryId = transcriptEntryIdForPayload(payload);
+      const briefId = briefIdForPayload(payload);
       const text = (entryId ? transcriptEntryText(transcriptEntriesById[entryId]) : undefined) ??
+        (briefId ? briefRecordsById[briefId]?.text : undefined) ??
         (typeof payload.text === "string" ? payload.text : undefined);
       const createdAt = typeof payload.created_at === "string" ? payload.created_at : event.ts;
       const kind = typeof payload.kind === "string" ? payload.kind : undefined;

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -71,6 +71,32 @@ function disconnectedAgentDetail(agentId: string, error: string): AgentDetail {
   };
 }
 
+function disconnectedAgentSummary(agentId: string, error: string): AgentSummary {
+  return {
+    id: agentId,
+    badge: "!",
+    badgeTone: "muted",
+    profile: "unavailable",
+    lifecycle: "unknown",
+    focusSummary: "Runtime API unavailable",
+    workspace: "unavailable",
+    attention: "API disconnected",
+    model: "unavailable",
+    modelReasoningEffort: undefined,
+    footer: "disconnected",
+    subtitle: "Runtime API unavailable",
+    lastBrief: "",
+    lastTurnTime: "",
+    pending: 0,
+    activeTaskCount: 0,
+    waitingCount: 0,
+    posture: "disconnected",
+    postureReason: error,
+    tasks: [],
+    workItems: [],
+  };
+}
+
 async function fetchAgentDetail(
   baseUrl: string,
   fetchImpl: typeof fetch,
@@ -113,6 +139,23 @@ async function fetchAgentDetail(
     oldestEventSeq: events.oldest_seq,
     hasOlderEvents: events.has_older,
   };
+}
+
+async function fetchAgentState(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  agentId: string,
+): Promise<AgentSummary> {
+  const encodedAgentId = encodeURIComponent(agentId);
+  const [entry, state] = await Promise.all([
+    getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers })
+      .then((agents) => agents.find((agent) => agent.identity?.agent_id === agentId))
+      .catch(() => undefined),
+    getJson<AgentStateDto>(fetchImpl, baseUrl, `/agents/${encodedAgentId}/state`, { headers }),
+  ]);
+  const fallbackEntry: AgentListEntryDto = entry ?? { identity: { agent_id: agentId } };
+  return projectAgent(fallbackEntry, state);
 }
 
 interface AgentListEntryDto {
@@ -478,6 +521,17 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return disconnectedAgentDetail(agentId, message);
+      }
+    },
+    async getAgentState(agentId: string): Promise<AgentSummary> {
+      if (!baseUrl) {
+        return disconnectedAgentSummary(agentId, "Holon API base URL is not configured.");
+      }
+      try {
+        return await fetchAgentState(baseUrl, fetchImpl, requestHeaders, agentId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return disconnectedAgentSummary(agentId, message);
       }
     },
     async getAgentWorkItems(agentId: string, options: { limit?: number } = {}): Promise<WorkItemSummary[]> {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1516,7 +1516,7 @@ function badgeFor(id: string): string {
 
 /**
  * Deterministic hue (0-360) from agent id for avatar color.
- * Uses a curated palette of 10 evenly-spaced hues with controlled
+ * Uses a curated palette of 20 evenly-spaced hues with controlled
  * saturation/lightness so white text stays readable (WCAG AA).
  */
 function hueFor(id: string): number {
@@ -1524,7 +1524,7 @@ function hueFor(id: string): number {
   for (let i = 0; i < id.length; i++) {
     hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0;
   }
-  const palette = [12, 38, 160, 190, 210, 260, 290, 330, 350, 0];
+  const palette = [0, 18, 35, 52, 90, 130, 160, 175, 190, 205, 220, 240, 260, 275, 290, 310, 325, 340, 355, 8];
   return palette[Math.abs(hash) % palette.length];
 }
 

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -141,6 +141,8 @@ interface AgentListEntryDto {
     workspace_anchor?: string;
     execution_root?: string;
     cwd?: string;
+    projection_kind?: string;
+    access_mode?: string;
     projection_metadata?: {
       worktree_branch?: string;
       worktree_path?: string;
@@ -188,6 +190,8 @@ interface AgentStateDto {
 interface AgentWorkspaceDto {
     active_workspace_entry?: AgentListEntryDto["active_workspace_entry"];
     worktree_session?: {
+      original_branch?: string;
+      original_cwd?: string;
       worktree_branch?: string;
       worktree_path?: string;
     } | null;
@@ -1036,6 +1040,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   const waitingCount = state?.waiting_intents?.length ?? state?.agent?.active_waiting_intents?.length ?? (entry.waiting_reason ? 1 : 0);
   const posture = state?.agent?.scheduling_posture?.posture ?? entry.scheduling_posture?.posture ?? "unknown";
   const postureReason = state?.agent?.scheduling_posture?.reason ?? entry.scheduling_posture?.reason ?? "posture unavailable";
+  const focusSummary = currentWork?.objective ?? postureReason;
   const model = state?.agent?.model?.active_model ?? state?.agent?.model?.effective_model ?? entry.model?.active_model ?? entry.model?.effective_model ?? "runtime default";
   const modelSource = state?.agent?.model?.source ?? entry.model?.source;
   const modelReasoningEffort = state?.agent?.model?.override_reasoning_effort ?? entry.model?.override_reasoning_effort ?? undefined;
@@ -1047,7 +1052,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
     badge: badgeFor(id),
     profile,
     lifecycle: normalizeKebab(status),
-    focusSummary: postureReason,
+    focusSummary,
     workspace,
     attention: attentionLabel(pending, waitingCount),
     model,
@@ -1084,9 +1089,19 @@ function projectWorkspace(
     id: workspaceEntry?.workspace_id ?? "not bound",
     name,
     anchor,
+    projectionKind: workspaceEntry?.projection_kind,
+    accessMode: workspaceEntry?.access_mode,
     executionRoot: workspaceEntry?.execution_root,
     cwd: workspaceEntry?.cwd,
-    worktree: worktreeBranch || worktreePath ? { branch: worktreeBranch, path: worktreePath } : undefined,
+    worktree:
+      worktreeBranch || worktreePath
+        ? {
+            branch: worktreeBranch,
+            path: worktreePath,
+            originalBranch: worktreeSession?.original_branch,
+            originalCwd: worktreeSession?.original_cwd,
+          }
+        : undefined,
   };
 }
 

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -14,7 +14,9 @@ import type {
   RuntimeMessageEnvelope,
   RuntimeModelCatalog,
   RuntimeModelOption,
+  RuntimeTaskOutputResult,
   RuntimeTranscriptEntry,
+  RuntimeToolExecutionRecord,
   SearchResponse,
   TaskSummary,
   WorkItemSummary,
@@ -472,6 +474,28 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         return {};
       }
       return fetchBriefRecordsById(baseUrl, fetchImpl, requestHeaders, agentId, briefIds);
+    },
+    async getToolExecution(agentId: string, toolExecutionId: string): Promise<RuntimeToolExecutionRecord> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      return getJson<RuntimeToolExecutionRecord>(
+        fetchImpl,
+        baseUrl,
+        `/agents/${encodeURIComponent(agentId)}/tool-executions/${encodeURIComponent(toolExecutionId)}`,
+        { headers: requestHeaders },
+      );
+    },
+    async getTaskOutput(agentId: string, taskId: string): Promise<RuntimeTaskOutputResult> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      return getJson<RuntimeTaskOutputResult>(
+        fetchImpl,
+        baseUrl,
+        `/agents/${encodeURIComponent(agentId)}/tasks/${encodeURIComponent(taskId)}/output?block=false`,
+        { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers: requestHeaders },
+      );
     },
     async getModels(): Promise<RuntimeModelCatalog> {
       if (!baseUrl) {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -80,7 +80,7 @@ async function fetchAgentDetail(
 ): Promise<AgentDetail> {
   const encodedAgentId = encodeURIComponent(agentId);
   const eventDisplayLevel = displayLevel;
-  const [entry, state, events] = await Promise.all([
+  const [entry, state, events, workItems] = await Promise.all([
     getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers })
       .then((agents) => agents.find((agent) => agent.identity?.agent_id === agentId))
       .catch(() => undefined),
@@ -89,6 +89,7 @@ async function fetchAgentDetail(
       events: [],
       has_older: false,
     })),
+    fetchAgentWorkItems(baseUrl, fetchImpl, headers, agentId, { limit: 50 }).catch((): WorkItemDto[] => []),
   ]);
   const fallbackEntry: AgentListEntryDto = entry ?? { identity: { agent_id: agentId } };
   const transcriptEntriesById = await fetchTranscriptEntriesForEvents(baseUrl, fetchImpl, headers, agentId, events.events ?? []);
@@ -97,6 +98,7 @@ async function fetchAgentDetail(
     fallbackEntry,
     state,
     newestBriefFromEvents(events.events ?? [], transcriptEntriesById, briefRecordsById),
+    workItems,
   );
   const timeline = reduceAgentSessionTimeline({ events, eventDisplayLevel, transcriptEntriesById, briefRecordsById });
 
@@ -185,6 +187,13 @@ interface AgentStateDto {
   }>;
   waiting_intents?: unknown[];
   workspace?: AgentWorkspaceDto;
+}
+
+interface WorkItemDto {
+  id?: string;
+  objective?: string;
+  state?: string;
+  plan_status?: string;
 }
 
 interface AgentWorkspaceDto {
@@ -443,6 +452,13 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         return disconnectedAgentDetail(agentId, message);
       }
     },
+    async getAgentWorkItems(agentId: string, options: { limit?: number } = {}): Promise<WorkItemSummary[]> {
+      if (!baseUrl) {
+        return [];
+      }
+      const workItems = await fetchAgentWorkItems(baseUrl, fetchImpl, requestHeaders, agentId, options);
+      return projectWorkItems(workItems);
+    },
     async getAgentEvents(agentId: string, options: AgentEventPageOptions = {}): Promise<EventPageResponseDto> {
       if (!baseUrl) {
         return { events: [], has_older: false };
@@ -626,6 +642,24 @@ async function fetchAgentEvents(
   const queryString = query.toString();
   const path = `/agents/${encodeURIComponent(agentId)}/events${queryString ? `?${queryString}` : ""}`;
   return getJson<EventPageResponseDto>(fetchImpl, baseUrl, path, { headers });
+}
+
+async function fetchAgentWorkItems(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  agentId: string,
+  options: { limit?: number } = {},
+): Promise<WorkItemDto[]> {
+  const query = new URLSearchParams();
+  if (options.limit != null) query.set("limit", String(options.limit));
+  const queryString = query.toString();
+  return getJson<WorkItemDto[]>(
+    fetchImpl,
+    baseUrl,
+    `/agents/${encodeURIComponent(agentId)}/work-items${queryString ? `?${queryString}` : ""}`,
+    { timeoutMs: OPTIONAL_DETAIL_TIMEOUT_MS, headers },
+  );
 }
 
 async function fetchTranscriptEntriesForEvents(
@@ -1025,15 +1059,15 @@ function projectSearchResponse(response: SearchResponseDto): SearchResponse {
   };
 }
 
-function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: BriefRecordDto): AgentSummary {
+function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: BriefRecordDto, workItemRecords?: WorkItemDto[]): AgentSummary {
   const id = entry.identity?.agent_id ?? state?.agent?.agent?.id ?? "unknown-agent";
   const status = state?.agent?.agent?.status ?? entry.status ?? "unknown";
   const profile = compactJoin([entry.identity?.visibility ?? "public", entry.identity?.ownership, entry.identity?.profile_preset]);
   const workspaceEntry = state?.workspace?.active_workspace_entry ?? entry.active_workspace_entry;
   const workspace = workspaceEntry?.workspace_alias ?? workspaceEntry?.workspace_id ?? state?.workspace?.worktree_session?.worktree_branch ?? "not bound";
   const workspaceSummary = projectWorkspace(workspaceEntry, state?.workspace?.worktree_session);
-  const currentWork = selectCurrentWork(state?.work_items ?? [], state?.agent?.agent?.current_work_item_id);
-  const workItems = selectOpenWorkItems(state?.work_items ?? [], state?.agent?.agent?.current_work_item_id);
+  const currentWork = selectCurrentWork(workItemRecords ?? state?.work_items ?? [], state?.agent?.agent?.current_work_item_id);
+  const workItems = selectWorkItems(workItemRecords ?? state?.work_items ?? [], state?.agent?.agent?.current_work_item_id);
   const tasks = projectTasks(state?.tasks ?? []);
   const pending = state?.session?.pending_count ?? entry.pending ?? 0;
   const activeTaskCount = state?.tasks?.length ?? state?.agent?.active_task_count ?? 0;
@@ -1220,7 +1254,7 @@ function compareModelOptions(left: RuntimeModelOption, right: RuntimeModelOption
 }
 
 function selectCurrentWork(
-  workItems: Array<{ id?: string; objective?: string; state?: string }>,
+  workItems: Array<{ id?: string; objective?: string; state?: string; plan_status?: string }>,
   currentWorkItemId?: string | null,
 ): WorkItemSummary | undefined {
   if (!currentWorkItemId) return undefined;
@@ -1230,16 +1264,23 @@ function selectCurrentWork(
     id: selected.id,
     objective: selected.objective ?? selected.id,
     state: selected.state ?? "unknown",
+    planStatus: selected.plan_status,
     current: true,
   };
 }
 
-function selectOpenWorkItems(
+function projectWorkItems(
+  workItems: Array<{ id?: string; objective?: string; state?: string; plan_status?: string }>,
+): WorkItemSummary[] {
+  return selectWorkItems(workItems);
+}
+
+function selectWorkItems(
   workItems: Array<{ id?: string; objective?: string; state?: string; plan_status?: string }>,
   currentWorkItemId?: string | null,
 ): WorkItemSummary[] {
   return workItems
-    .filter((item) => item.id && item.state !== "completed")
+    .filter((item) => item.id)
     .map((item) => ({
       id: item.id ?? "unknown-work-item",
       objective: item.objective ?? item.id ?? "Work item",

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -680,6 +680,10 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       if (!baseUrl) return undefined;
       return streamAgentEvents(baseUrl, fetchImpl, requestHeaders, agentId, options);
     },
+    streamGlobalEvents(options: AgentEventStreamOptions): AgentEventStreamSubscription | undefined {
+      if (!baseUrl) return undefined;
+      return streamGlobalEvents(baseUrl, fetchImpl, requestHeaders, options);
+    },
     async sendOperatorPrompt(agentId: string, text: string): Promise<void> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
@@ -849,6 +853,19 @@ function streamAgentEvents(
 
   void readEventStream(fetchImpl, `${baseUrl}${path}`, headers, controller.signal, options);
 
+  return {
+    close: () => controller.abort(),
+  };
+}
+function streamGlobalEvents(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  options: AgentEventStreamOptions,
+): AgentEventStreamSubscription {
+  const controller = new AbortController();
+  const path = "/events/stream";
+  void readEventStream(fetchImpl, `${baseUrl}${path}`, headers, controller.signal, options);
   return {
     close: () => controller.abort(),
   };

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -22,6 +22,7 @@ import type {
 } from "./types";
 
 export interface RuntimeClientOptions {
+  mode?: "local" | "remote";
   baseUrl?: string;
   token?: string;
   fetchImpl?: typeof fetch;
@@ -410,18 +411,20 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? import.meta.env.VITE_HOLON_API_BASE ?? defaultBaseUrl);
   const fetchImpl = options.fetchImpl ?? fetch;
   const requestHeaders = authorizationHeaders(options.token);
+  const connectionMode = options.mode ?? (options.baseUrl ? "remote" : "local");
+  const hasToken = Boolean(options.token?.trim());
 
   return {
     async getBootstrap(): Promise<RuntimeBootstrap> {
       if (!baseUrl) {
-        return buildDisconnectedBootstrap(undefined, "Holon API base URL is not configured.");
+        return buildDisconnectedBootstrap(undefined, "Holon API base URL is not configured.", connectionMode, hasToken);
       }
 
       try {
-        return await fetchRuntimeBootstrap(baseUrl, fetchImpl, requestHeaders);
+        return await fetchRuntimeBootstrap(baseUrl, fetchImpl, requestHeaders, connectionMode, hasToken);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return buildDisconnectedBootstrap(baseUrl, message);
+        return buildDisconnectedBootstrap(baseUrl, message, connectionMode, hasToken);
       }
     },
     async getAgentDetail(agentId: string, displayLevel: DisplayLevel = "info"): Promise<AgentDetail> {
@@ -715,7 +718,13 @@ function parseSseEventFrame(frame: string): StreamEventEnvelopeDto | undefined {
   return JSON.parse(dataLines.join("\n")) as StreamEventEnvelopeDto;
 }
 
-async function fetchRuntimeBootstrap(baseUrl: string, fetchImpl: typeof fetch, headers: Record<string, string>): Promise<RuntimeBootstrap> {
+async function fetchRuntimeBootstrap(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+  connectionMode: "local" | "remote",
+  hasToken: boolean,
+): Promise<RuntimeBootstrap> {
   const [handshake, agentEntries] = await Promise.all([
     getJson<{ auth?: { mode?: string } }>(fetchImpl, baseUrl, "/handshake", { headers }),
     getJson<AgentListEntryDto[]>(fetchImpl, baseUrl, "/agents/list", { headers }),
@@ -726,10 +735,11 @@ async function fetchRuntimeBootstrap(baseUrl: string, fetchImpl: typeof fetch, h
   const activeTaskCount = agents.reduce((sum, agent) => sum + agent.activeTaskCount, 0);
   const currentWorkCount = agents.filter((agent) => agent.currentWork).length;
   const connection: RuntimeConnection = {
-    mode: handshake.auth?.mode === "bearer" ? "remote" : "local",
+    mode: connectionMode,
     source: "http",
     baseUrl,
-    summary: `${baseUrl} · ${handshake.auth?.mode ?? "local"} · existing /agents routes`,
+    hasToken,
+    summary: `${baseUrl} · ${connectionMode}${hasToken ? " bearer" : ""} · existing /agents routes`,
   };
 
   return {
@@ -747,11 +757,11 @@ async function getJson<T>(
   options: { timeoutMs?: number; headers?: Record<string, string> } = {},
 ): Promise<T> {
   const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+  const timeout = globalThis.setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
   const response = await fetchImpl(`${baseUrl}${path}`, {
     headers: { Accept: "application/json", ...options.headers },
     signal: controller.signal,
-  }).finally(() => window.clearTimeout(timeout));
+  }).finally(() => globalThis.clearTimeout(timeout));
   if (!response.ok) {
     throw new Error(`GET ${path} failed with ${response.status}`);
   }
@@ -766,7 +776,7 @@ async function postJson<T>(
   headers: Record<string, string> = {},
 ): Promise<T> {
   const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
+  const timeout = globalThis.setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
   const response = await fetchImpl(`${baseUrl}${path}`, {
     method: "POST",
     headers: {
@@ -776,7 +786,7 @@ async function postJson<T>(
     },
     body: JSON.stringify(body),
     signal: controller.signal,
-  }).finally(() => window.clearTimeout(timeout));
+  }).finally(() => globalThis.clearTimeout(timeout));
   if (!response.ok) {
     throw new Error(`POST ${path} failed with ${response.status}`);
   }
@@ -793,7 +803,7 @@ async function patchJson<T>(
   headers: Record<string, string> = {},
 ): Promise<T> {
   const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
+  const timeout = globalThis.setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
   const response = await fetchImpl(`${baseUrl}${path}`, {
     method: "PATCH",
     headers: {
@@ -803,7 +813,7 @@ async function patchJson<T>(
     },
     body: JSON.stringify(body),
     signal: controller.signal,
-  }).finally(() => window.clearTimeout(timeout));
+  }).finally(() => globalThis.clearTimeout(timeout));
   if (!response.ok) {
     throw new Error(`PATCH ${path} failed with ${response.status}`);
   }
@@ -1164,13 +1174,19 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
-function buildDisconnectedBootstrap(baseUrl: string | undefined, error: string): RuntimeBootstrap {
+function buildDisconnectedBootstrap(
+  baseUrl: string | undefined,
+  error: string,
+  mode: "local" | "remote" = "local",
+  hasToken = false,
+): RuntimeBootstrap {
   return {
     attentionCount: 0,
     connection: {
       source: "fixture",
-      mode: "local",
+      mode,
       baseUrl,
+      hasToken,
       error,
       summary: baseUrl ? `${baseUrl} unavailable` : "Holon API unavailable",
     },

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -1205,6 +1205,7 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   return {
     id,
     badge: badgeFor(id),
+    badgeHue: hueFor(id),
     profile,
     lifecycle: normalizeKebab(status),
     focusSummary,
@@ -1511,6 +1512,20 @@ function compactJoin(parts: Array<string | undefined | null>): string {
 function badgeFor(id: string): string {
   const words = id.split(/[-_]/).filter(Boolean);
   return (words.length > 1 ? words.map((word) => word[0]).join("") : id.slice(0, 3)).slice(0, 4).toUpperCase();
+}
+
+/**
+ * Deterministic hue (0-360) from agent id for avatar color.
+ * Uses a curated palette of 10 evenly-spaced hues with controlled
+ * saturation/lightness so white text stays readable (WCAG AA).
+ */
+function hueFor(id: string): number {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0;
+  }
+  const palette = [12, 38, 160, 190, 210, 260, 290, 330, 350, 0];
+  return palette[Math.abs(hash) % palette.length];
 }
 
 function attentionLabel(pending: number, waiting: number): string {

--- a/web-gui/app/src/runtime/fixtures.ts
+++ b/web-gui/app/src/runtime/fixtures.ts
@@ -17,6 +17,7 @@ export const runtimeFixture: RuntimeBootstrap = {
     {
       id: "holon-pm",
       badge: "PM",
+      badgeHue: 190,
       profile: "public · project manager profile",
       lifecycle: "asleep",
       focusSummary: "standalone Web GUI implementation plan",
@@ -82,6 +83,7 @@ export const runtimeFixture: RuntimeBootstrap = {
       id: "holon-dev",
       badge: "DEV",
       badgeTone: "muted",
+      badgeHue: 210,
       profile: "public · implementation profile",
       lifecycle: "stopped",
       focusSummary: "no active workspace",

--- a/web-gui/app/src/runtime/fixtures.ts
+++ b/web-gui/app/src/runtime/fixtures.ts
@@ -42,11 +42,15 @@ export const runtimeFixture: RuntimeBootstrap = {
         id: "ws_fixture",
         name: "holon",
         anchor: "/Users/jolestar/opensource/src/github.com/holon-run/holon",
+        projectionKind: "git_worktree_root",
+        accessMode: "direct",
         executionRoot: "/Users/jolestar/opensource/src/github.com/holon-run/.holon-worktrees-holon/web-gui-prototype",
         cwd: "/Users/jolestar/opensource/src/github.com/holon-run/.holon-worktrees-holon/web-gui-prototype",
         worktree: {
           branch: "web-gui-prototype",
           path: "/Users/jolestar/opensource/src/github.com/holon-run/.holon-worktrees-holon/web-gui-prototype",
+          originalBranch: "main",
+          originalCwd: "/Users/jolestar/opensource/src/github.com/holon-run/holon",
         },
       },
       tasks: [

--- a/web-gui/app/src/runtime/idb-cache.ts
+++ b/web-gui/app/src/runtime/idb-cache.ts
@@ -1,0 +1,210 @@
+/**
+ * Thin IndexedDB wrapper for client-side session caching.
+ *
+ * All operations are defensive: if IndexedDB is unavailable (private mode,
+ * quota exceeded, etc.) they resolve to empty/no-op results so the caller
+ * can silently fall back to a memory-only mode.
+ */
+
+const DB_NAME = "holon-webgui-cache";
+const DB_VERSION = 1;
+export const CACHE_SCHEMA_VERSION = 1;
+const SESSIONS_STORE = "sessions";
+const META_STORE = "meta";
+
+export interface CachedAgentSession {
+  remoteKey: string;
+  agentId: string;
+  schemaVersion: number;
+  eventsBySeq: Record<number, unknown>;
+  eventSeqs: number[];
+  messagesById: Record<string, unknown>;
+  transcriptEntriesById: Record<string, unknown>;
+  briefRecordsById: Record<string, unknown>;
+  newestSeq?: number;
+  oldestSeq?: number;
+  cachedAt: number;
+}
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function openDB(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+
+  dbPromise = new Promise<IDBDatabase | null>((resolve) => {
+    if (typeof indexedDB === "undefined") {
+      resolve(null);
+      return;
+    }
+    let request: IDBOpenDBRequest;
+    try {
+      request = indexedDB.open(DB_NAME, DB_VERSION);
+    } catch {
+      resolve(null);
+      return;
+    }
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(SESSIONS_STORE)) {
+        const store = db.createObjectStore(SESSIONS_STORE, { keyPath: ["remoteKey", "agentId"] });
+        store.createIndex("byRemoteKey", "remoteKey", { unique: false });
+      }
+      if (!db.objectStoreNames.contains(META_STORE)) {
+        db.createObjectStore(META_STORE, { keyPath: "remoteKey" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(null);
+  });
+
+  return dbPromise;
+}
+
+function runRequest<T>(
+  db: IDBDatabase,
+  storeName: string,
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest,
+): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, mode);
+    const request = fn(tx.objectStore(storeName));
+    request.onsuccess = () => resolve(request.result as T);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function cachePutSession(session: CachedAgentSession): Promise<void> {
+  const db = await openDB();
+  if (!db) return;
+  try {
+    await runRequest(db, SESSIONS_STORE, "readwrite", (store) => store.put(session));
+  } catch {
+    // Silent fallback — cache is best-effort.
+  }
+}
+
+export async function cacheGetSession(remoteKey: string, agentId: string): Promise<CachedAgentSession | undefined> {
+  const db = await openDB();
+  if (!db) return undefined;
+  try {
+    return await runRequest<CachedAgentSession>(db, SESSIONS_STORE, "readonly", (store) =>
+      store.get([remoteKey, agentId]),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export async function cacheGetAllSessions(remoteKey: string): Promise<CachedAgentSession[]> {
+  const db = await openDB();
+  if (!db) return [];
+  try {
+    const index = db.transaction(SESSIONS_STORE, "readonly").objectStore(SESSIONS_STORE).index("byRemoteKey");
+    return await new Promise<CachedAgentSession[]>((resolve, reject) => {
+      const result: CachedAgentSession[] = [];
+      const request = index.openCursor(IDBKeyRange.only(remoteKey));
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor) {
+          result.push(cursor.value as CachedAgentSession);
+          cursor.continue();
+        } else {
+          resolve(result);
+        }
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    return [];
+  }
+}
+
+export async function cacheDeleteSession(remoteKey: string, agentId: string): Promise<void> {
+  const db = await openDB();
+  if (!db) return;
+  try {
+    await runRequest(db, SESSIONS_STORE, "readwrite", (store) => store.delete([remoteKey, agentId]));
+  } catch {
+    // Silent fallback.
+  }
+}
+
+export async function cacheClearRemote(remoteKey: string): Promise<void> {
+  const db = await openDB();
+  if (!db) return;
+  try {
+    const store = db.transaction(SESSIONS_STORE, "readwrite").objectStore(SESSIONS_STORE);
+    const index = store.index("byRemoteKey");
+    const range = IDBKeyRange.only(remoteKey);
+    await new Promise<void>((resolve, reject) => {
+      const request = index.openCursor(range);
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor) {
+          cursor.delete();
+          cursor.continue();
+        } else {
+          resolve();
+        }
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch {
+    // Silent fallback.
+  }
+}
+
+/**
+ * Check if the cache schema is compatible. If any cached entry has a
+ * mismatched schema version, wipe the entire database and return false.
+ */
+export async function ensureCacheSchemaVersion(): Promise<boolean> {
+  const db = await openDB();
+  if (!db) return false;
+  try {
+    const store = db.transaction(SESSIONS_STORE, "readonly").objectStore(SESSIONS_STORE);
+    const incompatible = await new Promise<boolean>((resolve, reject) => {
+      const request = store.openCursor();
+      let foundIncompatible = false;
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor) {
+          const entry = cursor.value as CachedAgentSession;
+          if (entry.schemaVersion !== CACHE_SCHEMA_VERSION) {
+            foundIncompatible = true;
+            resolve(true);
+            return;
+          }
+          cursor.continue();
+        } else {
+          resolve(foundIncompatible);
+        }
+      };
+      request.onerror = () => reject(request.error);
+    });
+    if (incompatible) {
+      db.close();
+      dbPromise = null;
+      await new Promise<void>((resolve) => {
+        try {
+          const req = indexedDB.deleteDatabase(DB_NAME);
+          req.onsuccess = () => resolve();
+          req.onerror = () => resolve();
+          req.onblocked = () => resolve();
+        } catch {
+          resolve();
+        }
+      });
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Reset the DB promise (test utility). */
+export function _resetDbPromise(): void {
+  dbPromise = null;
+}

--- a/web-gui/app/src/runtime/runtime-store-helpers.ts
+++ b/web-gui/app/src/runtime/runtime-store-helpers.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared type definitions extracted from runtime-store.ts to avoid
+ * circular imports when other modules (like session-cache) need
+ * AgentSessionState.
+ */
+
+import type {
+  AgentDetail,
+  RuntimeBriefRecord,
+  RuntimeMessageEnvelope,
+  RuntimeTranscriptEntry,
+  WorkItemDetailState,
+} from "./types";
+
+export type { WorkItemDetailState };
+
+export type AgentLiveStatus = "idle" | "connecting" | "streaming" | "reconnecting" | "recovering" | "stale" | "error";
+
+export interface AgentSessionState {
+  loading: boolean;
+  loadingOlder: boolean;
+  liveStatus: AgentLiveStatus;
+  sendingPrompt: boolean;
+  detail: AgentDetail | null;
+  eventsBySeq: Record<number, unknown>;
+  eventSeqs: number[];
+  messagesById: Record<string, RuntimeMessageEnvelope>;
+  missingMessageIds: Record<string, true>;
+  transcriptEntriesById: Record<string, RuntimeTranscriptEntry>;
+  missingTranscriptEntryIds: Record<string, true>;
+  briefRecordsById: Record<string, RuntimeBriefRecord>;
+  missingBriefIds: Record<string, true>;
+  newestSeq?: number;
+  oldestSeq?: number;
+  hasOlder?: boolean;
+  lastStreamActivityAt?: string;
+  reconnectAttempt?: number;
+  error?: string;
+  historyError?: string;
+  promptError?: string;
+  modelError?: string;
+  workItemDetailsById: Record<string, WorkItemDetailState>;
+}

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -93,3 +93,89 @@ describe("runtime connection storage", () => {
     });
   });
 });
+
+describe("roster activity unread state", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("hydrates persisted roster activity per remote key", async () => {
+    const sharedLocalStorage = new MemoryStorage();
+    installWindow(sharedLocalStorage, new MemoryStorage());
+    sharedLocalStorage.setItem(
+      "holon.webGui.rosterActivityByRemote.v1",
+      JSON.stringify({
+        local: {
+          localAgent: { unreadCount: 2, lastUnreadSeq: 12, lastReadSeq: 7, briefAt: "2026-01-01T00:00:00.000Z" },
+        },
+        "http://remote.example:7878": {
+          remoteAgent: { unreadCount: 4, lastUnreadSeq: 20 },
+        },
+      }),
+    );
+
+    const { readStoredRosterActivity } = await import("./runtime-store");
+
+    expect(readStoredRosterActivity("local")).toEqual({
+      localAgent: { unreadCount: 2, lastUnreadSeq: 12, lastReadSeq: 7, briefAt: "2026-01-01T00:00:00.000Z" },
+    });
+    expect(readStoredRosterActivity("http://remote.example:7878")).toEqual({
+      remoteAgent: { unreadCount: 4, lastUnreadSeq: 20 },
+    });
+  });
+
+  it("counts unread brief and non-operator message events once by seq", async () => {
+    const { touchRosterActivityFromEvent } = await import("./runtime-store");
+    const afterBrief = touchRosterActivityFromEvent(
+      {},
+      "agent-a",
+      { agent_id: "agent-a", event_seq: 10, ts: "2026-01-01T00:00:00.000Z", type: "brief_created", payload: {} },
+      "agent-b",
+    );
+    const afterDuplicate = touchRosterActivityFromEvent(
+      afterBrief,
+      "agent-a",
+      { agent_id: "agent-a", event_seq: 10, ts: "2026-01-01T00:00:01.000Z", type: "brief_created", payload: {} },
+      "agent-b",
+    );
+    const afterAgentMessage = touchRosterActivityFromEvent(
+      afterDuplicate,
+      "agent-a",
+      {
+        agent_id: "agent-a",
+        event_seq: 11,
+        ts: "2026-01-01T00:00:02.000Z",
+        type: "message_enqueued",
+        payload: { origin: { kind: "agent" } },
+      },
+      "agent-b",
+    );
+
+    expect(afterAgentMessage["agent-a"]).toMatchObject({ unreadCount: 2, lastUnreadSeq: 11 });
+  });
+
+  it("does not count unread for the currently open agent or operator messages", async () => {
+    const { touchRosterActivityFromEvent } = await import("./runtime-store");
+    const afterSelectedBrief = touchRosterActivityFromEvent(
+      {},
+      "agent-a",
+      { agent_id: "agent-a", event_seq: 10, ts: "2026-01-01T00:00:00.000Z", type: "brief_created", payload: {} },
+      "agent-a",
+    );
+    const afterOperatorMessage = touchRosterActivityFromEvent(
+      afterSelectedBrief,
+      "agent-a",
+      {
+        agent_id: "agent-a",
+        event_seq: 11,
+        ts: "2026-01-01T00:00:01.000Z",
+        type: "message_enqueued",
+        payload: { origin: { kind: "operator" }, created_at: "2026-01-01T00:00:01.000Z" },
+      },
+      "agent-b",
+    );
+
+    expect(afterOperatorMessage["agent-a"]?.unreadCount).toBeUndefined();
+    expect(afterOperatorMessage["agent-a"]?.operatorAt).toBe("2026-01-01T00:00:01.000Z");
+  });
+});

--- a/web-gui/app/src/runtime/runtime-store.test.ts
+++ b/web-gui/app/src/runtime/runtime-store.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readStoredRuntimeConnectionConfig, writeStoredRuntimeConnectionConfig } from "./runtime-store";
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length() {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.items.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}
+
+function installWindow(localStorage: Storage, sessionStorage: Storage) {
+  vi.stubGlobal("window", {
+    clearTimeout: () => undefined,
+    localStorage,
+    sessionStorage,
+  });
+}
+
+describe("runtime connection storage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps active runtime connections isolated per window session", () => {
+    const sharedLocalStorage = new MemoryStorage();
+    const remoteWindowSession = new MemoryStorage();
+    const localWindowSession = new MemoryStorage();
+
+    installWindow(sharedLocalStorage, remoteWindowSession);
+    writeStoredRuntimeConnectionConfig({
+      mode: "remote",
+      baseUrl: "http://remote.example:7878/",
+      token: "remote-token",
+    });
+
+    installWindow(sharedLocalStorage, localWindowSession);
+    expect(readStoredRuntimeConnectionConfig()).toEqual({ mode: "local" });
+    writeStoredRuntimeConnectionConfig({ mode: "local" });
+
+    installWindow(sharedLocalStorage, remoteWindowSession);
+    expect(readStoredRuntimeConnectionConfig()).toEqual({
+      mode: "remote",
+      baseUrl: "http://remote.example:7878",
+      token: "remote-token",
+    });
+
+    installWindow(sharedLocalStorage, localWindowSession);
+    expect(readStoredRuntimeConnectionConfig()).toEqual({ mode: "local" });
+  });
+
+  it("retains saved remote tokens without making new windows remote by default", () => {
+    const sharedLocalStorage = new MemoryStorage();
+    const firstWindowSession = new MemoryStorage();
+    const secondWindowSession = new MemoryStorage();
+
+    installWindow(sharedLocalStorage, firstWindowSession);
+    writeStoredRuntimeConnectionConfig({
+      mode: "remote",
+      baseUrl: "http://remote.example:7878",
+      token: "saved-token",
+    });
+
+    installWindow(sharedLocalStorage, secondWindowSession);
+    expect(readStoredRuntimeConnectionConfig()).toEqual({ mode: "local" });
+    writeStoredRuntimeConnectionConfig({ mode: "remote", baseUrl: "http://remote.example:7878" });
+
+    expect(readStoredRuntimeConnectionConfig()).toEqual({
+      mode: "remote",
+      baseUrl: "http://remote.example:7878",
+      token: "saved-token",
+    });
+  });
+});

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -27,6 +27,7 @@ import type {
   RuntimeModelCatalog,
   RuntimeTranscriptEntry,
   RuntimeToolExecutionRecord,
+  WorkItemSummary,
   SearchResponse,
 } from "./types";
 
@@ -198,6 +199,7 @@ export interface RuntimeStoreState {
   deleteCredential: (profile: string) => Promise<void>;
   runSearch: (query: string, options?: { agentIds?: string[]; limit?: number }) => Promise<void>;
   refreshAgentDetail: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
+  refreshAgentWorkItems: (agentId: string | undefined) => Promise<void>;
   loadOlderAgentEvents: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   sendOperatorPrompt: (agentId: string | undefined, text: string, displayLevel: DisplayLevel) => Promise<void>;
   setAgentModel: (agentId: string | undefined, model: string, displayLevel: DisplayLevel, reasoningEffort?: string) => Promise<void>;
@@ -221,6 +223,7 @@ const messageHydrationInFlight = new Map<string, Set<string>>();
 const transcriptHydrationInFlight = new Map<string, Set<string>>();
 const briefHydrationInFlight = new Map<string, Set<string>>();
 const inspectorDetailInFlight = new Set<string>();
+const workItemRefreshInFlight = new Set<string>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 const STREAM_FLUSH_INTERVAL_MS = 100;
@@ -715,6 +718,28 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }
   },
 
+  refreshAgentWorkItems: async (agentId) => {
+    if (!agentId || workItemRefreshInFlight.has(agentId)) return;
+    workItemRefreshInFlight.add(agentId);
+    try {
+      const workItems = await runtimeClient.getAgentWorkItems(agentId, { limit: 50 });
+      set((state) => mergeAgentWorkItemsIntoState(state, agentId, workItems));
+    } catch (error) {
+      set((state) => ({
+        sessionsByAgentId: {
+          ...state.sessionsByAgentId,
+          [agentId]: {
+            ...emptyAgentSession(),
+            ...state.sessionsByAgentId[agentId],
+            historyError: error instanceof Error ? error.message : String(error),
+          },
+        },
+      }));
+    } finally {
+      workItemRefreshInFlight.delete(agentId);
+    }
+  },
+
   loadOlderAgentEvents: async (agentId, displayLevel) => {
     if (!agentId) return;
     const session = get().sessionsByAgentId[agentId] ?? emptyAgentSession();
@@ -1201,6 +1226,45 @@ function mergeAgentIntoBootstrap(bootstrap: RuntimeBootstrap, updatedAgent: Agen
   };
 }
 
+function mergeAgentWorkItemsIntoState(state: RuntimeStoreState, agentId: string, workItems: WorkItemSummary[]): Partial<RuntimeStoreState> {
+  const session = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
+  const detail = session.detail
+    ? {
+        ...session.detail,
+        agent: patchAgentWorkItems(session.detail.agent, workItems),
+      }
+    : session.detail;
+  const agents = state.bootstrap.agents.map((agent) => (agent.id === agentId ? patchAgentWorkItems(agent, workItems) : agent));
+
+  return {
+    bootstrap: sortBootstrapAgents(
+      {
+        ...state.bootstrap,
+        agents,
+        metrics: buildBootstrapMetrics(agents),
+      },
+      state.rosterActivityByAgentId,
+    ),
+    sessionsByAgentId: {
+      ...state.sessionsByAgentId,
+      [agentId]: {
+        ...emptyAgentSession(),
+        ...session,
+        detail,
+      },
+    },
+  };
+}
+
+function patchAgentWorkItems(agent: AgentSummary, workItems: WorkItemSummary[]): AgentSummary {
+  const currentWork = workItems.find((item) => item.current);
+  return {
+    ...agent,
+    currentWork,
+    workItems,
+  };
+}
+
 function sortBootstrapAgents(bootstrap: RuntimeBootstrap, rosterActivityByAgentId: Record<string, AgentRosterActivity>): RuntimeBootstrap {
   return {
     ...bootstrap,
@@ -1435,6 +1499,9 @@ async function catchUpAgentEvents(
       append: true,
     }),
   );
+  if ((page.events ?? []).some(isWorkItemCacheInvalidationEvent)) {
+    void useRuntimeStore.getState().refreshAgentWorkItems(agentId);
+  }
   scheduleMessageHydration(get, set, agentId, "debug");
   scheduleTranscriptHydration(get, set, agentId, "debug");
   scheduleBriefHydration(get, set, agentId, "debug");
@@ -1515,6 +1582,15 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
   scheduleMessageHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
   scheduleTranscriptHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
   scheduleBriefHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
+  if (events.some(isWorkItemCacheInvalidationEvent)) {
+    void useRuntimeStore.getState().refreshAgentWorkItems(agentId);
+  }
+}
+
+function isWorkItemCacheInvalidationEvent(event: StreamEventEnvelopeDto): boolean {
+  if (event.type !== "work_item_written") return false;
+  const action = stringField(asRecord(event.payload), "action");
+  return action === "created" || action === "completed";
 }
 
 function scheduleMessageHydration(

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -203,6 +203,7 @@ export interface RuntimeStoreState {
   runSearch: (query: string, options?: { agentIds?: string[]; limit?: number }) => Promise<void>;
   refreshAgentDetail: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   refreshAgentWorkItems: (agentId: string | undefined) => Promise<void>;
+  refreshAgentState: (agentId: string | undefined) => Promise<void>;
   loadAgentWorkItemDetail: (agentId: string | undefined, workItemId: string | undefined) => Promise<void>;
   loadOlderAgentEvents: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   sendOperatorPrompt: (agentId: string | undefined, text: string, displayLevel: DisplayLevel) => Promise<void>;
@@ -229,6 +230,7 @@ const briefHydrationInFlight = new Map<string, Set<string>>();
 const inspectorDetailInFlight = new Set<string>();
 const workItemRefreshInFlight = new Set<string>();
 const workItemDetailInFlight = new Set<string>();
+const agentStateRefreshInFlight = new Set<string>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 const STREAM_FLUSH_INTERVAL_MS = 100;
@@ -747,6 +749,19 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       }));
     } finally {
       workItemRefreshInFlight.delete(agentId);
+    }
+  },
+
+  refreshAgentState: async (agentId) => {
+    if (!agentId || agentStateRefreshInFlight.has(agentId)) return;
+    agentStateRefreshInFlight.add(agentId);
+    try {
+      const freshAgent = await runtimeClient.getAgentState(agentId);
+      set((state) => mergeAgentStateIntoState(state, agentId, freshAgent));
+    } catch {
+      // Swallow — state refresh is best-effort; the next full detail refresh will recover.
+    } finally {
+      agentStateRefreshInFlight.delete(agentId);
     }
   },
 
@@ -1323,6 +1338,43 @@ function patchAgentWorkItems(agent: AgentSummary, workItems: WorkItemSummary[]):
   };
 }
 
+function mergeAgentStateIntoState(state: RuntimeStoreState, agentId: string, freshAgent: AgentSummary): Partial<RuntimeStoreState> {
+  const session = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
+  // Preserve cached work items and tasks from existing detail — those are managed by
+  // refreshAgentWorkItems and don't come from the lightweight state endpoint.
+  const cachedDetail = session.detail;
+  const mergedAgent: AgentSummary = cachedDetail
+    ? {
+        ...freshAgent,
+        workItems: cachedDetail.agent.workItems?.length ? cachedDetail.agent.workItems : freshAgent.workItems,
+        currentWork: cachedDetail.agent.currentWork ?? freshAgent.currentWork,
+        tasks: cachedDetail.agent.tasks?.length ? cachedDetail.agent.tasks : freshAgent.tasks,
+        lastBrief: cachedDetail.agent.lastBrief || freshAgent.lastBrief,
+      }
+    : freshAgent;
+  const detail = cachedDetail ? { ...cachedDetail, agent: mergedAgent } : cachedDetail;
+  const agents = state.bootstrap.agents.map((agent) => (agent.id === agentId ? mergedAgent : agent));
+
+  return {
+    bootstrap: sortBootstrapAgents(
+      {
+        ...state.bootstrap,
+        agents,
+        metrics: buildBootstrapMetrics(agents),
+      },
+      state.rosterActivityByAgentId,
+    ),
+    sessionsByAgentId: {
+      ...state.sessionsByAgentId,
+      [agentId]: {
+        ...emptyAgentSession(),
+        ...session,
+        detail,
+      },
+    },
+  };
+}
+
 function sortBootstrapAgents(bootstrap: RuntimeBootstrap, rosterActivityByAgentId: Record<string, AgentRosterActivity>): RuntimeBootstrap {
   return {
     ...bootstrap,
@@ -1560,6 +1612,9 @@ async function catchUpAgentEvents(
   if ((page.events ?? []).some(isWorkItemCacheInvalidationEvent)) {
     void useRuntimeStore.getState().refreshAgentWorkItems(agentId);
   }
+  if ((page.events ?? []).some(isAgentStateCacheInvalidationEvent)) {
+    void useRuntimeStore.getState().refreshAgentState(agentId);
+  }
   scheduleMessageHydration(get, set, agentId, "debug");
   scheduleTranscriptHydration(get, set, agentId, "debug");
   scheduleBriefHydration(get, set, agentId, "debug");
@@ -1643,12 +1698,19 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
   if (events.some(isWorkItemCacheInvalidationEvent)) {
     void useRuntimeStore.getState().refreshAgentWorkItems(agentId);
   }
+  if (events.some(isAgentStateCacheInvalidationEvent)) {
+    void useRuntimeStore.getState().refreshAgentState(agentId);
+  }
 }
 
 function isWorkItemCacheInvalidationEvent(event: StreamEventEnvelopeDto): boolean {
   if (event.type !== "work_item_written") return false;
   const action = stringField(asRecord(event.payload), "action");
   return action === "created" || action === "completed";
+}
+
+function isAgentStateCacheInvalidationEvent(event: StreamEventEnvelopeDto): boolean {
+  return event.type === "agent_state_changed" || event.type === "state_changed" || event.type === "work_item_written";
 }
 
 function scheduleMessageHydration(

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -211,6 +211,10 @@ export interface RuntimeStoreState {
   clearAgentModel: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   startAgentEventStream: (agentId: string | undefined, displayLevel: DisplayLevel) => void;
   stopAgentEventStream: (agentId: string | undefined) => void;
+  startGlobalEventStream: () => void;
+  stopGlobalEventStream: () => void;
+  registerAgentForEvents: (agentId: string) => void;
+  unregisterAgentForEvents: (agentId: string) => void;
 }
 
 const LEGACY_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.runtimeConnection.v1";
@@ -224,6 +228,13 @@ const pendingStreamEvents = new Map<string, StreamEventEnvelopeDto[]>();
 const streamFlushTimers = new Map<string, number>();
 const reconnectTimers = new Map<string, number>();
 const staleTimers = new Map<string, number>();
+let globalEventStream: AgentEventStreamSubscription | undefined;
+let globalStreamReconnectTimer: number | undefined;
+let globalStreamStaleTimer: number | undefined;
+let globalStreamReconnectAttempt = 0;
+const globalStreamSubscribedAgents = new Set<string>();
+const agentLastSeenSeq = new Map<string, number>();
+const backfillInFlight = new Set<string>();
 const messageHydrationInFlight = new Map<string, Set<string>>();
 const transcriptHydrationInFlight = new Map<string, Set<string>>();
 const briefHydrationInFlight = new Map<string, Set<string>>();
@@ -237,6 +248,8 @@ const STREAM_FLUSH_INTERVAL_MS = 100;
 const STREAM_STALE_TIMEOUT_MS = 45_000;
 const STREAM_RECONNECT_BASE_MS = 1_000;
 const STREAM_RECONNECT_MAX_MS = 15_000;
+const GLOBAL_STREAM_STALE_TIMEOUT_MS = 45_000;
+const GLOBAL_BACKFILL_LIMIT = 100;
 
 function runtimeClientOptions(config: RuntimeConnectionConfig) {
   return config.mode === "remote" ? { mode: "remote" as const, baseUrl: config.baseUrl, token: config.token } : { mode: "local" as const };
@@ -513,6 +526,20 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     for (const subscription of activeEventStreams.values()) subscription.close();
     activeEventStreams.clear();
     pendingStreamEvents.clear();
+    globalEventStream?.close();
+    globalEventStream = undefined;
+    if (globalStreamReconnectTimer != null) {
+      window.clearTimeout(globalStreamReconnectTimer);
+      globalStreamReconnectTimer = undefined;
+    }
+    if (globalStreamStaleTimer != null) {
+      window.clearTimeout(globalStreamStaleTimer);
+      globalStreamStaleTimer = undefined;
+    }
+    globalStreamSubscribedAgents.clear();
+    agentLastSeenSeq.clear();
+    backfillInFlight.clear();
+    globalStreamReconnectAttempt = 0;
     messageHydrationInFlight.clear();
     transcriptHydrationInFlight.clear();
     briefHydrationInFlight.clear();
@@ -989,6 +1016,18 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     if (!agentId) return;
     stopAgentEventStream(agentId, set);
   },
+  startGlobalEventStream: () => {
+    startGlobalEventStream(get, set);
+  },
+  stopGlobalEventStream: () => {
+    stopGlobalEventStream(set);
+  },
+  registerAgentForEvents: (agentId) => {
+    registerAgentForEvents(get, set, agentId);
+  },
+  unregisterAgentForEvents: (agentId) => {
+    unregisterAgentForEvents(agentId);
+  },
 }));
 
 function emptyAgentSession(): AgentSessionState {
@@ -1017,6 +1056,169 @@ type StoreSet = (
     | ((state: RuntimeStoreState) => Partial<RuntimeStoreState> | RuntimeStoreState),
   replace?: false,
 ) => void;
+
+// ─── Global event stream ────────────────────────────────────────────
+
+function startGlobalEventStream(get: () => RuntimeStoreState, set: StoreSet): void {
+  if (globalEventStream) return;
+
+  const subscription = runtimeClient.streamGlobalEvents({
+    onOpen: () => {
+      globalStreamReconnectAttempt = 0;
+      scheduleGlobalStaleWatchdog(get, set);
+      // Backfill all registered agents on (re)connect.
+      for (const agentId of globalStreamSubscribedAgents) {
+        void backfillAgentEvents(set, agentId);
+      }
+    },
+    onActivity: () => {
+      scheduleGlobalStaleWatchdog(get, set);
+    },
+    onEvent: (event) => {
+      scheduleGlobalStaleWatchdog(get, set);
+      dispatchGlobalStreamEvent(set, event);
+    },
+    onClose: () => scheduleGlobalStreamReconnect(get, set, "global event stream closed"),
+    onError: (error) => scheduleGlobalStreamReconnect(get, set, error.message),
+  });
+  if (!subscription) return;
+  globalEventStream = subscription;
+}
+
+function stopGlobalEventStream(set: StoreSet): void {
+  globalEventStream?.close();
+  globalEventStream = undefined;
+  if (globalStreamReconnectTimer != null) {
+    window.clearTimeout(globalStreamReconnectTimer);
+    globalStreamReconnectTimer = undefined;
+  }
+  if (globalStreamStaleTimer != null) {
+    window.clearTimeout(globalStreamStaleTimer);
+    globalStreamStaleTimer = undefined;
+  }
+  globalStreamReconnectAttempt = 0;
+  // Flush any pending events for all agents.
+  for (const agentId of globalStreamSubscribedAgents) {
+    flushStreamEvents(set, agentId);
+  }
+}
+
+function registerAgentForEvents(get: () => RuntimeStoreState, set: StoreSet, agentId: string): void {
+  globalStreamSubscribedAgents.add(agentId);
+  // Initialize seq tracking from existing session state.
+  const session = get().sessionsByAgentId[agentId];
+  if (session) {
+    const lastSeq = highestSeq(session.eventSeqs) ?? session.newestSeq;
+    if (lastSeq != null) {
+      agentLastSeenSeq.set(agentId, lastSeq);
+    }
+  }
+  // Start global stream if not running.
+  startGlobalEventStream(get, set);
+  // Initial backfill from the last known seq.
+  void backfillAgentEvents(set, agentId);
+}
+
+function unregisterAgentForEvents(agentId: string): void {
+  globalStreamSubscribedAgents.delete(agentId);
+  agentLastSeenSeq.delete(agentId);
+}
+
+function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto): void {
+  const agentId = event.agent_id;
+  if (!agentId || !globalStreamSubscribedAgents.has(agentId)) return;
+
+  const seq = event.event_seq;
+  if (seq != null) {
+    const lastSeq = agentLastSeenSeq.get(agentId);
+    if (lastSeq != null && seq > lastSeq + 1) {
+      // Gap detected — trigger backfill.
+      void backfillAgentEvents(set, agentId);
+    }
+    agentLastSeenSeq.set(agentId, Math.max(seq, lastSeq ?? 0));
+  }
+
+  enqueueStreamEvent(set, agentId, event);
+  scheduleBootstrapRefresh(useRuntimeStore.getState);
+}
+
+async function backfillAgentEvents(set: StoreSet, agentId: string): Promise<void> {
+  if (backfillInFlight.has(agentId)) return;
+  const afterSeq = agentLastSeenSeq.get(agentId);
+  if (afterSeq == null) return; // No seq baseline yet; initial fetch handles this.
+  backfillInFlight.add(agentId);
+  try {
+    let cursor = afterSeq;
+    let hasMore = true;
+    while (hasMore) {
+      const page = await runtimeClient.getAgentEvents(agentId, {
+        afterSeq: cursor,
+        order: "asc",
+        limit: GLOBAL_BACKFILL_LIMIT,
+      });
+      const events = (page.events ?? []).filter((e) => e.event_seq != null);
+      if (!events.length) break;
+      // Convert EventEnvelopeDto to StreamEventEnvelopeDto for the reducer.
+      const streamEvents: StreamEventEnvelopeDto[] = events.map((e) => ({
+        id: e.id,
+        event_seq: e.event_seq,
+        ts: e.ts,
+        agent_id: agentId,
+        type: e.type,
+        payload: e.payload,
+      }));
+      applyStreamEvents(set, agentId, streamEvents);
+      const maxSeq = events.reduce((max, e) => Math.max(max, e.event_seq!), 0);
+      agentLastSeenSeq.set(agentId, Math.max(maxSeq, agentLastSeenSeq.get(agentId) ?? 0));
+      cursor = maxSeq;
+      hasMore = events.length >= GLOBAL_BACKFILL_LIMIT;
+    }
+  } catch {
+    // Silently ignore backfill errors; the stream will retry.
+  } finally {
+    backfillInFlight.delete(agentId);
+  }
+}
+
+function scheduleGlobalStaleWatchdog(get: () => RuntimeStoreState, set: StoreSet): void {
+  if (globalStreamStaleTimer != null) window.clearTimeout(globalStreamStaleTimer);
+  globalStreamStaleTimer = window.setTimeout(() => {
+    if (!globalEventStream) return;
+    for (const agentId of globalStreamSubscribedAgents) {
+      flushStreamEvents(set, agentId);
+    }
+    scheduleGlobalStreamReconnect(get, set, "global event stream idle timeout");
+  }, GLOBAL_STREAM_STALE_TIMEOUT_MS);
+}
+
+function scheduleGlobalStreamReconnect(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  reason: string,
+): void {
+  globalEventStream?.close();
+  globalEventStream = undefined;
+  if (globalStreamStaleTimer != null) {
+    window.clearTimeout(globalStreamStaleTimer);
+    globalStreamStaleTimer = undefined;
+  }
+  if (globalStreamReconnectTimer != null) return;
+
+  globalStreamReconnectAttempt += 1;
+  const delay = reconnectDelayMs(globalStreamReconnectAttempt);
+  for (const agentId of globalStreamSubscribedAgents) {
+    setStreamState(set, agentId, "reconnecting", {
+      reconnectAttempt: globalStreamReconnectAttempt,
+      error: reason,
+    });
+  }
+  globalStreamReconnectTimer = window.setTimeout(() => {
+    globalStreamReconnectTimer = undefined;
+    startGlobalEventStream(get, set);
+  }, delay);
+}
+
+// ─── End global event stream ────────────────────────────────────────
 
 function stopAgentEventStream(agentId: string, set?: StoreSet): void {
   if (set) flushStreamEvents(set, agentId);

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -188,6 +188,7 @@ export interface RuntimeStoreState {
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
   setRightPanelOpen: (open: boolean) => void;
   showAgentOverview: (agentId?: string) => void;
+  showWorkItemDetail: (agentId: string, workItem: WorkItemSummary) => void;
   inspectActivity: (agentId: string, activity: AgentTimelineActivity) => void;
   toggleRightPanel: () => void;
   toggleNavCollapsed: () => void;
@@ -471,6 +472,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       rightPanelOpen: true,
       rightPanelView: { kind: "agent_overview", agentId: agentId ?? state.selectedAgentId },
     })),
+  showWorkItemDetail: (agentId, workItem) =>
+    set({
+      rightPanelOpen: true,
+      rightPanelView: { kind: "work_item_detail", agentId, workItem },
+    }),
   inspectActivity: (agentId, activity) => {
     set({
       rightPanelOpen: true,

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -22,9 +22,11 @@ import type {
   CredentialProfileStatus,
   CredentialStoreState,
   RuntimeBriefRecord,
+  RuntimeTaskOutputResult,
   RuntimeMessageEnvelope,
   RuntimeModelCatalog,
   RuntimeTranscriptEntry,
+  RuntimeToolExecutionRecord,
   SearchResponse,
 } from "./types";
 
@@ -218,6 +220,7 @@ const staleTimers = new Map<string, number>();
 const messageHydrationInFlight = new Map<string, Set<string>>();
 const transcriptHydrationInFlight = new Map<string, Set<string>>();
 const briefHydrationInFlight = new Map<string, Set<string>>();
+const inspectorDetailInFlight = new Set<string>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 const STREAM_FLUSH_INTERVAL_MS = 100;
@@ -456,11 +459,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       return { displayLevel, displayLevelsByAgentId };
     }),
   setInspectorOpen: (open) => set({ inspectorOpen: open }),
-  inspectActivity: (agentId, activity) =>
+  inspectActivity: (agentId, activity) => {
     set({
       inspectorOpen: true,
       inspectorSelection: { kind: "activity", agentId, activity },
-    }),
+    });
+    hydrateInspectorActivityDetail(get, set, agentId, activity);
+  },
   clearInspectorSelection: () => set({ inspectorSelection: undefined }),
   toggleInspector: () => set((state) => ({ inspectorOpen: !state.inspectorOpen })),
   toggleNavCollapsed: () => set((state) => ({ navCollapsed: !state.navCollapsed })),
@@ -492,6 +497,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     messageHydrationInFlight.clear();
     transcriptHydrationInFlight.clear();
     briefHydrationInFlight.clear();
+    inspectorDetailInFlight.clear();
     for (const timer of streamFlushTimers.values()) window.clearTimeout(timer);
     for (const timer of reconnectTimers.values()) window.clearTimeout(timer);
     for (const timer of staleTimers.values()) window.clearTimeout(timer);
@@ -956,6 +962,89 @@ function stopAgentEventStream(agentId: string, set?: StoreSet): void {
     window.clearTimeout(staleTimer);
     staleTimers.delete(agentId);
   }
+}
+
+function hydrateInspectorActivityDetail(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  activity: AgentTimelineActivity,
+): void {
+  const refs = inspectorDetailRefs(activity);
+  if (!refs.toolExecutionId && !refs.taskId) return;
+
+  const key = `${agentId}:${activity.id}:${refs.toolExecutionId ?? ""}:${refs.taskId ?? ""}`;
+  if (inspectorDetailInFlight.has(key)) return;
+  inspectorDetailInFlight.add(key);
+  setInspectorActivityDetailState(set, agentId, activity.id, { loading: true });
+
+  void Promise.all([
+    refs.toolExecutionId ? runtimeClient.getToolExecution(agentId, refs.toolExecutionId) : Promise.resolve(undefined),
+    refs.taskId ? runtimeClient.getTaskOutput(agentId, refs.taskId) : Promise.resolve(undefined),
+  ])
+    .then(([toolExecution, taskOutput]) => {
+      setInspectorActivityDetailState(set, agentId, activity.id, {
+        loading: false,
+        toolExecution,
+        taskOutput,
+      });
+    })
+    .catch((error) => {
+      setInspectorActivityDetailState(set, agentId, activity.id, {
+        loading: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    })
+    .finally(() => {
+      inspectorDetailInFlight.delete(key);
+      const selection = get().inspectorSelection;
+      if (selection?.kind === "activity" && selection.agentId === agentId && selection.activity.id === activity.id) {
+        set({ inspectorSelection: selection });
+      }
+    });
+}
+
+function setInspectorActivityDetailState(
+  set: StoreSet,
+  agentId: string,
+  activityId: string,
+  detailState: {
+    loading?: boolean;
+    error?: string;
+    toolExecution?: RuntimeToolExecutionRecord;
+    taskOutput?: RuntimeTaskOutputResult;
+  },
+): void {
+  set((state) => {
+    const selection = state.inspectorSelection;
+    if (selection?.kind !== "activity" || selection.agentId !== agentId || selection.activity.id !== activityId) return {};
+    return {
+      inspectorSelection: {
+        ...selection,
+        detailState: {
+          ...selection.detailState,
+          ...detailState,
+        },
+      },
+    };
+  });
+}
+
+function inspectorDetailRefs(activity: AgentTimelineActivity): { toolExecutionId?: string; taskId?: string } {
+  const rawEvent = asRecord(activity.rawEvent);
+  const payload = asRecord(rawEvent?.payload) ?? asRecord(activity.rawEvent);
+  return {
+    toolExecutionId: firstStringField(payload, ["tool_execution_id", "toolExecutionId"]),
+    taskId: firstStringField(payload, ["task_id", "taskId"]),
+  };
+}
+
+function firstStringField(record: Record<string, unknown> | undefined, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = stringField(record, key);
+    if (value) return value;
+  }
+  return undefined;
 }
 
 function enqueueStreamEvent(set: StoreSet, agentId: string, event: StreamEventEnvelopeDto): void {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -538,6 +538,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   runtimeConfigSaving: false,
   search: null,
   searchLoading: false,
+  credentialStore: { profiles: [] },
+  credentialStoreLoading: false,
+  credentialStoreError: undefined,
   rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig)),
   sessionsByAgentId: {},
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -704,6 +704,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
             bootstrapError: bootstrap.connection.error,
           };
         });
+        syncGlobalEventRoster(get, set);
       } catch (error) {
         set({
           bootstrapLoading: false,
@@ -1220,10 +1221,11 @@ function stopGlobalEventStream(set: StoreSet): void {
 }
 
 function registerAgentForEvents(get: () => RuntimeStoreState, set: StoreSet, agentId: string): void {
+  const wasSubscribed = globalStreamSubscribedAgents.has(agentId);
   globalStreamSubscribedAgents.add(agentId);
   // Initialize seq tracking from existing session state.
-  const session = get().sessionsByAgentId[agentId];
-  if (session) {
+  const session = wasSubscribed ? undefined : get().sessionsByAgentId[agentId];
+  if (session && !agentLastSeenSeq.has(agentId)) {
     const lastSeq = highestSeq(session.eventSeqs) ?? session.newestSeq;
     if (lastSeq != null) {
       agentLastSeenSeq.set(agentId, lastSeq);
@@ -1232,12 +1234,22 @@ function registerAgentForEvents(get: () => RuntimeStoreState, set: StoreSet, age
   // Start global stream if not running.
   startGlobalEventStream(get, set);
   // Initial backfill from the last known seq.
-  void backfillAgentEvents(set, agentId);
+  if (!wasSubscribed) void backfillAgentEvents(set, agentId);
 }
 
 function unregisterAgentForEvents(agentId: string): void {
   globalStreamSubscribedAgents.delete(agentId);
   agentLastSeenSeq.delete(agentId);
+}
+
+function syncGlobalEventRoster(get: () => RuntimeStoreState, set: StoreSet): void {
+  const agentIds = new Set(get().bootstrap.agents.map((agent) => agent.id));
+  for (const agentId of Array.from(globalStreamSubscribedAgents)) {
+    if (!agentIds.has(agentId)) unregisterAgentForEvents(agentId);
+  }
+  for (const agentId of agentIds) {
+    registerAgentForEvents(get, set, agentId);
+  }
 }
 
 function dispatchGlobalStreamEvent(set: StoreSet, event: StreamEventEnvelopeDto): void {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -219,7 +219,7 @@ const STREAM_RECONNECT_BASE_MS = 1_000;
 const STREAM_RECONNECT_MAX_MS = 15_000;
 
 function runtimeClientOptions(config: RuntimeConnectionConfig) {
-  return config.mode === "remote" ? { baseUrl: config.baseUrl, token: config.token } : {};
+  return config.mode === "remote" ? { mode: "remote" as const, baseUrl: config.baseUrl, token: config.token } : { mode: "local" as const };
 }
 
 function readStoredRuntimeConnectionConfig(): RuntimeConnectionConfig {
@@ -305,6 +305,7 @@ function pendingBootstrap(config: RuntimeConnectionConfig): RuntimeBootstrap {
       mode: config.mode,
       source: "fixture",
       baseUrl: config.mode === "remote" ? config.baseUrl : undefined,
+      hasToken: config.mode === "remote" ? Boolean(config.token?.trim()) : false,
       summary: config.mode === "remote" ? "Connecting to remote runtime…" : "Connecting to local runtime…",
     },
   };
@@ -369,12 +370,20 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   toggleNavCollapsed: () => set((state) => ({ navCollapsed: !state.navCollapsed })),
 
   setRuntimeConnection: async (config) => {
+    const normalizedBaseUrl = config.mode === "remote" ? normalizeConnectionBaseUrl(config.baseUrl) : "";
+    const retainedToken =
+      config.mode === "remote" &&
+      config.token === undefined &&
+      runtimeConnectionConfig.mode === "remote" &&
+      normalizeConnectionBaseUrl(runtimeConnectionConfig.baseUrl) === normalizedBaseUrl
+        ? runtimeConnectionConfig.token
+        : undefined;
     const normalizedConfig: RuntimeConnectionConfig =
       config.mode === "remote"
         ? {
             mode: "remote",
-            baseUrl: normalizeConnectionBaseUrl(config.baseUrl),
-            token: config.token?.trim() || undefined,
+            baseUrl: normalizedBaseUrl,
+            token: config.token?.trim() || retainedToken,
           }
         : { mode: "local" };
     runtimeConnectionConfig = normalizedConfig;

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -14,7 +14,7 @@ import type {
   AgentTimelineActivity,
   AgentTimelineItem,
   DisplayLevel,
-  InspectorSelection,
+  RightPanelView,
   RouteKey,
   RuntimeBootstrap,
   RuntimeConnectionConfig,
@@ -157,8 +157,8 @@ export interface RuntimeStoreState {
   selectedAgentId: string;
   displayLevel: DisplayLevel;
   displayLevelsByAgentId: Record<string, DisplayLevel>;
-  inspectorOpen: boolean;
-  inspectorSelection?: InspectorSelection;
+  rightPanelOpen: boolean;
+  rightPanelView?: RightPanelView;
   navCollapsed: boolean;
 
   bootstrap: RuntimeBootstrap;
@@ -183,10 +183,10 @@ export interface RuntimeStoreState {
   setRoute: (route: RouteKey) => void;
   openAgent: (agentId: string) => void;
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
-  setInspectorOpen: (open: boolean) => void;
+  setRightPanelOpen: (open: boolean) => void;
+  showAgentOverview: (agentId?: string) => void;
   inspectActivity: (agentId: string, activity: AgentTimelineActivity) => void;
-  clearInspectorSelection: () => void;
-  toggleInspector: () => void;
+  toggleRightPanel: () => void;
   toggleNavCollapsed: () => void;
   setRuntimeConnection: (config: RuntimeConnectionConfig) => Promise<void>;
   refreshBootstrap: (options?: BootstrapRefreshOptions) => Promise<void>;
@@ -424,8 +424,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   selectedAgentId: "",
   displayLevel: "info",
   displayLevelsByAgentId: readStoredDisplayLevels(),
-  inspectorOpen: true,
-  inspectorSelection: undefined,
+  rightPanelOpen: true,
+  rightPanelView: undefined,
   navCollapsed: false,
 
   bootstrap: pendingBootstrap(runtimeConnectionConfig),
@@ -458,16 +458,20 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       writeStoredDisplayLevels(displayLevelsByAgentId);
       return { displayLevel, displayLevelsByAgentId };
     }),
-  setInspectorOpen: (open) => set({ inspectorOpen: open }),
+  setRightPanelOpen: (open) => set({ rightPanelOpen: open }),
+  showAgentOverview: (agentId) =>
+    set((state) => ({
+      rightPanelOpen: true,
+      rightPanelView: { kind: "agent_overview", agentId: agentId ?? state.selectedAgentId },
+    })),
   inspectActivity: (agentId, activity) => {
     set({
-      inspectorOpen: true,
-      inspectorSelection: { kind: "activity", agentId, activity },
+      rightPanelOpen: true,
+      rightPanelView: { kind: "activity_inspector", agentId, activity },
     });
     hydrateInspectorActivityDetail(get, set, agentId, activity);
   },
-  clearInspectorSelection: () => set({ inspectorSelection: undefined }),
-  toggleInspector: () => set((state) => ({ inspectorOpen: !state.inspectorOpen })),
+  toggleRightPanel: () => set((state) => ({ rightPanelOpen: !state.rightPanelOpen })),
   toggleNavCollapsed: () => set((state) => ({ navCollapsed: !state.navCollapsed })),
 
   setRuntimeConnection: async (config) => {
@@ -997,9 +1001,9 @@ function hydrateInspectorActivityDetail(
     })
     .finally(() => {
       inspectorDetailInFlight.delete(key);
-      const selection = get().inspectorSelection;
-      if (selection?.kind === "activity" && selection.agentId === agentId && selection.activity.id === activity.id) {
-        set({ inspectorSelection: selection });
+      const selection = get().rightPanelView;
+      if (selection?.kind === "activity_inspector" && selection.agentId === agentId && selection.activity.id === activity.id) {
+        set({ rightPanelView: selection });
       }
     });
 }
@@ -1016,10 +1020,10 @@ function setInspectorActivityDetailState(
   },
 ): void {
   set((state) => {
-    const selection = state.inspectorSelection;
-    if (selection?.kind !== "activity" || selection.agentId !== agentId || selection.activity.id !== activityId) return {};
+    const selection = state.rightPanelView;
+    if (selection?.kind !== "activity_inspector" || selection.agentId !== agentId || selection.activity.id !== activityId) return {};
     return {
-      inspectorSelection: {
+      rightPanelView: {
         ...selection,
         detailState: {
           ...selection.detailState,

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -1,6 +1,14 @@
 import { create } from "zustand";
 
 import { createRuntimeClient, type AgentEventStreamSubscription, type StreamEventEnvelopeDto } from "./client";
+import { cacheClearRemote } from "./idb-cache";
+import {
+  currentRemoteKey,
+  hydrateAllSessions,
+  initSessionCache,
+  SessionCacheWriter,
+} from "./session-cache";
+import type { AgentSessionState as AgentSessionStateBase } from "./runtime-store-helpers";
 import {
   compactAgentTimelineItems,
   mergeAgentTimelineItems,
@@ -28,11 +36,11 @@ import type {
   RuntimeTranscriptEntry,
   RuntimeToolExecutionRecord,
   WorkItemSummary,
-  WorkItemDetailState,
   SearchResponse,
 } from "./types";
 
-export type AgentLiveStatus = "idle" | "connecting" | "streaming" | "reconnecting" | "recovering" | "stale" | "error";
+export type { AgentLiveStatus, AgentSessionState } from "./runtime-store-helpers";
+import type { AgentLiveStatus, AgentSessionState, WorkItemDetailState } from "./runtime-store-helpers";
 
 export interface BootstrapRefreshOptions {
   background?: boolean;
@@ -84,32 +92,6 @@ function cachedAgentsByIdFromState(state: RuntimeStoreState): Record<string, Age
     agentsById[agent.id] = agentsById[agent.id] ? mergeCachedAgentState(agentsById[agent.id], agent) : agent;
   }
   return agentsById;
-}
-
-export interface AgentSessionState {
-  loading: boolean;
-  loadingOlder: boolean;
-  liveStatus: AgentLiveStatus;
-  sendingPrompt: boolean;
-  detail: AgentDetail | null;
-  eventsBySeq: Record<number, unknown>;
-  eventSeqs: number[];
-  messagesById: Record<string, RuntimeMessageEnvelope>;
-  missingMessageIds: Record<string, true>;
-  transcriptEntriesById: Record<string, RuntimeTranscriptEntry>;
-  missingTranscriptEntryIds: Record<string, true>;
-  briefRecordsById: Record<string, RuntimeBriefRecord>;
-  missingBriefIds: Record<string, true>;
-  newestSeq?: number;
-  oldestSeq?: number;
-  hasOlder?: boolean;
-  lastStreamActivityAt?: string;
-  reconnectAttempt?: number;
-  error?: string;
-  historyError?: string;
-  promptError?: string;
-  modelError?: string;
-  workItemDetailsById: Record<string, WorkItemDetailState>;
 }
 
 interface AgentRosterActivity {
@@ -250,6 +232,10 @@ const STREAM_RECONNECT_BASE_MS = 1_000;
 const STREAM_RECONNECT_MAX_MS = 15_000;
 const GLOBAL_STREAM_STALE_TIMEOUT_MS = 45_000;
 const GLOBAL_BACKFILL_LIMIT = 100;
+
+// ─── Session cache (IndexedDB persistence) ──────────────────────────
+let sessionCacheWriter: SessionCacheWriter | null = null;
+let sessionCacheInitPromise: Promise<void> | null = null;
 
 function runtimeClientOptions(config: RuntimeConnectionConfig) {
   return config.mode === "remote" ? { mode: "remote" as const, baseUrl: config.baseUrl, token: config.token } : { mode: "local" as const };
@@ -442,6 +428,42 @@ const emptyRuntimeConfig: RuntimeConfigState = {
   source: "fixture",
 };
 
+/**
+ * Initialize session cache for the current remote and hydrate any cached
+ * sessions into the store. Called on initial load and remote switch.
+ */
+function initSessionCacheForRemote(set: StoreSet): void {
+  if (sessionCacheInitPromise) return;
+  const remoteKey = currentRemoteKey(runtimeConnectionConfig);
+
+  sessionCacheInitPromise = (async () => {
+    const ok = await initSessionCache();
+    if (!ok) {
+      sessionCacheWriter = null;
+      return;
+    }
+
+    // Set up writer for this remote.
+    sessionCacheWriter?.cancel();
+    sessionCacheWriter = new SessionCacheWriter(remoteKey);
+
+    // Hydrate cached sessions into store.
+    const cached = await hydrateAllSessions(remoteKey);
+    if (Object.keys(cached).length === 0) return;
+
+    set((state) => {
+      const sessionsByAgentId = { ...state.sessionsByAgentId };
+      for (const [agentId, partial] of Object.entries(cached)) {
+        sessionsByAgentId[agentId] = {
+          ...emptyAgentSession(),
+          ...partial,
+        };
+      }
+      return { sessionsByAgentId };
+    });
+  })();
+}
+
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   route: "dashboard",
   selectedAgentId: "",
@@ -550,6 +572,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     streamFlushTimers.clear();
     reconnectTimers.clear();
     staleTimers.clear();
+    // Flush pending cache writes for the old remote before switching.
+    sessionCacheWriter?.flush();
+    sessionCacheWriter = null;
+    sessionCacheInitPromise = null;
     set({
       bootstrap: pendingBootstrap(normalizedConfig),
       bootstrapLoading: true,
@@ -568,6 +594,8 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       route: "dashboard",
     });
     await get().refreshBootstrap();
+    // Initialize cache for the new remote (async, non-blocking).
+    initSessionCacheForRemote(set);
   },
 
   refreshBootstrap: async (options = {}) => {
@@ -741,6 +769,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
+      scheduleCacheWrite(get, agentId);
     } catch (error) {
       set((state) => ({
         sessionsByAgentId: {
@@ -1030,6 +1059,11 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 }));
 
+// Initialize session cache on first load.
+if (typeof window !== "undefined") {
+  initSessionCacheForRemote((partial) => useRuntimeStore.setState(partial));
+}
+
 function emptyAgentSession(): AgentSessionState {
   return {
     loading: false,
@@ -1056,6 +1090,17 @@ type StoreSet = (
     | ((state: RuntimeStoreState) => Partial<RuntimeStoreState> | RuntimeStoreState),
   replace?: false,
 ) => void;
+
+/**
+ * Schedule a debounced cache write for the given agent's session.
+ * Best-effort: silently skips if the cache writer isn't initialized.
+ */
+function scheduleCacheWrite(get: () => RuntimeStoreState, agentId: string): void {
+  if (!sessionCacheWriter) return;
+  const session = get().sessionsByAgentId[agentId];
+  if (!session) return;
+  sessionCacheWriter.scheduleWrite(agentId, session);
+}
 
 // ─── Global event stream ────────────────────────────────────────────
 
@@ -1897,6 +1942,7 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
   scheduleMessageHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
   scheduleTranscriptHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
   scheduleBriefHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
+  scheduleCacheWrite(useRuntimeStore.getState, agentId);
   if (events.some(isWorkItemCacheInvalidationEvent)) {
     void useRuntimeStore.getState().refreshAgentWorkItems(agentId);
   }

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -5,6 +5,7 @@ import {
   compactAgentTimelineItems,
   mergeAgentTimelineItems,
   reduceAgentSessionTimeline,
+  briefIdForPayload,
   transcriptEntryIdForPayload,
 } from "./session-reducer";
 import type {
@@ -20,6 +21,7 @@ import type {
   RuntimeConfigState,
   CredentialProfileStatus,
   CredentialStoreState,
+  RuntimeBriefRecord,
   RuntimeMessageEnvelope,
   RuntimeModelCatalog,
   RuntimeTranscriptEntry,
@@ -92,6 +94,8 @@ export interface AgentSessionState {
   missingMessageIds: Record<string, true>;
   transcriptEntriesById: Record<string, RuntimeTranscriptEntry>;
   missingTranscriptEntryIds: Record<string, true>;
+  briefRecordsById: Record<string, RuntimeBriefRecord>;
+  missingBriefIds: Record<string, true>;
   newestSeq?: number;
   oldestSeq?: number;
   hasOlder?: boolean;
@@ -211,6 +215,7 @@ const reconnectTimers = new Map<string, number>();
 const staleTimers = new Map<string, number>();
 const messageHydrationInFlight = new Map<string, Set<string>>();
 const transcriptHydrationInFlight = new Map<string, Set<string>>();
+const briefHydrationInFlight = new Map<string, Set<string>>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 const STREAM_FLUSH_INTERVAL_MS = 100;
@@ -395,6 +400,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     pendingStreamEvents.clear();
     messageHydrationInFlight.clear();
     transcriptHydrationInFlight.clear();
+    briefHydrationInFlight.clear();
     for (const timer of streamFlushTimers.values()) window.clearTimeout(timer);
     for (const timer of reconnectTimers.values()) window.clearTimeout(timer);
     for (const timer of staleTimers.values()) window.clearTimeout(timer);
@@ -591,6 +597,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
+      scheduleBriefHydration(get, set, agentId, displayLevel);
     } catch (error) {
       set((state) => ({
         sessionsByAgentId: {
@@ -635,6 +642,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       set((state) => mergeEventPageIntoSession(state, agentId, page.events ?? [], page.oldest_seq, page.has_older, displayLevel));
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
+      scheduleBriefHydration(get, set, agentId, displayLevel);
     } catch (error) {
       set((state) => ({
         sessionsByAgentId: {
@@ -825,6 +833,8 @@ function emptyAgentSession(): AgentSessionState {
     missingMessageIds: {},
     transcriptEntriesById: {},
     missingTranscriptEntryIds: {},
+    briefRecordsById: {},
+    missingBriefIds: {},
   };
 }
 
@@ -1172,6 +1182,10 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
     ...current.eventsBySeq,
     ...eventsBySeqFromPage(pageEvents),
   };
+  const briefRecordsById = {
+    ...current.briefRecordsById,
+    ...(detail.briefRecordsById ?? {}),
+  };
   const eventSeqs = Array.from(new Set([...current.eventSeqs, ...eventSeqsFromPage(pageEvents)])).sort((left, right) => left - right);
   const events = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
   const pageTimeline = reduceAgentSessionTimeline({
@@ -1179,6 +1193,7 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
     eventDisplayLevel: "debug",
     messagesById: current.messagesById,
     transcriptEntriesById: current.transcriptEntriesById,
+    briefRecordsById,
   });
   const liveDetailIsNewer = (current.newestSeq ?? 0) > Math.max(detail.eventCursorSeq ?? 0, detail.newestEventSeq ?? 0);
   const agent = liveDetailIsNewer && current.detail ? mergeCachedAgentState(detail.agent, current.detail.agent) : detail.agent;
@@ -1208,6 +1223,7 @@ function mergeAgentDetailIntoSession(state: RuntimeStoreState, agentId: string, 
         liveStatus: detail.error ? "error" : current.liveStatus,
         eventsBySeq,
         eventSeqs,
+        briefRecordsById,
         newestSeq: newestSeq || undefined,
         oldestSeq: detail.oldestEventSeq ?? current.oldestSeq ?? eventSeqs[0],
         hasOlder: detail.hasOlderEvents,
@@ -1237,6 +1253,7 @@ async function catchUpAgentEvents(
   );
   scheduleMessageHydration(get, set, agentId, "debug");
   scheduleTranscriptHydration(get, set, agentId, "debug");
+  scheduleBriefHydration(get, set, agentId, "debug");
 }
 
 function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEnvelopeDto[]): void {
@@ -1272,12 +1289,13 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
       eventDisplayLevel: "debug",
       messagesById: current.messagesById,
       transcriptEntriesById: current.transcriptEntriesById,
+      briefRecordsById: current.briefRecordsById,
     });
     const detailEvents = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
     const baseDetail = current.detail ?? createLiveAgentDetail(state.bootstrap.agents.find((agent) => agent.id === agentId));
     const highestIncomingSeq = highestSeq(eventSeqs) ?? 0;
     const runPatch = agentRunPatchFromEvents(uniqueEvents);
-    const briefPatch = agentBriefPatchFromEvents(uniqueEvents);
+    const briefPatch = agentBriefPatchFromEvents(uniqueEvents, current.transcriptEntriesById, current.briefRecordsById);
     const patchedBaseDetail = patchAgentDetail(baseDetail, runPatch, briefPatch);
     const detail = patchedBaseDetail
       ? {
@@ -1312,6 +1330,7 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
   });
   scheduleMessageHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
   scheduleTranscriptHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
+  scheduleBriefHydration(useRuntimeStore.getState, set, agentId, useRuntimeStore.getState().displayLevel);
 }
 
 function scheduleMessageHydration(
@@ -1408,20 +1427,67 @@ function scheduleTranscriptHydration(
     });
 }
 
+function scheduleBriefHydration(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  displayLevel: DisplayLevel,
+): void {
+  const session = get().sessionsByAgentId[agentId];
+  const briefIds = missingBriefIdsForHydration(session);
+  if (!briefIds.length) return;
+
+  let inFlight = briefHydrationInFlight.get(agentId);
+  if (!inFlight) {
+    inFlight = new Set<string>();
+    briefHydrationInFlight.set(agentId, inFlight);
+  }
+  const requestIds = briefIds.filter((briefId) => !inFlight.has(briefId));
+  if (!requestIds.length) return;
+  requestIds.forEach((briefId) => inFlight.add(briefId));
+
+  void runtimeClient
+    .getAgentBriefsById(agentId, requestIds)
+    .then((recordsById) => {
+      set((state) => mergeHydratedBriefRecordsIntoSession(state, agentId, recordsById, requestIds, displayLevel));
+    })
+    .catch((error) => {
+      set((state) => ({
+        sessionsByAgentId: {
+          ...state.sessionsByAgentId,
+          [agentId]: {
+            ...(state.sessionsByAgentId[agentId] ?? emptyAgentSession()),
+            historyError: error instanceof Error ? error.message : String(error),
+          },
+        },
+      }));
+    })
+    .finally(() => {
+      const current = briefHydrationInFlight.get(agentId);
+      if (!current) return;
+      requestIds.forEach((briefId) => current.delete(briefId));
+      if (!current.size) briefHydrationInFlight.delete(agentId);
+    });
+}
+
 function agentBriefPatchFromEvents(
   events: StreamEventEnvelopeDto[],
   transcriptEntriesById: Record<string, RuntimeTranscriptEntry> = {},
+  briefRecordsById: Record<string, RuntimeBriefRecord> = {},
 ): Pick<AgentSummary, "lastBrief" | "lastTurnTime"> | undefined {
   let patch: Pick<AgentSummary, "lastBrief" | "lastTurnTime"> | undefined;
   for (const event of events) {
     if (event.type !== "brief_created") continue;
     const payload = asRecord(event.payload);
     const entryId = transcriptEntryIdForPayload(payload);
+    const briefId = briefIdForPayload(payload);
     const text = (entryId ? transcriptEntryText(transcriptEntriesById[entryId]) : undefined) ?? stringField(payload, "text");
-    if (!text) continue;
+    const fallbackText = briefId ? briefRecordsById[briefId]?.text : undefined;
+    const resolvedText = text ?? fallbackText;
+    if (!resolvedText) continue;
     const createdAt = stringField(payload, "created_at") ?? event.ts;
     patch = {
-      lastBrief: text,
+      lastBrief: resolvedText,
       lastTurnTime: formatTime(createdAt),
     };
   }
@@ -1465,6 +1531,27 @@ function missingTranscriptEntryIdsForHydration(session: AgentSessionState | unde
   return missing;
 }
 
+function missingBriefIdsForHydration(session: AgentSessionState | undefined): string[] {
+  if (!session) return [];
+  const seen = new Set<string>();
+  const missing: string[] = [];
+  for (const eventSeq of session.eventSeqs) {
+    const event = session.eventsBySeq[eventSeq];
+    if (!isStreamEventEnvelope(event) || event.type !== "brief_created") continue;
+    const payload = asRecord(event.payload);
+    const briefId = briefIdForPayload(payload);
+    if (!briefId || seen.has(briefId) || session.briefRecordsById[briefId] || session.missingBriefIds[briefId]) {
+      continue;
+    }
+    const entryId = transcriptEntryIdForPayload(payload);
+    const hydratedByTranscript = entryId ? transcriptEntryText(session.transcriptEntriesById[entryId]) : undefined;
+    if (hydratedByTranscript || stringField(payload, "text")) continue;
+    seen.add(briefId);
+    missing.push(briefId);
+  }
+  return missing;
+}
+
 function mergeHydratedMessagesIntoSession(
   state: RuntimeStoreState,
   agentId: string,
@@ -1496,6 +1583,7 @@ function mergeHydratedMessagesIntoSession(
     eventDisplayLevel: displayLevel,
     messagesById,
     transcriptEntriesById: current.transcriptEntriesById,
+    briefRecordsById: current.briefRecordsById,
   });
   const detail = current.detail
     ? {
@@ -1548,8 +1636,9 @@ function mergeHydratedTranscriptEntriesIntoSession(
     eventDisplayLevel: displayLevel,
     messagesById: current.messagesById,
     transcriptEntriesById,
+    briefRecordsById: current.briefRecordsById,
   });
-  const briefPatch = agentBriefPatchFromEvents(events, transcriptEntriesById);
+  const briefPatch = agentBriefPatchFromEvents(events, transcriptEntriesById, current.briefRecordsById);
   const detail = current.detail
     ? patchAgentDetail(
         {
@@ -1570,6 +1659,65 @@ function mergeHydratedTranscriptEntriesIntoSession(
         detail,
         transcriptEntriesById,
         missingTranscriptEntryIds: missingById,
+      },
+    },
+  };
+}
+
+function mergeHydratedBriefRecordsIntoSession(
+  state: RuntimeStoreState,
+  agentId: string,
+  recordsById: Record<string, RuntimeBriefRecord>,
+  requestedBriefIds: string[],
+  displayLevel: DisplayLevel,
+): Partial<RuntimeStoreState> {
+  const current = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
+  const briefRecordsById = { ...current.briefRecordsById };
+  let changed = false;
+  for (const [briefId, record] of Object.entries(recordsById)) {
+    if (!briefId || !record?.text) continue;
+    briefRecordsById[briefId] = record;
+    changed = true;
+  }
+
+  const missingById = { ...current.missingBriefIds };
+  for (const briefId of requestedBriefIds) {
+    if (!briefId || recordsById[briefId]) continue;
+    missingById[briefId] = true;
+    changed = true;
+  }
+  if (!changed) return {};
+
+  const events = current.eventSeqs.map((eventSeq) => current.eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
+  const timeline = reduceAgentSessionTimeline({
+    events: { events },
+    eventDisplayLevel: displayLevel,
+    messagesById: current.messagesById,
+    transcriptEntriesById: current.transcriptEntriesById,
+    briefRecordsById,
+  });
+  const briefPatch = agentBriefPatchFromEvents(events, current.transcriptEntriesById, briefRecordsById);
+  const detail = current.detail
+    ? patchAgentDetail(
+        {
+          ...current.detail,
+          timeline,
+          briefRecordsById,
+        },
+        undefined,
+        briefPatch,
+      )
+    : current.detail;
+
+  return {
+    bootstrap: patchBootstrapAgent(state.bootstrap, agentId, undefined, briefPatch),
+    sessionsByAgentId: {
+      ...state.sessionsByAgentId,
+      [agentId]: {
+        ...current,
+        detail,
+        briefRecordsById,
+        missingBriefIds: missingById,
       },
     },
   };
@@ -1654,6 +1802,7 @@ function mergeEventPageIntoSession(
     eventDisplayLevel: displayLevel,
     messagesById: current.messagesById,
     transcriptEntriesById: current.transcriptEntriesById,
+    briefRecordsById: current.briefRecordsById,
   });
   const events = eventSeqs.map((eventSeq) => eventsBySeq[eventSeq]).filter(isStreamEventEnvelope);
   const detail = current.detail

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -204,7 +204,9 @@ export interface RuntimeStoreState {
   stopAgentEventStream: (agentId: string | undefined) => void;
 }
 
-const RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.runtimeConnection.v1";
+const LEGACY_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.runtimeConnection.v1";
+const ACTIVE_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.activeRuntimeConnection.v1";
+const RUNTIME_CONNECTION_PROFILES_STORAGE_KEY = "holon.webGui.runtimeConnectionProfiles.v1";
 const DISPLAY_LEVEL_STORAGE_KEY = "holon.webGui.displayLevelsByAgentId.v1";
 let runtimeConnectionConfig = readStoredRuntimeConnectionConfig();
 let runtimeClient = createRuntimeClient(runtimeClientOptions(runtimeConnectionConfig));
@@ -227,31 +229,107 @@ function runtimeClientOptions(config: RuntimeConnectionConfig) {
   return config.mode === "remote" ? { mode: "remote" as const, baseUrl: config.baseUrl, token: config.token } : { mode: "local" as const };
 }
 
-function readStoredRuntimeConnectionConfig(): RuntimeConnectionConfig {
+export function readStoredRuntimeConnectionConfig(): RuntimeConnectionConfig {
   if (typeof window === "undefined") return { mode: "local" };
+  const activeConfig = coerceRuntimeConnectionConfig(readStoredJson(window.sessionStorage, ACTIVE_RUNTIME_CONNECTION_STORAGE_KEY));
+  if (activeConfig) return withStoredRemoteProfileToken(activeConfig);
+
+  const legacyConfig = coerceRuntimeConnectionConfig(readStoredJson(window.localStorage, LEGACY_RUNTIME_CONNECTION_STORAGE_KEY));
+  if (legacyConfig?.mode === "remote") {
+    writeStoredRuntimeConnectionConfig(legacyConfig);
+    removeStoredItem(window.localStorage, LEGACY_RUNTIME_CONNECTION_STORAGE_KEY);
+    return withStoredRemoteProfileToken(legacyConfig);
+  }
+
+  if (legacyConfig?.mode === "local") {
+    writeActiveRuntimeConnectionConfig(legacyConfig);
+    removeStoredItem(window.localStorage, LEGACY_RUNTIME_CONNECTION_STORAGE_KEY);
+  }
+
+  return { mode: "local" };
+}
+
+export function writeStoredRuntimeConnectionConfig(config: RuntimeConnectionConfig): void {
   try {
-    const raw = window.localStorage.getItem(RUNTIME_CONNECTION_STORAGE_KEY);
-    if (!raw) return { mode: "local" };
-    const parsed = JSON.parse(raw) as Partial<RuntimeConnectionConfig>;
-    if (parsed.mode !== "remote") return { mode: "local" };
-    return {
-      mode: "remote",
-      baseUrl: typeof parsed.baseUrl === "string" ? parsed.baseUrl : "",
-      token: typeof parsed.token === "string" ? parsed.token : "",
-    };
+    removeStoredItem(window.localStorage, LEGACY_RUNTIME_CONNECTION_STORAGE_KEY);
+    writeActiveRuntimeConnectionConfig(config);
+    if (config.mode === "remote") writeStoredRemoteProfile(config);
   } catch {
-    return { mode: "local" };
+    // Ignore storage failures; the in-memory connection still applies.
   }
 }
 
-function writeStoredRuntimeConnectionConfig(config: RuntimeConnectionConfig): void {
-  if (typeof window === "undefined") return;
+function coerceRuntimeConnectionConfig(value: unknown): RuntimeConnectionConfig | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const parsed = value as Partial<RuntimeConnectionConfig>;
+  if (parsed.mode === "local") return { mode: "local" };
+  if (parsed.mode !== "remote") return undefined;
+  const baseUrl = normalizeConnectionBaseUrl(parsed.baseUrl);
+  if (!baseUrl) return undefined;
+  return {
+    mode: "remote",
+    baseUrl,
+    token: typeof parsed.token === "string" && parsed.token.trim() ? parsed.token.trim() : undefined,
+  };
+}
+
+function readStoredJson(storage: Storage, key: string): unknown {
   try {
-    if (config.mode === "local") {
-      window.localStorage.removeItem(RUNTIME_CONNECTION_STORAGE_KEY);
-      return;
+    const raw = storage.getItem(key);
+    return raw ? JSON.parse(raw) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function removeStoredItem(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Ignore storage failures; the in-memory connection still applies.
+  }
+}
+
+function writeActiveRuntimeConnectionConfig(config: RuntimeConnectionConfig): void {
+  if (typeof window === "undefined") return;
+  const activeConfig = coerceRuntimeConnectionConfig(config) ?? { mode: "local" };
+  try {
+    window.sessionStorage.setItem(ACTIVE_RUNTIME_CONNECTION_STORAGE_KEY, JSON.stringify(activeConfig));
+  } catch {
+    // Ignore storage failures; the in-memory connection still applies.
+  }
+}
+
+function readStoredRemoteProfiles(): Record<string, RuntimeConnectionConfig> {
+  if (typeof window === "undefined") return {};
+  const parsed = readStoredJson(window.localStorage, RUNTIME_CONNECTION_PROFILES_STORAGE_KEY);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const profiles: Record<string, RuntimeConnectionConfig> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    const profile = coerceRuntimeConnectionConfig(value);
+    const profileBaseUrl = profile?.baseUrl;
+    if (profile?.mode === "remote" && profileBaseUrl && key === remoteProfileKey(profileBaseUrl)) {
+      profiles[key] = profile;
     }
-    window.localStorage.setItem(RUNTIME_CONNECTION_STORAGE_KEY, JSON.stringify(config));
+  }
+  return profiles;
+}
+
+function writeStoredRemoteProfile(config: RuntimeConnectionConfig): void {
+  if (typeof window === "undefined" || config.mode !== "remote") return;
+  const profile = coerceRuntimeConnectionConfig(config);
+  if (profile?.mode !== "remote") return;
+  const profileBaseUrl = profile.baseUrl;
+  if (!profileBaseUrl) return;
+  const profiles = readStoredRemoteProfiles();
+  const key = remoteProfileKey(profileBaseUrl);
+  const existingProfile = profiles[key];
+  profiles[key] = {
+    ...profile,
+    token: profile.token ?? (existingProfile?.mode === "remote" ? existingProfile.token : undefined),
+  };
+  try {
+    window.localStorage.setItem(RUNTIME_CONNECTION_PROFILES_STORAGE_KEY, JSON.stringify(profiles));
   } catch {
     // Ignore storage failures; the in-memory connection still applies.
   }
@@ -259,6 +337,19 @@ function writeStoredRuntimeConnectionConfig(config: RuntimeConnectionConfig): vo
 
 function normalizeConnectionBaseUrl(value: string | undefined): string {
   return value?.trim().replace(/\/+$/, "") ?? "";
+}
+
+function remoteProfileKey(baseUrl: string): string {
+  return normalizeConnectionBaseUrl(baseUrl);
+}
+
+function withStoredRemoteProfileToken(config: RuntimeConnectionConfig): RuntimeConnectionConfig {
+  if (config.mode !== "remote" || config.token) return config;
+  const baseUrl = config.baseUrl;
+  if (!baseUrl) return config;
+  const profile = readStoredRemoteProfiles()[remoteProfileKey(baseUrl)];
+  if (profile?.mode !== "remote" || !profile.token) return config;
+  return { ...config, token: profile.token };
 }
 
 function readStoredDisplayLevels(): Record<string, DisplayLevel> {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -28,6 +28,7 @@ import type {
   RuntimeTranscriptEntry,
   RuntimeToolExecutionRecord,
   WorkItemSummary,
+  WorkItemDetailState,
   SearchResponse,
 } from "./types";
 
@@ -108,6 +109,7 @@ export interface AgentSessionState {
   historyError?: string;
   promptError?: string;
   modelError?: string;
+  workItemDetailsById: Record<string, WorkItemDetailState>;
 }
 
 interface AgentRosterActivity {
@@ -200,6 +202,7 @@ export interface RuntimeStoreState {
   runSearch: (query: string, options?: { agentIds?: string[]; limit?: number }) => Promise<void>;
   refreshAgentDetail: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   refreshAgentWorkItems: (agentId: string | undefined) => Promise<void>;
+  loadAgentWorkItemDetail: (agentId: string | undefined, workItemId: string | undefined) => Promise<void>;
   loadOlderAgentEvents: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
   sendOperatorPrompt: (agentId: string | undefined, text: string, displayLevel: DisplayLevel) => Promise<void>;
   setAgentModel: (agentId: string | undefined, model: string, displayLevel: DisplayLevel, reasoningEffort?: string) => Promise<void>;
@@ -224,6 +227,7 @@ const transcriptHydrationInFlight = new Map<string, Set<string>>();
 const briefHydrationInFlight = new Map<string, Set<string>>();
 const inspectorDetailInFlight = new Set<string>();
 const workItemRefreshInFlight = new Set<string>();
+const workItemDetailInFlight = new Set<string>();
 let bootstrapRefreshInFlight: Promise<void> | undefined;
 let bootstrapRefreshTimer: number | undefined;
 const STREAM_FLUSH_INTERVAL_MS = 100;
@@ -740,6 +744,26 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     }
   },
 
+  loadAgentWorkItemDetail: async (agentId, workItemId) => {
+    if (!agentId || !workItemId) return;
+    const key = `${agentId}:${workItemId}`;
+    const cached = get().sessionsByAgentId[agentId]?.workItemDetailsById[workItemId];
+    if (cached?.workItem || cached?.loading || workItemDetailInFlight.has(key)) return;
+    workItemDetailInFlight.add(key);
+    setWorkItemDetailState(set, agentId, workItemId, { loading: true, error: undefined });
+    try {
+      const workItem = await runtimeClient.getAgentWorkItem(agentId, workItemId);
+      setWorkItemDetailState(set, agentId, workItemId, { loading: false, workItem });
+    } catch (error) {
+      setWorkItemDetailState(set, agentId, workItemId, {
+        loading: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      workItemDetailInFlight.delete(key);
+    }
+  },
+
   loadOlderAgentEvents: async (agentId, displayLevel) => {
     if (!agentId) return;
     const session = get().sessionsByAgentId[agentId] ?? emptyAgentSession();
@@ -961,6 +985,7 @@ function emptyAgentSession(): AgentSessionState {
     missingTranscriptEntryIds: {},
     briefRecordsById: {},
     missingBriefIds: {},
+    workItemDetailsById: {},
   };
 }
 
@@ -1053,6 +1078,33 @@ function setInspectorActivityDetailState(
         detailState: {
           ...selection.detailState,
           ...detailState,
+        },
+      },
+    };
+  });
+}
+
+function setWorkItemDetailState(
+  set: StoreSet,
+  agentId: string,
+  workItemId: string,
+  detailState: WorkItemDetailState,
+): void {
+  set((state) => {
+    const session = state.sessionsByAgentId[agentId] ?? emptyAgentSession();
+    const previous = session.workItemDetailsById[workItemId] ?? {};
+    return {
+      sessionsByAgentId: {
+        ...state.sessionsByAgentId,
+        [agentId]: {
+          ...session,
+          workItemDetailsById: {
+            ...session.workItemDetailsById,
+            [workItemId]: {
+              ...previous,
+              ...detailState,
+            },
+          },
         },
       },
     };

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -94,9 +94,12 @@ function cachedAgentsByIdFromState(state: RuntimeStoreState): Record<string, Age
   return agentsById;
 }
 
-interface AgentRosterActivity {
+export interface AgentRosterActivity {
   operatorAt?: string;
   briefAt?: string;
+  unreadCount?: number;
+  lastUnreadSeq?: number;
+  lastReadSeq?: number;
 }
 
 function appendOptimisticOperatorPrompt(detail: AgentDetail | null, agent: AgentSummary | undefined, prompt: string): AgentDetail | null {
@@ -203,6 +206,7 @@ const LEGACY_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.runtimeConnection.v1
 const ACTIVE_RUNTIME_CONNECTION_STORAGE_KEY = "holon.webGui.activeRuntimeConnection.v1";
 const RUNTIME_CONNECTION_PROFILES_STORAGE_KEY = "holon.webGui.runtimeConnectionProfiles.v1";
 const DISPLAY_LEVEL_STORAGE_KEY = "holon.webGui.displayLevelsByAgentId.v1";
+const ROSTER_ACTIVITY_STORAGE_KEY = "holon.webGui.rosterActivityByRemote.v1";
 let runtimeConnectionConfig = readStoredRuntimeConnectionConfig();
 let runtimeClient = createRuntimeClient(runtimeClientOptions(runtimeConnectionConfig));
 const activeEventStreams = new Map<string, AgentEventStreamSubscription>();
@@ -391,6 +395,58 @@ function writeStoredDisplayLevels(displayLevelsByAgentId: Record<string, Display
   }
 }
 
+export function readStoredRosterActivity(remoteKey: string): Record<string, AgentRosterActivity> {
+  if (typeof window === "undefined") return {};
+  try {
+    const parsed = readStoredJson(window.localStorage, ROSTER_ACTIVITY_STORAGE_KEY);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const byRemote = parsed as Record<string, unknown>;
+    const rawActivity = byRemote[remoteKey];
+    if (!rawActivity || typeof rawActivity !== "object" || Array.isArray(rawActivity)) return {};
+    const activityByAgentId: Record<string, AgentRosterActivity> = {};
+    for (const [agentId, value] of Object.entries(rawActivity)) {
+      if (typeof agentId !== "string" || !agentId || !value || typeof value !== "object" || Array.isArray(value)) continue;
+      const activity = coerceRosterActivity(value);
+      if (activity) activityByAgentId[agentId] = activity;
+    }
+    return activityByAgentId;
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredRosterActivity(remoteKey: string, activityByAgentId: Record<string, AgentRosterActivity>): void {
+  if (typeof window === "undefined") return;
+  try {
+    const parsed = readStoredJson(window.localStorage, ROSTER_ACTIVITY_STORAGE_KEY);
+    const byRemote =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, Record<string, AgentRosterActivity>>)
+        : {};
+    byRemote[remoteKey] = activityByAgentId;
+    window.localStorage.setItem(ROSTER_ACTIVITY_STORAGE_KEY, JSON.stringify(byRemote));
+  } catch {
+    // Ignore storage failures; unread state falls back to memory-only.
+  }
+}
+
+function coerceRosterActivity(value: unknown): AgentRosterActivity | undefined {
+  const parsed = value as Partial<AgentRosterActivity>;
+  const activity: AgentRosterActivity = {};
+  if (typeof parsed.operatorAt === "string") activity.operatorAt = parsed.operatorAt;
+  if (typeof parsed.briefAt === "string") activity.briefAt = parsed.briefAt;
+  if (typeof parsed.unreadCount === "number" && Number.isFinite(parsed.unreadCount) && parsed.unreadCount > 0) {
+    activity.unreadCount = Math.floor(parsed.unreadCount);
+  }
+  if (typeof parsed.lastUnreadSeq === "number" && Number.isFinite(parsed.lastUnreadSeq)) {
+    activity.lastUnreadSeq = Math.floor(parsed.lastUnreadSeq);
+  }
+  if (typeof parsed.lastReadSeq === "number" && Number.isFinite(parsed.lastReadSeq)) {
+    activity.lastReadSeq = Math.floor(parsed.lastReadSeq);
+  }
+  return Object.keys(activity).length ? activity : undefined;
+}
+
 function isDisplayLevel(value: unknown): value is DisplayLevel {
   return value === "info" || value === "verbose" || value === "debug";
 }
@@ -482,16 +538,27 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   runtimeConfigSaving: false,
   search: null,
   searchLoading: false,
-  rosterActivityByAgentId: {},
+  rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig)),
   sessionsByAgentId: {},
 
   setRoute: (route) => set({ route }),
   openAgent: (agentId) =>
-    set((state) => ({
-      selectedAgentId: agentId,
-      route: "agent",
-      displayLevel: state.displayLevelsByAgentId[agentId] ?? "info",
-    })),
+    set((state) => {
+      const rosterActivityByAgentId = markAgentRead(
+        state.rosterActivityByAgentId,
+        agentId,
+        state.sessionsByAgentId[agentId]?.newestSeq,
+      );
+      if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
+        writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
+      }
+      return {
+        selectedAgentId: agentId,
+        route: "agent",
+        displayLevel: state.displayLevelsByAgentId[agentId] ?? "info",
+        rosterActivityByAgentId,
+      };
+    }),
   setDisplayLevel: (displayLevel, agentId) =>
     set((state) => {
       const targetAgentId = agentId ?? state.selectedAgentId;
@@ -590,6 +657,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       search: null,
       searchError: undefined,
       sessionsByAgentId: {},
+      rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(normalizedConfig)),
       selectedAgentId: "",
       route: "dashboard",
     });
@@ -894,6 +962,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
 
     set((state) => {
       const rosterActivityByAgentId = touchRosterActivity(state.rosterActivityByAgentId, agentId, "operator", new Date().toISOString());
+      if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
+        writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
+      }
       return {
         bootstrap: sortBootstrapAgents(state.bootstrap, rosterActivityByAgentId),
         rosterActivityByAgentId,
@@ -1682,18 +1753,64 @@ function touchRosterActivity(
   };
 }
 
-function touchRosterActivityFromEvent(
+function markAgentRead(
+  current: Record<string, AgentRosterActivity>,
+  agentId: string,
+  newestSeq: number | undefined,
+): Record<string, AgentRosterActivity> {
+  const existing = current[agentId];
+  if (!existing?.unreadCount && (newestSeq == null || existing?.lastReadSeq === newestSeq)) return current;
+  return {
+    ...current,
+    [agentId]: {
+      ...existing,
+      unreadCount: 0,
+      lastReadSeq: Math.max(newestSeq ?? 0, existing?.lastUnreadSeq ?? 0, existing?.lastReadSeq ?? 0),
+    },
+  };
+}
+
+export function touchRosterActivityFromEvent(
+  current: Record<string, AgentRosterActivity>,
+  agentId: string,
+  event: StreamEventEnvelopeDto,
+  selectedAgentId: string,
+): Record<string, AgentRosterActivity> {
+  let next = current;
+  if (event.type === "brief_created") {
+    next = touchRosterActivity(next, agentId, "brief", eventTimestamp(event));
+  }
+  if (event.type === "message_enqueued" && messageOrigin(event.payload) === "operator") {
+    next = touchRosterActivity(next, agentId, "operator", eventTimestamp(event));
+  }
+  if (isUnreadEvent(event) && agentId !== selectedAgentId) {
+    next = incrementUnreadFromEvent(next, agentId, event);
+  }
+  return next;
+}
+
+function isUnreadEvent(event: StreamEventEnvelopeDto): boolean {
+  if (event.type === "brief_created") return true;
+  return event.type === "message_enqueued" && messageOrigin(event.payload) !== "operator";
+}
+
+function incrementUnreadFromEvent(
   current: Record<string, AgentRosterActivity>,
   agentId: string,
   event: StreamEventEnvelopeDto,
 ): Record<string, AgentRosterActivity> {
-  if (event.type === "brief_created") {
-    return touchRosterActivity(current, agentId, "brief", eventTimestamp(event));
-  }
-  if (event.type === "message_enqueued" && messageOrigin(event.payload) === "operator") {
-    return touchRosterActivity(current, agentId, "operator", eventTimestamp(event));
-  }
-  return current;
+  const existing = current[agentId];
+  const seq = event.event_seq;
+  if (seq != null && existing?.lastReadSeq != null && seq <= existing.lastReadSeq) return current;
+  if (seq != null && existing?.lastUnreadSeq != null && seq <= existing.lastUnreadSeq) return current;
+  return {
+    ...current,
+    [agentId]: {
+      ...existing,
+      unreadCount: (existing?.unreadCount ?? 0) + 1,
+      lastUnreadSeq: seq ?? existing?.lastUnreadSeq,
+    },
+  };
 }
 
 function eventTimestamp(event: StreamEventEnvelopeDto): string | undefined {
@@ -1887,9 +2004,13 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
       };
     }
     const rosterActivityByAgentId = uniqueEvents.reduce(
-      (activityByAgentId, event) => touchRosterActivityFromEvent(activityByAgentId, agentId, event),
+      (activityByAgentId, event) =>
+        touchRosterActivityFromEvent(activityByAgentId, agentId, event, state.route === "agent" ? state.selectedAgentId : ""),
       state.rosterActivityByAgentId,
     );
+    if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
+      writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
+    }
     const eventsBySeq = {
       ...current.eventsBySeq,
       ...eventsBySeqFromPage(uniqueEvents),

--- a/web-gui/app/src/runtime/session-cache.test.ts
+++ b/web-gui/app/src/runtime/session-cache.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  currentRemoteKey,
+  extractCacheableSession,
+  hydrateSessionFromCache,
+  SessionCacheWriter,
+} from "./session-cache";
+import type { AgentSessionState } from "./runtime-store-helpers";
+import { CACHE_SCHEMA_VERSION } from "./idb-cache";
+
+function makeSession(overrides: Partial<AgentSessionState> = {}): AgentSessionState {
+  return {
+    loading: false,
+    loadingOlder: false,
+    liveStatus: "idle",
+    sendingPrompt: false,
+    detail: null,
+    eventsBySeq: {},
+    eventSeqs: [],
+    messagesById: {},
+    missingMessageIds: {},
+    transcriptEntriesById: {},
+    missingTranscriptEntryIds: {},
+    briefRecordsById: {},
+    missingBriefIds: {},
+    workItemDetailsById: {},
+    ...overrides,
+  };
+}
+
+describe("currentRemoteKey", () => {
+  it("returns 'local' for local mode", () => {
+    expect(currentRemoteKey({ mode: "local" })).toBe("local");
+  });
+
+  it("returns normalized baseUrl for remote mode", () => {
+    expect(currentRemoteKey({ mode: "remote", baseUrl: "https://example.com/" })).toBe("https://example.com");
+    expect(currentRemoteKey({ mode: "remote", baseUrl: "https://example.com///" })).toBe("https://example.com");
+  });
+
+  it("returns 'remote' for empty baseUrl", () => {
+    expect(currentRemoteKey({ mode: "remote", baseUrl: "" })).toBe("remote");
+    expect(currentRemoteKey({ mode: "remote", baseUrl: undefined })).toBe("remote");
+  });
+});
+
+describe("extractCacheableSession", () => {
+  it("extracts core data fields with correct metadata", () => {
+    const session = makeSession({
+      eventsBySeq: { 1: { id: "e1" }, 2: { id: "e2" } },
+      eventSeqs: [1, 2],
+      messagesById: { m1: { id: "m1" } },
+      newestSeq: 2,
+      oldestSeq: 1,
+    });
+
+    const result = extractCacheableSession("local", "agent-1", session);
+
+    expect(result.remoteKey).toBe("local");
+    expect(result.agentId).toBe("agent-1");
+    expect(result.schemaVersion).toBe(CACHE_SCHEMA_VERSION);
+    expect(result.eventsBySeq).toEqual(session.eventsBySeq);
+    expect(result.eventSeqs).toEqual(session.eventSeqs);
+    expect(result.messagesById).toEqual(session.messagesById);
+    expect(result.newestSeq).toBe(2);
+    expect(result.oldestSeq).toBe(1);
+    expect(result.cachedAt).toBeGreaterThan(0);
+  });
+
+  it("excludes UI state fields", () => {
+    const session = makeSession({
+      loading: true,
+      liveStatus: "streaming",
+      error: "some error",
+      sendingPrompt: true,
+    });
+
+    const result = extractCacheableSession("local", "agent-1", session);
+
+    expect(result).not.toHaveProperty("loading");
+    expect(result).not.toHaveProperty("liveStatus");
+    expect(result).not.toHaveProperty("error");
+    expect(result).not.toHaveProperty("sendingPrompt");
+  });
+
+  it("trims events exceeding MAX_EVENTS_PER_AGENT", () => {
+    const MAX = 5000;
+    const eventSeqs = Array.from({ length: MAX + 100 }, (_, i) => i + 1);
+    const eventsBySeq: Record<number, unknown> = {};
+    for (const seq of eventSeqs) eventsBySeq[seq] = { id: `e${seq}` };
+
+    const session = makeSession({ eventsBySeq, eventSeqs });
+
+    const result = extractCacheableSession("local", "agent-1", session);
+
+    expect(result.eventSeqs.length).toBe(MAX);
+    expect(result.eventSeqs[0]).toBe(101); // First 100 trimmed
+    expect(result.eventSeqs[MAX - 1]).toBe(MAX + 100);
+  });
+});
+
+describe("hydrateSessionFromCache", () => {
+  it("returns partial session with cached data", () => {
+    const cached = {
+      remoteKey: "local",
+      agentId: "agent-1",
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      eventsBySeq: { 1: { id: "e1" } },
+      eventSeqs: [1],
+      messagesById: { m1: { id: "m1" } },
+      transcriptEntriesById: {},
+      briefRecordsById: {},
+      newestSeq: 1,
+      oldestSeq: 1,
+      cachedAt: Date.now(),
+    };
+
+    const result = hydrateSessionFromCache(cached);
+
+    expect(result.eventsBySeq).toEqual({ 1: { id: "e1" } });
+    expect(result.eventSeqs).toEqual([1]);
+    expect(result.newestSeq).toBe(1);
+    expect(result.oldestSeq).toBe(1);
+  });
+
+  it("does not include UI state fields", () => {
+    const cached = {
+      remoteKey: "local",
+      agentId: "agent-1",
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      eventsBySeq: {},
+      eventSeqs: [],
+      messagesById: {},
+      transcriptEntriesById: {},
+      briefRecordsById: {},
+      cachedAt: Date.now(),
+    };
+
+    const result = hydrateSessionFromCache(cached);
+
+    expect(result).not.toHaveProperty("loading");
+    expect(result).not.toHaveProperty("liveStatus");
+    expect(result).not.toHaveProperty("detail");
+  });
+});
+
+describe("SessionCacheWriter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("schedules debounced writes", async () => {
+    const writer = new SessionCacheWriter("local");
+    const session = makeSession({ eventsBySeq: { 1: { id: "e1" } }, eventSeqs: [1] });
+
+    // Mock the module's cachePutSession
+    const putSpy = vi.spyOn(await import("./idb-cache"), "cachePutSession").mockResolvedValue(undefined);
+
+    writer.scheduleWrite("agent-1", session);
+
+    // Not flushed yet
+    expect(putSpy).not.toHaveBeenCalled();
+
+    // Advance timers to trigger write
+    vi.advanceTimersByTime(2001);
+
+    // Wait for async flush
+    await vi.waitFor(() => expect(putSpy).toHaveBeenCalledTimes(1));
+
+    putSpy.mockRestore();
+    writer.cancel();
+  });
+
+  it("flush writes all pending immediately", async () => {
+    const writer = new SessionCacheWriter("local");
+    const session1 = makeSession({ eventSeqs: [1] });
+    const session2 = makeSession({ eventSeqs: [2] });
+
+    const putSpy = vi.spyOn(await import("./idb-cache"), "cachePutSession").mockResolvedValue(undefined);
+
+    writer.scheduleWrite("agent-1", session1);
+    writer.scheduleWrite("agent-2", session2);
+
+    await writer.flush();
+
+    expect(putSpy).toHaveBeenCalledTimes(2);
+
+    putSpy.mockRestore();
+  });
+
+  it("cancel stops pending writes", async () => {
+    const writer = new SessionCacheWriter("local");
+    const session = makeSession();
+
+    const putSpy = vi.spyOn(await import("./idb-cache"), "cachePutSession").mockResolvedValue(undefined);
+
+    writer.scheduleWrite("agent-1", session);
+    writer.cancel();
+
+    vi.advanceTimersByTime(5000);
+
+    expect(putSpy).not.toHaveBeenCalled();
+
+    putSpy.mockRestore();
+  });
+});

--- a/web-gui/app/src/runtime/session-cache.test.ts
+++ b/web-gui/app/src/runtime/session-cache.test.ts
@@ -5,6 +5,7 @@ import {
   extractCacheableSession,
   hydrateSessionFromCache,
   SessionCacheWriter,
+  enforceCacheLimits,
 } from "./session-cache";
 import type { AgentSessionState } from "./runtime-store-helpers";
 import { CACHE_SCHEMA_VERSION } from "./idb-cache";
@@ -207,5 +208,83 @@ describe("SessionCacheWriter", () => {
     expect(putSpy).not.toHaveBeenCalled();
 
     putSpy.mockRestore();
+  });
+});
+
+describe("enforceCacheLimits", () => {
+  const remoteKey = "local";
+
+  function makeCachedSession(agentId: string, cachedAt: number) {
+    return {
+      remoteKey,
+      agentId,
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      eventsBySeq: {},
+      eventSeqs: [] as number[],
+      messagesById: {},
+      transcriptEntriesById: {},
+      briefRecordsById: {},
+      cachedAt,
+    };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when agent count is within limit (<= 50)", async () => {
+    const sessions = Array.from({ length: 50 }, (_, i) =>
+      makeCachedSession(`agent-${i}`, Date.now() + i),
+    );
+    const idbModule = await import("./idb-cache");
+    const getAllSpy = vi.spyOn(idbModule, "cacheGetAllSessions").mockResolvedValue(sessions);
+    const deleteSpy = vi.spyOn(idbModule, "cacheDeleteSession").mockResolvedValue(undefined);
+
+    await enforceCacheLimits(remoteKey);
+
+    expect(getAllSpy).toHaveBeenCalledTimes(1);
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes oldest sessions when exceeding 50 agents", async () => {
+    // 55 sessions: oldest 5 should be deleted to bring it to 50
+    const sessions = Array.from({ length: 55 }, (_, i) =>
+      makeCachedSession(`agent-${i}`, 1000 + i * 100),
+    );
+    const idbModule = await import("./idb-cache");
+    vi.spyOn(idbModule, "cacheGetAllSessions").mockResolvedValue(sessions);
+    const deleteSpy = vi.spyOn(idbModule, "cacheDeleteSession").mockResolvedValue(undefined);
+
+    await enforceCacheLimits(remoteKey);
+
+    expect(deleteSpy).toHaveBeenCalledTimes(5);
+    // Oldest 5 are agent-0 through agent-4 (cachedAt 1000..1400)
+    const deletedAgentIds = deleteSpy.mock.calls.map((c) => c[1]);
+    expect(deletedAgentIds).toEqual(
+      expect.arrayContaining(["agent-0", "agent-1", "agent-2", "agent-3", "agent-4"]),
+    );
+    // Newest sessions are NOT deleted
+    expect(deletedAgentIds).not.toContain("agent-54");
+  });
+
+  it("preserves newest 50 sessions when count is well above limit", async () => {
+ const sessions = Array.from({ length: 100 }, (_, i) =>
+      makeCachedSession(`agent-${i}`, 5000 + i * 10),
+    );
+    const idbModule = await import("./idb-cache");
+    vi.spyOn(idbModule, "cacheGetAllSessions").mockResolvedValue(sessions);
+    const deleteSpy = vi.spyOn(idbModule, "cacheDeleteSession").mockResolvedValue(undefined);
+
+    await enforceCacheLimits(remoteKey);
+
+    expect(deleteSpy).toHaveBeenCalledTimes(50);
+    // agent-50..agent-99 should survive
+    const deletedAgentIds = new Set(deleteSpy.mock.calls.map((c) => c[1]));
+    for (let i = 50; i < 100; i++) {
+      expect(deletedAgentIds.has(`agent-${i}`)).toBe(false);
+    }
+    for (let i = 0; i < 50; i++) {
+      expect(deletedAgentIds.has(`agent-${i}`)).toBe(true);
+    }
   });
 });

--- a/web-gui/app/src/runtime/session-cache.ts
+++ b/web-gui/app/src/runtime/session-cache.ts
@@ -23,7 +23,7 @@ import type { RuntimeConnectionConfig } from "./types";
 
 export type { CachedAgentSession };
 
-const MAX_CACHED_AGENTS_PER_REMOTE = 20;
+const MAX_CACHED_AGENTS_PER_REMOTE = 50;
 const MAX_EVENTS_PER_AGENT = 5000;
 const WRITE_DEBOUNCE_MS = 2000;
 

--- a/web-gui/app/src/runtime/session-cache.ts
+++ b/web-gui/app/src/runtime/session-cache.ts
@@ -1,0 +1,189 @@
+/**
+ * Business logic layer for session caching on top of idb-cache.
+ *
+ * Provides remote-key computation, extract/hydrate between AgentSessionState
+ * and CachedAgentSession, a debounced writer, and eviction enforcement.
+ */
+
+import {
+  CACHE_SCHEMA_VERSION,
+  cacheDeleteSession,
+  cacheGetAllSessions,
+  cachePutSession,
+  ensureCacheSchemaVersion,
+  type CachedAgentSession,
+} from "./idb-cache";
+import type { AgentSessionState } from "./runtime-store-helpers";
+import type {
+  RuntimeBriefRecord,
+  RuntimeMessageEnvelope,
+  RuntimeTranscriptEntry,
+} from "./types";
+import type { RuntimeConnectionConfig } from "./types";
+
+export type { CachedAgentSession };
+
+const MAX_CACHED_AGENTS_PER_REMOTE = 20;
+const MAX_EVENTS_PER_AGENT = 5000;
+const WRITE_DEBOUNCE_MS = 2000;
+
+/**
+ * Compute the isolation key for a remote connection.
+ * Local mode uses "local"; remote mode uses the normalized baseUrl.
+ */
+export function currentRemoteKey(config: RuntimeConnectionConfig): string {
+  if (config.mode === "local") return "local";
+  return config.baseUrl?.trim().replace(/\/+$/, "") || "remote";
+}
+
+/**
+ * Extract cacheable fields from an AgentSessionState into a CachedAgentSession.
+ * Only the "heavy" data is cached: events, messages, transcripts, briefs.
+ * UI state (loading, liveStatus, etc.) is excluded.
+ */
+export function extractCacheableSession(
+  remoteKey: string,
+  agentId: string,
+  session: AgentSessionState,
+): CachedAgentSession {
+  // Trim events if exceeding the per-agent limit (keep the newest).
+  let eventsBySeq = session.eventsBySeq;
+  let eventSeqs = session.eventSeqs;
+  if (eventSeqs.length > MAX_EVENTS_PER_AGENT) {
+    const keepSeqs = eventSeqs.slice(eventSeqs.length - MAX_EVENTS_PER_AGENT);
+    const keepSet = new Set(keepSeqs);
+    eventsBySeq = {};
+    for (const seq of keepSeqs) {
+      if (keepSet.has(seq)) {
+        eventsBySeq[seq] = session.eventsBySeq[seq];
+      }
+    }
+    eventSeqs = keepSeqs;
+  }
+
+  return {
+    remoteKey,
+    agentId,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    eventsBySeq,
+    eventSeqs,
+    messagesById: session.messagesById as Record<string, unknown>,
+    transcriptEntriesById: session.transcriptEntriesById as Record<string, unknown>,
+    briefRecordsById: session.briefRecordsById as Record<string, unknown>,
+    newestSeq: session.newestSeq,
+    oldestSeq: session.oldestSeq,
+    cachedAt: Date.now(),
+  };
+}
+
+/**
+ * Hydrate a partial AgentSessionState from cached data.
+ * The caller merges this into an emptyAgentSession() base.
+ */
+export function hydrateSessionFromCache(cached: CachedAgentSession): Partial<AgentSessionState> {
+  return {
+    eventsBySeq: cached.eventsBySeq,
+    eventSeqs: cached.eventSeqs,
+    messagesById: cached.messagesById as Record<string, RuntimeMessageEnvelope>,
+    transcriptEntriesById: cached.transcriptEntriesById as Record<string, RuntimeTranscriptEntry>,
+    briefRecordsById: cached.briefRecordsById as Record<string, RuntimeBriefRecord>,
+    newestSeq: cached.newestSeq,
+    oldestSeq: cached.oldestSeq,
+  };
+}
+
+/**
+ * Enforce the max-agents-per-remote limit by deleting oldest entries.
+ */
+export async function enforceCacheLimits(remoteKey: string): Promise<void> {
+  const sessions = await cacheGetAllSessions(remoteKey);
+  if (sessions.length <= MAX_CACHED_AGENTS_PER_REMOTE) return;
+
+  sessions.sort((a, b) => a.cachedAt - b.cachedAt);
+  const toDelete = sessions.slice(0, sessions.length - MAX_CACHED_AGENTS_PER_REMOTE);
+  await Promise.all(toDelete.map((s) => cacheDeleteSession(s.remoteKey, s.agentId)));
+}
+
+/**
+ * Debounced cache writer for session updates.
+ * Schedules writes at most once per WRITE_DEBOUNCE_MS per agent.
+ */
+export class SessionCacheWriter {
+  private timers = new Map<string, number>();
+  private pending = new Map<string, { remoteKey: string; session: AgentSessionState }>();
+  private readonly remoteKey: string;
+
+  constructor(remoteKey: string) {
+    this.remoteKey = remoteKey;
+  }
+
+  scheduleWrite(agentId: string, session: AgentSessionState): void {
+    this.pending.set(agentId, { remoteKey: this.remoteKey, session });
+
+    const existing = this.timers.get(agentId);
+    if (existing != null) {
+      globalThis.clearTimeout(existing);
+    }
+
+    const timer = globalThis.setTimeout(() => {
+      this.timers.delete(agentId);
+      void this.flushAgent(agentId);
+    }, WRITE_DEBOUNCE_MS);
+    this.timers.set(agentId, timer);
+  }
+
+  private async flushAgent(agentId: string): Promise<void> {
+    const entry = this.pending.get(agentId);
+    if (!entry) return;
+    this.pending.delete(agentId);
+    try {
+      const cached = extractCacheableSession(entry.remoteKey, agentId, entry.session);
+      await cachePutSession(cached);
+    } catch {
+      // Silent fallback.
+    }
+  }
+
+  /** Flush all pending writes immediately. */
+  async flush(): Promise<void> {
+    for (const timer of this.timers.values()) {
+      globalThis.clearTimeout(timer);
+    }
+    this.timers.clear();
+
+    const agentIds = Array.from(this.pending.keys());
+    await Promise.all(agentIds.map((id) => this.flushAgent(id)));
+  }
+
+  /** Stop all pending writes without flushing. */
+  cancel(): void {
+    for (const timer of this.timers.values()) {
+      globalThis.clearTimeout(timer);
+    }
+    this.timers.clear();
+    this.pending.clear();
+  }
+}
+
+/**
+ * One-time initialization: check schema version and prepare for hydration.
+ * Returns true if the cache is usable.
+ */
+export async function initSessionCache(): Promise<boolean> {
+  return ensureCacheSchemaVersion();
+}
+
+/**
+ * Load all cached sessions for a remote key and return them as a map
+ * of agentId -> partial AgentSessionState.
+ */
+export async function hydrateAllSessions(
+  remoteKey: string,
+): Promise<Record<string, Partial<AgentSessionState>>> {
+  const cached = await cacheGetAllSessions(remoteKey);
+  const result: Record<string, Partial<AgentSessionState>> = {};
+  for (const entry of cached) {
+    result[entry.agentId] = hydrateSessionFromCache(entry);
+  }
+  return result;
+}

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -101,6 +101,35 @@ describe("reduceAgentSessionTimeline", () => {
     ]);
   });
 
+  it("does not dedupe distinct pending slim operator messages by placeholder body", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "event-1",
+            event_seq: 1,
+            type: "message_enqueued",
+            payload: {
+              message_id: "msg-1",
+              origin: { kind: "operator" },
+            },
+          }),
+          event({
+            id: "event-2",
+            event_seq: 2,
+            type: "message_enqueued",
+            payload: {
+              message_id: "msg-2",
+              origin: { kind: "operator" },
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline.map((item) => item.id)).toEqual(["event-1", "event-2"]);
+  });
+
   it("keeps the raw event on projected timeline items", () => {
     const rawEvent = event({
       id: "event-raw",
@@ -279,6 +308,60 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("renders slim work item payloads from preview and top-level fields", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "work-item-updated",
+            event_seq: 15,
+            type: "work_item_updated",
+            payload: {
+              work_item_id: "work_123",
+              objective_preview: "Improve slim event display",
+              plan_status: "ready",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "work-item-updated",
+        kind: "system",
+        label: "Work item",
+        body: "Work Item Updated · Improve slim event display · ready",
+        minDisplayLevel: "verbose",
+      }),
+    );
+  });
+
+  it("renders current work item focus from slim top-level ids", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "focus-released",
+            event_seq: 16,
+            type: "work_item_focus_released",
+            payload: {
+              current_work_item_id: "work_456",
+              reason: "yielded",
+              readiness: "runnable",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        body: "Released work item focus · yielded · runnable",
+      }),
+    );
+  });
+
   it("renders focus release details from top-level work item fields", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {
@@ -365,6 +448,90 @@ describe("reduceAgentSessionTimeline", () => {
         kind: "system",
         label: "Work item",
         body: "Promoted completion report candidate · Candidate completion text.",
+      }),
+    );
+  });
+
+  it("projects task lifecycle events with readable status and output previews", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "task-created",
+            event_seq: 30,
+            type: "task_created",
+            payload: {
+              task_id: "task_123",
+              status: "queued",
+              summary: "Run command: npm test",
+            },
+          }),
+          event({
+            id: "task-result",
+            event_seq: 31,
+            type: "task_result_received",
+            payload: {
+              task_id: "task_123",
+              status: "completed",
+              summary: "Run command: npm test",
+              exit_status: 0,
+              output_summary_preview: "42 tests passed",
+              output_path: "/tmp/task.log",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "task-created",
+        kind: "event",
+        label: "Task queued",
+        body: "Run command: npm test",
+        minDisplayLevel: "verbose",
+      }),
+    );
+    expect(timeline[1]).toEqual(
+      expect.objectContaining({
+        id: "task-result",
+        kind: "event",
+        label: "Task completed",
+        body: "Run command: npm test · exit 0 · 42 tests passed",
+        detail: {
+          label: "Task details",
+          text: "task: task_123 · output: /tmp/task.log · 42 tests passed",
+          tone: "output",
+        },
+      }),
+    );
+  });
+
+  it("promotes failed task lifecycle events to info", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "task-failed",
+            event_seq: 32,
+            type: "task_result_received",
+            payload: {
+              task_id: "task_failed",
+              status: "failed",
+              summary: "Run command: cargo test",
+              exit_status: 101,
+              error: "tests failed",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        label: "Task failed",
+        body: "Run command: cargo test · exit 101 · tests failed",
+        minDisplayLevel: "info",
       }),
     );
   });

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -915,3 +915,35 @@ function timelineItem(overrides: Partial<AgentTimelineItem> = {}): AgentTimeline
     ...overrides,
   };
 }
+
+describe("turn_started projection", () => {
+  it("projects turn_started events as info-level system items with turn index and trigger", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          {
+            id: "evt-turn-1",
+            event_seq: 1,
+            type: "turn_started",
+            ts: "2026-06-15T10:00:00Z",
+            payload: {
+              turn_index: 42,
+              message_kind: "InternalFollowup",
+              agent_id: "agent-1",
+              message_id: "msg-1",
+              run_id: "run-1",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(timeline).toHaveLength(1);
+    const item = timeline[0]!;
+    expect(item.kind).toBe("system");
+    expect(item.minDisplayLevel).toBe("info");
+    expect(item.body).toContain("Turn #42");
+    expect(item.body).toContain("internal followup");
+    expect(item.meta.startsWith("turn_started")).toBe(true);
+  });
+});

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -626,6 +626,40 @@ describe("reduceAgentSessionTimeline", () => {
       }),
     );
   });
+
+  it("hydrates slim brief events from brief records when transcript content is unavailable", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          event({
+            id: "brief-event",
+            event_seq: 22,
+            type: "brief_created",
+            payload: {
+              id: "brief_123",
+              kind: "result",
+              content_source: { kind: "inline" },
+            },
+          }),
+        ],
+      },
+      briefRecordsById: {
+        brief_123: {
+          id: "brief_123",
+          text: "Full persisted brief text.",
+          kind: "result",
+        },
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        id: "brief-event",
+        label: "Result",
+        body: "Full persisted brief text.",
+      }),
+    );
+  });
 });
 
 describe("filterTimelineByDisplayLevel", () => {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -198,6 +198,41 @@ describe("reduceAgentSessionTimeline", () => {
     );
   });
 
+  it("projects ListTasks tools as readable active task summaries", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("list-tasks", "ListTasks", {
+            list_tasks_result: {
+              total_active: 1,
+              returned: 1,
+              tasks: [
+                {
+                  task_id: "task_1",
+                  kind: "command_task",
+                  status: "running",
+                  summary: "Run command: npm run dev",
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        body: "1 active task · Run command: npm run dev · running · command_task · task_1 · 11ms",
+        detail: {
+          label: "Tasks",
+          text: "Run command: npm run dev · running · command_task · task_1",
+          tone: "data",
+        },
+      }),
+    );
+  });
+
   it("falls back to the tool name when a tool has no readable summary", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -239,13 +239,14 @@ describe("reduceAgentSessionTimeline", () => {
         events: [
           toolEvent("task-output", "TaskOutput", {
             task_output_result: {
+              retrieval_status: "success",
               task: {
                 task_id: "task_abc123",
                 status: "completed",
                 summary: "Run command: cargo build",
                 exit_status: 0,
+                output_preview: "Compiling holon v0.1.0\nFinished",
               },
-              output_preview: "Compiling holon v0.1.0\nFinished",
             },
           }),
         ],
@@ -260,7 +261,37 @@ describe("reduceAgentSessionTimeline", () => {
     );
     // Duration should be suppressed for read/control tools
     expect(timeline[0].body).not.toContain("ms");
+    expect(timeline[0].body).not.toContain("success");
     expect(timeline[0].detail?.tone).toBe("output");
+  });
+
+  it("projects TaskOutput retrieval status without collapsing to success or timeout", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("task-output-timeout", "TaskOutput", {
+            task_output_result: {
+              retrieval_status: "timeout",
+              task: {
+                task_id: "task_waiting",
+                kind: "command_task",
+                status: "running",
+                summary: "Run command: npm run dev",
+                output_preview: "server booting",
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        body: "Task output · task_waiting · retrieval timeout · running · command_task · Run command: npm run dev",
+      }),
+    );
+    expect(timeline[0].body).not.toBe("timeout");
   });
 
   it("projects TaskOutput with truncated flag", () => {

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -223,12 +223,112 @@ describe("reduceAgentSessionTimeline", () => {
     expect(timeline[0]).toEqual(
       expect.objectContaining({
         kind: "tool",
-        body: "1 active task · Run command: npm run dev · running · command_task · task_1 · 11ms",
+        body: "1 active task · Run command: npm run dev · running · command_task · task_1",
         detail: {
           label: "Tasks",
           text: "Run command: npm run dev · running · command_task · task_1",
           tone: "data",
         },
+      }),
+    );
+  });
+
+  it("projects TaskOutput with task status and output preview", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("task-output", "TaskOutput", {
+            task_output_result: {
+              task: {
+                task_id: "task_abc123",
+                status: "completed",
+                summary: "Run command: cargo build",
+                exit_status: 0,
+              },
+              output_preview: "Compiling holon v0.1.0\nFinished",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        body: "Task output · task_abc123 · completed · Run command: cargo build · exit 0",
+      }),
+    );
+    // Duration should be suppressed for read/control tools
+    expect(timeline[0].body).not.toContain("ms");
+    expect(timeline[0].detail?.tone).toBe("output");
+  });
+
+  it("projects TaskOutput with truncated flag", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("task-output-trunc", "TaskOutput", {
+            task_output_result: {
+              task: { task_id: "task_xyz", status: "running" },
+              output_preview: "...partial output...",
+              output_truncated: true,
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0].body).toContain("truncated");
+  });
+
+  it("projects TaskStatus with status and kind", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("task-status", "TaskStatus", {
+            task_status_result: {
+              task_id: "task_789",
+              status: "running",
+              kind: "command_task",
+              summary: "Run command: npm test",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        body: "Task status · task_789 · running · command_task · Run command: npm test",
+      }),
+    );
+    expect(timeline[0].body).not.toContain("ms");
+  });
+
+  it("projects TaskStop and TaskInput", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("task-stop", "TaskStop", {
+            task_stop_result: { task_id: "task_stop1", status: "cancelled" },
+          }),
+          toolEvent("task-input", "TaskInput", {
+            task_input_result: { task_id: "task_in1", status: "accepted" },
+            input: "y\n",
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        body: "Stopped task · task_stop1 · cancelled",
+      }),
+    );
+    expect(timeline[1]).toEqual(
+      expect.objectContaining({
+        body: "Task input · task_in1 · y",
       }),
     );
   });

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -953,16 +953,19 @@ describe("WebSearch tool projection", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {
         events: [
-          toolEvent("web-search-1", "mcp__web-search-prime__web_search_prime", {
+          toolEvent("web-search-1", "WebSearch", {
             duration_ms: 3200,
             input: {
-              search_query: "rust async runtime",
-              location: "cn",
+              query: "rust async runtime",
+              max_results: 5,
             },
             output: {
+              query: "rust async runtime",
+              provider: "brave",
+              mode: "single",
               results: [
-                { title: "Tokio", url: "https://tokio.rs", summary: "Async runtime" },
-                { title: "async-std", url: "https://async.rs", summary: "Fast runtime" },
+                { title: "Tokio", url: "https://tokio.rs", snippet: "Async runtime", source: "tokio.rs" },
+                { title: "async-std", url: "https://async.rs", snippet: "Fast runtime", source: "async.rs" },
               ],
             },
           }),
@@ -984,17 +987,22 @@ describe("WebSearch tool projection", () => {
   });
 });
 
-describe("WebReader tool projection", () => {
-  it("projects WebReader tool with URL and content on timeline", () => {
+describe("WebFetch tool projection", () => {
+  it("projects WebFetch tool with URL and content on timeline", () => {
     const timeline = reduceAgentSessionTimeline({
       events: {
         events: [
-          toolEvent("web-reader-1", "mcp__web_reader__webReader", {
+          toolEvent("web-fetch-1", "WebFetch", {
             duration_ms: 5400,
-            input: { url: "https://example.com/article" },
+            input: { url: "https://example.com/article", max_chars: 10000 },
             output: {
-              title: "Example Article",
-              markdown: "# Example Article\n\nContent here.",
+              url: "https://example.com/article",
+              final_url: "https://example.com/article",
+              status: 200,
+              content_type: "text/html",
+              bytes_read: 1024,
+              truncated: false,
+              text: "# Example Article\n\nContent here.",
             },
           }),
         ],
@@ -1004,11 +1012,11 @@ describe("WebReader tool projection", () => {
     expect(timeline[0]).toEqual(
       expect.objectContaining({
         kind: "tool",
-        label: "Web page read",
-        body: expect.stringContaining("Read webpage · Example Article"),
+        label: "Web fetch completed",
+        body: expect.stringContaining("Web fetch · https://example.com/article · 200"),
       }),
     );
-    expect(timeline[0].detail?.label).toBe("Webpage content");
+    expect(timeline[0].detail?.label).toBe("Fetched content");
     expect(timeline[0].detail?.text).toContain("# Example Article");
   });
 });

--- a/web-gui/app/src/runtime/session-reducer.test.ts
+++ b/web-gui/app/src/runtime/session-reducer.test.ts
@@ -947,3 +947,68 @@ describe("turn_started projection", () => {
     expect(item.meta.startsWith("turn_started")).toBe(true);
   });
 });
+
+describe("WebSearch tool projection", () => {
+  it("projects WebSearch tool with query and result count on timeline", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("web-search-1", "mcp__web-search-prime__web_search_prime", {
+            duration_ms: 3200,
+            input: {
+              search_query: "rust async runtime",
+              location: "cn",
+            },
+            output: {
+              results: [
+                { title: "Tokio", url: "https://tokio.rs", summary: "Async runtime" },
+                { title: "async-std", url: "https://async.rs", summary: "Fast runtime" },
+              ],
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        label: "Web search completed",
+        body: expect.stringContaining("Web search · rust async runtime · 2 results"),
+      }),
+    );
+    expect(timeline[0].detail?.label).toBe("Search results");
+    expect(timeline[0].detail?.text).toContain("1. Tokio");
+    expect(timeline[0].detail?.text).toContain("https://tokio.rs");
+    expect(timeline[0].detail?.text).toContain("2. async-std");
+  });
+});
+
+describe("WebReader tool projection", () => {
+  it("projects WebReader tool with URL and content on timeline", () => {
+    const timeline = reduceAgentSessionTimeline({
+      events: {
+        events: [
+          toolEvent("web-reader-1", "mcp__web_reader__webReader", {
+            duration_ms: 5400,
+            input: { url: "https://example.com/article" },
+            output: {
+              title: "Example Article",
+              markdown: "# Example Article\n\nContent here.",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(timeline[0]).toEqual(
+      expect.objectContaining({
+        kind: "tool",
+        label: "Web page read",
+        body: expect.stringContaining("Read webpage · Example Article"),
+      }),
+    );
+    expect(timeline[0].detail?.label).toBe("Webpage content");
+    expect(timeline[0].detail?.text).toContain("# Example Article");
+  });
+});

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -537,8 +537,10 @@ function projectToolExecution(
   const promoted = disposition === "promoted_to_task";
   const stringPreview = toolStringPreview(toolName, payload, commandPreview) || undefined;
   const toolSummary = projection?.body ?? stringPreview ?? summary ?? genericToolDescription(toolName, payload) ?? toolName;
-  // For promoted tasks, duration_ms is the yield_time timeout, not real execution time — suppress it.
-  const effectiveDuration = promoted ? undefined : durationMs;
+  // Suppress duration for promoted tasks (yield_time, not real execution) and for read/control tools
+  // where duration_ms is just API round-trip time with no user-facing meaning.
+  const suppressDuration = promoted || isReadControlTool(toolName);
+  const effectiveDuration = suppressDuration ? undefined : durationMs;
   const promotedTaskId = promoted ? firstStringField(asRecord(payload?.task_handle), ["task_id"]) : undefined;
   const body = compactJoin([
     toolSummary,
@@ -582,6 +584,10 @@ function projectKnownToolExecution(
   if (isWebFetchTool(toolName)) return projectWebFetchTool(payload);
   if (toolName === "MemorySearch") return projectMemorySearchTool(payload);
   if (toolName === "MemoryGet") return projectMemoryGetTool(payload);
+  if (toolName === "TaskOutput") return projectTaskOutputTool(payload);
+  if (toolName === "TaskStatus") return projectTaskStatusTool(payload);
+  if (toolName === "TaskStop") return projectTaskStopTool(payload);
+  if (toolName === "TaskInput") return projectTaskInputTool(payload);
   return undefined;
 }
 
@@ -595,6 +601,24 @@ function isWebSearchTool(toolName: string): boolean {
 
 function isWebFetchTool(toolName: string): boolean {
   return toolName === "WebFetch";
+}
+
+/**
+ * Read/control tools where duration_ms is just API round-trip time, not meaningful execution time.
+ * Suppress showing it in the timeline to avoid noise like "success · 272ms".
+ */
+function isReadControlTool(toolName: string): boolean {
+  return (
+    toolName === "TaskOutput" ||
+    toolName === "TaskStatus" ||
+    toolName === "TaskStop" ||
+    toolName === "TaskInput" ||
+    toolName === "ListTasks" ||
+    toolName === "ListWorkItems" ||
+    toolName === "GetWorkItem" ||
+    toolName === "MemorySearch" ||
+    toolName === "MemoryGet"
+  );
 }
 
 function toolStringPreview(
@@ -670,6 +694,101 @@ function projectListTasksTool(payload: Record<string, unknown> | undefined): Pic
     detail: taskSummaries.length
       ? { label: "Tasks", text: taskSummaries.join("\n"), tone: "data" }
       : { label: "Result", text: debugJson(result ?? payload ?? {}), tone: "data" },
+  };
+}
+
+function extractTaskFromOutput(payload: Record<string, unknown> | undefined): {
+  task?: Record<string, unknown>;
+  taskId?: string;
+  status?: string;
+  summary?: string;
+  exitStatus?: number;
+  outputPreview?: string;
+  truncated?: boolean;
+} {
+  const result = asRecord(payload?.task_output_result) ?? unwrapToolResult(payload);
+  const task = asRecord(result.task) ?? asRecord(result.task_record);
+  const taskId = firstStringField(task, ["task_id", "id"]) ?? stringField(payload, "task_id");
+  const status = firstStringField(task, ["status"]) ?? stringField(result, "status") ?? stringField(result, "retrieval_status");
+  const summary = stringField(task, "summary") ?? stringField(result, "summary") ?? stringField(result, "result_summary");
+  const exitStatus = numberField(task, "exit_status") ?? numberField(result, "exit_status");
+  const outputPreview =
+    stringField(result, "output_preview") ??
+    stringField(result, "output") ??
+    stringField(result, "stdout") ??
+    stringField(result, "stderr");
+  const truncated = result.output_truncated === true || result.truncated === true;
+  return { task, taskId, status, summary, exitStatus, outputPreview, truncated };
+}
+
+function projectTaskOutputTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const info = extractTaskFromOutput(payload);
+  const body = compactJoin([
+    "Task output",
+    info.taskId ? shortTaskId(info.taskId) : undefined,
+    info.status,
+    info.summary,
+    info.exitStatus != null ? `exit ${info.exitStatus}` : undefined,
+    info.truncated ? "truncated" : undefined,
+  ]);
+  return {
+    body,
+    detail: info.outputPreview
+      ? {
+          label: info.truncated ? "Task output (truncated)" : "Task output",
+          text: truncateText(info.outputPreview, 2000),
+          tone: "output",
+        }
+      : undefined,
+  };
+}
+
+function projectTaskStatusTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.task_status_result) ?? unwrapToolResult(payload);
+  const taskId = stringField(result, "task_id") ?? stringField(payload, "task_id");
+  const status = stringField(result, "status");
+  const summary = stringField(result, "summary");
+  const kind = stringField(result, "kind");
+  const body = compactJoin([
+    "Task status",
+    taskId ? shortTaskId(taskId) : undefined,
+    status,
+    kind,
+    summary,
+  ]);
+  return {
+    body,
+    detail: undefined,
+  };
+}
+
+function projectTaskStopTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.task_stop_result) ?? unwrapToolResult(payload);
+  const taskId = stringField(result, "task_id") ?? stringField(payload, "task_id");
+  const status = stringField(result, "status");
+  const body = compactJoin([
+    "Stopped task",
+    taskId ? shortTaskId(taskId) : undefined,
+    status,
+  ]);
+  return {
+    body,
+    detail: undefined,
+  };
+}
+
+function projectTaskInputTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.task_input_result) ?? unwrapToolResult(payload);
+  const taskId = stringField(result, "task_id") ?? stringField(payload, "task_id");
+  const input = stringField(payload, "input") ?? stringField(result, "input");
+  const body = compactJoin([
+    "Task input",
+    taskId ? shortTaskId(taskId) : undefined,
+    input ? truncateText(input.replace(/\s+/g, " ").trim(), 100) : undefined,
+  ]);
+  return {
+    body,
+    detail: undefined,
   };
 }
 
@@ -1034,6 +1153,10 @@ function toolFriendlyLabel(toolName: string, failed: boolean): string {
   if (toolName === "CompleteWorkItem") return failed ? "Work item completion failed" : "Completed work item";
   if (isWebSearchTool(toolName)) return failed ? "Web search failed" : "Web search completed";
   if (isWebFetchTool(toolName)) return failed ? "Web fetch failed" : "Web fetch completed";
+  if (toolName === "TaskOutput") return failed ? "Task output failed" : "Task output";
+  if (toolName === "TaskStatus") return failed ? "Task status failed" : "Task status";
+  if (toolName === "TaskStop") return failed ? "Task stop failed" : "Stopped task";
+  if (toolName === "TaskInput") return failed ? "Task input failed" : "Task input";
   return failed ? "Tool failed" : "Tool finished";
 }
 

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -533,12 +533,18 @@ function projectToolExecution(
   const exitStatus = numberField(payload, "exit_status") ?? numberField(result, "exit_status");
   const durationMs = numberField(payload, "duration_ms") ?? numberField(result, "duration_ms");
   const error = toolErrorMessage(payload);
+  const disposition = firstStringField(payload, ["exec_command_disposition"]) ?? firstStringField(result, ["disposition"]);
+  const promoted = disposition === "promoted_to_task";
   const stringPreview = toolStringPreview(toolName, payload, commandPreview) || undefined;
   const toolSummary = projection?.body ?? stringPreview ?? summary ?? genericToolDescription(toolName, payload) ?? toolName;
+  // For promoted tasks, duration_ms is the yield_time timeout, not real execution time — suppress it.
+  const effectiveDuration = promoted ? undefined : durationMs;
+  const promotedTaskId = promoted ? firstStringField(asRecord(payload?.task_handle), ["task_id"]) : undefined;
   const body = compactJoin([
     toolSummary,
+    promotedTaskId ? `task ${shortTaskId(promotedTaskId)}` : undefined,
     exitStatus == null ? undefined : `exit ${exitStatus}`,
-    durationMs == null ? undefined : formatDuration(durationMs),
+    effectiveDuration == null ? undefined : formatDuration(effectiveDuration),
     error,
   ]);
   const outputPreview = commandOutputPreview(payload);
@@ -551,6 +557,10 @@ function projectToolExecution(
     detail,
     minDisplayLevel: toolTimelineDisplayLevel(toolName),
   };
+}
+
+function shortTaskId(taskId: string): string {
+  return taskId.length > 20 ? taskId.slice(0, 20) + "…" : taskId;
 }
 
 function toolTimelineDisplayLevel(toolName: string): DisplayLevel {
@@ -570,6 +580,8 @@ function projectKnownToolExecution(
   if (toolName === "ViewImage") return projectViewImageTool(payload);
   if (isWebSearchTool(toolName)) return projectWebSearchTool(toolName, payload);
   if (isWebFetchTool(toolName)) return projectWebFetchTool(payload);
+  if (toolName === "MemorySearch") return projectMemorySearchTool(payload);
+  if (toolName === "MemoryGet") return projectMemoryGetTool(payload);
   return undefined;
 }
 
@@ -783,6 +795,50 @@ function unwrapToolResult(payload: Record<string, unknown> | undefined): Record<
   const envelope = asRecord(output.envelope);
   if (envelope) return asRecord(envelope.result) ?? envelope;
   return output;
+}
+
+function projectMemorySearchTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const output = unwrapToolResult(payload);
+  const query = stringField(output, "query") ?? firstStringField(asRecord(payload?.input), ["query"]);
+  const results = arrayField(output, "results") ?? [];
+  const resultCount = results.length;
+  const body = compactJoin([
+    "Memory search",
+    query ? `“${truncateText(query, 60)}”` : undefined,
+    resultCount === 0 ? "no matches" : `${resultCount} ${resultCount === 1 ? "result" : "results"}`,
+  ]);
+  const detailText = results.length
+    ? results
+        .map((item) => {
+          const record = asRecord(item);
+          const sourceRef = stringField(record, "source_ref");
+          const preview = stringField(record, "preview");
+          return compactJoin([sourceRef, preview]);
+        })
+        .filter(Boolean)
+        .join("\n\n")
+    : undefined;
+  return {
+    body,
+    detail: detailText ? { label: "Memory results", text: detailText, tone: "output" } : undefined,
+  };
+}
+
+function projectMemoryGetTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const output = unwrapToolResult(payload);
+  const sourceRef = stringField(output, "source_ref") ?? firstStringField(asRecord(payload?.input), ["source_ref"]);
+  const content = stringField(output, "content");
+  const body = compactJoin([
+    "Memory get",
+    sourceRef ? truncateText(sourceRef, 80) : undefined,
+    content ? `${formatBytesRead(content.length)} retrieved` : undefined,
+  ]);
+  return {
+    body,
+    detail: content
+      ? { label: "Memory content", text: truncateText(content, 800), tone: "output" }
+      : undefined,
+  };
 }
 
 function formatBytesRead(bytes: number): string {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -547,6 +547,7 @@ function projectKnownToolExecution(
   payload: Record<string, unknown> | undefined,
 ): Pick<SessionItemDraft, "body" | "detail"> | undefined {
   if (toolName === "ApplyPatch") return projectApplyPatchTool(payload);
+  if (toolName === "ListTasks") return projectListTasksTool(payload);
   if (toolName === "ListWorkItems") return projectListWorkItemsTool(payload);
   if (toolName === "GetWorkItem") return projectGetWorkItemTool(payload);
   if (isWorkItemMutationTool(toolName)) return projectWorkItemMutationTool(payload);
@@ -613,6 +614,24 @@ function projectApplyPatchTool(payload: Record<string, unknown> | undefined): Pi
           tone: "diff",
         }
       : undefined,
+  };
+}
+
+function projectListTasksTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const result = asRecord(payload?.list_tasks_result) ?? asRecord(payload?.result);
+  const tasks = arrayField(result, "tasks") ?? arrayField(result, "active_tasks");
+  const total = numberField(result, "total_active") ?? numberField(result, "total") ?? tasks?.length;
+  const returned = numberField(result, "returned") ?? tasks?.length;
+  const taskSummaries = summarizeTaskRecords(tasks);
+  return {
+    body: compactJoin([
+      total == null ? "Listed tasks" : `${total} active task${total === 1 ? "" : "s"}`,
+      returned != null && total != null && returned !== total ? `${returned} returned` : undefined,
+      taskSummaries.length ? taskSummaries.slice(0, 3).join("; ") : undefined,
+    ]),
+    detail: taskSummaries.length
+      ? { label: "Tasks", text: taskSummaries.join("\n"), tone: "data" }
+      : { label: "Result", text: debugJson(result ?? payload ?? {}), tone: "data" },
   };
 }
 
@@ -683,6 +702,24 @@ function summarizeWorkItemRecords(items: unknown[] | undefined): string[] {
     .map(asRecord)
     .filter((item): item is Record<string, unknown> => Boolean(item))
     .map(summarizeWorkItemRecord)
+    .filter(Boolean);
+}
+
+function summarizeTaskRecords(tasks: unknown[] | undefined): string[] {
+  return (tasks ?? [])
+    .map(asRecord)
+    .filter((task): task is Record<string, unknown> => Boolean(task))
+    .map((task) => {
+      const command = firstStringField(asRecord(task.command), ["cmd_preview", "cmd"]);
+      const retrieval = firstStringField(asRecord(task.retrieval), ["status", "output"]);
+      return compactJoin([
+        stringField(task, "summary") ?? command ?? stringField(task, "kind"),
+        stringField(task, "status"),
+        stringField(task, "kind"),
+        firstStringField(task, ["task_id", "id"]),
+        retrieval,
+      ]);
+    })
     .filter(Boolean);
 }
 

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -5,6 +5,7 @@ import type {
   AgentTimelineItemKind,
   DisplayLevel,
   RuntimeMessageEnvelope,
+  RuntimeBriefRecord,
   RuntimeTranscriptEntry,
 } from "./types";
 
@@ -34,6 +35,7 @@ export interface ReduceAgentSessionInput {
   includeDebug?: boolean;
   messagesById?: Record<string, RuntimeMessageEnvelope>;
   transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>;
+  briefRecordsById?: Record<string, RuntimeBriefRecord>;
 }
 
 interface SessionItemDraft {
@@ -81,6 +83,7 @@ export function reduceAgentSessionTimeline(input: ReduceAgentSessionInput): Agen
       input.includeDebug ?? false,
       input.messagesById,
       input.transcriptEntriesById,
+      input.briefRecordsById,
     ),
   );
 
@@ -144,12 +147,13 @@ function projectEventEnvelope(
   includeDebug: boolean,
   messagesById: Record<string, RuntimeMessageEnvelope> | undefined,
   transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>,
+  briefRecordsById?: Record<string, RuntimeBriefRecord>,
 ): AgentTimelineItem | undefined {
   if (!event.id && event.event_seq == null) return undefined;
   const id = event.id ?? `event-${event.event_seq}`;
   const payload = asRecord(event.payload);
   const eventType = event.type ?? "runtime_event";
-  const projection = projectRuntimeEvent(eventType, payload, messagesById, transcriptEntriesById);
+  const projection = projectRuntimeEvent(eventType, payload, messagesById, transcriptEntriesById, briefRecordsById);
   if (!projection) return undefined;
   const meta = eventMeta(eventType, payload, event.event_seq);
 
@@ -233,6 +237,7 @@ function projectRuntimeEvent(
   payload: Record<string, unknown> | undefined,
   messagesById?: Record<string, RuntimeMessageEnvelope>,
   transcriptEntriesById?: Record<string, RuntimeTranscriptEntry>,
+  briefRecordsById?: Record<string, RuntimeBriefRecord>,
 ): (Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> & { timestamp?: string }) | undefined {
   if (eventType === "message_enqueued") {
     const message = messageEnvelopeProjection(payload, messagesById);
@@ -257,7 +262,11 @@ function projectRuntimeEvent(
     return {
       kind: "assistant",
       label: stringField(payload, "kind") === "result" ? "Result" : "Brief Created",
-      body: transcriptTextForPayload(payload, transcriptEntriesById) || readableTextWithoutSummary(payload) || "Brief text unavailable.",
+      body:
+        transcriptTextForPayload(payload, transcriptEntriesById) ||
+        briefTextForPayload(payload, briefRecordsById) ||
+        readableTextWithoutSummary(payload) ||
+        "Brief text unavailable.",
       timestamp: stringField(payload, "created_at"),
       minDisplayLevel: runtimeEventDisplayLevel(eventType),
     };
@@ -991,6 +1000,19 @@ function transcriptTextForPayload(
   const entryId = transcriptEntryIdForPayload(payload);
   const entry = entryId ? transcriptEntriesById?.[entryId] : undefined;
   return transcriptEntryText(entry);
+}
+
+function briefTextForPayload(
+  payload: Record<string, unknown> | undefined,
+  briefRecordsById: Record<string, RuntimeBriefRecord> | undefined,
+): string | undefined {
+  const briefId = briefIdForPayload(payload);
+  const text = briefId ? briefRecordsById?.[briefId]?.text : undefined;
+  return text && text.trim() ? text : undefined;
+}
+
+export function briefIdForPayload(payload: Record<string, unknown> | undefined): string | undefined {
+  return stringField(payload, "brief_id") ?? stringField(payload, "id");
 }
 
 export function transcriptEntryIdForPayload(payload: Record<string, unknown> | undefined): string | undefined {

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -290,6 +290,22 @@ function projectRuntimeEvent(
     };
   }
 
+  if (eventType === "turn_started") {
+    const turnIndex = numberField(payload, "turn_index");
+    const messageKind = stringField(payload, "message_kind");
+    const triggerLabel = messageKind ? turnTriggerLabel(messageKind) : undefined;
+    return {
+      kind: "system",
+      label: "Turn started",
+      body: compactJoin([
+        turnIndex != null ? `Turn #${turnIndex}` : undefined,
+        triggerLabel,
+      ]) || "Turn started",
+      timestamp: stringField(payload, "created_at"),
+      minDisplayLevel: "info",
+    };
+  }
+
   if (debugRuntimeEvents.has(eventType)) {
     return {
       kind: "system",
@@ -1002,9 +1018,24 @@ function summarizeSystemRuntimeEvent(eventType: string, payload: Record<string, 
 
 function systemRuntimeLabel(eventType: string): string {
   if (eventType.startsWith("turn_local_checkpoint_")) return "Context checkpoint";
+  if (eventType === "turn_started") return "Turn started";
   if (eventType.startsWith("continuation_")) return "Continuation";
   if (eventType === "closure_decided") return "Closure";
   return humanizeEventType(eventType);
+}
+
+function turnTriggerLabel(messageKind: string): string | undefined {
+  switch (messageKind) {
+    case "OperatorPrompt": return "operator";
+    case "InternalFollowup": return "internal followup";
+    case "SystemTick": return "system tick";
+    case "TimerTick": return "timer";
+    case "CallbackEvent": return "callback";
+    case "WebhookEvent": return "webhook";
+    case "ChannelEvent": return "channel event";
+    case "TaskResultContinuation": return "task result";
+    default: return undefined;
+  }
 }
 
 function messageEnvelopeProjection(

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -568,11 +568,21 @@ function projectKnownToolExecution(
   if (toolName === "GetWorkItem") return projectGetWorkItemTool(payload);
   if (isWorkItemMutationTool(toolName)) return projectWorkItemMutationTool(payload);
   if (toolName === "ViewImage") return projectViewImageTool(payload);
+  if (isWebSearchTool(toolName)) return projectWebSearchTool(toolName, payload);
+  if (isWebReaderTool(toolName)) return projectWebReaderTool(payload);
   return undefined;
 }
 
 function isWorkItemMutationTool(toolName: string): boolean {
   return toolName === "CreateWorkItem" || toolName === "UpdateWorkItem" || toolName === "PickWorkItem" || toolName === "CompleteWorkItem";
+}
+
+function isWebSearchTool(toolName: string): boolean {
+  return toolName === "mcp__web-search-prime__web_search_prime" || toolName === "WebSearch";
+}
+
+function isWebReaderTool(toolName: string): boolean {
+  return toolName === "mcp__web_reader__webReader";
 }
 
 function toolStringPreview(
@@ -711,6 +721,136 @@ function projectViewImageTool(payload: Record<string, unknown> | undefined): Pic
       ? { label: "Visual observation", text: observation, tone: "data" }
       : { label: "Result", text: debugJson(result ?? payload ?? {}), tone: "data" },
   };
+}
+
+function projectWebSearchTool(
+  toolName: string,
+  payload: Record<string, unknown> | undefined,
+): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const input = asRecord(payload?.input) ?? payload;
+  const query = firstStringField(input, ["search_query", "query", "q"]);
+  const output = unwrapMcpOutput(payload?.output ?? payload?.result ?? payload);
+  const results = extractSearchResults(output);
+  const body = compactJoin([
+    "Web search",
+    query,
+    results.length ? `${results.length} result${results.length === 1 ? "" : "s"}` : undefined,
+  ]);
+
+  const detailText = results.length
+    ? results
+        .slice(0, 10)
+        .map((item, index) =>
+          compactJoin([
+            `${index + 1}. ${firstStringField(item, ["title", "name"]) ?? "Untitled"}`,
+            firstStringField(item, ["url", "link", "href"]),
+            firstStringField(item, ["siteName", "site_name", "websiteName", "website_name"]),
+            firstStringField(item, ["summary", "snippet", "description"])
+              ? truncateText(firstStringField(item, ["summary", "snippet", "description"])!, 200)
+              : undefined,
+          ]),
+        )
+        .join("\n\n")
+    : undefined;
+
+  return {
+    body,
+    detail: detailText ? { label: "Search results", text: detailText, tone: "output" } : undefined,
+  };
+}
+
+function projectWebReaderTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const input = asRecord(payload?.input) ?? payload;
+  const url = firstStringField(input, ["url"]);
+  const output = unwrapMcpOutput(payload?.output ?? payload?.result ?? payload);
+  const title = firstStringField(asRecord(output), ["title", "pageTitle"]);
+  const contentLength = extractContentLength(output);
+  const body = compactJoin([
+    "Read webpage",
+    title ?? (url ? truncateText(url, 80) : undefined),
+    contentLength > 0 ? formatContentLength(contentLength) : undefined,
+  ]);
+  const preview = extractMarkdownPreview(output, 600);
+  return {
+    body,
+    detail: preview ? { label: "Webpage content", text: preview, tone: "output" } : undefined,
+  };
+}
+
+function unwrapMcpOutput(value: unknown): unknown {
+  let current = value;
+  for (let depth = 0; depth < 4; depth++) {
+    const record = asRecord(current);
+    if (!record) break;
+    if (record.envelope && asRecord(record.envelope)) {
+      current = (record.envelope as Record<string, unknown>).result ?? record.envelope;
+      continue;
+    }
+    if (record.result !== undefined) {
+      current = record.result;
+      continue;
+    }
+    if (record.content !== undefined && Array.isArray(record.content)) {
+      current = record.content;
+      break;
+    }
+    break;
+  }
+  return current;
+}
+
+function extractSearchResults(value: unknown): Record<string, unknown>[] {
+  const record = asRecord(value);
+  if (!record) return [];
+  for (const key of ["results", "search_results", "data", "items"]) {
+    const candidate = record[key];
+    if (Array.isArray(candidate)) {
+      return candidate.filter((item): item is Record<string, unknown> => Boolean(asRecord(item)));
+    }
+  }
+  return [];
+}
+
+function extractContentLength(value: unknown): number {
+  const record = asRecord(value);
+  if (!record) return 0;
+  const content = record.content;
+  if (typeof content === "string") return content.length;
+  if (record.markdown && typeof record.markdown === "string") return record.markdown.length;
+  if (record.text && typeof record.text === "string") return record.text.length;
+  if (Array.isArray(content)) {
+    return content.reduce((sum: number, item: unknown) => {
+      const text = asRecord(item)?.text;
+      return sum + (typeof text === "string" ? text.length : 0);
+    }, 0);
+  }
+  return 0;
+}
+
+function extractMarkdownPreview(value: unknown, maxChars: number): string | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  for (const key of ["markdown", "content", "text"]) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return truncateText(candidate, maxChars);
+    }
+  }
+  const content = record.content;
+  if (Array.isArray(content)) {
+    const text = content
+      .map((item) => asRecord(item)?.text)
+      .filter((text): text is string => typeof text === "string")
+      .join("\n");
+    return text.trim() ? truncateText(text, maxChars) : undefined;
+  }
+  return undefined;
+}
+
+function formatContentLength(chars: number): string {
+  if (chars < 1000) return `${chars} chars`;
+  if (chars < 1_000_000) return `${(chars / 1000).toFixed(0)}K chars`;
+  return `${(chars / 1_000_000).toFixed(1)}M chars`;
 }
 
 function summarizeWorkItemRecords(items: unknown[] | undefined): string[] {
@@ -898,6 +1038,8 @@ function toolFriendlyLabel(toolName: string, failed: boolean): string {
   if (toolName === "UpdateWorkItem") return failed ? "Work item update failed" : "Updated work item";
   if (toolName === "PickWorkItem") return failed ? "Work item switch failed" : "Picked work item";
   if (toolName === "CompleteWorkItem") return failed ? "Work item completion failed" : "Completed work item";
+  if (isWebSearchTool(toolName)) return failed ? "Web search failed" : "Web search completed";
+  if (isWebReaderTool(toolName)) return failed ? "Web page read failed" : "Web page read";
   return failed ? "Tool failed" : "Tool finished";
 }
 

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -700,7 +700,9 @@ function projectListTasksTool(payload: Record<string, unknown> | undefined): Pic
 function extractTaskFromOutput(payload: Record<string, unknown> | undefined): {
   task?: Record<string, unknown>;
   taskId?: string;
-  status?: string;
+  taskStatus?: string;
+  retrievalStatus?: string;
+  kind?: string;
   summary?: string;
   exitStatus?: number;
   outputPreview?: string;
@@ -708,17 +710,34 @@ function extractTaskFromOutput(payload: Record<string, unknown> | undefined): {
 } {
   const result = asRecord(payload?.task_output_result) ?? unwrapToolResult(payload);
   const task = asRecord(result.task) ?? asRecord(result.task_record);
-  const taskId = firstStringField(task, ["task_id", "id"]) ?? stringField(payload, "task_id");
-  const status = firstStringField(task, ["status"]) ?? stringField(result, "status") ?? stringField(result, "retrieval_status");
+  const taskId = firstStringField(task, ["task_id", "id"]) ?? stringField(result, "task_id") ?? stringField(payload, "task_id");
+  const resultStatus = stringField(result, "status");
+  const taskStatus =
+    firstStringField(task, ["status"]) ?? (resultStatus && !isTaskOutputRetrievalStatus(resultStatus) ? resultStatus : undefined);
+  const retrievalStatus =
+    stringField(result, "retrieval_status") ?? (resultStatus && isTaskOutputRetrievalStatus(resultStatus) ? resultStatus : undefined);
+  const kind = stringField(task, "kind") ?? stringField(result, "kind");
   const summary = stringField(task, "summary") ?? stringField(result, "summary") ?? stringField(result, "result_summary");
   const exitStatus = numberField(task, "exit_status") ?? numberField(result, "exit_status");
   const outputPreview =
+    stringField(task, "output_preview") ??
     stringField(result, "output_preview") ??
     stringField(result, "output") ??
     stringField(result, "stdout") ??
     stringField(result, "stderr");
-  const truncated = result.output_truncated === true || result.truncated === true;
-  return { task, taskId, status, summary, exitStatus, outputPreview, truncated };
+  const truncated = task?.output_truncated === true || result.output_truncated === true || result.truncated === true;
+  return { task, taskId, taskStatus, retrievalStatus, kind, summary, exitStatus, outputPreview, truncated };
+}
+
+function isTaskOutputRetrievalStatus(status: string): boolean {
+  return status === "success" || status === "timeout" || status === "not_ready";
+}
+
+function formatTaskOutputRetrievalStatus(status: string | undefined): string | undefined {
+  if (!status || status === "success") return undefined;
+  if (status === "timeout") return "retrieval timeout";
+  if (status === "not_ready") return "not ready";
+  return status;
 }
 
 function projectTaskOutputTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
@@ -726,7 +745,9 @@ function projectTaskOutputTool(payload: Record<string, unknown> | undefined): Pi
   const body = compactJoin([
     "Task output",
     info.taskId ? shortTaskId(info.taskId) : undefined,
-    info.status,
+    formatTaskOutputRetrievalStatus(info.retrievalStatus),
+    info.taskStatus,
+    info.kind,
     info.summary,
     info.exitStatus != null ? `exit ${info.exitStatus}` : undefined,
     info.truncated ? "truncated" : undefined,
@@ -752,7 +773,7 @@ function projectTaskStatusTool(payload: Record<string, unknown> | undefined): Pi
   const body = compactJoin([
     "Task status",
     taskId ? shortTaskId(taskId) : undefined,
-    status,
+    status === "success" ? undefined : status,
     kind,
     summary,
   ]);
@@ -769,7 +790,7 @@ function projectTaskStopTool(payload: Record<string, unknown> | undefined): Pick
   const body = compactJoin([
     "Stopped task",
     taskId ? shortTaskId(taskId) : undefined,
-    status,
+    status === "success" ? undefined : status,
   ]);
   return {
     body,

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -290,6 +290,10 @@ function projectRuntimeEvent(
     };
   }
 
+  if (eventType === "task_created" || eventType === "task_status_updated" || eventType === "task_result_received") {
+    return projectTaskLifecycleEvent(eventType, payload);
+  }
+
   if (eventType.startsWith("work_item_")) {
     return {
       kind: "system",
@@ -373,7 +377,7 @@ function projectAssistantRoundRecorded(
 
 function timelineDedupeKey(item: AgentTimelineItem): string {
   if (item.kind === "operator") {
-    return `operator:${normalizeTextKey(item.body)}`;
+    return `operator:${item.sourceIds[0] ?? item.id}`;
   }
   if (item.kind === "assistant") {
     return `assistant:${item.id}`;
@@ -675,9 +679,11 @@ function summarizeWorkItemRecords(items: unknown[] | undefined): string[] {
 
 function summarizeWorkItemRecord(record: Record<string, unknown> | undefined): string {
   const id = stringField(record, "id") ?? stringField(record, "work_item_id");
-  const objective = stringField(record, "objective");
-  const lifecycle = stringField(record, "lifecycle") ?? stringField(record, "status");
-  return compactJoin([objective, lifecycle, id]);
+  const objective = firstStringField(record, ["objective", "objective_preview"]);
+  const lifecycle = firstStringField(record, ["lifecycle", "state", "status"]);
+  const planStatus = stringField(record, "plan_status");
+  const readiness = stringField(record, "readiness");
+  return compactJoin([objective, lifecycle, planStatus, readiness, id]);
 }
 
 function applyPatchDetailText(
@@ -841,10 +847,12 @@ function formatDuration(milliseconds: number): string {
 function summarizeWorkItemEvent(eventType: string, payload: Record<string, unknown> | undefined): string {
   const action = stringField(payload, "action") ?? eventType.replace(/^work_item_/, "");
   const record = asRecord(payload?.record);
-  const objective = stringField(record, "objective");
+  const objective = firstStringField(record, ["objective", "objective_preview"]) ?? stringField(payload, "objective_preview");
+  const workItemId = firstStringField(payload, ["work_item_id", "current_work_item_id"]);
   const reason = stringField(payload, "reason");
+  const state = firstStringField(payload, ["state", "plan_status", "readiness"]);
   if (eventType === "work_item_picked") {
-    return compactJoin(["Picked work item", objective, reason]);
+    return compactJoin(["Picked work item", objective, reason, state]);
   }
   if (eventType === "work_item_focus_released") {
     return compactJoin(["Released work item focus", objective, reason, stringField(payload, "readiness")]);
@@ -855,7 +863,63 @@ function summarizeWorkItemEvent(eventType: string, payload: Record<string, unkno
   if (eventType === "work_item_completion_report_candidate_promoted") {
     return compactJoin(["Promoted completion report candidate", objective, stringField(payload, "text_preview")]);
   }
-  return compactJoin([humanizeEventType(`work_item_${action}`), objective]);
+  return compactJoin([humanizeEventType(`work_item_${action}`), objective, state, objective ? undefined : workItemId]);
+}
+
+function projectTaskLifecycleEvent(
+  eventType: string,
+  payload: Record<string, unknown> | undefined,
+): Pick<SessionItemDraft, "kind" | "label" | "body" | "minDisplayLevel" | "detail"> {
+  const status = firstStringField(payload, ["task_status", "status"]);
+  const summary = stringField(payload, "summary");
+  const outputPreview = stringField(payload, "output_summary_preview");
+  const error = stringField(payload, "error");
+  const taskId = stringField(payload, "task_id");
+  const exitStatus = numberField(payload, "exit_status");
+  const outputPath = stringField(payload, "output_path");
+  const label = taskLifecycleLabel(eventType, status);
+  const body = compactJoin([
+    summary || taskId,
+    status && !label.toLowerCase().includes(status.toLowerCase()) ? status : undefined,
+    exitStatus == null ? undefined : `exit ${exitStatus}`,
+    error,
+    outputPreview,
+  ]) || humanizeEventType(eventType);
+  const detailText = compactJoin([
+    taskId ? `task: ${taskId}` : undefined,
+    outputPath ? `output: ${outputPath}` : undefined,
+    outputPreview,
+  ]);
+
+  return {
+    kind: "event",
+    label,
+    body,
+    minDisplayLevel: error || isFailedTaskStatus(status) ? "info" : "verbose",
+    detail: detailText ? { label: "Task details", text: detailText, tone: outputPreview ? "output" : "data" } : undefined,
+  };
+}
+
+function taskLifecycleLabel(eventType: string, status: string | undefined): string {
+  if (eventType === "task_created") return "Task queued";
+  if (eventType === "task_result_received") {
+    if (status === "completed") return "Task completed";
+    if (status === "failed") return "Task failed";
+    if (status === "cancelled") return "Task cancelled";
+    if (status === "interrupted") return "Task interrupted";
+    return "Task result received";
+  }
+  if (status === "running") return "Task running";
+  if (status === "cancelling") return "Task cancelling";
+  if (status === "completed") return "Task completed";
+  if (status === "failed") return "Task failed";
+  if (status === "cancelled") return "Task cancelled";
+  if (status === "interrupted") return "Task interrupted";
+  return "Task updated";
+}
+
+function isFailedTaskStatus(status: string | undefined): boolean {
+  return status === "failed" || status === "cancelled" || status === "interrupted";
 }
 
 function summarizeDebugEvent(eventType: string, payload: Record<string, unknown> | undefined): string {
@@ -1007,8 +1071,12 @@ function collectReadableEventFacts(value: Record<string, unknown>, facts: Map<st
     "status",
     "priority",
     "objective",
+    "objective_preview",
     "work_item_id",
+    "current_work_item_id",
     "task_id",
+    "task_status",
+    "output_summary_preview",
     "agent_id",
     "turn_id",
     "run_id",

--- a/web-gui/app/src/runtime/session-reducer.ts
+++ b/web-gui/app/src/runtime/session-reducer.ts
@@ -569,7 +569,7 @@ function projectKnownToolExecution(
   if (isWorkItemMutationTool(toolName)) return projectWorkItemMutationTool(payload);
   if (toolName === "ViewImage") return projectViewImageTool(payload);
   if (isWebSearchTool(toolName)) return projectWebSearchTool(toolName, payload);
-  if (isWebReaderTool(toolName)) return projectWebReaderTool(payload);
+  if (isWebFetchTool(toolName)) return projectWebFetchTool(payload);
   return undefined;
 }
 
@@ -578,11 +578,11 @@ function isWorkItemMutationTool(toolName: string): boolean {
 }
 
 function isWebSearchTool(toolName: string): boolean {
-  return toolName === "mcp__web-search-prime__web_search_prime" || toolName === "WebSearch";
+  return toolName === "WebSearch";
 }
 
-function isWebReaderTool(toolName: string): boolean {
-  return toolName === "mcp__web_reader__webReader";
+function isWebFetchTool(toolName: string): boolean {
+  return toolName === "WebFetch";
 }
 
 function toolStringPreview(
@@ -727,10 +727,9 @@ function projectWebSearchTool(
   toolName: string,
   payload: Record<string, unknown> | undefined,
 ): Pick<SessionItemDraft, "body" | "detail"> | undefined {
-  const input = asRecord(payload?.input) ?? payload;
-  const query = firstStringField(input, ["search_query", "query", "q"]);
-  const output = unwrapMcpOutput(payload?.output ?? payload?.result ?? payload);
-  const results = extractSearchResults(output);
+  const output = unwrapToolResult(payload);
+  const query = stringField(output, "query") ?? firstStringField(asRecord(payload?.input), ["query", "search_query", "q"]);
+  const results = arrayField(output, "results")?.map(asRecord).filter((r): r is Record<string, unknown> => Boolean(r)) ?? [];
   const body = compactJoin([
     "Web search",
     query,
@@ -742,12 +741,10 @@ function projectWebSearchTool(
         .slice(0, 10)
         .map((item, index) =>
           compactJoin([
-            `${index + 1}. ${firstStringField(item, ["title", "name"]) ?? "Untitled"}`,
-            firstStringField(item, ["url", "link", "href"]),
-            firstStringField(item, ["siteName", "site_name", "websiteName", "website_name"]),
-            firstStringField(item, ["summary", "snippet", "description"])
-              ? truncateText(firstStringField(item, ["summary", "snippet", "description"])!, 200)
-              : undefined,
+            `${index + 1}. ${stringField(item, "title") ?? "Untitled"}`,
+            stringField(item, "url"),
+            stringField(item, "source"),
+            stringField(item, "snippet") ? truncateText(stringField(item, "snippet")!, 200) : undefined,
           ]),
         )
         .join("\n\n")
@@ -759,98 +756,39 @@ function projectWebSearchTool(
   };
 }
 
-function projectWebReaderTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
-  const input = asRecord(payload?.input) ?? payload;
-  const url = firstStringField(input, ["url"]);
-  const output = unwrapMcpOutput(payload?.output ?? payload?.result ?? payload);
-  const title = firstStringField(asRecord(output), ["title", "pageTitle"]);
-  const contentLength = extractContentLength(output);
+function projectWebFetchTool(payload: Record<string, unknown> | undefined): Pick<SessionItemDraft, "body" | "detail"> | undefined {
+  const output = unwrapToolResult(payload);
+  const url = stringField(output, "url") ?? firstStringField(asRecord(payload?.input), ["url"]);
+  const status = numberField(output, "status");
+  const bytesRead = numberField(output, "bytes_read");
   const body = compactJoin([
-    "Read webpage",
-    title ?? (url ? truncateText(url, 80) : undefined),
-    contentLength > 0 ? formatContentLength(contentLength) : undefined,
+    "Web fetch",
+    url ? truncateText(url, 80) : undefined,
+    status != null ? `${status}` : undefined,
+    bytesRead != null ? formatBytesRead(bytesRead) : undefined,
   ]);
-  const preview = extractMarkdownPreview(output, 600);
+  const text = stringField(output, "text");
+  const truncated = output && typeof output === "object" && "truncated" in output ? output.truncated === true : false;
   return {
     body,
-    detail: preview ? { label: "Webpage content", text: preview, tone: "output" } : undefined,
+    detail: text
+      ? { label: truncated ? "Fetched content (truncated)" : "Fetched content", text: truncateText(text, 600), tone: "output" }
+      : undefined,
   };
 }
 
-function unwrapMcpOutput(value: unknown): unknown {
-  let current = value;
-  for (let depth = 0; depth < 4; depth++) {
-    const record = asRecord(current);
-    if (!record) break;
-    if (record.envelope && asRecord(record.envelope)) {
-      current = (record.envelope as Record<string, unknown>).result ?? record.envelope;
-      continue;
-    }
-    if (record.result !== undefined) {
-      current = record.result;
-      continue;
-    }
-    if (record.content !== undefined && Array.isArray(record.content)) {
-      current = record.content;
-      break;
-    }
-    break;
-  }
-  return current;
+function unwrapToolResult(payload: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!payload) return {};
+  const output = asRecord(payload.output) ?? asRecord(payload.result) ?? payload;
+  const envelope = asRecord(output.envelope);
+  if (envelope) return asRecord(envelope.result) ?? envelope;
+  return output;
 }
 
-function extractSearchResults(value: unknown): Record<string, unknown>[] {
-  const record = asRecord(value);
-  if (!record) return [];
-  for (const key of ["results", "search_results", "data", "items"]) {
-    const candidate = record[key];
-    if (Array.isArray(candidate)) {
-      return candidate.filter((item): item is Record<string, unknown> => Boolean(asRecord(item)));
-    }
-  }
-  return [];
-}
-
-function extractContentLength(value: unknown): number {
-  const record = asRecord(value);
-  if (!record) return 0;
-  const content = record.content;
-  if (typeof content === "string") return content.length;
-  if (record.markdown && typeof record.markdown === "string") return record.markdown.length;
-  if (record.text && typeof record.text === "string") return record.text.length;
-  if (Array.isArray(content)) {
-    return content.reduce((sum: number, item: unknown) => {
-      const text = asRecord(item)?.text;
-      return sum + (typeof text === "string" ? text.length : 0);
-    }, 0);
-  }
-  return 0;
-}
-
-function extractMarkdownPreview(value: unknown, maxChars: number): string | undefined {
-  const record = asRecord(value);
-  if (!record) return undefined;
-  for (const key of ["markdown", "content", "text"]) {
-    const candidate = record[key];
-    if (typeof candidate === "string" && candidate.trim()) {
-      return truncateText(candidate, maxChars);
-    }
-  }
-  const content = record.content;
-  if (Array.isArray(content)) {
-    const text = content
-      .map((item) => asRecord(item)?.text)
-      .filter((text): text is string => typeof text === "string")
-      .join("\n");
-    return text.trim() ? truncateText(text, maxChars) : undefined;
-  }
-  return undefined;
-}
-
-function formatContentLength(chars: number): string {
-  if (chars < 1000) return `${chars} chars`;
-  if (chars < 1_000_000) return `${(chars / 1000).toFixed(0)}K chars`;
-  return `${(chars / 1_000_000).toFixed(1)}M chars`;
+function formatBytesRead(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
 function summarizeWorkItemRecords(items: unknown[] | undefined): string[] {
@@ -1039,7 +977,7 @@ function toolFriendlyLabel(toolName: string, failed: boolean): string {
   if (toolName === "PickWorkItem") return failed ? "Work item switch failed" : "Picked work item";
   if (toolName === "CompleteWorkItem") return failed ? "Work item completion failed" : "Completed work item";
   if (isWebSearchTool(toolName)) return failed ? "Web search failed" : "Web search completed";
-  if (isWebReaderTool(toolName)) return failed ? "Web page read failed" : "Web page read";
+  if (isWebFetchTool(toolName)) return failed ? "Web fetch failed" : "Web fetch completed";
   return failed ? "Tool failed" : "Tool finished";
 }
 

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -93,6 +93,7 @@ export interface AgentSummary {
   id: string;
   badge: string;
   badgeTone?: "muted";
+  badgeHue?: number;
   profile: string;
   lifecycle: string;
   focusSummary: string;

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -330,6 +330,11 @@ export type RightPanelView =
       agentId: string;
     }
   | {
+      kind: "work_item_detail";
+      agentId: string;
+      workItem: WorkItemSummary;
+    }
+  | {
       kind: "activity_inspector";
       agentId: string;
       activity: AgentTimelineActivity;

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -96,6 +96,13 @@ export interface RuntimeModelCatalog {
   error?: string;
 }
 
+export interface RuntimeBriefRecord {
+  id?: string;
+  created_at?: string;
+  text?: string;
+  kind?: string;
+}
+
 export interface RuntimeProviderSummary {
   id: string;
   transport: string;
@@ -265,6 +272,7 @@ export interface AgentDetail {
   newestEventSeq?: number;
   oldestEventSeq?: number;
   hasOlderEvents?: boolean;
+  briefRecordsById?: Record<string, RuntimeBriefRecord>;
 }
 
 export interface RuntimeBootstrap {

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -29,11 +29,15 @@ export interface WorkspaceSummary {
   id: string;
   name: string;
   anchor: string;
+  projectionKind?: string;
+  accessMode?: string;
   executionRoot?: string;
   cwd?: string;
   worktree?: {
     branch?: string;
     path?: string;
+    originalBranch?: string;
+    originalCwd?: string;
   };
 }
 

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -6,6 +6,7 @@ export interface RuntimeConnection {
   mode: "local" | "remote";
   summary: string;
   baseUrl?: string;
+  hasToken?: boolean;
   source: "http" | "fixture";
   error?: string;
 }

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -243,6 +243,7 @@ export interface RuntimeToolExecutionRecord {
   status?: string;
   summary?: string;
   input?: unknown;
+  output?: unknown;
   result?: unknown;
   error?: unknown;
   duration_ms?: number;

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -187,7 +187,7 @@ export interface RuntimeWebSearchProviderSummary {
 
 export interface RuntimeConfigUpdateResult {
   key: string;
-  effect: "accepted_requires_restart" | "rejected";
+  effect: "accepted_requires_restart" | "accepted_reloaded" | "rejected";
   reason: string;
 }
 

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -235,10 +235,56 @@ export interface AgentTimelineActivity {
   debug?: string;
 }
 
+export interface RuntimeToolExecutionRecord {
+  id?: string;
+  agent_id?: string;
+  tool_call_id?: string;
+  tool_name?: string;
+  status?: string;
+  summary?: string;
+  input?: unknown;
+  result?: unknown;
+  error?: unknown;
+  duration_ms?: number;
+  created_at?: string;
+  completed_at?: string;
+  [key: string]: unknown;
+}
+
+export interface RuntimeTaskOutputResult {
+  retrieval_status?: string;
+  task?: {
+    task_id?: string;
+    kind?: string;
+    status?: string;
+    summary?: string;
+    output_preview?: string;
+    output_truncated?: boolean;
+    result_summary?: string;
+    exit_status?: number;
+    [key: string]: unknown;
+  };
+  status?: string;
+  stdout?: string;
+  stderr?: string;
+  output?: string;
+  summary?: string;
+  truncated?: boolean;
+  [key: string]: unknown;
+}
+
+export interface InspectorActivityDetailState {
+  loading?: boolean;
+  error?: string;
+  toolExecution?: RuntimeToolExecutionRecord;
+  taskOutput?: RuntimeTaskOutputResult;
+}
+
 export interface InspectorSelection {
   kind: "activity";
   agentId: string;
   activity: AgentTimelineActivity;
+  detailState?: InspectorActivityDetailState;
 }
 
 export interface AgentTimelineItem {

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -23,6 +23,39 @@ export interface WorkItemSummary {
   state: string;
   planStatus?: string;
   current?: boolean;
+  revision?: number;
+  createdAt?: string;
+  updatedAt?: string;
+  blockedBy?: string;
+  recheckAt?: string;
+  resultBriefId?: string;
+  resultSummary?: string;
+  planArtifact?: WorkItemPlanArtifactSummary;
+  todoList?: WorkItemTodoItem[];
+  workRefs?: WorkItemRefSummary[];
+}
+
+export interface WorkItemPlanArtifactSummary {
+  path?: string;
+  relativePath?: string;
+  workspaceAlias?: string;
+  preview?: string;
+  previewComplete?: boolean;
+  updatedAt?: string;
+}
+
+export interface WorkItemTodoItem {
+  text: string;
+  state: string;
+}
+
+export interface WorkItemRefSummary {
+  kind: string;
+  ref: string;
+  title?: string;
+  reason?: string;
+  status?: string;
+  lastSeenAt?: string;
 }
 
 export interface WorkspaceSummary {
@@ -283,6 +316,12 @@ export interface InspectorActivityDetailState {
   error?: string;
   toolExecution?: RuntimeToolExecutionRecord;
   taskOutput?: RuntimeTaskOutputResult;
+}
+
+export interface WorkItemDetailState {
+  loading?: boolean;
+  error?: string;
+  workItem?: WorkItemSummary;
 }
 
 export type RightPanelView =

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -281,12 +281,17 @@ export interface InspectorActivityDetailState {
   taskOutput?: RuntimeTaskOutputResult;
 }
 
-export interface InspectorSelection {
-  kind: "activity";
-  agentId: string;
-  activity: AgentTimelineActivity;
-  detailState?: InspectorActivityDetailState;
-}
+export type RightPanelView =
+  | {
+      kind: "agent_overview";
+      agentId: string;
+    }
+  | {
+      kind: "activity_inspector";
+      agentId: string;
+      activity: AgentTimelineActivity;
+      detailState?: InspectorActivityDetailState;
+    };
 
 export interface AgentTimelineItem {
   id: string;

--- a/web-gui/app/src/runtime/useAgentDetail.ts
+++ b/web-gui/app/src/runtime/useAgentDetail.ts
@@ -14,7 +14,6 @@ export function useAgentDetail(agentId: string | undefined, displayLevel: Displa
   const loading = useRuntimeStore((state) => (agentId ? state.sessionsByAgentId[agentId]?.loading ?? false : false));
   const refreshAgentDetail = useRuntimeStore((state) => state.refreshAgentDetail);
   const registerAgentForEvents = useRuntimeStore((state) => state.registerAgentForEvents);
-  const unregisterAgentForEvents = useRuntimeStore((state) => state.unregisterAgentForEvents);
   const refresh = async () => {
     await refreshAgentDetail(agentId, displayLevel);
   };
@@ -22,11 +21,10 @@ export function useAgentDetail(agentId: string | undefined, displayLevel: Displa
   useEffect(() => {
     if (!agentId) return;
     registerAgentForEvents(agentId);
-    void refreshAgentDetail(agentId, displayLevel);
-    return () => {
-      unregisterAgentForEvents(agentId);
-    };
-  }, [agentId, displayLevel, refreshAgentDetail, registerAgentForEvents, unregisterAgentForEvents]);
+    if (!detail || detail.error) {
+      void refreshAgentDetail(agentId, displayLevel);
+    }
+  }, [agentId, detail, displayLevel, refreshAgentDetail, registerAgentForEvents]);
 
   return { detail, loading, refresh };
 }

--- a/web-gui/app/src/runtime/useAgentDetail.ts
+++ b/web-gui/app/src/runtime/useAgentDetail.ts
@@ -13,19 +13,20 @@ export function useAgentDetail(agentId: string | undefined, displayLevel: Displa
   const detail = useRuntimeStore((state) => (agentId ? state.sessionsByAgentId[agentId]?.detail ?? null : null));
   const loading = useRuntimeStore((state) => (agentId ? state.sessionsByAgentId[agentId]?.loading ?? false : false));
   const refreshAgentDetail = useRuntimeStore((state) => state.refreshAgentDetail);
-  const startAgentEventStream = useRuntimeStore((state) => state.startAgentEventStream);
-  const stopAgentEventStream = useRuntimeStore((state) => state.stopAgentEventStream);
+  const registerAgentForEvents = useRuntimeStore((state) => state.registerAgentForEvents);
+  const unregisterAgentForEvents = useRuntimeStore((state) => state.unregisterAgentForEvents);
   const refresh = async () => {
     await refreshAgentDetail(agentId, displayLevel);
   };
 
   useEffect(() => {
-    startAgentEventStream(agentId, displayLevel);
+    if (!agentId) return;
+    registerAgentForEvents(agentId);
     void refreshAgentDetail(agentId, displayLevel);
     return () => {
-      stopAgentEventStream(agentId);
+      unregisterAgentForEvents(agentId);
     };
-  }, [agentId, displayLevel, refreshAgentDetail, startAgentEventStream, stopAgentEventStream]);
+  }, [agentId, displayLevel, refreshAgentDetail, registerAgentForEvents, unregisterAgentForEvents]);
 
   return { detail, loading, refresh };
 }

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1424,6 +1424,12 @@ code {
   text-transform: none;
 }
 
+.timeline-turn-label {
+  color: var(--faint);
+  text-transform: capitalize;
+  letter-spacing: 0.04em;
+}
+
 .message {
   max-width: 100%;
 }

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2570,6 +2570,16 @@ code {
   min-width: 0;
 }
 
+.settings-provider-hint {
+  margin: 0;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--surface-warn-soft, rgba(255, 180, 0, 0.08));
+  color: var(--text-muted, #888);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .settings-provider-editor label {
   display: grid;
   gap: 6px;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2601,6 +2601,36 @@ code {
   gap: 12px;
 }
 
+.settings-advanced {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface-soft);
+}
+
+.settings-advanced > summary {
+  cursor: pointer;
+  width: fit-content;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 760;
+  list-style: none;
+}
+
+.settings-advanced > summary::before {
+  content: "▸ ";
+}
+
+.settings-advanced[open] > summary::before {
+  content: "▾ ";
+}
+
 .settings-diagnostics summary {
   cursor: pointer;
   width: fit-content;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -301,6 +301,21 @@ button {
   margin-left: auto;
 }
 
+.agent-row-unread {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--danger);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 780;
+  line-height: 1;
+}
+
 .agent-row strong,
 .connection-status strong {
   display: block;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -246,12 +246,12 @@ button {
   width: 36px;
   height: 36px;
   border-radius: 10px;
-  background: var(--accent);
+  background: hsl(var(--badge-hue, 197) 52% 42%);
   color: #fff;
   font-size: 12px;
   font-weight: 760;
   letter-spacing: 0.04em;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28), 0 6px 14px rgba(8, 126, 164, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28), 0 6px 14px hsl(var(--badge-hue, 197) 52% 42% / 0.20);
 }
 
 .agent-badge.muted {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -305,14 +305,15 @@ button {
   display: grid;
   flex: 0 0 auto;
   place-items: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
   border-radius: 999px;
-  background: var(--danger);
-  color: #fff;
-  font-size: 10px;
-  font-weight: 780;
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
+  background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 760;
   line-height: 1;
 }
 
@@ -374,6 +375,41 @@ button {
   line-height: 1;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.agent-row-status-dot {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  margin-left: auto;
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 820;
+  line-height: 1;
+}
+
+.agent-row-status-dot.running {
+  color: var(--accent);
+}
+
+.agent-row-status-dot.needs-input {
+  background: color-mix(in srgb, var(--warning) 10%, transparent);
+  color: var(--warning);
+}
+
+.agent-row-status-dot.waiting {
+  color: var(--muted);
+}
+
+.agent-row-status-dot.ready {
+  color: var(--success);
+}
+
+.agent-row-status-dot.stopped {
+  color: var(--faint);
 }
 
 .agent-row-status.input {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2785,6 +2785,15 @@ code {
   text-transform: uppercase;
 }
 
+.work-item-detail-section summary {
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .work-item-detail-section pre {
   overflow: auto;
   max-height: 220px;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2755,6 +2755,57 @@ code {
   background: color-mix(in srgb, var(--accent) 10%, var(--surface));
 }
 
+.work-item-button {
+  width: 100%;
+  color: inherit;
+  text-align: left;
+}
+
+.work-item-button:hover,
+.work-item-button.selected {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+}
+
+.work-item-detail {
+  margin-top: 12px;
+}
+
+.work-item-detail-section {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.work-item-detail-section h3 {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.work-item-detail-section pre {
+  overflow: auto;
+  max-height: 220px;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, #000 18%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--page) 72%, var(--surface));
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.inspector-error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 12px;
+}
+
 .inspector-list-head {
   display: flex;
   align-items: flex-start;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2817,6 +2817,32 @@ code {
   color: #fef3c7;
 }
 
+.inspector-raw-detail {
+  overflow: hidden;
+}
+
+.inspector-raw-detail summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.inspector-raw-detail pre {
+  overflow: auto;
+  max-height: 42vh;
+  margin: 12px 0 0;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, #000 24%, transparent);
+  border-radius: 12px;
+  background: #0f172a;
+  color: #dbeafe;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
 .search-inner {
   display: grid;
   gap: 16px;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2500,6 +2500,21 @@ code {
   gap: 10px;
 }
 
+.settings-hint {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: var(--font-size-xs, 11px);
+  color: var(--text-secondary, var(--muted));
+  line-height: 1.5;
+}
+
+.settings-hint code {
+  font-size: inherit;
+  background: var(--surface-raised, rgba(0, 0, 0, 0.06));
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
 .settings-checkbox {
   display: flex !important;
   grid-template-columns: none !important;


### PR DESCRIPTION
## Summary
- audit and document event timeline projections plus a projection query/subscription API direction
- improve the web GUI runtime stream/cache model, right-side panels, activity inspector, unread updates, and tool-event projections
- add Settings/provider UX refinements and runtime config hot-reload support, including clearer Task/Memory/Web tool timeline and inspector output

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --lib config::`
- `cargo test --lib runtime::tests::task_recovery::runtime_tracks_background_task -- --nocapture` (isolated rerun for known flaky coverage)
- `cd web-gui/app && npm test -- --run`
- `cd web-gui/app && npx tsc --noEmit`
