### PR TITLE
feat: add SkillsRegistry refresh support

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -5863,6 +5863,54 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
+    "/api/skills/catalog": {
+      "get": {
+        "description": "Return the precedence-resolved skills catalog. Query parameters: agent_id, scope.",
+        "operationId": "skillsCatalog",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Skills catalog",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
     "/briefs": {
       "get": {
         "description": "Compatibility alias for the default agent briefs route. Query parameter: limit.",

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -73,6 +73,7 @@ pub(crate) use crate::{
     },
     policy::{default_authority_for_origin, validate_message_kind_for_origin},
     runtime::{CurrentRunAbortError, CurrentRunAbortMode, CurrentRunAbortRequest},
+    skills::registry::SkillsRegistry,
     storage::EventLogPageOrder,
     system::{ExecutionScopeKind, HostLocalBoundary},
     types::{
@@ -164,6 +165,7 @@ pub struct AppState {
     pub runtime_service: Option<RuntimeServiceHandle>,
     pub advertise_url: Option<String>,
     pub web_dist: Option<Arc<PathBuf>>,
+    pub skills_registry: Arc<tokio::sync::RwLock<SkillsRegistry>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -228,6 +230,7 @@ impl AppState {
             runtime_service,
             advertise_url: None,
             web_dist: None,
+            skills_registry: Arc::new(tokio::sync::RwLock::new(SkillsRegistry::new())),
         }
     }
 
@@ -246,6 +249,7 @@ impl AppState {
             runtime_service,
             advertise_url: None,
             web_dist: None,
+            skills_registry: Arc::new(tokio::sync::RwLock::new(SkillsRegistry::new())),
         }
     }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -108,7 +108,7 @@ pub use agents::*;
 pub use control::*;
 pub use events::{events, events_stream, global_events_stream, message, messages_batch_get};
 pub use ingress::{callback_ingress_enqueue, callback_ingress_wake, generic_webhook};
-pub use skills::{install_skill, list_skills, uninstall_skill};
+pub use skills::{install_skill, list_skills, skills_catalog, uninstall_skill};
 pub use state::{
     agent_state, brief, briefs, briefs_default, enqueue, enqueue_default, state_default, status,
     status_default, transcript, transcript_batch_get, transcript_default, transcript_entry,
@@ -447,6 +447,7 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/enqueue", post(state::enqueue_default))
         .route("/agents/{agent_id}/skills", get(skills::list_skills))
+        .route("/api/skills/catalog", get(skills::skills_catalog))
         .route(
             "/control/agents/{agent_id}/skills/install",
             post(skills::install_skill),

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::types::SkillRootRegistration;
+use axum::extract::Query;
 
 pub async fn list_skills(
     Path(agent_id): Path<String>,
@@ -81,5 +83,39 @@ pub async fn uninstall_skill(
         "ok": true,
         "agent_id": agent_id,
         "skill_name": request.name,
+    })))
+}
+
+pub async fn skills_catalog(
+    Query(params): Query<std::collections::HashMap<String, String>>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+
+    let scope_filter = params.get("scope").and_then(|s| match s.as_str() {
+        "agent" => Some(crate::types::SkillScope::Agent),
+        "workspace" => Some(crate::types::SkillScope::Workspace),
+        "user" => Some(crate::types::SkillScope::User),
+        _ => None,
+    });
+
+    let user_home = crate::agent_template::user_home_dir().ok();
+    let mut registry = crate::skills::registry::SkillsRegistry::new();
+
+    let root = SkillRootRegistration {
+        source_kind: crate::types::SkillRootSourceKind::UserGlobal,
+        owner_agent_id: None,
+        root_path: user_home.clone().unwrap_or_default().join(".agents/skills"),
+        scan_status: crate::types::SkillRootScanStatus::NeverScanned,
+        watch_status: crate::types::SkillRootWatchStatus::NotWatched,
+    };
+    registry.register_root(root).map_err(error_response)?;
+
+    let catalog = registry.catalog_with_filter(scope_filter);
+    Ok(Json(json!({
+        "ok": true,
+        "catalog": catalog,
+        "scope": scope_filter,
     })))
 }

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -1,6 +1,9 @@
 use super::*;
-use crate::types::SkillRootRegistration;
+use crate::types::{
+    SkillRootRegistration, SkillRootScanStatus, SkillRootSourceKind, SkillRootWatchStatus,
+};
 use axum::extract::Query;
+use std::path::PathBuf;
 
 pub async fn list_skills(
     Path(agent_id): Path<String>,
@@ -100,22 +103,75 @@ pub async fn skills_catalog(
         _ => None,
     });
 
-    let user_home = crate::agent_template::user_home_dir().ok();
-    let mut registry = crate::skills::registry::SkillsRegistry::new();
+    let agent_id = params.get("agent_id").cloned();
+    let mut roots = Vec::new();
+    if let Some(user_home) = crate::agent_template::user_home_dir().ok() {
+        for root in crate::skills::existing_skill_roots(
+            Some(&user_home),
+            &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
+        ) {
+            roots.push(skill_root_registration(
+                SkillRootSourceKind::UserGlobal,
+                None,
+                root,
+            ));
+        }
+    }
 
-    let root = SkillRootRegistration {
-        source_kind: crate::types::SkillRootSourceKind::UserGlobal,
-        owner_agent_id: None,
-        root_path: user_home.clone().unwrap_or_default().join(".agents/skills"),
-        scan_status: crate::types::SkillRootScanStatus::NeverScanned,
-        watch_status: crate::types::SkillRootWatchStatus::NotWatched,
-    };
-    registry.register_root(root).map_err(error_response)?;
+    if let Some(agent_id) = agent_id.as_deref() {
+        let runtime = state
+            .host
+            .get_public_agent(agent_id)
+            .await
+            .map_err(agent_access_error)?;
+        let agent_home = runtime.agent_home();
+        for root in crate::skills::existing_skill_roots(
+            Some(&agent_home),
+            &crate::skills::SKILL_ROOT_SUFFIXES,
+        ) {
+            roots.push(skill_root_registration(
+                SkillRootSourceKind::AgentHome,
+                Some(agent_id.to_string()),
+                root,
+            ));
+        }
+        let execution = runtime.execution_snapshot().await.map_err(error_response)?;
+        for root in crate::skills::existing_skill_roots(
+            Some(&execution.workspace_anchor),
+            &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
+        ) {
+            roots.push(skill_root_registration(
+                SkillRootSourceKind::Workspace,
+                None,
+                root,
+            ));
+        }
+    }
 
+    let mut registry = state.skills_registry.write().await;
+    for root in roots {
+        registry.register_root(root).map_err(error_response)?;
+    }
+    registry.rescan();
     let catalog = registry.catalog_with_filter(scope_filter);
     Ok(Json(json!({
         "ok": true,
+        "agent_id": agent_id,
         "catalog": catalog,
         "scope": scope_filter,
     })))
+}
+
+fn skill_root_registration(
+    source_kind: SkillRootSourceKind,
+    owner_agent_id: Option<String>,
+    root_path: PathBuf,
+) -> SkillRootRegistration {
+    SkillRootRegistration {
+        source_kind,
+        owner_agent_id,
+        root_path,
+        scan_status: SkillRootScanStatus::NeverScanned,
+        watch_status: SkillRootWatchStatus::NotWatched,
+    }
 }

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -91,6 +91,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List skills", "Return installed skills for an agent.", None, AuthKind::RemoteAccess),
+    route("get", "/api/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the precedence-resolved skills catalog. Query parameters: agent_id, scope.", None, AuthKind::RemoteAccess),
     route_with_response("post", "/search", "runtimeSearch", "search", "Search runtime memory", "Search the same memory v2 index used by the agent MemorySearch tool.", Some("SearchRequest"), "SearchResponse", AuthKind::RemoteAccess),
     route_with_response("post", "/memory/get", "runtimeMemoryGet", "search", "Fetch runtime memory source", "Fetch exact bounded memory content by source_ref, matching the agent MemoryGet tool contract.", Some("MemoryGetRequest"), "MemoryGetResult", AuthKind::RemoteAccess),
     route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -16,13 +16,14 @@ use crate::types::{
 
 const SKILL_ENTRYPOINT: &str = "SKILL.md";
 const INSTALL_METADATA_FILENAME: &str = ".holon-skill-install.json";
-const SKILL_ROOT_SUFFIXES: [&str; 4] = [
+pub(crate) const SKILL_ROOT_SUFFIXES: [&str; 4] = [
     "skills",
     ".agents/skills",
     ".codex/skills",
     ".claude/skills",
 ];
-const COMPAT_SKILL_ROOT_SUFFIXES: [&str; 3] = [".agents/skills", ".codex/skills", ".claude/skills"];
+pub(crate) const COMPAT_SKILL_ROOT_SUFFIXES: [&str; 3] =
+    [".agents/skills", ".codex/skills", ".claude/skills"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkillVisibility {
@@ -119,7 +120,7 @@ fn select_skill_root(base: Option<&Path>, suffixes: &[&str]) -> Option<PathBuf> 
     None
 }
 
-fn existing_skill_roots(base: Option<&Path>, suffixes: &[&str]) -> Vec<PathBuf> {
+pub(crate) fn existing_skill_roots(base: Option<&Path>, suffixes: &[&str]) -> Vec<PathBuf> {
     let Some(base) = base else {
         return Vec::new();
     };

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -130,7 +130,7 @@ fn existing_skill_roots(base: Option<&Path>, suffixes: &[&str]) -> Vec<PathBuf> 
         .collect()
 }
 
-fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<SkillCatalogEntry>> {
+pub fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<SkillCatalogEntry>> {
     let mut entries = Vec::new();
     let read_dir = match fs::read_dir(root) {
         Ok(read_dir) => read_dir,

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -1,0 +1,4 @@
+pub mod base;
+pub mod registry;
+
+pub use base::*;

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -63,13 +63,17 @@ impl SkillsRegistry {
     }
 
     /// Rescan all registered roots and replace the complete registry snapshot.
-    pub fn rescan(&mut self) -> Result<()> {
-        let roots = self.roots.clone();
-        self.entries.clear();
-        for root in roots {
-            let _ = self.refresh_root(&root.root_path)?;
+    ///
+    /// Per-root scan failures are recorded on the root status and do not make
+    /// catalog reads fail.
+    pub fn rescan(&mut self) {
+        let mut next_entries = Vec::new();
+        for root in &mut self.roots {
+            let (entries, scan_status) = Self::scan_root(root);
+            next_entries.extend(entries);
+            root.scan_status = scan_status;
         }
-        Ok(())
+        self.entries = next_entries;
     }
 
     /// Record watcher setup or delivery failure without affecting catalog reads.
@@ -349,7 +353,7 @@ mod tests {
         assert_eq!(registry.catalog()[0].description, "agent");
 
         fs::remove_dir_all(agent_root.join("same")).unwrap();
-        registry.rescan().unwrap();
+        registry.rescan();
         assert_eq!(registry.catalog()[0].description, "user");
     }
 

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -1,0 +1,376 @@
+//! Skills registry: skill root registration and catalog management.
+//!
+//! This module implements a registry for skill discovery across multiple roots,
+//! supporting user-global, agent-local, and workspace-local skill sources.
+//! It maintains registration metadata and provides catalog views with scope filtering.
+
+use anyhow::Result;
+use chrono::Utc;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+use tracing::warn;
+
+use crate::types::{
+    SkillCatalogEntry, SkillRootRegistration, SkillRootScanStatus, SkillRootSourceKind,
+    SkillRootWatchStatus, SkillScope,
+};
+
+/// Read-only skills registry.
+///
+/// The registry maintains skill entries from registered roots and provides
+/// a catalog view with precedence resolution (agent > workspace > user).
+#[derive(Debug, Clone, Default)]
+pub struct SkillsRegistry {
+    roots: Vec<SkillRootRegistration>,
+    entries: Vec<SkillCatalogEntry>,
+}
+
+impl SkillsRegistry {
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a skill root and scan it for skills.
+    pub fn register_root(&mut self, registration: SkillRootRegistration) -> Result<()> {
+        if !registration.root_path.exists() {
+            return Ok(());
+        }
+
+        self.upsert_root(registration.clone());
+        self.refresh_root(&registration.root_path)?;
+        Ok(())
+    }
+
+    /// Refresh a single registered root, replacing that root's snapshot entries.
+    ///
+    /// Scan failures are recorded on the root and remove stale entries for that
+    /// root, but do not make the registry operation fail for catalog readers.
+    pub fn refresh_root(&mut self, root_path: &Path) -> Result<bool> {
+        let Some(root_index) = self.root_index(root_path) else {
+            return Ok(false);
+        };
+        let registration = self.roots[root_index].clone();
+        let (entries, scan_status) = Self::scan_root(&registration);
+
+        self.entries
+            .retain(|entry| !entry.path.starts_with(&registration.root_path));
+        self.entries.extend(entries);
+        self.roots[root_index].scan_status = scan_status;
+        Ok(true)
+    }
+
+    /// Rescan all registered roots and replace the complete registry snapshot.
+    pub fn rescan(&mut self) -> Result<()> {
+        let roots = self.roots.clone();
+        self.entries.clear();
+        for root in roots {
+            let _ = self.refresh_root(&root.root_path)?;
+        }
+        Ok(())
+    }
+
+    /// Record watcher setup or delivery failure without affecting catalog reads.
+    pub fn record_watcher_failure(
+        &mut self,
+        root_path: impl AsRef<Path>,
+        error: impl Into<String>,
+    ) -> bool {
+        let Some(root_index) = self.root_index(root_path.as_ref()) else {
+            return false;
+        };
+        let error = error.into();
+        warn!(
+            root = %self.roots[root_index].root_path.display(),
+            error = %error,
+            "skill root watcher failed; registry will rely on manual rescan"
+        );
+        self.roots[root_index].watch_status = SkillRootWatchStatus::Failed { error };
+        true
+    }
+
+    /// Mark a registered root as actively watched.
+    pub fn record_watcher_started(&mut self, root_path: impl AsRef<Path>) -> bool {
+        let Some(root_index) = self.root_index(root_path.as_ref()) else {
+            return false;
+        };
+        self.roots[root_index].watch_status = SkillRootWatchStatus::Watching;
+        true
+    }
+
+    fn upsert_root(&mut self, registration: SkillRootRegistration) {
+        if let Some(root_index) = self.root_index(&registration.root_path) {
+            self.roots[root_index] = registration;
+        } else {
+            self.roots.push(registration);
+        }
+    }
+
+    fn root_index(&self, root_path: &Path) -> Option<usize> {
+        let root_path = normalize_path(root_path);
+        self.roots
+            .iter()
+            .position(|root| normalize_path(&root.root_path) == root_path)
+    }
+
+    fn scan_root(
+        registration: &SkillRootRegistration,
+    ) -> (Vec<SkillCatalogEntry>, SkillRootScanStatus) {
+        let scope = match registration.source_kind {
+            SkillRootSourceKind::UserGlobal => SkillScope::User,
+            SkillRootSourceKind::AgentHome => SkillScope::Agent,
+            SkillRootSourceKind::Workspace => SkillScope::Workspace,
+        };
+
+        match crate::skills::load_catalog_for_scope(scope, &registration.root_path) {
+            Ok(entries) => (
+                entries,
+                SkillRootScanStatus::Scanned {
+                    at: Utc::now().timestamp(),
+                },
+            ),
+            Err(error) => (
+                Vec::new(),
+                SkillRootScanStatus::Failed {
+                    error: error.to_string(),
+                },
+            ),
+        }
+    }
+
+    /// Get the current catalog with precedence applied.
+    pub fn catalog(&self) -> Vec<SkillCatalogEntry> {
+        self.catalog_with_filter(None)
+    }
+
+    /// Get catalog filtered by optional scope.
+    pub fn catalog_with_filter(&self, scope: Option<SkillScope>) -> Vec<SkillCatalogEntry> {
+        let filtered: Vec<&SkillCatalogEntry> = if let Some(filter_scope) = scope {
+            self.entries
+                .iter()
+                .filter(|e| e.scope == filter_scope)
+                .collect()
+        } else {
+            self.entries.iter().collect()
+        };
+
+        let selected_by_name: BTreeMap<String, &SkillCatalogEntry> =
+            filtered
+                .into_iter()
+                .fold(BTreeMap::new(), |mut acc, entry| {
+                    let existing = acc.get(&entry.name);
+                    if existing.map_or(true, |existing| {
+                        self.skill_wins_catalog_selection(entry, existing)
+                    }) {
+                        acc.insert(entry.name.clone(), entry);
+                    }
+                    acc
+                });
+        selected_by_name.into_values().cloned().collect()
+    }
+
+    /// Get all registered roots.
+    pub fn roots(&self) -> &[SkillRootRegistration] {
+        &self.roots
+    }
+
+    fn skill_wins_catalog_selection(
+        &self,
+        candidate: &SkillCatalogEntry,
+        existing: &SkillCatalogEntry,
+    ) -> bool {
+        let candidate_precedence = self.skill_precedence(candidate.scope);
+        let existing_precedence = self.skill_precedence(existing.scope);
+        candidate_precedence > existing_precedence
+            || (candidate_precedence == existing_precedence
+                && (&candidate.skill_id, &candidate.path) < (&existing.skill_id, &existing.path))
+    }
+
+    fn skill_precedence(&self, scope: SkillScope) -> u8 {
+        match scope {
+            SkillScope::Agent => 3,
+            SkillScope::Workspace => 2,
+            SkillScope::User => 1,
+        }
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.components().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf};
+    use tempfile::TempDir;
+
+    fn registration(root_path: PathBuf, source_kind: SkillRootSourceKind) -> SkillRootRegistration {
+        SkillRootRegistration {
+            source_kind,
+            owner_agent_id: None,
+            root_path,
+            scan_status: SkillRootScanStatus::NeverScanned,
+            watch_status: SkillRootWatchStatus::NotWatched,
+        }
+    }
+
+    fn write_skill(root: &Path, dirname: &str, name: &str, description: &str) {
+        let skill_dir = root.join(dirname);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\n\nBody\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_registry_new() {
+        let registry = SkillsRegistry::new();
+        assert!(registry.catalog().is_empty());
+        assert!(registry.roots().is_empty());
+    }
+
+    #[test]
+    fn test_register_nonexistent_root() {
+        let mut registry = SkillsRegistry::new();
+        let result = registry.register_root(registration(
+            PathBuf::from("/nonexistent"),
+            SkillRootSourceKind::UserGlobal,
+        ));
+        assert!(result.is_ok());
+        assert!(registry.catalog().is_empty());
+        assert!(registry.roots().is_empty());
+    }
+
+    #[test]
+    fn test_catalog_precedence() {
+        let mut registry = SkillsRegistry::new();
+
+        registry.entries.push(SkillCatalogEntry {
+            skill_id: "user_skill".to_string(),
+            name: "test".to_string(),
+            description: "user".to_string(),
+            path: PathBuf::from("/user/test"),
+            scope: SkillScope::User,
+        });
+
+        registry.entries.push(SkillCatalogEntry {
+            skill_id: "agent_skill".to_string(),
+            name: "test".to_string(),
+            description: "agent".to_string(),
+            path: PathBuf::from("/agent/test"),
+            scope: SkillScope::Agent,
+        });
+
+        let catalog = registry.catalog();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].scope, SkillScope::Agent);
+        assert_eq!(catalog[0].description, "agent");
+    }
+
+    #[test]
+    fn test_catalog_with_filter() {
+        let mut registry = SkillsRegistry::new();
+
+        registry.entries.push(SkillCatalogEntry {
+            skill_id: "skill1".to_string(),
+            name: "skill_a".to_string(),
+            description: "agent".to_string(),
+            path: PathBuf::from("/a"),
+            scope: SkillScope::Agent,
+        });
+
+        registry.entries.push(SkillCatalogEntry {
+            skill_id: "skill2".to_string(),
+            name: "skill_b".to_string(),
+            description: "user".to_string(),
+            path: PathBuf::from("/b"),
+            scope: SkillScope::User,
+        });
+
+        let agent_catalog = registry.catalog_with_filter(Some(SkillScope::Agent));
+        assert_eq!(agent_catalog.len(), 1);
+        assert_eq!(agent_catalog[0].scope, SkillScope::Agent);
+    }
+
+    #[test]
+    fn refresh_root_replaces_snapshot_for_create_update_and_delete() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("skills");
+        fs::create_dir_all(&root).unwrap();
+        write_skill(&root, "demo", "demo", "first");
+
+        let mut registry = SkillsRegistry::new();
+        registry
+            .register_root(registration(root.clone(), SkillRootSourceKind::UserGlobal))
+            .unwrap();
+        assert_eq!(registry.catalog()[0].description, "first");
+
+        write_skill(&root, "demo", "demo", "updated");
+        assert!(registry.refresh_root(&root).unwrap());
+        assert_eq!(registry.catalog()[0].description, "updated");
+
+        fs::remove_dir_all(root.join("demo")).unwrap();
+        assert!(registry.refresh_root(&root).unwrap());
+        assert!(registry.catalog().is_empty());
+        assert!(matches!(
+            registry.roots()[0].scan_status,
+            SkillRootScanStatus::Scanned { .. }
+        ));
+    }
+
+    #[test]
+    fn rescan_rebuilds_all_registered_root_snapshots() {
+        let temp = TempDir::new().unwrap();
+        let user_root = temp.path().join("user");
+        let agent_root = temp.path().join("agent");
+        fs::create_dir_all(&user_root).unwrap();
+        fs::create_dir_all(&agent_root).unwrap();
+        write_skill(&user_root, "same", "same", "user");
+        write_skill(&agent_root, "same", "same", "agent");
+
+        let mut registry = SkillsRegistry::new();
+        registry
+            .register_root(registration(
+                user_root.clone(),
+                SkillRootSourceKind::UserGlobal,
+            ))
+            .unwrap();
+        registry
+            .register_root(registration(
+                agent_root.clone(),
+                SkillRootSourceKind::AgentHome,
+            ))
+            .unwrap();
+        assert_eq!(registry.catalog()[0].description, "agent");
+
+        fs::remove_dir_all(agent_root.join("same")).unwrap();
+        registry.rescan().unwrap();
+        assert_eq!(registry.catalog()[0].description, "user");
+    }
+
+    #[test]
+    fn watcher_failure_is_recorded_without_changing_catalog() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("skills");
+        fs::create_dir_all(&root).unwrap();
+        write_skill(&root, "demo", "demo", "available");
+
+        let mut registry = SkillsRegistry::new();
+        registry
+            .register_root(registration(root.clone(), SkillRootSourceKind::UserGlobal))
+            .unwrap();
+
+        assert!(registry.record_watcher_started(&root));
+        assert!(registry.record_watcher_failure(&root, "backend unavailable"));
+        assert_eq!(registry.catalog()[0].description, "available");
+        assert!(matches!(
+            registry.roots()[0].watch_status,
+            SkillRootWatchStatus::Failed { .. }
+        ));
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -5842,3 +5842,65 @@ mod tests {
         assert!(payload.get("apply_patch_result").is_none());
     }
 }
+
+/// Source kind of a skill root registration.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillRootSourceKind {
+    /// Global user library (~/.agents/skills).
+    UserGlobal,
+    /// Agent-local skills (agent_home/skills).
+    AgentHome,
+    /// Workspace-local skills (workspace/.agents/skills or workspace/.codex/skills).
+    Workspace,
+}
+
+/// Last scan status of a registered skill root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SkillRootScanStatus {
+    /// Root has never been scanned.
+    NeverScanned,
+    /// Last scan succeeded at the given timestamp.
+    Scanned { at: i64 },
+    /// Last scan failed with an error message.
+    Failed { error: String },
+}
+
+impl Default for SkillRootScanStatus {
+    fn default() -> Self {
+        Self::NeverScanned
+    }
+}
+
+/// Filesystem watcher status for a registered skill root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SkillRootWatchStatus {
+    /// No watcher has been started for this root.
+    NotWatched,
+    /// A watcher is active for this root.
+    Watching,
+    /// Watcher setup or delivery failed; manual rescan remains available.
+    Failed { error: String },
+}
+
+impl Default for SkillRootWatchStatus {
+    fn default() -> Self {
+        Self::NotWatched
+    }
+}
+/// A registered skill root with metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillRootRegistration {
+    pub source_kind: SkillRootSourceKind,
+    /// Owner agent id for agent-local roots; None for user-global or workspace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_agent_id: Option<String>,
+    /// Root path on disk.
+    pub root_path: PathBuf,
+    /// Last scan status.
+    #[serde(default)]
+    pub scan_status: SkillRootScanStatus,
+    /// Filesystem watcher status. Watch failures must not make catalog reads fail.
+    #[serde(default)]
+    pub watch_status: SkillRootWatchStatus,
+}

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -20,6 +20,7 @@ http_async_tests!(
     agent_state_route_scopes_work_items_to_requested_agent,
     agent_state_route_includes_bootstrap_projection_fields_when_present,
     list_skills_includes_all_agent_skill_roots,
+    skills_catalog_uses_shared_registry_with_agent_and_workspace_roots,
     install_skill_existing_destination_returns_conflict,
     control_agent_model_override_set_and_clear_updates_status,
     control_prompt_requires_bearer_token_when_required,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -72,7 +72,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 72, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 73, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -503,6 +503,22 @@
   },
   {
     "method": "get",
+    "path": "/api/skills/catalog",
+    "handler": "skills_catalog",
+    "operation_id": "skillsCatalog",
+    "tag": "skills",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/briefs",
     "handler": "briefs_default",
     "operation_id": "defaultBriefs",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -558,6 +558,59 @@ pub async fn list_skills_includes_all_agent_skill_roots() -> Result<()> {
     Ok(())
 }
 
+pub async fn skills_catalog_uses_shared_registry_with_agent_and_workspace_roots() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let agent_home = host.config().data_dir.join("agents/default");
+    let agent_skill_dir = agent_home.join("skills/agent-demo");
+    std::fs::create_dir_all(&agent_skill_dir)?;
+    std::fs::write(
+        agent_skill_dir.join("SKILL.md"),
+        "---\nname: shared-demo\ndescription: agent\n---\nbody",
+    )?;
+
+    let workspace_skill_dir = host
+        .config()
+        .workspace_dir
+        .join(".agents/skills/workspace-demo");
+    std::fs::create_dir_all(&workspace_skill_dir)?;
+    std::fs::write(
+        workspace_skill_dir.join("SKILL.md"),
+        "---\nname: workspace-demo\ndescription: workspace\n---\nbody",
+    )?;
+
+    let client = Client::new();
+    let payload: serde_json::Value = client
+        .get(format!("{base}/api/skills/catalog?agent_id=default"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let skills = payload["catalog"]
+        .as_array()
+        .expect("catalog should be an array");
+    assert!(skills
+        .iter()
+        .any(|skill| skill["name"] == "shared-demo" && skill["scope"] == "agent"));
+    assert!(skills
+        .iter()
+        .any(|skill| skill["name"] == "workspace-demo" && skill["scope"] == "workspace"));
+
+    std::fs::remove_dir_all(&agent_skill_dir)?;
+    let payload: serde_json::Value = client
+        .get(format!("{base}/api/skills/catalog?agent_id=default"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let skills = payload["catalog"]
+        .as_array()
+        .expect("catalog should be an array");
+    assert!(!skills.iter().any(|skill| skill["name"] == "shared-demo"));
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn install_skill_existing_destination_returns_conflict() -> Result<()> {
     let (_host, base, server) = spawn_server().await?;
     let client = Client::new();


### PR DESCRIPTION
## Summary

Fixes #1926.

This PR adds the `SkillsRegistry` refresh/rescan layer needed for skill root snapshots:

- splits `src/skills.rs` into `src/skills/base.rs` plus a new `src/skills/registry.rs` module
- adds registered skill root metadata (`source_kind`, `owner_agent_id`, scan status, watch status)
- supports refreshing one registered root and fully rescanning all roots
- records watcher start/failure state without breaking catalog reads
- exposes the current registry-backed catalog route shape at `/api/skills/catalog`

## Notes

The issue asks for runtime watcher registration and event delivery. This PR adds the registry-side contract and failure-state hooks; there is no existing filesystem watcher backend in this crate yet, so watcher setup/event delivery can be wired in a follow-up once that backend exists.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p holon --lib skills::registry`
- `cargo check --lib -p holon`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
