### PR TITLE
fix: refresh model discovery cache automatically

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -99,6 +99,8 @@ pub struct ModelsResponse {
     pub available_models: Vec<BuiltInModelMetadata>,
     #[serde(default)]
     pub model_availability: Vec<ResolvedModelAvailability>,
+    #[serde(default)]
+    pub model_discovery_cache: Vec<crate::model_discovery::ModelDiscoveryCacheStatus>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1002,12 +1002,17 @@ pub async fn models_handler(
     let runtime = state.host.default_runtime().await.map_err(error_response)?;
     let available_models = runtime.available_models().await.map_err(error_response)?;
     let model_availability = runtime.model_availability().await.map_err(error_response)?;
+    let model_discovery_cache = runtime
+        .model_discovery_status()
+        .await
+        .map_err(error_response)?;
     traced_json(
         "/models",
         started_at,
         json!({
             "available_models": available_models,
             "model_availability": model_availability,
+            "model_discovery_cache": model_discovery_cache,
         }),
     )
 }

--- a/src/model_discovery.rs
+++ b/src/model_discovery.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fs,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -14,6 +15,7 @@ use crate::{
 };
 
 const OPENROUTER_MODELS_PATH: &str = "/models";
+pub const DEFAULT_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ModelDiscoveryCacheFile {
@@ -51,8 +53,90 @@ pub struct ModelDiscoveryRefreshReport {
     pub cache_path: PathBuf,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelDiscoveryCacheState {
+    Fresh,
+    Missing,
+    Stale,
+    Unsupported,
+    Unauthenticated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelDiscoveryCacheStatus {
+    pub provider: ProviderId,
+    pub state: ModelDiscoveryCacheState,
+    pub supports_auto_refresh: bool,
+    pub credential_configured: bool,
+    pub refresh_in_flight: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fetched_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub age_seconds: Option<u64>,
+    pub ttl_seconds: u64,
+    pub model_count: usize,
+}
+
 pub fn discovery_cache_path(home_dir: &Path) -> PathBuf {
     home_dir.join("model-discovery-cache.json")
+}
+
+pub fn provider_supports_model_discovery(provider: &ProviderRuntimeConfig) -> bool {
+    provider.id.as_str() == "openrouter"
+}
+
+pub fn discovery_cache_status_for_provider(
+    provider: &ProviderRuntimeConfig,
+    cache: &ModelDiscoveryCacheFile,
+    ttl: Duration,
+    refresh_in_flight: bool,
+) -> ModelDiscoveryCacheStatus {
+    let supports_auto_refresh = provider_supports_model_discovery(provider);
+    let credential_configured = provider.has_configured_credential();
+    let entry = cache.providers.get(&provider.id);
+    let age = entry.and_then(|entry| {
+        Utc::now()
+            .signed_duration_since(entry.fetched_at)
+            .to_std()
+            .ok()
+    });
+    let state = if !supports_auto_refresh {
+        ModelDiscoveryCacheState::Unsupported
+    } else if !credential_configured {
+        ModelDiscoveryCacheState::Unauthenticated
+    } else if let Some(age) = age {
+        if age <= ttl {
+            ModelDiscoveryCacheState::Fresh
+        } else {
+            ModelDiscoveryCacheState::Stale
+        }
+    } else {
+        ModelDiscoveryCacheState::Missing
+    };
+
+    ModelDiscoveryCacheStatus {
+        provider: provider.id.clone(),
+        state,
+        supports_auto_refresh,
+        credential_configured,
+        refresh_in_flight,
+        fetched_at: entry.map(|entry| entry.fetched_at),
+        age_seconds: age.map(|age| age.as_secs()),
+        ttl_seconds: ttl.as_secs(),
+        model_count: entry.map(|entry| entry.models.len()).unwrap_or(0),
+    }
+}
+
+pub fn discovery_cache_needs_refresh(
+    provider: &ProviderRuntimeConfig,
+    cache: &ModelDiscoveryCacheFile,
+    ttl: Duration,
+) -> bool {
+    matches!(
+        discovery_cache_status_for_provider(provider, cache, ttl, false).state,
+        ModelDiscoveryCacheState::Missing | ModelDiscoveryCacheState::Stale
+    )
 }
 
 pub fn load_discovery_cache_at(path: &Path) -> Result<ModelDiscoveryCacheFile> {
@@ -261,6 +345,28 @@ fn sha256_hex(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn openrouter_provider() -> ProviderRuntimeConfig {
+        ProviderRuntimeConfig {
+            id: ProviderId::parse("openrouter").unwrap(),
+            transport: crate::config::ProviderTransportKind::OpenAiChatCompletions,
+            base_url: "https://openrouter.ai/api/v1".into(),
+            auth: crate::config::ProviderAuthConfig {
+                source: crate::config::CredentialSource::Env,
+                kind: crate::config::CredentialKind::ApiKey,
+                env: None,
+                profile: None,
+                external: None,
+            },
+            credential: Some("test-key".into()),
+            credential_store_path: None,
+            codex_home: None,
+            originator: None,
+            reasoning_effort: None,
+            context_management: Default::default(),
+            builtin_web_search: None,
+        }
+    }
+
     #[test]
     fn maps_openrouter_models_to_remote_metadata() {
         let payload: OpenRouterModelsResponse = serde_json::from_str(
@@ -281,5 +387,36 @@ mod tests {
         assert_eq!(model.max_output_tokens_upper_limit, Some(8192));
         assert!(model.capabilities.image_input);
         assert_eq!(model.source, ModelMetadataSource::RemoteDiscovered);
+    }
+
+    #[test]
+    fn discovery_cache_status_reports_missing_stale_and_fresh() {
+        let provider = openrouter_provider();
+        let ttl = Duration::from_secs(60);
+        let mut cache = ModelDiscoveryCacheFile::default();
+
+        let missing = discovery_cache_status_for_provider(&provider, &cache, ttl, false);
+        assert_eq!(missing.state, ModelDiscoveryCacheState::Missing);
+        assert!(discovery_cache_needs_refresh(&provider, &cache, ttl));
+
+        cache.providers.insert(
+            provider.id.clone(),
+            ProviderModelDiscoveryCache {
+                provider: provider.id.clone(),
+                fetched_at: Utc::now() - chrono::TimeDelta::seconds(120),
+                source_url: None,
+                response_hash: None,
+                models: Vec::new(),
+            },
+        );
+        let stale = discovery_cache_status_for_provider(&provider, &cache, ttl, true);
+        assert_eq!(stale.state, ModelDiscoveryCacheState::Stale);
+        assert!(stale.refresh_in_flight);
+        assert!(discovery_cache_needs_refresh(&provider, &cache, ttl));
+
+        cache.providers.get_mut(&provider.id).unwrap().fetched_at = Utc::now();
+        let fresh = discovery_cache_status_for_provider(&provider, &cache, ttl, false);
+        assert_eq!(fresh.state, ModelDiscoveryCacheState::Fresh);
+        assert!(!discovery_cache_needs_refresh(&provider, &cache, ttl));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -32,7 +32,7 @@ pub use tasks::{
 pub(crate) use waiting::{WaitForScope, WaitForWakeKind};
 
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     sync::{
@@ -245,6 +245,7 @@ struct RuntimeInner {
         Mutex<HashMap<BuiltinWebSearchProbeKey, BuiltinWebSearchProbeCacheEntry>>,
     view_image_observation_cache:
         Mutex<HashMap<ViewImageObservationCacheKey, ViewImageObservation>>,
+    model_discovery_refreshes: Mutex<HashSet<crate::config::ProviderId>>,
     callback_base_url: String,
     tools: ToolRegistry,
     system: Arc<LocalSystem>,

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::PathBuf,
     sync::{atomic::AtomicBool, Arc},
 };
@@ -14,7 +14,11 @@ use crate::{
     context::ContextConfig,
     host::RuntimeHostBridge,
     model_catalog::BuiltInModelMetadata,
-    model_discovery::{discovery_cache_path, load_discovery_cache_at},
+    model_discovery::{
+        discovery_cache_needs_refresh, discovery_cache_path, discovery_cache_status_for_provider,
+        load_discovery_cache_at, refresh_provider_models, ModelDiscoveryCacheFile,
+        ModelDiscoveryCacheStatus, DEFAULT_DISCOVERY_CACHE_TTL,
+    },
     provider::{
         build_provider_from_model_chain, resolved_model_availability, AgentProvider,
         ConversationMessage, ModelBlock, ProviderJsonSchemaResponseFormat,
@@ -291,6 +295,7 @@ impl RuntimeHandle {
                 context_config: RwLock::new(resolved_context_config),
                 builtin_web_search_probe_cache: Mutex::new(HashMap::new()),
                 view_image_observation_cache: Mutex::new(HashMap::new()),
+                model_discovery_refreshes: Mutex::new(HashSet::new()),
                 callback_base_url,
                 tools: ToolRegistry::new(PathBuf::new()),
                 system: Arc::new(LocalSystem::new()),
@@ -525,6 +530,7 @@ impl RuntimeHandle {
         let cache_path = discovery_cache_path(&config.home_dir);
         match tokio::task::spawn_blocking(move || load_discovery_cache_at(&cache_path)).await {
             Ok(Ok(cache)) => {
+                self.spawn_model_discovery_refreshes(&config, &cache).await;
                 config.model_discovery_cache = cache;
                 Some(config)
             }
@@ -543,6 +549,105 @@ impl RuntimeHandle {
                 None
             }
         }
+    }
+
+    async fn spawn_model_discovery_refreshes(
+        &self,
+        config: &AppConfig,
+        cache: &ModelDiscoveryCacheFile,
+    ) {
+        let providers = config
+            .providers
+            .values()
+            .filter(|provider| {
+                discovery_cache_needs_refresh(provider, cache, DEFAULT_DISCOVERY_CACHE_TTL)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for provider in providers {
+            let provider_id = provider.id.clone();
+            {
+                let mut in_flight = self.inner.model_discovery_refreshes.lock().await;
+                if !in_flight.insert(provider_id.clone()) {
+                    continue;
+                }
+            }
+
+            let runtime = self.clone();
+            let cache_path = discovery_cache_path(&config.home_dir);
+            tokio::spawn(async move {
+                let result = refresh_provider_models(&provider, &cache_path).await;
+                match result {
+                    Ok(report) => {
+                        tracing::info!(
+                            provider = %report.provider.as_str(),
+                            model_count = report.model_count,
+                            "refreshed model discovery cache"
+                        );
+                        if let Err(err) = runtime.reload_model_discovery_cache_snapshot().await {
+                            tracing::warn!(
+                                error = %err,
+                                "failed to reload model discovery cache after refresh"
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            provider = %provider_id.as_str(),
+                            error = %err,
+                            "model discovery cache refresh failed"
+                        );
+                    }
+                }
+                runtime
+                    .inner
+                    .model_discovery_refreshes
+                    .lock()
+                    .await
+                    .remove(&provider_id);
+            });
+        }
+    }
+
+    async fn reload_model_discovery_cache_snapshot(&self) -> Result<()> {
+        let snap = self.inner.config_snapshot.load();
+        let Some(reconfig) = snap.provider_reconfig.as_ref() else {
+            return Ok(());
+        };
+        let mut config = reconfig.config.clone();
+        let cache_path = discovery_cache_path(&config.home_dir);
+        let cache =
+            tokio::task::spawn_blocking(move || load_discovery_cache_at(&cache_path)).await??;
+        config.model_discovery_cache = cache;
+        self.inner
+            .config_snapshot
+            .store(Arc::new(ConfigSnapshot::from_config(&config)));
+        Ok(())
+    }
+
+    pub(crate) async fn model_discovery_status(&self) -> Result<Vec<ModelDiscoveryCacheStatus>> {
+        let snap = self.inner.config_snapshot.load();
+        let Some(reconfig) = snap.provider_reconfig.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let config = reconfig.config.clone();
+        let cache_path = discovery_cache_path(&config.home_dir);
+        let cache =
+            tokio::task::spawn_blocking(move || load_discovery_cache_at(&cache_path)).await??;
+        self.spawn_model_discovery_refreshes(&config, &cache).await;
+        let in_flight = self.inner.model_discovery_refreshes.lock().await.clone();
+        Ok(config
+            .providers
+            .values()
+            .map(|provider| {
+                discovery_cache_status_for_provider(
+                    provider,
+                    &cache,
+                    DEFAULT_DISCOVERY_CACHE_TTL,
+                    in_flight.contains(&provider.id),
+                )
+            })
+            .collect())
     }
 
     pub(crate) async fn available_models(&self) -> Result<Vec<BuiltInModelMetadata>> {

--- a/src/tool/tools/list_model_providers.rs
+++ b/src/tool/tools/list_model_providers.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+    model_discovery::ModelDiscoveryCacheStatus,
     runtime::RuntimeHandle,
     tool::spec::typed_spec,
     types::{AuthorityClass, ModelProviderAvailability, ModelProviderEntry, ToolCapabilityFamily},
@@ -27,6 +28,8 @@ pub(crate) struct ListModelProvidersArgs {
 #[derive(Serialize, Deserialize)]
 pub(crate) struct ListModelProvidersResult {
     pub(crate) include_unavailable: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) model_discovery_cache: Vec<ModelDiscoveryCacheStatus>,
     pub(crate) providers: Vec<ModelProviderEntry>,
 }
 
@@ -48,6 +51,7 @@ pub(crate) async fn execute(
 ) -> Result<crate::tool::ToolResult> {
     let args: ListModelProvidersArgs = parse_tool_args(NAME, input)?;
     let mut providers = runtime.model_providers().await?;
+    let model_discovery_cache = runtime.model_discovery_status().await?;
     if !args.include_unavailable {
         providers
             .retain(|provider| provider.availability != ModelProviderAvailability::Unavailable);
@@ -56,6 +60,7 @@ pub(crate) async fn execute(
         NAME,
         &ListModelProvidersResult {
             include_unavailable: args.include_unavailable,
+            model_discovery_cache,
             providers,
         },
     )

--- a/src/tool/tools/list_provider_models.rs
+++ b/src/tool/tools/list_provider_models.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+    model_discovery::ModelDiscoveryCacheStatus,
     runtime::RuntimeHandle,
     tool::spec::typed_spec,
     types::{AuthorityClass, ModelAvailability, ProviderModelEntry, ToolCapabilityFamily},
@@ -38,6 +39,8 @@ pub(crate) struct ListProviderModelsResult {
     pub(crate) limit: usize,
     pub(crate) returned: usize,
     pub(crate) next_cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) discovery_cache: Option<ModelDiscoveryCacheStatus>,
     pub(crate) models: Vec<ProviderModelEntry>,
 }
 
@@ -72,6 +75,11 @@ pub(crate) async fn execute(
     let limit = args.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
     let cursor = normalize_optional_non_empty(args.cursor);
     let mut models = runtime.provider_models(&provider).await?;
+    let discovery_cache = runtime
+        .model_discovery_status()
+        .await?
+        .into_iter()
+        .find(|status| status.provider.as_str() == provider);
     if !args.include_unavailable {
         models.retain(|model| model.availability != ModelAvailability::Unavailable);
     }
@@ -85,6 +93,7 @@ pub(crate) async fn execute(
             limit,
             returned,
             next_cursor,
+            discovery_cache,
             models: page,
         },
     )


### PR DESCRIPTION
## Summary
- auto-refresh stale or missing dynamic model discovery caches for providers that support it
- expose cache freshness/refresh diagnostics through `/models` and model listing tools
- reload the runtime model snapshot after a successful refresh

Closes #1903

## Verification
- cargo test model_discovery --lib
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets