### PR TITLE
fix: restore xiaomi token plan provider

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -53,6 +53,7 @@ running Holon.
 | `volcengine-coding` | OpenAI Chat Completions | `https://ark.cn-beijing.volces.com/api/coding/v3` | `VOLCENGINE_CODING_API_KEY or VOLCENGINE_API_KEY or ARK_API_KEY` |
 | `xai` | OpenAI Chat Completions | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `xiaomi` | OpenAI Chat Completions | `https://api.xiaomimimo.com/v1` | `XIAOMI_API_KEY` |
+| `xiaomi-token-plan` | OpenAI Chat Completions | `https://token-plan-cn.xiaomimimo.com/v1` | `XIAOMI_TOKEN_PLAN_API_KEY` |
 | `zai` | Anthropic Messages | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` |
 
 ## Model Catalog

--- a/src/config.rs
+++ b/src/config.rs
@@ -3485,6 +3485,13 @@ fn built_in_provider_registry_with_settings(
     )?;
     insert_openai_compatible_provider(
         &mut registry,
+        "xiaomi-token-plan",
+        "https://token-plan-cn.xiaomimimo.com/v1",
+        &["XIAOMI_TOKEN_PLAN_API_KEY"],
+        settings_env,
+    )?;
+    insert_openai_compatible_provider(
+        &mut registry,
         "xai",
         "https://api.x.ai/v1",
         &["XAI_API_KEY"],
@@ -6140,6 +6147,22 @@ mod tests {
         );
         assert_eq!(xiaomi.base_url, "https://api.xiaomimimo.com/v1");
         assert_eq!(xiaomi.credential.as_deref(), Some("xiaomi-key"));
+
+        let xiaomi_token_plan = providers
+            .get(&ProviderId::parse("xiaomi-token-plan").unwrap())
+            .unwrap();
+        assert_eq!(
+            xiaomi_token_plan.transport,
+            ProviderTransportKind::OpenAiChatCompletions
+        );
+        assert_eq!(
+            xiaomi_token_plan.base_url,
+            "https://token-plan-cn.xiaomimimo.com/v1"
+        );
+        assert_eq!(
+            xiaomi_token_plan.credential.as_deref(),
+            Some("xiaomi-token-plan-key")
+        );
 
         let zai = providers.get(&ProviderId::parse("zai").unwrap()).unwrap();
         assert_eq!(zai.transport, ProviderTransportKind::AnthropicMessages);


### PR DESCRIPTION
## Summary
- restore the `xiaomi-token-plan` built-in provider registration
- document its endpoint and `XIAOMI_TOKEN_PLAN_API_KEY` credential env var
- cover the provider in the built-in provider registry defaults test

## Verification
- `cargo test built_in_provider_registry_includes_compatible_provider_defaults`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
