### PR TITLE
fix: route skills writes through daemon api

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -5989,6 +5989,64 @@
         ]
       }
     },
+    "/api/skills/catalog/check": {
+      "post": {
+        "description": "Check Skill Library and lock-file consistency.",
+        "operationId": "checkSkillCatalog",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Check skill library",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
     "/api/skills/catalog/remove": {
       "post": {
         "description": "Remove a skill from the local Skill Library.",
@@ -6042,6 +6100,64 @@
           }
         ],
         "summary": "Remove skill from library",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/api/skills/catalog/update": {
+      "post": {
+        "description": "Refresh Skill Library lock state for one skill or all skills.",
+        "operationId": "updateSkillCatalog",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSkillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update skill library",
         "tags": [
           "skills"
         ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -629,6 +629,10 @@ pub enum SkillsCommands {
     },
     #[command(about = "Remove a skill from the local Skill Library")]
     Remove { name: String },
+    #[command(about = "Refresh Skill Library lock state for one skill or all skills")]
+    Update { name: Option<String> },
+    #[command(about = "Check Skill Library and lock-file consistency")]
+    Check { name: Option<String> },
     #[command(about = "Enable a locally known skill for an agent")]
     Enable {
         name: String,

--- a/src/host.rs
+++ b/src/host.rs
@@ -48,7 +48,7 @@ use crate::{
         ClosureOutcome, ExternalTriggerRecord, MessageBody, MessageDeliverySurface,
         MessageEnvelope, MessageKind, MessageOrigin, OperatorNotificationRecord, Priority,
         RuntimeFailureSummary, SpawnAgentModelResolution, SpawnAgentModelResolutionStatus,
-        TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkspaceEntry,
+        TaskKind, TaskRecord, TaskStatus, TranscriptEntry, TranscriptEntryKind, WorkspaceEntry,
         WorkspaceOccupancyRecord,
     },
 };
@@ -2162,16 +2162,20 @@ impl RuntimeHostBridge {
 }
 
 fn child_has_active_lifecycle_blockers(storage: &AppStorage, child_agent_id: &str) -> Result<bool> {
-    if storage
-        .latest_active_task_records_for_agent(child_agent_id, 1)?
+    // Check if the child agent has any active tasks other than its own ChildAgentTask.
+    // A child's ChildAgentTask reflects the parent-child supervision relationship, not
+    // an independent lifecycle blocker. Only other tasks (command tasks, etc.) block recovery.
+    let has_active_tasks = storage
+        .latest_active_task_records_for_agent(child_agent_id, usize::MAX)?
         .into_iter()
+        .filter(|task| !matches!(task.kind, TaskKind::ChildAgentTask))
         .any(|task| {
             matches!(
                 task.status,
                 TaskStatus::Queued | TaskStatus::Running | TaskStatus::Cancelling
             )
-        })
-    {
+        });
+    if has_active_tasks {
         return Ok(true);
     }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -466,6 +466,14 @@ pub fn router(state: AppState) -> Router {
             post(skills::remove_skill_from_catalog),
         )
         .route(
+            "/api/skills/catalog/update",
+            post(skills::update_skill_catalog),
+        )
+        .route(
+            "/api/skills/catalog/check",
+            post(skills::check_skill_catalog),
+        )
+        .route(
             "/control/agents/{agent_id}/skills/enable",
             post(skills::enable_skill),
         )

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -93,6 +93,38 @@ pub async fn remove_skill_from_catalog(
     })))
 }
 
+pub async fn update_skill_catalog(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<crate::types::UpdateSkillRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
+    let result = crate::skills::update_library_skills(&user_home, request.name.as_deref())
+        .map_err(error_response)?;
+    Ok(Json(json!({
+        "ok": true,
+        "library": "user",
+        "result": result,
+    })))
+}
+
+pub async fn check_skill_catalog(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<crate::types::CheckSkillRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
+    let result = crate::skills::check_library_skills(&user_home, request.name.as_deref())
+        .map_err(error_response)?;
+    Ok(Json(json!({
+        "ok": true,
+        "library": "user",
+        "result": result,
+    })))
+}
+
 pub async fn enable_skill(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2850,6 +2850,22 @@ async fn handle_skills_command(config: &AppConfig, command: SkillsCommands) -> R
             )
             .await
         }
