### PR TITLE
fix: filter HTTP search by agent ids

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -1835,6 +1835,16 @@
       },
       "SearchRequest": {
         "properties": {
+          "agent_ids": {
+            "default": null,
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "include_all_workspaces": {
             "default": false,
             "type": "boolean"

--- a/src/host.rs
+++ b/src/host.rs
@@ -1896,6 +1896,10 @@ impl RuntimeHostBridge {
         Ok(RuntimeHost { inner })
     }
 
+    pub(crate) fn agent_storage(&self, agent_id: &str) -> Result<AppStorage> {
+        self.host()?.agent_storage(agent_id)
+    }
+
     pub(crate) async fn identity_for_agent(
         &self,
         agent_id: &str,

--- a/src/http.rs
+++ b/src/http.rs
@@ -525,6 +525,8 @@ pub struct SearchRequest {
     pub limit: Option<usize>,
     #[serde(default)]
     pub include_all_workspaces: bool,
+    #[serde(default)]
+    pub agent_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -979,10 +981,25 @@ pub async fn search(
         .unwrap_or(SEARCH_DEFAULT_LIMIT)
         .clamp(1, SEARCH_MAX_LIMIT);
     let runtime = state.host.default_runtime().await.map_err(error_response)?;
-    let search_result = runtime
-        .search_memory(&query, limit, request.include_all_workspaces)
-        .await
-        .map_err(error_response)?;
+    let agent_ids = normalize_search_agent_ids(request.agent_ids)?;
+    let search_result = if agent_ids.is_empty() {
+        runtime
+            .search_memory(&query, limit, request.include_all_workspaces)
+            .await
+            .map_err(error_response)?
+    } else {
+        for agent_id in &agent_ids {
+            state
+                .host
+                .get_public_agent(agent_id)
+                .await
+                .map_err(agent_access_error)?;
+        }
+        runtime
+            .search_memory_for_agents(&query, limit, request.include_all_workspaces, &agent_ids)
+            .await
+            .map_err(error_response)?
+    };
     traced_json(
         "/search",
         started_at,
@@ -993,6 +1010,25 @@ pub async fn search(
             index_status: search_result.index_status,
         },
     )
+}
+
+fn normalize_search_agent_ids(
+    agent_ids: Option<Vec<String>>,
+) -> Result<Vec<String>, (StatusCode, Json<Value>)> {
+    let Some(agent_ids) = agent_ids else {
+        return Ok(Vec::new());
+    };
+    let mut normalized = Vec::new();
+    for agent_id in agent_ids {
+        let agent_id = agent_id.trim();
+        if agent_id.is_empty() {
+            return Err(bad_request("agent_ids must not contain empty agent ids"));
+        }
+        if !normalized.iter().any(|existing| existing == agent_id) {
+            normalized.push(agent_id.to_string());
+        }
+    }
+    Ok(normalized)
 }
 
 pub async fn handshake(

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1,12 +1,12 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, params_from_iter, types::Value as SqlValue, Connection, OptionalExtension};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -182,12 +182,51 @@ pub fn search_memory_query(
     active_workspace_id: Option<&str>,
     include_all_workspaces: bool,
 ) -> Result<MemorySearchQueryResult> {
-    let index = ensure_memory_index_current(storage, active_workspace_id)?;
+    search_memory_query_for_agents(
+        storage,
+        query,
+        limit,
+        active_workspace_id,
+        include_all_workspaces,
+        &[],
+    )
+}
+
+pub fn search_memory_query_for_agents(
+    storage: &AppStorage,
+    query: &str,
+    limit: usize,
+    active_workspace_id: Option<&str>,
+    include_all_workspaces: bool,
+    agent_ids: &[String],
+) -> Result<MemorySearchQueryResult> {
+    search_memory_query_for_agent_storages(
+        storage,
+        query,
+        limit,
+        active_workspace_id,
+        include_all_workspaces,
+        agent_ids,
+        &[],
+    )
+}
+
+pub fn search_memory_query_for_agent_storages(
+    storage: &AppStorage,
+    query: &str,
+    limit: usize,
+    active_workspace_id: Option<&str>,
+    include_all_workspaces: bool,
+    agent_ids: &[String],
+    agent_storages: &[AppStorage],
+) -> Result<MemorySearchQueryResult> {
     let agent_id = storage_agent_id(storage);
+    let agent_filter = normalize_memory_search_agent_filter(&agent_id, agent_ids);
+    let index = ensure_memory_indexes_current(storage, active_workspace_id, agent_storages)?;
     let results = index.search(
         query,
         limit,
-        &agent_id,
+        &agent_filter,
         active_workspace_id,
         include_all_workspaces,
     )?;
@@ -196,6 +235,24 @@ pub fn search_memory_query(
         results,
         index_status,
     })
+}
+
+fn normalize_memory_search_agent_filter(
+    default_agent_id: &str,
+    agent_ids: &[String],
+) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut filter = Vec::new();
+    for agent_id in agent_ids {
+        let agent_id = agent_id.trim();
+        if !agent_id.is_empty() && seen.insert(agent_id.to_string()) {
+            filter.push(agent_id.to_string());
+        }
+    }
+    if filter.is_empty() {
+        filter.push(default_agent_id.to_string());
+    }
+    filter
 }
 
 pub fn get_memory(
@@ -243,11 +300,35 @@ fn ensure_memory_index_current(
     storage: &AppStorage,
     active_workspace_id: Option<&str>,
 ) -> Result<MemoryIndex> {
+    ensure_memory_indexes_current(storage, active_workspace_id, &[])
+}
+
+fn ensure_memory_indexes_current(
+    storage: &AppStorage,
+    active_workspace_id: Option<&str>,
+    agent_storages: &[AppStorage],
+) -> Result<MemoryIndex> {
     log_legacy_index_deprecation(storage);
     let mut index = MemoryIndex::open(storage)?;
+    let mut refreshed_agent_ids = BTreeSet::new();
+    refresh_memory_index_for_storage(&mut index, storage, active_workspace_id)?;
+    refreshed_agent_ids.insert(storage_agent_id(storage));
+    for agent_storage in agent_storages {
+        if refreshed_agent_ids.insert(storage_agent_id(agent_storage)) {
+            refresh_memory_index_for_storage(&mut index, agent_storage, active_workspace_id)?;
+        }
+    }
+    Ok(index)
+}
+
+fn refresh_memory_index_for_storage(
+    index: &mut MemoryIndex,
+    storage: &AppStorage,
+    active_workspace_id: Option<&str>,
+) -> Result<()> {
     index.consume_runtime_outbox(storage, MEMORY_INDEX_OUTBOX_CONSUME_LIMIT)?;
     index.consume_pending_sources(storage, MEMORY_INDEX_OUTBOX_CONSUME_LIMIT)?;
-    repair_known_markdown_sources(storage, &index)?;
+    repair_known_markdown_sources(storage, index)?;
     if memory_index_is_dirty(storage) {
         let agent_id = storage_agent_id(storage);
         tracing::debug!(
@@ -256,7 +337,7 @@ fn ensure_memory_index_current(
             "memory index remains dirty; search returns bounded stale v2 projection"
         );
     }
-    Ok(index)
+    Ok(())
 }
 
 fn log_legacy_index_deprecation(storage: &AppStorage) {
@@ -830,19 +911,26 @@ impl MemoryIndex {
         &self,
         query: &str,
         limit: usize,
-        agent_id: &str,
+        agent_ids: &[String],
         active_workspace_id: Option<&str>,
         include_all_workspaces: bool,
     ) -> Result<Vec<MemorySearchResult>> {
         let query = search_query(query);
         let limit = limit.clamp(1, SEARCH_LIMIT_MAX);
+        let agent_filter = if agent_ids.is_empty() {
+            "0".to_string()
+        } else {
+            std::iter::repeat_n("?", agent_ids.len())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
         let workspace_filter = if include_all_workspaces {
             None
         } else {
             active_workspace_id.map(ToString::to_string)
         };
         let include_all_workspaces = include_all_workspaces as i64;
-        let mut statement = self.connection.prepare(
+        let sql = format!(
             r#"
             SELECT d.source_ref, d.source_kind, d.scope_kind, d.workspace_id, d.agent_id,
                    d.source_path, d.title, d.sanitized_excerpt, d.metadata_json,
@@ -850,40 +938,43 @@ impl MemoryIndex {
             FROM memory_documents_fts
             JOIN memory_documents d ON d.document_key = memory_documents_fts.document_key
             WHERE memory_documents_fts MATCH ?1
-              AND d.agent_id = ?5
-              AND (?3 OR d.scope_kind = 'agent' OR (?2 IS NOT NULL AND d.workspace_id = ?2))
+              AND d.agent_id IN ({agent_filter})
+              AND (? OR d.scope_kind = 'agent' OR (? IS NOT NULL AND d.workspace_id = ?))
             ORDER BY score ASC, d.updated_at DESC
-            LIMIT ?4
+            LIMIT ?
             "#,
-        )?;
-        let rows = statement.query_map(
-            params![
-                query,
-                workspace_filter,
-                include_all_workspaces,
-                limit as i64,
-                agent_id
-            ],
-            |row| {
-                let metadata_json: String = row.get(8)?;
-                let updated_at: String = row.get(9)?;
-                Ok(MemorySearchResult {
-                    kind: row.get(1)?,
-                    source_ref: row.get(0)?,
-                    scope_kind: row.get(2)?,
-                    workspace_id: row.get(3)?,
-                    agent_id: row.get(4)?,
-                    source_path: row.get(5)?,
-                    title: row.get(6)?,
-                    snippet: row.get(7)?,
-                    score: row.get(10)?,
-                    updated_at: DateTime::parse_from_rfc3339(&updated_at)
-                        .map(|dt| dt.with_timezone(&Utc))
-                        .unwrap_or_else(|_| Utc::now()),
-                    metadata: serde_json::from_str(&metadata_json).unwrap_or(Value::Null),
-                })
-            },
-        )?;
+        );
+        let workspace_value = workspace_filter
+            .as_ref()
+            .map(|value| SqlValue::Text(value.clone()))
+            .unwrap_or(SqlValue::Null);
+        let mut sql_params = Vec::with_capacity(agent_ids.len() + 5);
+        sql_params.push(SqlValue::Text(query));
+        sql_params.extend(agent_ids.iter().cloned().map(SqlValue::Text));
+        sql_params.push(SqlValue::Integer(include_all_workspaces));
+        sql_params.push(workspace_value.clone());
+        sql_params.push(workspace_value);
+        sql_params.push(SqlValue::Integer(limit as i64));
+        let mut statement = self.connection.prepare(&sql)?;
+        let rows = statement.query_map(params_from_iter(sql_params), |row| {
+            let metadata_json: String = row.get(8)?;
+            let updated_at: String = row.get(9)?;
+            Ok(MemorySearchResult {
+                kind: row.get(1)?,
+                source_ref: row.get(0)?,
+                scope_kind: row.get(2)?,
+                workspace_id: row.get(3)?,
+                agent_id: row.get(4)?,
+                source_path: row.get(5)?,
+                title: row.get(6)?,
+                snippet: row.get(7)?,
+                score: row.get(10)?,
+                updated_at: DateTime::parse_from_rfc3339(&updated_at)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now()),
+                metadata: serde_json::from_str(&metadata_json).unwrap_or(Value::Null),
+            })
+        })?;
         let mut results = Vec::new();
         for row in rows {
             results.push(row?);

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6,7 +6,7 @@ pub mod working;
 pub use episode::refresh_episode_memory;
 pub use index::{
     get_memory, rebuild_memory_index, repair_memory_index_for_paths, search_memory,
-    search_memory_query, MemoryGetResult, MemorySearchIndexStatus, MemorySearchQueryResult,
-    MemorySearchResult,
+    search_memory_query, search_memory_query_for_agent_storages, search_memory_query_for_agents,
+    MemoryGetResult, MemorySearchIndexStatus, MemorySearchQueryResult, MemorySearchResult,
 };
 pub use working::refresh_working_memory;

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -627,6 +627,47 @@ impl RuntimeHandle {
         .await?
     }
 
+    pub async fn search_memory_for_agents(
+        &self,
+        query: &str,
+        limit: usize,
+        include_all_workspaces: bool,
+        agent_ids: &[String],
+    ) -> Result<crate::memory::MemorySearchQueryResult> {
+        let active_workspace_id = self
+            .agent_state()
+            .await?
+            .active_workspace_entry
+            .map(|entry| entry.workspace_id);
+        let storage = self.inner.storage.clone();
+        let agent_storages = self
+            .inner
+            .host_bridge
+            .as_ref()
+            .map(|bridge| {
+                agent_ids
+                    .iter()
+                    .map(|agent_id| bridge.agent_storage(agent_id))
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let query = query.to_string();
+        let agent_ids = agent_ids.to_vec();
+        tokio::task::spawn_blocking(move || {
+            crate::memory::search_memory_query_for_agent_storages(
+                &storage,
+                &query,
+                limit,
+                active_workspace_id.as_deref(),
+                include_all_workspaces,
+                &agent_ids,
+                &agent_storages,
+            )
+        })
+        .await?
+    }
+
     pub async fn get_memory(
         &self,
         source_ref: &str,

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -15,6 +15,7 @@ http_async_tests!(
     control_prompt_is_open_on_loopback_auto,
     agent_state_route_returns_aggregated_snapshot,
     runtime_search_route_returns_memory_search_results,
+    runtime_search_route_filters_memory_results_by_agent_ids,
     agent_brief_route_returns_full_brief_by_id,
     agent_state_route_scopes_work_items_to_requested_agent,
     agent_state_route_includes_bootstrap_projection_fields_when_present,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -177,6 +177,102 @@ pub async fn runtime_search_route_returns_memory_search_results() -> Result<()> 
     Ok(())
 }
 
+pub async fn runtime_search_route_filters_memory_results_by_agent_ids() -> Result<()> {
+    let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    host.create_named_agent("alpha", None).await?;
+    host.create_named_agent("beta", None).await?;
+    let alpha = host.get_or_create_agent("alpha").await?;
+    let beta = host.get_or_create_agent("beta").await?;
+
+    let mut alpha_message = MessageEnvelope::new(
+        "alpha",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator:test".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "shared agent search sentinel agentfilter1879 alpha".into(),
+        },
+    );
+    alpha_message.id = "msg-http-search-alpha".into();
+    alpha.storage().append_message(&alpha_message)?;
+
+    let mut beta_message = MessageEnvelope::new(
+        "beta",
+        MessageKind::OperatorPrompt,
+        MessageOrigin::Operator {
+            actor_id: Some("operator:test".into()),
+        },
+        AuthorityClass::OperatorInstruction,
+        Priority::Normal,
+        MessageBody::Text {
+            text: "shared agent search sentinel agentfilter1879 beta".into(),
+        },
+    );
+    beta_message.id = "msg-http-search-beta".into();
+    beta.storage().append_message(&beta_message)?;
+
+    let (base, server) = spawn_server_for_host(host.clone()).await?;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("{base}/search"))
+        .json(&serde_json::json!({
+            "query": "agentfilter1879",
+            "limit": 10,
+            "agent_ids": ["alpha"]
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let payload: serde_json::Value = response.json().await?;
+    let results = payload["results"].as_array().expect("results array");
+    assert!(results.iter().any(|result| {
+        result["agent_id"] == "alpha" && result["source_ref"] == "message:msg-http-search-alpha"
+    }));
+    assert!(results.iter().all(|result| result["agent_id"] == "alpha"));
+
+    let response = client
+        .post(format!("{base}/search"))
+        .json(&serde_json::json!({
+            "query": "agentfilter1879",
+            "limit": 10,
+            "agent_ids": ["alpha", "beta"]
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let payload: serde_json::Value = response.json().await?;
+    let refs = payload["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|result| result["source_ref"].as_str().unwrap_or_default())
+        .collect::<Vec<_>>();
+    assert!(refs.contains(&"message:msg-http-search-alpha"));
+    assert!(refs.contains(&"message:msg-http-search-beta"));
+
+    let response = client
+        .post(format!("{base}/search"))
+        .json(&serde_json::json!({
+            "query": "agentfilter1879",
+            "limit": 10
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert!(response.json::<serde_json::Value>().await?["results"]
+        .as_array()
+        .expect("results array")
+        .is_empty());
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn agent_brief_route_returns_full_brief_by_id() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let runtime = host.default_runtime().await?;


### PR DESCRIPTION
## Summary
- restore HTTP `/search` support for `agent_ids` as a filter over memory search results
- keep default search behavior scoped to the calling/default agent when `agent_ids` is omitted
- refresh target agents' memory v2 index before cross-agent HTTP searches instead of relying on legacy message search or HTTP-layer search side effects

## Verification
- `cargo fmt --all -- --check`
- `cargo test runtime_search_route_filters_memory_results_by_agent_ids`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
