### PR TITLE
test: scheduler_executor.rs + lifecycle.rs 补充测试 (#1862)

### DIFF
--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1693,4 +1693,135 @@ mod tests {
         assert_eq!(snapshot.waiting_reason, None);
         assert_ne!(snapshot.phase, ChildAgentPhase::Blocked);
     }
+
+    // --- resolve_enter_cwd: path escape safety ---
+
+    #[test]
+    fn resolve_enter_cwd_none_returns_execution_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let result = resolve_enter_cwd(&root, None).unwrap();
+        assert_eq!(result, root);
+    }
+
+    #[test]
+    fn resolve_enter_cwd_relative_inside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        let nested = root.join("src").join("lib");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let result = resolve_enter_cwd(&root, Some(Path::new("src/lib"))).unwrap();
+        assert_eq!(result, root.join("src/lib"));
+    }
+
+    #[test]
+    fn resolve_enter_cwd_absolute_inside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        let nested = root.join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let abs = root.join("src");
+        let result = resolve_enter_cwd(&root, Some(&abs)).unwrap();
+        assert_eq!(result, abs);
+    }
+
+    #[test]
+    fn resolve_enter_cwd_relative_escape_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let result = resolve_enter_cwd(&root, Some(Path::new("../escape")));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("escapes execution root"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_enter_cwd_absolute_escape_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let result = resolve_enter_cwd(&root, Some(&outside));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("escapes execution root"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_enter_cwd_dotdot_within_root_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        let deep = root.join("a").join("b");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        // "a/b/../c" resolves to "a/c" which is still inside root
+        let result = resolve_enter_cwd(&root, Some(Path::new("a/b/../c"))).unwrap();
+        assert_eq!(result, root.join("a/b/../c"));
+    }
+
+    #[test]
+    fn resolve_enter_cwd_multiple_dotdot_escape_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let result = resolve_enter_cwd(&root, Some(Path::new("../../escape")));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_enter_cwd_exact_root_via_dotdot_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("workspace");
+        let sub = root.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        // "sub/.." resolves to root itself, which is valid
+        let result = resolve_enter_cwd(&root, Some(Path::new("sub/.."))).unwrap();
+        assert_eq!(result, root.join("sub/.."));
+    }
+
+    // --- workspace_paths_match ---
+
+    #[test]
+    fn workspace_paths_match_identical() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("workspace");
+        std::fs::create_dir_all(&path).unwrap();
+        assert!(workspace_paths_match(&path, &path));
+    }
+
+    #[test]
+    fn workspace_paths_match_different() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        assert!(!workspace_paths_match(&a, &b));
+    }
+
+    #[test]
+    fn workspace_paths_match_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert!(workspace_paths_match(&real, &link));
+    }
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1010,3 +1010,177 @@ pub(crate) fn wake_hint_idempotency_key(pending: &PendingWakeHint) -> String {
         pending.created_at.timestamp_micros()
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AdmissionContext, AgentState, MessageBody, MessageDeliverySurface};
+
+    // --- apply_start_projection ---
+
+    #[test]
+    fn apply_start_sets_awake_idle_and_clears_run() {
+        let mut state = AgentState::new("test");
+        state.status = AgentStatus::Stopped;
+        state.current_run_id = Some("stale".into());
+        apply_start_projection(&mut state);
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
+        assert_eq!(state.current_run_id, None);
+    }
+
+    // --- apply_stop_projection ---
+
+    #[test]
+    fn apply_stop_clears_all_runtime_state() {
+        let mut state = AgentState::new("test");
+        state.status = AgentStatus::AwakeRunning;
+        state.current_run_id = Some("run-1".into());
+        state.sleeping_until = Some(Utc::now());
+        state.pending_wake_hint = Some(PendingWakeHint {
+            reason: "test".into(),
+            description: None,
+            source: None,
+            scope: None,
+            waiting_intent_id: None,
+            external_trigger_id: None,
+            resource: None,
+            body: None,
+            content_type: None,
+            correlation_id: None,
+            causation_id: None,
+            created_at: Utc::now(),
+        });
+        apply_stop_projection(&mut state);
+        assert_eq!(state.status, AgentStatus::Stopped);
+        assert_eq!(state.current_run_id, None);
+        assert_eq!(state.sleeping_until, None);
+        assert_eq!(state.pending_wake_hint, None);
+    }
+
+    // --- apply_sleep_projection ---
+
+    #[test]
+    fn apply_sleep_sets_status_and_clears_run() {
+        let mut state = AgentState::new("test");
+        state.status = AgentStatus::AwakeRunning;
+        state.current_run_id = Some("run-1".into());
+        let until = Utc::now() + chrono::Duration::hours(1);
+        apply_sleep_projection(&mut state, Some(until));
+        assert_eq!(state.status, AgentStatus::Asleep);
+        assert_eq!(state.current_run_id, None);
+        assert_eq!(state.sleeping_until, Some(until));
+    }
+
+    #[test]
+    fn apply_sleep_indefinite_clears_sleeping_until() {
+        let mut state = AgentState::new("test");
+        state.sleeping_until = Some(Utc::now());
+        apply_sleep_projection(&mut state, None);
+        assert_eq!(state.status, AgentStatus::Asleep);
+        assert_eq!(state.sleeping_until, None);
+    }
+
+    // --- apply_running_projection ---
+
+    #[test]
+    fn apply_running_sets_awake_running_with_run_id() {
+        let mut state = AgentState::new("test");
+        state.status = AgentStatus::AwakeIdle;
+        apply_running_projection(&mut state, "run-42".into());
+        assert_eq!(state.status, AgentStatus::AwakeRunning);
+        assert_eq!(state.current_run_id.as_deref(), Some("run-42"));
+    }
+
+    // --- apply_message_wake_projection ---
+
+    #[test]
+    fn apply_message_wake_from_asleep_returns_true() {
+        let mut state = AgentState::new("test");
+        state.status = AgentStatus::Asleep;
+        state.sleeping_until = Some(Utc::now());
+        assert!(apply_message_wake_projection(&mut state));
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
+        assert_eq!(state.sleeping_until, None);
+    }
+
+    #[test]
+    fn apply_message_wake_from_booting_returns_true() {
+        let mut state = AgentState::new("test");
+        state.status = AgentStatus::Booting;
+        assert!(apply_message_wake_projection(&mut state));
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
+    }
+
+    #[test]
+    fn apply_message_wake_from_running_returns_false() {
+        let mut state = AgentState::new("test");
+        state.status = AgentStatus::AwakeRunning;
+        assert!(!apply_message_wake_projection(&mut state));
+        assert_eq!(state.status, AgentStatus::AwakeRunning);
+    }
+
+    // --- is_operator_interjection_message ---
+
+    #[test]
+    fn operator_interjection_detected() {
+        let msg = MessageEnvelope::new(
+            "agent-1",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("user".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Interject,
+            MessageBody::Text {
+                text: "urgent".into(),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            AdmissionContext::RuntimeOwned,
+        );
+        assert!(is_operator_interjection_message(&msg));
+    }
+
+    #[test]
+    fn non_interjection_priority_rejected() {
+        let msg = MessageEnvelope::new(
+            "agent-1",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator {
+                actor_id: Some("user".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Next,
+            MessageBody::Text {
+                text: "normal".into(),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            AdmissionContext::RuntimeOwned,
+        );
+        assert!(!is_operator_interjection_message(&msg));
+    }
+
+    #[test]
+    fn non_operator_kind_rejected() {
+        let msg = MessageEnvelope::new(
+            "agent-1",
+            MessageKind::SystemTick,
+            MessageOrigin::Operator {
+                actor_id: Some("user".into()),
+            },
+            AuthorityClass::OperatorInstruction,
+            Priority::Interject,
+            MessageBody::Text {
+                text: "tick".into(),
+            },
+        )
+        .with_admission(
+            MessageDeliverySurface::RuntimeSystem,
+            AdmissionContext::RuntimeOwned,
+        );
+        assert!(!is_operator_interjection_message(&msg));
+    }
+}

--- a/src/runtime/scheduler_executor.rs
+++ b/src/runtime/scheduler_executor.rs
@@ -533,4 +533,62 @@ mod tests {
         assert_eq!(state.status, AgentStatus::AwakeIdle);
         assert_eq!(state.current_run_id, None);
     }
+
+    #[test]
+    fn bootstrap_recovery_with_pending_wake_hint_becomes_idle() {
+        let mut state = bootstrap_state(AgentStatus::Asleep);
+        state.pending_wake_hint = Some(crate::types::PendingWakeHint {
+            reason: "external".into(),
+            description: None,
+            source: None,
+            scope: None,
+            waiting_intent_id: None,
+            external_trigger_id: None,
+            resource: None,
+            body: None,
+            content_type: None,
+            correlation_id: None,
+            causation_id: None,
+            created_at: chrono::Utc::now(),
+        });
+        assert!(apply_bootstrap_recovered_projection(
+            &mut state,
+            BootstrapRecoveryFacts { queued_messages: 0 },
+        ));
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
+    }
+
+    #[test]
+    fn bootstrap_recovery_awaiting_task_transitions_to_idle() {
+        let mut state = bootstrap_state(AgentStatus::AwaitingTask);
+        state.current_run_id = Some("run-task".into());
+        assert!(apply_bootstrap_recovered_projection(
+            &mut state,
+            BootstrapRecoveryFacts { queued_messages: 0 },
+        ));
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
+        assert_eq!(state.current_run_id, None);
+    }
+
+    #[test]
+    fn bootstrap_recovery_already_idle_clears_run_id() {
+        let mut state = bootstrap_state(AgentStatus::AwakeIdle);
+        state.current_run_id = Some("stale-run".into());
+        assert!(apply_bootstrap_recovered_projection(
+            &mut state,
+            BootstrapRecoveryFacts { queued_messages: 0 },
+        ));
+        assert_eq!(state.status, AgentStatus::AwakeIdle);
+        assert_eq!(state.current_run_id, None);
+    }
+
+    #[test]
+    fn bootstrap_recovery_no_change_when_already_idle_without_pending() {
+        let mut state = bootstrap_state(AgentStatus::AwakeIdle);
+        // Already AwakeIdle, no run_id, no pending → returns false (no state change)
+        assert!(!apply_bootstrap_recovered_projection(
+            &mut state,
+            BootstrapRecoveryFacts { queued_messages: 0 },
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1862

Add 26 tests covering scheduler_executor.rs, lifecycle.rs, and scheduler.rs core functions.

### Path escape safety (`resolve_enter_cwd`) — 8 tests
- `None` cwd returns execution root
- Relative/absolute paths inside root succeed
- `../` escape paths rejected with clear error
- Multiple `../` escape rejected
- Boundary: `../` that resolves to root itself succeeds
- `a/b/../c` within root succeeds

### `workspace_paths_match` — 3 tests
- Identical paths match
- Different paths don't match
- Symlink paths resolve and match

### `apply_bootstrap_recovered_projection` — 4 edge cases
- `pending_wake_hint` set → transitions to AwakeIdle
- `AwaitingTask` status → transitions to AwakeIdle, clears run_id
- Already idle with stale run_id → clears run_id
- Already idle without pending → returns false (no state change)

### Scheduler projection functions — 8 tests
- `apply_start_projection`: sets AwakeIdle, clears run
- `apply_stop_projection`: clears status, run, sleep, wake hint
- `apply_sleep_projection`: sets Asleep, clears run (with/without sleeping_until)
- `apply_running_projection`: sets AwakeRunning with run_id
- `apply_message_wake_projection`: wakes from Asleep/Booting, no-op on Running

### `is_operator_interjection_message` — 3 tests
- Valid operator interjection detected
- Wrong priority rejected
- Wrong message kind rejected

### Verification
- 1856 tests pass (0 failures)
- `cargo fmt --all -- --check` clean
- `RUSTFLAGS="-D warnings" cargo check --all-targets` clean