### PR TITLE
fix: prioritize completed run-once final status

### DIFF
--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -259,30 +259,59 @@ pub async fn run_once_with_host(
                 .saturating_sub(baseline.total_model_rounds)
                 >= max
         });
+        let terminal_within_max_turns = request.max_turns.is_none_or(|max| {
+            state
+                .total_model_rounds
+                .saturating_sub(baseline.total_model_rounds)
+                <= max
+        });
 
+        let terminal_status = if foreground_idle && poll_view.turn_terminal_observed {
+            session.runtime.current_closure().await?.map(|closure| {
+                (
+                    match closure.outcome {
+                        ClosureOutcome::Completed => RunFinalStatus::Completed,
+                        ClosureOutcome::Continuable => RunFinalStatus::Waiting,
+                        ClosureOutcome::Failed => RunFinalStatus::Failed,
+                        ClosureOutcome::Waiting => RunFinalStatus::Waiting,
+                    },
+                    closure.waiting_reason,
+                )
+            })
+        } else {
+            None
+        };
+        let terminal_final_text_observed = state
+            .last_turn_terminal
+            .as_ref()
+            .filter(|record| record.turn_index > baseline.turn_index)
+            .and_then(|record| record.last_assistant_message.as_ref())
+            .is_some_and(|text| !text.trim().is_empty());
+
+        let waiting_for_active_tasks = request.wait_for_tasks && !active_new_task_ids.is_empty();
         let candidate_status = if poll_view.runtime_error && foreground_idle {
             Some((RunFinalStatus::Failed, None))
+        } else if terminal_within_max_turns
+            && (matches!(terminal_status, Some((RunFinalStatus::Failed, _)))
+                || (terminal_final_text_observed
+                    && matches!(terminal_status, Some((RunFinalStatus::Completed, _)))))
+        {
+            if waiting_for_active_tasks {
+                None
+            } else {
+                terminal_status
+            }
         } else if max_turns_hit && foreground_idle {
-            if request.wait_for_tasks && !active_new_task_ids.is_empty() {
+            if waiting_for_active_tasks {
                 None
             } else {
                 Some((RunFinalStatus::MaxTurnsExceeded, None))
             }
-        } else if foreground_idle && poll_view.turn_terminal_observed {
-            if request.wait_for_tasks && !active_new_task_ids.is_empty() {
+        } else if terminal_status.is_some() {
+            if waiting_for_active_tasks {
                 None
             } else {
-                session.runtime.current_closure().await?.map(|closure| {
-                    (
-                        match closure.outcome {
-                            ClosureOutcome::Completed => RunFinalStatus::Completed,
-                            ClosureOutcome::Continuable => RunFinalStatus::Waiting,
-                            ClosureOutcome::Failed => RunFinalStatus::Failed,
-                            ClosureOutcome::Waiting => RunFinalStatus::Waiting,
-                        },
-                        closure.waiting_reason,
-                    )
-                })
+                terminal_status
             }
         } else {
             None

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -1143,7 +1143,56 @@ impl AgentProvider for TwoRoundProvider {
 }
 
 #[tokio::test]
-async fn run_once_enforces_soft_max_turns_boundary() -> Result<()> {
+async fn run_once_reports_completed_when_final_result_is_below_max_turns() -> Result<()> {
+    let home_dir = tempdir()?.keep();
+    let workspace_dir = tempdir()?.keep();
+    let host = RuntimeHost::new_with_provider(
+        test_config(workspace_dir, home_dir),
+        Arc::new(StubProvider::new("stub result")),
+    )?;
+
+    let response = run_once_with_host(
+        host,
+        RunOnceRequest {
+            max_turns: Some(2),
+            ..run_request("hello")
+        },
+    )
+    .await?;
+
+    assert_eq!(response.final_status, RunFinalStatus::Completed);
+    assert_eq!(response.final_text, "stub result");
+    assert_eq!(response.model_rounds, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_once_reports_completed_when_final_result_lands_on_max_turn_boundary() -> Result<()> {
+    let home_dir = tempdir()?.keep();
+    let workspace_dir = tempdir()?.keep();
+    let host = RuntimeHost::new_with_provider(
+        test_config(workspace_dir, home_dir),
+        Arc::new(StubProvider::new("stub result")),
+    )?;
+
+    let response = run_once_with_host(
+        host,
+        RunOnceRequest {
+            max_turns: Some(1),
+            ..run_request("hello")
+        },
+    )
+    .await?;
+
+    assert_eq!(response.final_status, RunFinalStatus::Completed);
+    assert_eq!(response.final_text, "stub result");
+    assert_eq!(response.model_rounds, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn run_once_reports_completed_when_final_text_arrives_after_last_allowed_model_round(
+) -> Result<()> {
     let home_dir = tempdir()?.keep();
     let workspace_dir = tempdir()?.keep();
     let host = RuntimeHost::new_with_provider(
@@ -1154,13 +1203,14 @@ async fn run_once_enforces_soft_max_turns_boundary() -> Result<()> {
     let response = run_once_with_host(
         host,
         RunOnceRequest {
-            max_turns: Some(1),
+            max_turns: Some(2),
             ..run_request("two round prompt")
         },
     )
     .await?;
 
-    assert_eq!(response.final_status, RunFinalStatus::MaxTurnsExceeded);
+    assert_eq!(response.final_status, RunFinalStatus::Completed);
+    assert_eq!(response.final_text, "two rounds complete");
     assert_eq!(response.model_rounds, 2);
     Ok(())
 }


### PR DESCRIPTION
Fixes #1914

## Summary
- let run_once report completed/failed terminal status before max_turns_exceeded when the terminal turn lands within the max_turns limit
- keep max_turns_exceeded for runs that only finish after exceeding the limit or while waiting for spawned tasks
- add run_once regression coverage for below-limit and exact-boundary completed results

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test --test run_once run_once_reports_completed_when_final
- cargo test --test run_once run_once_max_turns_respects_wait_for_command_tasks