### PR TITLE
fix: enable localhost CORS by default

### DIFF
--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -58,13 +58,19 @@ The `models.catalog` key lets you override runtime metadata for specific provide
 
 ### HTTP API CORS
 
-CORS is disabled by default. Enable it only for browser-based Web UI origins
-that should call the Holon HTTP/control API. For LAN access, the API must also
-bind to a reachable address such as `0.0.0.0:7878` or a specific LAN IP; a
-`127.0.0.1` bind is not reachable from other devices.
+CORS is enabled by default for localhost/loopback browser origins on any port:
+`http://localhost:<port>`, `https://localhost:<port>`,
+`http://127.0.0.1:<port>`, and `http://[::1]:<port>`. This lets local Web UIs
+call a local or remote Holon HTTP/control API when they provide the required
+`Authorization: Bearer <token>` header.
+
+Configure `api.cors.allowed_origins` to add non-local browser origins such as a
+LAN-hosted Web UI. These origins are added to the built-in localhost/loopback
+allowlist. For LAN access, the API must also bind to a reachable address such
+as `0.0.0.0:7878` or a specific LAN IP; a `127.0.0.1` bind is not reachable
+from other devices. Set `api.cors.enabled=false` to disable CORS entirely.
 
 ```bash
-holon config set api.cors.enabled true
 holon config set api.cors.allowed_origins '["http://192.168.1.10:5173"]'
 holon config set api.cors.allowed_methods '["GET","POST","PATCH","DELETE","OPTIONS"]'
 holon config set api.cors.allowed_headers '["content-type","authorization"]'
@@ -266,8 +272,8 @@ TUI debug instrumentation is controlled by environment variables:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `api.cors.enabled` | boolean | `false` | Enable CORS responses on the HTTP/control API |
-| `api.cors.allowed_origins` | string_list | `[]` | Explicit browser origins allowed to call the API |
+| `api.cors.enabled` | boolean | `true` | Enable CORS responses on the HTTP/control API; localhost/loopback origins are allowed by default |
+| `api.cors.allowed_origins` | string_list | `[]` | Additional explicit browser origins allowed to call the API |
 | `api.cors.allowed_methods` | string_list | `["GET","POST","PATCH","DELETE","OPTIONS"]` | HTTP methods allowed by CORS preflight |
 | `api.cors.allowed_headers` | string_list | `["content-type","authorization"]` | Request headers allowed by CORS preflight |
 | `api.cors.allow_credentials` | boolean | `false` | Allow credentialed CORS requests; incompatible with wildcard origins |

--- a/src/config.rs
+++ b/src/config.rs
@@ -299,7 +299,7 @@ impl ApiCorsConfigFile {
     }
 
     pub fn enabled(&self) -> bool {
-        self.enabled.unwrap_or(false)
+        self.enabled.unwrap_or(true)
     }
 
     pub fn allow_credentials(&self) -> bool {
@@ -1964,14 +1964,14 @@ pub fn config_schema() -> Vec<ConfigSchemaEntry> {
         ConfigSchemaEntry {
             key: "api.cors.enabled",
             kind: "boolean",
-            description: "Enable CORS responses on the HTTP/control API. Disabled by default.",
-            default: json!(false),
+            description: "Enable CORS responses on the HTTP/control API. Enabled by default for localhost/loopback browser origins.",
+            default: json!(true),
             allowed_values: vec!["true", "false"],
         },
         ConfigSchemaEntry {
             key: "api.cors.allowed_origins",
             kind: "string_list",
-            description: "Allowed browser origins for HTTP/control API CORS. Use explicit origins for LAN Web UI access; wildcard is rejected when credentials are enabled.",
+            description: "Additional browser origins for HTTP/control API CORS. Localhost/loopback origins are allowed by default; wildcard is rejected when credentials are enabled.",
             default: json!([]),
             allowed_values: vec![],
         },

--- a/src/http.rs
+++ b/src/http.rs
@@ -492,12 +492,14 @@ fn api_cors_layer(config: &ApiCorsConfigFile) -> CorsLayer {
     let allow_origin = if config.allowed_origins.iter().any(|origin| origin == "*") {
         AllowOrigin::any()
     } else {
-        AllowOrigin::list(
-            config
-                .allowed_origins
-                .iter()
-                .filter_map(|origin| origin.parse::<HeaderValue>().ok()),
-        )
+        let configured_origins = config
+            .allowed_origins
+            .iter()
+            .filter_map(|origin| origin.parse::<HeaderValue>().ok())
+            .collect::<Vec<_>>();
+        AllowOrigin::predicate(move |origin, _| {
+            is_default_localhost_cors_origin(origin) || configured_origins.contains(origin)
+        })
     };
 
     let mut layer = CorsLayer::new()
@@ -511,6 +513,27 @@ fn api_cors_layer(config: &ApiCorsConfigFile) -> CorsLayer {
     }
 
     layer
+}
+
+fn is_default_localhost_cors_origin(origin: &HeaderValue) -> bool {
+    let Ok(origin) = origin.to_str() else {
+        return false;
+    };
+    let Ok(origin) = url::Url::parse(origin) else {
+        return false;
+    };
+    if !matches!(origin.scheme(), "http" | "https") {
+        return false;
+    }
+    if origin.path() != "/" || origin.query().is_some() || origin.fragment().is_some() {
+        return false;
+    }
+    match origin.host() {
+        Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(addr)) => addr == std::net::Ipv4Addr::LOCALHOST,
+        Some(url::Host::Ipv6(addr)) => addr == std::net::Ipv6Addr::LOCALHOST,
+        None => false,
+    }
 }
 
 fn traced_json<T: Serialize>(

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -35,6 +35,7 @@ http_async_tests!(
     runtime_status_route_reports_runtime_metadata,
     runtime_readiness_route_omits_activity_summary,
     runtime_config_route_reads_and_updates_persisted_runtime_config,
+    cors_preflight_allows_default_localhost_origins,
     cors_preflight_respects_configured_origin,
     runtime_status_route_reports_waiting_activity_summary,
     runtime_status_route_reports_last_runtime_failure_summary,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -1651,6 +1651,65 @@ pub async fn runtime_config_route_reads_and_updates_persisted_runtime_config() -
     Ok(())
 }
 
+pub async fn cors_preflight_allows_default_localhost_origins() -> Result<()> {
+    let config = test_config();
+    std::fs::create_dir_all(&config.workspace_dir)?;
+    init_git_repo(&config.workspace_dir)?;
+    let host = RuntimeHost::new_with_provider(config.clone(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    let router: Router = http::router(AppState::for_tcp(host));
+    let listener = TcpListener::bind(&config.http_addr).await?;
+    let addr = connect_addr(listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let client = reqwest::Client::new();
+    for origin in [
+        "http://localhost:5173",
+        "https://localhost:5173",
+        "http://127.0.0.1:3000",
+        "http://[::1]:8080",
+    ] {
+        let allowed = client
+            .request(
+                reqwest::Method::OPTIONS,
+                format!("http://{addr}/control/runtime/status"),
+            )
+            .header("origin", origin)
+            .header("access-control-request-method", "GET")
+            .header("access-control-request-headers", "authorization")
+            .send()
+            .await?;
+        assert!(allowed.status().is_success());
+        assert_eq!(
+            allowed
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some(origin)
+        );
+    }
+
+    let denied = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("http://{addr}/control/runtime/status"),
+        )
+        .header("origin", "http://evil.example")
+        .header("access-control-request-method", "GET")
+        .send()
+        .await?;
+    assert!(denied
+        .headers()
+        .get("access-control-allow-origin")
+        .is_none());
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn cors_preflight_respects_configured_origin() -> Result<()> {
     let mut config = test_config();
     config.api_cors = ApiCorsConfigFile {


### PR DESCRIPTION
## Summary
- enable API CORS by default while keeping `api.cors.enabled=false` as a full opt-out
- allow localhost/loopback browser origins on any port by default and union them with configured origins
- document the new default CORS behavior and add HTTP preflight coverage

## Tests
- cargo fmt --all -- --check
- cargo test --test http_control cors_preflight -- --nocapture
- cargo test -p holon api_cors -- --nocapture
- cargo test --test openapi_snapshot
- RUSTFLAGS="-D warnings" cargo check --all-targets