### PR TITLE
fix: qualify skill catalog identities

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1346,7 +1346,7 @@ fn working_memory_is_empty(snapshot: &WorkingMemorySnapshot) -> bool {
 
 fn scope_label(scope: &crate::types::SkillScope) -> &'static str {
     match scope {
-        crate::types::SkillScope::User => "user_global",
+        crate::types::SkillScope::UserGlobal => "user_global",
         crate::types::SkillScope::Agent => "agent",
         crate::types::SkillScope::Workspace => "workspace",
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1346,7 +1346,7 @@ fn working_memory_is_empty(snapshot: &WorkingMemorySnapshot) -> bool {
 
 fn scope_label(scope: &crate::types::SkillScope) -> &'static str {
     match scope {
-        crate::types::SkillScope::User => "user",
+        crate::types::SkillScope::User => "user_global",
         crate::types::SkillScope::Agent => "agent",
         crate::types::SkillScope::Workspace => "workspace",
     }
@@ -4988,6 +4988,9 @@ mod tests {
             discoverable_skills: vec![
                 crate::types::SkillCatalogEntry {
                     skill_id: "agent:demo".into(),
+                    root_id: "agent_home:test-root".into(),
+                    skill_dir: "demo".into(),
+                    legacy_id: Some("agent:demo".into()),
                     name: "demo".into(),
                     description: "agent demo skill summary".into(),
                     path: PathBuf::from("/tmp/agent/skills/demo/SKILL.md"),
@@ -4995,6 +4998,9 @@ mod tests {
                 },
                 crate::types::SkillCatalogEntry {
                     skill_id: "workspace:other".into(),
+                    root_id: "workspace:test-root".into(),
+                    skill_dir: "other".into(),
+                    legacy_id: None,
                     name: "other".into(),
                     description: "other skill summary".into(),
                     path: PathBuf::from("/tmp/workspace/.agents/skills/other/SKILL.md"),
@@ -7570,6 +7576,9 @@ mod tests {
             agent_templates_catalog: Vec::new(),
             discoverable_skills: vec![crate::types::SkillCatalogEntry {
                 skill_id: "skill/large-catalog-entry".into(),
+                root_id: "workspace:test-root".into(),
+                skill_dir: "large-catalog-entry".into(),
+                legacy_id: None,
                 name: "Large Catalog Entry".into(),
                 description:
                     "catalog description repeats to consume prompt budget aggressively ".repeat(12),

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -1,6 +1,8 @@
 use super::*;
 use axum::extract::Query;
 
+const USER_GLOBAL_LIBRARY_LABEL: &str = "user_global";
+
 pub async fn list_skills(
     Path(agent_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -74,7 +76,7 @@ pub async fn add_skill_to_catalog(
     Ok(Json(json!({
         "ok": true,
         "skill_name": skill_name,
-        "library": "user",
+        "library": USER_GLOBAL_LIBRARY_LABEL,
     })))
 }
 
@@ -89,7 +91,7 @@ pub async fn remove_skill_from_catalog(
     Ok(Json(json!({
         "ok": true,
         "skill_name": request.name,
-        "library": "user",
+        "library": USER_GLOBAL_LIBRARY_LABEL,
     })))
 }
 
@@ -104,7 +106,7 @@ pub async fn update_skill_catalog(
         .map_err(error_response)?;
     Ok(Json(json!({
         "ok": true,
-        "library": "user",
+        "library": USER_GLOBAL_LIBRARY_LABEL,
         "result": result,
     })))
 }
@@ -120,7 +122,7 @@ pub async fn check_skill_catalog(
         .map_err(error_response)?;
     Ok(Json(json!({
         "ok": true,
-        "library": "user",
+        "library": USER_GLOBAL_LIBRARY_LABEL,
         "result": result,
     })))
 }
@@ -234,7 +236,8 @@ pub async fn skills_catalog(
     let scope_filter = params.get("scope").and_then(|s| match s.as_str() {
         "agent" => Some(crate::types::SkillScope::Agent),
         "workspace" => Some(crate::types::SkillScope::Workspace),
-        "user" => Some(crate::types::SkillScope::User),
+        "user" => Some(crate::types::SkillScope::UserGlobal),
+        "user_global" => Some(crate::types::SkillScope::UserGlobal),
         _ => None,
     });
 
@@ -260,7 +263,7 @@ pub async fn skills_catalog(
     let catalog = registry.catalog_for_roots(&roots, scope_filter);
     Ok(Json(json!({
         "ok": true,
-        "library": "user",
+        "library": USER_GLOBAL_LIBRARY_LABEL,
         "catalog": catalog,
         "scope": scope_filter,
     })))

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -2112,6 +2112,9 @@ mod tests {
             &SkillsRuntimeView {
                 discoverable_skills: vec![crate::types::SkillCatalogEntry {
                     skill_id: "workspace:review".into(),
+                    root_id: "workspace:test-root".into(),
+                    skill_dir: "review".into(),
+                    legacy_id: None,
                     name: "review".into(),
                     description: "Review workflow".into(),
                     path: PathBuf::from("/repo/.agents/skills/review/SKILL.md"),
@@ -2468,6 +2471,9 @@ mod tests {
             &SkillsRuntimeView {
                 discoverable_skills: vec![crate::types::SkillCatalogEntry {
                     skill_id: "user:demo".into(),
+                    root_id: "user_global:test-root".into(),
+                    skill_dir: "demo".into(),
+                    legacy_id: Some("user:demo".into()),
                     name: "demo".into(),
                     description: "demo skill".into(),
                     path: PathBuf::from("/tmp/user/.agents/skills/demo/SKILL.md"),

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -2477,7 +2477,7 @@ mod tests {
                     name: "demo".into(),
                     description: "demo skill".into(),
                     path: PathBuf::from("/tmp/user/.agents/skills/demo/SKILL.md"),
-                    scope: crate::types::SkillScope::User,
+                    scope: crate::types::SkillScope::UserGlobal,
                 }],
                 ..SkillsRuntimeView::default()
             },

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2864,7 +2864,8 @@ async fn reading_discovered_skill_marks_it_active_and_promotes_on_success() {
     let state = runtime.agent_state().await.unwrap();
     assert_eq!(state.active_skills.len(), 1);
     let skill = &state.active_skills[0];
-    assert_eq!(skill.skill_id, "workspace:demo");
+    assert!(skill.skill_id.starts_with("workspace:"));
+    assert!(skill.skill_id.ends_with(":demo"));
     assert_eq!(
         skill.activation_source,
         SkillActivationSource::ImplicitFromCatalog
@@ -2875,7 +2876,7 @@ async fn reading_discovered_skill_marks_it_active_and_promotes_on_success() {
     let events = runtime.storage().read_recent_events(20).unwrap();
     let activation = events
         .iter()
-        .find(|event| event.kind == "skill_activated" && event.data["skill_id"] == "workspace:demo")
+        .find(|event| event.kind == "skill_activated" && event.data["skill_id"] == skill.skill_id)
         .expect("skill_activated event should be recorded");
     assert_eq!(activation.data["skill_name"], "demo");
     assert_eq!(activation.data["load_reason"], "read_skill_md");
@@ -2913,9 +2914,11 @@ async fn batch_command_reading_discovered_skill_marks_it_active() {
 
     let state = runtime.agent_state().await.unwrap();
     assert_eq!(state.active_skills.len(), 1);
-    assert_eq!(state.active_skills[0].skill_id, "workspace:demo");
+    let skill_id = state.active_skills[0].skill_id.clone();
+    assert!(skill_id.starts_with("workspace:"));
+    assert!(skill_id.ends_with(":demo"));
 
-    let activation = skill_activation_event(&runtime, "workspace:demo");
+    let activation = skill_activation_event(&runtime, &skill_id);
     assert_eq!(activation.data["skill_name"], "demo");
     assert_eq!(activation.data["load_reason"], "read_skill_md");
     assert_eq!(activation.data["path"], activation.data["entrypoint_path"]);
@@ -2937,9 +2940,11 @@ async fn command_running_skill_script_marks_it_active_with_script_reason() {
 
     let state = runtime.agent_state().await.unwrap();
     assert_eq!(state.active_skills.len(), 1);
-    assert_eq!(state.active_skills[0].skill_id, "workspace:demo");
+    let skill_id = state.active_skills[0].skill_id.clone();
+    assert!(skill_id.starts_with("workspace:"));
+    assert!(skill_id.ends_with(":demo"));
 
-    let activation = skill_activation_event(&runtime, "workspace:demo");
+    let activation = skill_activation_event(&runtime, &skill_id);
     assert_eq!(activation.data["skill_name"], "demo");
     assert_eq!(
         activation.data["load_reason"],

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -2795,12 +2795,16 @@ async fn runtime_skills_view_filters_active_skills_to_effective_registry_snapsho
     let identity = runtime.agent_identity_view().await.unwrap();
     let skills = runtime.skills_runtime_view(&identity).await.unwrap();
 
-    assert!(skills
+    let discoverable = skills
         .discoverable_skills
         .iter()
-        .any(|skill| skill.skill_id == "workspace:demo"));
+        .find(|skill| skill.name == "demo")
+        .unwrap();
+    assert!(discoverable.skill_id.starts_with("workspace:"));
+    assert!(discoverable.skill_id.ends_with(":demo"));
+    assert_eq!(discoverable.legacy_id.as_deref(), Some("workspace:demo"));
     assert_eq!(skills.active_skills.len(), 1);
-    assert_eq!(skills.active_skills[0].skill_id, "workspace:demo");
+    assert_eq!(skills.active_skills[0].skill_id, discoverable.skill_id);
 }
 
 #[tokio::test]

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -47,9 +47,9 @@ pub fn load_skills_runtime_view(
 
     if matches!(visibility, SkillVisibility::DefaultAgent) {
         if let Some(root) = select_skill_root(user_home, &COMPAT_SKILL_ROOT_SUFFIXES) {
-            discoverable_skills.extend(load_catalog_for_scope(SkillScope::User, &root)?);
+            discoverable_skills.extend(load_catalog_for_scope(SkillScope::UserGlobal, &root)?);
             discovered_roots.push(SkillRootView {
-                scope: SkillScope::User,
+                scope: SkillScope::UserGlobal,
                 path: root,
             });
         }
@@ -271,7 +271,7 @@ fn collect_discovered_roots_from_registrations(
         .filter(|registration| registration.root_path.is_dir())
         .map(|registration| SkillRootView {
             scope: match registration.source_kind {
-                SkillRootSourceKind::UserGlobal => SkillScope::User,
+                SkillRootSourceKind::UserGlobal => SkillScope::UserGlobal,
                 SkillRootSourceKind::AgentHome => SkillScope::Agent,
                 SkillRootSourceKind::Workspace => SkillScope::Workspace,
             },
@@ -319,7 +319,7 @@ pub(crate) fn skill_root_id(registration: &SkillRootRegistration) -> String {
 
 fn skill_root_id_for_scope(scope: SkillScope, root: &Path) -> String {
     let source = match scope {
-        SkillScope::User => "user_global",
+        SkillScope::UserGlobal => "user_global",
         SkillScope::Agent => "agent_home",
         SkillScope::Workspace => "workspace",
     };
@@ -389,7 +389,7 @@ fn skill_precedence(scope: SkillScope) -> u8 {
     match scope {
         SkillScope::Agent => 3,
         SkillScope::Workspace => 2,
-        SkillScope::User => 1,
+        SkillScope::UserGlobal => 1,
     }
 }
 
@@ -446,7 +446,7 @@ fn first_body_paragraph(content: &str) -> String {
 
 fn scope_label(scope: SkillScope) -> &'static str {
     match scope {
-        SkillScope::User => "user",
+        SkillScope::UserGlobal => "user_global",
         SkillScope::Agent => "agent",
         SkillScope::Workspace => "workspace",
     }
@@ -933,7 +933,7 @@ fn normalize_local_skill_path(path: &Path) -> Result<PathBuf> {
 fn resolve_user_skill_by_name(user_home: Option<&Path>, name: &str) -> Result<PathBuf> {
     for root in existing_skill_roots(user_home, &COMPAT_SKILL_ROOT_SUFFIXES) {
         let mut root_matches = Vec::new();
-        for skill in load_catalog_for_scope(SkillScope::User, &root)? {
+        for skill in load_catalog_for_scope(SkillScope::UserGlobal, &root)? {
             let dir_name = skill
                 .path
                 .parent()
@@ -1593,12 +1593,13 @@ mod tests {
             .map(|skill| skill.skill_id.as_str())
             .collect::<Vec<_>>();
         assert!(ids.iter().all(|id| id.starts_with("agent_home:")));
-        let names = view
+        let mut names = view
             .discoverable_skills
             .iter()
             .map(|skill| skill.name.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["beta", "alpha"]);
+        names.sort();
+        assert_eq!(names, vec!["alpha", "beta"]);
     }
 
     #[test]
@@ -1639,11 +1640,11 @@ mod tests {
         assert!(default_view
             .discoverable_skills
             .iter()
-            .any(|entry| entry.scope == SkillScope::User));
+            .any(|entry| entry.scope == SkillScope::UserGlobal));
         assert!(non_default_view
             .discoverable_skills
             .iter()
-            .all(|entry| entry.scope != SkillScope::User));
+            .all(|entry| entry.scope != SkillScope::UserGlobal));
     }
 
     #[test]

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -445,8 +445,11 @@ fn first_body_paragraph(content: &str) -> String {
 }
 
 fn scope_label(scope: SkillScope) -> &'static str {
+    // Preserve the legacy label for backward-compatible `legacy_id` values.
+    // `UserGlobal` was previously `User` with label "user"; `legacy_id` must
+    // match old active-skill records that use the "user:" prefix.
     match scope {
-        SkillScope::UserGlobal => "user_global",
+        SkillScope::UserGlobal => "user",
         SkillScope::Agent => "agent",
         SkillScope::Workspace => "workspace",
     }

--- a/src/skills/base.rs
+++ b/src/skills/base.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
 use tracing::warn;
 
 use crate::types::{
@@ -73,15 +74,7 @@ pub fn load_skills_runtime_view(
     discoverable_skills = retain_highest_precedence_skills(discoverable_skills);
     discoverable_skills.sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
     let attached_skills = discoverable_skills.clone();
-    let active_skill_ids = discoverable_skills
-        .iter()
-        .map(|entry| entry.skill_id.as_str())
-        .collect::<std::collections::BTreeSet<_>>();
-    let active_skills = active_skills
-        .iter()
-        .filter(|record| active_skill_ids.contains(record.skill_id.as_str()))
-        .cloned()
-        .collect::<Vec<_>>();
+    let active_skills = retain_active_skills_for_catalog(&discoverable_skills, active_skills);
 
     Ok(SkillsRuntimeView {
         agent_templates_catalog: Vec::new(),
@@ -135,6 +128,14 @@ pub(crate) fn existing_skill_roots(base: Option<&Path>, suffixes: &[&str]) -> Ve
 }
 
 pub fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<SkillCatalogEntry>> {
+    load_catalog_for_root(scope, root, skill_root_id_for_scope(scope, root))
+}
+
+pub(crate) fn load_catalog_for_root(
+    scope: SkillScope,
+    root: &Path,
+    root_id: String,
+) -> Result<Vec<SkillCatalogEntry>> {
     let mut entries = Vec::new();
     let read_dir = match fs::read_dir(root) {
         Ok(read_dir) => read_dir,
@@ -188,8 +189,12 @@ pub fn load_catalog_for_scope(scope: SkillScope, root: &Path) -> Result<Vec<Skil
         let description = parsed
             .description
             .unwrap_or_else(|| first_body_paragraph(&content));
+        let legacy_id = format!("{}:{skill_name}", scope_label(scope));
         entries.push(SkillCatalogEntry {
-            skill_id: format!("{}:{skill_name}", scope_label(scope)),
+            skill_id: format!("{root_id}:{skill_name}"),
+            root_id: root_id.clone(),
+            skill_dir: skill_name,
+            legacy_id: Some(legacy_id),
             name,
             description,
             path: skill_path,
@@ -248,15 +253,7 @@ pub fn skills_runtime_view_from_catalog(
             .then_with(|| left.skill_id.cmp(&right.skill_id))
             .then_with(|| left.path.cmp(&right.path))
     });
-    let active_skill_ids = catalog
-        .iter()
-        .map(|entry| entry.skill_id.as_str())
-        .collect::<std::collections::BTreeSet<_>>();
-    let active_skills = active_skills
-        .iter()
-        .filter(|record| active_skill_ids.contains(record.skill_id.as_str()))
-        .cloned()
-        .collect::<Vec<_>>();
+    let active_skills = retain_active_skills_for_catalog(&catalog, active_skills);
     SkillsRuntimeView {
         agent_templates_catalog: Vec::new(),
         discovered_roots: collect_discovered_roots_from_registrations(roots),
@@ -304,6 +301,37 @@ pub fn skill_root_registration(
     }
 }
 
+pub(crate) fn skill_root_id(registration: &SkillRootRegistration) -> String {
+    let source = match registration.source_kind {
+        SkillRootSourceKind::UserGlobal => "user_global",
+        SkillRootSourceKind::AgentHome => "agent_home",
+        SkillRootSourceKind::Workspace => "workspace",
+    };
+    let hash = short_root_hash(&registration.root_path);
+    match (
+        registration.source_kind,
+        registration.owner_agent_id.as_deref(),
+    ) {
+        (SkillRootSourceKind::AgentHome, Some(owner)) => format!("{source}:{owner}:{hash}"),
+        _ => format!("{source}:{hash}"),
+    }
+}
+
+fn skill_root_id_for_scope(scope: SkillScope, root: &Path) -> String {
+    let source = match scope {
+        SkillScope::User => "user_global",
+        SkillScope::Agent => "agent_home",
+        SkillScope::Workspace => "workspace",
+    };
+    format!("{source}:{}", short_root_hash(root))
+}
+
+fn short_root_hash(root: &Path) -> String {
+    let normalized = root.components().collect::<PathBuf>();
+    let digest = Sha256::digest(normalized.to_string_lossy().as_bytes());
+    format!("{digest:x}")[..12].to_string()
+}
+
 fn retain_highest_precedence_skills(skills: Vec<SkillCatalogEntry>) -> Vec<SkillCatalogEntry> {
     let mut selected_by_name: std::collections::BTreeMap<String, SkillCatalogEntry> =
         std::collections::BTreeMap::new();
@@ -316,6 +344,34 @@ fn retain_highest_precedence_skills(skills: Vec<SkillCatalogEntry>) -> Vec<Skill
         }
     }
     selected_by_name.into_values().collect()
+}
+
+fn retain_active_skills_for_catalog(
+    catalog: &[SkillCatalogEntry],
+    active_skills: &[ActiveSkillRecord],
+) -> Vec<ActiveSkillRecord> {
+    active_skills
+        .iter()
+        .filter_map(|record| {
+            catalog
+                .iter()
+                .find(|entry| {
+                    entry.skill_id == record.skill_id
+                        || entry
+                            .legacy_id
+                            .as_deref()
+                            .is_some_and(|legacy_id| legacy_id == record.skill_id)
+                })
+                .map(|entry| {
+                    let mut record = record.clone();
+                    record.skill_id = entry.skill_id.clone();
+                    record.name = entry.name.clone();
+                    record.path = entry.path.clone();
+                    record.scope = entry.scope;
+                    record
+                })
+        })
+        .collect()
 }
 
 fn skill_wins_catalog_selection(
@@ -1341,6 +1397,7 @@ pub struct InstalledSkillView {
 pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<InstalledSkillView>> {
     let mut entries = Vec::new();
     for skills_root in existing_skill_roots(Some(agent_home), &SKILL_ROOT_SUFFIXES) {
+        let root_id = skill_root_id_for_scope(SkillScope::Agent, &skills_root);
         let read_dir = match fs::read_dir(&skills_root) {
             Ok(read_dir) => read_dir,
             Err(error) => {
@@ -1359,13 +1416,17 @@ pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<InstalledSkillView
             }
             let skill_name = child.file_name().to_string_lossy().to_string();
             let skill_path = child.path().join(SKILL_ENTRYPOINT);
+            let legacy_id = format!("agent:{skill_name}");
             let catalog = if skill_path.is_file() {
                 let content = fs::read_to_string(&skill_path).with_context(|| {
                     format!("failed to read installed skill {}", skill_path.display())
                 })?;
                 let parsed = parse_skill_metadata(&content);
                 SkillCatalogEntry {
-                    skill_id: format!("agent:{skill_name}"),
+                    skill_id: format!("{root_id}:{skill_name}"),
+                    root_id: root_id.clone(),
+                    skill_dir: skill_name.clone(),
+                    legacy_id: Some(legacy_id.clone()),
                     name: parsed.name.unwrap_or_else(|| skill_name.clone()),
                     description: parsed
                         .description
@@ -1375,7 +1436,10 @@ pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<InstalledSkillView
                 }
             } else {
                 SkillCatalogEntry {
-                    skill_id: format!("agent:{skill_name}"),
+                    skill_id: format!("{root_id}:{skill_name}"),
+                    root_id: root_id.clone(),
+                    skill_dir: skill_name.clone(),
+                    legacy_id: Some(legacy_id),
                     name: skill_name.clone(),
                     description: String::new(),
                     path: skill_path,
@@ -1387,8 +1451,9 @@ pub fn list_installed_skills(agent_home: &Path) -> Result<Vec<InstalledSkillView
     }
     entries.sort_by(|left, right| {
         left.catalog
-            .skill_id
-            .cmp(&right.catalog.skill_id)
+            .name
+            .cmp(&right.catalog.name)
+            .then_with(|| left.catalog.skill_id.cmp(&right.catalog.skill_id))
             .then_with(|| left.catalog.path.cmp(&right.catalog.path))
     });
     Ok(entries)
@@ -1522,12 +1587,18 @@ mod tests {
                 .unwrap();
 
         assert_eq!(view.discovered_roots.len(), 2);
+        let ids = view
+            .discoverable_skills
+            .iter()
+            .map(|skill| skill.skill_id.as_str())
+            .collect::<Vec<_>>();
+        assert!(ids.iter().all(|id| id.starts_with("agent_home:")));
         let names = view
             .discoverable_skills
             .iter()
             .map(|skill| skill.name.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["alpha", "beta"]);
+        assert_eq!(names, vec!["beta", "alpha"]);
     }
 
     #[test]
@@ -1628,10 +1699,20 @@ mod tests {
         .unwrap();
 
         assert_eq!(view.discoverable_skills.len(), 1);
-        assert_eq!(view.discoverable_skills[0].skill_id, "agent:ghx");
+        assert!(view.discoverable_skills[0]
+            .skill_id
+            .starts_with("agent_home:"));
+        assert!(view.discoverable_skills[0].skill_id.ends_with(":ghx"));
+        assert_eq!(
+            view.discoverable_skills[0].legacy_id.as_deref(),
+            Some("agent:ghx")
+        );
         assert_eq!(view.discoverable_skills[0].description, "agent skill");
         assert_eq!(view.active_skills.len(), 1);
-        assert_eq!(view.active_skills[0].skill_id, "agent:ghx");
+        assert_eq!(
+            view.active_skills[0].skill_id,
+            view.discoverable_skills[0].skill_id
+        );
     }
 
     #[test]
@@ -1645,6 +1726,9 @@ mod tests {
         let selected = retain_highest_precedence_skills(vec![
             SkillCatalogEntry {
                 skill_id: "agent:z-skill".into(),
+                root_id: "agent_home:z-root".into(),
+                skill_dir: "z-skill".into(),
+                legacy_id: Some("agent:z-skill".into()),
                 name: "shared".into(),
                 description: "later id".into(),
                 path: later_id_path,
@@ -1652,6 +1736,9 @@ mod tests {
             },
             SkillCatalogEntry {
                 skill_id: "agent:a-skill".into(),
+                root_id: "agent_home:a-root".into(),
+                skill_dir: "a-skill".into(),
+                legacy_id: Some("agent:a-skill".into()),
                 name: "shared".into(),
                 description: "earlier id".into(),
                 path: earlier_id_path,
@@ -1659,6 +1746,9 @@ mod tests {
             },
             SkillCatalogEntry {
                 skill_id: "workspace:skill".into(),
+                root_id: "workspace:z-root".into(),
+                skill_dir: "skill".into(),
+                legacy_id: None,
                 name: "same-id".into(),
                 description: "later path".into(),
                 path: same_id_later_path,
@@ -1666,6 +1756,9 @@ mod tests {
             },
             SkillCatalogEntry {
                 skill_id: "workspace:skill".into(),
+                root_id: "workspace:a-root".into(),
+                skill_dir: "skill".into(),
+                legacy_id: None,
                 name: "same-id".into(),
                 description: "earlier path".into(),
                 path: same_id_earlier_path,
@@ -1746,7 +1839,10 @@ mod tests {
         let visible_path = PathBuf::from("/agent/skills/demo/SKILL.md");
         let view = skills_runtime_view_from_catalog(
             vec![SkillCatalogEntry {
-                skill_id: "agent:demo".into(),
+                skill_id: "agent_home:test-root:demo".into(),
+                root_id: "agent_home:test-root".into(),
+                skill_dir: "demo".into(),
+                legacy_id: Some("agent:demo".into()),
                 name: "demo".into(),
                 description: "visible".into(),
                 path: visible_path.clone(),
@@ -1783,7 +1879,7 @@ mod tests {
 
         assert_eq!(view.discoverable_skills.len(), 1);
         assert_eq!(view.active_skills.len(), 1);
-        assert_eq!(view.active_skills[0].skill_id, "agent:demo");
+        assert_eq!(view.active_skills[0].skill_id, "agent_home:test-root:demo");
     }
 
     #[test]

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -155,7 +155,7 @@ impl SkillsRegistry {
         registration: &SkillRootRegistration,
     ) -> (Vec<SkillCatalogEntry>, SkillRootScanStatus) {
         let scope = match registration.source_kind {
-            SkillRootSourceKind::UserGlobal => SkillScope::User,
+            SkillRootSourceKind::UserGlobal => SkillScope::UserGlobal,
             SkillRootSourceKind::AgentHome => SkillScope::Agent,
             SkillRootSourceKind::Workspace => SkillScope::Workspace,
         };
@@ -246,7 +246,7 @@ impl SkillsRegistry {
         match scope {
             SkillScope::Agent => 3,
             SkillScope::Workspace => 2,
-            SkillScope::User => 1,
+            SkillScope::UserGlobal => 1,
         }
     }
 }
@@ -312,7 +312,7 @@ mod tests {
             name: "test".to_string(),
             description: "user".to_string(),
             path: PathBuf::from("/user/test"),
-            scope: SkillScope::User,
+            scope: SkillScope::UserGlobal,
         });
 
         registry.entries.push(SkillCatalogEntry {
@@ -355,7 +355,7 @@ mod tests {
             name: "skill_b".to_string(),
             description: "user".to_string(),
             path: PathBuf::from("/b"),
-            scope: SkillScope::User,
+            scope: SkillScope::UserGlobal,
         });
 
         let agent_catalog = registry.catalog_with_filter(Some(SkillScope::Agent));

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -160,7 +160,11 @@ impl SkillsRegistry {
             SkillRootSourceKind::Workspace => SkillScope::Workspace,
         };
 
-        match crate::skills::load_catalog_for_scope(scope, &registration.root_path) {
+        match crate::skills::load_catalog_for_root(
+            scope,
+            &registration.root_path,
+            crate::skills::skill_root_id(registration),
+        ) {
             Ok(entries) => (
                 entries,
                 SkillRootScanStatus::Scanned {
@@ -302,6 +306,9 @@ mod tests {
 
         registry.entries.push(SkillCatalogEntry {
             skill_id: "user_skill".to_string(),
+            root_id: "user_global:test-root".to_string(),
+            skill_dir: "test".to_string(),
+            legacy_id: Some("user:test".to_string()),
             name: "test".to_string(),
             description: "user".to_string(),
             path: PathBuf::from("/user/test"),
@@ -310,6 +317,9 @@ mod tests {
 
         registry.entries.push(SkillCatalogEntry {
             skill_id: "agent_skill".to_string(),
+            root_id: "agent_home:test-root".to_string(),
+            skill_dir: "test".to_string(),
+            legacy_id: Some("agent:test".to_string()),
             name: "test".to_string(),
             description: "agent".to_string(),
             path: PathBuf::from("/agent/test"),
@@ -328,6 +338,9 @@ mod tests {
 
         registry.entries.push(SkillCatalogEntry {
             skill_id: "skill1".to_string(),
+            root_id: "agent_home:test-root".to_string(),
+            skill_dir: "skill_a".to_string(),
+            legacy_id: Some("agent:skill_a".to_string()),
             name: "skill_a".to_string(),
             description: "agent".to_string(),
             path: PathBuf::from("/a"),
@@ -336,6 +349,9 @@ mod tests {
 
         registry.entries.push(SkillCatalogEntry {
             skill_id: "skill2".to_string(),
+            root_id: "user_global:test-root".to_string(),
+            skill_dir: "skill_b".to_string(),
+            legacy_id: Some("user:skill_b".to_string()),
             name: "skill_b".to_string(),
             description: "user".to_string(),
             path: PathBuf::from("/b"),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -222,7 +222,7 @@ pub(super) fn render_agent_state_text(app: &TuiApp) -> String {
                 skill.name,
                 match skill.scope {
                     crate::types::SkillScope::Agent => "agent",
-                    crate::types::SkillScope::User => "user",
+                    crate::types::SkillScope::UserGlobal => "user_global",
                     crate::types::SkillScope::Workspace => "workspace",
                 }
             ));

--- a/src/types.rs
+++ b/src/types.rs
@@ -611,8 +611,7 @@ pub struct LoadedAgentMemoryView {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillScope {
-    #[serde(rename = "user_global", alias = "user")]
-    User,
+    UserGlobal,
     Agent,
     Workspace,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -611,6 +611,7 @@ pub struct LoadedAgentMemoryView {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillScope {
+    #[serde(alias = "user")]
     UserGlobal,
     Agent,
     Workspace,

--- a/src/types.rs
+++ b/src/types.rs
@@ -611,6 +611,7 @@ pub struct LoadedAgentMemoryView {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillScope {
+    #[serde(rename = "user_global", alias = "user")]
     User,
     Agent,
     Workspace,
@@ -619,6 +620,10 @@ pub enum SkillScope {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillCatalogEntry {
     pub skill_id: String,
+    pub root_id: String,
+    pub skill_dir: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_id: Option<String>,
     pub name: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -712,7 +712,7 @@ pub async fn skills_catalog_returns_global_user_library_only() -> Result<()> {
         .expect("catalog should be an array");
     assert!(skills
         .iter()
-        .any(|skill| skill["name"] == skill_name && skill["scope"] == "user"));
+        .any(|skill| skill["name"] == skill_name && skill["scope"] == "user_global"));
     assert!(!skills
         .iter()
         .any(|skill| skill["name"] == "shared-demo" || skill["name"] == "workspace-demo"));

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -706,7 +706,7 @@ pub async fn skills_catalog_returns_global_user_library_only() -> Result<()> {
         .await?
         .json()
         .await?;
-    assert_eq!(payload["library"], "user");
+    assert_eq!(payload["library"], "user_global");
     let skills = payload["catalog"]
         .as_array()
         .expect("catalog should be an array");
@@ -718,6 +718,17 @@ pub async fn skills_catalog_returns_global_user_library_only() -> Result<()> {
         .any(|skill| skill["name"] == "shared-demo" || skill["name"] == "workspace-demo"));
 
     std::fs::remove_dir_all(&agent_skill_dir)?;
+    let payload: serde_json::Value = client
+        .get(format!("{base}/api/skills/catalog?scope=user_global"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let skills = payload["catalog"]
+        .as_array()
+        .expect("catalog should be an array");
+    assert!(skills.iter().any(|skill| skill["name"] == skill_name));
+
     let payload: serde_json::Value = client
         .get(format!("{base}/api/skills/catalog?scope=user"))
         .send()


### PR DESCRIPTION
## Summary
- introduce root-qualified skill_id values for skills catalog entries
- expose root_id, skill_dir, and legacy_id compatibility metadata
- report user-global skill scope as user_global while accepting legacy user input

Fixes #1956
Fixes #1954

## Verification
- cargo test -q skills
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets