### PR TITLE
feat: add skill detail API and page

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -6163,6 +6163,64 @@
         ]
       }
     },
+    "/api/skills/catalog/{skill_id}": {
+      "get": {
+        "description": "Return catalog metadata and SKILL.md content for a Global Skill Library skill.",
+        "operationId": "skillDetail",
+        "parameters": [
+          {
+            "description": "Root-qualified skill id.",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Skill detail",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
     "/briefs": {
       "get": {
         "description": "Compatibility alias for the default agent briefs route. Query parameter: limit.",

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -457,6 +457,7 @@ pub fn router(state: AppState) -> Router {
         .route("/enqueue", post(state::enqueue_default))
         .route("/agents/{agent_id}/skills", get(skills::list_skills))
         .route("/api/skills/catalog", get(skills::skills_catalog))
+        .route("/api/skills/catalog/{skill_id}", get(skills::skill_detail))
         .route(
             "/api/skills/catalog/add",
             post(skills::add_skill_to_catalog),

--- a/src/http/skills.rs
+++ b/src/http/skills.rs
@@ -268,3 +268,54 @@ pub async fn skills_catalog(
         "scope": scope_filter,
     })))
 }
+
+pub async fn skill_detail(
+    Path(skill_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+
+    let user_home = crate::agent_template::user_home_dir().ok();
+    let roots = crate::skills::existing_skill_roots(
+        user_home.as_deref(),
+        &crate::skills::COMPAT_SKILL_ROOT_SUFFIXES,
+    )
+    .into_iter()
+    .map(|root| {
+        crate::skills::skill_root_registration(
+            crate::types::SkillRootSourceKind::UserGlobal,
+            None,
+            root,
+        )
+    })
+    .collect::<Vec<_>>();
+
+    let mut registry = state.skills_registry.write().await;
+    registry
+        .sync_effective_roots(roots.clone())
+        .map_err(error_response)?;
+    let Some(skill) = registry
+        .catalog_for_roots(&roots, Some(crate::types::SkillScope::UserGlobal))
+        .into_iter()
+        .find(|entry| {
+            entry.skill_id == skill_id
+                || entry
+                    .legacy_id
+                    .as_deref()
+                    .is_some_and(|legacy_id| legacy_id == skill_id)
+        })
+    else {
+        return Err(not_found(format!("skill {skill_id} not found")));
+    };
+    let content = tokio::fs::read_to_string(&skill.path)
+        .await
+        .map_err(|error| error_response(error.into()))?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "library": USER_GLOBAL_LIBRARY_LABEL,
+        "skill": skill,
+        "content": content,
+    })))
+}

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -92,6 +92,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/timers/{timer_id}", "agentTimer", "timers", "Timer detail", "Return a timer record by id.", None, AuthKind::RemoteAccess),
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List agent skills", "Return skills enabled/effective for an agent.", None, AuthKind::RemoteAccess),
     route("get", "/api/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the global user Skill Library catalog. Query parameter: scope.", None, AuthKind::RemoteAccess),
+    route("get", "/api/skills/catalog/{skill_id}", "skillDetail", "skills", "Skill detail", "Return catalog metadata and SKILL.md content for a Global Skill Library skill.", None, AuthKind::RemoteAccess),
     route("post", "/api/skills/catalog/add", "addSkillToCatalog", "skills", "Add skill to library", "Add or import a skill into the local Skill Library.", Some("AddSkillRequest"), AuthKind::Control),
     route("post", "/api/skills/catalog/remove", "removeSkillFromCatalog", "skills", "Remove skill from library", "Remove a skill from the local Skill Library.", Some("RemoveSkillRequest"), AuthKind::Control),
     route("post", "/api/skills/catalog/update", "updateSkillCatalog", "skills", "Update skill library", "Refresh Skill Library lock state for one skill or all skills.", Some("UpdateSkillRequest"), AuthKind::Control),

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -405,6 +405,9 @@ fn path_parameters(path: &str) -> Vec<Value> {
     if path.contains("{message_id}") {
         params.push(path_param("message_id", "Message id."));
     }
+    if path.contains("{skill_id}") {
+        params.push(path_param("skill_id", "Root-qualified skill id."));
+    }
     if path.contains("{callback_token}") {
         params.push(path_param(
             "callback_token",

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -23,6 +23,7 @@ http_async_tests!(
     agent_skills_endpoint_uses_effective_registry_snapshot,
     agent_skills_endpoint_does_not_leak_stale_roots_between_agents,
     skills_catalog_returns_global_user_library_only,
+    skill_detail_returns_catalog_skill_markdown,
     install_skill_existing_destination_returns_conflict,
     add_skill_to_catalog_existing_destination_returns_conflict,
     skill_library_add_remove_and_agent_enable_disable_are_separate,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -72,7 +72,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 79, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 80, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -519,6 +519,28 @@
   },
   {
     "method": "get",
+    "path": "/api/skills/catalog/{skill_id}",
+    "handler": "skill_detail",
+    "operation_id": "skillDetail",
+    "tag": "skills",
+    "parameters": [
+      {
+        "name": "skill_id",
+        "location": "path",
+        "required": true
+      }
+    ],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/briefs",
     "handler": "briefs_default",
     "operation_id": "defaultBriefs",

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -745,6 +745,66 @@ pub async fn skills_catalog_returns_global_user_library_only() -> Result<()> {
     Ok(())
 }
 
+pub async fn skill_detail_returns_catalog_skill_markdown() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let skill_name = format!("http-skill-detail-{}", std::process::id());
+    let user_home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("HOME must be set for skill library tests"))?;
+    let library_root = [".agents/skills", ".codex/skills", ".claude/skills"]
+        .iter()
+        .map(|suffix| user_home.join(suffix))
+        .find(|path| path.is_dir())
+        .unwrap_or_else(|| user_home.join(".agents").join("skills"));
+    let user_skill_dir = library_root.join(&skill_name);
+    std::fs::create_dir_all(&user_skill_dir)?;
+    std::fs::write(
+        user_skill_dir.join("SKILL.md"),
+        format!("---\nname: {skill_name}\ndescription: detail\n---\n\nDetail body"),
+    )?;
+
+    let client = Client::new();
+    let catalog: serde_json::Value = client
+        .get(format!("{base}/api/skills/catalog"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let skill_id = catalog["catalog"]
+        .as_array()
+        .and_then(|skills| {
+            skills
+                .iter()
+                .find(|skill| skill["name"] == skill_name)
+                .and_then(|skill| skill["skill_id"].as_str())
+        })
+        .ok_or_else(|| anyhow::anyhow!("test skill should appear in catalog"))?;
+
+    let payload: serde_json::Value = client
+        .get(format!("{base}/api/skills/catalog/{skill_id}"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(payload["library"], "user_global");
+    assert_eq!(payload["skill"]["name"], skill_name);
+    assert_eq!(payload["skill"]["scope"], "user_global");
+    assert!(payload["content"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("Detail body"));
+
+    let missing = client
+        .get(format!("{base}/api/skills/catalog/not-a-real-skill"))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let _ = std::fs::remove_dir_all(&user_skill_dir);
+    server.abort();
+    Ok(())
+}
+
 pub async fn install_skill_existing_destination_returns_conflict() -> Result<()> {
     let (_host, base, server) = spawn_server().await?;
     let client = Client::new();

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -10,7 +10,7 @@ import { DashboardPage } from "../features/dashboard/DashboardPage";
 import { RightSidePanel } from "../features/right-panel/RightSidePanel";
 import { SearchPage } from "../features/search/SearchPage";
 import { SettingsPage } from "../features/settings/SettingsPage";
-import { SkillsPage } from "../features/skills/SkillsPage";
+import { SkillDetailPage, SkillsPage } from "../features/skills/SkillsPage";
 import { deriveAgentDisplayStatus } from "../runtime/agent-status";
 import { selectSelectedAgent } from "../runtime/runtime-selectors";
 import { canUseRemoteRuntimeConnections, readStoredRemoteConnectionProfiles, useRuntimeStore } from "../runtime/runtime-store";
@@ -32,6 +32,7 @@ export function App() {
   const { bootstrap, loading, refresh } = useRuntimeDashboard();
   const route = useRuntimeStore((state) => state.route);
   const selectedAgentId = useRuntimeStore((state) => state.selectedAgentId);
+  const selectedSkillId = useRuntimeStore((state) => state.selectedSkillId);
   const displayLevel = useRuntimeStore((state) =>
     state.displayLevelsByAgentId[selectedAgentId] ?? "info",
   );
@@ -40,6 +41,7 @@ export function App() {
   const navCollapsed = useRuntimeStore((state) => state.navCollapsed);
   const setRoute = useRuntimeStore((state) => state.setRoute);
   const openAgent = useRuntimeStore((state) => state.openAgent);
+  const openSkill = useRuntimeStore((state) => state.openSkill);
   const setDisplayLevel = useRuntimeStore((state) => state.setDisplayLevel);
   const setRightPanelOpen = useRuntimeStore((state) => state.setRightPanelOpen);
   const inspectActivity = useRuntimeStore((state) => state.inspectActivity);
@@ -70,6 +72,15 @@ export function App() {
   const skillCatalog = useRuntimeStore((state) => state.skillCatalog);
   const skillCatalogLoading = useRuntimeStore((state) => state.skillCatalogLoading);
   const skillCatalogError = useRuntimeStore((state) => state.skillCatalogError);
+  const skillDetail = useRuntimeStore((state) =>
+    selectedSkillId ? state.skillDetailById[selectedSkillId] : undefined,
+  );
+  const skillDetailLoading = useRuntimeStore((state) =>
+    selectedSkillId ? state.skillDetailLoadingById[selectedSkillId] ?? false : false,
+  );
+  const skillDetailError = useRuntimeStore((state) =>
+    selectedSkillId ? state.skillDetailErrorById[selectedSkillId] : undefined,
+  );
   const addSkillToCatalog = useRuntimeStore((state) => state.addSkillToCatalog);
   const removeSkillFromCatalog = useRuntimeStore((state) => state.removeSkillFromCatalog);
   const agentSkillCatalog = useRuntimeStore((state) =>
@@ -84,6 +95,7 @@ export function App() {
   const runSearch = useRuntimeStore((state) => state.runSearch);
   const loadSearchResultContent = useRuntimeStore((state) => state.loadSearchResultContent);
   const refreshSkillCatalog = useRuntimeStore((state) => state.refreshSkillCatalog);
+  const refreshSkillDetail = useRuntimeStore((state) => state.refreshSkillDetail);
   const refreshAgentSkillCatalog = useRuntimeStore((state) => state.refreshAgentSkillCatalog);
   const enableAgentSkill = useRuntimeStore((state) => state.enableAgentSkill);
   const disableAgentSkill = useRuntimeStore((state) => state.disableAgentSkill);
@@ -171,13 +183,17 @@ export function App() {
         openAgent(nextRoute.agentId, nextRoute.eventSeq);
         return;
       }
+      if (nextRoute.route === "skillDetail" && nextRoute.skillId) {
+        openSkill(nextRoute.skillId);
+        return;
+      }
       setRoute(nextRoute.route);
     };
 
     applyBrowserRoute();
     window.addEventListener("popstate", applyBrowserRoute);
     return () => window.removeEventListener("popstate", applyBrowserRoute);
-  }, [openAgent, setRoute]);
+  }, [openAgent, openSkill, setRoute]);
 
   useEffect(() => {
     if ((route !== "agent" && route !== "settings") || modelCatalogLoading || modelCatalog.options.length > 0) return;
@@ -195,6 +211,11 @@ export function App() {
   }, [refreshSkillCatalog, route, skillCatalog.catalog.length, skillCatalogLoading]);
 
   useEffect(() => {
+    if (route !== "skillDetail" || !selectedSkillId || skillDetailLoading || skillDetail) return;
+    void refreshSkillDetail(selectedSkillId);
+  }, [refreshSkillDetail, route, selectedSkillId, skillDetail, skillDetailLoading]);
+
+  useEffect(() => {
     if (route !== "agent" || !activeAgentId || agentSkillCatalogLoading || agentSkillCatalog) return;
     void refreshAgentSkillCatalog(activeAgentId);
   }, [activeAgentId, agentSkillCatalog, agentSkillCatalogLoading, refreshAgentSkillCatalog, route]);
@@ -206,6 +227,11 @@ export function App() {
   function navigateRoute(nextRoute: RouteKey) {
     setRoute(nextRoute);
     pushBrowserRoute(nextRoute, selectedAgentId);
+  }
+
+  function navigateSkill(skillId: string) {
+    openSkill(skillId);
+    pushBrowserRoute("skillDetail", skillId);
   }
 
   function navigateAgent(agentId: string, eventSeq?: number) {
@@ -442,6 +468,17 @@ export function App() {
             onRefresh={refreshSkillCatalog}
             onAddSkill={addSkillToCatalog}
             onRemoveSkill={removeSkillFromCatalog}
+            onOpenSkill={navigateSkill}
+          />
+        ) : null}
+        {route === "skillDetail" ? (
+          <SkillDetailPage
+            skillId={selectedSkillId}
+            detail={skillDetail}
+            loading={skillDetailLoading}
+            error={skillDetailError}
+            onBack={() => navigateRoute("skills")}
+            onRefresh={() => refreshSkillDetail(selectedSkillId)}
           />
         ) : null}
         {route === "settings" ? (
@@ -793,14 +830,14 @@ function agentStatusIcon(tone: string): string {
 
 function pageTitle(route: RouteKey): string {
   if (route === "search") return "Search";
-  if (route === "skills") return "Skills";
+  if (route === "skills" || route === "skillDetail") return "Skills";
   if (route === "settings") return "Settings";
   return "Dashboard";
 }
 
 function pageSubtitle(route: RouteKey, attentionCount: number, agentCount: number): string {
   if (route === "search") return "cross-agent lookup · messages · briefs · work evidence";
-  if (route === "skills") return "global library · catalog · daemon-managed skills";
+  if (route === "skills" || route === "skillDetail") return "global library · catalog · daemon-managed skills";
   if (route === "settings") return "local connection · providers · model defaults";
   return attentionCount > 0 ? `${agentCount} agents · ${attentionCount} need attention` : `${agentCount} agents · all clear`;
 }

--- a/web-gui/app/src/app/routes.test.ts
+++ b/web-gui/app/src/app/routes.test.ts
@@ -24,4 +24,11 @@ describe("routeFromLocation", () => {
       route: "skills",
     });
   });
+
+  it("parses skill detail links", () => {
+    expect(routeFromLocation({ pathname: "/skills/user_global%3Aghx", search: "" })).toEqual({
+      route: "skillDetail",
+      skillId: "user_global:ghx",
+    });
+  });
 });

--- a/web-gui/app/src/app/routes.ts
+++ b/web-gui/app/src/app/routes.ts
@@ -3,6 +3,7 @@ import type { RouteKey } from "../runtime/types";
 interface BrowserRoute {
   route: RouteKey;
   agentId?: string;
+  skillId?: string;
   eventSeq?: number;
 }
 
@@ -19,6 +20,13 @@ export function routeFromLocation(location: Pick<Location, "pathname" | "search"
   if (path === "/") return { route: "dashboard" };
   if (path === "/search") return { route: "search" };
   if (path === "/skills") return { route: "skills" };
+  const skillMatch = path.match(/^\/skills\/([^/]+)$/);
+  if (skillMatch) {
+    return {
+      route: "skillDetail",
+      skillId: safeDecodeURIComponent(skillMatch[1]),
+    };
+  }
   if (path === "/settings") return { route: "settings" };
 
   const agentMatch = path.match(/^\/agents\/([^/]+)(?:\/conversation)?$/);
@@ -37,6 +45,7 @@ export function pathForRoute(route: RouteKey, agentId?: string, query?: Record<s
   const queryString = query ? new URLSearchParams(Object.entries(query).flatMap(([key, value]) => (value == null ? [] : [[key, String(value)]]))).toString() : "";
   if (route === "search") return "/search";
   if (route === "skills") return "/skills";
+  if (route === "skillDetail" && agentId) return `/skills/${encodeURIComponent(agentId)}`;
   if (route === "settings") return "/settings";
   if (route === "agent" && agentId) return `/agents/${encodeURIComponent(agentId)}/conversation${queryString ? `?${queryString}` : ""}`;
   return "/";

--- a/web-gui/app/src/features/skills/SkillsPage.tsx
+++ b/web-gui/app/src/features/skills/SkillsPage.tsx
@@ -3,8 +3,9 @@ import { useMemo, useState, type FormEvent } from "react";
 import { Button } from "../../components/ui/Button";
 import { Card, CardContent, CardHeader } from "../../components/ui/Card";
 import { EmptyState } from "../../components/ui/EmptyState";
+import { MarkdownContent } from "../../components/MarkdownContent";
 import { StatusBadge } from "../../components/ui/StatusChip";
-import type { AddSkillInput, SkillCatalogEntry, SkillCatalogState, SkillInstallMode } from "../../runtime/types";
+import type { AddSkillInput, SkillCatalogEntry, SkillCatalogState, SkillDetailState, SkillInstallMode } from "../../runtime/types";
 
 interface SkillsPageProps {
   catalog: SkillCatalogState;
@@ -13,6 +14,7 @@ interface SkillsPageProps {
   onRefresh: () => void;
   onAddSkill: (input: AddSkillInput) => Promise<boolean>;
   onRemoveSkill: (name: string) => Promise<boolean>;
+  onOpenSkill: (skillId: string) => void;
 }
 
 type AddSourceType = Extract<AddSkillInput["kind"], "local" | "remote">;
@@ -24,6 +26,7 @@ export function SkillsPage({
   onRefresh,
   onAddSkill,
   onRemoveSkill,
+  onOpenSkill,
 }: SkillsPageProps) {
   const skills = catalog.catalog;
   const [query, setQuery] = useState("");
@@ -200,6 +203,7 @@ export function SkillsPage({
                   skill={skill}
                   loading={loading}
                   onRemove={removeSkill}
+                  onOpen={onOpenSkill}
                 />
               ))}
             </ul>
@@ -224,10 +228,12 @@ function SkillRow({
   skill,
   loading,
   onRemove,
+  onOpen,
 }: {
   skill: SkillCatalogEntry;
   loading: boolean;
   onRemove: (name: string) => void;
+  onOpen: (skillId: string) => void;
 }) {
   return (
     <li className="skills-row">
@@ -241,11 +247,87 @@ function SkillRow({
         <p>{skill.description || "No description provided."}</p>
       </div>
       <div className="skills-row-actions">
+        <Button type="button" size="sm" variant="outline" onClick={() => onOpen(skill.skillId)}>
+          Details
+        </Button>
         <Button type="button" size="sm" variant="outline" disabled={loading || skill.scope !== "user"} onClick={() => onRemove(skill.name)}>
           Remove
         </Button>
       </div>
     </li>
+  );
+}
+
+export function SkillDetailPage({
+  skillId,
+  detail,
+  loading,
+  error,
+  onBack,
+  onRefresh,
+}: {
+  skillId: string;
+  detail?: SkillDetailState;
+  loading: boolean;
+  error?: string;
+  onBack: () => void;
+  onRefresh: () => void;
+}) {
+  const skill = detail?.skill;
+  return (
+    <div className="skills-inner scroll-surface">
+      <section className="skills-hero context-card">
+        <div className="skills-hero-copy">
+          <span className="eyebrow">Skill detail</span>
+          <h1>{skill?.name ?? skillId}</h1>
+          <p>{skill?.description || "Read-only SKILL.md content resolved through the Global Skill Library catalog."}</p>
+        </div>
+        <div className="skills-actions" aria-label="Skill detail actions">
+          <Button type="button" variant="outline" onClick={onBack}>
+            Back to skills
+          </Button>
+          <Button type="button" variant="outline" disabled={loading} onClick={onRefresh}>
+            {loading ? "Refreshing…" : "Refresh"}
+          </Button>
+        </div>
+      </section>
+
+      {error || detail?.error ? (
+        <div className="skills-error" role="alert">
+          <strong>Skill detail failed</strong>
+          <span>{error ?? detail?.error}</span>
+        </div>
+      ) : null}
+
+      {skill ? (
+        <Card className="skills-library-card">
+          <CardHeader className="skills-library-head">
+            <div>
+              <p>
+                <code>{skill.skillId}</code>
+              </p>
+              <p>{collapseHome(skill.path)}</p>
+            </div>
+            <StatusBadge className="state-chip" kind="connection" value={skill.scope}>
+              {skillScopeLabel(skill.scope)}
+            </StatusBadge>
+          </CardHeader>
+          <CardContent>
+            <MarkdownContent text={detail?.content ?? ""} />
+          </CardContent>
+        </Card>
+      ) : (
+        <EmptyState
+          icon="◇"
+          title={loading ? "Loading skill…" : "Skill not found"}
+          description={
+            loading
+              ? "Resolving the skill through the catalog."
+              : "The requested skill id was not found in the Global Skill Library."
+          }
+        />
+      )}
+    </div>
   );
 }
 

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -18,6 +18,7 @@ import type {
   RuntimeModelOption,
   RuntimeSearchOptions,
   SkillCatalogState,
+  SkillDetailState,
   SkillScope,
   SkillInstallMode,
   RuntimeTaskOutputResult,
@@ -525,6 +526,11 @@ interface SkillCatalogResponseDto {
   catalog?: SkillCatalogEntryDto[];
 }
 
+interface SkillDetailResponseDto {
+  skill?: SkillCatalogEntryDto;
+  content?: string;
+}
+
 interface AgentSkillsResponseDto {
   skills?: SkillCatalogEntryDto[];
 }
@@ -683,6 +689,22 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       }
       const response = await getJson<SkillCatalogResponseDto>(fetchImpl, baseUrl, "/skills/catalog", { headers: requestHeaders });
       return projectSkillCatalog(response, agentId);
+    },
+    async getSkillDetail(skillId: string): Promise<SkillDetailState> {
+      if (!baseUrl) {
+        return { source: "fixture", error: "Holon API base URL is not configured." };
+      }
+      const response = await getJson<SkillDetailResponseDto>(
+        fetchImpl,
+        baseUrl,
+        `/skills/catalog/${encodeURIComponent(skillId)}`,
+        { headers: requestHeaders },
+      );
+      return {
+        source: "http",
+        skill: response.skill ? projectSkillCatalogEntry(response.skill) : undefined,
+        content: response.content ?? "",
+      };
     },
     async addSkillToCatalog(input: AddSkillInput): Promise<void> {
       if (!baseUrl) {
@@ -1112,13 +1134,17 @@ function projectSkillCatalog(response: SkillCatalogResponseDto, agentId?: string
     agentId,
     catalog: (response.catalog ?? [])
       .filter((entry) => Boolean(entry.name || entry.skill_id))
-      .map((entry) => ({
-        skillId: entry.skill_id ?? entry.name ?? "unknown",
-        name: entry.name ?? entry.skill_id ?? "unknown",
-        description: entry.description ?? "",
-        path: entry.path ?? "",
-        scope: entry.scope ?? "user",
-      })),
+      .map(projectSkillCatalogEntry),
+  };
+}
+
+function projectSkillCatalogEntry(entry: SkillCatalogEntryDto) {
+  return {
+    skillId: entry.skill_id ?? entry.name ?? "unknown",
+    name: entry.name ?? entry.skill_id ?? "unknown",
+    description: entry.description ?? "",
+    path: entry.path ?? "",
+    scope: entry.scope ?? "user",
   };
 }
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -38,6 +38,7 @@ import type {
   RuntimeModelCatalog,
   RuntimeSearchOptions,
   SkillCatalogState,
+  SkillDetailState,
   RuntimeTranscriptEntry,
   RuntimeToolExecutionRecord,
   WorkItemSummary,
@@ -148,6 +149,7 @@ function markOptimisticOperatorPromptsSent(detail: AgentDetail | null): AgentDet
 export interface RuntimeStoreState {
   route: RouteKey;
   selectedAgentId: string;
+  selectedSkillId: string;
   displayLevel: DisplayLevel;
   displayLevelsByAgentId: Record<string, DisplayLevel>;
   rightPanelOpen: boolean;
@@ -167,6 +169,9 @@ export interface RuntimeStoreState {
   skillCatalog: SkillCatalogState;
   skillCatalogLoading: boolean;
   skillCatalogError?: string;
+  skillDetailById: Record<string, SkillDetailState>;
+  skillDetailLoadingById: Record<string, boolean>;
+  skillDetailErrorById: Record<string, string | undefined>;
   agentSkillCatalogByAgentId: Record<string, SkillCatalogState>;
   agentSkillCatalogLoadingByAgentId: Record<string, boolean>;
   agentSkillCatalogErrorByAgentId: Record<string, string | undefined>;
@@ -184,6 +189,7 @@ export interface RuntimeStoreState {
 
   setRoute: (route: RouteKey) => void;
   openAgent: (agentId: string, targetEventSeq?: number) => void;
+  openSkill: (skillId: string) => void;
   setDisplayLevel: (displayLevel: DisplayLevel, agentId?: string) => void;
   setRightPanelOpen: (open: boolean) => void;
   showAgentOverview: (agentId?: string) => void;
@@ -197,6 +203,7 @@ export interface RuntimeStoreState {
   refreshRuntimeConfig: () => Promise<void>;
   updateRuntimeConfig: (updates: Array<{ key: string; value?: unknown; unset?: boolean }>) => Promise<RuntimeConfigState | undefined>;
   refreshSkillCatalog: () => Promise<void>;
+  refreshSkillDetail: (skillId: string | undefined) => Promise<void>;
   addSkillToCatalog: (input: AddSkillInput) => Promise<boolean>;
   removeSkillFromCatalog: (name: string) => Promise<boolean>;
   updateSkillCatalog: (name?: string) => Promise<boolean>;
@@ -589,6 +596,7 @@ function initSessionCacheForRemote(set: StoreSet): void {
 export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   route: "dashboard",
   selectedAgentId: "",
+  selectedSkillId: "",
   displayLevel: "info",
   displayLevelsByAgentId: readStoredDisplayLevels(),
   rightPanelOpen: true,
@@ -604,6 +612,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   runtimeConfigSaving: false,
   skillCatalog: emptySkillCatalog,
   skillCatalogLoading: false,
+  skillDetailById: {},
+  skillDetailLoadingById: {},
+  skillDetailErrorById: {},
   agentSkillCatalogByAgentId: {},
   agentSkillCatalogLoadingByAgentId: {},
   agentSkillCatalogErrorByAgentId: {},
@@ -619,6 +630,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   sessionsByAgentId: {},
 
   setRoute: (route) => set({ route }),
+  openSkill: (skillId) => set({ route: "skillDetail", selectedSkillId: skillId }),
   openAgent: (agentId, targetEventSeq) =>
     set((state) => {
       const currentSession = state.sessionsByAgentId[agentId];
@@ -746,6 +758,9 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       skillCatalog: emptySkillCatalog,
       skillCatalogLoading: false,
       skillCatalogError: undefined,
+      skillDetailById: {},
+      skillDetailLoadingById: {},
+      skillDetailErrorById: {},
       agentSkillCatalogByAgentId: {},
       agentSkillCatalogLoadingByAgentId: {},
       agentSkillCatalogErrorByAgentId: {},
@@ -757,6 +772,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       sessionsByAgentId: {},
       rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(normalizedConfig)),
       selectedAgentId: "",
+      selectedSkillId: "",
       route: "dashboard",
     });
     await get().refreshBootstrap();
@@ -888,6 +904,32 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
         skillCatalog: { ...state.skillCatalog, error: message },
         skillCatalogLoading: false,
         skillCatalogError: message,
+      }));
+    }
+  },
+
+  refreshSkillDetail: async (skillId) => {
+    if (!skillId) return;
+    set((state) => ({
+      skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: true },
+      skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: undefined },
+    }));
+    try {
+      const detail = await runtimeClient.getSkillDetail(skillId);
+      set((state) => ({
+        skillDetailById: { ...state.skillDetailById, [skillId]: detail },
+        skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: false },
+        skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: detail.error },
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set((state) => ({
+        skillDetailById: {
+          ...state.skillDetailById,
+          [skillId]: { source: "http", error: message },
+        },
+        skillDetailLoadingById: { ...state.skillDetailLoadingById, [skillId]: false },
+        skillDetailErrorById: { ...state.skillDetailErrorById, [skillId]: message },
       }));
     }
   },

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -1,6 +1,6 @@
 export type DisplayLevel = "info" | "verbose" | "debug";
 
-export type RouteKey = "dashboard" | "agent" | "search" | "skills" | "settings";
+export type RouteKey = "dashboard" | "agent" | "search" | "skills" | "skillDetail" | "settings";
 
 export interface RuntimeConnection {
   mode: "local" | "remote";
@@ -31,6 +31,13 @@ export interface SkillCatalogEntry {
   description: string;
   path: string;
   scope: SkillScope;
+}
+
+export interface SkillDetailState {
+  source: "http" | "fixture";
+  skill?: SkillCatalogEntry;
+  content?: string;
+  error?: string;
 }
 
 export interface SkillCatalogState {


### PR DESCRIPTION
## Summary
- add a remote-access skill detail API that resolves skills through the Global Skill Library catalog and returns SKILL.md content
- add Skills list detail navigation and a read-only markdown detail page
- add HTTP and route tests for skill detail lookup

Fixes #1952

## Verification
- cargo fmt --all -- --check
- cargo test -q skill_detail_returns_catalog_skill_markdown -- --nocapture
- npm --prefix web-gui/app test -- routes.test.ts
- npm --prefix web-gui/app run typecheck
- RUSTFLAGS="-D warnings" cargo check --all-targets