### PR TITLE
docs: add guides for Web GUI, memory auto-load, child token usage, and performance diagnostics (v0.19.0)

### DIFF
--- a/docs/website/concepts/memory.md
+++ b/docs/website/concepts/memory.md
@@ -124,6 +124,65 @@ Holon exposes two memory tools for indexed retrieval:
 These tools let the agent pull relevant past context on demand without
 rendering every archived episode into every prompt.
 
+## Agent Memory Auto-Load
+
+Holon automatically injects a compact slice of the agent's curated memory
+files into every turn's system prompt. This gives the agent persistent
+self-knowledge and operator preferences without manual recall or search.
+
+Two files participate in auto-load:
+
+| File | Purpose | Who writes it |
+|------|---------|---------------|
+| `agent_home/memory/operator.md` | Operator preferences, standing instructions | Operator |
+| `agent_home/memory/self.md` | Agent self-knowledge, role facts | Agent |
+
+At turn assembly, each file is read and a **compact slice** is injected under
+a fixed per-file character budget (default 1500 characters). If the file
+exceeds the budget, the injected slice is truncated and the agent receives a
+note that the remainder is retrievable via `MemoryGet`. If the file is empty,
+the agent receives a note that curated content is not yet present.
+
+The auto-loaded sections appear in the prompt as:
+
+- **`agent_memory_operator`** — Curated operator memory, loaded with
+  `Stability::AgentScoped` (changes only when the operator edits the file).
+- **`agent_memory_self`** — Curated self memory, loaded with
+  `Stability::AgentScoped` (changes only when the agent edits the file).
+
+These sections sit between `AGENTS.md` guidance and the workspace scope in
+the prompt hierarchy. They carry lower authority than workspace or turn-scoped
+instructions but provide persistent facts that survive context compaction.
+
+### When to use each file
+
+- **`operator.md`** — Store cross-agent operator preferences: preferred
+  language, naming conventions, tool defaults, communication style. These
+  apply regardless of which agent is running.
+- **`self.md`** — Store agent-specific durable facts: the agent's role,
+  standing responsibilities, past decisions worth remembering, recurring
+  workflow notes.
+
+## Notes Catalog
+
+In addition to curated memory files, Holon can inject a metadata catalog of
+the agent's `notes/` directory into the prompt. The notes catalog acts as a
+bounded reference index, not as instruction content.
+
+The catalog is rendered from each Markdown file in `agent_home/notes/` and
+includes:
+
+- **Title** — extracted from frontmatter, the first heading, or the filename.
+- **Summary** — extracted from frontmatter or the first paragraph excerpt.
+- **Tags** — extracted from frontmatter (lower-cased, deduped).
+
+The catalog is bounded: at most 20 entries and 2000 total characters. Note
+bodies are **never** injected — the catalog is a metadata index only. The
+agent can retrieve full note content by reading the referenced file.
+
+Notes are treated as reference material, not as instructions. They do not
+override operator input, AGENTS.md guidance, or the current WorkItem objective.
+
 ## Memory and Work Items
 
 Memory is tightly coupled to work items:

--- a/docs/website/guides/README.md
+++ b/docs/website/guides/README.md
@@ -17,6 +17,11 @@ Start here if you want to see what Holon can do with minimal setup.
 - **[Local runtime](/guides/local-runtime)** — conservative workflow for
   running and inspecting Holon from source.
 
+## Use the graphical interface
+
+- **[Web GUI](/guides/web-gui)** — embedded browser interface for agent
+  management, conversation, search, and settings.
+
 ## Automate GitHub work
 
 - **[holon solve](/guides/solve)** — headless automation for GitHub issues and
@@ -64,6 +69,10 @@ Edit and build the Holon documentation website.
 
 - [Local runtime](./local-runtime.md)
   A conservative workflow for running and inspecting Holon locally.
+  <!-- mdorigin:index kind=article -->
+
+- [Web GUI](./web-gui.md)
+  Use Holon's embedded web interface to manage agents, monitor runtime state, and configure settings from a browser.
   <!-- mdorigin:index kind=article -->
 
 - [TUI guide](./tui.md)

--- a/docs/website/guides/multi-agent.md
+++ b/docs/website/guides/multi-agent.md
@@ -36,6 +36,37 @@ When spawning a `private_child`, the parent receives a `task_handle` with a
 - **TaskInput** — Send follow-up input to the child
 - **TaskStop** — Stop the child agent explicitly
 
+### Child Agent Token Usage
+
+Task status and output snapshots include a `token_usage` field with the
+child agent's cumulative token consumption:
+
+```json
+{
+  "total": {
+    "input_tokens": 12450,
+    "output_tokens": 3840,
+    "total_tokens": 16290
+  },
+  "total_model_rounds": 5,
+  "last_turn": {
+    "input_tokens": 2100,
+    "output_tokens": 720,
+    "total_tokens": 2820
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `total` | Cumulative tokens across all child turns |
+| `total_model_rounds` | Number of model round-trips the child has made |
+| `last_turn` | Token usage for the most recent turn (if available) |
+
+Use token usage to estimate child agent costs, detect unexpectedly expensive
+delegations, or decide whether to stop a child that is consuming more tokens
+than its output warrants.
+
 ## Usage Patterns
 
 ### Parallel investigation

--- a/docs/website/guides/troubleshooting.md
+++ b/docs/website/guides/troubleshooting.md
@@ -213,6 +213,66 @@ holon config list
 holon config schema
 ```
 
