### PR TITLE
fix: ignore legacy null message seq for anchor recency

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
@@ -1817,14 +1818,31 @@ fn latest_trusted_operator_input<'a>(
     messages: &'a [MessageEnvelope],
     current_message: &'a MessageEnvelope,
 ) -> Option<&'a MessageEnvelope> {
-    std::iter::once(current_message)
-        .chain(messages.iter().rev())
-        .find(|message| is_trusted_operator_input(message))
+    if is_trusted_operator_input(current_message) {
+        return Some(current_message);
+    }
+
+    messages
+        .iter()
+        .filter(|message| is_trusted_operator_input(message))
+        .max_by(|left, right| compare_message_recency(left, right))
 }
 
 fn is_trusted_operator_input(message: &MessageEnvelope) -> bool {
     message.authority_class == AuthorityClass::OperatorInstruction
         && matches!(message.origin, MessageOrigin::Operator { .. })
+}
+
+fn compare_message_recency(left: &MessageEnvelope, right: &MessageEnvelope) -> Ordering {
+    match (left.message_seq, right.message_seq) {
+        (Some(left_seq), Some(right_seq)) => left_seq.cmp(&right_seq),
+        (Some(_), None) => Ordering::Greater,
+        (None, Some(_)) => Ordering::Less,
+        (None, None) => left
+            .created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.id.cmp(&right.id)),
+    }
 }
 
 fn current_input_relation(
@@ -7854,6 +7872,61 @@ mod tests {
         let record = TurnRecord::new("default", "", 4);
 
         assert!(!turn_record_matches_message(&record, &message));
+    }
+
+    #[test]
+    fn latest_trusted_operator_input_prefers_sequenced_history_over_legacy_null_sequence() {
+        let mut sequenced = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "new sequenced request".into(),
+            },
+        );
+        sequenced.id = "msg-sequenced".into();
+        sequenced.message_seq = Some(42);
+        sequenced.created_at = chrono::DateTime::parse_from_rfc3339("2026-06-18T10:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        let mut legacy_without_sequence = MessageEnvelope::new(
+            "default",
+            MessageKind::OperatorPrompt,
+            MessageOrigin::Operator { actor_id: None },
+            AuthorityClass::OperatorInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "old legacy request without message_seq".into(),
+            },
+        );
+        legacy_without_sequence.id = "msg-legacy".into();
+        legacy_without_sequence.message_seq = None;
+        legacy_without_sequence.created_at =
+            chrono::DateTime::parse_from_rfc3339("2026-06-18T11:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc);
+
+        let current_message = MessageEnvelope::new(
+            "default",
+            MessageKind::TaskResult,
+            MessageOrigin::System {
+                subsystem: "task".into(),
+            },
+            AuthorityClass::RuntimeInstruction,
+            Priority::Normal,
+            MessageBody::Text {
+                text: "task completed".into(),
+            },
+        );
+
+        let messages = vec![sequenced.clone(), legacy_without_sequence];
+        let latest = latest_trusted_operator_input(&messages, &current_message)
+            .expect("sequenced operator message should be selected");
+
+        assert_eq!(latest.id, "msg-sequenced");
     }
 
     fn execution_snapshot_for(session: &AgentState) -> ExecutionSnapshot {

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -2096,7 +2096,7 @@ impl MessageRepository<'_> {
                 "SELECT payload_json
                  FROM messages
                  WHERE agent_id = ?1
-                 ORDER BY COALESCE(message_seq, 9223372036854775807) DESC, created_at DESC, message_id ASC
+                 ORDER BY message_seq IS NULL ASC, message_seq DESC, created_at DESC, message_id ASC
                  LIMIT ?2",
             )?;
             let rows =
@@ -2107,7 +2107,7 @@ impl MessageRepository<'_> {
             let mut statement = connection.prepare(
                 "SELECT payload_json
                  FROM messages
-                 ORDER BY COALESCE(message_seq, 9223372036854775807) DESC, created_at DESC, message_id ASC
+                 ORDER BY message_seq IS NULL ASC, message_seq DESC, created_at DESC, message_id ASC
                  LIMIT ?1",
             )?;
             let rows = statement.query_map([limit], |row| row.get::<_, String>(0))?;
