### PR TITLE
fix: move memory search indexing to runtime outbox

### DIFF
--- a/docs/implementation-decisions/061-memory-index-v2-outbox.md
+++ b/docs/implementation-decisions/061-memory-index-v2-outbox.md
@@ -1,0 +1,15 @@
+# Memory Index v2 Uses Runtime Outbox
+
+Runtime writes that affect `MemorySearch` discovery now record lightweight
+index changes in `runtime_index_outbox` inside the same `runtime.sqlite`
+transaction as the canonical record.
+
+The memory index is a rebuildable ref discovery projection, not a content store.
+`memory.v2.sqlite3` stores bounded searchable text, snippets, provenance, and
+opaque `source_ref` values. Exact content remains owned by runtime evidence,
+state tables, or governed memory files and is read through `MemoryGet`.
+
+`MemorySearch` must not synchronously full-rebuild the index. Search may consume
+a bounded number of outbox rows and return stale or empty results with index
+status when the projection is missing or behind. Full rebuild/backfill is an
+explicit maintenance action, not a model tool side effect.

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -15,7 +15,7 @@ use crate::{
     agent_template::{agent_memory_operator_path, agent_memory_self_path},
     memory::refs::{RuntimeRef, ToolExecutionRefSelector, ToolOutputSelector},
     object_resolver::RuntimeObjectResolver,
-    runtime_db::{EvidenceKind, RuntimeDb},
+    runtime_db::{EvidenceKind, RuntimeDb, RuntimeIndexOperation, RuntimeIndexOutboxRow},
     storage::AppStorage,
     tool::helpers::{
         command_digest, command_output_source_ref, command_preview, command_receipt_source_ref,
@@ -27,13 +27,16 @@ use crate::{
     },
 };
 
-const INDEX_FILENAME: &str = "memory.sqlite3";
+const INDEX_FILENAME: &str = "memory.v2.sqlite3";
 const DIRTY_FILENAME: &str = "memory.dirty";
 const SEARCH_LIMIT_MAX: usize = 50;
+const MEMORY_INDEX_OUTBOX_CONSUME_LIMIT: usize = 500;
 const GET_CHARS_DEFAULT: usize = 12_000;
 const GET_CHARS_MAX: usize = 50_000;
-const MEMORY_INDEX_DOCUMENT_SCHEMA_VERSION: i64 = 1;
+const MEMORY_INDEX_DOCUMENT_SCHEMA_VERSION: i64 = 2;
 const MEMORY_INDEX_BACKFILL_CURSOR: &str = "full";
+const MEMORY_INDEX_OUTBOX_CURSOR: &str = "runtime_index_outbox";
+const MEMORY_INDEX_SEARCH_TEXT_MAX_CHARS: usize = 12_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -51,6 +54,24 @@ pub struct MemorySearchResult {
     pub score: f64,
     pub updated_at: DateTime<Utc>,
     pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct MemorySearchIndexStatus {
+    pub freshness: String,
+    pub cursor: i64,
+    pub high_watermark: i64,
+    pub lag: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_indexed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct MemorySearchQueryResult {
+    pub results: Vec<MemorySearchResult>,
+    pub index_status: MemorySearchIndexStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -134,15 +155,37 @@ pub fn search_memory(
     active_workspace_id: Option<&str>,
     include_all_workspaces: bool,
 ) -> Result<Vec<MemorySearchResult>> {
+    Ok(search_memory_query(
+        storage,
+        query,
+        limit,
+        active_workspace_id,
+        include_all_workspaces,
+    )?
+    .results)
+}
+
+pub fn search_memory_query(
+    storage: &AppStorage,
+    query: &str,
+    limit: usize,
+    active_workspace_id: Option<&str>,
+    include_all_workspaces: bool,
+) -> Result<MemorySearchQueryResult> {
     let index = ensure_memory_index_current(storage, active_workspace_id)?;
     let agent_id = storage_agent_id(storage);
-    index.search(
+    let results = index.search(
         query,
         limit,
         &agent_id,
         active_workspace_id,
         include_all_workspaces,
-    )
+    )?;
+    let index_status = index.index_status(storage, &agent_id)?;
+    Ok(MemorySearchQueryResult {
+        results,
+        index_status,
+    })
 }
 
 pub fn get_memory(
@@ -190,19 +233,17 @@ fn ensure_memory_index_current(
     storage: &AppStorage,
     active_workspace_id: Option<&str>,
 ) -> Result<MemoryIndex> {
-    let index_file_exists = memory_index_path(storage).exists();
     let mut index = MemoryIndex::open(storage)?;
-    let agent_id = storage_agent_id(storage);
-    if !index_file_exists
-        || memory_index_is_dirty(storage)
-        || !index.has_backfill_checkpoints_for_agent(&agent_id)?
-        || !index.has_current_source_state_for_agent(&agent_id)?
-        || !index.has_any_documents_for_agent(&agent_id)?
-    {
-        index.rebuild(storage, active_workspace_id)?;
-    } else {
-        index.consume_pending_sources(storage)?;
-        repair_known_markdown_sources(storage, &index)?;
+    index.consume_runtime_outbox(storage, MEMORY_INDEX_OUTBOX_CONSUME_LIMIT)?;
+    index.consume_pending_sources(storage, MEMORY_INDEX_OUTBOX_CONSUME_LIMIT)?;
+    repair_known_markdown_sources(storage, &index)?;
+    if memory_index_is_dirty(storage) {
+        let agent_id = storage_agent_id(storage);
+        tracing::debug!(
+            agent_id,
+            active_workspace_id,
+            "memory index remains dirty; search returns bounded stale v2 projection"
+        );
     }
     Ok(index)
 }
@@ -310,7 +351,7 @@ impl MemoryIndex {
 
     fn ensure_schema(&self) -> Result<()> {
         if self.table_exists("memory_documents")?
-            && (!self.table_has_column("memory_documents", "original_body")?
+            && (self.table_has_column("memory_documents", "original_body")?
                 || !self.table_has_column("memory_documents", "document_key")?)
         {
             self.connection.execute_batch(
@@ -331,7 +372,6 @@ impl MemoryIndex {
                 agent_id TEXT NOT NULL,
                 source_path TEXT,
                 title TEXT NOT NULL,
-                original_body TEXT NOT NULL,
                 body TEXT NOT NULL,
                 sanitized_excerpt TEXT NOT NULL,
                 metadata_json TEXT NOT NULL,
@@ -370,6 +410,14 @@ impl MemoryIndex {
                 cursor TEXT NOT NULL,
                 updated_at TEXT NOT NULL,
                 PRIMARY KEY (agent_id, source_kind)
+            );
+            CREATE TABLE IF NOT EXISTS memory_index_cursors (
+                runtime_id TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                cursor_kind TEXT NOT NULL,
+                last_change_seq INTEGER NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (runtime_id, agent_id, cursor_kind)
             );
             "#,
         )?;
@@ -519,9 +567,9 @@ impl MemoryIndex {
         Ok(())
     }
 
-    fn consume_pending_sources(&mut self, storage: &AppStorage) -> Result<()> {
+    fn consume_pending_sources(&mut self, storage: &AppStorage, limit: usize) -> Result<()> {
         let agent_id = storage_agent_id(storage);
-        let pending = self.pending_sources_for_agent(&agent_id)?;
+        let pending = self.pending_sources_for_agent_with_limit(&agent_id, limit)?;
         for source in pending {
             let transaction = self.connection.transaction()?;
             let result = if source.operation == "delete" {
@@ -567,14 +615,148 @@ impl MemoryIndex {
         Ok(())
     }
 
+    fn consume_runtime_outbox(&mut self, storage: &AppStorage, limit: usize) -> Result<()> {
+        let Some(runtime_db) = storage.runtime_db()? else {
+            return Ok(());
+        };
+        let agent_id = storage_agent_id(storage);
+        let runtime_id = runtime_index_runtime_id(&runtime_db);
+        let cursor = self.cursor(&runtime_id, &agent_id, MEMORY_INDEX_OUTBOX_CURSOR)?;
+        let rows = runtime_db
+            .runtime_index_outbox()
+            .read_after(&agent_id, cursor, limit)?;
+        let mut last_change_seq = cursor;
+        for row in rows {
+            last_change_seq = last_change_seq.max(row.change_seq);
+            let source = pending_source_from_outbox_row(&row);
+            let transaction = self.connection.transaction()?;
+            let result = if row.operation == RuntimeIndexOperation::Delete {
+                delete_document_tx(&transaction, &source.document_key)
+            } else {
+                match document_for_pending_source(storage, &source)? {
+                    Some(document) => {
+                        let hash = content_hash(&document.body);
+                        let existing_hash = transaction
+                            .query_row(
+                                "SELECT content_hash FROM memory_index_source_state WHERE document_key = ?1",
+                                [&source.document_key],
+                                |row| row.get::<_, String>(0),
+                            )
+                            .optional()?;
+                        if existing_hash.as_deref() != Some(hash.as_str()) {
+                            upsert_document_tx(&transaction, &document)?;
+                        }
+                        upsert_source_state_tx(&transaction, &document, &source.source_id)
+                    }
+                    None => delete_document_tx(&transaction, &source.document_key),
+                }
+            };
+            result?;
+            upsert_cursor_tx(
+                &transaction,
+                &runtime_id,
+                &agent_id,
+                MEMORY_INDEX_OUTBOX_CURSOR,
+                last_change_seq,
+            )?;
+            transaction.commit()?;
+        }
+        Ok(())
+    }
+
+    fn cursor(&self, runtime_id: &str, agent_id: &str, cursor_kind: &str) -> Result<i64> {
+        self.connection
+            .query_row(
+                "SELECT last_change_seq FROM memory_index_cursors
+                 WHERE runtime_id = ?1 AND agent_id = ?2 AND cursor_kind = ?3",
+                params![runtime_id, agent_id, cursor_kind],
+                |row| row.get(0),
+            )
+            .optional()
+            .map(|value| value.unwrap_or(0))
+            .map_err(Into::into)
+    }
+
+    fn cursor_updated_at(
+        &self,
+        runtime_id: &str,
+        agent_id: &str,
+        cursor_kind: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        let updated_at: Option<String> = self
+            .connection
+            .query_row(
+                "SELECT updated_at FROM memory_index_cursors
+                 WHERE runtime_id = ?1 AND agent_id = ?2 AND cursor_kind = ?3",
+                params![runtime_id, agent_id, cursor_kind],
+                |row| row.get(0),
+            )
+            .optional()?;
+        updated_at
+            .map(|value| DateTime::parse_from_rfc3339(&value).map(|dt| dt.with_timezone(&Utc)))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    fn index_status(
+        &self,
+        storage: &AppStorage,
+        agent_id: &str,
+    ) -> Result<MemorySearchIndexStatus> {
+        let Some(runtime_db) = storage.runtime_db()? else {
+            return Ok(MemorySearchIndexStatus {
+                freshness: "fresh".into(),
+                cursor: 0,
+                high_watermark: 0,
+                lag: 0,
+                last_indexed_at: None,
+            });
+        };
+        let runtime_id = runtime_index_runtime_id(&runtime_db);
+        let cursor = self.cursor(&runtime_id, agent_id, MEMORY_INDEX_OUTBOX_CURSOR)?;
+        let high_watermark = runtime_db
+            .runtime_index_outbox()
+            .high_watermark_for_agent(agent_id)?;
+        let lag = high_watermark.saturating_sub(cursor);
+        let freshness = if !memory_index_path(storage).exists() {
+            "missing"
+        } else if memory_index_is_dirty(storage) || lag > 0 {
+            "stale"
+        } else {
+            "fresh"
+        };
+        Ok(MemorySearchIndexStatus {
+            freshness: freshness.into(),
+            cursor,
+            high_watermark,
+            lag,
+            last_indexed_at: self.cursor_updated_at(
+                &runtime_id,
+                agent_id,
+                MEMORY_INDEX_OUTBOX_CURSOR,
+            )?,
+        })
+    }
+
+    #[cfg(test)]
     fn pending_sources_for_agent(&self, agent_id: &str) -> Result<Vec<PendingSource>> {
+        self.pending_sources_for_agent_with_limit(agent_id, usize::MAX)
+    }
+
+    fn pending_sources_for_agent_with_limit(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<PendingSource>> {
         let mut statement = self.connection.prepare(
             "SELECT document_key, source_ref, agent_id, source_kind, source_id, operation
              FROM memory_index_pending_sources
              WHERE agent_id = ?1
-             ORDER BY enqueued_at ASC, document_key ASC",
+             ORDER BY enqueued_at ASC, document_key ASC
+             LIMIT ?2",
         )?;
-        let rows = statement.query_map([agent_id], |row| {
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let rows = statement.query_map(params![agent_id, limit], |row| {
             Ok(PendingSource {
                 document_key: row.get(0)?,
                 source_ref: row.get(1)?,
@@ -586,15 +768,7 @@ impl MemoryIndex {
         rows.map(|row| row.map_err(Into::into)).collect()
     }
 
-    fn has_any_documents_for_agent(&self, agent_id: &str) -> Result<bool> {
-        let count: i64 = self.connection.query_row(
-            "SELECT COUNT(*) FROM memory_documents WHERE agent_id = ?1",
-            [agent_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
-    }
-
+    #[cfg(test)]
     fn has_backfill_checkpoints_for_agent(&self, agent_id: &str) -> Result<bool> {
         for source_kind in all_backfill_source_kinds() {
             let exists = self
@@ -615,6 +789,7 @@ impl MemoryIndex {
         Ok(true)
     }
 
+    #[cfg(test)]
     fn has_current_source_state_for_agent(&self, agent_id: &str) -> Result<bool> {
         let stale: i64 = self.connection.query_row(
             "SELECT COUNT(*) FROM memory_index_source_state
@@ -724,7 +899,7 @@ impl MemoryIndex {
             .query_row(
                 r#"
                 SELECT source_ref, source_kind, scope_kind, workspace_id, agent_id, source_path,
-                       title, original_body, metadata_json, updated_at
+                       title, body, metadata_json, updated_at
                 FROM memory_documents
                 WHERE source_ref = ?1 AND agent_id = ?2
                 "#,
@@ -765,9 +940,49 @@ struct PendingSource {
     operation: String,
 }
 
+fn pending_source_from_outbox_row(row: &RuntimeIndexOutboxRow) -> PendingSource {
+    PendingSource {
+        document_key: document_key_for(&row.agent_id, &row.source_ref),
+        source_ref: row.source_ref.clone(),
+        source_kind: row.source_kind.clone(),
+        source_id: row.source_id.clone(),
+        operation: row.operation.as_str().to_string(),
+    }
+}
+
+fn runtime_index_runtime_id(runtime_db: &RuntimeDb) -> String {
+    runtime_db.path().display().to_string()
+}
+
+fn upsert_cursor_tx(
+    connection: &Connection,
+    runtime_id: &str,
+    agent_id: &str,
+    cursor_kind: &str,
+    last_change_seq: i64,
+) -> Result<()> {
+    connection.execute(
+        "INSERT INTO memory_index_cursors (
+            runtime_id, agent_id, cursor_kind, last_change_seq, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(runtime_id, agent_id, cursor_kind) DO UPDATE SET
+            last_change_seq=excluded.last_change_seq,
+            updated_at=excluded.updated_at",
+        params![
+            runtime_id,
+            agent_id,
+            cursor_kind,
+            last_change_seq,
+            Utc::now().to_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
 fn upsert_document_tx(connection: &Connection, document: &MemoryDocument) -> Result<()> {
     let metadata_json = serde_json::to_string(&document.metadata)?;
     let hash = content_hash(&document.body);
+    let search_text = indexed_text(&bounded_search_text(&document.body));
     let document_key = document_key(document);
     let source_path = document
         .source_path
@@ -777,8 +992,8 @@ fn upsert_document_tx(connection: &Connection, document: &MemoryDocument) -> Res
         r#"
         INSERT INTO memory_documents (
             document_key, source_ref, source_kind, scope_kind, workspace_id, agent_id, source_path,
-            title, original_body, body, sanitized_excerpt, metadata_json, content_hash, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            title, body, sanitized_excerpt, metadata_json, content_hash, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
         ON CONFLICT(document_key) DO UPDATE SET
             source_ref=excluded.source_ref,
             source_kind=excluded.source_kind,
@@ -787,7 +1002,6 @@ fn upsert_document_tx(connection: &Connection, document: &MemoryDocument) -> Res
             agent_id=excluded.agent_id,
             source_path=excluded.source_path,
             title=excluded.title,
-            original_body=excluded.original_body,
             body=excluded.body,
             sanitized_excerpt=excluded.sanitized_excerpt,
             metadata_json=excluded.metadata_json,
@@ -803,8 +1017,7 @@ fn upsert_document_tx(connection: &Connection, document: &MemoryDocument) -> Res
             document.agent_id,
             source_path,
             document.title,
-            document.body,
-            indexed_text(&document.body),
+            search_text,
             document.sanitized_excerpt,
             metadata_json,
             hash,
@@ -820,11 +1033,15 @@ fn upsert_document_tx(connection: &Connection, document: &MemoryDocument) -> Res
         params![
             document_key,
             indexed_text(&document.title),
-            indexed_text(&document.body),
+            indexed_text(&bounded_search_text(&document.body)),
             indexed_text(&document.sanitized_excerpt)
         ],
     )?;
     Ok(())
+}
+
+fn bounded_search_text(value: &str) -> String {
+    truncate_chars(value, MEMORY_INDEX_SEARCH_TEXT_MAX_CHARS).0
 }
 
 fn upsert_source_state_tx(
@@ -919,10 +1136,6 @@ fn collect_documents(
     documents.extend(work_item_documents(storage, runtime_db.as_ref())?);
     documents.extend(task_documents(storage, runtime_db.as_ref())?);
     documents.extend(command_execution_documents(storage, runtime_db.as_ref())?);
-    documents.extend(generic_tool_execution_output_documents(
-        storage,
-        runtime_db.as_ref(),
-    )?);
     Ok(documents)
 }
 
@@ -942,10 +1155,10 @@ fn document_for_pending_source(
         "context_episode" => context_episode_document_by_id(storage, &source.source_id),
         "work_item" => work_item_document_by_id(storage, &source.source_id),
         "task" => task_document_by_id(storage, &source.source_id),
-        "tool_command_receipt" | "tool_command_output" => {
+        "tool_command_receipt" | "tool_command_output" | "tool_command_output_preview" => {
             command_tool_execution_document_by_ref(storage, &source.source_ref)
         }
-        "tool_execution_output" => {
+        "tool_execution_output" | "tool_execution_output_preview" => {
             generic_tool_execution_output_document_by_ref(storage, &source.source_ref)
         }
         _ => Ok(None),
@@ -1824,7 +2037,6 @@ fn command_execution_documents(
             "ExecCommand" => {
                 if let Some(cmd) = record.input.get("cmd").and_then(Value::as_str) {
                     documents.push(command_receipt_document(&record, None, None, cmd));
-                    documents.extend(command_output_documents(&record, None));
                 }
             }
             "ExecCommandBatch" => {
@@ -1838,44 +2050,12 @@ fn command_execution_documents(
                                 Some(item),
                                 cmd,
                             ));
-                            documents.extend(command_output_documents(&record, Some(index)));
                         }
                     }
                 }
             }
             _ => {}
         }
-    }
-    Ok(documents)
-}
-
-fn generic_tool_execution_output_documents(
-    storage: &AppStorage,
-    runtime_db: Option<&RuntimeDb>,
-) -> Result<Vec<MemoryDocument>> {
-    let mut documents = Vec::new();
-    let records = if let Some(runtime_db) = runtime_db {
-        runtime_db
-            .evidence()
-            .recent_payloads(
-                EvidenceKind::ToolExecution,
-                &storage_agent_id(storage),
-                usize::MAX,
-            )?
-            .into_iter()
-            .map(|row| serde_json::from_str::<ToolExecutionRecord>(&row.payload_json))
-            .collect::<std::result::Result<Vec<_>, _>>()?
-    } else {
-        storage.read_recent_tool_executions(usize::MAX)?
-    };
-    for record in records {
-        if matches!(
-            record.tool_name.as_str(),
-            "ExecCommand" | "ExecCommandBatch"
-        ) {
-            continue;
-        }
-        documents.push(generic_tool_execution_output_document_from_record(&record));
     }
     Ok(documents)
 }
@@ -2038,16 +2218,6 @@ fn generic_tool_execution_output_document_from_record(
         }),
         updated_at: record.completed_at.unwrap_or(record.created_at),
     }
-}
-
-fn command_output_documents(
-    record: &ToolExecutionRecord,
-    batch_item_index: Option<usize>,
-) -> Vec<MemoryDocument> {
-    ["stdout", "stderr", "output"]
-        .into_iter()
-        .filter_map(|stream| command_output_document(record, batch_item_index, stream))
-        .collect()
 }
 
 fn command_output_document(
@@ -2883,6 +3053,47 @@ mod tests {
     }
 
     #[test]
+    fn memory_search_consumes_runtime_outbox_without_full_rebuild() {
+        let dir = tempdir().unwrap();
+        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        storage.write_agent(&AgentState::new("default")).unwrap();
+        let runtime_db = RuntimeDb::open_and_migrate(
+            storage.runtime_dir().join("state/runtime.sqlite"),
+            storage.runtime_dir().join("state/runtime.lock"),
+        )
+        .unwrap();
+        storage
+            .enable_scheduler_control_plane_db(runtime_db.clone())
+            .unwrap();
+        let brief = brief_with_workspace(
+            "default",
+            BriefKind::Result,
+            "outbox discovery sentinel 1848",
+            "ws-holon",
+        );
+        let brief_ref = format!("brief:{}", brief.id);
+
+        storage.append_brief(&brief).unwrap();
+        assert_eq!(
+            runtime_db
+                .runtime_index_outbox()
+                .read_after("default", 0, 10)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let response =
+            search_memory_query(&storage, "outbox discovery", 10, Some("ws-holon"), false).unwrap();
+        assert!(response
+            .results
+            .iter()
+            .any(|result| result.source_ref == brief_ref));
+        assert_eq!(response.index_status.freshness, "fresh");
+        assert_eq!(response.index_status.lag, 0);
+    }
+
+    #[test]
     fn memory_get_hydrates_transcript_backed_brief_content() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
@@ -3104,7 +3315,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_index_rebuilds_all_existing_memory_sources_before_repair() {
+    fn missing_index_does_not_rebuild_all_existing_memory_sources_during_search() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
@@ -3165,11 +3376,10 @@ mod tests {
         );
 
         let results = search_memory(&storage, "existing", 10, Some("ws-existing"), false).unwrap();
-        assert!(results.iter().any(|result| result.kind == "brief"));
-        assert!(results.iter().any(|result| result.kind == "work_item"));
-        assert!(results
-            .iter()
-            .any(|result| result.kind == "context_episode"));
+        assert!(
+            results.is_empty(),
+            "MemorySearch must not synchronously rebuild all runtime sources"
+        );
     }
 
     #[test]
@@ -3519,7 +3729,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_checkpoint_forces_full_backfill_recovery() {
+    fn missing_checkpoint_does_not_force_full_backfill_recovery() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
@@ -3553,15 +3763,18 @@ mod tests {
 
         let results =
             search_memory(&storage, "checkpoint recovery", 10, Some("ws-holon"), false).unwrap();
-        assert!(results.iter().any(|result| result.kind == "brief"));
-        assert!(MemoryIndex::open(&storage)
+        assert!(
+            results.is_empty(),
+            "MemorySearch must not use missing checkpoints to trigger full rebuild"
+        );
+        assert!(!MemoryIndex::open(&storage)
             .unwrap()
             .has_backfill_checkpoints_for_agent("default")
             .unwrap());
     }
 
     #[test]
-    fn stale_source_state_schema_forces_rebuild() {
+    fn stale_source_state_schema_does_not_force_search_rebuild() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
@@ -3595,7 +3808,7 @@ mod tests {
         )
         .unwrap();
         assert!(results.iter().any(|result| result.kind == "brief"));
-        assert!(MemoryIndex::open(&storage)
+        assert!(!MemoryIndex::open(&storage)
             .unwrap()
             .has_current_source_state_for_agent("default")
             .unwrap());

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6,6 +6,7 @@ pub mod working;
 pub use episode::refresh_episode_memory;
 pub use index::{
     get_memory, rebuild_memory_index, repair_memory_index_for_paths, search_memory,
-    MemoryGetResult, MemorySearchResult,
+    search_memory_query, MemoryGetResult, MemorySearchIndexStatus, MemorySearchQueryResult,
+    MemorySearchResult,
 };
 pub use working::refresh_working_memory;

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -607,7 +607,7 @@ impl RuntimeHandle {
         query: &str,
         limit: usize,
         include_all_workspaces: bool,
-    ) -> Result<Vec<crate::memory::MemorySearchResult>> {
+    ) -> Result<crate::memory::MemorySearchQueryResult> {
         let active_workspace_id = self
             .agent_state()
             .await?
@@ -616,7 +616,7 @@ impl RuntimeHandle {
         let storage = self.inner.storage.clone();
         let query = query.to_string();
         tokio::task::spawn_blocking(move || {
-            crate::memory::search_memory(
+            crate::memory::search_memory_query(
                 &storage,
                 &query,
                 limit,

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -245,6 +245,56 @@ pub struct ContextEpisodeRepository<'a> {
     db: &'a RuntimeDb,
 }
 
+pub struct RuntimeIndexOutboxRepository<'a> {
+    db: &'a RuntimeDb,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeIndexOperation {
+    Upsert,
+    Delete,
+}
+
+impl RuntimeIndexOperation {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Upsert => "upsert",
+            Self::Delete => "delete",
+        }
+    }
+
+    fn parse(value: &str) -> Self {
+        match value {
+            "delete" => Self::Delete,
+            _ => Self::Upsert,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeIndexChange {
+    pub agent_id: String,
+    pub source_kind: String,
+    pub source_id: String,
+    pub source_ref: String,
+    pub operation: RuntimeIndexOperation,
+    pub source_updated_at: Option<DateTime<Utc>>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeIndexOutboxRow {
+    pub change_seq: i64,
+    pub agent_id: String,
+    pub source_kind: String,
+    pub source_id: String,
+    pub source_ref: String,
+    pub operation: RuntimeIndexOperation,
+    pub source_updated_at: Option<DateTime<Utc>>,
+    pub reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageDomainSnapshot {
     pub domain: String,
@@ -306,6 +356,107 @@ impl EvidenceKind {
             Self::DeliverySummary => "delivery_summaries",
             Self::ArtifactMetadata => "artifact_metadata",
         }
+    }
+}
+
+impl RuntimeIndexOutboxRepository<'_> {
+    pub fn append_changes(&self, changes: &[RuntimeIndexChange]) -> Result<()> {
+        if changes.is_empty() {
+            return Ok(());
+        }
+        self.db
+            .transaction(|tx| insert_runtime_index_changes_tx(tx, changes))
+    }
+
+    pub fn high_watermark(&self) -> Result<i64> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT COALESCE(MAX(change_seq), 0) FROM runtime_index_outbox",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    }
+
+    pub fn high_watermark_for_agent(&self, agent_id: &str) -> Result<i64> {
+        let connection = self.db.connection()?;
+        connection
+            .query_row(
+                "SELECT COALESCE(MAX(change_seq), 0)
+                 FROM runtime_index_outbox
+                 WHERE agent_id = ?1",
+                [agent_id],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    }
+
+    pub fn read_after(
+        &self,
+        agent_id: &str,
+        after_change_seq: i64,
+        limit: usize,
+    ) -> Result<Vec<RuntimeIndexOutboxRow>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT change_seq, agent_id, source_kind, source_id, source_ref, operation,
+                    source_updated_at, reason, created_at
+             FROM runtime_index_outbox
+             WHERE agent_id = ?1 AND change_seq > ?2
+             ORDER BY change_seq ASC
+             LIMIT ?3",
+        )?;
+        let rows = statement.query_map(params![agent_id, after_change_seq, limit], |row| {
+            let source_updated_at: Option<String> = row.get(6)?;
+            let created_at: String = row.get(8)?;
+            Ok(RuntimeIndexOutboxRow {
+                change_seq: row.get(0)?,
+                agent_id: row.get(1)?,
+                source_kind: row.get(2)?,
+                source_id: row.get(3)?,
+                source_ref: row.get(4)?,
+                operation: RuntimeIndexOperation::parse(&row.get::<_, String>(5)?),
+                source_updated_at: source_updated_at
+                    .as_deref()
+                    .map(DateTime::parse_from_rfc3339)
+                    .transpose()
+                    .map_err(|error| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            6,
+                            rusqlite::types::Type::Text,
+                            Box::new(error),
+                        )
+                    })?
+                    .map(|dt| dt.with_timezone(&Utc)),
+                reason: row.get(7)?,
+                created_at: DateTime::parse_from_rfc3339(&created_at)
+                    .map_err(|error| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            8,
+                            rusqlite::types::Type::Text,
+                            Box::new(error),
+                        )
+                    })?
+                    .with_timezone(&Utc),
+            })
+        })?;
+        rows.map(|row| row.map_err(Into::into)).collect()
+    }
+
+    pub fn delete_through(&self, agent_id: &str, through_change_seq: i64) -> Result<usize> {
+        self.db.transaction(|tx| {
+            tx.execute(
+                "DELETE FROM runtime_index_outbox
+                 WHERE agent_id = ?1 AND change_seq <= ?2",
+                params![agent_id, through_change_seq],
+            )
+            .map_err(Into::into)
+        })
     }
 }
 
@@ -691,6 +842,18 @@ impl WorkItemRepository<'_> {
             .transaction(|tx| upsert_work_item_tx(tx, record, current_focus))
     }
 
+    pub fn upsert_with_index_changes(
+        &self,
+        record: &WorkItemRecord,
+        current_focus: bool,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            upsert_work_item_tx(tx, record, current_focus)?;
+            insert_runtime_index_changes_tx(tx, changes)
+        })
+    }
+
     pub fn set_current_focus(&self, agent_id: &str, work_item_id: Option<&str>) -> Result<()> {
         self.db.transaction(|tx| {
             tx.execute(
@@ -850,6 +1013,17 @@ impl WorkspaceEntryRepository<'_> {
     pub fn upsert(&self, record: &WorkspaceEntry) -> Result<()> {
         self.db
             .transaction(|tx| upsert_workspace_entry_tx(tx, record))
+    }
+
+    pub fn upsert_with_index_changes(
+        &self,
+        record: &WorkspaceEntry,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            upsert_workspace_entry_tx(tx, record)?;
+            insert_runtime_index_changes_tx(tx, changes)
+        })
     }
 
     pub fn latest_all(&self) -> Result<Vec<WorkspaceEntry>> {
@@ -1179,6 +1353,17 @@ impl ContextEpisodeRepository<'_> {
             .transaction(|tx| upsert_context_episode_tx(tx, record))
     }
 
+    pub fn upsert_with_index_changes(
+        &self,
+        record: &ContextEpisodeRecord,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            upsert_context_episode_tx(tx, record)?;
+            insert_runtime_index_changes_tx(tx, changes)
+        })
+    }
+
     pub fn recent(&self, limit: usize) -> Result<Vec<ContextEpisodeRecord>> {
         if limit == 0 {
             return Ok(Vec::new());
@@ -1372,6 +1557,17 @@ impl TaskRepository<'_> {
 
     pub fn upsert(&self, record: &TaskRecord) -> Result<()> {
         self.db.transaction(|tx| upsert_task_tx(tx, record))
+    }
+
+    pub fn upsert_with_index_changes(
+        &self,
+        record: &TaskRecord,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            upsert_task_tx(tx, record)?;
+            insert_runtime_index_changes_tx(tx, changes)
+        })
     }
 
     pub fn latest(&self, task_id: &str) -> Result<Option<TaskRecord>> {
@@ -2319,9 +2515,31 @@ impl EvidenceRepository<'_> {
             .transaction(|tx| insert_tool_evidence_tx(tx, record))
     }
 
+    pub fn append_tool_execution_with_index_changes(
+        &self,
+        record: &ToolExecutionRecord,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            insert_tool_evidence_tx(tx, record)?;
+            insert_runtime_index_changes_tx(tx, changes)
+        })
+    }
+
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
         self.db
             .transaction(|tx| insert_brief_evidence_tx(tx, brief))
+    }
+
+    pub fn append_brief_with_index_changes(
+        &self,
+        brief: &BriefRecord,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            insert_brief_evidence_tx(tx, brief)?;
+            insert_runtime_index_changes_tx(tx, changes)
+        })
     }
 
     pub fn append_delivery_summary(&self, record: &DeliverySummaryRecord) -> Result<()> {
@@ -3184,6 +3402,31 @@ fn upsert_transcript_entry_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) -> 
             payload_json,
         ],
     )?;
+    Ok(())
+}
+
+fn insert_runtime_index_changes_tx(
+    tx: &Transaction<'_>,
+    changes: &[RuntimeIndexChange],
+) -> Result<()> {
+    for change in changes {
+        tx.execute(
+            "INSERT INTO runtime_index_outbox (
+                agent_id, source_kind, source_id, source_ref, operation,
+                source_updated_at, reason, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                change.agent_id,
+                change.source_kind,
+                change.source_id,
+                change.source_ref,
+                change.operation.as_str(),
+                change.source_updated_at.map(timestamp),
+                change.reason,
+                timestamp(Utc::now()),
+            ],
+        )?;
+    }
     Ok(())
 }
 
@@ -5312,6 +5555,29 @@ CREATE INDEX IF NOT EXISTS idx_queue_entries_agent_status
   ON queue_entries(agent_id, status, updated_at);
 "#,
     },
+    Migration {
+        version: 19,
+        name: "runtime_index_outbox",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS runtime_index_outbox (
+  change_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  source_ref TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  source_updated_at TEXT,
+  reason TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_index_outbox_agent_seq
+  ON runtime_index_outbox(agent_id, change_seq);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_index_outbox_source
+  ON runtime_index_outbox(source_kind, source_id);
+"#,
+    },
 ];
 
 impl RuntimeDb {
@@ -5445,6 +5711,10 @@ impl RuntimeDb {
 
     pub fn context_episodes(&self) -> ContextEpisodeRepository<'_> {
         ContextEpisodeRepository { db: self }
+    }
+
+    pub fn runtime_index_outbox(&self) -> RuntimeIndexOutboxRepository<'_> {
+        RuntimeIndexOutboxRepository { db: self }
     }
 
     pub const fn expected_storage_domains() -> &'static [ExpectedStorageDomain] {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,19 +15,19 @@ use tokio::sync::broadcast;
 
 use crate::{
     memory::index::enqueue_memory_index_upsert,
-    runtime_db::RuntimeDb,
+    runtime_db::{RuntimeDb, RuntimeIndexChange, RuntimeIndexOperation},
     tool::helpers::{command_output_source_ref, command_receipt_source_ref},
     types::{
         AgentIdentityRecord, AgentPostureProjection, AgentSchedulingPosture, AgentState,
-        AgentStatus, AuditEvent, BriefRecord, ContextEpisodeRecord, DeliverySummaryRecord,
-        ExternalTriggerRecord, ExternalWaitRecoverability, MessageEnvelope, OperatorDeliveryRecord,
-        OperatorNotificationRecord, OperatorTransportBinding, QueueEntryRecord, QueueEntryStatus,
-        TaskRecord, TaskStatus, TimerRecord, TodoItem, TodoItemState, ToolExecutionRecord,
-        TranscriptEntry, TurnRecord, WaitConditionKind, WaitConditionRecord, WaitConditionStatus,
-        WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus, WakeSource,
-        WorkItemContinuationFrame, WorkItemContinuationState, WorkItemDelegationRecord,
-        WorkItemDelegationState, WorkItemReadiness, WorkItemRecord, WorkItemSchedulingState,
-        WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
+        AgentStatus, AuditEvent, BriefKind, BriefRecord, ContextEpisodeRecord,
+        DeliverySummaryRecord, ExternalTriggerRecord, ExternalWaitRecoverability, MessageEnvelope,
+        OperatorDeliveryRecord, OperatorNotificationRecord, OperatorTransportBinding,
+        QueueEntryRecord, QueueEntryStatus, TaskRecord, TaskStatus, TimerRecord, TodoItem,
+        TodoItemState, ToolExecutionRecord, TranscriptEntry, TurnRecord, WaitConditionKind,
+        WaitConditionRecord, WaitConditionStatus, WaitingIntentRecord, WaitingIntentScope,
+        WaitingIntentStatus, WakeSource, WorkItemContinuationFrame, WorkItemContinuationState,
+        WorkItemDelegationRecord, WorkItemDelegationState, WorkItemReadiness, WorkItemRecord,
+        WorkItemSchedulingState, WorkItemState, WorkspaceEntry, WorkspaceOccupancyRecord,
     },
 };
 
@@ -656,8 +656,10 @@ impl AppStorage {
 
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.evidence().append_brief(brief)?;
-            return self.enqueue_memory_index_brief_best_effort(brief);
+            let changes = self.index_changes_for_brief(brief)?;
+            return runtime_db
+                .evidence()
+                .append_brief_with_index_changes(brief, &changes);
         }
         self.append_jsonl(&self.briefs_path, brief)?;
         self.enqueue_memory_index_brief_best_effort(brief)
@@ -685,8 +687,8 @@ impl AppStorage {
 
     pub fn append_task(&self, task: &TaskRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.tasks().upsert(task)?;
-            return self.enqueue_memory_index_task_best_effort(task);
+            let changes = self.index_changes_for_task(task)?;
+            return runtime_db.tasks().upsert_with_index_changes(task, &changes);
         }
         self.append_jsonl(&self.tasks_path, task)?;
         self.enqueue_memory_index_task_best_effort(task)
@@ -699,8 +701,12 @@ impl AppStorage {
                 .and_then(|agent| agent.current_work_item_id)
                 .as_deref()
                 == Some(record.id.as_str());
-            runtime_db.work_items().upsert(record, current_focus)?;
-            return self.enqueue_memory_index_work_item_best_effort(record);
+            let changes = self.index_changes_for_work_item(record)?;
+            return runtime_db.work_items().upsert_with_index_changes(
+                record,
+                current_focus,
+                &changes,
+            );
         }
         self.append_jsonl(&self.work_items_path, record)?;
         self.enqueue_memory_index_work_item_best_effort(record)
@@ -740,23 +746,13 @@ impl AppStorage {
 
     pub fn append_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.evidence().append_tool_execution(record)?;
-            if matches!(
-                record.tool_name.as_str(),
-                "ExecCommand" | "ExecCommandBatch"
-            ) {
-                self.enqueue_memory_index_tool_execution_best_effort(record)?;
-            }
-            return Ok(());
+            let changes = self.index_changes_for_tool_execution(record)?;
+            return runtime_db
+                .evidence()
+                .append_tool_execution_with_index_changes(record, &changes);
         }
         self.append_jsonl(&self.tools_path, record)?;
-        if matches!(
-            record.tool_name.as_str(),
-            "ExecCommand" | "ExecCommandBatch"
-        ) {
-            self.enqueue_memory_index_tool_execution_best_effort(record)?;
-        }
-        Ok(())
+        self.enqueue_memory_index_tool_execution_best_effort(record)
     }
 
     pub fn append_turn(&self, record: &TurnRecord) -> Result<()> {
@@ -863,8 +859,10 @@ impl AppStorage {
 
     pub fn append_context_episode(&self, record: &ContextEpisodeRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.context_episodes().upsert(record)?;
-            return self.enqueue_memory_index_context_episode_best_effort(record);
+            let changes = self.index_changes_for_context_episode(record)?;
+            return runtime_db
+                .context_episodes()
+                .upsert_with_index_changes(record, &changes);
         }
         self.append_jsonl(&self.context_episodes_path, record)?;
         self.enqueue_memory_index_context_episode_best_effort(record)
@@ -872,8 +870,10 @@ impl AppStorage {
 
     pub fn append_workspace_entry(&self, entry: &WorkspaceEntry) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.workspace_entries().upsert(entry)?;
-            return self.enqueue_memory_index_workspace_entry_best_effort(entry);
+            let changes = self.index_changes_for_workspace_entry(entry)?;
+            return runtime_db
+                .workspace_entries()
+                .upsert_with_index_changes(entry, &changes);
         }
         self.append_jsonl(&self.workspaces_path, entry)?;
         self.enqueue_memory_index_workspace_entry_best_effort(entry)
@@ -918,6 +918,175 @@ impl AppStorage {
         }
         fs::create_dir_all(self.shared_indexes_dir())?;
         fs::write(&dirty_path, b"dirty").with_context(|| "failed to mark memory index dirty")
+    }
+
+    fn runtime_index_upsert(
+        &self,
+        agent_id: impl Into<String>,
+        source_kind: impl Into<String>,
+        source_id: impl Into<String>,
+        source_ref: impl Into<String>,
+        source_updated_at: Option<DateTime<Utc>>,
+        reason: &'static str,
+    ) -> Result<RuntimeIndexChange> {
+        Ok(RuntimeIndexChange {
+            agent_id: agent_id.into(),
+            source_kind: source_kind.into(),
+            source_id: source_id.into(),
+            source_ref: source_ref.into(),
+            operation: RuntimeIndexOperation::Upsert,
+            source_updated_at,
+            reason: reason.into(),
+        })
+    }
+
+    fn index_changes_for_brief(&self, brief: &BriefRecord) -> Result<Vec<RuntimeIndexChange>> {
+        if brief.kind == BriefKind::Ack || brief.text.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(vec![self.runtime_index_upsert(
+            brief.agent_id.clone(),
+            "brief",
+            brief.id.clone(),
+            format!("brief:{}", brief.id),
+            Some(brief.created_at),
+            "brief_written",
+        )?])
+    }
+
+    fn index_changes_for_task(&self, task: &TaskRecord) -> Result<Vec<RuntimeIndexChange>> {
+        Ok(vec![self.runtime_index_upsert(
+            task.agent_id.clone(),
+            "task",
+            task.id.clone(),
+            format!("task:{}", task.id),
+            Some(task.updated_at),
+            "task_written",
+        )?])
+    }
+
+    fn index_changes_for_work_item(
+        &self,
+        record: &WorkItemRecord,
+    ) -> Result<Vec<RuntimeIndexChange>> {
+        Ok(vec![self.runtime_index_upsert(
+            record.agent_id.clone(),
+            "work_item",
+            record.id.clone(),
+            format!("work_item:{}", record.id),
+            Some(record.updated_at),
+            "work_item_written",
+        )?])
+    }
+
+    fn index_changes_for_context_episode(
+        &self,
+        record: &ContextEpisodeRecord,
+    ) -> Result<Vec<RuntimeIndexChange>> {
+        Ok(vec![self.runtime_index_upsert(
+            record.agent_id.clone(),
+            "context_episode",
+            record.id.clone(),
+            format!("episode:{}", record.id),
+            Some(record.finalized_at),
+            "context_episode_written",
+        )?])
+    }
+
+    fn index_changes_for_workspace_entry(
+        &self,
+        entry: &WorkspaceEntry,
+    ) -> Result<Vec<RuntimeIndexChange>> {
+        let Some(agent_id) = entry
+            .owner_agent_id
+            .clone()
+            .or_else(|| self.storage_agent_id().ok())
+        else {
+            return Ok(Vec::new());
+        };
+        Ok(vec![self.runtime_index_upsert(
+            agent_id,
+            "workspace_profile",
+            entry.workspace_id.clone(),
+            format!("workspace_profile:{}", entry.workspace_id),
+            Some(entry.updated_at),
+            "workspace_profile_written",
+        )?])
+    }
+
+    fn index_changes_for_tool_execution(
+        &self,
+        record: &ToolExecutionRecord,
+    ) -> Result<Vec<RuntimeIndexChange>> {
+        let mut changes = Vec::new();
+        match record.tool_name.as_str() {
+            "ExecCommand" => {
+                if record.input.get("cmd").and_then(Value::as_str).is_some() {
+                    let source_ref = command_receipt_source_ref(&record.id, None);
+                    changes.push(self.runtime_index_upsert(
+                        record.agent_id.clone(),
+                        "tool_command_receipt",
+                        source_ref.clone(),
+                        source_ref,
+                        record.completed_at.or(Some(record.created_at)),
+                        "tool_command_receipt_written",
+                    )?);
+                    for stream in ["stdout", "stderr", "output"] {
+                        let source_ref = command_output_source_ref(&record.id, None, stream);
+                        changes.push(self.runtime_index_upsert(
+                            record.agent_id.clone(),
+                            "tool_command_output_preview",
+                            source_ref.clone(),
+                            source_ref,
+                            record.completed_at.or(Some(record.created_at)),
+                            "tool_command_output_preview_written",
+                        )?);
+                    }
+                }
+            }
+            "ExecCommandBatch" => {
+                if let Some(items) = record.input.get("items").and_then(Value::as_array) {
+                    for (offset, item) in items.iter().enumerate() {
+                        if item.get("cmd").and_then(Value::as_str).is_some() {
+                            let index = offset + 1;
+                            let source_ref = command_receipt_source_ref(&record.id, Some(index));
+                            changes.push(self.runtime_index_upsert(
+                                record.agent_id.clone(),
+                                "tool_command_receipt",
+                                source_ref.clone(),
+                                source_ref,
+                                record.completed_at.or(Some(record.created_at)),
+                                "tool_command_receipt_written",
+                            )?);
+                            for stream in ["stdout", "stderr", "output"] {
+                                let source_ref =
+                                    command_output_source_ref(&record.id, Some(index), stream);
+                                changes.push(self.runtime_index_upsert(
+                                    record.agent_id.clone(),
+                                    "tool_command_output_preview",
+                                    source_ref.clone(),
+                                    source_ref,
+                                    record.completed_at.or(Some(record.created_at)),
+                                    "tool_command_output_preview_written",
+                                )?);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {
+                let source_ref = command_output_source_ref(&record.id, None, "output");
+                changes.push(self.runtime_index_upsert(
+                    record.agent_id.clone(),
+                    "tool_execution_output_preview",
+                    source_ref.clone(),
+                    source_ref,
+                    record.completed_at.or(Some(record.created_at)),
+                    "tool_execution_output_preview_written",
+                )?);
+            }
+        }
+        Ok(changes)
     }
 
     fn enqueue_memory_index_brief(&self, brief: &BriefRecord) -> Result<()> {
@@ -4240,7 +4409,7 @@ mod tests {
     }
 
     #[test]
-    fn memory_index_enqueue_failure_does_not_fail_tool_evidence_append() {
+    fn runtime_index_outbox_write_does_not_touch_memory_index_db() {
         let dir = tempdir().unwrap();
         let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
@@ -4275,10 +4444,21 @@ mod tests {
         storage.append_tool_execution(&tool).unwrap();
 
         assert_eq!(storage.read_recent_tool_executions(10).unwrap(), vec![tool]);
-        assert!(storage
-            .shared_indexes_dir()
-            .join("memory.default.dirty")
-            .exists());
+        let runtime_db = storage.runtime_db().unwrap().unwrap();
+        let changes = runtime_db
+            .runtime_index_outbox()
+            .read_after("default", 0, 10)
+            .unwrap();
+        assert!(changes
+            .iter()
+            .any(|change| change.source_kind == "tool_command_receipt"));
+        assert!(
+            !storage
+                .shared_indexes_dir()
+                .join("memory.default.dirty")
+                .exists(),
+            "runtime outbox replaces direct memory index writes on the critical path"
+        );
     }
 
     #[test]
@@ -4373,16 +4553,14 @@ mod tests {
 
         assert_eq!(storage.read_recent_briefs(10).unwrap(), vec![brief]);
         assert_eq!(storage.count_briefs().unwrap(), 1);
-        let index = rusqlite::Connection::open(storage.shared_indexes_dir().join("memory.sqlite3"))
+        let runtime_db = storage.runtime_db().unwrap().unwrap();
+        let changes = runtime_db
+            .runtime_index_outbox()
+            .read_after("default", 0, 10)
             .unwrap();
-        let pending_agent_id: String = index
-            .query_row(
-                "SELECT agent_id FROM memory_index_pending_sources WHERE source_kind = 'brief'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(pending_agent_id, "default");
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].agent_id, "default");
+        assert_eq!(changes[0].source_kind, "brief");
     }
 
     #[test]

--- a/src/tool/tools/memory_search.rs
+++ b/src/tool/tools/memory_search.rs
@@ -27,6 +27,7 @@ pub(crate) struct MemorySearchArgs {
 struct MemorySearchResponse {
     query: String,
     results: Vec<crate::memory::MemorySearchResult>,
+    index_status: crate::memory::MemorySearchIndexStatus,
 }
 
 pub(crate) fn definition() -> Result<BuiltinToolDefinition> {
@@ -47,12 +48,19 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: MemorySearchArgs = parse_tool_args(NAME, input)?;
     let query = validate_non_empty(args.query, NAME, "query")?;
-    let results = runtime
+    let response = runtime
         .search_memory(
             &query,
             args.limit.unwrap_or(10),
             args.include_all_workspaces,
         )
         .await?;
-    serialize_success(NAME, &MemorySearchResponse { query, results })
+    serialize_success(
+        NAME,
+        &MemorySearchResponse {
+            query,
+            results: response.results,
+            index_status: response.index_status,
+        },
+    )
 }


### PR DESCRIPTION
## Summary

Fixes #1848 by moving MemorySearch indexing to an explicit runtime outbox boundary.

- add `runtime_index_outbox` in `runtime.sqlite` and write lightweight index changes in the same transaction as canonical runtime state/evidence writes
- switch MemorySearch to `memory.v2.sqlite3`, store bounded searchable projection text, and report `index_status` with cursor/high-watermark/lag
- stop MemorySearch from synchronously full-rebuilding on missing index, dirty markers, missing checkpoints, or stale source-state schema
- keep full source content owned by runtime DB/governed memory files and resolve exact content through refs/MemoryGet
- document the decision in `docs/implementation-decisions/061-memory-index-v2-outbox.md`

## Notes

This PR uses bounded outbox consumption on the MemorySearch path. Full rebuild/backfill remains an explicit maintenance operation instead of a model-tool side effect.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test memory::index::tests::memory_search_consumes_runtime_outbox_without_full_rebuild --lib -- --nocapture`
- `git diff --check`
- `cargo test --lib`
