### PR TITLE
fix: honor conversation event seq links

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -148,7 +148,7 @@ export function App() {
     const applyBrowserRoute = () => {
       const nextRoute = routeFromLocation(window.location);
       if (nextRoute.route === "agent" && nextRoute.agentId) {
-        openAgent(nextRoute.agentId);
+        openAgent(nextRoute.agentId, nextRoute.eventSeq);
         return;
       }
       setRoute(nextRoute.route);
@@ -179,7 +179,7 @@ export function App() {
   }
 
   function navigateAgent(agentId: string, eventSeq?: number) {
-    openAgent(agentId);
+    openAgent(agentId, eventSeq);
     pushBrowserRoute("agent", agentId, eventSeq == null ? undefined : { event_seq: eventSeq });
   }
 
@@ -372,6 +372,7 @@ export function App() {
             hasOlderEvents={selectedAgentSession?.hasOlder ?? selectedAgentDetail?.hasOlderEvents ?? false}
             loadingOlderEvents={selectedAgentSession?.loadingOlder ?? false}
             historyError={selectedAgentSession?.historyError}
+            targetEventSeq={selectedAgentSession?.targetEventSeq}
             onRefreshModels={refreshModelCatalog}
             onSetModel={(model, reasoningEffort) => setAgentModel(activeAgent.id, model, displayLevel, reasoningEffort)}
             onClearModel={() => clearAgentModel(activeAgent.id, displayLevel)}

--- a/web-gui/app/src/app/routes.test.ts
+++ b/web-gui/app/src/app/routes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { routeFromLocation } from "./routes";
+
+describe("routeFromLocation", () => {
+  it("parses conversation event_seq links", () => {
+    expect(routeFromLocation({ pathname: "/agents/holon-pm/conversation", search: "?event_seq=740" })).toEqual({
+      route: "agent",
+      agentId: "holon-pm",
+      eventSeq: 740,
+    });
+  });
+
+  it("ignores invalid event_seq values", () => {
+    expect(routeFromLocation({ pathname: "/agents/holon-pm/conversation", search: "?event_seq=latest" })).toEqual({
+      route: "agent",
+      agentId: "holon-pm",
+      eventSeq: undefined,
+    });
+  });
+});

--- a/web-gui/app/src/app/routes.ts
+++ b/web-gui/app/src/app/routes.ts
@@ -3,9 +3,17 @@ import type { RouteKey } from "../runtime/types";
 interface BrowserRoute {
   route: RouteKey;
   agentId?: string;
+  eventSeq?: number;
 }
 
-export function routeFromLocation(location: Pick<Location, "pathname">): BrowserRoute {
+function eventSeqFromSearch(search: string): number | undefined {
+  const raw = new URLSearchParams(search).get("event_seq");
+  if (!raw) return undefined;
+  const eventSeq = Number(raw);
+  return Number.isInteger(eventSeq) && eventSeq > 0 ? eventSeq : undefined;
+}
+
+export function routeFromLocation(location: Pick<Location, "pathname" | "search">): BrowserRoute {
   const path = location.pathname.replace(/\/+$/, "") || "/";
 
   if (path === "/") return { route: "dashboard" };
@@ -14,7 +22,11 @@ export function routeFromLocation(location: Pick<Location, "pathname">): Browser
 
   const agentMatch = path.match(/^\/agents\/([^/]+)(?:\/conversation)?$/);
   if (agentMatch) {
-    return { route: "agent", agentId: safeDecodeURIComponent(agentMatch[1]) };
+    return {
+      route: "agent",
+      agentId: safeDecodeURIComponent(agentMatch[1]),
+      eventSeq: eventSeqFromSearch(location.search),
+    };
   }
 
   return { route: "dashboard" };

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -27,6 +27,7 @@ interface AgentPageProps {
   modelCatalogLoading: boolean;
   modelCatalogError?: string;
   historyError?: string;
+  targetEventSeq?: number;
   onRefreshModels: () => Promise<void>;
   onSetModel: (model: string, reasoningEffort?: string) => Promise<void>;
   onClearModel: () => Promise<void>;
@@ -91,6 +92,7 @@ export function AgentPage({
   modelCatalogLoading,
   modelCatalogError,
   historyError,
+  targetEventSeq,
   onRefreshModels,
   onSetModel,
   onClearModel,
@@ -129,6 +131,7 @@ export function AgentPage({
   const isWorking = isAgentWorking(activeAgent, sendingPrompt);
   const workingActivities = useMemo(() => (isWorking ? collectWorkingActivitiesForCurrentTurn(sourceTimeline) : []), [isWorking, sourceTimeline]);
   const timelineTurns = useMemo(() => groupTimelineTurns(timeline), [timeline]);
+  const targetTimelineItemId = useMemo(() => timeline.find((item) => itemHasEventSeq(item, targetEventSeq))?.id, [targetEventSeq, timeline]);
   const trimmedPrompt = prompt.trim();
   const canSendPrompt = trimmedPrompt.length > 0 && !sendingPrompt;
   const newestTimelineItem = timeline[timeline.length - 1];
@@ -175,6 +178,15 @@ export function AgentPage({
       list.scrollTop = list.scrollHeight;
     }
   }, [timelineVersion]);
+
+  useLayoutEffect(() => {
+    if (!targetTimelineItemId) return;
+    const list = messageListRef.current;
+    const target = list?.querySelector<HTMLElement>(`[data-timeline-item-id="${cssEscape(targetTimelineItemId)}"]`);
+    if (!target) return;
+    stickToBottomRef.current = false;
+    target.scrollIntoView({ block: "center" });
+  }, [targetTimelineItemId, timelineVersion]);
 
   async function sendDraftPrompt() {
     if (!canSendPrompt) return;
@@ -285,6 +297,7 @@ export function AgentPage({
                 onOpenInspector={onOpenInspector}
                 onInspectActivity={onInspectActivity}
                 selectedActivityId={selectedActivityId}
+                targetTimelineItemId={targetTimelineItemId}
                 turn={turn}
               />
             ))}
@@ -610,18 +623,37 @@ function isTurnStartedItem(item: AgentTimelineItem): boolean {
   return item.meta.startsWith("turn_started");
 }
 
+function itemHasEventSeq(item: AgentTimelineItem, eventSeq: number | undefined): boolean {
+  if (eventSeq == null) return false;
+  if (rawEventSeq(item.rawEvent) === eventSeq) return true;
+  return (item.activities ?? []).some((activity) => rawEventSeq(activity.rawEvent) === eventSeq);
+}
+
+function rawEventSeq(rawEvent: unknown): number | undefined {
+  return typeof rawEvent === "object" && rawEvent !== null && "event_seq" in rawEvent && typeof rawEvent.event_seq === "number"
+    ? rawEvent.event_seq
+    : undefined;
+}
+
+function cssEscape(value: string): string {
+  if (typeof CSS !== "undefined" && CSS.escape) return CSS.escape(value);
+  return value.replace(/["\\]/g, "\\$&");
+}
+
 const TimelineTurnGroup = memo(function TimelineTurnGroup({
   turn,
   displayLevel,
   onOpenInspector,
   onInspectActivity,
   selectedActivityId,
+  targetTimelineItemId,
 }: {
   turn: TimelineTurn;
   displayLevel: DisplayLevel;
   onOpenInspector: () => void;
   onInspectActivity: (activity: AgentTimelineActivity) => void;
   selectedActivityId?: string;
+  targetTimelineItemId?: string;
 }) {
   return (
     <section className="timeline-turn" aria-label={turn.label}>
@@ -640,6 +672,7 @@ const TimelineTurnGroup = memo(function TimelineTurnGroup({
             onOpenInspector={onOpenInspector}
             onInspectActivity={onInspectActivity}
             selectedActivityId={selectedActivityId}
+            targetTimelineItemId={targetTimelineItemId}
           />
         ))}
       </div>
@@ -654,6 +687,7 @@ const TimelineMessage = memo(function TimelineMessage({
   onOpenInspector,
   onInspectActivity,
   selectedActivityId,
+  targetTimelineItemId,
 }: {
   item: AgentTimelineItem;
   compactAssistant: boolean;
@@ -661,6 +695,7 @@ const TimelineMessage = memo(function TimelineMessage({
   onOpenInspector: () => void;
   onInspectActivity: (activity: AgentTimelineActivity) => void;
   selectedActivityId?: string;
+  targetTimelineItemId?: string;
 }) {
   const isRuntimeItem = isRuntimeActivityItem(item);
   const activities =
@@ -671,7 +706,10 @@ const TimelineMessage = memo(function TimelineMessage({
         : (item.activities ?? []);
   if (isRuntimeItem) {
     return (
-      <article className="message activity-message">
+      <article
+        className={`message activity-message${targetTimelineItemId === item.id ? " is-targeted" : ""}`}
+        data-timeline-item-id={item.id}
+      >
         {activities.length ? (
           <ActivityTrail
             activities={activities}
@@ -689,7 +727,10 @@ const TimelineMessage = memo(function TimelineMessage({
   const inspectItem = () => onInspectActivity(timelineItemToWorkingActivity(item));
 
   return (
-    <article className={`message ${item.kind}${compactAssistant ? " is-compact" : ""}`}>
+    <article
+      className={`message ${item.kind}${compactAssistant ? " is-compact" : ""}${targetTimelineItemId === item.id ? " is-targeted" : ""}`}
+      data-timeline-item-id={item.id}
+    >
       <div className="bubble">
         <TimelineItemContent item={item} />
         <TimelineItemDetail detail={item.detail} />

--- a/web-gui/app/src/features/search/SearchPage.test.ts
+++ b/web-gui/app/src/features/search/SearchPage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatSearchPreview, searchOptionsForSelection } from "./SearchPage";
+import { canSearchSelection, formatSearchPreview, searchOptionsForSelection } from "./SearchPage";
 import type { AgentSummary } from "../../runtime/types";
 
 function agent(id: string): AgentSummary {
@@ -40,6 +40,13 @@ describe("searchOptionsForSelection", () => {
       includeAllWorkspaces: false,
       limit: 20,
     });
+  });
+});
+
+describe("canSearchSelection", () => {
+  it("waits for visible agents before searching the All agents option", () => {
+    expect(canSearchSelection("all", [])).toBe(false);
+    expect(canSearchSelection("all", [agent("holon-pm")])).toBe(true);
   });
 });
 

--- a/web-gui/app/src/features/search/SearchPage.tsx
+++ b/web-gui/app/src/features/search/SearchPage.tsx
@@ -66,6 +66,7 @@ export function SearchPage({
   useEffect(() => {
     const initialQuery = readInitialQuery();
     if (!initialQuery || search || loading) return;
+    if (!canSearchSelection("all", agents)) return;
     void onSearch(initialQuery, searchOptionsForSelection("all", agents, limit));
   }, [agents, limit, loading, onSearch, search]);
 
@@ -109,7 +110,7 @@ export function SearchPage({
             <span>Limit</span>
             <input value={limit} inputMode="numeric" onChange={(event) => setLimit(event.target.value)} />
           </label>
-          <Button type="submit" variant="accent" disabled={!trimmedQuery || loading}>
+          <Button type="submit" variant="accent" disabled={!trimmedQuery || loading || !canSearchSelection(agentId, agents)}>
             {loading ? "Searching…" : "Search"}
           </Button>
         </form>
@@ -458,4 +459,9 @@ export function searchOptionsForSelection(agentId: string, agents: AgentSummary[
     includeAllWorkspaces: agentId === "all",
     limit: numberFromInput(limit, DEFAULT_LIMIT),
   };
+}
+
+export function canSearchSelection(agentId: string, agents: AgentSummary[]): boolean {
+  if (agentId !== "all") return Boolean(agentId.trim());
+  return agents.some((agent) => Boolean(agent.id.trim()));
 }

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -178,6 +178,43 @@ describe("createRuntimeClient", () => {
     expect(seen).toEqual(["http://example.test:7878/api/agents/agent%2Fone/tasks/task%2F42/output?block=false"]);
   });
 
+  it("fetches an agent event window with pagination parameters", async () => {
+    const seen: string[] = [];
+    const fetchImpl = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.endsWith("/agents/agent%2Fone/events?after_seq=739&limit=80&order=asc&max_level=info")) {
+        return Response.json({
+          events: [{ agent_id: "agent/one", event_seq: 740, ts: "2026-06-22T00:00:00Z", type: "message_enqueued" }],
+          has_older: true,
+          cursor_seq: 819,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(
+      client.getAgentEvents("agent/one", {
+        afterSeq: 739,
+        limit: 80,
+        order: "asc",
+        displayLevel: "info",
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        events: [expect.objectContaining({ event_seq: 740 })],
+        cursor_seq: 819,
+      }),
+    );
+    expect(seen).toEqual(["http://example.test:7878/api/agents/agent%2Fone/events?after_seq=739&limit=80&order=asc&max_level=info"]);
+  });
+
   it("posts runtime search filters for cross-agent all-workspace search", async () => {
     const seen: Array<{ url: string; body: unknown }> = [];
     const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/web-gui/app/src/runtime/runtime-store-helpers.ts
+++ b/web-gui/app/src/runtime/runtime-store-helpers.ts
@@ -33,6 +33,7 @@ export interface AgentSessionState {
   newestSeq?: number;
   oldestSeq?: number;
   hasOlder?: boolean;
+  targetEventSeq?: number;
   lastStreamActivityAt?: string;
   reconnectAttempt?: number;
   error?: string;

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -175,7 +175,7 @@ export interface RuntimeStoreState {
   sessionsByAgentId: Record<string, AgentSessionState>;
 
   setRoute: (route: RouteKey) => void;
-  openAgent: (agentId: string) => void;
+  openAgent: (agentId: string, targetEventSeq?: number) => void;
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
   setRightPanelOpen: (open: boolean) => void;
   showAgentOverview: (agentId?: string) => void;
@@ -593,12 +593,13 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   sessionsByAgentId: {},
 
   setRoute: (route) => set({ route }),
-  openAgent: (agentId) =>
+  openAgent: (agentId, targetEventSeq) =>
     set((state) => {
+      const currentSession = state.sessionsByAgentId[agentId];
       const rosterActivityByAgentId = markAgentRead(
         state.rosterActivityByAgentId,
         agentId,
-        state.sessionsByAgentId[agentId]?.newestSeq,
+        currentSession?.newestSeq,
       );
       if (rosterActivityByAgentId !== state.rosterActivityByAgentId) {
         writeStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig), rosterActivityByAgentId);
@@ -608,6 +609,18 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         route: "agent",
         displayLevel: state.displayLevelsByAgentId[agentId] ?? "info",
         rosterActivityByAgentId,
+        sessionsByAgentId:
+          targetEventSeq == null
+            ? state.sessionsByAgentId
+            : {
+                ...state.sessionsByAgentId,
+                [agentId]: {
+                  ...emptyAgentSession(),
+                  ...currentSession,
+                  targetEventSeq,
+                  historyError: undefined,
+                },
+              },
       };
     }),
   setDisplayLevel: (displayLevel, agentId) =>
@@ -972,6 +985,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     try {
       const detail = await runtimeClient.getAgentDetail(agentId, displayLevel);
       set((state) => mergeAgentDetailIntoSession(state, agentId, detail));
+      await loadTargetAgentEventWindow(get, set, agentId, displayLevel);
       scheduleMessageHydration(get, set, agentId, displayLevel);
       scheduleTranscriptHydration(get, set, agentId, displayLevel);
       scheduleBriefHydration(get, set, agentId, displayLevel);
@@ -2730,6 +2744,56 @@ function mergeEventPageIntoSession(
       },
     },
   };
+}
+
+async function loadTargetAgentEventWindow(
+  get: () => RuntimeStoreState,
+  set: StoreSet,
+  agentId: string,
+  displayLevel: DisplayLevel,
+): Promise<void> {
+  const session = get().sessionsByAgentId[agentId];
+  const targetEventSeq = session?.targetEventSeq;
+  if (targetEventSeq == null || session?.eventsBySeq[targetEventSeq]) return;
+
+  set((state) => ({
+    sessionsByAgentId: {
+      ...state.sessionsByAgentId,
+      [agentId]: {
+        ...emptyAgentSession(),
+        ...state.sessionsByAgentId[agentId],
+        loadingOlder: true,
+        historyError: undefined,
+      },
+    },
+  }));
+
+  try {
+    const page = await runtimeClient.getAgentEvents(agentId, {
+      afterSeq: targetEventSeq - 1,
+      limit: 80,
+      order: "asc",
+      displayLevel,
+    });
+    set((state) =>
+      mergeEventPageIntoSession(state, agentId, page.events ?? [], page.oldest_seq, page.has_older, displayLevel, {
+        newestSeq: page.cursor_seq ?? page.newest_seq,
+        append: true,
+      }),
+    );
+  } catch (error) {
+    set((state) => ({
+      sessionsByAgentId: {
+        ...state.sessionsByAgentId,
+        [agentId]: {
+          ...emptyAgentSession(),
+          ...state.sessionsByAgentId[agentId],
+          loadingOlder: false,
+          historyError: error instanceof Error ? error.message : String(error),
+        },
+      },
+    }));
+  }
 }
 
 function eventsBySeq(events: StreamEventEnvelopeDto[]): Record<number, unknown> {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -1684,6 +1684,12 @@ code {
   align-self: flex-start;
 }
 
+.message.is-targeted {
+  border-radius: 16px;
+  outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  outline-offset: 6px;
+}
+
 .message.activity-message {
   align-self: flex-start;
   width: min(760px, 88%);


### PR DESCRIPTION
## Summary
- parse conversation route query params and carry event_seq into agent page state
- fetch an event-centered conversation window when event_seq is present
- highlight and scroll to the target event from search result links

## Verification
- npm test -- src/app/routes.test.ts src/runtime/client.test.ts src/features/agent/AgentPage.test.tsx
- npm run typecheck