### PR TITLE
fix: resolve brief text from slim audit events for dedup

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1504,9 +1504,16 @@ fn final_brief_texts(
                     text: normalized_text(text),
                 });
             }
-            let _brief =
+            let brief =
                 serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone()).ok()?;
-            None
+            // Resolve text from the hydration cache for TranscriptEntry briefs;
+            // Inline briefs have no text in slimmed audit events.
+            brief_texts.resolve_for_event(event).and_then(|text| {
+                (!text.trim().is_empty()).then_some(FinalBriefText {
+                    agent_id: brief.agent_id,
+                    text: normalized_text(text),
+                })
+            })
         })
         .collect()
 }


### PR DESCRIPTION
## Problem

TUI brief messages sometimes show duplicates.

### Root Cause

In `src/presentation.rs`, `final_brief_texts()` processes projection events to collect brief texts and deduplicate them. Events contain briefs in two formats:

- **`BriefRecord`** (old format, text inline in the event payload) — correctly resolved via `resolve_for_record()`
- **`BriefCreatedAuditEvent`** (new slim format, text stored in hydration cache as `TranscriptEntry`) — the branch **always returned `None`**, so briefs in this format were silently dropped

Because slim-audit briefs never appeared in the dedup set, the TUI couldn't detect that they were duplicates of other briefs (including briefs from other projection events), causing repeated display.

## Fix

The `BriefCreatedAuditEvent` branch now calls `brief_texts.resolve_for_event()` to extract the text from the hydration cache, and returns it via the same `FinalBriefText` struct as the `BriefRecord` branch. This unifies both storage formats in the dedup set.

## Testing

- `cargo check --all-targets` ✅
- `cargo fmt --all -- --check` ✅