### PR TITLE
fix: unify HTTP search with memory index

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1835,12 +1835,9 @@
       },
       "SearchRequest": {
         "properties": {
-          "agent_ids": {
-            "default": [],
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
+          "include_all_workspaces": {
+            "default": false,
+            "type": "boolean"
           },
           "limit": {
             "format": "uint",
@@ -1852,16 +1849,6 @@
           },
           "query": {
             "type": "string"
-          },
-          "types": {
-            "default": [],
-            "items": {
-              "enum": [
-                "message"
-              ],
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -1872,6 +1859,47 @@
       },
       "SearchResponse": {
         "properties": {
+          "index_status": {
+            "properties": {
+              "consumption_was_limited": {
+                "type": "boolean"
+              },
+              "cursor": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "freshness": {
+                "type": "string"
+              },
+              "high_watermark": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "lag": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "last_indexed_at": {
+                "format": "date-time",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "skipped_error_count": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "freshness",
+              "cursor",
+              "high_watermark",
+              "lag"
+            ],
+            "type": "object"
+          },
           "limit": {
             "format": "uint",
             "minimum": 0,
@@ -1886,64 +1914,53 @@
                 "agent_id": {
                   "type": "string"
                 },
-                "created_at": {
-                  "type": "string"
-                },
                 "kind": {
                   "type": "string"
                 },
-                "locator": {
-                  "properties": {
-                    "evidence_id": {
-                      "type": "string"
-                    },
-                    "message_id": {
-                      "type": "string"
-                    },
-                    "task_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "turn_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "work_item_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "evidence_id",
-                    "message_id"
-                  ],
-                  "type": "object"
+                "metadata": true,
+                "scope_kind": {
+                  "type": "string"
                 },
-                "preview": {
+                "score": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "snippet": {
+                  "type": "string"
+                },
+                "source_path": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "type": {
-                  "enum": [
-                    "message"
-                  ],
+                "source_ref": {
                   "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
               "required": [
-                "type",
+                "kind",
+                "source_ref",
+                "scope_kind",
                 "agent_id",
-                "locator",
-                "created_at",
-                "kind"
+                "title",
+                "snippet",
+                "score",
+                "updated_at",
+                "metadata"
               ],
               "type": "object"
             },
@@ -1953,7 +1970,8 @@
         "required": [
           "query",
           "limit",
-          "results"
+          "results",
+          "index_status"
         ],
         "title": "SearchResponse",
         "type": "object"
@@ -8259,7 +8277,7 @@
     },
     "/search": {
       "post": {
-        "description": "Search indexed runtime history across visible agents. First version indexes message bodies and returns message result locators.",
+        "description": "Search the same memory v2 index used by the agent MemorySearch tool.",
         "operationId": "runtimeSearch",
         "parameters": [],
         "requestBody": {
@@ -8309,7 +8327,7 @@
             "BearerAuth": []
           }
         ],
-        "summary": "Search runtime history",
+        "summary": "Search runtime memory",
         "tags": [
           "search"
         ]

--- a/src/http.rs
+++ b/src/http.rs
@@ -71,7 +71,6 @@ use crate::{
     },
     policy::{default_authority_for_origin, validate_message_kind_for_origin},
     runtime::{CurrentRunAbortError, CurrentRunAbortMode, CurrentRunAbortRequest},
-    runtime_db::{MessageSearchQuery, MessageSearchRow},
     storage::EventLogPageOrder,
     system::{ExecutionScopeKind, HostLocalBoundary},
     types::{
@@ -518,52 +517,22 @@ fn traced_json<T: Serialize>(
 }
 
 const SEARCH_DEFAULT_LIMIT: usize = 20;
-const SEARCH_MAX_LIMIT: usize = 100;
-
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum SearchItemType {
-    Message,
-}
+const SEARCH_MAX_LIMIT: usize = 50;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct SearchRequest {
     pub query: String,
-    #[serde(default)]
-    pub agent_ids: Vec<String>,
-    #[serde(default)]
-    pub types: Vec<SearchItemType>,
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_all_workspaces: bool,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct SearchResponse {
     pub query: String,
     pub limit: usize,
-    pub results: Vec<SearchResultItem>,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct SearchResultItem {
-    #[serde(rename = "type")]
-    pub result_type: SearchItemType,
-    pub agent_id: String,
-    pub locator: SearchResultLocator,
-    pub created_at: String,
-    pub kind: String,
-    pub preview: Option<String>,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct SearchResultLocator {
-    pub evidence_id: String,
-    pub message_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_item_id: Option<String>,
+    pub results: Vec<crate::memory::MemorySearchResult>,
+    pub index_status: crate::memory::MemorySearchIndexStatus,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -1005,26 +974,14 @@ pub async fn search(
     if query.is_empty() {
         return Err(bad_request("query must not be empty"));
     }
-    if request
-        .types
-        .iter()
-        .any(|result_type| *result_type != SearchItemType::Message)
-    {
-        return Err(bad_request("only message search is currently supported"));
-    }
     let limit = request
         .limit
         .unwrap_or(SEARCH_DEFAULT_LIMIT)
         .clamp(1, SEARCH_MAX_LIMIT);
-    let rows = state
-        .host
-        .runtime_db()
-        .messages()
-        .search(MessageSearchQuery {
-            query: query.clone(),
-            agent_ids: request.agent_ids,
-            limit,
-        })
+    let runtime = state.host.default_runtime().await.map_err(error_response)?;
+    let search_result = runtime
+        .search_memory(&query, limit, request.include_all_workspaces)
+        .await
         .map_err(error_response)?;
     traced_json(
         "/search",
@@ -1032,26 +989,10 @@ pub async fn search(
         SearchResponse {
             query,
             limit,
-            results: rows.into_iter().map(search_result_from_message).collect(),
+            results: search_result.results,
+            index_status: search_result.index_status,
         },
     )
-}
-
-fn search_result_from_message(row: MessageSearchRow) -> SearchResultItem {
-    SearchResultItem {
-        result_type: SearchItemType::Message,
-        agent_id: row.agent_id,
-        locator: SearchResultLocator {
-            evidence_id: row.evidence_id,
-            message_id: row.message_id,
-            turn_id: row.turn_id,
-            task_id: row.task_id,
-            work_item_id: row.work_item_id,
-        },
-        created_at: row.created_at,
-        kind: row.kind,
-        preview: row.preview,
-    }
 }
 
 pub async fn handshake(

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -39,7 +40,7 @@ const MEMORY_INDEX_BACKFILL_CURSOR: &str = "full";
 const MEMORY_INDEX_OUTBOX_CURSOR: &str = "runtime_index_outbox";
 const MEMORY_INDEX_SEARCH_TEXT_MAX_CHARS: usize = 12_000;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MemorySearchResult {
     pub kind: String,
@@ -57,7 +58,7 @@ pub struct MemorySearchResult {
     pub metadata: Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MemorySearchIndexStatus {
     pub freshness: String,
@@ -72,7 +73,7 @@ pub struct MemorySearchIndexStatus {
     pub last_indexed_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MemorySearchQueryResult {
     pub results: Vec<MemorySearchResult>,
@@ -1140,6 +1141,7 @@ fn all_backfill_source_kinds() -> &'static [&'static str] {
     &[
         "agent_memory_markdown",
         "workspace_profile",
+        "message",
         "brief",
         "context_episode",
         "work_item",
@@ -1163,6 +1165,7 @@ fn collect_documents(
     let mut documents = Vec::new();
     documents.extend(agent_memory_documents(storage)?);
     documents.extend(workspace_profile_documents(storage)?);
+    documents.extend(message_documents(storage)?);
     documents.extend(brief_documents(storage, runtime_db.as_ref())?);
     documents.extend(context_episode_documents(storage)?);
     documents.extend(work_item_documents(storage, runtime_db.as_ref())?);
@@ -1183,6 +1186,7 @@ fn document_for_pending_source(
             .transpose()
             .map(|value| value.flatten()),
         "workspace_profile" => workspace_profile_document_by_id(storage, &source.source_id),
+        "message" => message_document_by_id(storage, &source.source_id),
         "brief" => brief_document_by_id(storage, &source.source_id),
         "context_episode" => context_episode_document_by_id(storage, &source.source_id),
         "work_item" => work_item_document_by_id(storage, &source.source_id),
@@ -1405,13 +1409,21 @@ fn message_document_by_id(
         .map(message_document))
 }
 
+fn message_documents(storage: &AppStorage) -> Result<Vec<MemoryDocument>> {
+    Ok(storage
+        .read_all_messages()?
+        .into_iter()
+        .map(message_document)
+        .collect())
+}
+
 fn message_document(message: MessageEnvelope) -> MemoryDocument {
     let body = message_document_body(&message);
     let title = format!("Message {}", message.id);
     MemoryDocument {
         source_ref: format!("message:{}", message.id),
         source_kind: "message".into(),
-        scope_kind: "workspace".into(),
+        scope_kind: "agent".into(),
         workspace_id: None,
         agent_id: message.agent_id.clone(),
         source_path: None,
@@ -3275,6 +3287,20 @@ mod tests {
                 "ws-other",
             ))
             .unwrap();
+        let mut message = MessageEnvelope::new(
+            "default",
+            crate::types::MessageKind::OperatorPrompt,
+            crate::types::MessageOrigin::Operator {
+                actor_id: Some("operator:test".into()),
+            },
+            crate::types::AuthorityClass::OperatorInstruction,
+            crate::types::Priority::Normal,
+            MessageBody::Text {
+                text: "searchable operator message sentinel1879".into(),
+            },
+        );
+        message.id = "msg-memory-search".into();
+        storage.append_message(&message).unwrap();
         let mut work_item = WorkItemRecord::new(
             "default",
             "MemorySearch index implementation",
@@ -3359,6 +3385,10 @@ mod tests {
             .any(|result| result.kind == "context_episode"));
         let results = search_memory(&storage, "MemorySearch", 10, Some("ws-holon"), false).unwrap();
         assert!(results.iter().any(|result| result.kind == "work_item"));
+        let results = search_memory(&storage, "sentinel1879", 10, Some("ws-holon"), false).unwrap();
+        assert!(results
+            .iter()
+            .any(|result| result.source_ref == "message:msg-memory-search"));
         let results = search_memory(&storage, "checksum", 10, Some("ws-holon"), false).unwrap();
         assert!(results.iter().any(|result| result.kind == "work_item"));
         let results = search_memory(&storage, "checklist", 10, Some("ws-holon"), false).unwrap();

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -90,7 +90,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List skills", "Return installed skills for an agent.", None, AuthKind::RemoteAccess),
-    route_with_response("post", "/search", "runtimeSearch", "search", "Search runtime history", "Search indexed runtime history across visible agents. First version indexes message bodies and returns message result locators.", Some("SearchRequest"), "SearchResponse", AuthKind::RemoteAccess),
+    route_with_response("post", "/search", "runtimeSearch", "search", "Search runtime memory", "Search the same memory v2 index used by the agent MemorySearch tool.", Some("SearchRequest"), "SearchResponse", AuthKind::RemoteAccess),
     route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
     route("post", "/agents/{agent_id}/enqueue", "enqueueAgent", "ingress", "Enqueue agent message", "Enqueue a public channel/webhook message for the named agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),
     route("post", "/webhooks/generic/{agent_id}", "genericWebhook", "ingress", "Generic webhook", "Convert an arbitrary JSON webhook body into a trusted integration message.", Some("GenericJsonPayload"), AuthKind::None),

--- a/src/runtime_db.rs
+++ b/src/runtime_db.rs
@@ -786,26 +786,6 @@ pub struct EvidencePayloadRow {
     pub payload_json: String,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct MessageSearchQuery {
-    pub query: String,
-    pub agent_ids: Vec<String>,
-    pub limit: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MessageSearchRow {
-    pub evidence_id: String,
-    pub agent_id: String,
-    pub turn_id: Option<String>,
-    pub message_id: String,
-    pub task_id: Option<String>,
-    pub work_item_id: Option<String>,
-    pub created_at: String,
-    pub kind: String,
-    pub preview: Option<String>,
-}
-
 impl WorkItemRepository<'_> {
     pub fn import_legacy(
         &self,
@@ -2076,6 +2056,17 @@ impl MessageRepository<'_> {
         self.db.transaction(|tx| upsert_message_tx(tx, message))
     }
 
+    pub fn upsert_with_index_changes(
+        &self,
+        message: &MessageEnvelope,
+        changes: &[RuntimeIndexChange],
+    ) -> Result<()> {
+        self.db.transaction(|tx| {
+            upsert_message_tx(tx, message)?;
+            insert_runtime_index_changes_tx(tx, changes)
+        })
+    }
+
     pub fn upsert_many(&self, messages: &[MessageEnvelope]) -> Result<()> {
         self.db.transaction(|tx| {
             for message in messages {
@@ -2185,67 +2176,6 @@ impl MessageRepository<'_> {
             .into_iter()
             .map(|message| serde_json::to_value(message).map_err(Into::into))
             .collect()
-    }
-
-    pub fn search(&self, query: MessageSearchQuery) -> Result<Vec<MessageSearchRow>> {
-        if query.limit == 0 {
-            return Ok(Vec::new());
-        }
-        let Some(search_terms) = message_search_match_query(&query.query) else {
-            return Ok(Vec::new());
-        };
-
-        let mut clauses = vec!["message_search_index MATCH ?".to_string()];
-        let mut values = Vec::<String>::new();
-        values.push(search_terms);
-        if !query.agent_ids.is_empty() {
-            let placeholders = std::iter::repeat("?")
-                .take(query.agent_ids.len())
-                .collect::<Vec<_>>()
-                .join(", ");
-            clauses.push(format!("messages.agent_id IN ({placeholders})"));
-            values.extend(query.agent_ids);
-        }
-
-        let limit = i64::try_from(query.limit).unwrap_or(i64::MAX);
-        let sql = format!(
-            "SELECT messages.evidence_id,
-                    messages.agent_id,
-                    messages.turn_id,
-                    messages.message_id,
-                    messages.task_id,
-                    messages.work_item_id,
-                    messages.created_at,
-                    messages.kind,
-                    messages.preview
-             FROM message_search_index
-             JOIN messages ON messages.evidence_id = message_search_index.evidence_id
-             WHERE {}
-             ORDER BY bm25(message_search_index), messages.created_at DESC, messages.evidence_id ASC
-             LIMIT {}",
-            clauses.join(" AND "),
-            limit
-        );
-        let connection = self.db.connection()?;
-        let mut statement = connection.prepare(&sql)?;
-        let params = values
-            .iter()
-            .map(|value| value as &dyn ToSql)
-            .collect::<Vec<_>>();
-        let rows = statement.query_map(params.as_slice(), |row| {
-            Ok(MessageSearchRow {
-                evidence_id: row.get(0)?,
-                agent_id: row.get(1)?,
-                turn_id: row.get(2)?,
-                message_id: row.get(3)?,
-                task_id: row.get(4)?,
-                work_item_id: row.get(5)?,
-                created_at: row.get(6)?,
-                kind: row.get(7)?,
-                preview: row.get(8)?,
-            })
-        })?;
-        rows.map(|row| row.map_err(Into::into)).collect()
     }
 
     pub fn by_id(
@@ -3285,71 +3215,7 @@ fn upsert_message_tx(tx: &Transaction<'_>, message: &MessageEnvelope) -> Result<
             payload_json,
         ],
     )?;
-    upsert_message_search_index_tx(tx, message, &kind)?;
     Ok(())
-}
-
-fn upsert_message_search_index_tx(
-    tx: &Transaction<'_>,
-    message: &MessageEnvelope,
-    kind: &str,
-) -> Result<()> {
-    tx.execute(
-        "DELETE FROM message_search_index WHERE evidence_id = ?1",
-        params![message.id],
-    )?;
-    tx.execute(
-        "INSERT INTO message_search_index (
-            evidence_id, agent_id, turn_id, message_id, task_id, work_item_id,
-            kind, body_text
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-        params![
-            message.id,
-            message.agent_id,
-            message.turn_id,
-            message.id,
-            message.task_id,
-            message.work_item_id,
-            kind,
-            message_body_search_text(&message.body),
-        ],
-    )?;
-    Ok(())
-}
-
-fn message_body_search_text(body: &crate::types::MessageBody) -> String {
-    match body {
-        crate::types::MessageBody::Text { text } => text.clone(),
-        crate::types::MessageBody::Json { value } => value.to_string(),
-        crate::types::MessageBody::Brief {
-            title,
-            text,
-            attachments,
-        } => {
-            let mut fields = Vec::new();
-            if let Some(title) = title {
-                fields.push(title.clone());
-            }
-            fields.push(text.clone());
-            if let Some(attachments) = attachments {
-                fields.push(serde_json::to_string(attachments).unwrap_or_default());
-            }
-            fields.join("\n")
-        }
-    }
-}
-
-fn message_search_match_query(query: &str) -> Option<String> {
-    let terms = query
-        .split(|ch: char| !ch.is_alphanumeric())
-        .filter(|term| !term.is_empty())
-        .map(|term| format!("\"{}\"", term))
-        .collect::<Vec<_>>();
-    if terms.is_empty() {
-        None
-    } else {
-        Some(terms.join(" AND "))
-    }
 }
 
 fn upsert_transcript_entry_tx(tx: &Transaction<'_>, entry: &TranscriptEntry) -> Result<()> {
@@ -5436,54 +5302,10 @@ DELETE FROM storage_domains WHERE domain = 'working_memory_deltas';
     },
     Migration {
         version: 15,
-        name: "message_search_index",
+        name: "reserved_message_search_index",
         sql: r#"
-CREATE TABLE IF NOT EXISTS messages (
-  evidence_id TEXT PRIMARY KEY,
-  agent_id TEXT NOT NULL,
-  turn_id TEXT,
-  message_id TEXT,
-  message_seq INTEGER,
-  task_id TEXT,
-  work_item_id TEXT,
-  created_at TEXT NOT NULL,
-  kind TEXT NOT NULL,
-  content_ref TEXT,
-  content_hash TEXT,
-  preview TEXT,
-  payload_json TEXT NOT NULL
-);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS message_search_index USING fts5(
-  evidence_id UNINDEXED,
-  agent_id UNINDEXED,
-  turn_id UNINDEXED,
-  message_id UNINDEXED,
-  task_id UNINDEXED,
-  work_item_id UNINDEXED,
-  kind,
-  body_text
-);
-
-INSERT INTO message_search_index (
-  evidence_id, agent_id, turn_id, message_id, task_id, work_item_id,
-  kind, body_text
-)
-SELECT
-  messages.evidence_id,
-  messages.agent_id,
-  messages.turn_id,
-  messages.message_id,
-  messages.task_id,
-  messages.work_item_id,
-  messages.kind,
-  COALESCE(messages.preview, '')
-FROM messages
-WHERE NOT EXISTS (
-  SELECT 1
-  FROM message_search_index
-  WHERE message_search_index.evidence_id = messages.evidence_id
-);
+-- Deprecated before release. HTTP and tool search now use memory v2.
+SELECT 1;
 "#,
     },
     Migration {
@@ -5576,6 +5398,13 @@ CREATE INDEX IF NOT EXISTS idx_runtime_index_outbox_agent_seq
 
 CREATE INDEX IF NOT EXISTS idx_runtime_index_outbox_source
   ON runtime_index_outbox(source_kind, source_id);
+"#,
+    },
+    Migration {
+        version: 20,
+        name: "drop_message_search_index",
+        sql: r#"
+DROP TABLE IF EXISTS message_search_index;
 "#,
     },
 ];
@@ -7333,76 +7162,6 @@ CREATE TABLE working_memory_deltas (
                 .collect::<Vec<_>>(),
             vec!["brief-a", "brief-b"]
         );
-        Ok(())
-    }
-
-    #[test]
-    fn message_search_indexes_messages_across_agents() -> Result<()> {
-        let (_temp_dir, db_path, lock_path) = temp_paths()?;
-        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
-        let columns = db
-            .connection()?
-            .prepare("PRAGMA table_info(message_search_index)")?
-            .query_map([], |row| row.get::<_, String>(1))?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        assert!(!columns.iter().any(|column| column == "payload_json"));
-
-        let mut first = MessageEnvelope::new(
-            "agent-a",
-            crate::types::MessageKind::OperatorPrompt,
-            crate::types::MessageOrigin::Operator {
-                actor_id: Some("operator:test".into()),
-            },
-            crate::types::AuthorityClass::OperatorInstruction,
-            crate::types::Priority::Normal,
-            crate::types::MessageBody::Text {
-                text:
-                    "find the kestrel runtime note for PR #1786 on feature/issue-1783 with foo-bar"
-                        .into(),
-            },
-        );
-        first.id = "msg-search-a".into();
-        let mut second = MessageEnvelope::new(
-            "agent-b",
-            crate::types::MessageKind::OperatorPrompt,
-            crate::types::MessageOrigin::Operator {
-                actor_id: Some("operator:test".into()),
-            },
-            crate::types::AuthorityClass::OperatorInstruction,
-            crate::types::Priority::Normal,
-            crate::types::MessageBody::Text {
-                text: "another kestrel message".into(),
-            },
-        );
-        second.id = "msg-search-b".into();
-        db.messages().upsert(&first)?;
-        db.messages().upsert(&second)?;
-
-        let all = db.messages().search(MessageSearchQuery {
-            query: "kestrel".into(),
-            agent_ids: Vec::new(),
-            limit: 10,
-        })?;
-        assert_eq!(all.len(), 2);
-
-        let filtered = db.messages().search(MessageSearchQuery {
-            query: "kestrel".into(),
-            agent_ids: vec!["agent-b".into()],
-            limit: 10,
-        })?;
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].agent_id, "agent-b");
-        assert_eq!(filtered[0].message_id, "msg-search-b");
-
-        for query in ["PR #1786", "feature/issue-1783", "foo-bar"] {
-            let results = db.messages().search(MessageSearchQuery {
-                query: query.into(),
-                agent_ids: Vec::new(),
-                limit: 10,
-            })?;
-            assert_eq!(results.len(), 1, "query {query:?}");
-            assert_eq!(results[0].message_id, "msg-search-a");
-        }
         Ok(())
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -666,23 +666,30 @@ impl AppStorage {
     }
 
     pub fn append_message(&self, message: &MessageEnvelope) -> Result<()> {
-        let _guard = self
-            .append_mutex
-            .lock()
-            .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
         let mut message = message.clone();
-        let mut counter = self
-            .message_seq_counter
-            .lock()
-            .map_err(|_| anyhow::anyhow!("message sequence counter mutex poisoned"))?;
-        *counter += 1;
-        message.message_seq = Some(*counter);
-        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.messages().upsert(&message)?;
-            return Ok(());
+        {
+            let _guard = self
+                .append_mutex
+                .lock()
+                .map_err(|_| anyhow::anyhow!("storage append mutex poisoned"))?;
+            let mut counter = self
+                .message_seq_counter
+                .lock()
+                .map_err(|_| anyhow::anyhow!("message sequence counter mutex poisoned"))?;
+            *counter += 1;
+            message.message_seq = Some(*counter);
+            drop(counter);
+            if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+                let changes = self.index_changes_for_message(&message)?;
+                runtime_db
+                    .messages()
+                    .upsert_with_index_changes(&message, &changes)?;
+                return Ok(());
+            }
+            let bytes = jsonl_bytes(&message)?;
+            append_jsonl_bytes(&self.messages_path, &bytes)?;
         }
-        let bytes = jsonl_bytes(&message)?;
-        append_jsonl_bytes(&self.messages_path, &bytes)
+        self.enqueue_memory_index_message_best_effort(&message)
     }
 
     pub fn append_task(&self, task: &TaskRecord) -> Result<()> {
@@ -954,6 +961,20 @@ impl AppStorage {
         )?])
     }
 
+    fn index_changes_for_message(
+        &self,
+        message: &MessageEnvelope,
+    ) -> Result<Vec<RuntimeIndexChange>> {
+        Ok(vec![self.runtime_index_upsert(
+            message.agent_id.clone(),
+            "message",
+            message.id.clone(),
+            format!("message:{}", message.id),
+            Some(message.created_at),
+            "message_written",
+        )?])
+    }
+
     fn index_changes_for_task(&self, task: &TaskRecord) -> Result<Vec<RuntimeIndexChange>> {
         Ok(vec![self.runtime_index_upsert(
             task.agent_id.clone(),
@@ -1096,6 +1117,20 @@ impl AppStorage {
     fn enqueue_memory_index_brief_best_effort(&self, brief: &BriefRecord) -> Result<()> {
         let result = self.enqueue_memory_index_brief(brief);
         self.finish_memory_index_enqueue(result, "brief", &brief.id, &format!("brief:{}", brief.id))
+    }
+
+    fn enqueue_memory_index_message(&self, message: &MessageEnvelope) -> Result<()> {
+        self.enqueue_memory_index_source("message", &message.id, &format!("message:{}", message.id))
+    }
+
+    fn enqueue_memory_index_message_best_effort(&self, message: &MessageEnvelope) -> Result<()> {
+        let result = self.enqueue_memory_index_message(message);
+        self.finish_memory_index_enqueue(
+            result,
+            "message",
+            &message.id,
+            &format!("message:{}", message.id),
+        )
     }
 
     fn enqueue_memory_index_task(&self, task: &TaskRecord) -> Result<()> {

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -14,6 +14,7 @@ macro_rules! http_async_tests {
 http_async_tests!(
     control_prompt_is_open_on_loopback_auto,
     agent_state_route_returns_aggregated_snapshot,
+    runtime_search_route_returns_memory_search_results,
     agent_brief_route_returns_full_brief_by_id,
     agent_state_route_scopes_work_items_to_requested_agent,
     agent_state_route_includes_bootstrap_projection_fields_when_present,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -22,8 +22,8 @@ use holon::{
     types::{
         AdmissionContext, AgentStatus, AuthorityClass, BriefKind, BriefRecord,
         CallbackDeliveryMode, CommandTaskSpec, ContinuationClass, ControlAction, MessageBody,
-        MessageDeliverySurface, MessageKind, MessageOrigin, Priority, TodoItem, TodoItemState,
-        WorkItemState,
+        MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority, TodoItem,
+        TodoItemState, WorkItemState,
     },
 };
 use reqwest::Client;
@@ -107,6 +107,71 @@ pub async fn agent_state_route_returns_aggregated_snapshot() -> Result<()> {
     assert!(state_payload.get("operator_notifications").is_none());
     assert!(state_payload.get("execution").is_none());
     assert!(state_payload.get("cursor").is_none());
+
+    server.abort();
+    Ok(())
+}
+
+pub async fn runtime_search_route_returns_memory_search_results() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let runtime = host.default_runtime().await?;
+    let client = reqwest::Client::new();
+    let mut message = MessageEnvelope::new(
+        "default",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator:test".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "http memory search sentinel issue1879".into(),
+        },
+    );
+    message.id = "msg-http-search-memory-v2".into();
+    runtime.storage().append_message(&message)?;
+
+    let response = client
+        .post(format!("{base}/search"))
+        .json(&serde_json::json!({
+            "query": "issue1879",
+            "limit": 5
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let payload: serde_json::Value = response.json().await?;
+    assert_eq!(payload["query"], "issue1879");
+    assert_eq!(payload["limit"], 5);
+    assert!(payload["index_status"].is_object());
+
+    let http_refs = payload["results"]
+        .as_array()
+        .expect("search results should be an array")
+        .iter()
+        .map(|result| {
+            result["source_ref"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    let tool_result = runtime.search_memory("issue1879", 5, false).await?;
+    assert_eq!(
+        payload["index_status"]["freshness"],
+        serde_json::to_value(tool_result.index_status.freshness)?
+    );
+    let tool_refs = tool_result
+        .results
+        .into_iter()
+        .map(|result| result.source_ref)
+        .collect::<Vec<_>>();
+    assert_eq!(http_refs, tool_refs);
+    assert!(payload["results"].as_array().unwrap().iter().any(|result| {
+        result["kind"] == "message"
+            && result["source_ref"] == "message:msg-http-search-memory-v2"
+            && result["scope_kind"] == "agent"
+    }));
 
     server.abort();
     Ok(())


### PR DESCRIPTION
## Summary
- route HTTP `/search` through the same MemorySearch v2 query path used by the agent tool
- return memory search result semantics (`source_ref`, `kind`, scope, metadata, index status) instead of message-only locators
- index messages in memory v2 and retire the old `message_search_index` query/write path
- refresh the OpenAPI snapshot and add HTTP/memory search regression coverage

Fixes #1879

## Verification
- `cargo fmt --all -- --check`
- `cargo test memory_search_indexes_workspace_profile_briefs_episodes_and_work_items`
- `cargo test --test http_control runtime_search_route_returns_memory_search_results`
- `cargo test --test http_route_snapshot`
- `cargo test --test openapi_snapshot`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
