### PR TITLE
fix: adjust dashscope coding plan capabilities

### DIFF
--- a/docs/website/reference/models.md
+++ b/docs/website/reference/models.md
@@ -132,8 +132,8 @@ and capabilities.
 | `dashscope-coding-plan` | `qwen3-coder-next` | `dashscope-coding-plan/qwen3-coder-next` | 262144 | 65536 | — | — |
 | `dashscope-coding-plan` | `qwen3-coder-plus` | `dashscope-coding-plan/qwen3-coder-plus` | 1000000 | 65536 | — | — |
 | `dashscope-coding-plan` | `qwen3-max-2026-01-23` | `dashscope-coding-plan/qwen3-max-2026-01-23` | 262144 | 65536 | — | — |
-| `dashscope-coding-plan` | `qwen3.5-plus` | `dashscope-coding-plan/qwen3.5-plus` | 1000000 | 65536 | ✅ | ✅ |
-| `dashscope-coding-plan` | `qwen3.6-plus` | `dashscope-coding-plan/qwen3.6-plus` | 1000000 | 65536 | ✅ | ✅ |
+| `dashscope-coding-plan` | `qwen3.5-plus` | `dashscope-coding-plan/qwen3.5-plus` | 1000000 | 65536 | — | ✅ |
+| `dashscope-coding-plan` | `qwen3.6-plus` | `dashscope-coding-plan/qwen3.6-plus` | 1000000 | 65536 | — | ✅ |
 | `dashscope-coding-plan` | `qwen3.7-plus` | `dashscope-coding-plan/qwen3.7-plus` | 1000000 | 65536 | ✅ | ✅ |
 | `dashscope-token-plan` | `MiniMax-M2.5` | `dashscope-token-plan/MiniMax-M2.5` | 196608 | 32768 | ✅ | — |
 | `dashscope-token-plan` | `deepseek-v3.2` | `dashscope-token-plan/deepseek-v3.2` | 128000 | 32768 | ✅ | — |

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1557,7 +1557,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "qwen3.6-plus",
             1_000_000,
             65_536,
-            true,
+            false,
             true,
         ),
         catalog_model(
@@ -1566,7 +1566,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "qwen3.5-plus",
             1_000_000,
             65_536,
-            true,
+            false,
             true,
         ),
         catalog_model(


### PR DESCRIPTION
## Summary
- align DashScope Coding Plan qwen3.5-plus/qwen3.6-plus reasoning summary capability with the base DashScope provider
- regenerate model reference docs

## Verification
- cargo fmt --all -- --check
- cargo test --lib dashscope_plan_providers_have_separate_exact_model_catalogs -- --nocapture
- RUSTFLAGS="-D warnings" cargo check --all-targets