### PR TITLE
fix: default Holon action to release binary

### DIFF
--- a/.github/workflows/holon-solve.yml
+++ b/.github/workflows/holon-solve.yml
@@ -52,7 +52,7 @@ on:
         description: Build Holon from source.
         required: false
         type: boolean
-        default: true
+        default: false
       holon_repository:
         description: Holon repository for source builds.
         required: false

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ inputs:
   build_from_source:
     description: Build Holon from source before running.
     required: false
-    default: 'true'
+    default: 'false'
   holon_repository:
     description: Holon repository for source builds.
     required: false


### PR DESCRIPTION
## Summary
- change the composite action build_from_source default to false
- change the reusable holon-solve workflow build_from_source default to false
- keep explicit build_from_source: true as the opt-in source build path

## Verification
- python YAML parse for action.yml and .github/workflows/holon-solve.yml
- actionlint .github/workflows/holon-solve.yml
- git diff --check

## Compatibility
Existing callers that explicitly set build_from_source: true keep building from source. Callers that omit the input now download the configured release binary instead of compiling Holon.