### PR TITLE
feat: add DashScope plan providers

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -6,10 +6,14 @@ generated: auto-generated from holon source — do not edit directly
 
 # Supported Models
 
-Holon includes built-in configuration for **37 providers** and **194 models**.
+Holon includes built-in configuration for **39 providers** and **218 models**.
 
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
+
+Note: subscription-scoped providers such as `dashscope-token-plan` and
+`dashscope-coding-plan` are intended for interactive AI coding/agent tool usage
+under the upstream service terms, not backend automation or generic scripts.
 
 ## Provider Setup
 
@@ -25,6 +29,8 @@ running Holon.
 | `byteplus-coding` | OpenAI Chat Completions | `https://ark.ap-southeast.bytepluses.com/api/coding/v3` | `BYTEPLUS_CODING_API_KEY or BYTEPLUS_API_KEY` |
 | `chutes` | OpenAI Chat Completions | `https://llm.chutes.ai/v1` | `CHUTES_API_KEY` |
 | `dashscope` | Anthropic Messages | `https://dashscope.aliyuncs.com/apps/anthropic` | `DASHSCOPE_API_KEY or QWEN_API_KEY` |
+| `dashscope-coding-plan` | Anthropic Messages | `https://coding.dashscope.aliyuncs.com/apps/anthropic` | `DASHSCOPE_CODING_PLAN_API_KEY` |
+| `dashscope-token-plan` | Anthropic Messages | `https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic` | `DASHSCOPE_TOKEN_PLAN_API_KEY` |
 | `deepseek` | Anthropic Messages | `https://api.deepseek.com/anthropic` | `DEEPSEEK_API_KEY` |
 | `fireworks` | OpenAI Chat Completions | `https://api.fireworks.ai/inference/v1` | `FIREWORKS_API_KEY` |
 | `gemini` | Gemini Generate Content | `https://generativelanguage.googleapis.com/v1beta` | `GEMINI_API_KEY` |
@@ -119,6 +125,30 @@ and capabilities.
 | `dashscope` | `qwen3.7-max-2026-06-08` | `dashscope/qwen3.7-max-2026-06-08` | 1000000 | 65536 | ✅ | — |
 | `dashscope` | `qwen3.7-plus` | `dashscope/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope` | `qwen3.7-plus-2026-05-26` | `dashscope/qwen3.7-plus-2026-05-26` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-coding-plan` | `MiniMax-M2.5` | `dashscope-coding-plan/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
+| `dashscope-coding-plan` | `glm-4.7` | `dashscope-coding-plan/glm-4.7` | 202752 | 16384 | — | — |
+| `dashscope-coding-plan` | `glm-5` | `dashscope-coding-plan/glm-5` | 202752 | 16384 | ✅ | — |
+| `dashscope-coding-plan` | `kimi-k2.5` | `dashscope-coding-plan/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
+| `dashscope-coding-plan` | `qwen3-coder-next` | `dashscope-coding-plan/qwen3-coder-next` | 262144 | 65536 | — | — |
+| `dashscope-coding-plan` | `qwen3-coder-plus` | `dashscope-coding-plan/qwen3-coder-plus` | 1000000 | 65536 | — | — |
+| `dashscope-coding-plan` | `qwen3-max-2026-01-23` | `dashscope-coding-plan/qwen3-max-2026-01-23` | 262144 | 65536 | — | — |
+| `dashscope-coding-plan` | `qwen3.5-plus` | `dashscope-coding-plan/qwen3.5-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-coding-plan` | `qwen3.6-plus` | `dashscope-coding-plan/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-coding-plan` | `qwen3.7-plus` | `dashscope-coding-plan/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-token-plan` | `MiniMax-M2.5` | `dashscope-token-plan/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
+| `dashscope-token-plan` | `deepseek-v3.2` | `dashscope-token-plan/deepseek-v3.2` | 128000 | 32768 | ✅ | — |
+| `dashscope-token-plan` | `deepseek-v4-flash` | `dashscope-token-plan/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |
+| `dashscope-token-plan` | `deepseek-v4-pro` | `dashscope-token-plan/deepseek-v4-pro` | 1000000 | 384000 | ✅ | — |
+| `dashscope-token-plan` | `glm-5` | `dashscope-token-plan/glm-5` | 202752 | 16384 | ✅ | — |
+| `dashscope-token-plan` | `glm-5.1` | `dashscope-token-plan/glm-5.1` | 202752 | 131072 | ✅ | — |
+| `dashscope-token-plan` | `glm-5.2` | `dashscope-token-plan/glm-5.2` | 1000000 | 131072 | ✅ | — |
+| `dashscope-token-plan` | `kimi-k2.5` | `dashscope-token-plan/kimi-k2.5` | 262144 | 32768 | ✅ | ✅ |
+| `dashscope-token-plan` | `kimi-k2.6` | `dashscope-token-plan/kimi-k2.6` | 262144 | 98304 | ✅ | ✅ |
+| `dashscope-token-plan` | `kimi-k2.7-code` | `dashscope-token-plan/kimi-k2.7-code` | 262144 | 98304 | ✅ | ✅ |
+| `dashscope-token-plan` | `qwen3.6-flash` | `dashscope-token-plan/qwen3.6-flash` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-token-plan` | `qwen3.6-plus` | `dashscope-token-plan/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-token-plan` | `qwen3.7-max` | `dashscope-token-plan/qwen3.7-max` | 1000000 | 65536 | ✅ | — |
+| `dashscope-token-plan` | `qwen3.7-plus` | `dashscope-token-plan/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `deepseek` | `deepseek-chat` | `deepseek/deepseek-chat` | 131072 | 8192 | — | — |
 | `deepseek` | `deepseek-reasoner` | `deepseek/deepseek-reasoner` | 131072 | 65536 | ✅ | — |
 | `deepseek` | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1000000 | 384000 | ✅ | — |

--- a/src/bin/holon-docgen.rs
+++ b/src/bin/holon-docgen.rs
@@ -61,6 +61,10 @@ Holon includes built-in configuration for **{provider_count} providers** and **{
 This page is auto-generated from the Holon source code (`src/model_catalog.rs` and `src/config.rs`).
 Run `cargo run --bin holon-docgen -- models > docs/website/reference/models.md` to regenerate.
 
+Note: subscription-scoped providers such as `dashscope-token-plan` and
+`dashscope-coding-plan` are intended for interactive AI coding/agent tool usage
+under the upstream service terms, not backend automation or generic scripts.
+
 ## Provider Setup
 
 Each provider requires an API key or credential to use. Set the listed environment variable before

--- a/src/config/builtin_providers.rs
+++ b/src/config/builtin_providers.rs
@@ -442,6 +442,20 @@ pub(crate) fn built_in_provider_registry_with_settings(
     )?;
     insert_anthropic_compatible_provider(
         &mut registry,
+        "dashscope-token-plan",
+        "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+        &["DASHSCOPE_TOKEN_PLAN_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
+        "dashscope-coding-plan",
+        "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+        &["DASHSCOPE_CODING_PLAN_API_KEY"],
+        settings_env,
+    )?;
+    insert_anthropic_compatible_provider(
+        &mut registry,
         "deepseek",
         "https://api.deepseek.com/anthropic",
         &["DEEPSEEK_API_KEY"],

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1252,6 +1252,14 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
     settings_env.insert("ZAI_API_KEY".to_string(), "zai-key".to_string());
     settings_env.insert("BIGMODEL_API_KEY".to_string(), "bigmodel-key".to_string());
     settings_env.insert("DASHSCOPE_API_KEY".to_string(), "dashscope-key".to_string());
+    settings_env.insert(
+        "DASHSCOPE_TOKEN_PLAN_API_KEY".to_string(),
+        "dashscope-token-plan-key".to_string(),
+    );
+    settings_env.insert(
+        "DASHSCOPE_CODING_PLAN_API_KEY".to_string(),
+        "dashscope-coding-plan-key".to_string(),
+    );
     settings_env.insert("NEARAI_API_KEY".to_string(), "nearai-key".to_string());
     settings_env.insert("GEMINI_API_KEY".to_string(), "gemini-key".to_string());
     settings_env.insert(
@@ -1299,6 +1307,46 @@ fn built_in_provider_registry_includes_compatible_provider_defaults() {
     assert_eq!(
         dashscope.context_management.cache_strategy,
         AnthropicCacheStrategy::ClaudeCodePromptCache
+    );
+
+    let dashscope_token_plan = providers
+        .get(&ProviderId::parse("dashscope-token-plan").unwrap())
+        .unwrap();
+    assert_eq!(
+        dashscope_token_plan.transport,
+        ProviderTransportKind::AnthropicMessages
+    );
+    assert_eq!(
+        dashscope_token_plan.base_url,
+        "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic"
+    );
+    assert_eq!(
+        dashscope_token_plan.auth.env.as_deref(),
+        Some("DASHSCOPE_TOKEN_PLAN_API_KEY")
+    );
+    assert_eq!(
+        dashscope_token_plan.credential.as_deref(),
+        Some("dashscope-token-plan-key")
+    );
+
+    let dashscope_coding_plan = providers
+        .get(&ProviderId::parse("dashscope-coding-plan").unwrap())
+        .unwrap();
+    assert_eq!(
+        dashscope_coding_plan.transport,
+        ProviderTransportKind::AnthropicMessages
+    );
+    assert_eq!(
+        dashscope_coding_plan.base_url,
+        "https://coding.dashscope.aliyuncs.com/apps/anthropic"
+    );
+    assert_eq!(
+        dashscope_coding_plan.auth.env.as_deref(),
+        Some("DASHSCOPE_CODING_PLAN_API_KEY")
+    );
+    assert_eq!(
+        dashscope_coding_plan.credential.as_deref(),
+        Some("dashscope-coding-plan-key")
     );
 
     let nearai = providers

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1417,6 +1417,222 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             false,
         ),
         catalog_model(
+            "dashscope-token-plan",
+            "qwen3.7-max",
+            "qwen3.7-max",
+            1_000_000,
+            65_536,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "qwen3.7-plus",
+            "qwen3.7-plus",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "qwen3.6-plus",
+            "qwen3.6-plus",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "qwen3.6-flash",
+            "qwen3.6-flash",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "deepseek-v4-pro",
+            "DeepSeek V4 Pro",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "deepseek-v4-flash",
+            "DeepSeek V4 Flash",
+            1_000_000,
+            384_000,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "deepseek-v3.2",
+            "DeepSeek V3.2",
+            128_000,
+            32_768,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "kimi-k2.7-code",
+            "kimi-k2.7-code",
+            262_144,
+            98_304,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "kimi-k2.6",
+            "kimi-k2.6",
+            262_144,
+            98_304,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "kimi-k2.5",
+            "kimi-k2.5",
+            262_144,
+            32_768,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "glm-5.2",
+            "glm-5.2",
+            1_000_000,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "glm-5.1",
+            "glm-5.1",
+            202_752,
+            131_072,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "glm-5",
+            "glm-5",
+            202_752,
+            16_384,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-token-plan",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5",
+            196_608,
+            32_768,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "qwen3.7-plus",
+            "qwen3.7-plus",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "qwen3.6-plus",
+            "qwen3.6-plus",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "qwen3.5-plus",
+            "qwen3.5-plus",
+            1_000_000,
+            65_536,
+            true,
+            true,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "qwen3-max-2026-01-23",
+            "qwen3-max-2026-01-23",
+            262_144,
+            65_536,
+            false,
+            false,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "qwen3-coder-next",
+            "qwen3-coder-next",
+            262_144,
+            65_536,
+            false,
+            false,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "qwen3-coder-plus",
+            "qwen3-coder-plus",
+            1_000_000,
+            65_536,
+            false,
+            false,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5",
+            196_608,
+            32_768,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "glm-5",
+            "glm-5",
+            202_752,
+            16_384,
+            true,
+            false,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "glm-4.7",
+            "glm-4.7",
+            202_752,
+            16_384,
+            false,
+            false,
+        ),
+        catalog_model(
+            "dashscope-coding-plan",
+            "kimi-k2.5",
+            "kimi-k2.5",
+            262_144,
+            32_768,
+            true,
+            true,
+        ),
+        catalog_model(
             "stepfun",
             "step-3.5-flash",
             "Step 3.5 Flash",
@@ -2412,6 +2628,56 @@ mod tests {
         assert!(catalog
             .get(&ModelRef::parse("dashscope-openai/MiniMax-M2.5").unwrap())
             .is_none());
+    }
+
+    #[test]
+    fn dashscope_plan_providers_have_separate_exact_model_catalogs() {
+        let catalog = BuiltInModelCatalog::new();
+
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("dashscope-token-plan").unwrap())
+                .unwrap()
+                .as_string(),
+            "dashscope-token-plan/qwen3.7-max"
+        );
+        assert_eq!(
+            catalog
+                .preferred_model_for_provider(&ProviderId::parse("dashscope-coding-plan").unwrap())
+                .unwrap()
+                .as_string(),
+            "dashscope-coding-plan/qwen3.7-plus"
+        );
+
+        for model_ref in [
+            "dashscope-token-plan/qwen3.7-max",
+            "dashscope-token-plan/kimi-k2.7-code",
+            "dashscope-token-plan/glm-5.2",
+            "dashscope-token-plan/MiniMax-M2.5",
+            "dashscope-coding-plan/qwen3-coder-plus",
+            "dashscope-coding-plan/glm-5",
+            "dashscope-coding-plan/kimi-k2.5",
+            "dashscope-coding-plan/MiniMax-M2.5",
+        ] {
+            assert!(
+                catalog.get(&ModelRef::parse(model_ref).unwrap()).is_some(),
+                "{model_ref} should be registered"
+            );
+        }
+
+        for unsupported in [
+            "dashscope-token-plan/ZHIPU/GLM-5.2",
+            "dashscope-token-plan/MiniMax/MiniMax-M3",
+            "dashscope-coding-plan/glm-5.2",
+            "dashscope-coding-plan/kimi-k2.7-code",
+        ] {
+            assert!(
+                catalog
+                    .get(&ModelRef::parse(unsupported).unwrap())
+                    .is_none(),
+                "{unsupported} should not be inferred from another DashScope catalog"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add built-in Anthropic-compatible providers for DashScope Token Plan and Coding Plan
- register the Token Plan and Coding Plan model allowlists from the DashScope tools docs
- regenerate the supported models reference and document subscription-scoped provider usage constraints

## Verification
- cargo fmt --all -- --check
- cargo test config::tests::built_in_providers_include_dashscope_plan_variants -- --nocapture
- cargo test model_catalog::tests::dashscope_plan_providers_have_separate_exact_model_catalogs -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets
