### PR TITLE
fix: clarify skills catalog API scope

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -5885,7 +5885,7 @@
     },
     "/api/skills/catalog": {
       "get": {
-        "description": "Return the precedence-resolved skills catalog. Query parameters: agent_id, scope.",
+        "description": "Return the global user Skill Library catalog. Query parameter: scope.",
         "operationId": "skillsCatalog",
         "parameters": [],
         "responses": {

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -238,48 +238,20 @@ pub async fn skills_catalog(
         _ => None,
     });
 
-    let agent_id = params.get("agent_id").cloned();
     let user_home = crate::agent_template::user_home_dir().ok();
-    let mut roots = Vec::new();
-    if let Some(agent_id) = agent_id.as_deref() {
-        let runtime = state
-            .host
-            .get_public_agent(agent_id)
-            .await
-            .map_err(agent_access_error)?;
-        let identity = runtime
-            .agent_identity_view()
-            .await
-            .map_err(error_response)?;
-        let agent_home = runtime.agent_home();
-        let execution = runtime.execution_snapshot().await.map_err(error_response)?;
-        roots.extend(crate::skills::effective_skill_root_registrations(
-            if identity.kind == crate::types::AgentKind::Default {
-                crate::skills::SkillVisibility::DefaultAgent
-            } else {
-                crate::skills::SkillVisibility::NonDefaultAgent
-            },
-            user_home.as_deref(),
-            agent_id,
-            &agent_home,
-            Some(&execution.workspace_anchor),
-        ));
-    } else {
-        roots.extend(
-            crate::skills::existing_skill_roots(
-                user_home.as_deref(),
-                &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
-            )
-            .into_iter()
-            .map(|root| {
-                crate::skills::skill_root_registration(
-                    crate::types::SkillRootSourceKind::UserGlobal,
-                    None,
-                    root,
-                )
-            }),
-        );
-    }
+    let roots = crate::skills::existing_skill_roots(
+        user_home.as_deref(),
+        &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
+    )
+    .into_iter()
+    .map(|root| {
+        crate::skills::skill_root_registration(
+            crate::types::SkillRootSourceKind::UserGlobal,
+            None,
+            root,
+        )
+    })
+    .collect::<Vec<_>>();
 
     let mut registry = state.skills_registry.write().await;
     registry
@@ -288,7 +260,7 @@ pub async fn skills_catalog(
     let catalog = registry.catalog_for_roots(&roots, scope_filter);
     Ok(Json(json!({
         "ok": true,
-        "agent_id": agent_id,
+        "library": "user",
         "catalog": catalog,
         "scope": scope_filter,
     })))

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -91,7 +91,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/timers", "agentTimers", "timers", "List timers", "Return recent timer records. Query parameter: limit.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List agent skills", "Return skills enabled/effective for an agent.", None, AuthKind::RemoteAccess),
-    route("get", "/api/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the precedence-resolved skills catalog. Query parameters: agent_id, scope.", None, AuthKind::RemoteAccess),
+    route("get", "/api/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the global user Skill Library catalog. Query parameter: scope.", None, AuthKind::RemoteAccess),
     route("post", "/api/skills/catalog/add", "addSkillToCatalog", "skills", "Add skill to library", "Add or import a skill into the local Skill Library.", Some("AddSkillRequest"), AuthKind::Control),
     route("post", "/api/skills/catalog/remove", "removeSkillFromCatalog", "skills", "Remove skill from library", "Remove a skill from the local Skill Library.", Some("RemoveSkillRequest"), AuthKind::Control),
     route("post", "/api/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Refresh Skill Library lock state for one skill or all skills.", Some("UpdateSkillRequest"), AuthKind::Control),

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -22,7 +22,7 @@ http_async_tests!(
     list_skills_includes_all_agent_skill_roots,
     agent_skills_endpoint_uses_effective_registry_snapshot,
     agent_skills_endpoint_does_not_leak_stale_roots_between_agents,
-    skills_catalog_uses_shared_registry_with_agent_and_workspace_roots,
+    skills_catalog_returns_global_user_library_only,
     install_skill_existing_destination_returns_conflict,
     add_skill_to_catalog_existing_destination_returns_conflict,
     skill_library_add_remove_and_agent_enable_disable_are_separate,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -579,52 +579,28 @@ pub async fn agent_skills_endpoint_uses_effective_registry_snapshot() -> Result<
     )?;
 
     let client = Client::new();
-    let catalog_payload: serde_json::Value = client
-        .get(format!("{base}/api/skills/catalog?agent_id=default"))
-        .send()
-        .await?
-        .json()
-        .await?;
     let list_payload: serde_json::Value = client
         .get(format!("{base}/agents/default/skills"))
         .send()
         .await?
         .json()
         .await?;
-    let catalog_names = catalog_payload["catalog"]
-        .as_array()
-        .expect("catalog should be an array")
-        .iter()
-        .filter_map(|skill| skill["name"].as_str())
-        .collect::<std::collections::BTreeSet<_>>();
     let listed_names = list_payload["skills"]
         .as_array()
         .expect("skills should be an array")
         .iter()
         .filter_map(|skill| skill["name"].as_str())
         .collect::<std::collections::BTreeSet<_>>();
-    assert_eq!(catalog_names, listed_names);
     assert!(listed_names.contains("shared-demo"));
     assert!(listed_names.contains("workspace-demo"));
 
     std::fs::remove_dir_all(&agent_skill_dir)?;
-    let catalog_payload: serde_json::Value = client
-        .get(format!("{base}/api/skills/catalog?agent_id=default"))
-        .send()
-        .await?
-        .json()
-        .await?;
     let list_payload: serde_json::Value = client
         .get(format!("{base}/agents/default/skills"))
         .send()
         .await?
         .json()
         .await?;
-    assert!(!catalog_payload["catalog"]
-        .as_array()
-        .expect("catalog should be an array")
-        .iter()
-        .any(|skill| skill["name"] == "shared-demo"));
     assert!(!list_payload["skills"]
         .as_array()
         .expect("skills should be an array")
@@ -691,8 +667,20 @@ pub async fn agent_skills_endpoint_does_not_leak_stale_roots_between_agents() ->
     Ok(())
 }
 
-pub async fn skills_catalog_uses_shared_registry_with_agent_and_workspace_roots() -> Result<()> {
+pub async fn skills_catalog_returns_global_user_library_only() -> Result<()> {
     let (host, base, server) = spawn_server().await?;
+    let skill_name = format!("http-global-catalog-{}", std::process::id());
+    let user_home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("HOME must be set for skill library tests"))?;
+    let user_skill_dir = user_home.join(".agents").join("skills").join(&skill_name);
+    let _ = std::fs::remove_dir_all(&user_skill_dir);
+    std::fs::create_dir_all(&user_skill_dir)?;
+    std::fs::write(
+        user_skill_dir.join("SKILL.md"),
+        format!("---\nname: {skill_name}\ndescription: user\n---\nbody"),
+    )?;
+
     let agent_home = host.config().data_dir.join("agents/default");
     let agent_skill_dir = agent_home.join("skills/agent-demo");
     std::fs::create_dir_all(&agent_skill_dir)?;
@@ -713,24 +701,25 @@ pub async fn skills_catalog_uses_shared_registry_with_agent_and_workspace_roots(
 
     let client = Client::new();
     let payload: serde_json::Value = client
-        .get(format!("{base}/api/skills/catalog?agent_id=default"))
+        .get(format!("{base}/api/skills/catalog"))
         .send()
         .await?
         .json()
         .await?;
+    assert_eq!(payload["library"], "user");
     let skills = payload["catalog"]
         .as_array()
         .expect("catalog should be an array");
     assert!(skills
         .iter()
-        .any(|skill| skill["name"] == "shared-demo" && skill["scope"] == "agent"));
-    assert!(skills
+        .any(|skill| skill["name"] == skill_name && skill["scope"] == "user"));
+    assert!(!skills
         .iter()
-        .any(|skill| skill["name"] == "workspace-demo" && skill["scope"] == "workspace"));
+        .any(|skill| skill["name"] == "shared-demo" || skill["name"] == "workspace-demo"));
 
     std::fs::remove_dir_all(&agent_skill_dir)?;
     let payload: serde_json::Value = client
-        .get(format!("{base}/api/skills/catalog?agent_id=default"))
+        .get(format!("{base}/api/skills/catalog?scope=user"))
         .send()
         .await?
         .json()
@@ -738,8 +727,9 @@ pub async fn skills_catalog_uses_shared_registry_with_agent_and_workspace_roots(
     let skills = payload["catalog"]
         .as_array()
         .expect("catalog should be an array");
-    assert!(!skills.iter().any(|skill| skill["name"] == "shared-demo"));
+    assert!(skills.iter().any(|skill| skill["name"] == skill_name));
 
+    let _ = std::fs::remove_dir_all(&user_skill_dir);
     server.abort();
     Ok(())
 }


### PR DESCRIPTION
## Summary
- make `GET /api/skills/catalog` return only the global user Skill Library catalog
- leave agent effective skill state on `GET /agents/{agent_id}/skills`
- update OpenAPI route text and HTTP tests for the clarified boundary

Closes #1925.

## Tests
- `cargo test -q skills_`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`