### PR TITLE
fix: compute effective agent skills from registry

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -34,7 +34,10 @@ use crate::{
     provider::{build_provider_from_config, AgentProvider},
     runtime::{InitialWorkspaceBinding, RuntimeHandle},
     runtime_db::RuntimeDb,
-    skills::{load_skills_runtime_view, SkillVisibility},
+    skills::{
+        effective_skill_root_registrations, skills_runtime_view_from_catalog, SkillVisibility,
+        SkillsRegistry,
+    },
     storage::{AppStorage, EventBus, PublishedAuditEvent},
     system::{ExecutionScopeKind, HostLocalBoundary, WorkspaceAccessMode},
     tool::{apply_patch::ApplyPatchSurface, ToolRegistry},
@@ -102,6 +105,7 @@ struct HostInner {
     registry: RuntimeRegistry,
     runtime_db: RuntimeDb,
     event_bus: EventBus,
+    skills_registry: Arc<RwLock<SkillsRegistry>>,
     static_provider: Option<Arc<dyn AgentProvider>>,
     agents: RwLock<HashMap<String, AgentEntry>>,
 }
@@ -200,6 +204,7 @@ impl RuntimeHost {
                 registry,
                 runtime_db,
                 event_bus: EventBus::new(1024),
+                skills_registry: Arc::new(RwLock::new(SkillsRegistry::new())),
                 static_provider,
                 agents: RwLock::new(HashMap::new()),
             }),
