### PR TITLE
fix: stop turn loop after wait-for sleep

### DIFF
--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -235,12 +235,11 @@ pub fn search_memory_query_for_agent_storages(
     active_workspace_id: Option<&str>,
     include_all_workspaces: bool,
     agent_ids: &[String],
-    _agent_storages: &[AppStorage],
+    agent_storages: &[AppStorage],
 ) -> Result<MemorySearchQueryResult> {
     let agent_id = storage_agent_id(storage);
     let agent_filter = normalize_memory_search_agent_filter(&agent_id, agent_ids);
-    log_legacy_index_deprecation(storage);
-    let index = MemoryIndex::open(storage)?;
+    let index = ensure_memory_indexes_current(storage, active_workspace_id, agent_storages)?;
     let results = index.search(
         query,
         limit,

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -235,11 +235,12 @@ pub fn search_memory_query_for_agent_storages(
     active_workspace_id: Option<&str>,
     include_all_workspaces: bool,
     agent_ids: &[String],
-    agent_storages: &[AppStorage],
+    _agent_storages: &[AppStorage],
 ) -> Result<MemorySearchQueryResult> {
     let agent_id = storage_agent_id(storage);
     let agent_filter = normalize_memory_search_agent_filter(&agent_id, agent_ids);
-    let index = ensure_memory_indexes_current(storage, active_workspace_id, agent_storages)?;
+    log_legacy_index_deprecation(storage);
+    let index = MemoryIndex::open(storage)?;
     let results = index.search(
         query,
         limit,

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -386,6 +386,16 @@ impl SleepOnlyToolProvider {
     }
 }
 
+pub(crate) struct WaitForOnlyToolProvider {
+    pub(crate) calls: Mutex<usize>,
+}
+
+impl WaitForOnlyToolProvider {
+    pub(crate) async fn call_count(&self) -> usize {
+        *self.calls.lock().await
+    }
+}
+
 pub(crate) struct DisallowedToolThenTextProvider {
     pub(crate) calls: Mutex<usize>,
 }
@@ -664,6 +674,39 @@ impl AgentProvider for SleepOnlyToolProvider {
                 input: serde_json::json!({
                     "reason": "waiting for review",
                     "duration_ms": 250,
+                }),
+            }],
+            stop_reason: None,
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_usage: None,
+            request_diagnostics: None,
+        })
+    }
+}
+
+#[async_trait]
+impl AgentProvider for WaitForOnlyToolProvider {
+    async fn complete_turn(&self, request: ProviderTurnRequest) -> Result<ProviderTurnResponse> {
+        let mut calls = self.calls.lock().await;
+        *calls += 1;
+        if *calls > 1 {
+            anyhow::bail!("wait-for-only round should not force another provider turn");
+        }
+        assert!(
+            request.tools.iter().any(|tool| tool.name == "WaitFor"),
+            "WaitFor must be exposed to the provider tool surface"
+        );
+
+        Ok(ProviderTurnResponse {
+            blocks: vec![ModelBlock::ToolUse {
+                id: "wait-for-1".into(),
+                name: "WaitFor".into(),
+                input: serde_json::json!({
+                    "reason": "waiting for PR checks",
+                    "wake": "external",
+                    "resource": "github:holon-run/holon#1939",
+                    "recheck_after_ms": 1800000,
                 }),
             }],
             stop_reason: None,

--- a/src/runtime/tests/turns.rs
+++ b/src/runtime/tests/turns.rs
@@ -226,6 +226,54 @@ async fn sleep_only_tool_round_completes_without_extra_provider_turn() {
 }
 
 #[tokio::test]
+async fn wait_for_only_tool_round_completes_without_extra_provider_turn() {
+    let dir = tempdir().unwrap();
+    let workspace = tempdir().unwrap();
+    let provider = Arc::new(WaitForOnlyToolProvider {
+        calls: Mutex::new(0),
+    });
+    let runtime = RuntimeHandle::new(
+        "default",
+        dir.path().to_path_buf(),
+        workspace.path().to_path_buf(),
+        "http://127.0.0.1:7878".into(),
+        provider.clone(),
+        "default".into(),
+        context_config(),
+    )
+    .unwrap();
+
+    let outcome = runtime
+        .run_agent_loop(
+            "default",
+            AuthorityClass::OperatorInstruction,
+            test_effective_prompt(),
+            LoopControlOptions {
+                max_tool_rounds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(*provider.calls.lock().await, 1);
+    assert_eq!(outcome.terminal_kind, TurnTerminalKind::Completed);
+    assert!(outcome.final_text.is_empty());
+    assert!(outcome.should_sleep);
+    assert_eq!(outcome.sleep_duration_ms, None);
+
+    let waiting = runtime
+        .storage()
+        .active_wait_conditions_for_agent("default")
+        .unwrap();
+    assert_eq!(waiting.len(), 1);
+    assert_eq!(waiting[0].waiting_for, "waiting for PR checks");
+    assert_eq!(
+        waiting[0].subject_ref.as_deref(),
+        Some("github:holon-run/holon#1939")
+    );
+}
+
+#[tokio::test]
 async fn disallowed_tool_call_is_auditable_and_continuation_stays_valid() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1002,9 +1002,9 @@ impl TurnExecution<'_> {
             crate::diagnostics::record_turn_provider_round(provider_round_started.elapsed());
             crate::diagnostics::record_provider_round_total(provider_round_started.elapsed());
             let completed_round_assistant_blocks = assistant_blocks.clone();
-            let only_sleep_tools =
+            let only_legacy_sleep_tool_calls =
                 !tool_calls.is_empty() && tool_calls.iter().all(|call| call.name == "Sleep");
-            let legacy_sleep_duration_ms = if only_sleep_tools {
+            let legacy_sleep_duration_ms = if only_legacy_sleep_tool_calls {
                 tool_calls
                     .iter()
                     .filter_map(|call| call.input.get("duration_ms").and_then(Value::as_u64))
@@ -1062,7 +1062,7 @@ impl TurnExecution<'_> {
                     "tool_names": tool_calls.iter().map(|call| call.name.clone()).collect::<Vec<_>>(),
                     "text_block_count": text_blocks.len(),
                     "text_char_count": combined_text.chars().count(),
-                    "only_sleep_tools": only_sleep_tools,
+                    "only_sleep_tools": only_legacy_sleep_tool_calls,
                     "provider_cache_usage": cache_usage,
                     "prompt_cache_key": effective_prompt.cache_identity.prompt_cache_key.clone(),
                     "context_fingerprint": effective_prompt.cache_identity.context_fingerprint.clone(),
@@ -1349,6 +1349,7 @@ impl TurnExecution<'_> {
             let mut tool_results = Vec::new();
             let mut tool_result_envelopes = Vec::new();
             let mut tool_execution_refs: Vec<(String, String)> = Vec::new();
+            let mut all_tool_results_should_sleep = !round_tool_calls.is_empty();
             for call in tool_calls {
                 if let Err(err) = runtime.ensure_not_aborted().await {
                     if let Some(aborted) = err.downcast_ref::<CurrentRunAborted>() {
@@ -1418,6 +1419,7 @@ impl TurnExecution<'_> {
                         error: Some(error.clone()),
                     });
                     tool_result_envelopes.push(result.envelope);
+                    all_tool_results_should_sleep = false;
                     continue;
                 }
                 if is_max_output_stop_reason(stop_reason.as_deref())
@@ -1457,6 +1459,7 @@ impl TurnExecution<'_> {
                         error: Some(error.clone()),
                     });
                     tool_result_envelopes.push(result.envelope);
+                    all_tool_results_should_sleep = false;
                     continue;
                 }
                 let pre_tool_work_item_id = {
@@ -1514,6 +1517,8 @@ impl TurnExecution<'_> {
 
                         if result.should_sleep {
                             sleep_duration_ms = result.sleep_duration_ms;
+                        } else {
+                            all_tool_results_should_sleep = false;
                         }
                         tool_execution_refs.push((tool_call_id.clone(), record.id.clone()));
                         runtime.persist_tool_execution_evidence(&record)?;
@@ -1625,6 +1630,7 @@ impl TurnExecution<'_> {
                             error: Some(error.clone()),
                         });
                         tool_result_envelopes.push(result.envelope);
+                        all_tool_results_should_sleep = false;
                     }
                 }
             }
@@ -1725,7 +1731,7 @@ impl TurnExecution<'_> {
                 },
             ));
 
-            if only_sleep_tools && !has_operator_interjections {
+            if all_tool_results_should_sleep && !has_operator_interjections {
                 let final_text = last_assistant_message.clone().unwrap_or_default();
                 let terminal = runtime
                     .persist_turn_terminal_record(


### PR DESCRIPTION
## Summary
- stop the turn loop when every tool result signals sleep, not only for legacy Sleep calls
- keep legacy Sleep duration fallback behavior
- add a WaitFor-only regression provider/test so WaitFor does not force a second provider turn

Fixes #1939

## Verification
- cargo fmt --all -- --check
- cargo test runtime::tests::turns:: -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets