### PR TITLE
fix: add response body read timeout to prevent non-streaming hang

### DIFF
--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -28,7 +28,7 @@ use crate::{
     },
 };
 
-use super::{build_http_client, request_send_timeout, stream_idle_timeout};
+use super::{build_http_client, request_send_timeout, response_body_timeout, stream_idle_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
     invalid_response_error_with_trace, provider_transport_error,
@@ -276,7 +276,10 @@ impl AgentProvider for AnthropicProvider {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
+            let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+                Ok(Ok(text)) => text,
+                _ => String::new(),
+            };
             if let Some(trace) = request_trace.as_ref() {
                 trace.write_response_body(&body);
             }
@@ -395,17 +398,31 @@ async fn read_anthropic_json_response(
     url: &str,
     trace: Option<&ProviderHttpTraceRequest>,
 ) -> Result<MessagesResponse> {
-    let response_body = response.text().await.map_err(|error| {
-        classify_reqwest_transport_error_with_trace(
-            "Anthropic response body failed",
-            "response_body",
-            "anthropic",
-            Some(model_ref),
-            Some(url),
-            error,
-            trace,
-        )
-    })?;
+    let response_body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+        Ok(Ok(text)) => text,
+        Ok(Err(error)) => {
+            return Err(classify_reqwest_transport_error_with_trace(
+                "Anthropic response body failed",
+                "response_body",
+                "anthropic",
+                Some(model_ref),
+                Some(url),
+                error,
+                trace,
+            ));
+        }
+        Err(_elapsed) => {
+            return Err(timeout_transport_error_with_trace(
+                "Anthropic response body read timed out",
+                "response_body",
+                "anthropic",
+                Some(model_ref),
+                Some(url),
+                format!("timed out after {:?}", response_body_timeout()),
+                trace,
+            ));
+        }
+    };
     if let Some(trace) = trace {
         trace.write_response_body(&response_body);
     }

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -15,10 +15,10 @@ use crate::{
     },
 };
 
-use super::{build_http_client, request_send_timeout};
+use super::{build_http_client, request_send_timeout, response_body_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
-    invalid_response_error,
+    invalid_response_error, timeout_transport_error_with_trace,
 };
 
 #[derive(Clone)]
@@ -193,7 +193,10 @@ impl AgentProvider for GeminiProvider {
         }
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
+            let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+                Ok(Ok(text)) => text,
+                _ => String::new(),
+            };
             if let Some(trace) = request_trace.as_ref() {
                 trace.write_response_body(&body);
             }
@@ -209,17 +212,32 @@ impl AgentProvider for GeminiProvider {
             ));
         }
 
-        let response_body = response.text().await.map_err(|error| {
-            classify_reqwest_transport_error_with_trace(
-                "Gemini response body failed",
-                "response_body",
-                "gemini",
-                Some(&model_ref),
-                Some(url.as_str()),
-                error,
-                request_trace.as_ref(),
-            )
-        })?;
+        let response_body =
+            match tokio::time::timeout(response_body_timeout(), response.text()).await {
+                Ok(Ok(text)) => text,
+                Ok(Err(error)) => {
+                    return Err(classify_reqwest_transport_error_with_trace(
+                        "Gemini response body failed",
+                        "response_body",
+                        "gemini",
+                        Some(&model_ref),
+                        Some(url.as_str()),
+                        error,
+                        request_trace.as_ref(),
+                    ));
+                }
+                Err(_elapsed) => {
+                    return Err(timeout_transport_error_with_trace(
+                        "Gemini response body read timed out",
+                        "response_body",
+                        "gemini",
+                        Some(&model_ref),
+                        Some(url.as_str()),
+                        format!("timed out after {:?}", response_body_timeout()),
+                        request_trace.as_ref(),
+                    ));
+                }
+            };
         if let Some(trace) = request_trace.as_ref() {
             trace.write_response_body(&response_body);
         }

--- a/src/provider/transports/mod.rs
+++ b/src/provider/transports/mod.rs
@@ -67,3 +67,12 @@ pub(super) fn request_send_timeout() -> Duration {
         .unwrap_or(DEFAULT_REQUEST_SEND_TIMEOUT_SECS);
     Duration::from_secs(timeout_secs)
 }
+
+pub(super) fn response_body_timeout() -> Duration {
+    let timeout_secs = env::var("HOLON_PROVIDER_RESPONSE_BODY_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(request_send_timeout().as_secs());
+    Duration::from_secs(timeout_secs)
+}

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -38,7 +38,7 @@ use crate::{
     token_estimate::estimate_json_tokens,
 };
 
-use super::{build_http_client, request_send_timeout, stream_idle_timeout};
+use super::{build_http_client, request_send_timeout, response_body_timeout, stream_idle_timeout};
 use crate::provider::retry::{
     classify_reqwest_transport_error_with_trace, classify_status_error_with_trace,
     invalid_response_error, provider_transport_error, timeout_transport_error_with_trace,
@@ -3397,7 +3397,10 @@ async fn send_chat_completion_request(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+            Ok(Ok(text)) => text,
+            _ => String::new(),
+        };
         trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_chat_completion_status_error(
             "OpenAI Chat Completions request failed",
@@ -3409,17 +3412,31 @@ async fn send_chat_completion_request(
         ));
     }
 
-    let body = response.text().await.map_err(|error| {
-        classify_reqwest_transport_error_with_trace(
-            "OpenAI Chat Completions response body failed",
-            "response_body",
-            "openai",
-            Some(&model_ref),
-            Some(url.as_str()),
-            error,
-            request_trace.as_ref(),
-        )
-    })?;
+    let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+        Ok(Ok(text)) => text,
+        Ok(Err(error)) => {
+            return Err(classify_reqwest_transport_error_with_trace(
+                "OpenAI Chat Completions response body failed",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                error,
+                request_trace.as_ref(),
+            ));
+        }
+        Err(_elapsed) => {
+            return Err(timeout_transport_error_with_trace(
+                "OpenAI Chat Completions response body read timed out",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                format!("timed out after {:?}", response_body_timeout()),
+                request_trace.as_ref(),
+            ));
+        }
+    };
     trace_response_body(request_trace.as_ref(), &body);
 
     let parsed: Value = serde_json::from_str(&body)
