### PR TITLE
fix: make skill root lifecycle additive

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -946,9 +946,9 @@ impl RuntimeHost {
             workspace_anchor,
         );
         let mut skill_registry = self.inner.skills_registry.write().await;
-        skill_registry.replace_roots(skill_roots.clone())?;
+        skill_registry.sync_effective_roots(skill_roots.clone())?;
         let mut skills = skills_runtime_view_from_catalog(
-            skill_registry.catalog(),
+            skill_registry.catalog_for_roots(&skill_roots, None),
             &skill_roots,
             &state.active_skills,
         );

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -149,8 +149,10 @@ pub async fn skills_catalog(
     }
 
     let mut registry = state.skills_registry.write().await;
-    registry.replace_roots(roots).map_err(error_response)?;
-    let catalog = registry.catalog_with_filter(scope_filter);
+    registry
+        .sync_effective_roots(roots.clone())
+        .map_err(error_response)?;
+    let catalog = registry.catalog_for_roots(&roots, scope_filter);
     Ok(Json(json!({
         "ok": true,
         "agent_id": agent_id,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1097,8 +1097,12 @@ impl RuntimeHandle {
         let mut view = if let Some(bridge) = self.inner.host_bridge.as_ref() {
             let registry = bridge.skills_registry()?;
             let mut registry = registry.write().await;
-            registry.replace_roots(skill_roots.clone())?;
-            skills_runtime_view_from_catalog(registry.catalog(), &skill_roots, &state.active_skills)
+            registry.sync_effective_roots(skill_roots.clone())?;
+            skills_runtime_view_from_catalog(
+                registry.catalog_for_roots(&skill_roots, None),
+                &skill_roots,
+                &state.active_skills,
+            )
         } else {
             let mut registry = crate::skills::SkillsRegistry::new();
             registry.replace_roots(skill_roots.clone())?;
@@ -1109,6 +1113,29 @@ impl RuntimeHandle {
             self.agent_home().as_path(),
         );
         Ok(view)
+    }
+
+    pub(crate) async fn sync_effective_skill_roots_for_state(
+        &self,
+        state: &AgentState,
+    ) -> Result<()> {
+        let Some(bridge) = self.inner.host_bridge.as_ref() else {
+            return Ok(());
+        };
+        let identity = self.agent_identity_view().await?;
+        let skill_roots = effective_skill_root_registrations(
+            self.skill_visibility(&identity),
+            self.user_home().as_deref(),
+            &state.id,
+            self.agent_home().as_path(),
+            state
+                .active_workspace_entry
+                .as_ref()
+                .map(|entry| entry.workspace_anchor.as_path()),
+        );
+        let registry = bridge.skills_registry()?;
+        registry.write().await.sync_effective_roots(skill_roots)?;
+        Ok(())
     }
 
     async fn begin_interactive_turn(

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -802,6 +802,8 @@ impl RuntimeHandle {
         }
         self.inner.storage.append_workspace_entry(workspace)?;
         guard.persist_state(&self.inner.storage)?;
+        let state = guard.state.clone();
+        drop(guard);
         self.inner.storage.append_event(&AuditEvent::new(
             "workspace_attached",
             serde_json::json!({
@@ -809,6 +811,7 @@ impl RuntimeHandle {
                 "workspace_anchor": workspace.workspace_anchor,
             }),
         ))?;
+        self.sync_effective_skill_roots_for_state(&state).await?;
         Ok(())
     }
 
@@ -1026,6 +1029,8 @@ impl RuntimeHandle {
                 let _ = bridge.release_workspace_occupancy(occupancy_id).await?;
             }
         }
+        let state = self.agent_state().await?;
+        self.sync_effective_skill_roots_for_state(&state).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "workspace_used",
             serde_json::json!({
@@ -1174,6 +1179,8 @@ impl RuntimeHandle {
                 }
             }
         }
+        let state = self.agent_state().await?;
+        self.sync_effective_skill_roots_for_state(&state).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "workspace_entered",
             serde_json::json!({
@@ -1185,7 +1192,7 @@ impl RuntimeHandle {
                 "access_mode": access_mode,
                 "cwd": selected_cwd,
                 "boundary": crate::system::HostLocalBoundary::from_parts(
-                    &self.agent_state().await?.execution_profile,
+                    &state.execution_profile,
                     Some(projection_kind),
                     Some(access_mode),
                     Some(execution_root_id),
@@ -1303,6 +1310,8 @@ impl RuntimeHandle {
                 }
             }
         }
+        let state = self.agent_state().await?;
+        self.sync_effective_skill_roots_for_state(&state).await?;
         self.inner.storage.append_event(&AuditEvent::new(
             "workspace_entered",
             serde_json::json!({
@@ -1316,7 +1325,7 @@ impl RuntimeHandle {
                 "detected_kind": "existing_git_worktree",
                 "ownership": "external",
                 "boundary": crate::system::HostLocalBoundary::from_parts(
-                    &self.agent_state().await?.execution_profile,
+                    &state.execution_profile,
                     Some(WorkspaceProjectionKind::GitWorktreeRoot),
                     Some(access_mode),
                     Some(execution_root_id),

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -44,6 +44,22 @@ impl SkillsRegistry {
         Ok(())
     }
 
+    /// Synchronize lifecycle-owned effective roots into the registry snapshot.
+    ///
+    /// This is intentionally additive: lifecycle transitions register or refresh
+    /// the roots that are effective for an agent/workspace, while catalog readers
+    /// select from the existing snapshot without clearing roots owned by other
+    /// agents or workspaces.
+    pub fn sync_effective_roots(
+        &mut self,
+        registrations: impl IntoIterator<Item = SkillRootRegistration>,
+    ) -> Result<()> {
+        for registration in registrations {
+            self.register_root(registration)?;
+        }
+        Ok(())
+    }
+
     /// Replace the registered roots with the provided effective set.
     ///
     /// This keeps shared registries scoped to the current caller's effective
@@ -167,27 +183,41 @@ impl SkillsRegistry {
 
     /// Get catalog filtered by optional scope.
     pub fn catalog_with_filter(&self, scope: Option<SkillScope>) -> Vec<SkillCatalogEntry> {
-        let filtered: Vec<&SkillCatalogEntry> = if let Some(filter_scope) = scope {
-            self.entries
-                .iter()
-                .filter(|e| e.scope == filter_scope)
-                .collect()
-        } else {
-            self.entries.iter().collect()
-        };
+        self.catalog_from_entries(self.entries.iter(), scope)
+    }
 
-        let selected_by_name: BTreeMap<String, &SkillCatalogEntry> =
-            filtered
-                .into_iter()
-                .fold(BTreeMap::new(), |mut acc, entry| {
-                    let existing = acc.get(&entry.name);
-                    if existing.map_or(true, |existing| {
-                        self.skill_wins_catalog_selection(entry, existing)
-                    }) {
-                        acc.insert(entry.name.clone(), entry);
-                    }
-                    acc
-                });
+    /// Get catalog for a caller's effective roots without mutating the registry.
+    pub fn catalog_for_roots(
+        &self,
+        roots: &[SkillRootRegistration],
+        scope: Option<SkillScope>,
+    ) -> Vec<SkillCatalogEntry> {
+        self.catalog_from_entries(
+            self.entries.iter().filter(|entry| {
+                roots
+                    .iter()
+                    .any(|root| entry.path.starts_with(&root.root_path))
+            }),
+            scope,
+        )
+    }
+
+    fn catalog_from_entries<'a>(
+        &self,
+        entries: impl Iterator<Item = &'a SkillCatalogEntry>,
+        scope: Option<SkillScope>,
+    ) -> Vec<SkillCatalogEntry> {
+        let selected_by_name: BTreeMap<String, &SkillCatalogEntry> = entries
+            .filter(|entry| scope.is_none_or(|filter_scope| entry.scope == filter_scope))
+            .fold(BTreeMap::new(), |mut acc, entry| {
+                let existing = acc.get(&entry.name);
+                if existing.map_or(true, |existing| {
+                    self.skill_wins_catalog_selection(entry, existing)
+                }) {
+                    acc.insert(entry.name.clone(), entry);
+                }
+                acc
+            });
         selected_by_name.into_values().cloned().collect()
     }
 
@@ -403,6 +433,30 @@ mod tests {
         assert_eq!(catalog[0].name, "second");
         assert_eq!(registry.roots().len(), 1);
         assert_eq!(registry.roots()[0].root_path, second_root);
+    }
+
+    #[test]
+    fn catalog_for_roots_selects_without_clearing_shared_registry() {
+        let temp = TempDir::new().unwrap();
+        let first_root = temp.path().join("first");
+        let second_root = temp.path().join("second");
+        fs::create_dir_all(&first_root).unwrap();
+        fs::create_dir_all(&second_root).unwrap();
+        write_skill(&first_root, "first", "first", "one");
+        write_skill(&second_root, "second", "second", "two");
+
+        let first_registration = registration(first_root.clone(), SkillRootSourceKind::Workspace);
+        let second_registration = registration(second_root.clone(), SkillRootSourceKind::Workspace);
+
+        let mut registry = SkillsRegistry::new();
+        registry
+            .sync_effective_roots(vec![first_registration.clone(), second_registration])
+            .unwrap();
+
+        let first_catalog = registry.catalog_for_roots(&[first_registration], None);
+        assert_eq!(first_catalog.len(), 1);
+        assert_eq!(first_catalog[0].name, "first");
+        assert_eq!(registry.catalog().len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an explicit additive skills registry lifecycle boundary via `sync_effective_roots`
- make prompt/API catalog readers select from the caller's effective roots without clearing the shared registry snapshot
- refresh lifecycle-owned effective roots when workspace state changes

Fixes #1927.

## Verification
- `cargo test -p holon skills::registry::tests::catalog_for_roots_selects_without_clearing_shared_registry`
- `cargo test -p holon http_control::skills_catalog_uses_shared_registry_with_agent_and_workspace_roots`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
