### PR TITLE
chore: prepare v0.19.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,15 +107,18 @@ jobs:
 
           This line is intentionally breaking relative to the old Go-line releases. If you need the old Go implementation, stay on \`v0.12.0\`.
 
-          This patch release restores the \`xiaomi-token-plan\` provider alias, fixes inline brief hydration in the TUI, and adds docs for recently added Web GUI and runtime diagnostics features.
+          This patch release improves memory indexing and search, hardens GitHub Action event handling, fixes model discovery refresh behavior, and corrects several runtime lifecycle edge cases.
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
 
           ## Changes
 
-          - Restore the \`xiaomi-token-plan\` provider with its own base URL and \`XIAOMI_TOKEN_PLAN_API_KEY\` environment variable ([#1890](https://github.com/holon-run/holon/pull/1890)).
-          - Fix TUI rendering for inline brief hydration so brief text can be displayed without an extra lookup ([#1889](https://github.com/holon-run/holon/pull/1889)).
-          - Add user-facing guides for the Web GUI, memory auto-load, child token usage, and performance diagnostics ([#1888](https://github.com/holon-run/holon/pull/1888)).
+          - Move Holon trigger orchestration into the GitHub Action so issue and PR automation can run with clearer event handling ([#1902](https://github.com/holon-run/holon/pull/1902)).
+          - Improve memory search excerpts and expandable source handling for clearer retrieval evidence ([#1907](https://github.com/holon-run/holon/pull/1907)).
+          - Index memory asynchronously and route rebuild/backfill work through the indexer for a more consistent memory maintenance path ([#1905](https://github.com/holon-run/holon/pull/1905), [#1915](https://github.com/holon-run/holon/pull/1915)).
+          - Refresh model discovery caches automatically and raise the unknown fallback prompt budget to reduce stale or undersized model-selection context ([#1909](https://github.com/holon-run/holon/pull/1909), [#1910](https://github.com/holon-run/holon/pull/1910)).
+          - Harden Holon Action behavior for cross-repo pull requests, active model reporting, and GitHub CLI installation ([#1918](https://github.com/holon-run/holon/pull/1918), [#1919](https://github.com/holon-run/holon/pull/1919), [#1920](https://github.com/holon-run/holon/pull/1920)).
+          - Fix runtime continuation and resume edge cases around stale work-item waits, legacy null message sequence values, conversation event sequence links, and completed \`run_once\` final status precedence ([#1898](https://github.com/holon-run/holon/pull/1898), [#1899](https://github.com/holon-run/holon/pull/1899), [#1921](https://github.com/holon-run/holon/pull/1921), [#1924](https://github.com/holon-run/holon/pull/1924)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Current release
 
 The current recommended release is
-[`v0.19.1`](https://github.com/holon-run/holon/releases/tag/v0.19.1).
+[`v0.19.2`](https://github.com/holon-run/holon/releases/tag/v0.19.2).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project will maintain
 compatibility for the CLI, daemon/API semantics, and local persistent storage.
 
 See the full changes in the
-[v0.19.1 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.19.1).
+[v0.19.2 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.19.2).
 
 ## Status and compatibility
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -100,7 +100,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.19.1`](https://github.com/holon-run/holon/releases/tag/v0.19.1).
+[`v0.19.2`](https://github.com/holon-run/holon/releases/tag/v0.19.2).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -4394,7 +4394,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.19.1"
+    "version": "0.19.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -578,17 +578,31 @@ async fn collect_run_poll_view(
 ) -> Result<RunPollView> {
     let events = runtime.all_events()?;
     let latest_tasks = runtime.latest_task_records_snapshot().await?;
+    let new_tools = runtime
+        .all_tool_executions()?
+        .into_iter()
+        .filter(|tool| !baseline.tool_ids.contains(&tool.id))
+        .collect::<Vec<_>>();
     let runtime_error = events
         .iter()
         .rev()
         .take_while(|event| !baseline.event_ids.contains(&event.id))
         .any(|event| event.kind == "runtime_error");
 
-    let new_task_ids = latest_tasks
+    let mut new_task_ids = latest_tasks
         .iter()
         .filter(|task| !baseline.task_ids.contains(&task.id))
         .map(|task| task.id.clone())
-        .collect();
+        .collect::<Vec<_>>();
+    new_task_ids.extend(new_tools.iter().filter_map(exec_command_task_id));
+    new_task_ids.extend(
+        events
+            .iter()
+            .filter(|event| !baseline.event_ids.contains(&event.id))
+            .filter_map(run_event_task_id),
+    );
+    new_task_ids.sort();
+    new_task_ids.dedup();
 
     let activity_signature = PollActivitySignature {
         storage_marker,
@@ -623,6 +637,11 @@ async fn collect_run_view(
         .into_iter()
         .filter(|message| !baseline.message_ids.contains(&message.id))
         .collect::<Vec<_>>();
+    let new_events = runtime
+        .all_events()?
+        .into_iter()
+        .filter(|event| !baseline.event_ids.contains(&event.id))
+        .collect::<Vec<_>>();
     let mut task_ids = observed_task_ids.clone();
     task_ids.extend(new_messages.iter().filter_map(message_task_id));
 
@@ -632,6 +651,7 @@ async fn collect_run_view(
         .filter(|tool| !baseline.tool_ids.contains(&tool.id))
         .collect::<Vec<_>>();
     task_ids.extend(new_tools.iter().filter_map(exec_command_task_id));
+    task_ids.extend(new_events.iter().filter_map(run_event_task_id));
 
     let mut tasks_by_id = runtime
         .latest_task_records_snapshot()
@@ -653,11 +673,6 @@ async fn collect_run_view(
         .filter(|task| !baseline.task_ids.contains(&task.id))
         .collect::<Vec<_>>();
     new_tasks.sort_by(|left, right| left.created_at.cmp(&right.created_at));
-    let new_events = runtime
-        .all_events()?
-        .into_iter()
-        .filter(|event| !baseline.event_ids.contains(&event.id))
-        .collect::<Vec<_>>();
     Ok(RunView {
         new_tasks,
         new_tools,
@@ -687,6 +702,49 @@ fn exec_command_task_id(tool: &ToolExecutionRecord) -> Option<String> {
         .and_then(|value| value.get("task_id"))
         .and_then(|value| value.as_str())
         .map(ToString::to_string)
+}
+
+fn exec_command_event_task_id(event: &AuditEvent) -> Option<String> {
+    if event.kind != "tool_executed"
+        || event.data.get("tool_name").and_then(|value| value.as_str()) != Some("ExecCommand")
+        || event
+            .data
+            .get("status")
+            .and_then(|value| value.as_str())
+            .is_some_and(|status| status != "success")
+    {
+        return None;
+    }
+
+    event
+        .data
+        .get("task_handle")
+        .and_then(|value| value.get("task_id"))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+}
+
+fn process_execution_event_task_id(event: &AuditEvent) -> Option<String> {
+    if event.kind != "process_execution_requested"
+        || event.data.get("surface").and_then(|value| value.as_str()) != Some("command_task")
+        || event
+            .data
+            .get("promoted_from_exec_command")
+            .and_then(|value| value.as_bool())
+            != Some(true)
+    {
+        return None;
+    }
+
+    event
+        .data
+        .get("task_id")
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+}
+
+fn run_event_task_id(event: &AuditEvent) -> Option<String> {
+    exec_command_event_task_id(event).or_else(|| process_execution_event_task_id(event))
 }
 
 fn exec_command_result_value(output: &serde_json::Value) -> Option<&serde_json::Value> {
@@ -1467,6 +1525,27 @@ mod tests {
         };
 
         assert_eq!(exec_command_task_id(&tool), Some("task-promoted".into()));
+    }
+
+    #[test]
+    fn exec_command_event_task_id_reads_tool_executed_task_handle() {
+        let event = AuditEvent::new(
+            "tool_executed",
+            json!({
+                "tool_name": "ExecCommand",
+                "status": "success",
+                "task_handle": {
+                    "task_id": "task-promoted",
+                    "task_kind": "command_task",
+                    "status": "running"
+                }
+            }),
+        );
+
+        assert_eq!(
+            exec_command_event_task_id(&event),
+            Some("task-promoted".into())
+        );
     }
 
     #[test]

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -36,8 +36,10 @@ const INPUT_CHANNEL_CAPACITY: usize = 16;
 const STREAM_TAIL_CHAR_LIMIT: usize = 128_000;
 const COMBINED_TAIL_CHAR_LIMIT: usize = 256_000;
 const PROCESS_STATUS_POLL_INTERVAL: Duration = Duration::from_millis(25);
-// After the main process exits, cap output drain so background pipe-holders cannot block forever.
-const COLLECT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+// After the main process exits, only give readers a short grace period to
+// deliver already-buffered output. Background children may inherit stdout/stderr
+// and keep the pipes open long after the foreground command has completed.
+const COLLECT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub(super) enum ManagedTaskHandle {
     Async(JoinHandle<()>),
@@ -239,6 +241,18 @@ impl RuntimeHandle {
         }
         let mut running = self.start_command_process(&resolved).await?;
         let mut captured = CapturedOutput::default();
+        if spec.yield_time_ms == 0 {
+            return self
+                .promote_exec_command_to_task(
+                    spec,
+                    resolved,
+                    running,
+                    authority_class.clone(),
+                    captured,
+                    diagnostics,
+                )
+                .await;
+        }
         let sleep = tokio::time::sleep(Duration::from_millis(spec.yield_time_ms));
         let mut status_tick = tokio::time::interval(PROCESS_STATUS_POLL_INTERVAL);
         status_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -270,46 +284,69 @@ impl RuntimeHandle {
                     }
                 }
                 _ = &mut sleep => {
-                    if let Some(status) = running
-                        .process
-                        .try_status()
-                        .await
-                        .context("failed to query command status")?
-                    {
-                        collect_remaining_output(&mut running, &mut captured).await;
-                        return self
-                            .complete_exec_command_result(
-                                &captured,
-                                &status,
-                                spec.max_output_tokens,
-                                Some(diagnostics.clone()),
-                            )
-                            .await;
+                    if spec.yield_time_ms > 0 {
+                        if let Some(status) = running
+                            .process
+                            .try_status()
+                            .await
+                            .context("failed to query command status")?
+                        {
+                            collect_remaining_output(&mut running, &mut captured).await;
+                            return self
+                                .complete_exec_command_result(
+                                    &captured,
+                                    &status,
+                                    spec.max_output_tokens,
+                                    Some(diagnostics.clone()),
+                                )
+                                .await;
+                        }
                     }
-                    let task = self
-                        .register_command_task(
-                            format!("Run command: {}", truncate_text(&spec.cmd, 80)),
+                    return self
+                        .promote_exec_command_to_task(
+                            spec,
                             resolved,
                             running,
                             authority_class.clone(),
-                            true,
-                            captured.clone(),
+                            captured,
+                            diagnostics,
                         )
-                        .await?;
-                    let (initial_output_preview, initial_output_truncated) =
-                        captured.initial_output_with_flag(spec.max_output_tokens);
-                    return Ok(ExecCommandResult {
-                        outcome: ExecCommandOutcome::PromotedToTask {
-                            task_handle: TaskHandle::from_task_record(&task, None),
-                            initial_output_preview,
-                            initial_output_truncated,
-                        },
-                        summary_text: Some("command promoted to a managed task".to_string()),
-                        command_diagnostics: Some(diagnostics),
-                    });
+                        .await;
                 }
             }
         }
+    }
+
+    async fn promote_exec_command_to_task(
+        &self,
+        spec: CommandTaskSpec,
+        resolved: ResolvedCommandTask,
+        running: RunningCommand,
+        authority_class: AuthorityClass,
+        captured: CapturedOutput,
+        diagnostics: CommandCostDiagnostics,
+    ) -> Result<ExecCommandResult> {
+        let task = self
+            .register_command_task(
+                format!("Run command: {}", truncate_text(&spec.cmd, 80)),
+                resolved,
+                running,
+                authority_class,
+                true,
+                captured.clone(),
+            )
+            .await?;
+        let (initial_output_preview, initial_output_truncated) =
+            captured.initial_output_with_flag(spec.max_output_tokens);
+        Ok(ExecCommandResult {
+            outcome: ExecCommandOutcome::PromotedToTask {
+                task_handle: TaskHandle::from_task_record(&task, None),
+                initial_output_preview,
+                initial_output_truncated,
+            },
+            summary_text: Some("command promoted to a managed task".to_string()),
+            command_diagnostics: Some(diagnostics),
+        })
     }
 
     pub(crate) async fn execute_exec_command_once(

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -853,7 +853,7 @@ impl AgentProvider for CommandTaskProvider {
                     input: json!({
                         "cmd": &self.cmd,
                         "shell": "sh",
-                        "yield_time_ms": 10,
+                        "yield_time_ms": 0,
                         "login": false,
                         "tty": false,
                         "max_output_tokens": 256


### PR DESCRIPTION
## Summary
- Bump Holon to `0.19.2` across Cargo metadata, docs, OpenAPI metadata, and release workflow notes.
- Refresh the release notes for changes since `v0.19.1`.
- Harden release-blocking runtime edges found during local full verification: `ExecCommand` immediate promotion, command-task output drain, and `run_once` task discovery from audit events.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `cargo test --all-targets`
- Targeted regressions while fixing release-blocking failures:
  - `cargo test --test runtime_tasks exec_command_batch_does_not_wait_for_background_pipe_holders`
  - `cargo test --test run_once command_tasks`
  - `cargo test --test run_once run_once_waits_for_command_tasks_by_default -- --nocapture`
  - `cargo test --test run_once run_once_no_wait_allows_short_command_tasks_to_finish_during_quiescence`