@@ -2134,7 +2134,7 @@ impl MessageRepository<'_> {
                 "SELECT payload_json
                  FROM messages
                  WHERE agent_id = ?1
-                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC
+                 ORDER BY message_seq IS NULL DESC, message_seq ASC, created_at ASC, message_id ASC
                  LIMIT -1 OFFSET ?2",
             )?;
             let rows =
@@ -2145,7 +2145,7 @@ impl MessageRepository<'_> {
             let mut statement = connection.prepare(
                 "SELECT payload_json
                  FROM messages
-                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC
+                 ORDER BY message_seq IS NULL DESC, message_seq ASC, created_at ASC, message_id ASC
                  LIMIT -1 OFFSET ?1",
             )?;
             let rows = statement.query_map([offset], |row| row.get::<_, String>(0))?;
@@ -2165,7 +2165,7 @@ impl MessageRepository<'_> {
                 "SELECT payload_json
                  FROM messages
                  WHERE agent_id = ?1
-                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC",
+                 ORDER BY message_seq IS NULL DESC, message_seq ASC, created_at ASC, message_id ASC",
             )?;
             let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
             rows.map(|row| decode_message_payload(&row?)).collect()
@@ -2173,7 +2173,7 @@ impl MessageRepository<'_> {
             let mut statement = connection.prepare(
                 "SELECT payload_json
                  FROM messages
-                 ORDER BY COALESCE(message_seq, 9223372036854775807) ASC, created_at ASC, message_id ASC",
+                 ORDER BY message_seq IS NULL DESC, message_seq ASC, created_at ASC, message_id ASC",
             )?;
             let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
             rows.map(|row| decode_message_payload(&row?)).collect()
@@ -7475,6 +7475,58 @@ CREATE TABLE working_memory_deltas (
             connection.query_row("SELECT COUNT(*) FROM queue_entries", [], |row| row.get(0))?;
         assert_eq!(rows, 1);
         assert!(db.queue_entries().queued_for_agent("agent-a")?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn message_repository_orders_null_message_seq_as_legacy_history() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let base = Utc::now();
+
+        let mut sequenced_1 = MessageEnvelope::new(
+            "agent-a",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator { actor_id: None },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            crate::types::MessageBody::Text { text: "one".into() },
+        );
+        sequenced_1.id = "msg-seq-1".into();
+        sequenced_1.message_seq = Some(1);
+        sequenced_1.created_at = base;
+
+        let mut sequenced_2 = sequenced_1.clone();
+        sequenced_2.id = "msg-seq-2".into();
+        sequenced_2.message_seq = Some(2);
+        sequenced_2.created_at = base + chrono::Duration::seconds(1);
+
+        let mut legacy_without_sequence = sequenced_1.clone();
+        legacy_without_sequence.id = "msg-legacy".into();
+        legacy_without_sequence.message_seq = None;
+        legacy_without_sequence.created_at = base + chrono::Duration::seconds(2);
+
+        db.messages().upsert_many(&[
+            sequenced_1.clone(),
+            sequenced_2.clone(),
+            legacy_without_sequence.clone(),
+        ])?;
+
+        let all_ids = db
+            .messages()
+            .all(Some("agent-a"))?
+            .into_iter()
+            .map(|message| message.id)
+            .collect::<Vec<_>>();
+        assert_eq!(all_ids, vec!["msg-legacy", "msg-seq-1", "msg-seq-2"]);
+
+        let recent_ids = db
+            .messages()
+            .recent(Some("agent-a"), 2)?
+            .into_iter()
+            .map(|message| message.id)
+            .collect::<Vec<_>>();
+        assert_eq!(recent_ids, vec!["msg-seq-1", "msg-seq-2"]);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- treat messages with `NULL message_seq` as legacy history in DB message ordering instead of newest records
- make continuation anchor recency selection explicit so sequenced operator prompts win over legacy null-seq prompts
- add regression coverage for both DB ordering and anchor selection

## Verification
- `cargo fmt --all -- --check`
- `cargo test null_message_seq`
- `cargo test latest_trusted_operator_input_prefers_sequenced_history_over_legacy_null_sequence`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
