### PR TITLE
docs: update for v0.20.0 features — skills redesign, Web GUI skill management, search excerpts, async memory indexing

### DIFF
--- a/docs/website/concepts/memory.md
+++ b/docs/website/concepts/memory.md
@@ -10,6 +10,17 @@ Holon is designed for long-lived agents. Memory preserves what matters across
 turns without replaying the entire conversation history. The runtime derives
 memory from durable evidence rather than relying on free-form model summaries.
 
+## Memory Indexing
+
+Holon indexes memory asynchronously at startup. The index build runs in the
+background and does **not block daemon startup**. New events continue to be
+indexed as they are written to the durable ledger.
+
+During the initial index build, search results may be incomplete. The
+runtime prioritizes newly written events so recent memory is always
+findable, even while the background build catches up on historical
+records.
+
 ## Memory Layers
 
 Holon's context memory has four layers, each with a distinct role:

--- a/docs/website/guides/integration.md
+++ b/docs/website/guides/integration.md
@@ -67,7 +67,12 @@ Access modes: `local`, `tunnel`, `lan`, `tailnet`.
 | `POST` | `/control/agents/:agent_id/workspace/attach` | Attach a workspace |
 | `POST` | `/control/agents/:agent_id/workspace/detach` | Detach workspace |
 | `GET` | `/agents/:agent_id/skills` | List agent skills |
-| `POST` | `/control/agents/:agent_id/skills/install` | Install a skill |
+| `POST` | `/control/agents/:agent_id/skills/enable` | Enable a skill for an agent |
+| `POST` | `/control/agents/:agent_id/skills/disable` | Disable a skill for an agent |
+| `GET` | `/api/skills/catalog` | List Skill Library catalog |
+| `POST` | `/api/skills/catalog/add` | Add a skill to the library |
+| `POST` | `/api/skills/catalog/remove` | Remove a skill from the library |
+| `POST` | `/api/skills/catalog/reconcile` | Reconcile library with lock file |
 
 ### Callbacks & Webhooks
 

--- a/docs/website/guides/skills.md
+++ b/docs/website/guides/skills.md
@@ -49,74 +49,172 @@ This keeps skills explicit and avoids loading irrelevant guidance.
 
 ## Managing skills with the CLI
 
-Holon provides CLI commands for installing, listing, and removing skills:
+Holon separates skill management into two layers:
 
-### List installed skills
+- **Skill Library** — A global catalog of known skills managed with
+  `holon skills add/remove/check/reconcile/catalog`. Think of it as your
+  local skill registry.
+- **Agent Skills** — Per-agent enablement managed with
+  `holon skills enable/disable/list`. A skill must exist in the library
+  before it can be enabled for an agent.
+
+### Skill Library (global)
+
+The Skill Library is your local catalog of skills. Manage it with:
+
+#### List the library catalog
 
 ```bash
-holon skills list
+holon skills catalog
 ```
 
-Shows all discoverable skills for the current agent, including their name,
+Shows all skills registered in the local Skill Library.
+
+#### Add a skill to the library
+
+```bash
+# Add from a local directory or SKILL.md file
+holon skills add /path/to/skill-dir
+
+# Add from a remote source
+holon skills add https://github.com/user/repo/tree/main/skills/my-skill --remote
+
+# Add a built-in skill by name
+holon skills add my-skill --builtin
+
+# Copy the skill into the user directory instead of referencing it
+holon skills add /path/to/skill --copy
+```
+
+#### Remove a skill from the library
+
+```bash
+holon skills remove my-skill
+```
+
+#### Check library consistency
+
+```bash
+# Check all library entries against .skill-lock.json
+holon skills check
+
+# Check a specific skill
+holon skills check my-skill
+```
+
+#### Reconcile library with lock file
+
+```bash
+# Reconcile all library entries
+holon skills reconcile
+
+# Reconcile a specific skill
+holon skills reconcile my-skill
+```
+
+### Agent Skills (per-agent)
+
+Once a skill is in the library, enable it for a specific agent:
+
+#### List enabled skills for an agent
+
+```bash
+# List for the default agent
+holon skills list
+
+# List for a specific agent
+holon skills list --agent reviewer
+```
+
+Shows all skills currently enabled for the agent, including their name,
 scope (agent, workspace, or user), and source.
 