+## Runtime Performance Diagnostics
+
+Holon tracks granular performance metrics across turn lifecycle phases,
+provider interactions, tool execution, and persistence. These metrics are
+cumulative — they cover the entire process lifetime since daemon start.
+
+### Retrieving metrics
+
+```bash
+curl http://127.0.0.1:7878/control/runtime/performance
+```
+
+The response is a JSON snapshot grouped by category:
+
+### Metric groups
+
+| Group | Key metrics | What to watch |
+|-------|-------------|---------------|
+| `turn.*` | `turn.total`, `turn.context_build`, `turn.provider_round`, `turn.tool_execution`, `turn.cleanup` | Slow context builds (growing prompt assembly), dominant tool time |
+| `provider.*` | `provider.request_build`, `provider.round_total`, `provider.retry` | High retry counts or latency point to provider issues |
+| `tool.execution` | Cumulative tool timing | Identify tools with unusually high `avg_ms` |
+| `storage.*` | `storage.append_event`, `storage.persist_state` | Persistence slowdowns suggest DB pressure |
+| `projection.agent_state.*` | `tasks`, `timers`, `work_items`, `waiting_intents`, `external_triggers` | State projection overhead per agent |
+| `projection.agents_list` | Agent list projection time | Dashboard/API list latency |
+| `http.*` | Per-route HTTP timing | Slow endpoints, large payloads |
+| `scheduler.*` | `scheduler.poll.all`, `.message`, `.idle`, `.stopped` | Scheduler health (idle ratio, poll latency) |
+
+Each metric entry contains:
+
+| Field | Description |
+|-------|-------------|
+| `count` | Total calls to this phase |
+| `total_ms` | Cumulative wall-clock time |
+| `max_ms` | Worst single call |
+| `avg_ms` | Average call duration |
+
+### Common diagnosis patterns
+
+**High `turn.tool_execution`** — A specific tool is dominating turn time. Check
+`ToolLatencyMetrics` on the agent status endpoint to identify the tool.
+
+**Frequent `provider.retry`** — The model provider is returning errors or
+timeouts. Check provider logs (`holon daemon logs`) and network connectivity.
+
+**Growing `turn.context_build`** — Prompt assembly is slowing. This may
+indicate accumulated memory that needs compaction. Check agent
+`compacted_message_count` vs `total_message_count`.
+
+**High `scheduler.poll.idle` ratio** — Normal when no agents are awake. If
+agents have pending work, check wake hints and wait conditions.
+
+### Resetting metrics
+
+Metrics reset on daemon restart. To observe a specific scenario, restart the
+daemon, reproduce the issue, then capture the snapshot:
+
+```bash
+holon daemon restart && sleep 2 && curl http://127.0.0.1:7878/control/runtime/performance
+```
+
 ## See Also
 
 - [Configuration Reference](/reference/configuration.md) — Configuration keys and credential management

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -1,0 +1,146 @@
+---
+title: Web GUI
+summary: Use Holon's embedded web interface to manage agents, monitor runtime state, and configure settings from a browser.
+order: 25
+---
+
+# Web GUI
+
+Holon includes an embedded web GUI served directly from the daemon. No separate
+frontend build or deployment is needed — start the daemon and open a browser.
+
+## Quick Start
+
+```bash
+# Start the daemon (Web GUI is enabled by default)
+holon daemon start
+```
+
+Then open [http://127.0.0.1:7878/app/](http://127.0.0.1:7878/app/) in a
+browser.
+
+The Web GUI is served from embedded assets compiled into the `holon` binary.
+The default CORS configuration permits `localhost` origins so the GUI works
+out of the box on the same machine.
+
+> **Note:** If you configured a custom listen address or port, adjust the URL
+> accordingly.
+
+## Pages
+
+### Dashboard
+
+The Dashboard provides a runtime overview:
+
+- **Agent roster** — all agents with their status (Awake, Asleep, Booting),
+  pending message counts, and current model.
+- **Runtime health** — scheduler posture, wake hints, and recent activity.
+- **Quick actions** — create agents, attach workspaces, and view agent detail.
+
+### Agent Conversation
+
+Select an agent from the Dashboard to open its conversation page:
+
+- **Message stream** — recent messages, tool calls, and briefs displayed as a
+  threaded conversation.
+- **Display levels** — switch between Info (compact user-facing output),
+  Verbose (tool calls and intermediate results), and Debug (full runtime
+  metadata including tool execution records).
+- **Input bar** — send operator messages to the selected agent.
+- **Event timeline** — a sidebar timeline of recent events including turns,
+  tool executions, and state transitions.
+
+### Search
+
+Search across agent memory from the browser:
+
+- **Full-text search** — query runtime memory index across agents.
+- **Filter by agent** — scope results to one or more agent IDs.
+- **Result navigation** — click a result to view the full memory record.
+
+### Settings
+
+Configure Holon from the browser:
+
+- **Model settings** — view and change the default model, override per-agent
+  models, and set reasoning effort.
+- **API keys** — add or update provider credentials (API keys) through the
+  credential store without editing JSON files.
+- **Runtime configuration** — view the current execution environment,
+  attached workspaces, and policy snapshot.
+
+### Inspector (Right Panel)
+
+When viewing an agent or the Dashboard, the right panel shows:
+
+- **Agent identity** — agent ID, visibility, ownership, and profile preset.
+- **Current work** — active work item, plan status, and todo list.
+- **Token usage** — cumulative and per-turn token consumption.
+- **Active children** — spawned child agents and their status.
+- **Tool latency** — per-tool call count and total duration.
+
+## Remote Access
+
+The Web GUI works with Holon's remote access modes. When the daemon is
+configured for remote access (tunnel, tailnet, or LAN), open the GUI URL
+through the same endpoint:
+
+```bash
+# Example: LAN access from another machine on the same network
+http://<daemon-host>:7878/app/
+```
+
+Configure CORS if accessing from a different origin. See
+[Remote Access](/guides/remote-access) and
+[Configuration](/reference/configuration) for details.
+
+## Embedded vs Development Build
+
+| Mode | How to access | When to use |
+|------|--------------|-------------|
+| **Embedded** (default) | `holon daemon start` → `/app/` | Normal use |
+| **Dev server** | `cd web-gui/app && npm run dev` | UI development |
+
+The embedded build is compiled into the `holon` binary at release time via
+`rust-embed`. No separate `npm` install or build step is required for
+production use.
+
+To run the development server for UI work:
+
+```bash
+cd web-gui/app
+npm install
+npm run dev
+```
+
+The dev server includes hot reload and uses fixture data when no Holon server
+is running. Set `VITE_HOLON_API_BASE=/holon-api` to proxy through the Vite dev
+server to a running Holon daemon.
+
+## Performance Diagnostics
+
+The Web GUI exposes runtime performance metrics at
+`/control/runtime/performance`. This endpoint returns granular timing data
+grouped by phase:
+
+| Group | Metrics |
+|-------|---------|
+| `turn.*` | Total turn time, context build, provider round, tool execution, cleanup |
+| `provider.*` | Request build, round total, retry latency |
+| `tool.execution` | Cumulative tool execution timing |
+| `storage.*` | Event append and state persistence timing |
+| `projection.*` | Agent state projection substeps (tasks, timers, work items, etc.) |
+| `http.*` | Per-route HTTP response timing |
+| `scheduler.*` | Poll latency by outcome |
+
+Each metric includes `count`, `total_ms`, `max_ms`, and `avg_ms`. Use this to
+diagnose slow turns, identify expensive tools, or track provider latency over
+time.
+
+## See Also
+
+- [Quick Examples](/guides/quick-examples) — Try Holon in a few commands
+- [Remote Access](/guides/remote-access) — Connect to a remote daemon
+- [Troubleshooting](/guides/troubleshooting) — Diagnose common issues
+- [Configuration Reference](/reference/configuration) — CORS, ports, and
+  control plane settings


### PR DESCRIPTION
## Summary

Documentation for features introduced in v0.18.x ~ v0.19.0 that previously had no user-facing coverage.

## Changes (5 files, +305 lines)

| # | File | Change | Feature |
|---|------|--------|---------|
| 1 | `docs/website/guides/web-gui.md` | New | Web GUI usage guide |
| 2 | `docs/website/concepts/memory.md` | Updated | Agent Memory Auto-Load and Notes Catalog |
| 3 | `docs/website/guides/multi-agent.md` | Updated | Child Agent Token Usage |
| 4 | `docs/website/guides/troubleshooting.md` | Updated | Runtime Performance Diagnostics |
| 5 | `docs/website/guides/README.md` | Updated | Web GUI navigation entry |

## Details

### web-gui.md (new)
Covers the embedded Web GUI: quick start, Dashboard, Agent Conversation (with display levels), Search, Settings (API keys, models), Inspector (token usage, tool latency), remote access, embedded vs dev build, and the performance diagnostics endpoint.

### memory.md (updated)
Two new sections added:
- Agent Memory Auto-Load: documents the v0.19.0 prompt auto-injection of `operator.md` and `self.md` compact slices
- Notes Catalog: documents the bounded metadata catalog injection from `agent_home/notes/`

### multi-agent.md (updated)
Added Child Agent Token Usage subsection under Task Handle Supervision, documenting the `token_usage` field with JSON example.

### troubleshooting.md (updated)
Added Runtime Performance Diagnostics section: metric retrieval, metric groups table, common diagnosis patterns, and resetting metrics.
