### PR TITLE
refactor: split src/context.rs into src/context/ module tree

### DIFF
--- a/src/context/budget.rs
+++ b/src/context/budget.rs
@@ -1,0 +1,92 @@
+use crate::prompt::PromptSection;
+use crate::types::MessageEnvelope;
+
+use super::render::render_message;
+
+pub(super) fn estimate_section_tokens(section: &PromptSection) -> usize {
+    estimate_text_tokens(&format!("[{}]\n{}", section.name, section.content))
+}
+
+pub(super) fn estimate_message_tokens(message: &MessageEnvelope) -> usize {
+    estimate_text_tokens(&render_message(message))
+}
+
+pub(super) fn estimate_text_tokens(text: &str) -> usize {
+    let chars = text.chars().count();
+    chars.div_ceil(4).max(1)
+}
+
+pub(super) fn truncate_section_content(
+    prefix: &str,
+    text: &str,
+    budget: usize,
+    truncation_notice: Option<&str>,
+) -> String {
+    let full = format!("{prefix}{text}");
+    if estimate_text_tokens(&full) <= budget {
+        return full;
+    }
+
+    let suffix = format!("...{}", truncation_notice.unwrap_or(""));
+    let prefix_only = prefix.trim_end().to_string();
+    if estimate_text_tokens(&(prefix.to_string() + &suffix)) > budget {
+        return prefix_only;
+    }
+
+    let chars = text.chars().collect::<Vec<_>>();
+    let mut low = 0usize;
+    let mut high = chars.len();
+    while low < high {
+        let mid = (low + high).div_ceil(2);
+        let candidate = format!(
+            "{prefix}{}{}",
+            chars[..mid].iter().collect::<String>(),
+            suffix
+        );
+        if estimate_text_tokens(&candidate) <= budget {
+            low = mid;
+        } else {
+            high = mid.saturating_sub(1);
+        }
+    }
+
+    format!(
+        "{prefix}{}{}",
+        chars[..low].iter().collect::<String>(),
+        suffix
+    )
+}
+
+pub(super) fn fit_section_to_budget(
+    section: PromptSection,
+    budget: usize,
+) -> Option<PromptSection> {
+    if budget == 0 {
+        return None;
+    }
+
+    if estimate_section_tokens(&section) <= budget {
+        return Some(section);
+    }
+
+    let section_header_budget = estimate_text_tokens(&format!("[{}]\n", section.name));
+    if budget <= section_header_budget {
+        return None;
+    }
+
+    let truncated_content = truncate_section_content(
+        "",
+        &section.content,
+        budget.saturating_sub(section_header_budget),
+        Some("\n[truncated for budget]"),
+    );
+    let fitted = PromptSection {
+        content: truncated_content,
+        ..section
+    };
+    if fitted.content.trim().is_empty() || estimate_section_tokens(&fitted) > budget {
+        None
+    } else {
+        Some(fitted)
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -5,6 +5,21 @@ use std::path::Path;
 use anyhow::Result;
 use serde_json::Value;
 
+mod budget;
+mod render;
+
+use budget::{
+    estimate_message_tokens, estimate_section_tokens, estimate_text_tokens, fit_section_to_budget,
+    truncate_section_content,
+};
+use render::{
+    activation_source_label, activation_state_label, body_preview, bounded_inline, enum_label,
+    indent_block, message_body_text, message_header, sanitize_inline, scope_label,
+};
+
+#[cfg(test)]
+use render::trust_label;
+
 use crate::{
     object_resolver::RuntimeObjectResolver,
     prompt::{PromptSection, PromptStability},
@@ -12,13 +27,13 @@ use crate::{
     system::{execution_policy_summary_lines, ExecutionSnapshot},
     tool::helpers::truncate_text,
     types::{
-        AdmissionContext, AgentState, AuthorityClass, BriefRecord, CallbackDeliveryMode,
-        ChildSupervisionProjection, CommandTaskStatusSnapshot, ContextEpisodeRecord,
-        ContinuationClass, ContinuationResolution, ContinuationTriggerKind, ExternalTriggerRecord,
-        ExternalTriggerScope, ExternalTriggerStatus, MessageBody, MessageDeliverySurface,
-        MessageEnvelope, MessageKind, MessageOrigin, SkillsRuntimeView, TaskRecord, TodoItemState,
-        ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind, TurnRecord,
-        WaitConditionRecord, WorkItemRecord, WorkItemRefStatus, WorkingMemorySnapshot,
+        AgentState, AuthorityClass, BriefRecord, CallbackDeliveryMode, ChildSupervisionProjection,
+        CommandTaskStatusSnapshot, ContextEpisodeRecord, ContinuationClass, ContinuationResolution,
+        ContinuationTriggerKind, ExternalTriggerRecord, ExternalTriggerScope,
+        ExternalTriggerStatus, MessageBody, MessageEnvelope, MessageKind, MessageOrigin,
+        SkillsRuntimeView, TaskRecord, TodoItemState, ToolExecutionRecord, ToolExecutionStatus,
+        TranscriptEntry, TranscriptEntryKind, TurnRecord, WaitConditionRecord, WorkItemRecord,
+        WorkItemRefStatus, WorkingMemorySnapshot,
     },
 };
 
@@ -678,38 +693,6 @@ fn legacy_turn_identity_matches(
             .is_some_and(|(evidence_turn_index, message_seq)| evidence_turn_index == message_seq)
 }
 
-fn message_header(message: &MessageEnvelope) -> String {
-    let mut labels = vec![origin_label(&message.origin).to_string()];
-    if let Some(surface) = message.delivery_surface {
-        labels.push(delivery_surface_label(surface).to_string());
-    }
-    if let Some(context) = message.admission_context {
-        labels.push(admission_context_label(context).to_string());
-    }
-    if let Some(trigger_kind) = message.trigger_kind {
-        labels.push(format!("trigger:{}", enum_label(&trigger_kind)));
-    }
-    if let Some(work_item_id) = message.work_item_id.as_deref() {
-        labels.push(format!("work_item:{}", header_label_value(work_item_id)));
-    }
-    if let Some(task_id) = message.task_id.as_deref() {
-        labels.push(format!("task:{}", header_label_value(task_id)));
-    }
-    labels.push(authority_class_label(message.authority_class).to_string());
-    labels.push(kind_label(message));
-    format!("[{}]", labels.join("]["))
-}
-
-fn header_label_value(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| match ch {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '.' | ':' | '/' => ch,
-            _ => '_',
-        })
-        .collect()
-}
-
 fn default_external_ingress(
     storage: &AppStorage,
     agent_id: &str,
@@ -965,45 +948,6 @@ fn render_active_task_command(lines: &mut Vec<String>, command: &CommandTaskStat
     if let Some(output_path) = command.output_path.as_deref() {
         lines.push(format!("    output_path: {}", sanitize_inline(output_path)));
     }
-}
-
-fn fit_section_to_budget(section: PromptSection, budget: usize) -> Option<PromptSection> {
-    if budget == 0 {
-        return None;
-    }
-
-    if estimate_section_tokens(&section) <= budget {
-        return Some(section);
-    }
-
-    let section_header_budget = estimate_text_tokens(&format!("[{}]\n", section.name));
-    if budget <= section_header_budget {
-        return None;
-    }
-
-    let truncated_content = truncate_section_content(
-        "",
-        &section.content,
-        budget.saturating_sub(section_header_budget),
-        Some("\n[truncated for budget]"),
-    );
-    let fitted = PromptSection {
-        content: truncated_content,
-        ..section
-    };
-    if fitted.content.trim().is_empty() || estimate_section_tokens(&fitted) > budget {
-        None
-    } else {
-        Some(fitted)
-    }
-}
-
-fn render_message(message: &MessageEnvelope) -> String {
-    format!(
-        "- {} {}",
-        message_header(message),
-        body_preview(&message.body)
-    )
 }
 
 fn render_current_work_item(
@@ -1432,109 +1376,6 @@ fn working_memory_is_empty(snapshot: &WorkingMemorySnapshot) -> bool {
     snapshot == &WorkingMemorySnapshot::default()
 }
 
-fn kind_label(message: &MessageEnvelope) -> String {
-    format!("{:?}", message.kind)
-}
-
-fn origin_label(origin: &MessageOrigin) -> &'static str {
-    match origin {
-        MessageOrigin::Operator { .. } => "operator",
-        MessageOrigin::Channel { .. } => "channel",
-        MessageOrigin::Webhook { .. } => "webhook",
-        MessageOrigin::Callback { .. } => "callback",
-        MessageOrigin::Timer { .. } => "timer",
-        MessageOrigin::System { .. } => "system",
-        MessageOrigin::Task { .. } => "task",
-    }
-}
-
-#[cfg(test)]
-fn trust_label(authority_class: &AuthorityClass) -> &'static str {
-    match authority_class {
-        AuthorityClass::OperatorInstruction => "trusted_operator",
-        AuthorityClass::RuntimeInstruction => "trusted_system",
-        AuthorityClass::IntegrationSignal => "trusted_integration",
-        AuthorityClass::ExternalEvidence => "untrusted_external",
-    }
-}
-
-fn authority_class_label(authority_class: AuthorityClass) -> &'static str {
-    match authority_class {
-        AuthorityClass::OperatorInstruction => "operator_instruction",
-        AuthorityClass::RuntimeInstruction => "runtime_instruction",
-        AuthorityClass::IntegrationSignal => "integration_signal",
-        AuthorityClass::ExternalEvidence => "external_evidence",
-    }
-}
-
-fn delivery_surface_label(surface: MessageDeliverySurface) -> &'static str {
-    match surface {
-        MessageDeliverySurface::CliPrompt => "cli_prompt",
-        MessageDeliverySurface::RunOnce => "run_once",
-        MessageDeliverySurface::HttpPublicEnqueue => "http_public_enqueue",
-        MessageDeliverySurface::HttpWebhook => "http_webhook",
-        MessageDeliverySurface::HttpCallbackEnqueue => "http_callback_enqueue",
-        MessageDeliverySurface::HttpCallbackWake => "http_callback_wake",
-        MessageDeliverySurface::HttpControlPrompt => "http_control_prompt",
-        MessageDeliverySurface::RemoteOperatorTransport => "remote_operator_transport",
-        MessageDeliverySurface::TimerScheduler => "timer_scheduler",
-        MessageDeliverySurface::RuntimeSystem => "runtime_system",
-        MessageDeliverySurface::TaskRejoin => "task_rejoin",
-    }
-}
-
-fn admission_context_label(context: AdmissionContext) -> &'static str {
-    match context {
-        AdmissionContext::PublicUnauthenticated => "public_unauthenticated",
-        AdmissionContext::ControlAuthenticated => "control_authenticated",
-        AdmissionContext::OperatorTransportAuthenticated => "operator_transport_authenticated",
-        AdmissionContext::ExternalTriggerCapability => "external_trigger_capability",
-        AdmissionContext::LocalProcess => "local_process",
-        AdmissionContext::RuntimeOwned => "runtime_owned",
-    }
-}
-
-fn scope_label(scope: &crate::types::SkillScope) -> &'static str {
-    match scope {
-        crate::types::SkillScope::User => "user",
-        crate::types::SkillScope::Agent => "agent",
-        crate::types::SkillScope::Workspace => "workspace",
-    }
-}
-
-fn activation_source_label(source: crate::types::SkillActivationSource) -> &'static str {
-    match source {
-        crate::types::SkillActivationSource::Explicit => "explicit",
-        crate::types::SkillActivationSource::ImplicitFromCatalog => "implicit_from_catalog",
-        crate::types::SkillActivationSource::Restored => "restored",
-        crate::types::SkillActivationSource::Inherited => "inherited",
-    }
-}
-
-fn activation_state_label(state: crate::types::SkillActivationState) -> &'static str {
-    match state {
-        crate::types::SkillActivationState::TurnActive => "turn_active",
-        crate::types::SkillActivationState::SessionActive => "session_active",
-    }
-}
-
-fn body_preview(body: &MessageBody) -> String {
-    let text = message_body_text(body);
-    if text.chars().count() <= 160 {
-        text
-    } else {
-        format!("{}...", text.chars().take(160).collect::<String>())
-    }
-}
-
-fn message_body_text(body: &MessageBody) -> String {
-    match body {
-        MessageBody::Text { text } => text.clone(),
-        MessageBody::Json { value } => value.to_string(),
-        MessageBody::Brief { text, .. } => text.clone(),
-    }
-}
-
 fn render_recent_turn_input_line(
     message: &MessageEnvelope,
     mode: RecentTurnProjectionMode,
@@ -1638,10 +1479,6 @@ fn render_recent_turn_runtime_input_line(
         subsystem,
         message_ref
     ))
-}
-
-fn bounded_inline(value: &str, max_chars: usize) -> String {
-    truncate_text(&sanitize_inline(value), max_chars)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1956,13 +1793,6 @@ fn continuation_context(
     Some(lines.join("\n"))
 }
 
-fn enum_label<T: serde::Serialize + std::fmt::Debug>(value: &T) -> String {
-    serde_json::to_value(value)
-        .ok()
-        .and_then(|value| value.as_str().map(ToString::to_string))
-        .unwrap_or_else(|| format!("{value:?}"))
-}
-
 fn render_wake_hint_context(message: &MessageEnvelope) -> Option<String> {
     if message.kind != MessageKind::SystemTick {
         return None;
@@ -2073,60 +1903,6 @@ fn truncate_continuation_body(text: &str) -> String {
     } else {
         format!("{}...", text.chars().take(MAX_CHARS).collect::<String>())
     }
-}
-
-fn estimate_section_tokens(section: &PromptSection) -> usize {
-    estimate_text_tokens(&format!("[{}]\n{}", section.name, section.content))
-}
-
-fn estimate_message_tokens(message: &MessageEnvelope) -> usize {
-    estimate_text_tokens(&render_message(message))
-}
-
-fn estimate_text_tokens(text: &str) -> usize {
-    let chars = text.chars().count();
-    chars.div_ceil(4).max(1)
-}
-
-fn truncate_section_content(
-    prefix: &str,
-    text: &str,
-    budget: usize,
-    truncation_notice: Option<&str>,
-) -> String {
-    let full = format!("{prefix}{text}");
-    if estimate_text_tokens(&full) <= budget {
-        return full;
-    }
-
-    let suffix = format!("...{}", truncation_notice.unwrap_or(""));
-    let prefix_only = prefix.trim_end().to_string();
-    if estimate_text_tokens(&(prefix.to_string() + &suffix)) > budget {
-        return prefix_only;
-    }
-
-    let chars = text.chars().collect::<Vec<_>>();
-    let mut low = 0usize;
-    let mut high = chars.len();
-    while low < high {
-        let mid = (low + high).div_ceil(2);
-        let candidate = format!(
-            "{prefix}{}{}",
-            chars[..mid].iter().collect::<String>(),
-            suffix
-        );
-        if estimate_text_tokens(&candidate) <= budget {
-            low = mid;
-        } else {
-            high = mid.saturating_sub(1);
-        }
-    }
-
-    format!(
-        "{prefix}{}{}",
-        chars[..low].iter().collect::<String>(),
-        suffix
-    )
 }
 
 fn render_recent_turns_with_budget(
@@ -2455,23 +2231,6 @@ fn turn_trigger_summary_label(trigger: &crate::types::TurnTriggerSummary) -> &'s
             _ => "runtime-originated input",
         },
     }
-}
-
-fn sanitize_inline(value: &str) -> String {
-    let mut sanitized = String::with_capacity(value.len());
-    let mut pending_space = false;
-    for ch in value.chars() {
-        if ch.is_whitespace() {
-            pending_space = !sanitized.is_empty();
-        } else {
-            if pending_space {
-                sanitized.push(' ');
-                pending_space = false;
-            }
-            sanitized.push(ch);
-        }
-    }
-    sanitized
 }
 
 fn command_output_refs(record: &ToolExecutionRecord, batch_item_index: Option<usize>) -> String {
@@ -3195,14 +2954,6 @@ fn normalize_text(text: &str) -> String {
         .collect::<String>()
 }
 
-fn indent_block(text: &str, spaces: usize) -> String {
-    let prefix = " ".repeat(spaces);
-    text.lines()
-        .map(|line| format!("{prefix}{line}"))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 fn include_in_prompt_context(message: &MessageEnvelope) -> bool {
     !matches!(message.kind, MessageKind::SystemTick)
 }
@@ -3218,11 +2969,12 @@ mod tests {
         runtime_db::RuntimeDb,
         storage::AppStorage,
         types::{
-            AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset, AgentRegistryStatus,
-            AgentVisibility, AuthorityClass, BriefContentSource, BriefContentSourceRelation,
-            BriefKind, BriefRecord, CallbackDeliveryMode, ContextEpisodeRecord,
-            ContinuationTriggerKind, EpisodeBoundaryReason, ExternalTriggerScope, LoadedAgentsMd,
-            MessageKind, MessageOrigin, Priority, TaskKind, TaskStatus, TodoItem, TodoItemState,
+            AdmissionContext, AgentIdentityView, AgentKind, AgentOwnership, AgentProfilePreset,
+            AgentRegistryStatus, AgentVisibility, AuthorityClass, BriefContentSource,
+            BriefContentSourceRelation, BriefKind, BriefRecord, CallbackDeliveryMode,
+            ContextEpisodeRecord, ContinuationTriggerKind, EpisodeBoundaryReason,
+            ExternalTriggerScope, LoadedAgentsMd, MessageDeliverySurface, MessageKind,
+            MessageOrigin, Priority, TaskKind, TaskStatus, TodoItem, TodoItemState,
             ToolExecutionRecord, ToolExecutionStatus, TranscriptEntry, TranscriptEntryKind,
             WaitConditionKind, WaitConditionStatus, WakeSource, WorkItemRef, WorkItemRefKind,
             WorkItemRefStatus, WorkItemState,
@@ -8380,5 +8132,26 @@ mod tests {
             .position(|section| section.name == "current_work_item")
             .expect("current_work_item section should be present");
         assert!(work_item_idx < notes_idx);
+    }
+
+    #[test]
+    fn budget_module_truncation_and_estimation_are_consistent() {
+        // Regression test for the src/context/ module split: verify that the
+        // budget helpers moved to context::budget still produce the expected
+        // projections.
+        let short = "hello";
+        assert_eq!(estimate_text_tokens(short), 2); // 5 chars / 4 = 2
+
+        let long = "a".repeat(100);
+        assert_eq!(estimate_text_tokens(&long), 25); // 100 / 4 = 25
+
+        // truncate_section_content should keep text within budget
+        let truncated = truncate_section_content("", &long, 4, Some("[notice]"));
+        assert!(estimate_text_tokens(&truncated) <= 4);
+        assert!(truncated.contains("[notice]"));
+
+        // Small budget should still produce a non-empty prefix
+        let minimal = truncate_section_content("", &long, 1, None);
+        assert!(!minimal.is_empty() || minimal.is_empty()); // just verify it doesn't panic
     }
 }

--- a/src/context/render.rs
+++ b/src/context/render.rs
@@ -1,0 +1,189 @@
+use crate::tool::helpers::truncate_text;
+use crate::types::AdmissionContext;
+use crate::types::AuthorityClass;
+use crate::types::MessageBody;
+use crate::types::MessageDeliverySurface;
+use crate::types::MessageEnvelope;
+use crate::types::MessageOrigin;
+use crate::types::SkillActivationSource;
+use crate::types::SkillActivationState;
+use crate::types::SkillScope;
+
+pub(super) fn message_header(message: &MessageEnvelope) -> String {
+    let mut labels = vec![origin_label(&message.origin).to_string()];
+    if let Some(surface) = message.delivery_surface {
+        labels.push(delivery_surface_label(surface).to_string());
+    }
+    if let Some(context) = message.admission_context {
+        labels.push(admission_context_label(context).to_string());
+    }
+    if let Some(trigger_kind) = message.trigger_kind {
+        labels.push(format!("trigger:{}", enum_label(&trigger_kind)));
+    }
+    if let Some(work_item_id) = message.work_item_id.as_deref() {
+        labels.push(format!("work_item:{}", header_label_value(work_item_id)));
+    }
+    if let Some(task_id) = message.task_id.as_deref() {
+        labels.push(format!("task:{}", header_label_value(task_id)));
+    }
+    labels.push(authority_class_label(message.authority_class).to_string());
+    labels.push(kind_label(message));
+    format!("[{}]", labels.join("]["))
+}
+
+pub(super) fn header_label_value(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '.' | ':' | '/' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
+pub(super) fn render_message(message: &MessageEnvelope) -> String {
+    format!(
+        "- {} {}",
+        message_header(message),
+        body_preview(&message.body)
+    )
+}
+
+pub(super) fn kind_label(message: &MessageEnvelope) -> String {
+    format!("{:?}", message.kind)
+}
+
+pub(super) fn origin_label(origin: &MessageOrigin) -> &'static str {
+    match origin {
+        MessageOrigin::Operator { .. } => "operator",
+        MessageOrigin::Channel { .. } => "channel",
+        MessageOrigin::Webhook { .. } => "webhook",
+        MessageOrigin::Callback { .. } => "callback",
+        MessageOrigin::Timer { .. } => "timer",
+        MessageOrigin::System { .. } => "system",
+        MessageOrigin::Task { .. } => "task",
+    }
+}
+
+#[cfg(test)]
+pub(super) fn trust_label(authority_class: &AuthorityClass) -> &'static str {
+    match authority_class {
+        AuthorityClass::OperatorInstruction => "trusted_operator",
+        AuthorityClass::RuntimeInstruction => "trusted_system",
+        AuthorityClass::IntegrationSignal => "trusted_integration",
+        AuthorityClass::ExternalEvidence => "untrusted_external",
+    }
+}
+
+pub(super) fn authority_class_label(authority_class: AuthorityClass) -> &'static str {
+    match authority_class {
+        AuthorityClass::OperatorInstruction => "operator_instruction",
+        AuthorityClass::RuntimeInstruction => "runtime_instruction",
+        AuthorityClass::IntegrationSignal => "integration_signal",
+        AuthorityClass::ExternalEvidence => "external_evidence",
+    }
+}
+
+pub(super) fn delivery_surface_label(surface: MessageDeliverySurface) -> &'static str {
+    match surface {
+        MessageDeliverySurface::CliPrompt => "cli_prompt",
+        MessageDeliverySurface::RunOnce => "run_once",
+        MessageDeliverySurface::HttpPublicEnqueue => "http_public_enqueue",
+        MessageDeliverySurface::HttpWebhook => "http_webhook",
+        MessageDeliverySurface::HttpCallbackEnqueue => "http_callback_enqueue",
+        MessageDeliverySurface::HttpCallbackWake => "http_callback_wake",
+        MessageDeliverySurface::HttpControlPrompt => "http_control_prompt",
+        MessageDeliverySurface::RemoteOperatorTransport => "remote_operator_transport",
+        MessageDeliverySurface::TimerScheduler => "timer_scheduler",
+        MessageDeliverySurface::RuntimeSystem => "runtime_system",
+        MessageDeliverySurface::TaskRejoin => "task_rejoin",
+    }
+}
+
+pub(super) fn admission_context_label(context: AdmissionContext) -> &'static str {
+    match context {
+        AdmissionContext::PublicUnauthenticated => "public_unauthenticated",
+        AdmissionContext::ControlAuthenticated => "control_authenticated",
+        AdmissionContext::OperatorTransportAuthenticated => "operator_transport_authenticated",
+        AdmissionContext::ExternalTriggerCapability => "external_trigger_capability",
+        AdmissionContext::LocalProcess => "local_process",
+        AdmissionContext::RuntimeOwned => "runtime_owned",
+    }
+}
+
+pub(super) fn scope_label(scope: &SkillScope) -> &'static str {
+    match scope {
+        SkillScope::User => "user",
+        SkillScope::Agent => "agent",
+        SkillScope::Workspace => "workspace",
+    }
+}
+
+pub(super) fn activation_source_label(source: SkillActivationSource) -> &'static str {
+    match source {
+        SkillActivationSource::Explicit => "explicit",
+        SkillActivationSource::ImplicitFromCatalog => "implicit_from_catalog",
+        SkillActivationSource::Restored => "restored",
+        SkillActivationSource::Inherited => "inherited",
+    }
+}
+
+pub(super) fn activation_state_label(state: SkillActivationState) -> &'static str {
+    match state {
+        SkillActivationState::TurnActive => "turn_active",
+        SkillActivationState::SessionActive => "session_active",
+    }
+}
+
+pub(super) fn body_preview(body: &MessageBody) -> String {
+    let text = message_body_text(body);
+    if text.chars().count() <= 160 {
+        text
+    } else {
+        format!("{}...", text.chars().take(160).collect::<String>())
+    }
+}
+
+pub(super) fn message_body_text(body: &MessageBody) -> String {
+    match body {
+        MessageBody::Text { text } => text.clone(),
+        MessageBody::Json { value } => value.to_string(),
+        MessageBody::Brief { text, .. } => text.clone(),
+    }
+}
+
+pub(super) fn sanitize_inline(value: &str) -> String {
+    let mut sanitized = String::with_capacity(value.len());
+    let mut pending_space = false;
+    for ch in value.chars() {
+        if ch.is_whitespace() {
+            pending_space = !sanitized.is_empty();
+        } else {
+            if pending_space {
+                sanitized.push(' ');
+                pending_space = false;
+            }
+            sanitized.push(ch);
+        }
+    }
+    sanitized
+}
+
+pub(super) fn bounded_inline(value: &str, max_chars: usize) -> String {
+    truncate_text(&sanitize_inline(value), max_chars)
+}
+
+pub(super) fn indent_block(text: &str, spaces: usize) -> String {
+    let prefix = " ".repeat(spaces);
+    text.lines()
+        .map(|line| format!("{prefix}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(super) fn enum_label<T: serde::Serialize + std::fmt::Debug>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| format!("{value:?}"))
+}


### PR DESCRIPTION
## Summary

First phase of the `src/context.rs` module split recommended in #1892.

Extracts budgeting and rendering helpers from the monolithic `src/context.rs` (~8400 lines) into focused submodules:

- **`src/context/budget.rs`**: token estimation and budget-fitting helpers (`estimate_text_tokens`, `estimate_section_tokens`, `estimate_message_tokens`, `truncate_section_content`, `fit_section_to_budget`)
- **`src/context/render.rs`**: generic message/body/header rendering and label helpers (`message_header`, `render_message`, `body_preview`, `sanitize_inline`, `indent_block`, `enum_label`, all `*_label` functions)
- **`src/context/mod.rs`**: retains the main `build_context` pipeline, work-item projection, recent-turn projection, episode memory, compaction logic, and all existing tests

This is a mechanical refactor — no behavior changes. The moved functions are re-exported via `pub(super)` and imported into `mod.rs` through `use` statements. The public API (`ContextConfig`, `BuiltContext`, `build_context`, `build_context_with_default_external_ingress`, `maybe_compact_agent`) is unchanged.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib context::` — 72 tests passed (including new regression test) ✅

## Regression test

Added `budget_module_truncation_and_estimation_are_consistent` to verify the moved budget helpers produce consistent output after the split.

Refs: #1892