-### Install a skill
+#### Enable a skill for an agent
 
 ```bash
-# Install from a local directory or SKILL.md file
-holon skills install /path/to/skill-dir
+# Enable for the default agent
+holon skills enable my-skill
 
-# Install from a remote source
-holon skills install https://github.com/user/repo/tree/main/skills/my-skill --remote
+# Enable for a specific agent
+holon skills enable my-skill --agent reviewer
 
-# Install a built-in skill by name
-holon skills install my-skill --builtin
-
-# Copy the skill into the agent instead of referencing it
-holon skills install /path/to/skill --copy
+# Enable and copy into the agent home
+holon skills enable my-skill --copy
 ```
 
-Install a skill for a specific agent:
+#### Disable a skill for an agent
 
 ```bash
-holon skills install my-skill --builtin --agent reviewer
+# Disable for the default agent
+holon skills disable my-skill
+
+# Disable for a specific agent
+holon skills disable my-skill --agent reviewer
 ```
 
-### Uninstall a skill
-
-```bash
-holon skills uninstall my-skill
-```
-
-For a specific agent:
-
-```bash
-holon skills uninstall my-skill --agent reviewer
-```
+> **Compatibility aliases:** `holon skills install` and
+> `holon skills uninstall` are still accepted but map to the new
+> add/enable and remove/disable model. Prefer the new commands for
+> clarity.
 
 ### Skill source types
 
 | Source | Flag | Example |
 |--------|------|---------|
-| Local path | (default) | `holon skills install ./skills/my-skill` |
-| Remote URL | `--remote` | `holon skills install https://... --remote` |
-| Built-in | `--builtin` | `holon skills install ghx --builtin` |
+| Local path | (default) | `holon skills add ./skills/my-skill` |
+| Remote URL | `--remote` | `holon skills add https://... --remote` |
+| Built-in | `--builtin` | `holon skills add ghx --builtin` |
+
+### Command summary
+
+| Layer | Command | Purpose |
+|-------|---------|---------|
+| Library | `holon skills catalog` | List library catalog |
+| Library | `holon skills add <source>` | Add a skill to the library |
+| Library | `holon skills remove <name>` | Remove from the library |
+| Library | `holon skills check [name]` | Check lock-file consistency |
+| Library | `holon skills reconcile [name]` | Reconcile with lock file |
+| Agent | `holon skills list [--agent]` | List enabled skills |
+| Agent | `holon skills enable <name>` | Enable for an agent |
+| Agent | `holon skills disable <name>` | Disable for an agent |
 
 ## Managing skills via HTTP
 
-The HTTP control plane exposes the same operations as API endpoints:
+The HTTP control plane separates library and agent operations:
 
-- `GET /agents/:agent_id/skills` — List installed or available skills
-- `POST /control/agents/:agent_id/skills/install` — Install a skill
-- `POST /control/agents/:agent_id/skills/uninstall` — Remove a skill
+### Library endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/skills/catalog` | List library catalog |
+| `GET` | `/api/skills/catalog/{skill_id}` | Get skill detail |
+| `POST` | `/api/skills/catalog/add` | Add a skill to the library |
+| `POST` | `/api/skills/catalog/remove` | Remove from the library |
+| `POST` | `/api/skills/catalog/reconcile` | Reconcile with lock file |
+| `POST` | `/api/skills/catalog/check` | Check consistency |
+
+### Agent endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/agents/:agent_id/skills` | List agent skills |
+| `POST` | `/control/agents/:agent_id/skills/enable` | Enable for agent |
+| `POST` | `/control/agents/:agent_id/skills/disable` | Disable for agent |
+
+> **Deprecated:** `POST /control/agents/:agent_id/skills/install` and
+> `POST /control/agents/:agent_id/skills/uninstall` remain for
+> compatibility but are superseded by enable/disable and
+> add/remove.
 
 ## TUI integration
 
 The Terminal UI provides skill management alongside the CLI:
 
-- **Slash commands** — Type `/skills` to view installed skills,
-  `/skill-install <source>` to install, and `/skill-uninstall <name>` to
-  remove skills directly from the chat input.
+- **Slash commands** — Type `/skills` to view agent skills,
+  `/skill-catalog` to browse the library, `/skill-add <source>` to add
+  to the library, `/skill-remove <name>` to remove, and
+  `/skill-enable <name>` / `/skill-disable <name>` to manage agent
+  enablement directly from the chat input.
 - **Skill name completion** — The TUI auto-completes skill names when
   using slash commands.
 - **Agent status sidebar** — The agent detail view under "Skills" shows
@@ -169,5 +267,7 @@ These are different layers:
 - [Multi-Agent Collaboration](/guides/multi-agent.md) — Delegating work to
   child agents
 - [Work Items Guide](/guides/work-items.md) — Tracking durable objectives
+- [Web GUI](/guides/web-gui.md) — Skill management in the browser
+- [TUI Guide](/guides/tui.md) — Skill management in the terminal
 - [Runtime Model](/concepts/runtime-model.md) — How skills fit into the agent
   operating loop

--- a/docs/website/guides/tui.md
+++ b/docs/website/guides/tui.md
@@ -93,11 +93,21 @@ and `Enter` to select. Press `Esc` to dismiss.
 
 ### Skills Commands
 
+Manage skills from the TUI:
+
 | Command | Description |
 |---------|-------------|
-| `/skills` | Show installed skills |
-| `/skill-install <name>` | Install a builtin skill |
-| `/skill-uninstall <name>` | Uninstall a skill |
+| `/skills` | Show enabled skills for the selected agent |
+| `/skill-catalog` | Browse the Skill Library catalog |
+| `/skill-add <source>` | Add a skill to the library |
+| `/skill-remove <name>` | Remove a skill from the library |
+| `/skill-enable <name>` | Enable a known skill for the agent |
+| `/skill-disable <name>` | Disable a skill for the agent |
+
+> `/skill-install` and `/skill-uninstall` are no longer the primary
+> slash commands. Use `/skill-add` and `/skill-enable` to add and
+> activate skills, or `/skill-remove` and `/skill-disable` to remove
+> and deactivate them.
 
 ### Debug Commands
 

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -52,11 +52,37 @@ Select an agent from the Dashboard to open its conversation page:
 
 ### Search
 
-Search across agent memory from the browser:
+Search across agent memory from the browser.
 
-- **Full-text search** — query runtime memory index across agents.
-- **Filter by agent** — scope results to one or more agent IDs.
-- **Result navigation** — click a result to view the full memory record.
+Results include:
+
+- **Excerpts** — Each result shows a contextual snippet highlighting the
+  matched terms so you can evaluate relevance without opening the full
+  record.
+- **Expandable sources** — Click a result to expand its full content
+  inline without navigating away from the search page.
+- **Agent filtering** — Scope results to one or more agent IDs.
+- **Full-text search** — Query the runtime memory index across agents.
+
+### Skill Management
+
+Manage the Skill Library and agent skills from the browser:
+
+- **Library catalog** — Browse all skills registered in the local Skill
+  Library with name, description, and source information.
+- **Add skill** — Import a skill from a local path, remote URL, or
+  built-in catalog.
+- **Remove skill** — Remove a skill from the library.
+- **Enable/disable** — Enable or disable individual skills per agent
+  with a toggle. View which skills are active for each agent.
+- **Skill detail** — Click a skill to view its full metadata including
+  scope, source root, and discovery path.
+
+The Skill Management page is available at `/app/skills` in the Web GUI.
+It is also accessible from the navigation sidebar when the daemon is
+running with the embedded GUI.
+
+For CLI-based skill management, see [Skills Guide](/guides/skills.md).
 
 ### Settings
 

--- a/docs/website/reference/api-contract-inventory.md
+++ b/docs/website/reference/api-contract-inventory.md
@@ -316,10 +316,21 @@ contains `binding_id?`, `transport`, `operator_actor_id`, `target_agent_id?`,
 
 ### Skills
 
+Skill management separates library operations from agent enablement:
+
 | Method | Path | Request body | Success response | Stability | Notes |
 |--------|------|--------------|------------------|-----------|-------|
-| `POST` | `/control/agents/:agent_id/skills/install` | `{ kind }` where `kind` is a `SkillInstallKind` tagged union. | `{ ok, agent_id, skill_name }` | Experimental | Install errors can map to conflict, failed dependency, bad gateway, or gateway timeout. |
-| `POST` | `/control/agents/:agent_id/skills/uninstall` | `{ name }` | `{ ok, agent_id, skill_name }` | Experimental | Removes a skill by name from the agent home. |
+| `GET` | `/api/skills/catalog` | none | `{ catalog: [...] }` | Experimental | Lists all skills in the Skill Library. |
+| `GET` | `/api/skills/catalog/:skill_id` | none | skill detail object | Experimental | Returns metadata for a single library skill. |
+| `POST` | `/api/skills/catalog/add` | `{ kind }` where `kind` is a `SkillInstallKind` tagged union. | `{ skill_name }` | Experimental | Adds a skill to the library. Errors map to conflict, not found, or timeout. |
+| `POST` | `/api/skills/catalog/remove` | `{ name }` | `{ skill_name }` | Experimental | Removes a skill from the library. |
+| `POST` | `/api/skills/catalog/reconcile` | `{ name? }` | `{ ... }` | Experimental | Reconciles library with `.skill-lock.json`. |
+| `POST` | `/api/skills/catalog/check` | `{ name? }` | `{ ... }` | Experimental | Checks library consistency. |
+| `GET` | `/agents/:agent_id/skills` | none | `{ skills: [...] }` | Experimental | Lists skills enabled for an agent. |
+| `POST` | `/control/agents/:agent_id/skills/enable` | `{ name, copy? }` | `{ ok, agent_id, skill_name }` | Experimental | Enables a library skill for an agent. |
+| `POST` | `/control/agents/:agent_id/skills/disable` | `{ name }` | `{ ok, agent_id, skill_name }` | Experimental | Disables a skill for an agent. |
+| `POST` | `/control/agents/:agent_id/skills/install` | `{ kind }` | `{ ok, agent_id, skill_name }` | Deprecated | Compatibility alias for add/enable. |
+| `POST` | `/control/agents/:agent_id/skills/uninstall` | `{ name }` | `{ ok, agent_id, skill_name }` | Deprecated | Compatibility alias for remove/disable. |
 
 ### Callback capability ingress
 

--- a/docs/website/reference/cli-contract-inventory.md
+++ b/docs/website/reference/cli-contract-inventory.md
@@ -139,11 +139,20 @@ New automation should use the `holon agent ...` lifecycle commands.
 
 ### Skills
 
+Skill management is split into library operations and agent enablement:
+
 | Command | Args | Options | Output | Initial stability | Notes |
 |---|---|---|---|---:|---|
-| `holon skills list` | none | `--agent <AGENT>` | JSON installed-skill response | `experimental` | Skill discovery/install contract is still active design work. |
-| `holon skills install` | `<NAME_OR_PATH>` | `--builtin`; `--remote`; `--skill <SKILL>`; `--copy`; `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Local paths are resolved relative to cwd when they are directories; otherwise treated as named skills. |
-| `holon skills uninstall` | `<NAME>` | `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Shares the normalized JSON output path with install/list. |
+| `holon skills catalog` | none | none | JSON catalog response | `experimental` | Lists all skills in the local Skill Library. |
+| `holon skills add` | `<SOURCE>` | `--builtin`; `--remote`; `--skill <SKILL>`; `--copy` | pretty JSON control-plane response | `experimental` | Adds a skill to the local Skill Library. Local paths resolved relative to cwd when directories. |
+| `holon skills remove` | `<NAME>` | none | pretty JSON control-plane response | `experimental` | Removes a skill from the local Skill Library. |
+| `holon skills check` | `[NAME]` | none | pretty JSON control-plane response | `experimental` | Checks Skill Library consistency against `.skill-lock.json`. |
+| `holon skills reconcile` | `[NAME]` | none | pretty JSON control-plane response | `experimental` | Reconciles library entries with lock file. |
+| `holon skills list` | none | `--agent <AGENT>` | JSON agent skills response | `experimental` | Lists skills enabled/effective for an agent. |
+| `holon skills enable` | `<NAME>` | `--agent <AGENT>`; `--copy` | pretty JSON control-plane response | `experimental` | Enables a locally known skill for an agent. |
+| `holon skills disable` | `<NAME>` | `--agent <AGENT>` | pretty JSON control-plane response | `experimental` | Disables a skill for an agent. |
+| `holon skills install` | `<NAME_OR_PATH>` | `--builtin`; `--remote`; `--skill <SKILL>`; `--copy`; `--agent <AGENT>` | pretty JSON control-plane response | `deprecated` | Compatibility alias. Prefer `skills add` for library or `skills enable` for agents. |
+| `holon skills uninstall` | `<NAME>` | `--agent <AGENT>` | pretty JSON control-plane response | `deprecated` | Compatibility alias. Prefer `skills remove` for library or `skills disable` for agents. |
 
 ### One-shot and solve workflows
 
