### PR TITLE
fix: hydrate inline brief text in tui

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1191,7 +1191,7 @@ impl<'a> BriefTextLookup<'a> {
             crate::types::BriefContentSource::TranscriptEntry { ref entry_id, .. } => {
                 self.0.get(entry_id).map(String::as_str)
             }
-            crate::types::BriefContentSource::Inline => None,
+            crate::types::BriefContentSource::Inline => self.0.get(&brief.id).map(String::as_str),
         }
     }
 
@@ -1201,7 +1201,9 @@ impl<'a> BriefTextLookup<'a> {
             crate::types::BriefContentSource::TranscriptEntry { ref entry_id, .. } => {
                 self.0.get(entry_id).map(String::as_str)
             }
-            crate::types::BriefContentSource::Inline => None,
+            crate::types::BriefContentSource::Inline => {
+                self.0.get(&brief.brief_id).map(String::as_str)
+            }
         }
     }
 }
@@ -3672,6 +3674,39 @@ mod tests {
             } => {
                 assert_eq!(brief_id.as_deref(), Some("brief-1"));
                 assert_eq!(body, "Result brief (22 chars)");
+                assert_eq!(*outcome, Outcome::Success);
+            }
+            other => panic!("expected AssistantResult, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reducer_brief_created_resolves_inline_audit_text() {
+        let event = make_event(
+            "brief_created",
+            "Brief created",
+            json!({
+                "brief_id": "brief-inline-1",
+                "agent_id": "default",
+                "workspace_id": "agent_home",
+                "kind": "result",
+                "created_at": "2026-01-01T00:00:00Z",
+                "content_source": { "kind": "inline" },
+                "content_char_count": 31
+            }),
+        );
+        let brief_texts = std::collections::BTreeMap::from([(
+            "brief-inline-1".to_string(),
+            "resolved inline body sentinel_8429".to_string(),
+        )]);
+
+        let mut reducer = PresentationReducer::new();
+        let items = reducer.reduce(&[event], &BriefTextLookup(&brief_texts));
+
+        assert_eq!(items.len(), 1);
+        match &items[0].item {
+            PresentationItem::AssistantResult { body, outcome, .. } => {
+                assert_eq!(body, "resolved inline body sentinel_8429");
                 assert_eq!(*outcome, Outcome::Success);
             }
             other => panic!("expected AssistantResult, got {:?}", other),

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -809,6 +809,29 @@ impl TuiProjection {
             .collect()
     }
 
+    pub(crate) fn missing_inline_brief_ids_for_hydration(&self) -> Vec<String> {
+        self.event_log
+            .iter()
+            .chain(self.durable_conversation_log.iter())
+            .filter(|event| event.kind == "brief_created")
+            .filter_map(|event| {
+                let brief =
+                    serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone()).ok()?;
+                match &brief.content_source {
+                    BriefContentSource::Inline => {
+                        if self.brief_text_cache.contains_key(&brief.brief_id) {
+                            return None;
+                        }
+                        Some(brief.brief_id.clone())
+                    }
+                    BriefContentSource::TranscriptEntry { .. } => None,
+                }
+            })
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
     pub(crate) fn hydrate_brief_texts(&mut self, entries: Vec<TranscriptEntry>) -> bool {
         let mut changed = false;
         for entry in entries {
@@ -821,13 +844,24 @@ impl TuiProjection {
         changed
     }
 
+    pub(crate) fn hydrate_brief_records(&mut self, briefs: Vec<BriefRecord>) -> bool {
+        let mut changed = false;
+        for brief in briefs {
+            changed |= self.brief_text_cache.insert(brief.id, brief.text).is_none();
+        }
+        changed
+    }
+
     pub(crate) fn brief_text_for_event(&self, event: &ProjectionEventRecord) -> Option<&str> {
         let brief = serde_json::from_value::<BriefCreatedAuditEvent>(event.payload.clone()).ok()?;
         match &brief.content_source {
             BriefContentSource::TranscriptEntry { entry_id, .. } => {
                 self.brief_text_cache.get(entry_id).map(String::as_str)
             }
-            BriefContentSource::Inline => None,
+            BriefContentSource::Inline => self
+                .brief_text_cache
+                .get(&brief.brief_id)
+                .map(String::as_str),
         }
     }
 
@@ -1685,15 +1719,15 @@ mod tests {
             AgentIdentityView, AgentKind, AgentLifecycleHint, AgentModelSource, AgentModelState,
             AgentOwnership, AgentProfilePreset, AgentRegistryStatus, AgentState,
             AgentStateChangedEvent, AgentSummary, AgentTokenUsageSummary, AgentVisibility,
-            BriefKind, BriefRecord, CallbackDeliveryMode, ChildAgentSummary, ClosureDecision,
-            ClosureOutcome, ExternalTriggerScope, ExternalTriggerStateSnapshot,
-            ExternalTriggerStatus, LoadedAgentsMdView, MessageBody, MessageDeliverySurface,
-            MessageEnvelope, MessageKind, MessageOrigin, Priority, RuntimePosture,
-            SkillsRuntimeView, TaskLifecycleAuditEvent, TaskRecord, TaskStatus, TimerRecord,
-            TimerStatus, TodoItem, TodoItemState, TokenUsage, TurnTerminalKind, TurnTerminalRecord,
-            WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus, WaitingIntentSummary,
-            WaitingReason, WorkItemRecord, WorkItemState, WorkspaceOccupancyRecord,
-            WorktreeSession,
+            BriefCreatedAuditEvent, BriefKind, BriefRecord, CallbackDeliveryMode,
+            ChildAgentSummary, ClosureDecision, ClosureOutcome, ExternalTriggerScope,
+            ExternalTriggerStateSnapshot, ExternalTriggerStatus, LoadedAgentsMdView, MessageBody,
+            MessageDeliverySurface, MessageEnvelope, MessageKind, MessageOrigin, Priority,
+            RuntimePosture, SkillsRuntimeView, TaskLifecycleAuditEvent, TaskRecord, TaskStatus,
+            TimerRecord, TimerStatus, TodoItem, TodoItemState, TokenUsage, TurnTerminalKind,
+            TurnTerminalRecord, WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus,
+            WaitingIntentSummary, WaitingReason, WorkItemRecord, WorkItemState,
+            WorkspaceOccupancyRecord, WorktreeSession,
         },
     };
     use chrono::Utc;
@@ -2076,6 +2110,40 @@ mod tests {
         assert_eq!(
             lanes,
             vec![ProjectionEventLane::Timeline, ProjectionEventLane::Timeline]
+        );
+    }
+
+    #[test]
+    fn projection_hydrates_inline_audit_brief_text_by_brief_id() {
+        let mut projection = TuiProjection::from_snapshot(sample_snapshot());
+        let brief = BriefRecord::new(
+            "default",
+            BriefKind::Result,
+            "resolved inline projection body",
+            None,
+            None,
+        );
+        let event_payload =
+            serde_json::to_value(BriefCreatedAuditEvent::from_brief(&brief)).unwrap();
+        let event = sample_event("brief_created", event_payload);
+        projection.apply_event(event, &test_log_writer());
+
+        assert_eq!(
+            projection.missing_inline_brief_ids_for_hydration(),
+            vec![brief.id.clone()]
+        );
+        assert!(projection
+            .brief_text_for_event(projection.event_log().last().unwrap())
+            .is_none());
+
+        assert!(projection.hydrate_brief_records(vec![brief.clone()]));
+        assert_eq!(
+            projection.missing_inline_brief_ids_for_hydration(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            projection.brief_text_for_event(projection.event_log().last().unwrap()),
+            Some("resolved inline projection body")
         );
     }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -5,7 +5,7 @@ use crate::client::{
     AgentStateSnapshot, AgentStreamEvent, EventPageRequest, EventPageResponse, EventStreamRequest,
     LocalEventStream, LocalHttpError, StreamEventEnvelope,
 };
-use crate::types::MessageEnvelope;
+use crate::types::{BriefRecord, MessageEnvelope, TranscriptEntry};
 use tokio::sync::mpsc;
 
 const REFRESH_RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -64,7 +64,7 @@ pub(super) enum TuiRuntimeMessage {
     },
     BriefsHydrated {
         agent_id: String,
-        result: Result<Vec<crate::types::TranscriptEntry>, String>,
+        result: Result<BriefHydrationResult, String>,
     },
     EventStreamOpened {
         request_id: u64,
@@ -80,6 +80,11 @@ type SnapshotBootstrapResult = (
     Option<u64>,
     bool,
 );
+
+pub(super) struct BriefHydrationResult {
+    entries: Vec<TranscriptEntry>,
+    briefs: Vec<BriefRecord>,
+}
 
 pub(super) struct EventStreamOpenError {
     message: String,
@@ -942,18 +947,31 @@ impl TuiApp {
             return;
         }
         let entry_ids = projection.missing_brief_entry_ids_for_hydration();
-        if entry_ids.is_empty() {
+        let brief_ids = projection.missing_inline_brief_ids_for_hydration();
+        if entry_ids.is_empty() && brief_ids.is_empty() {
             return;
         }
         self.brief_hydration_in_flight = Some(agent_id.clone());
         let client = self.client.clone();
         let tx = self.runtime_tx.clone();
         tokio::spawn(async move {
-            let result = client
-                .agent_transcript_entries_batch_get(&agent_id, entry_ids)
-                .await
-                .map(|response| response.entries)
-                .map_err(|err| err.to_string());
+            let result = async {
+                let entries = if entry_ids.is_empty() {
+                    Vec::new()
+                } else {
+                    client
+                        .agent_transcript_entries_batch_get(&agent_id, entry_ids)
+                        .await?
+                        .entries
+                };
+                let mut briefs = Vec::with_capacity(brief_ids.len());
+                for brief_id in brief_ids {
+                    briefs.push(client.agent_brief(&agent_id, &brief_id).await?);
+                }
+                Ok(BriefHydrationResult { entries, briefs })
+            }
+            .await
+            .map_err(|err: anyhow::Error| err.to_string());
             let _ = tx.send(TuiRuntimeMessage::BriefsHydrated { agent_id, result });
         });
     }
@@ -961,7 +979,7 @@ impl TuiApp {
     pub(super) fn apply_briefs_hydrated(
         &mut self,
         agent_id: String,
-        result: Result<Vec<crate::types::TranscriptEntry>, String>,
+        result: Result<BriefHydrationResult, String>,
     ) {
         if self.brief_hydration_in_flight.as_ref() == Some(&agent_id) {
             self.brief_hydration_in_flight = None;
@@ -974,14 +992,16 @@ impl TuiApp {
             self.begin_brief_hydration_if_needed();
             return;
         }
-        let entries = match result {
-            Ok(entries) => entries,
+        let hydrated = match result {
+            Ok(hydrated) => hydrated,
             Err(error) => {
                 self.status_line = format!("Brief hydration failed for {agent_id}: {error}");
                 return;
             }
         };
-        if projection.hydrate_brief_texts(entries) {
+        let changed = projection.hydrate_brief_texts(hydrated.entries)
+            | projection.hydrate_brief_records(hydrated.briefs);
+        if changed {
             self.chat_text_cache.borrow_mut().take();
             self.apply_projection_view();
         }


### PR DESCRIPTION
## Summary
- hydrate TUI brief text cache from inline `brief_created` audit events by `brief_id`
- let presentation resolve brief-created rows from the cached inline text before falling back to `Result brief (N chars)` labels
- keep the audit event lightweight while making delayed/missing cache behavior explicit in tests

## Verification
- `cargo test projection_hydrates_inline_audit_brief_text_by_brief_id -- --nocapture`
- `cargo test -q reducer_brief_created_resolves_inline_audit_text`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