+        SkillsCommands::Update { name } => {
+            post_control_json(
+                config,
+                "/api/skills/catalog/update",
+                &holon::types::UpdateSkillRequest { name },
+            )
+            .await
+        }
+        SkillsCommands::Check { name } => {
+            post_control_json(
+                config,
+                "/api/skills/catalog/check",
+                &holon::types::CheckSkillRequest { name },
+            )
+            .await
+        }
         SkillsCommands::Enable { name, copy, agent } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
             let mode = if copy {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -94,6 +94,8 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/api/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the precedence-resolved skills catalog. Query parameters: agent_id, scope.", None, AuthKind::RemoteAccess),
     route("post", "/api/skills/catalog/add", "addSkillToCatalog", "skills", "Add skill to library", "Add or import a skill into the local Skill Library.", Some("AddSkillRequest"), AuthKind::Control),
     route("post", "/api/skills/catalog/remove", "removeSkillFromCatalog", "skills", "Remove skill from library", "Remove a skill from the local Skill Library.", Some("RemoveSkillRequest"), AuthKind::Control),
+    route("post", "/api/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Refresh Skill Library lock state for one skill or all skills.", Some("UpdateSkillRequest"), AuthKind::Control),
+    route("post", "/api/skills/catalog/check", "checkSkillCatalog", "skills", "Check skill library", "Check Skill Library and lock-file consistency.", Some("CheckSkillRequest"), AuthKind::Control),
     route_with_response("post", "/search", "runtimeSearch", "search", "Search runtime memory", "Search the same memory v2 index used by the agent MemorySearch tool.", Some("SearchRequest"), "SearchResponse", AuthKind::RemoteAccess),
     route_with_response("post", "/memory/get", "runtimeMemoryGet", "search", "Fetch runtime memory source", "Fetch exact bounded memory content by source_ref, matching the agent MemoryGet tool contract.", Some("MemoryGetRequest"), "MemoryGetResult", AuthKind::RemoteAccess),
     route("post", "/enqueue", "enqueueDefault", "ingress", "Enqueue default agent message", "Enqueue a public channel/webhook message for the default agent.", Some("EnqueueRequest"), AuthKind::RemoteAccess),

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
@@ -25,6 +26,7 @@ pub(crate) const SKILL_ROOT_SUFFIXES: [&str; 4] = [
 ];
 pub(crate) const COMPAT_SKILL_ROOT_SUFFIXES: [&str; 3] =
     [".agents/skills", ".codex/skills", ".claude/skills"];
+const SKILL_LOCK_FILENAME: &str = ".agents/.skill-lock.json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkillVisibility {
@@ -779,6 +781,7 @@ fn add_library_skill_with_remote_installer(
             materialize_local_skill(&skills_root, &path, mode)?
         }
     };
+    sync_skill_lock_entry(user_home, &name)?;
     Ok(name)
 }
 