@@ -242,7 +251,7 @@ milestone by
 | 2 | Config command golden JSON for `get`, `set`, `unset`, `schema`, provider remove, credential list/remove | Lock offline scripting surfaces. |
 | 2 | Daemon/status/log JSON shape tests | Lock local operations surfaces. |
 | 2 | More error behavior tests for missing token and command-specific business states | Extend the baseline exit-code contract where commands promote domain failures to process failures. |
-| 3 | Normalize or document raw HTTP-body commands (`task`, `timer`, `agent create/abort`, skills install/uninstall) | Reduce output contract drift. |
+| 3 | Normalize or document raw HTTP-body commands (`task`, `timer`, `agent create/abort`, skills add/remove/enable/disable) | Reduce output contract drift. |
 
 ## Follow-up inventory scope
 

--- a/docs/website/reference/cli.md
+++ b/docs/website/reference/cli.md
@@ -71,10 +71,17 @@ holon (v0.16.0)
 │       ├── get  Get agent model override
 │       ├── set  Set agent model override
 │       └── clear Clear agent model override
-├── skills       Manage skills
-│   ├── list     List installed skills
-│   ├── install  Install a skill
-│   └── uninstall Uninstall a skill
+├── skills         Manage skills
+│   ├── catalog    List Skill Library catalog
+│   ├── add        Add a skill to the library
+│   ├── remove     Remove a skill from the library
+│   ├── check      Check library consistency
+│   ├── reconcile  Reconcile library with lock file
+│   ├── list       List agent enabled skills
+│   ├── enable     Enable a skill for an agent
+│   ├── disable    Disable a skill for an agent
+│   ├── install    [deprecated] Compatibility alias
+│   └── uninstall  [deprecated] Compatibility alias
 ├── run          One-shot agent interaction
 ├── solve        Solve a GitHub issue or similar target
 ├── workspace    Workspace management (attach, exit, detach)


### PR DESCRIPTION
## Summary

Updates documentation for v0.20.0 features and fixes #1948 (outdated skills CLI/API docs).

### Skill management redesign (#1948)

- **skills.md**: Rewrites the managing-skills sections to reflect the new two-layer model:
  - **Skill Library** (global): `add`, `remove`, `check`, `reconcile`, `catalog`
  - **Agent Skills** (per-agent): `enable`, `disable`, `list`
  - `install`/`uninstall` are documented as deprecated compatibility aliases
- **tui.md**: Updates slash commands to `/skill-catalog`, `/skill-add`, `/skill-remove`, `/skill-enable`, `/skill-disable`
- **cli-contract-inventory.md**, **api-contract-inventory.md**, **cli.md**, **integration.md**: Updated to new endpoints/commands; old endpoints marked deprecated

### Web GUI updates

- **web-gui.md**: Added Skill Management page section (catalog, add/remove, enable/disable, skill detail)
- **web-gui.md**: Updated Search section with excerpts and expandable sources

### Memory improvements

- **memory.md**: Documented async memory indexing (non-blocking daemon startup)

### Changes (8 files, +227/-48)

| File | Change |
|------|--------|
| `docs/website/guides/skills.md` | +160/-48: Full rewrite of CLI/HTTP/TUI sections |
| `docs/website/guides/web-gui.md` | +34: Skill Management page + Search excerpts |
| `docs/website/concepts/memory.md` | +11: Async indexing section |
| `docs/website/guides/tui.md` | +16: Updated slash commands |
| `docs/website/reference/cli-contract-inventory.md` | +17: New commands, old ones deprecated |
| `docs/website/reference/api-contract-inventory.md` | +15: New endpoints, old ones deprecated |
| `docs/website/reference/cli.md` | +15: Updated command tree |
| `docs/website/guides/integration.md` | +7: Updated endpoints |

Closes #1948