### PR TITLE
feat: move Holon trigger orchestration into action

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: ''
+      trigger:
+        description: Trigger mode. Use explicit for ref-driven runs or auto to derive ref/goal from the GitHub event.
+        required: false
+        type: string
+        default: auto
       repo:
         description: GitHub repository hint for shorthand refs such as #123.
         required: false
@@ -93,494 +98,44 @@ jobs:
       pull-requests: write
       id-token: write
     outputs:
-      result: ${{ steps.result.outputs.result }}
-      summary: ${{ steps.result.outputs.summary }}
+      result: ${{ steps.holon.outputs.result }}
+      summary: ${{ steps.holon.outputs.summary }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Prepare Holon directories
-        id: dirs
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/holon/input" "$RUNNER_TEMP/holon/output" "$RUNNER_TEMP/holon/home"
-          {
-            echo "input=$RUNNER_TEMP/holon/input"
-            echo "output=$RUNNER_TEMP/holon/output"
-            echo "home=$RUNNER_TEMP/holon/home"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Resolve Holon context
-        id: context
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          INPUT_REF: ${{ inputs.ref }}
-          INPUT_REPO: ${{ inputs.repo }}
-          INPUT_BASE: ${{ inputs.base }}
-          INPUT_GOAL: ${{ inputs.goal }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action || '' }}
-          REPO: ${{ github.repository }}
-          ACTOR: ${{ github.actor }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
-          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
-          ISSUE_IS_PR: ${{ github.event.issue.pull_request.url || '' }}
-          COMMENT_BODY: ${{ github.event.comment.body || '' }}
-          LABEL_NAME: ${{ github.event.label.name || '' }}
-          ASSIGNEE_LOGIN: ${{ github.event.assignee.login || '' }}
-          AUTO_REVIEW: ${{ vars.HOLON_AUTO_REVIEW || 'false' }}
-          AUTO_REVIEW_ON_PUSH: ${{ vars.HOLON_AUTO_REVIEW_ON_PUSH || 'false' }}
-        run: |
-          set -euo pipefail
-
-          should_run=false
-          reason="event not eligible"
-          ref=""
-          repo="$INPUT_REPO"
-          base="$INPUT_BASE"
-          goal="$INPUT_GOAL"
-
-          write_outputs() {
-            {
-              echo "should_run=$should_run"
-              echo "ref=$ref"
-              echo "repo=$repo"
-              echo "base=$base"
-              echo "reason=$reason"
-              echo "goal<<__HOLON_GOAL__"
-              if [ -n "$goal" ]; then
-                printf '%s\n' "$goal"
-              fi
-              echo "__HOLON_GOAL__"
-            } >> "$GITHUB_OUTPUT"
-          }
-
-          if [ -n "$INPUT_REF" ]; then
-            should_run=true
-            reason="explicit ref input"
-            ref="$INPUT_REF"
-            if [[ "$ref" =~ ^#[0-9]+$ ]] && [ -z "$repo" ]; then
-              repo="$REPO"
-            fi
-            write_outputs
-            exit 0
-          fi
-
-          if [ "$ACTOR" = "holonbot[bot]" ] || [ "$ACTOR" = "github-actions[bot]" ]; then
-            reason="skip bot actor: $ACTOR"
-            write_outputs
-            exit 0
-          fi
-
-          case "$EVENT_NAME:$EVENT_ACTION" in
-            issue_comment:created)
-              first_line="$(printf '%s\n' "$COMMENT_BODY" | sed -n '1s/^[[:space:]]*//;1s/[[:space:]]*$//;1p')"
-              permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || true)"
-              if [ "$permission" != "admin" ] && [ "$permission" != "maintain" ] && [ "$permission" != "write" ]; then
-                reason="insufficient permission for $ACTOR: ${permission:-none}"
-                write_outputs
-                exit 0
-              fi
-
-              if [ -n "$ISSUE_IS_PR" ]; then
-                ref="https://github.com/$REPO/pull/$ISSUE_NUMBER"
-                case "$first_line" in
-                  "@holonbot fix"|"@holonbot pr-fix")
-                    should_run=true
-                    reason="PR fix command"
-                    goal="${goal:-Fix the target pull request according to the latest requester comment. Push commits to the PR branch when changes are needed. Do not open another PR. Publish a concise completion summary and stop.}"
-                    ;;
-                  "@holonbot review")
-                    should_run=true
-                    reason="PR review command"
-                    goal="${goal:-Review the target pull request only. Publish exactly one structured review or PR comment. Do not edit files, push commits, open PRs, or close issues.}"
-                    ;;
-                  *)
-                    reason="unrecognized PR command: $first_line"
-                    ;;
-                esac
-              else
-                ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
-                case "$first_line" in
-                  "@holonbot fix"|"@holonbot solve")
-                    should_run=true
-                    reason="issue solve command"
-                    goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
-                    ;;
-                  *)
-                    reason="unrecognized issue command: $first_line"
-                    ;;
-                esac
-              fi
-              ;;
-            issues:labeled)
-              if [ "$LABEL_NAME" = "holon" ]; then
-                should_run=true
-                reason="issue labeled holon"
-                ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
-                goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
-              fi
-              ;;
-            issues:assigned)
-              if [ "$ASSIGNEE_LOGIN" = "holonbot" ] || [ "$ASSIGNEE_LOGIN" = "holonbot[bot]" ]; then
-                should_run=true
-                reason="issue assigned to holonbot"
-                ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
-                goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
-              fi
-              ;;
-            pull_request:labeled)
-              if [ "$LABEL_NAME" = "holon" ]; then
-                should_run=true
-                reason="PR labeled holon"
-              fi
-              ;;
-            pull_request:opened|pull_request:reopened|pull_request:ready_for_review)
-              if [ "$AUTO_REVIEW" = "true" ]; then
-                should_run=true
-                reason="auto review enabled"
-              fi
-              ;;
-            pull_request:synchronize)
-              if [ "$AUTO_REVIEW_ON_PUSH" = "true" ]; then
-                should_run=true
-                reason="auto review on push enabled"
-              fi
-              ;;
-          esac
-
-          if [ "$should_run" = "true" ] && [ -n "$PR_NUMBER" ]; then
-            ref="https://github.com/$REPO/pull/$PR_NUMBER"
-            is_cross_repo="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name != .base.repo.full_name' 2>/dev/null || echo "true")"
-            if [ "$is_cross_repo" = "true" ]; then
-              should_run=false
-              reason="skip cross-repo PR"
-              goal=""
-            else
-              goal="${goal:-Review the target pull request only. Publish exactly one structured review or PR comment. Do not edit files, push commits, open PRs, or close issues.}"
-            fi
-          fi
-
-          write_outputs
-
-      - name: Report skipped Holon run
-        if: steps.context.outputs.should_run != 'true'
-        shell: bash
-        run: |
-          echo "Holon skipped: ${{ steps.context.outputs.reason }}"
-
-      - name: Checkout Holon source
-        if: inputs.build_from_source && steps.context.outputs.should_run == 'true'
-        shell: bash
-        env:
-          HOLON_REPOSITORY: ${{ inputs.holon_repository }}
-          HOLON_REF: ${{ inputs.holon_ref }}
-        run: |
-          set -euo pipefail
-          src_dir="$RUNNER_TEMP/holon-source"
-          rm -rf "$src_dir"
-          git clone --depth 1 "https://github.com/${HOLON_REPOSITORY}.git" "$src_dir"
-          if [ -n "$HOLON_REF" ]; then
-            git -C "$src_dir" fetch --depth 1 origin "$HOLON_REF"
-            git -C "$src_dir" checkout FETCH_HEAD
-          fi
-          echo "HOLON_SOURCE_DIR=$src_dir" >> "$GITHUB_ENV"
-
-      - name: Set up Rust
-        if: inputs.build_from_source && steps.context.outputs.should_run == 'true'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build Holon from source
-        if: inputs.build_from_source && steps.context.outputs.should_run == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo build --release --locked --manifest-path "$HOLON_SOURCE_DIR/Cargo.toml"
-          mkdir -p "$RUNNER_TEMP/holon/bin"
-          cp "$HOLON_SOURCE_DIR/target/release/holon" "$RUNNER_TEMP/holon/bin/holon"
-          chmod +x "$RUNNER_TEMP/holon/bin/holon"
-
-      - name: Download Holon binary
-        if: ${{ !inputs.build_from_source && steps.context.outputs.should_run == 'true' }}
-        shell: bash
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
-          arch="$(uname -m)"
-          case "$arch" in
-            x86_64) arch=amd64 ;;
-            arm64|aarch64) arch=arm64 ;;
-          esac
-          if [ "$platform" != "linux" ] && [ "$platform" != "darwin" ]; then
-            echo "::error::Unsupported platform for Holon binary download: $platform"
-            exit 1
-          fi
-          if [ "$platform" = "linux" ] && [ "$arch" != "amd64" ]; then
-            echo "::error::Linux release assets currently support amd64 only. Set inputs.build_from_source=true or use a linux/amd64 runner."
-            exit 1
-          fi
-          release_path=latest/download
-          if [ "$INPUT_VERSION" != "latest" ]; then
-            release_path="download/$INPUT_VERSION"
-          fi
-          mkdir -p "$RUNNER_TEMP/holon/bin"
-          curl -fsSL "https://github.com/holon-run/holon/releases/$release_path/holon-$platform-$arch.tar.gz" |
-            tar -xz -C "$RUNNER_TEMP/holon/bin"
-          if [ -f "$RUNNER_TEMP/holon/bin/holon" ]; then
-            chmod +x "$RUNNER_TEMP/holon/bin/holon"
-          elif [ -f "$RUNNER_TEMP/holon/bin/holon-$platform-$arch" ]; then
-            mv "$RUNNER_TEMP/holon/bin/holon-$platform-$arch" "$RUNNER_TEMP/holon/bin/holon"
-            chmod +x "$RUNNER_TEMP/holon/bin/holon"
-          else
-            echo "::error::Failed to find holon binary after extracting release asset."
-            ls -la "$RUNNER_TEMP/holon/bin"
-            exit 1
-          fi
-
-      - name: Resolve GitHub token
-        id: github-token
-        if: steps.context.outputs.should_run == 'true'
-        shell: bash
-        env:
-          HOLON_GITHUB_TOKEN_INPUT: ${{ secrets.holon_github_token }}
-          HOLONBOT_BROKER_URL: ${{ inputs.holonbot_broker_url }}
-          HOLONBOT_OIDC_AUDIENCE: ${{ inputs.holonbot_oidc_audience }}
-          GITHUB_TOKEN_FALLBACK: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "$HOLON_GITHUB_TOKEN_INPUT" ]; then
-            echo "Using explicit holon_github_token secret."
-            echo "::add-mask::$HOLON_GITHUB_TOKEN_INPUT"
-            {
-              echo "token=$HOLON_GITHUB_TOKEN_INPUT"
-              echo "actor_source=explicit"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] && [ -n "$HOLONBOT_BROKER_URL" ]; then
-            echo "Fetching GitHub Actions OIDC token for Holonbot broker exchange."
-            oidc_url="$ACTIONS_ID_TOKEN_REQUEST_URL"
-            if [ -n "$HOLONBOT_OIDC_AUDIENCE" ]; then
-              if [[ "$oidc_url" == *\?* ]]; then
-                oidc_url="${oidc_url}&audience=${HOLONBOT_OIDC_AUDIENCE}"
-              else
-                oidc_url="${oidc_url}?audience=${HOLONBOT_OIDC_AUDIENCE}"
-              fi
-            fi
-
-            oidc_response="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$oidc_url" || true)"
-            oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty' 2>/dev/null || true)"
-            if [ -n "$oidc_token" ] && [ "$oidc_token" != "null" ]; then
-              broker_response="$(curl -sS -X POST "$HOLONBOT_BROKER_URL" \
-                -H "Authorization: Bearer $oidc_token" \
-                -H "Content-Type: application/json" || true)"
-              bot_token="$(printf '%s' "$broker_response" | jq -r '.token // empty' 2>/dev/null || true)"
-              if [ -n "$bot_token" ] && [ "$bot_token" != "null" ]; then
-                echo "Successfully obtained Holonbot token from broker."
-                echo "::add-mask::$bot_token"
-                {
-                  echo "token=$bot_token"
-                  echo "actor_login=holonbot[bot]"
-                  echo "actor_type=App"
-                  echo "actor_app_slug=holonbot"
-                  echo "actor_source=token"
-                } >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-              broker_error="$(printf '%s' "$broker_response" | jq -r '.error // empty' 2>/dev/null || true)"
-              broker_message="$(printf '%s' "$broker_response" | jq -r '.message // empty' 2>/dev/null || true)"
-              echo "::warning title=Holonbot Auth::Token broker exchange failed: ${broker_error:-unknown error} ${broker_message:-}"
-            else
-              echo "::warning title=Holonbot Auth::Failed to fetch OIDC token from GitHub Actions runtime."
-            fi
-          else
-            echo "Skipping Holonbot token exchange: id-token permission is unavailable or holonbot_broker_url is empty."
-          fi
-
-          echo "Falling back to github.token."
-          echo "::add-mask::$GITHUB_TOKEN_FALLBACK"
-          {
-            echo "token=$GITHUB_TOKEN_FALLBACK"
-            echo "actor_login=github-actions[bot]"
-            echo "actor_type=App"
-            echo "actor_app_slug=github-actions"
-            echo "actor_source=token"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Run Holon solve
-        id: run
-        if: steps.context.outputs.should_run == 'true'
-        shell: bash
-        env:
-          INPUT_REF: ${{ steps.context.outputs.ref }}
-          INPUT_REPO: ${{ steps.context.outputs.repo }}
-          INPUT_BASE: ${{ steps.context.outputs.base }}
-          INPUT_GOAL: ${{ steps.context.outputs.goal }}
-          INPUT_MODEL: ${{ inputs.model || vars.HOLON_MODEL || '' }}
-          ANTHROPIC_AUTH_TOKEN_INPUT: ${{ secrets.anthropic_auth_token || secrets.anthropic_api_key }}
-          ANTHROPIC_BASE_URL_INPUT: ${{ secrets.anthropic_base_url || 'https://api.anthropic.com' }}
-          OPENAI_API_KEY_INPUT: ${{ secrets.openai_api_key }}
-          OPENAI_BASE_URL_INPUT: ${{ secrets.openai_base_url }}
-          GITHUB_TOKEN_INPUT: ${{ steps.github-token.outputs.token }}
-          HOLON_ACTOR_LOGIN: ${{ steps.github-token.outputs.actor_login }}
-          HOLON_ACTOR_TYPE: ${{ steps.github-token.outputs.actor_type }}
-          HOLON_ACTOR_APP_SLUG: ${{ steps.github-token.outputs.actor_app_slug }}
-          HOLON_ACTOR_SOURCE: ${{ steps.github-token.outputs.actor_source }}
-        run: |
-          set -euo pipefail
-          export PATH="$RUNNER_TEMP/holon/bin:$PATH"
-          export GITHUB_TOKEN="$GITHUB_TOKEN_INPUT"
-          export GH_TOKEN="$GITHUB_TOKEN_INPUT"
-          export HOLON_GITHUB_TOKEN="$GITHUB_TOKEN_INPUT"
-          if [ -n "$ANTHROPIC_AUTH_TOKEN_INPUT" ]; then
-            export ANTHROPIC_AUTH_TOKEN="$ANTHROPIC_AUTH_TOKEN_INPUT"
-          fi
-          if [ -n "$ANTHROPIC_BASE_URL_INPUT" ]; then
-            export ANTHROPIC_BASE_URL="$ANTHROPIC_BASE_URL_INPUT"
-          fi
-          if [ -n "$OPENAI_API_KEY_INPUT" ]; then
-            export OPENAI_API_KEY="$OPENAI_API_KEY_INPUT"
-          fi
-          if [ -n "$OPENAI_BASE_URL_INPUT" ]; then
-            export OPENAI_BASE_URL="$OPENAI_BASE_URL_INPUT"
-          fi
-
-          args=("$INPUT_REF" --home "${{ steps.dirs.outputs.home }}" --workspace "${{ github.workspace }}" --input "${{ steps.dirs.outputs.input }}" --output "${{ steps.dirs.outputs.output }}" --json)
-          if [ -n "$INPUT_REPO" ]; then
-            args+=(--repo "$INPUT_REPO")
-          fi
-          if [ -n "$INPUT_BASE" ]; then
-            args+=(--base "$INPUT_BASE")
-          fi
-          if [ -n "$INPUT_GOAL" ]; then
-            args+=(--goal "$INPUT_GOAL")
-          fi
-          if [ -n "$INPUT_MODEL" ]; then
-            args+=(--model "$INPUT_MODEL")
-          fi
-          holon solve "${args[@]}"
-
-      - name: Add Holon summary
-        id: result
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          output="${{ steps.dirs.outputs.output }}"
-          if [ -f "$output/summary.md" ]; then
-            cat "$output/summary.md" >> "$GITHUB_STEP_SUMMARY"
-            echo "summary=$output/summary.md" >> "$GITHUB_OUTPUT"
-          else
-            echo "summary=" >> "$GITHUB_OUTPUT"
-          fi
-          echo "result=${{ steps.run.outcome }}" >> "$GITHUB_OUTPUT"
-
-      - name: Post Holon run report
-        if: always() && steps.run.outcome != 'skipped'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.github-token.outputs.token }}
-          HOLON_OUTPUT_DIR: ${{ steps.dirs.outputs.output }}
-          HOLON_TARGET_REF: ${{ steps.context.outputs.ref }}
-          HOLON_REPOSITORY: ${{ steps.context.outputs.repo || github.repository }}
-        run: |
-          set -euo pipefail
-
-          script="$RUNNER_TEMP/holon-post-run-report.sh"
-          cat >"$script" <<'SCRIPT'
-          #!/usr/bin/env bash
-          set -euo pipefail
-
-          output_dir="${HOLON_OUTPUT_DIR:?HOLON_OUTPUT_DIR is required}"
-          target_ref="${HOLON_TARGET_REF:-}"
-          repo_hint="${HOLON_REPOSITORY:-${GITHUB_REPOSITORY:-}}"
-          run_json="$output_dir/run.json"
-          summary_md="$output_dir/summary.md"
-          manifest_json="$output_dir/manifest.json"
-
-          if [ ! -f "$run_json" ]; then
-            echo "Skipping Holon run report: missing $run_json"
-            exit 0
-          fi
-
-          pr_url=""
-          if [[ "$target_ref" =~ ^https://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
-            pr_url="https://github.com/${BASH_REMATCH[1]}/pull/${BASH_REMATCH[2]}"
-          elif [[ "$target_ref" =~ ^([^#[:space:]]+/[^#[:space:]]+)#([0-9]+)$ ]]; then
-            candidate_repo="${BASH_REMATCH[1]}"
-            candidate_number="${BASH_REMATCH[2]}"
-            if gh pr view "$candidate_number" --repo "$candidate_repo" --json url >/tmp/holon-pr-view.json 2>/dev/null; then
-              pr_url="$(jq -r '.url // empty' /tmp/holon-pr-view.json)"
-            fi
-          elif [[ "$target_ref" =~ ^#([0-9]+)$ ]] && [ -n "$repo_hint" ]; then
-            candidate_number="${BASH_REMATCH[1]}"
-            if gh pr view "$candidate_number" --repo "$repo_hint" --json url >/tmp/holon-pr-view.json 2>/dev/null; then
-              pr_url="$(jq -r '.url // empty' /tmp/holon-pr-view.json)"
-            fi
-          fi
-
-          if [ -z "$pr_url" ]; then
-            pr_url="$(
-              {
-                [ -f "$summary_md" ] && grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$summary_md" || true
-                [ -f "$manifest_json" ] && grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$manifest_json" || true
-                grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$run_json" || true
-              } | head -n1
-            )"
-          fi
-
-          if [[ ! "$pr_url" =~ ^https://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
-            echo "Skipping Holon run report: no PR URL found."
-            exit 0
-          fi
-
-          target_repo="${BASH_REMATCH[1]}"
-          target_pr="${BASH_REMATCH[2]}"
-
-          input_tokens="$(jq -r '.token_usage.input_tokens // .input_tokens // 0' "$run_json")"
-          output_tokens="$(jq -r '.token_usage.output_tokens // .output_tokens // 0' "$run_json")"
-          total_tokens="$(jq -r '.token_usage.total_tokens // ((.input_tokens // 0) + (.output_tokens // 0))' "$run_json")"
-          model_rounds="$(jq -r '.model_rounds // 0' "$run_json")"
-          tool_calls="$(jq -r '.tool_calls // 0' "$run_json")"
-          cache_read="$(jq -r '.provider_cache_usage.read_input_tokens // 0' "$run_json")"
-          cache_created="$(jq -r '.provider_cache_usage.creation_input_tokens // 0' "$run_json")"
-          cacheable="$(jq -r '.provider_cache_usage.cacheable_input_tokens // 0' "$run_json")"
-          hit_rate="$(jq -r 'if (.provider_cache_usage.hit_rate // null) == null then "n/a" else ((.provider_cache_usage.hit_rate * 10000 | round) / 100 | tostring) + "%" end' "$run_json")"
-          final_status="$(jq -r '.final_status // "unknown"' "$run_json")"
-          report_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$repo_hint}/actions/runs/${GITHUB_RUN_ID:-}"
-
-          report_file="$(mktemp)"
-          cat >"$report_file" <<EOF
-          ## Holon Run Report
-
-          - Result: \`$final_status\`
-          - Target: $target_ref
-          - Workflow run: $report_url
-          - Token usage: input $input_tokens, output $output_tokens, total $total_tokens
-          - Provider cache: read $cache_read, created $cache_created, cacheable $cacheable, hit rate $hit_rate
-          - Model rounds: $model_rounds
-          - Tool calls: $tool_calls
-          EOF
-
-          gh api "repos/$target_repo/issues/$target_pr/comments" -X POST -F body=@"$report_file" >/dev/null
-          rm -f "$report_file"
-          echo "Posted Holon run report to $pr_url"
-          SCRIPT
-
-          bash "$script"
-
-      - name: Upload Holon artifact
-        if: always() && steps.dirs.outputs.output != ''
-        uses: actions/upload-artifact@v4
+      - name: Checkout Holon action
+        uses: actions/checkout@v4
         with:
-          name: holon-solve-output
-          path: ${{ steps.dirs.outputs.output }}/
-          retention-days: 7
+          repository: ${{ inputs.holon_repository }}
+          ref: ${{ inputs.holon_ref }}
+          path: .holon/action
+
+      - name: Run Holon
+        id: holon
+        uses: ./.holon/action
+        with:
+          ref: ${{ inputs.ref }}
+          trigger: ${{ inputs.trigger }}
+          repo: ${{ inputs.repo }}
+          base: ${{ inputs.base }}
+          goal: ${{ inputs.goal }}
+          model: ${{ inputs.model || vars.HOLON_MODEL || '' }}
+          version: ${{ inputs.version }}
+          build_from_source: ${{ inputs.build_from_source }}
+          holon_repository: ${{ inputs.holon_repository }}
+          holon_ref: ${{ inputs.holon_ref }}
+          holonbot_broker_url: ${{ inputs.holonbot_broker_url }}
+          holonbot_oidc_audience: ${{ inputs.holonbot_oidc_audience }}
+          github_token: ${{ secrets.holon_github_token }}
+          anthropic_auth_token: ${{ secrets.anthropic_auth_token || secrets.anthropic_api_key }}
+          anthropic_base_url: ${{ secrets.anthropic_base_url }}
+          openai_api_key: ${{ secrets.openai_api_key }}
+          openai_base_url: ${{ secrets.openai_base_url }}
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.anthropic_auth_token || secrets.anthropic_api_key }}
+          ANTHROPIC_BASE_URL: ${{ secrets.anthropic_base_url }}
+          OPENAI_API_KEY: ${{ secrets.openai_api_key }}
+          OPENAI_BASE_URL: ${{ secrets.openai_base_url }}

--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -13,6 +13,16 @@ on:
         required: false
         type: string
         default: auto
+      auto_review:
+        description: Enable automatic PR review for opened, reopened, or ready_for_review events in trigger:auto mode.
+        required: false
+        type: string
+        default: ''
+      auto_review_on_push:
+        description: Enable automatic PR review for synchronize events in trigger:auto mode.
+        required: false
+        type: string
+        default: ''
       repo:
         description: GitHub repository hint for shorthand refs such as #123.
         required: false
@@ -119,6 +129,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           trigger: ${{ inputs.trigger }}
+          auto_review: ${{ inputs.auto_review || vars.HOLON_AUTO_REVIEW || 'false' }}
+          auto_review_on_push: ${{ inputs.auto_review_on_push || vars.HOLON_AUTO_REVIEW_ON_PUSH || 'false' }}
           repo: ${{ inputs.repo }}
           base: ${{ inputs.base }}
           goal: ${{ inputs.goal }}

--- a/.github/workflows/holon-trigger.yml
+++ b/.github/workflows/holon-trigger.yml
@@ -22,10 +22,25 @@ concurrency:
 jobs:
   holon:
     name: Run Holon
-    uses: ./.github/workflows/holon-solve.yml
-    secrets:
-      anthropic_auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      anthropic_base_url: ${{ secrets.ANTHROPIC_BASE_URL }}
-      openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-      openai_base_url: ${{ secrets.OPENAI_BASE_URL }}
-      holon_github_token: ${{ secrets.HOLON_GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Holon
+        uses: ./
+        with:
+          trigger: auto
+          model: ${{ vars.HOLON_MODEL || '' }}
+          github_token: ${{ secrets.HOLON_GITHUB_TOKEN }}
+          anthropic_auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          anthropic_base_url: ${{ secrets.ANTHROPIC_BASE_URL }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          openai_base_url: ${{ secrets.OPENAI_BASE_URL }}
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}

--- a/.github/workflows/holon-trigger.yml
+++ b/.github/workflows/holon-trigger.yml
@@ -33,6 +33,8 @@ jobs:
         uses: ./
         with:
           trigger: auto
+          auto_review: ${{ vars.HOLON_AUTO_REVIEW || 'false' }}
+          auto_review_on_push: ${{ vars.HOLON_AUTO_REVIEW_ON_PUSH || 'false' }}
           model: ${{ vars.HOLON_MODEL || '' }}
           github_token: ${{ secrets.HOLON_GITHUB_TOKEN }}
           anthropic_auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,12 @@ branding:
 inputs:
   ref:
     description: GitHub issue or PR reference, such as owner/repo#123.
-    required: true
+    required: false
+    default: ''
+  trigger:
+    description: Trigger mode. Use explicit for ref-driven runs or auto to derive ref/goal from the GitHub event.
+    required: false
+    default: explicit
   repo:
     description: Repository hint for numeric refs.
     required: false
@@ -99,11 +104,186 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  result:
+    description: Holon solve step outcome.
+    value: ${{ steps.result.outputs.result }}
+  summary:
+    description: Path to Holon summary markdown when produced.
+    value: ${{ steps.result.outputs.summary }}
+
 runs:
   using: composite
   steps:
+    - name: Resolve Holon context
+      id: context
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        INPUT_REF: ${{ inputs.ref }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_GOAL: ${{ inputs.goal }}
+        INPUT_TRIGGER: ${{ inputs.trigger }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_ACTION: ${{ github.event.action || '' }}
+        REPO: ${{ github.repository }}
+        ACTOR: ${{ github.actor }}
+        ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+        PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+        ISSUE_IS_PR: ${{ github.event.issue.pull_request.url || '' }}
+        COMMENT_BODY: ${{ github.event.comment.body || '' }}
+        LABEL_NAME: ${{ github.event.label.name || '' }}
+        ASSIGNEE_LOGIN: ${{ github.event.assignee.login || '' }}
+        AUTO_REVIEW: ${{ vars.HOLON_AUTO_REVIEW || 'false' }}
+        AUTO_REVIEW_ON_PUSH: ${{ vars.HOLON_AUTO_REVIEW_ON_PUSH || 'false' }}
+      run: |
+        set -euo pipefail
+
+        should_run=false
+        reason="event not eligible"
+        ref=""
+        repo="$INPUT_REPO"
+        base="$INPUT_BASE"
+        goal="$INPUT_GOAL"
+
+        write_outputs() {
+          {
+            echo "should_run=$should_run"
+            echo "ref=$ref"
+            echo "repo=$repo"
+            echo "base=$base"
+            echo "reason=$reason"
+            echo "goal<<__HOLON_GOAL__"
+            if [ -n "$goal" ]; then
+              printf '%s\n' "$goal"
+            fi
+            echo "__HOLON_GOAL__"
+          } >> "$GITHUB_OUTPUT"
+        }
+
+        if [ -n "$INPUT_REF" ]; then
+          should_run=true
+          reason="explicit ref input"
+          ref="$INPUT_REF"
+          if [[ "$ref" =~ ^#[0-9]+$ ]] && [ -z "$repo" ]; then
+            repo="$REPO"
+          fi
+          write_outputs
+          exit 0
+        fi
+
+        if [ "$INPUT_TRIGGER" != "auto" ]; then
+          reason="no ref input and trigger mode is $INPUT_TRIGGER"
+          write_outputs
+          exit 0
+        fi
+
+        if [ "$ACTOR" = "holonbot[bot]" ] || [ "$ACTOR" = "github-actions[bot]" ]; then
+          reason="skip bot actor: $ACTOR"
+          write_outputs
+          exit 0
+        fi
+
+        case "$EVENT_NAME:$EVENT_ACTION" in
+          issue_comment:created)
+            first_line="$(printf '%s\n' "$COMMENT_BODY" | sed -n '1s/^[[:space:]]*//;1s/[[:space:]]*$//;1p')"
+            permission="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || true)"
+            if [ "$permission" != "admin" ] && [ "$permission" != "maintain" ] && [ "$permission" != "write" ]; then
+              reason="insufficient permission for $ACTOR: ${permission:-none}"
+              write_outputs
+              exit 0
+            fi
+
+            if [ -n "$ISSUE_IS_PR" ]; then
+              ref="https://github.com/$REPO/pull/$ISSUE_NUMBER"
+              case "$first_line" in
+                "@holonbot fix"|"@holonbot pr-fix")
+                  should_run=true
+                  reason="PR fix command"
+                  goal="${goal:-Fix the target pull request according to the latest requester comment. Push commits to the PR branch when changes are needed. Do not open another PR. Publish a concise completion summary and stop.}"
+                  ;;
+                "@holonbot review")
+                  should_run=true
+                  reason="PR review command"
+                  goal="${goal:-Review the target pull request only. Publish exactly one structured review or PR comment. Do not edit files, push commits, open PRs, or close issues.}"
+                  ;;
+                *)
+                  reason="unrecognized PR command: $first_line"
+                  ;;
+              esac
+            else
+              ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
+              case "$first_line" in
+                "@holonbot fix"|"@holonbot solve")
+                  should_run=true
+                  reason="issue solve command"
+                  goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
+                  ;;
+                *)
+                  reason="unrecognized issue command: $first_line"
+                  ;;
+              esac
+            fi
+            ;;
+          issues:labeled)
+            if [ "$LABEL_NAME" = "holon" ]; then
+              should_run=true
+              reason="issue labeled holon"
+              ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
+              goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
+            fi
+            ;;
+          issues:assigned)
+            if [ "$ASSIGNEE_LOGIN" = "holonbot" ] || [ "$ASSIGNEE_LOGIN" = "holonbot[bot]" ]; then
+              should_run=true
+              reason="issue assigned to holonbot"
+              ref="https://github.com/$REPO/issues/$ISSUE_NUMBER"
+              goal="${goal:-Solve the target issue end to end. Make the required changes, commit on a branch, push it, and open a pull request. Include the PR URL in summary.md and manifest.json when possible.}"
+            fi
+            ;;
+          pull_request:labeled)
+            if [ "$LABEL_NAME" = "holon" ]; then
+              should_run=true
+              reason="PR labeled holon"
+            fi
+            ;;
+          pull_request:opened|pull_request:reopened|pull_request:ready_for_review)
+            if [ "$AUTO_REVIEW" = "true" ]; then
+              should_run=true
+              reason="auto review enabled"
+            fi
+            ;;
+          pull_request:synchronize)
+            if [ "$AUTO_REVIEW_ON_PUSH" = "true" ]; then
+              should_run=true
+              reason="auto review on push enabled"
+            fi
+            ;;
+        esac
+
+        if [ "$should_run" = "true" ] && [ -n "$PR_NUMBER" ]; then
+          ref="https://github.com/$REPO/pull/$PR_NUMBER"
+          is_cross_repo="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name != .base.repo.full_name' 2>/dev/null || echo "true")"
+          if [ "$is_cross_repo" = "true" ]; then
+            should_run=false
+            reason="skip cross-repo PR"
+            goal=""
+          else
+            goal="${goal:-Review the target pull request only. Publish exactly one structured review or PR comment. Do not edit files, push commits, open PRs, or close issues.}"
+          fi
+        fi
+
+        write_outputs
+
+    - name: Report skipped Holon run
+      if: steps.context.outputs.should_run != 'true'
+      shell: bash
+      run: |
+        echo "Holon skipped: ${{ steps.context.outputs.reason }}"
+
     - name: Checkout Holon source
-      if: inputs.build_from_source == 'true'
+      if: inputs.build_from_source == 'true' && steps.context.outputs.should_run == 'true'
       shell: bash
       env:
         HOLON_REPOSITORY: ${{ inputs.holon_repository }}
@@ -120,11 +300,11 @@ runs:
         echo "HOLON_SOURCE_DIR=$src_dir" >> "$GITHUB_ENV"
 
     - name: Set up Rust
-      if: inputs.build_from_source == 'true'
+      if: inputs.build_from_source == 'true' && steps.context.outputs.should_run == 'true'
       uses: dtolnay/rust-toolchain@stable
 
     - name: Build Holon from source
-      if: inputs.build_from_source == 'true'
+      if: inputs.build_from_source == 'true' && steps.context.outputs.should_run == 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -134,7 +314,7 @@ runs:
         chmod +x "$RUNNER_TEMP/holon/bin/holon"
 
     - name: Download Holon binary
-      if: inputs.build_from_source != 'true'
+      if: inputs.build_from_source != 'true' && steps.context.outputs.should_run == 'true'
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
@@ -174,6 +354,7 @@ runs:
 
     - name: Resolve GitHub token
       id: github-token
+      if: steps.context.outputs.should_run == 'true'
       shell: bash
       env:
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
@@ -244,12 +425,14 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Run Holon solve
+      id: run
+      if: steps.context.outputs.should_run == 'true'
       shell: bash
       env:
-        INPUT_REF: ${{ inputs.ref }}
-        INPUT_REPO: ${{ inputs.repo }}
-        INPUT_BASE: ${{ inputs.base }}
-        INPUT_GOAL: ${{ inputs.goal }}
+        INPUT_REF: ${{ steps.context.outputs.ref }}
+        INPUT_REPO: ${{ steps.context.outputs.repo }}
+        INPUT_BASE: ${{ steps.context.outputs.base }}
+        INPUT_GOAL: ${{ steps.context.outputs.goal }}
         INPUT_ROLE: ${{ inputs.role }}
         INPUT_MODEL: ${{ inputs.model }}
         INPUT_MAX_TURNS: ${{ inputs.max_turns }}
@@ -326,3 +509,119 @@ runs:
         fi
 
         holon solve "${args[@]}"
+
+    - name: Add Holon summary
+      id: result
+      if: always()
+      shell: bash
+      env:
+        INPUT_OUTPUT_DIR: ${{ inputs.output_dir }}
+      run: |
+        set -euo pipefail
+        output="$INPUT_OUTPUT_DIR"
+        if [ -z "$output" ]; then
+          output="$RUNNER_TEMP/holon/output"
+        fi
+        if [ -f "$output/summary.md" ]; then
+          cat "$output/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          echo "summary=$output/summary.md" >> "$GITHUB_OUTPUT"
+        else
+          echo "summary=" >> "$GITHUB_OUTPUT"
+        fi
+        echo "result=${{ steps.run.outcome }}" >> "$GITHUB_OUTPUT"
+
+    - name: Post Holon run report
+      if: always() && steps.run.outcome != 'skipped'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        HOLON_OUTPUT_DIR: ${{ inputs.output_dir }}
+        HOLON_TARGET_REF: ${{ steps.context.outputs.ref }}
+        HOLON_REPOSITORY: ${{ steps.context.outputs.repo || github.repository }}
+      run: |
+        set -euo pipefail
+
+        output_dir="$HOLON_OUTPUT_DIR"
+        if [ -z "$output_dir" ]; then
+          output_dir="$RUNNER_TEMP/holon/output"
+        fi
+
+        target_ref="${HOLON_TARGET_REF:-}"
+        repo_hint="${HOLON_REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+        run_json="$output_dir/run.json"
+        summary_md="$output_dir/summary.md"
+        manifest_json="$output_dir/manifest.json"
+
+        if [ ! -f "$run_json" ]; then
+          echo "Skipping Holon run report: missing $run_json"
+          exit 0
+        fi
+
+        pr_url=""
+        if [[ "$target_ref" =~ ^https://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+          pr_url="https://github.com/${BASH_REMATCH[1]}/pull/${BASH_REMATCH[2]}"
+        elif [[ "$target_ref" =~ ^([^#[:space:]]+/[^#[:space:]]+)#([0-9]+)$ ]]; then
+          candidate_repo="${BASH_REMATCH[1]}"
+          candidate_number="${BASH_REMATCH[2]}"
+          if gh pr view "$candidate_number" --repo "$candidate_repo" --json url >/tmp/holon-pr-view.json 2>/dev/null; then
+            pr_url="$(jq -r '.url // empty' /tmp/holon-pr-view.json)"
+          fi
+        elif [[ "$target_ref" =~ ^#([0-9]+)$ ]] && [ -n "$repo_hint" ]; then
+          candidate_number="${BASH_REMATCH[1]}"
+          if gh pr view "$candidate_number" --repo "$repo_hint" --json url >/tmp/holon-pr-view.json 2>/dev/null; then
+            pr_url="$(jq -r '.url // empty' /tmp/holon-pr-view.json)"
+          fi
+        fi
+
+        if [ -z "$pr_url" ]; then
+          pr_url="$({
+            [ -f "$summary_md" ] && grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$summary_md" || true
+            [ -f "$manifest_json" ] && grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$manifest_json" || true
+            grep -Eo 'https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+' "$run_json" || true
+          } | head -n1)"
+        fi
+
+        if [[ ! "$pr_url" =~ ^https://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+          echo "Skipping Holon run report: no PR URL found."
+          exit 0
+        fi
+
+        target_repo="${BASH_REMATCH[1]}"
+        target_pr="${BASH_REMATCH[2]}"
+
+        input_tokens="$(jq -r '.token_usage.input_tokens // .input_tokens // 0' "$run_json")"
+        output_tokens="$(jq -r '.token_usage.output_tokens // .output_tokens // 0' "$run_json")"
+        total_tokens="$(jq -r '.token_usage.total_tokens // ((.input_tokens // 0) + (.output_tokens // 0))' "$run_json")"
+        model_rounds="$(jq -r '.model_rounds // 0' "$run_json")"
+        tool_calls="$(jq -r '.tool_calls // 0' "$run_json")"
+        cache_read="$(jq -r '.provider_cache_usage.read_input_tokens // 0' "$run_json")"
+        cache_created="$(jq -r '.provider_cache_usage.creation_input_tokens // 0' "$run_json")"
+        cacheable="$(jq -r '.provider_cache_usage.cacheable_input_tokens // 0' "$run_json")"
+        hit_rate="$(jq -r 'if (.provider_cache_usage.hit_rate // null) == null then "n/a" else ((.provider_cache_usage.hit_rate * 10000 | round) / 100 | tostring) + "%" end' "$run_json")"
+        final_status="$(jq -r '.final_status // "unknown"' "$run_json")"
+        report_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$repo_hint}/actions/runs/${GITHUB_RUN_ID:-}"
+
+        report_file="$(mktemp)"
+        {
+          echo "## Holon Run Report"
+          echo
+          echo "- Result: \`$final_status\`"
+          echo "- Target: $target_ref"
+          echo "- Workflow run: $report_url"
+          echo "- Token usage: input $input_tokens, output $output_tokens, total $total_tokens"
+          echo "- Provider cache: read $cache_read, created $cache_created, cacheable $cacheable, hit rate $hit_rate"
+          echo "- Model rounds: $model_rounds"
+          echo "- Tool calls: $tool_calls"
+        } >"$report_file"
+
+        gh api "repos/$target_repo/issues/$target_pr/comments" -X POST -F body=@"$report_file" >/dev/null
+        rm -f "$report_file"
+        echo "Posted Holon run report to $pr_url"
+
+    - name: Upload Holon artifact
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: holon-solve-output
+        path: ${{ inputs.output_dir || format('{0}/holon/output/', runner.temp) }}
+        retention-days: 7

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: Trigger mode. Use explicit for ref-driven runs or auto to derive ref/goal from the GitHub event.
     required: false
     default: explicit
+  auto_review:
+    description: Enable automatic PR review for opened, reopened, or ready_for_review events in trigger:auto mode.
+    required: false
+    default: 'false'
+  auto_review_on_push:
+    description: Enable automatic PR review for synchronize events in trigger:auto mode.
+    required: false
+    default: 'false'
   repo:
     description: Repository hint for numeric refs.
     required: false
@@ -135,8 +143,8 @@ runs:
         COMMENT_BODY: ${{ github.event.comment.body || '' }}
         LABEL_NAME: ${{ github.event.label.name || '' }}
         ASSIGNEE_LOGIN: ${{ github.event.assignee.login || '' }}
-        AUTO_REVIEW: ${{ vars.HOLON_AUTO_REVIEW || 'false' }}
-        AUTO_REVIEW_ON_PUSH: ${{ vars.HOLON_AUTO_REVIEW_ON_PUSH || 'false' }}
+        AUTO_REVIEW: ${{ inputs.auto_review }}
+        AUTO_REVIEW_ON_PUSH: ${{ inputs.auto_review_on_push }}
       run: |
         set -euo pipefail
 

--- a/docs/website/guides/solve.md
+++ b/docs/website/guides/solve.md
@@ -227,6 +227,41 @@ fi
 git push origin HEAD
 ```
 
+### GitHub Actions
+
+Use the composite action when you want a repository workflow with normal
+step-level environment variables for model providers:
+
+```yaml
+jobs:
+  holon:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: holon-run/holon@main
+        with:
+          trigger: auto
+          model: deepseek/deepseek-v3.2
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+```
+
+`trigger: auto` derives the target and goal from supported issue, pull request,
+label, assignment, and `@holonbot` comment events. For explicit runs, pass
+`ref: owner/repo#123` instead.
+
+The reusable workflow at `.github/workflows/holon-solve.yml` remains available
+as a compatibility wrapper, but the composite action is the recommended entry
+point when you need arbitrary provider environment variables.
+
 ## See also
 
 - [Holon CLI reference](/reference/cli) — full command tree


### PR DESCRIPTION
## Summary
- move Holon event trigger resolution, skip handling, summaries, reports, and artifacts into the composite action behind trigger: auto
- update the repo Holon trigger workflow to checkout the repository and call the local action directly
- keep holon-solve.yml as a reusable-workflow compatibility wrapper that delegates to the action
- document the composite action path for arbitrary provider env variables

## Verification
- python YAML parse for action.yml and Holon workflows
- extracted bash -n and shellcheck for action/workflow run scripts
- yamllint on action.yml and Holon workflows
- actionlint on .github/workflows/holon-trigger.yml and .github/workflows/holon-solve.yml