@@ -3732,7 +3749,10 @@ pub(crate) async fn send_chat_completion_stream_request(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+            Ok(Ok(text)) => text,
+            _ => String::new(),
+        };
         return Err(classify_chat_completion_status_error(
             "OpenAI Chat Completions streaming request failed",
             status,
@@ -4085,7 +4105,10 @@ async fn send_openai_responses_request(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+            Ok(Ok(text)) => text,
+            _ => String::new(),
+        };
         trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error_with_trace(
             "OpenAI-style request failed",
@@ -4099,17 +4122,31 @@ async fn send_openai_responses_request(
         ));
     }
 
-    let body = response.text().await.map_err(|error| {
-        classify_reqwest_transport_error_with_trace(
-            "OpenAI-style response body failed",
-            "response_body",
-            "openai",
-            Some(&model_ref),
-            Some(url.as_str()),
-            error,
-            request_trace.as_ref(),
-        )
-    })?;
+    let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+        Ok(Ok(text)) => text,
+        Ok(Err(error)) => {
+            return Err(classify_reqwest_transport_error_with_trace(
+                "OpenAI-style response body failed",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                error,
+                request_trace.as_ref(),
+            ));
+        }
+        Err(_elapsed) => {
+            return Err(timeout_transport_error_with_trace(
+                "OpenAI-style response body read timed out",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                format!("timed out after {:?}", response_body_timeout()),
+                request_trace.as_ref(),
+            ));
+        }
+    };
     trace_response_body(request_trace.as_ref(), &body);
     let parsed: Value = serde_json::from_str(&body)
         .map_err(|error| invalid_response_error("invalid OpenAI-style JSON", error))?;
@@ -4160,7 +4197,10 @@ async fn send_openai_compact_request(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+            Ok(Ok(text)) => text,
+            _ => String::new(),
+        };
         trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error_with_trace(
             "OpenAI compact request failed",
@@ -4174,17 +4214,31 @@ async fn send_openai_compact_request(
         ));
     }
 
-    let response_body = response.text().await.map_err(|error| {
-        classify_reqwest_transport_error_with_trace(
-            "OpenAI compact response body failed",
-            "response_body",
-            "openai",
-            Some(&model_ref),
-            Some(url.as_str()),
-            error,
-            request_trace.as_ref(),
-        )
-    })?;
+    let response_body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+        Ok(Ok(text)) => text,
+        Ok(Err(error)) => {
+            return Err(classify_reqwest_transport_error_with_trace(
+                "OpenAI compact response body failed",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                error,
+                request_trace.as_ref(),
+            ));
+        }
+        Err(_elapsed) => {
+            return Err(timeout_transport_error_with_trace(
+                "OpenAI compact response body read timed out",
+                "response_body",
+                "openai",
+                Some(&model_ref),
+                Some(url.as_str()),
+                format!("timed out after {:?}", response_body_timeout()),
+                request_trace.as_ref(),
+            ));
+        }
+    };
     trace_response_body(request_trace.as_ref(), &response_body);
     let parsed: Value = serde_json::from_str(&response_body)
         .map_err(|error| invalid_response_error("invalid OpenAI compact JSON", error))?;
@@ -4248,7 +4302,10 @@ async fn send_openai_responses_streaming_request(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = match tokio::time::timeout(response_body_timeout(), response.text()).await {
+            Ok(Ok(text)) => text,
+            _ => String::new(),
+        };
         trace_response_body(request_trace.as_ref(), &body);
         return Err(classify_status_error_with_trace(
             openai_codex_status_error_context(status),


### PR DESCRIPTION
## Summary

Wrap all `.text().await` calls in non-streaming response paths across anthropic, openai, and gemini transports with `tokio::time::timeout()` to prevent indefinite hangs when reading response bodies.

Fixes #1849.

## Changes

- **`mod.rs`**: New `response_body_timeout()` function, configurable via `HOLON_PROVIDER_RESPONSE_BODY_TIMEOUT_SECS` (default 300s, same as `HOLON_PROVIDER_HTTP_TIMEOUT_SECS`)
- **`anthropic.rs`**: 2 `.text().await` calls wrapped with timeout
- **`openai.rs`**: 8 `.text().await` calls wrapped with timeout
- **`gemini.rs`**: 2 `.text().await` calls wrapped with timeout

Timeout errors return a descriptive `anyhow!` error rather than hanging indefinitely.

Streaming paths are unaffected.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check --all-targets` ✅
- `cargo test provider::transports` — 42 passed ✅