### PR TITLE
test: codify runtime lifecycle continuation policy

### DIFF
--- a/docs/implementation-decisions/062-runtime-lifecycle-continuation-policy.md
+++ b/docs/implementation-decisions/062-runtime-lifecycle-continuation-policy.md
@@ -1,0 +1,24 @@
+# Runtime Lifecycle Continuation Policy
+
+Decision:
+
+- classify every admitted message as either model re-entry or liveness-only
+- let only matching, terminal `TaskResult` messages resume task-result waits
+- keep non-terminal task updates and mismatched task results liveness-only
+- let contentful external events and contentful system ticks resume external
+  rechecks
+- reserve `ResumeOverride` for operator input and same-work-item terminal task
+  results that safely close stale waits
+- select continuation anchors by explicit message identity and stable sequence
+  ordering, with sequenced operator messages preferred over legacy null
+  sequences
+
+Reason:
+
+- task status reduction and scheduler re-entry are separate lifecycle layers
+- non-terminal background progress should update projections without spending a
+  model turn
+- wake hints without content are coordination signals, not new task context
+- operator input remains the explicit trust-boundary override for stale waits
+- legacy/null message ordering must not make old operator prompts look newer
+  than sequenced requests

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -4306,7 +4306,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.19.0"
+    "version": "0.19.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -338,6 +338,48 @@ mod tests {
     }
 
     #[test]
+    fn non_terminal_task_result_does_not_resume_expected_wait() {
+        let resolution = resolve_continuation(
+            &waiting(WaitingReason::AwaitingTaskResult),
+            &ContinuationTrigger {
+                kind: ContinuationTriggerKind::TaskResult,
+                contentful: true,
+                task_terminal: false,
+                wake_hint_source: None,
+                task_work_item_id: None,
+            },
+            None,
+        );
+
+        assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
+        assert!(!resolution.model_reentry);
+        assert!(resolution.matched_waiting_reason);
+        assert!(resolution
+            .evidence
+            .iter()
+            .any(|entry| entry == "matches_waiting_reason"));
+    }
+
+    #[test]
+    fn terminal_task_result_for_other_work_item_does_not_resume_expected_wait() {
+        let resolution = resolve_continuation(
+            &waiting(WaitingReason::AwaitingTaskResult),
+            &ContinuationTrigger {
+                kind: ContinuationTriggerKind::TaskResult,
+                contentful: true,
+                task_terminal: true,
+                wake_hint_source: None,
+                task_work_item_id: Some("other-work".into()),
+            },
+            Some("active-work"),
+        );
+
+        assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
+        assert!(!resolution.model_reentry);
+        assert!(resolution.matched_waiting_reason);
+    }
+
+    #[test]
     fn wake_hint_system_tick_is_liveness_only() {
         let resolution = resolve_continuation(
             &waiting(WaitingReason::AwaitingExternalChange),
@@ -352,6 +394,25 @@ mod tests {
         );
         assert_eq!(resolution.class, ContinuationClass::LivenessOnly);
         assert!(!resolution.model_reentry);
+    }
+
+    #[test]
+    fn contentful_system_tick_resumes_external_wait_recheck() {
+        let resolution = resolve_continuation(
+            &waiting(WaitingReason::AwaitingExternalChange),
+            &ContinuationTrigger {
+                kind: ContinuationTriggerKind::SystemTick,
+                contentful: true,
+                task_terminal: false,
+                wake_hint_source: None,
+                task_work_item_id: None,
+            },
+            None,
+        );
+
+        assert_eq!(resolution.class, ContinuationClass::ResumeExpectedWait);
+        assert!(resolution.model_reentry);
+        assert!(resolution.matched_waiting_reason);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add regression tests for lifecycle continuation boundaries around task results, work item matching, and external rechecks
- document the runtime lifecycle continuation policy as an implementation decision

## Verification
- cargo test runtime::continuation
- cargo fmt --all -- --check
- git diff --check
- RUSTFLAGS="-D warnings" cargo check --all-targets

Part of #1878.