@@ -240,6 +245,10 @@ impl RuntimeHost {
 
     pub fn runtime_db(&self) -> &RuntimeDb {
         &self.inner.runtime_db
+    }
+
+    pub(crate) fn skills_registry(&self) -> Arc<RwLock<SkillsRegistry>> {
+        self.inner.skills_registry.clone()
     }
 
     pub fn agent_storage(&self, agent_id: &str) -> Result<AppStorage> {
@@ -921,16 +930,33 @@ impl RuntimeHost {
             crate::runtime::workspace::workspace_anchor_for_state_ref(&state),
         )?;
         let loaded_agent_memory = load_agent_memory(agent_home.as_path())?;
-        let mut skills = load_skills_runtime_view(
-            skill_visibility(&identity_view),
-            std::env::var_os("HOME").map(PathBuf::from).as_deref(),
+        let skill_visibility = skill_visibility(&identity_view);
+        let user_home = std::env::var_os("HOME").map(PathBuf::from);
+        let workspace_anchor = state
+            .active_workspace_entry
+            .as_ref()
+            .map(|entry| entry.workspace_anchor.as_path());
+        let skill_roots = effective_skill_root_registrations(
+            skill_visibility,
+            user_home.as_deref(),
+            &state.id,
             agent_home.as_path(),
-            state
-                .active_workspace_entry
-                .as_ref()
-                .map(|entry| entry.workspace_anchor.as_path()),
-            &state.active_skills,
-        )?;
+            workspace_anchor,
+        );
+        let mut skills = if let Ok(mut skill_registry) = self.inner.skills_registry.try_write() {
+            for root in skill_roots {
+                skill_registry.register_root(root)?;
+            }
+            skill_registry.rescan();
+            skills_runtime_view_from_catalog(skill_registry.catalog(), &state.active_skills)
+        } else {
+            let mut skill_registry = SkillsRegistry::new();
+            for root in skill_roots {
+                skill_registry.register_root(root)?;
+            }
+            skill_registry.rescan();
+            skills_runtime_view_from_catalog(skill_registry.catalog(), &state.active_skills)
+        };
         skills.agent_templates_catalog = discover_agent_templates_catalog(
             std::env::var_os("HOME").map(PathBuf::from).as_deref(),
             agent_home.as_path(),
@@ -1898,6 +1924,10 @@ impl RuntimeHostBridge {
 
     pub(crate) fn agent_storage(&self, agent_id: &str) -> Result<AppStorage> {
         self.host()?.agent_storage(agent_id)
+    }
+
+    pub(crate) fn skills_registry(&self) -> Result<Arc<RwLock<SkillsRegistry>>> {
+        Ok(self.host()?.skills_registry())
     }
 
     pub(crate) async fn identity_for_agent(

--- a/src/host.rs
+++ b/src/host.rs
@@ -944,18 +944,20 @@ impl RuntimeHost {
             workspace_anchor,
         );
         let mut skills = if let Ok(mut skill_registry) = self.inner.skills_registry.try_write() {
-            for root in skill_roots {
-                skill_registry.register_root(root)?;
-            }
-            skill_registry.rescan();
-            skills_runtime_view_from_catalog(skill_registry.catalog(), &state.active_skills)
+            skill_registry.replace_roots(skill_roots.clone())?;
+            skills_runtime_view_from_catalog(
+                skill_registry.catalog(),
+                &skill_roots,
+                &state.active_skills,
+            )
         } else {
             let mut skill_registry = SkillsRegistry::new();
-            for root in skill_roots {
-                skill_registry.register_root(root)?;
-            }
-            skill_registry.rescan();
-            skills_runtime_view_from_catalog(skill_registry.catalog(), &state.active_skills)
+            skill_registry.replace_roots(skill_roots.clone())?;
+            skills_runtime_view_from_catalog(
+                skill_registry.catalog(),
+                &skill_roots,
+                &state.active_skills,
+            )
         };
         skills.agent_templates_catalog = discover_agent_templates_catalog(
             std::env::var_os("HOME").map(PathBuf::from).as_deref(),

--- a/src/host.rs
+++ b/src/host.rs
@@ -835,7 +835,7 @@ impl RuntimeHost {
         Ok(snapshots)
     }
 
-    pub fn preview_public_agent_prompt(
+    pub async fn preview_public_agent_prompt(
         &self,
         agent_id: &str,
         text: String,
@@ -843,10 +843,11 @@ impl RuntimeHost {
     ) -> std::result::Result<EffectivePrompt, PublicAgentError> {
         let identity = self.public_agent_identity(agent_id)?;
         self.preview_agent_prompt_from_storage(&identity, text, authority_class)
+            .await
             .map_err(PublicAgentError::Runtime)
     }
 
-    pub fn preview_agent_prompt(
+    pub async fn preview_agent_prompt(
         &self,
         agent_id: &str,
         text: String,
@@ -874,6 +875,7 @@ impl RuntimeHost {
             return Err(anyhow!("agent {} is archived", agent_id));
         }
         self.preview_agent_prompt_from_storage(&identity, text, authority_class)
+            .await
     }
 
     pub fn public_agent_boundary_metadata(
@@ -885,7 +887,7 @@ impl RuntimeHost {
             .map_err(PublicAgentError::Runtime)
     }
 
-    fn preview_agent_prompt_from_storage(
+    async fn preview_agent_prompt_from_storage(
         &self,
         identity: &AgentIdentityRecord,
         text: String,
@@ -943,22 +945,13 @@ impl RuntimeHost {
             agent_home.as_path(),
             workspace_anchor,
         );
-        let mut skills = if let Ok(mut skill_registry) = self.inner.skills_registry.try_write() {
-            skill_registry.replace_roots(skill_roots.clone())?;
-            skills_runtime_view_from_catalog(
-                skill_registry.catalog(),
-                &skill_roots,
-                &state.active_skills,
-            )
-        } else {
-            let mut skill_registry = SkillsRegistry::new();
-            skill_registry.replace_roots(skill_roots.clone())?;
-            skills_runtime_view_from_catalog(
-                skill_registry.catalog(),
-                &skill_roots,
-                &state.active_skills,
-            )
-        };
+        let mut skill_registry = self.inner.skills_registry.write().await;
+        skill_registry.replace_roots(skill_roots.clone())?;
+        let mut skills = skills_runtime_view_from_catalog(
+            skill_registry.catalog(),
+            &skill_roots,
+            &state.active_skills,
+        );
         skills.agent_templates_catalog = discover_agent_templates_catalog(
             std::env::var_os("HOME").map(PathBuf::from).as_deref(),
             agent_home.as_path(),
@@ -2283,6 +2276,7 @@ mod tests {
                 "inspect prompt".into(),
                 AuthorityClass::OperatorInstruction,
             )
+            .await
             .unwrap();
 
         assert!(prompt.render_dump().contains("inspect prompt"));
@@ -2314,6 +2308,7 @@ mod tests {
                 "inspect prompt".into(),
                 AuthorityClass::OperatorInstruction,
             )
+            .await
             .unwrap();
 
         assert!(prompt.render_dump().contains("inspect prompt"));
@@ -2350,6 +2345,7 @@ mod tests {
                 "inspect prompt".into(),
                 AuthorityClass::OperatorInstruction,
             )
+            .await
             .unwrap();
         let rendered = prompt.render_dump();
 

--- a/src/http/control.rs
+++ b/src/http/control.rs
@@ -859,6 +859,7 @@ pub async fn control_debug_prompt(
     let dump = state
         .host
         .preview_public_agent_prompt(&agent_id, request.text.clone(), effective_trust.clone())
+        .await
         .map_err(agent_access_error)?
         .render_dump();
     Ok(Json(json!({

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -224,13 +224,14 @@ impl AppState {
         let require_control_token = host
             .config()
             .control_token_required(ControlTransportKind::Tcp);
+        let skills_registry = host.skills_registry();
         Self {
             host,
             require_control_token,
             runtime_service,
             advertise_url: None,
             web_dist: None,
-            skills_registry: Arc::new(tokio::sync::RwLock::new(SkillsRegistry::new())),
+            skills_registry,
         }
     }
 
@@ -243,13 +244,14 @@ impl AppState {
         runtime_service: Option<RuntimeServiceHandle>,
     ) -> Self {
         // Unix control is local IPC; filesystem permissions are the access boundary.
+        let skills_registry = host.skills_registry();
         Self {
             host,
             require_control_token: false,
             runtime_service,
             advertise_url: None,
             web_dist: None,
-            skills_registry: Arc::new(tokio::sync::RwLock::new(SkillsRegistry::new())),
+            skills_registry,
         }
     }
 

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -149,10 +149,7 @@ pub async fn skills_catalog(
     }
 
     let mut registry = state.skills_registry.write().await;
-    for root in roots {
-        registry.register_root(root).map_err(error_response)?;
-    }
-    registry.rescan();
+    registry.replace_roots(roots).map_err(error_response)?;
     let catalog = registry.catalog_with_filter(scope_filter);
     Ok(Json(json!({
         "ok": true,

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -1,9 +1,5 @@
 use super::*;
-use crate::types::{
-    SkillRootRegistration, SkillRootScanStatus, SkillRootSourceKind, SkillRootWatchStatus,
-};
 use axum::extract::Query;
-use std::path::PathBuf;
 
 pub async fn list_skills(
     Path(agent_id): Path<String>,
@@ -16,12 +12,18 @@ pub async fn list_skills(
         .get_public_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
-    let agent_home = runtime.agent_home();
-    let skills = crate::skills::list_installed_skills(&agent_home).map_err(error_response)?;
+    let identity = runtime
+        .agent_identity_view()
+        .await
+        .map_err(error_response)?;
+    let skills = runtime
+        .skills_runtime_view(&identity)
+        .await
+        .map_err(error_response)?;
     Ok(Json(json!({
         "ok": true,
         "agent_id": agent_id,
-        "skills": skills,
+        "skills": skills.discoverable_skills,
     })))
 }
 
@@ -104,48 +106,46 @@ pub async fn skills_catalog(
     });
 
     let agent_id = params.get("agent_id").cloned();
+    let user_home = crate::agent_template::user_home_dir().ok();
     let mut roots = Vec::new();
-    if let Some(user_home) = crate::agent_template::user_home_dir().ok() {
-        for root in crate::skills::existing_skill_roots(
-            Some(&user_home),
-            &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
-        ) {
-            roots.push(skill_root_registration(
-                SkillRootSourceKind::UserGlobal,
-                None,
-                root,
-            ));
-        }
-    }
-
     if let Some(agent_id) = agent_id.as_deref() {
         let runtime = state
             .host
             .get_public_agent(agent_id)
             .await
             .map_err(agent_access_error)?;
+        let identity = runtime
+            .agent_identity_view()
+            .await
+            .map_err(error_response)?;
         let agent_home = runtime.agent_home();
-        for root in crate::skills::existing_skill_roots(
-            Some(&agent_home),
-            &crate::skills::SKILL_ROOT_SUFFIXES,
-        ) {
-            roots.push(skill_root_registration(
-                SkillRootSourceKind::AgentHome,
-                Some(agent_id.to_string()),
-                root,
-            ));
-        }
         let execution = runtime.execution_snapshot().await.map_err(error_response)?;
-        for root in crate::skills::existing_skill_roots(
+        roots.extend(crate::skills::effective_skill_root_registrations(
+            if identity.kind == crate::types::AgentKind::Default {
+                crate::skills::SkillVisibility::DefaultAgent
+            } else {
+                crate::skills::SkillVisibility::NonDefaultAgent
+            },
+            user_home.as_deref(),
+            agent_id,
+            &agent_home,
             Some(&execution.workspace_anchor),
-            &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
-        ) {
-            roots.push(skill_root_registration(
-                SkillRootSourceKind::Workspace,
-                None,
-                root,
-            ));
-        }
+        ));
+    } else {
+        roots.extend(
+            crate::skills::existing_skill_roots(
+                user_home.as_deref(),
+                &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
+            )
+            .into_iter()
+            .map(|root| {
+                crate::skills::skill_root_registration(
+                    crate::types::SkillRootSourceKind::UserGlobal,
+                    None,
+                    root,
+                )
+            }),
+        );
     }
 
     let mut registry = state.skills_registry.write().await;
@@ -160,18 +160,4 @@ pub async fn skills_catalog(
         "catalog": catalog,
         "scope": scope_filter,
     })))
-}
-
-fn skill_root_registration(
-    source_kind: SkillRootSourceKind,
-    owner_agent_id: Option<String>,
-    root_path: PathBuf,
-) -> SkillRootRegistration {
-    SkillRootRegistration {
-        source_kind,
-        owner_agent_id,
-        root_path,
-        scan_status: SkillRootScanStatus::NeverScanned,
-        watch_status: SkillRootWatchStatus::NotWatched,
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -932,7 +932,9 @@ async fn dump_prompt(
 ) -> Result<()> {
     let host = RuntimeHost::new(config.clone())?;
     let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
-    let prompt = host.preview_agent_prompt(&agent, text, authority_class)?;
+    let prompt = host
+        .preview_agent_prompt(&agent, text, authority_class)
+        .await?;
     println!("{}", prompt.render_dump());
     Ok(())
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -76,8 +76,8 @@ use crate::{
     queue::RuntimeQueue,
     runtime_db::RuntimeDb,
     skills::{
-        find_skill_by_entrypoint, find_skill_by_script_path, load_skills_runtime_view,
-        SkillVisibility,
+        effective_skill_root_registrations, find_skill_by_entrypoint, find_skill_by_script_path,
+        skills_runtime_view_from_catalog, SkillVisibility,
     },
     storage::{to_json_value, AppStorage, PollActivityMarker},
     system::{
@@ -1076,23 +1076,40 @@ impl RuntimeHandle {
     ) -> Result<SkillsRuntimeView> {
         let guard = self.inner.agent.lock().await;
         self.skills_runtime_view_for_state(&guard.state, identity)
+            .await
     }
 
-    fn skills_runtime_view_for_state(
+    async fn skills_runtime_view_for_state(
         &self,
         state: &AgentState,
         identity: &AgentIdentityView,
     ) -> Result<SkillsRuntimeView> {
-        let mut view = load_skills_runtime_view(
+        let skill_roots = effective_skill_root_registrations(
             self.skill_visibility(identity),
             self.user_home().as_deref(),
+            &state.id,
             self.agent_home().as_path(),
             state
                 .active_workspace_entry
                 .as_ref()
                 .map(|entry| entry.workspace_anchor.as_path()),
-            &state.active_skills,
-        )?;
+        );
+        let mut view = if let Some(bridge) = self.inner.host_bridge.as_ref() {
+            let registry = bridge.skills_registry()?;
+            let mut registry = registry.write().await;
+            for root in skill_roots {
+                registry.register_root(root)?;
+            }
+            registry.rescan();
+            skills_runtime_view_from_catalog(registry.catalog(), &state.active_skills)
+        } else {
+            let mut registry = crate::skills::SkillsRegistry::new();
+            for root in skill_roots {
+                registry.register_root(root)?;
+            }
+            registry.rescan();
+            skills_runtime_view_from_catalog(registry.catalog(), &state.active_skills)
+        };
         view.agent_templates_catalog = discover_agent_templates_catalog(
             self.user_home().as_deref(),
             self.agent_home().as_path(),
@@ -1254,7 +1271,9 @@ impl RuntimeHandle {
             guard.state.clone()
         };
         let identity = self.agent_identity_view().await?;
-        let skills = self.skills_runtime_view_for_state(&state_snapshot, &identity)?;
+        let skills = self
+            .skills_runtime_view_for_state(&state_snapshot, &identity)
+            .await?;
         let Some(skill) = skill_for_activation_path(&skills.discoverable_skills, &resolved_path)
         else {
             return Ok(());
@@ -1320,7 +1339,9 @@ impl RuntimeHandle {
             guard.state.clone()
         };
         let identity = self.agent_identity_view().await?;
-        let skills = self.skills_runtime_view_for_state(&state_snapshot, &identity)?;
+        let skills = self
+            .skills_runtime_view_for_state(&state_snapshot, &identity)
+            .await?;
 
         for skill in skills.discoverable_skills {
             if let Some((activation_path, load_reason)) =

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1097,18 +1097,12 @@ impl RuntimeHandle {
         let mut view = if let Some(bridge) = self.inner.host_bridge.as_ref() {
             let registry = bridge.skills_registry()?;
             let mut registry = registry.write().await;
-            for root in skill_roots {
-                registry.register_root(root)?;
-            }
-            registry.rescan();
-            skills_runtime_view_from_catalog(registry.catalog(), &state.active_skills)
+            registry.replace_roots(skill_roots.clone())?;
+            skills_runtime_view_from_catalog(registry.catalog(), &skill_roots, &state.active_skills)
         } else {
             let mut registry = crate::skills::SkillsRegistry::new();
-            for root in skill_roots {
-                registry.register_root(root)?;
-            }
-            registry.rescan();
-            skills_runtime_view_from_catalog(registry.catalog(), &state.active_skills)
+            registry.replace_roots(skill_roots.clone())?;
+            skills_runtime_view_from_catalog(registry.catalog(), &skill_roots, &state.active_skills)
         };
         view.agent_templates_catalog = discover_agent_templates_catalog(
             self.user_home().as_deref(),

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -52,7 +52,9 @@ impl RuntimeHandle {
             );
             let loaded_agents_md = self.loaded_agents_md_for_state(&state)?;
             let loaded_agent_memory = self.loaded_agent_memory_for_state()?;
-            let skills = self.skills_runtime_view_for_state(&state, &identity)?;
+            let skills = self
+                .skills_runtime_view_for_state(&state, &identity)
+                .await?;
             build_effective_prompt_with_apply_patch_surface_and_default_external_ingress(
                 &self.inner.storage,
                 &state,
@@ -221,7 +223,9 @@ impl RuntimeHandle {
         let execution = self.execution_snapshot().await?;
         let loaded_agents_md = self.loaded_agents_md_for_state(&agent)?;
         let loaded_agent_memory = self.loaded_agent_memory_for_state()?;
-        let skills = self.skills_runtime_view_for_state(&agent, &identity)?;
+        let skills = self
+            .skills_runtime_view_for_state(&agent, &identity)
+            .await?;
         build_effective_prompt_with_apply_patch_surface_and_default_external_ingress(
             &self.inner.storage,
             &agent,
@@ -290,7 +294,9 @@ impl RuntimeHandle {
             lineage_parent_agent_id: None,
             delegated_from_task_id: None,
         };
-        let skills = self.skills_runtime_view_for_state(&state, &identity)?;
+        let skills = self
+            .skills_runtime_view_for_state(&state, &identity)
+            .await?;
         let continuation = ContinuationTrigger::from_message(&message, None).map(|trigger| {
             resolve_continuation(
                 &ClosureDecision {

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1,7 +1,8 @@
 use super::super::*;
 use super::support::*;
 use crate::types::{
-    AuthorityClass, QueueEntryStatus, SkillLoadReason, WaitConditionKind, WaitConditionRecord,
+    ActiveSkillRecord, AuthorityClass, QueueEntryStatus, SkillActivationSource,
+    SkillActivationState, SkillLoadReason, SkillScope, WaitConditionKind, WaitConditionRecord,
     WaitConditionStatus, WakeSource, WorkItemPlanStatus, WorkItemSchedulingState,
 };
 
@@ -2737,6 +2738,69 @@ async fn runtime_does_not_force_completion_after_post_verification_stagnation() 
         "unexpected final_text: {}",
         outcome.final_text
     );
+}
+
+#[tokio::test]
+async fn runtime_skills_view_filters_active_skills_to_effective_registry_snapshot() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let skill_dir = workspace.path().join(".agents/skills/demo");
+    let skill_path = skill_dir.join("SKILL.md");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        &skill_path,
+        "---\nname: demo\ndescription: demo skill\n---\nFollow the demo workflow.",
+    )
+    .unwrap();
+
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        Arc::new(StubProvider::new("done")),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+    runtime
+        .update_agent_state(|state| {
+            state.active_skills = vec![
+                ActiveSkillRecord {
+                    skill_id: "workspace:demo".into(),
+                    name: "demo".into(),
+                    path: skill_path.clone(),
+                    scope: SkillScope::Workspace,
+                    agent_id: "default".into(),
+                    activation_source: SkillActivationSource::ImplicitFromCatalog,
+                    activation_state: SkillActivationState::SessionActive,
+                    activated_at_turn: 1,
+                },
+                ActiveSkillRecord {
+                    skill_id: "agent:stale".into(),
+                    name: "stale".into(),
+                    path: dir.path().join("skills/stale/SKILL.md"),
+                    scope: SkillScope::Agent,
+                    agent_id: "default".into(),
+                    activation_source: SkillActivationSource::ImplicitFromCatalog,
+                    activation_state: SkillActivationState::SessionActive,
+                    activated_at_turn: 1,
+                },
+            ];
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    let identity = runtime.agent_identity_view().await.unwrap();
+    let skills = runtime.skills_runtime_view(&identity).await.unwrap();
+
+    assert!(skills
+        .discoverable_skills
+        .iter()
+        .any(|skill| skill.skill_id == "workspace:demo"));
+    assert_eq!(skills.active_skills.len(), 1);
+    assert_eq!(skills.active_skills[0].skill_id, "workspace:demo");
 }
 
 #[tokio::test]

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::types::{
-    ActiveSkillRecord, SkillCatalogEntry, SkillInstallMode, SkillRootView, SkillScope,
+    ActiveSkillRecord, SkillCatalogEntry, SkillInstallMode, SkillRootRegistration,
+    SkillRootScanStatus, SkillRootSourceKind, SkillRootView, SkillRootWatchStatus, SkillScope,
     SkillsRuntimeView,
 };
 
@@ -194,6 +195,107 @@ pub fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<Skil
         });
     }
     Ok(entries)
+}
+
+pub fn effective_skill_root_registrations(
+    visibility: SkillVisibility,
+    user_home: Option<&Path>,
+    agent_id: &str,
+    agent_home: &Path,
+    workspace_anchor: Option<&Path>,
+) -> Vec<SkillRootRegistration> {
+    let mut roots = Vec::new();
+    if matches!(visibility, SkillVisibility::DefaultAgent) {
+        roots.extend(
+            existing_skill_roots(user_home, &COMPAT_SKILL_ROOT_SUFFIXES)
+                .into_iter()
+                .map(|root_path| {
+                    skill_root_registration(SkillRootSourceKind::UserGlobal, None, root_path)
+                }),
+        );
+    }
+    roots.extend(
+        existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES)
+            .into_iter()
+            .map(|root_path| {
+                skill_root_registration(
+                    SkillRootSourceKind::AgentHome,
+                    Some(agent_id.to_string()),
+                    root_path,
+                )
+            }),
+    );
+    roots.extend(
+        existing_skill_roots(workspace_anchor, &COMPAT_SKILL_ROOT_SUFFIXES)
+            .into_iter()
+            .map(|root_path| {
+                skill_root_registration(SkillRootSourceKind::Workspace, None, root_path)
+            }),
+    );
+    roots
+}
+
+pub fn skills_runtime_view_from_catalog(
+    mut catalog: Vec<SkillCatalogEntry>,
+    active_skills: &[ActiveSkillRecord],
+) -> SkillsRuntimeView {
+    catalog.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.skill_id.cmp(&right.skill_id))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let active_skill_ids = catalog
+        .iter()
+        .map(|entry| entry.skill_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let active_skills = active_skills
+        .iter()
+        .filter(|record| active_skill_ids.contains(record.skill_id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    SkillsRuntimeView {
+        agent_templates_catalog: Vec::new(),
+        discovered_roots: collect_discovered_roots_from_catalog(&catalog),
+        discoverable_skills: catalog.clone(),
+        attached_skills: catalog,
+        active_skills,
+    }
+}
+
+fn collect_discovered_roots_from_catalog(entries: &[SkillCatalogEntry]) -> Vec<SkillRootView> {
+    let mut roots = entries
+        .iter()
+        .filter_map(|entry| {
+            let skill_dir = entry.path.parent()?;
+            let root = skill_dir.parent()?;
+            Some(SkillRootView {
+                scope: entry.scope,
+                path: root.to_path_buf(),
+            })
+        })
+        .collect::<Vec<_>>();
+    roots.sort_by(|left, right| {
+        skill_precedence(left.scope)
+            .cmp(&skill_precedence(right.scope))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    roots.dedup_by(|left, right| left.scope == right.scope && left.path == right.path);
+    roots
+}
+
+pub fn skill_root_registration(
+    source_kind: SkillRootSourceKind,
+    owner_agent_id: Option<String>,
+    root_path: PathBuf,
+) -> SkillRootRegistration {
+    SkillRootRegistration {
+        source_kind,
+        owner_agent_id,
+        root_path,
+        scan_status: SkillRootScanStatus::NeverScanned,
+        watch_status: SkillRootWatchStatus::NotWatched,
+    }
 }
 
 fn retain_highest_precedence_skills(skills: Vec<SkillCatalogEntry>) -> Vec<SkillCatalogEntry> {
@@ -1254,6 +1356,46 @@ mod tests {
         .unwrap();
 
         assert_eq!(view.active_skills.len(), 1);
+    }
+
+    #[test]
+    fn catalog_runtime_view_filters_active_skills_to_effective_catalog_snapshot() {
+        let visible_path = PathBuf::from("/agent/skills/demo/SKILL.md");
+        let view = skills_runtime_view_from_catalog(
+            vec![SkillCatalogEntry {
+                skill_id: "agent:demo".into(),
+                name: "demo".into(),
+                description: "visible".into(),
+                path: visible_path.clone(),
+                scope: SkillScope::Agent,
+            }],
+            &[
+                ActiveSkillRecord {
+                    skill_id: "agent:demo".into(),
+                    name: "demo".into(),
+                    path: visible_path,
+                    scope: SkillScope::Agent,
+                    agent_id: "default".into(),
+                    activation_source: SkillActivationSource::ImplicitFromCatalog,
+                    activation_state: SkillActivationState::SessionActive,
+                    activated_at_turn: 1,
+                },
+                ActiveSkillRecord {
+                    skill_id: "workspace:stale".into(),
+                    name: "stale".into(),
+                    path: PathBuf::from("/workspace/.agents/skills/stale/SKILL.md"),
+                    scope: SkillScope::Workspace,
+                    agent_id: "default".into(),
+                    activation_source: SkillActivationSource::ImplicitFromCatalog,
+                    activation_state: SkillActivationState::SessionActive,
+                    activated_at_turn: 1,
+                },
+            ],
+        );
+
+        assert_eq!(view.discoverable_skills.len(), 1);
+        assert_eq!(view.active_skills.len(), 1);
+        assert_eq!(view.active_skills[0].skill_id, "agent:demo");
     }
 
     #[test]

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -237,6 +237,7 @@ pub fn effective_skill_root_registrations(
 
 pub fn skills_runtime_view_from_catalog(
     mut catalog: Vec<SkillCatalogEntry>,
+    roots: &[SkillRootRegistration],
     active_skills: &[ActiveSkillRecord],
 ) -> SkillsRuntimeView {
     catalog.sort_by(|left, right| {
@@ -256,23 +257,26 @@ pub fn skills_runtime_view_from_catalog(
         .collect::<Vec<_>>();
     SkillsRuntimeView {
         agent_templates_catalog: Vec::new(),
-        discovered_roots: collect_discovered_roots_from_catalog(&catalog),
+        discovered_roots: collect_discovered_roots_from_registrations(roots),
         discoverable_skills: catalog.clone(),
         attached_skills: catalog,
         active_skills,
     }
 }
 
-fn collect_discovered_roots_from_catalog(entries: &[SkillCatalogEntry]) -> Vec<SkillRootView> {
-    let mut roots = entries
+fn collect_discovered_roots_from_registrations(
+    registrations: &[SkillRootRegistration],
+) -> Vec<SkillRootView> {
+    let mut roots = registrations
         .iter()
-        .filter_map(|entry| {
-            let skill_dir = entry.path.parent()?;
-            let root = skill_dir.parent()?;
-            Some(SkillRootView {
-                scope: entry.scope,
-                path: root.to_path_buf(),
-            })
+        .filter(|registration| registration.root_path.is_dir())
+        .map(|registration| SkillRootView {
+            scope: match registration.source_kind {
+                SkillRootSourceKind::UserGlobal => SkillScope::User,
+                SkillRootSourceKind::AgentHome => SkillScope::Agent,
+                SkillRootSourceKind::Workspace => SkillScope::Workspace,
+            },
+            path: registration.root_path.clone(),
         })
         .collect::<Vec<_>>();
     roots.sort_by(|left, right| {
@@ -1369,6 +1373,11 @@ mod tests {
                 path: visible_path.clone(),
                 scope: SkillScope::Agent,
             }],
+            &[skill_root_registration(
+                SkillRootSourceKind::AgentHome,
+                Some("default".into()),
+                PathBuf::from("/agent/skills"),
+            )],
             &[
                 ActiveSkillRecord {
                     skill_id: "agent:demo".into(),

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -2,3 +2,4 @@ pub mod base;
 pub mod registry;
 
 pub use base::*;
+pub use registry::SkillsRegistry;

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -44,6 +44,22 @@ impl SkillsRegistry {
         Ok(())
     }
 
+    /// Replace the registered roots with the provided effective set.
+    ///
+    /// This keeps shared registries scoped to the current caller's effective
+    /// roots instead of accumulating stale roots from other agents or workspaces.
+    pub fn replace_roots(&mut self, registrations: Vec<SkillRootRegistration>) -> Result<()> {
+        self.roots.clear();
+        self.entries.clear();
+        for registration in registrations {
+            if registration.root_path.exists() {
+                self.upsert_root(registration);
+            }
+        }
+        self.rescan();
+        Ok(())
+    }
+
     /// Refresh a single registered root, replacing that root's snapshot entries.
     ///
     /// Scan failures are recorded on the root and remove stale entries for that
@@ -355,6 +371,38 @@ mod tests {
         fs::remove_dir_all(agent_root.join("same")).unwrap();
         registry.rescan();
         assert_eq!(registry.catalog()[0].description, "user");
+    }
+
+    #[test]
+    fn replace_roots_removes_stale_root_entries() {
+        let temp = TempDir::new().unwrap();
+        let first_root = temp.path().join("first");
+        let second_root = temp.path().join("second");
+        fs::create_dir_all(&first_root).unwrap();
+        fs::create_dir_all(&second_root).unwrap();
+        write_skill(&first_root, "first", "first", "old");
+        write_skill(&second_root, "second", "second", "new");
+
+        let mut registry = SkillsRegistry::new();
+        registry
+            .replace_roots(vec![registration(
+                first_root.clone(),
+                SkillRootSourceKind::Workspace,
+            )])
+            .unwrap();
+        assert_eq!(registry.catalog()[0].name, "first");
+
+        registry
+            .replace_roots(vec![registration(
+                second_root.clone(),
+                SkillRootSourceKind::Workspace,
+            )])
+            .unwrap();
+        let catalog = registry.catalog();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].name, "second");
+        assert_eq!(registry.roots().len(), 1);
+        assert_eq!(registry.roots()[0].root_path, second_root);
     }
 
     #[test]

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -20,6 +20,7 @@ http_async_tests!(
     agent_state_route_scopes_work_items_to_requested_agent,
     agent_state_route_includes_bootstrap_projection_fields_when_present,
     list_skills_includes_all_agent_skill_roots,
+    agent_skills_endpoint_uses_effective_registry_snapshot,
     skills_catalog_uses_shared_registry_with_agent_and_workspace_roots,
     install_skill_existing_destination_returns_conflict,
     control_agent_model_override_set_and_clear_updates_status,

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -21,6 +21,7 @@ http_async_tests!(
     agent_state_route_includes_bootstrap_projection_fields_when_present,
     list_skills_includes_all_agent_skill_roots,
     agent_skills_endpoint_uses_effective_registry_snapshot,
+    agent_skills_endpoint_does_not_leak_stale_roots_between_agents,
     skills_catalog_uses_shared_registry_with_agent_and_workspace_roots,
     install_skill_existing_destination_returns_conflict,
     control_agent_model_override_set_and_clear_updates_status,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -558,6 +558,83 @@ pub async fn list_skills_includes_all_agent_skill_roots() -> Result<()> {
     Ok(())
 }
 
+pub async fn agent_skills_endpoint_uses_effective_registry_snapshot() -> Result<()> {
+    let (host, base, server) = spawn_server().await?;
+    let agent_home = host.config().data_dir.join("agents/default");
+    let agent_skill_dir = agent_home.join("skills/shared-demo");
+    std::fs::create_dir_all(&agent_skill_dir)?;
+    std::fs::write(
+        agent_skill_dir.join("SKILL.md"),
+        "---\nname: shared-demo\ndescription: agent\n---\nbody",
+    )?;
+
+    let workspace_skill_dir = host
+        .config()
+        .workspace_dir
+        .join(".agents/skills/workspace-demo");
+    std::fs::create_dir_all(&workspace_skill_dir)?;
+    std::fs::write(
+        workspace_skill_dir.join("SKILL.md"),
+        "---\nname: workspace-demo\ndescription: workspace\n---\nbody",
+    )?;
+
+    let client = Client::new();
+    let catalog_payload: serde_json::Value = client
+        .get(format!("{base}/api/skills/catalog?agent_id=default"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let list_payload: serde_json::Value = client
+        .get(format!("{base}/agents/default/skills"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let catalog_names = catalog_payload["catalog"]
+        .as_array()
+        .expect("catalog should be an array")
+        .iter()
+        .filter_map(|skill| skill["name"].as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let listed_names = list_payload["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .filter_map(|skill| skill["name"].as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(catalog_names, listed_names);
+    assert!(listed_names.contains("shared-demo"));
+    assert!(listed_names.contains("workspace-demo"));
+
+    std::fs::remove_dir_all(&agent_skill_dir)?;
+    let catalog_payload: serde_json::Value = client
+        .get(format!("{base}/api/skills/catalog?agent_id=default"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let list_payload: serde_json::Value = client
+        .get(format!("{base}/agents/default/skills"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert!(!catalog_payload["catalog"]
+        .as_array()
+        .expect("catalog should be an array")
+        .iter()
+        .any(|skill| skill["name"] == "shared-demo"));
+    assert!(!list_payload["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .any(|skill| skill["name"] == "shared-demo"));
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn skills_catalog_uses_shared_registry_with_agent_and_workspace_roots() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let agent_home = host.config().data_dir.join("agents/default");

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -635,6 +635,62 @@ pub async fn agent_skills_endpoint_uses_effective_registry_snapshot() -> Result<
     Ok(())
 }
 
+pub async fn agent_skills_endpoint_does_not_leak_stale_roots_between_agents() -> Result<()> {
+    let host = RuntimeHost::new_with_provider(test_config(), Arc::new(StubProvider::new("ok")))?;
+    attach_default_workspace(&host).await?;
+    host.create_named_agent("alpha", None).await?;
+
+    let default_home = host.config().data_dir.join("agents/default");
+    let default_skill_dir = default_home.join("skills/default-only");
+    std::fs::create_dir_all(&default_skill_dir)?;
+    std::fs::write(
+        default_skill_dir.join("SKILL.md"),
+        "---\nname: default-only\ndescription: default\n---\nbody",
+    )?;
+
+    let alpha_home = host.config().data_dir.join("agents/alpha");
+    let alpha_skill_dir = alpha_home.join("skills/alpha-only");
+    std::fs::create_dir_all(&alpha_skill_dir)?;
+    std::fs::write(
+        alpha_skill_dir.join("SKILL.md"),
+        "---\nname: alpha-only\ndescription: alpha\n---\nbody",
+    )?;
+
+    let (base, server) = spawn_server_for_host(host.clone()).await?;
+    let client = Client::new();
+
+    let default_payload: serde_json::Value = client
+        .get(format!("{base}/agents/default/skills"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert!(default_payload["skills"]
+        .as_array()
+        .expect("default skills should be an array")
+        .iter()
+        .any(|skill| skill["name"] == "default-only"));
+
+    let alpha_payload: serde_json::Value = client
+        .get(format!("{base}/agents/alpha/skills"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let alpha_skills = alpha_payload["skills"]
+        .as_array()
+        .expect("alpha skills should be an array");
+    assert!(alpha_skills
+        .iter()
+        .any(|skill| skill["name"] == "alpha-only"));
+    assert!(!alpha_skills
+        .iter()
+        .any(|skill| skill["name"] == "default-only"));
+
+    server.abort();
+    Ok(())
+}
+
 pub async fn skills_catalog_uses_shared_registry_with_agent_and_workspace_roots() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
     let agent_home = host.config().data_dir.join("agents/default");


### PR DESCRIPTION
## Summary
- compute per-agent effective skill snapshots from the shared `SkillsRegistry` snapshot
- reuse the same effective snapshot for runtime prompt state and `GET /agents/{agent_id}/skills`
- keep active skills filtered to entries present in the effective catalog and preserve user/workspace/agent scope semantics
- add regression coverage for catalog/runtime filtering and HTTP effective skills behavior

Closes #1928.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p holon skills::base::tests::catalog_runtime_view_filters_active_skills_to_effective_catalog_snapshot`
- `cargo test -p holon runtime::tests::runtime_state::runtime_skills_view_filters_active_skills_to_effective_registry_snapshot`
- `cargo test --test http_control agent_skills_endpoint_uses_effective_registry_snapshot`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