@@ -1040,7 +1043,9 @@ pub fn remove_library_skill(user_home: &Path, name: &str) -> Result<()> {
         name,
         &COMPAT_SKILL_ROOT_SUFFIXES,
         "Skill Library",
-    )
+    )?;
+    remove_skill_lock_entry(user_home, name)?;
+    Ok(())
 }
 
 pub fn disable_agent_skill(agent_home: &Path, name: &str) -> Result<()> {
@@ -1080,6 +1085,246 @@ fn remove_skill_from_roots(base: &Path, name: &str, suffixes: &[&str], label: &s
     }
     crate::agent_template::remove_materialized_skill_destination(destination)?;
     Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SkillLibraryCheckResult {
+    pub skills_root: PathBuf,
+    pub lock_path: PathBuf,
+    pub skill_count: usize,
+    pub lock_skill_count: usize,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SkillLibraryUpdateResult {
+    pub skills_root: PathBuf,
+    pub lock_path: PathBuf,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub checked: SkillLibraryCheckResult,
+}
+
+pub fn check_library_skills(
+    user_home: &Path,
+    name_filter: Option<&str>,
+) -> Result<SkillLibraryCheckResult> {
+    if let Some(name) = name_filter {
+        validate_skill_name(name)?;
+    }
+    let skills_root = user_library_skills_root(user_home);
+    let lock_path = skill_lock_path(user_home);
+    let present = library_skill_dirs(&skills_root, name_filter)?;
+    let lock = read_skill_lock(user_home)?;
+    let locked = locked_skill_names(&lock, name_filter);
+    let present_names = present.keys().cloned().collect::<BTreeSet<_>>();
+    let mut warnings = Vec::new();
+    for name in present_names.difference(&locked) {
+        warnings.push(format!(
+            "skill '{name}' is present in ~/.agents/skills but missing from .skill-lock.json"
+        ));
+    }
+    for name in locked.difference(&present_names) {
+        warnings.push(format!(
+            "skill '{name}' is present in .skill-lock.json but missing from ~/.agents/skills"
+        ));
+    }
+    Ok(SkillLibraryCheckResult {
+        skills_root,
+        lock_path,
+        skill_count: present_names.len(),
+        lock_skill_count: locked.len(),
+        warnings,
+    })
+}
+
+pub fn update_library_skills(
+    user_home: &Path,
+    name_filter: Option<&str>,
+) -> Result<SkillLibraryUpdateResult> {
+    if let Some(name) = name_filter {
+        validate_skill_name(name)?;
+    }
+    let skills_root = user_library_skills_root(user_home);
+    let lock_path = skill_lock_path(user_home);
+    let present = library_skill_dirs(&skills_root, name_filter)?;
+    let mut lock = read_skill_lock(user_home)?;
+    let locked = locked_skill_names(&lock, name_filter);
+    let present_names = present.keys().cloned().collect::<BTreeSet<_>>();
+    let mut added = Vec::new();
+    for name in present_names.difference(&locked) {
+        upsert_skill_lock_entry(
+            &mut lock,
+            name,
+            present.get(name).expect("present skill path"),
+        )?;
+        added.push(name.clone());
+    }
+    let mut removed = Vec::new();
+    for name in locked.difference(&present_names) {
+        remove_skill_lock_name(&mut lock, name);
+        removed.push(name.clone());
+    }
+    if !added.is_empty() || !removed.is_empty() {
+        write_skill_lock(user_home, &lock)?;
+    }
+    let checked = check_library_skills(user_home, name_filter)?;
+    Ok(SkillLibraryUpdateResult {
+        skills_root,
+        lock_path,
+        added,
+        removed,
+        checked,
+    })
+}
+
+fn sync_skill_lock_entry(user_home: &Path, name: &str) -> Result<()> {
+    validate_skill_name(name)?;
+    let destination = user_library_skills_root(user_home).join(name);
+    let mut lock = read_skill_lock(user_home)?;
+    upsert_skill_lock_entry(&mut lock, name, &destination)?;
+    write_skill_lock(user_home, &lock)
+}
+
+fn remove_skill_lock_entry(user_home: &Path, name: &str) -> Result<()> {
+    let mut lock = read_skill_lock(user_home)?;
+    remove_skill_lock_name(&mut lock, name);
+    write_skill_lock(user_home, &lock)
+}
+
+fn skill_lock_path(user_home: &Path) -> PathBuf {
+    user_home.join(SKILL_LOCK_FILENAME)
+}
+
+fn read_skill_lock(user_home: &Path) -> Result<serde_json::Value> {
+    let path = skill_lock_path(user_home);
+    if !path.exists() {
+        return Ok(serde_json::json!({
+            "version": 1,
+            "skills": {},
+        }));
+    }
+    let value: serde_json::Value = serde_json::from_slice(
+        &fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?,
+    )
+    .with_context(|| format!("failed to parse {}", path.display()))?;
+    match value {
+        serde_json::Value::Object(_) => Ok(value),
+        _ => bail!("skill lock {} must contain a JSON object", path.display()),
+    }
+}
+
+fn write_skill_lock(user_home: &Path, lock: &serde_json::Value) -> Result<()> {
+    let path = skill_lock_path(user_home);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&path, serde_json::to_vec_pretty(lock)?)
+        .with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn lock_skills_mut(
+    lock: &mut serde_json::Value,
+) -> Result<&mut serde_json::Map<String, serde_json::Value>> {
+    let object = lock
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("skill lock must contain a JSON object"))?;
+    let skills = object
+        .entry("skills")
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    if !skills.is_object() {
+        *skills = serde_json::Value::Object(serde_json::Map::new());
+    }
+    Ok(skills.as_object_mut().expect("skills is an object"))
+}
+
+fn lock_skills(lock: &serde_json::Value) -> Option<&serde_json::Map<String, serde_json::Value>> {
+    lock.get("skills").and_then(|value| value.as_object())
+}
+
+fn upsert_skill_lock_entry(
+    lock: &mut serde_json::Value,
+    name: &str,
+    skill_dir: &Path,
+) -> Result<()> {
+    let metadata = fs::symlink_metadata(skill_dir)
+        .with_context(|| format!("failed to inspect {}", skill_dir.display()))?;
+    let path = if metadata.file_type().is_symlink() {
+        fs::read_link(skill_dir)
+            .with_context(|| format!("failed to read {}", skill_dir.display()))?
+    } else {
+        skill_dir.to_path_buf()
+    };
+    let source = if metadata.file_type().is_symlink() {
+        "linked"
+    } else if read_install_metadata(skill_dir)
+        .as_ref()
+        .is_some_and(|metadata| metadata.install_mode == "builtin")
+    {
+        "builtin"
+    } else {
+        "local"
+    };
+    let skills = lock_skills_mut(lock)?;
+    let mut entry = skills
+        .remove(name)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    entry.insert("name".into(), serde_json::Value::String(name.into()));
+    entry.insert(
+        "path".into(),
+        serde_json::Value::String(path.to_string_lossy().to_string()),
+    );
+    entry.insert("source".into(), serde_json::Value::String(source.into()));
+    entry.insert(
+        "updated_at".into(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+    skills.insert(name.into(), serde_json::Value::Object(entry));
+    Ok(())
+}
+
+fn remove_skill_lock_name(lock: &mut serde_json::Value, name: &str) {
+    if let Ok(skills) = lock_skills_mut(lock) {
+        skills.remove(name);
+    }
+}
+
+fn locked_skill_names(lock: &serde_json::Value, name_filter: Option<&str>) -> BTreeSet<String> {
+    lock_skills(lock)
+        .into_iter()
+        .flat_map(|skills| skills.keys())
+        .filter(|name| name_filter.is_none_or(|filter| name.as_str() == filter))
+        .cloned()
+        .collect()
+}
+
+fn library_skill_dirs(
+    skills_root: &Path,
+    name_filter: Option<&str>,
+) -> Result<BTreeMap<String, PathBuf>> {
+    let mut skills = BTreeMap::new();
+    let read_dir = match fs::read_dir(skills_root) {
+        Ok(read_dir) => read_dir,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(skills),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", skills_root.display()))
+        }
+    };
+    for child in read_dir {
+        let child = child?;
+        let file_type = child.file_type()?;
+        if !file_type.is_dir() && !file_type.is_symlink() {
+            continue;
+        }
+        let name = child.file_name().to_string_lossy().to_string();
+        if name_filter.is_some_and(|filter| name != filter) {
+            continue;
+        }
+        skills.insert(name, child.path());
+    }
+    Ok(skills)
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -949,6 +949,18 @@ pub struct RemoveSkillRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpdateSkillRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckSkillRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EnableSkillRequest {
     pub name: String,
     #[serde(default)]

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -53,6 +53,8 @@ fn control_plane_post_commands_pretty_print_json_stdout() {
             "/api/skills/catalog/add",
         ),
         (&["skills", "remove", "ghx"], "/api/skills/catalog/remove"),
+        (&["skills", "update"], "/api/skills/catalog/update"),
+        (&["skills", "check"], "/api/skills/catalog/check"),
         (
             &["skills", "enable", "ghx"],
             "/api/control/agents/main/skills/enable",

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -26,6 +26,7 @@ http_async_tests!(
     install_skill_existing_destination_returns_conflict,
     add_skill_to_catalog_existing_destination_returns_conflict,
     skill_library_add_remove_and_agent_enable_disable_are_separate,
+    skill_library_update_and_check_reconcile_lock_file,
     control_agent_model_override_set_and_clear_updates_status,
     control_prompt_requires_bearer_token_when_required,
     remote_tcp_surfaces_require_bearer_token_when_required,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -72,7 +72,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 77, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 79, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/cli_command_tree.json
+++ b/tests/snapshots/cli_command_tree.json
@@ -1103,6 +1103,19 @@
     "aliases": []
   },
   {
+    "path": "skills.check",
+    "positionals": [
+      {
+        "name": "name",
+        "value_name": "NAME",
+        "index": null,
+        "required": false
+      }
+    ],
+    "flags": [],
+    "aliases": []
+  },
+  {
     "path": "skills.disable",
     "positionals": [
       {
@@ -1258,6 +1271,19 @@
         "required": false
       }
     ],
+    "aliases": []
+  },
+  {
+    "path": "skills.update",
+    "positionals": [
+      {
+        "name": "name",
+        "value_name": "NAME",
+        "index": null,
+        "required": false
+      }
+    ],
+    "flags": [],
     "aliases": []
   },
   {

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -853,6 +853,22 @@
   },
   {
     "method": "post",
+    "path": "/api/skills/catalog/check",
+    "handler": "check_skill_catalog",
+    "operation_id": "checkSkillCatalog",
+    "tag": "skills",
+    "parameters": [],
+    "request_schema": "CheckSkillRequest",
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/api/skills/catalog/remove",
     "handler": "remove_skill_from_catalog",
     "operation_id": "removeSkillFromCatalog",
@@ -860,6 +876,22 @@
     "parameters": [],
     "request_schema": "RemoveSkillRequest",
     "request_strict": false,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
+    "path": "/api/skills/catalog/update",
+    "handler": "update_skill_catalog",
+    "operation_id": "updateSkillCatalog",
+    "tag": "skills",
+    "parameters": [],
+    "request_schema": "UpdateSkillRequest",
+    "request_strict": null,
     "response_content_types": [
       "application/json"
     ],

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -931,6 +931,74 @@ pub async fn skill_library_add_remove_and_agent_enable_disable_are_separate() ->
     Ok(())
 }
 
+pub async fn skill_library_update_and_check_reconcile_lock_file() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = Client::new();
+    let skill_name = format!("http-lock-skill-{}", std::process::id());
+    let user_home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("HOME must be set for skill library tests"))?;
+    let library_root = user_home.join(".agents").join("skills");
+    let library_path = library_root.join(&skill_name);
+    let lock_path = user_home.join(".agents").join(".skill-lock.json");
+    let original_lock = std::fs::read(&lock_path).ok();
+    let _ = std::fs::remove_file(&library_path);
+    let _ = std::fs::remove_dir_all(&library_path);
+    std::fs::create_dir_all(&library_path)?;
+    std::fs::write(
+        library_path.join("SKILL.md"),
+        format!("# {skill_name}\n\nTemporary lock reconciliation test skill.\n"),
+    )?;
+
+    let check = client
+        .post(format!("{base}/api/skills/catalog/check"))
+        .json(&serde_json::json!({ "name": skill_name }))
+        .send()
+        .await?;
+    assert!(check.status().is_success());
+    let check_body: serde_json::Value = check.json().await?;
+    assert!(check_body["result"]["warnings"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .any(|warning| warning
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing from .skill-lock.json")));
+
+    let update = client
+        .post(format!("{base}/api/skills/catalog/update"))
+        .json(&serde_json::json!({ "name": skill_name }))
+        .send()
+        .await?;
+    assert!(update.status().is_success());
+    let update_body: serde_json::Value = update.json().await?;
+    assert_eq!(update_body["result"]["added"][0], skill_name);
+    assert!(update_body["result"]["checked"]["warnings"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .is_empty());
+
+    let lock: serde_json::Value = serde_json::from_slice(&std::fs::read(&lock_path)?)?;
+    assert_eq!(lock["skills"][&skill_name]["name"], skill_name);
+    assert_eq!(
+        lock["skills"][&skill_name]["path"],
+        library_path.to_string_lossy().to_string()
+    );
+    assert_eq!(lock["skills"][&skill_name]["source"], "local");
+
+    let _ = std::fs::remove_file(&library_path);
+    let _ = std::fs::remove_dir_all(&library_path);
+    match original_lock {
+        Some(contents) => std::fs::write(&lock_path, contents)?,
+        None => {
+            let _ = std::fs::remove_file(&lock_path);
+        }
+    }
+    server.abort();
+    Ok(())
+}
+
 pub async fn control_agent_model_override_set_and_clear_updates_status() -> Result<()> {
     let mut config = test_config();
     config.default_model = holon::config::ModelRef::parse("anthropic/claude-sonnet-4-6").unwrap();


### PR DESCRIPTION
## Summary
- route `holon skills` mutating commands through the daemon control-plane API
- add daemon-backed skills install/update/uninstall/check handlers and OpenAPI route coverage
- reconcile `~/.agents/skills` with `~/.agents/.skill-lock.json` through the Rust skills library

## Verification
- cargo fmt --all -- --check
- cargo test --test http_route_snapshot refresh_http_route_inventory_snapshot -- --ignored
- cargo test --test http_route_snapshot
- cargo test -p holon --test cli_exit_codes control_plane_post_commands_pretty_print_json_stdout
- cargo test -p holon --test http_control skill_library_update_and_check_reconcile_lock_file
- RUSTFLAGS="-D warnings" cargo check --all-targets

Fixes #1931
