### PR TITLE
feat: audit provider response identifiers

### DIFF
--- a/src/provider/fallback.rs
+++ b/src/provider/fallback.rs
@@ -69,6 +69,8 @@ mod tests {
                     read_input_tokens: 0,
                     creation_input_tokens: 0,
                 }),
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         }
@@ -104,6 +106,8 @@ mod tests {
                     read_input_tokens: 0,
                     creation_input_tokens: 0,
                 }),
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         }
@@ -124,6 +128,8 @@ mod tests {
                     read_input_tokens: 0,
                     creation_input_tokens: 0,
                 }),
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -63,6 +63,8 @@ pub struct ProviderTurnResponse {
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub cache_usage: Option<ProviderCacheUsage>,
+    pub provider_message_id: Option<String>,
+    pub provider_request_id: Option<String>,
     pub request_diagnostics: Option<ProviderRequestDiagnostics>,
 }
 
@@ -494,6 +496,8 @@ impl AgentProvider for StubProvider {
             input_tokens: 0,
             output_tokens: 0,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/src/provider/test_support.rs
+++ b/src/provider/test_support.rs
@@ -35,6 +35,8 @@ impl ScriptedProviderStep {
             input_tokens: 0,
             output_tokens: 0,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use reqwest::{Client, Response};
+use reqwest::{header::HeaderMap, Client, Response};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -102,6 +102,7 @@ struct ApiMessage {
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 struct MessagesResponse {
+    id: Option<String>,
     content: Vec<ApiResponseBlock>,
     stop_reason: Option<String>,
     usage: Option<ApiUsage>,
@@ -273,6 +274,7 @@ impl AgentProvider for AnthropicProvider {
         if let Some(trace) = request_trace.as_ref() {
             trace.write_response_headers(response.status(), response.headers());
         }
+        let provider_request_id = provider_request_id_from_headers(response.headers());
 
         if !response.status().is_success() {
             let status = response.status();
@@ -309,6 +311,7 @@ impl AgentProvider for AnthropicProvider {
         };
         anthropic_messages_response_to_turn_response(
             parsed,
+            provider_request_id,
             &request,
             &wire_conversation,
             rolling_cache_marker,
@@ -523,6 +526,7 @@ async fn read_anthropic_streaming_response(
 
 fn anthropic_messages_response_to_turn_response(
     parsed: MessagesResponse,
+    provider_request_id: Option<String>,
     request: &ProviderTurnRequest,
     wire_conversation: &[ConversationMessage],
     rolling_cache_marker: Option<(usize, usize)>,
@@ -619,6 +623,8 @@ fn anthropic_messages_response_to_turn_response(
         input_tokens,
         output_tokens,
         cache_usage,
+        provider_message_id: parsed.id,
+        provider_request_id,
         request_diagnostics: Some(crate::provider::ProviderRequestDiagnostics {
             request_lowering_mode: request_lowering_mode.to_string(),
             anthropic_cache: Some(cache_diagnostics),
@@ -630,6 +636,16 @@ fn anthropic_messages_response_to_turn_response(
             response_format: response_format_diagnostics(request),
         }),
     })
+}
+
+fn provider_request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-request-id")
+        .or_else(|| headers.get("request-id"))
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 #[derive(Default)]

--- a/src/provider/transports/gemini.rs
+++ b/src/provider/transports/gemini.rs
@@ -415,6 +415,8 @@ fn gemini_response_to_provider_turn_response(
             read_input_tokens: 0,
             creation_input_tokens: 0,
         }),
+        provider_message_id: None,
+        provider_request_id: None,
         request_diagnostics: Some(ProviderRequestDiagnostics {
             request_lowering_mode: "gemini_generate_content".to_string(),
             anthropic_cache: None,

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::Utc;
-use reqwest::{Client, RequestBuilder, Response};
+use reqwest::{header::HeaderMap, Client, RequestBuilder, Response};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
@@ -1228,6 +1228,24 @@ impl ProviderTurnResponse {
         self.request_diagnostics = Some(diagnostics);
         self
     }
+}
+
+impl ParsedOpenAiResponse {
+    fn with_provider_request_id(mut self, provider_request_id: Option<String>) -> Self {
+        self.response.provider_request_id = provider_request_id;
+        self
+    }
+}
+
+fn provider_request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-request-id")
+        .or_else(|| headers.get("request-id"))
+        .or_else(|| headers.get("openai-request-id"))
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 pub(crate) fn build_chat_completion_request(
@@ -3394,6 +3412,7 @@ async fn send_chat_completion_request(
         response.status(),
         response.headers(),
     );
+    let provider_request_id = provider_request_id_from_headers(response.headers());
 
     if !response.status().is_success() {
         let status = response.status();
@@ -3443,6 +3462,7 @@ async fn send_chat_completion_request(
         .map_err(|error| invalid_response_error("invalid OpenAI Chat Completions JSON", error))?;
 
     parse_chat_completion_response(parsed)
+        .map(|parsed| parsed.with_provider_request_id(provider_request_id))
 }
 
 fn classify_chat_completion_status_error(
@@ -3715,6 +3735,8 @@ pub(crate) fn parse_chat_completion_response(response: Value) -> Result<ParsedOp
                 .and_then(Value::as_u64)
                 .unwrap_or(0),
             cache_usage,
+            provider_message_id: response_id.clone(),
+            provider_request_id: None,
             request_diagnostics: None,
         },
         response_id,
@@ -4102,6 +4124,7 @@ async fn send_openai_responses_request(
         response.status(),
         response.headers(),
     );
+    let provider_request_id = provider_request_id_from_headers(response.headers());
 
     if !response.status().is_success() {
         let status = response.status();
@@ -4151,6 +4174,7 @@ async fn send_openai_responses_request(
     let parsed: Value = serde_json::from_str(&body)
         .map_err(|error| invalid_response_error("invalid OpenAI-style JSON", error))?;
     parse_openai_response_with_transport_state(parsed)
+        .map(|parsed| parsed.with_provider_request_id(provider_request_id))
 }
 
 async fn send_openai_compact_request(
@@ -4299,6 +4323,7 @@ async fn send_openai_responses_streaming_request(
         response.status(),
         response.headers(),
     );
+    let provider_request_id = provider_request_id_from_headers(response.headers());
 
     if !response.status().is_success() {
         let status = response.status();
@@ -4322,6 +4347,7 @@ async fn send_openai_responses_streaming_request(
     let terminal_response =
         read_openai_streaming_response(response, request_trace.as_ref()).await?;
     parse_openai_response_with_transport_state(terminal_response)
+        .map(|parsed| parsed.with_provider_request_id(provider_request_id))
 }
 
 fn openai_codex_auth_error(
@@ -4882,6 +4908,8 @@ fn parse_openai_response_with_transport_state(response: Value) -> Result<ParsedO
                 .and_then(Value::as_u64)
                 .unwrap_or(0),
             cache_usage,
+            provider_message_id: response_id.clone(),
+            provider_request_id: None,
             request_diagnostics: None,
         },
         response_id,

--- a/src/runtime/operator_dispatch.rs
+++ b/src/runtime/operator_dispatch.rs
@@ -749,6 +749,8 @@ mod tests {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         }

--- a/src/runtime/tests/agent_and_tools.rs
+++ b/src/runtime/tests/agent_and_tools.rs
@@ -14,6 +14,8 @@ impl AgentProvider for FreeformPromptProvider {
             input_tokens: 0,
             output_tokens: 0,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -205,6 +205,8 @@ impl AgentProvider for OperatorInterjectionProbeProvider {
                 input_tokens: 10,
                 output_tokens: 10,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         } else {
@@ -216,6 +218,8 @@ impl AgentProvider for OperatorInterjectionProbeProvider {
                 input_tokens: 10,
                 output_tokens: 10,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         }

--- a/src/runtime/tests/support.rs
+++ b/src/runtime/tests/support.rs
@@ -325,6 +325,8 @@ impl AgentProvider for OneToolThenTextProvider {
             input_tokens: 10,
             output_tokens: 10,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -430,6 +432,8 @@ impl AgentProvider for TruncatingProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -452,6 +456,8 @@ impl AgentProvider for TruncatingProvider {
             input_tokens: 50,
             output_tokens: 25,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -468,6 +474,8 @@ impl AgentProvider for TimelineProvider {
             input_tokens: 12,
             output_tokens: 6,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -542,6 +550,8 @@ impl AgentProvider for ToolCaptureProvider {
             input_tokens: 8,
             output_tokens: 4,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -572,6 +582,8 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             },
             2 => ProviderTurnResponse {
@@ -592,6 +604,8 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             },
             3 => ProviderTurnResponse {
@@ -612,6 +626,8 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             },
             _ => ProviderTurnResponse {
@@ -622,6 +638,8 @@ impl AgentProvider for TurnLocalCompactionProbeProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             },
         };
@@ -647,6 +665,8 @@ impl AgentProvider for BaselineOverBudgetProbeProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => panic!("continuation request should not be sent after baseline-over-budget"),
@@ -680,6 +700,8 @@ impl AgentProvider for SleepOnlyToolProvider {
             input_tokens: 10,
             output_tokens: 5,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -713,6 +735,8 @@ impl AgentProvider for WaitForOnlyToolProvider {
             input_tokens: 10,
             output_tokens: 5,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -736,6 +760,8 @@ impl AgentProvider for DisallowedToolThenTextProvider {
                 input_tokens: 10,
                 output_tokens: 5,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             2 => {
@@ -762,6 +788,8 @@ impl AgentProvider for DisallowedToolThenTextProvider {
                     input_tokens: 10,
                     output_tokens: 5,
                     cache_usage: None,
+                    provider_message_id: None,
+                    provider_request_id: None,
                     request_diagnostics: None,
                 })
             }
@@ -788,6 +816,8 @@ impl AgentProvider for MaxOutputMutationToolProvider {
                 input_tokens: 20,
                 output_tokens: 10,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             2 => {
@@ -814,6 +844,8 @@ impl AgentProvider for MaxOutputMutationToolProvider {
                     input_tokens: 15,
                     output_tokens: 8,
                     cache_usage: None,
+                    provider_message_id: None,
+                    provider_request_id: None,
                     request_diagnostics: None,
                 })
             }
@@ -960,6 +992,8 @@ impl AgentProvider for TextThenFailingFallbackProvider {
                 input_tokens: 20,
                 output_tokens: 10,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -1057,7 +1091,9 @@ impl AgentProvider for StagnatingAfterVerificationProvider {
                 input_tokens: 25,
                 output_tokens: 25,
                 cache_usage: None,
-                request_diagnostics: None,
+                provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
             });
         }
 
@@ -1103,6 +1139,8 @@ impl AgentProvider for StagnatingAfterVerificationProvider {
             input_tokens: 25,
             output_tokens: 25,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -1134,6 +1172,8 @@ impl AgentProvider for SkillReadProvider {
             input_tokens: 20,
             output_tokens: 20,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -1162,6 +1202,8 @@ impl AgentProvider for SkillActivationCommandProvider {
             input_tokens: 20,
             output_tokens: 20,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -1180,6 +1222,8 @@ impl AgentProvider for CountingProvider {
             input_tokens: 10,
             output_tokens: 5,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -75,6 +75,8 @@ impl AgentProvider for CompleteWorkItemReportProvider {
             input_tokens: 10,
             output_tokens: 10,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -122,6 +124,8 @@ impl AgentProvider for CompleteThenExecProvider {
             input_tokens: 10,
             output_tokens: 10,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -169,6 +173,8 @@ impl AgentProvider for StaleTextThenCompleteProvider {
             input_tokens: 10,
             output_tokens: 10,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -213,6 +219,8 @@ impl AgentProvider for MultiCompleteWorkItemReportProvider {
             input_tokens: 10,
             output_tokens: 10,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1058,6 +1058,8 @@ impl TurnExecution<'_> {
                     "input_tokens": response.input_tokens,
                     "output_tokens": response.output_tokens,
                     "token_usage": token_usage,
+                    "provider_message_id": response.provider_message_id,
+                    "provider_request_id": response.provider_request_id,
                     "tool_call_count": tool_calls.len(),
                     "tool_names": tool_calls.iter().map(|call| call.name.clone()).collect::<Vec<_>>(),
                     "text_block_count": text_blocks.len(),

--- a/tests/regression_fixture.rs
+++ b/tests/regression_fixture.rs
@@ -79,6 +79,8 @@ impl AgentProvider for FixtureProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -84,6 +84,8 @@ impl AgentProvider for TokenReportingProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: Some("msg-provider-123".into()),
+            provider_request_id: Some("req-provider-456".into()),
             request_diagnostics: None,
         })
     }
@@ -98,7 +100,7 @@ async fn run_once_surfaces_structured_token_usage_when_provider_reports_it() -> 
         Arc::new(TokenReportingProvider),
     )?;
 
-    let response = run_once_with_host(host, run_request("hello")).await?;
+    let response = run_once_with_host(host.clone(), run_request("hello")).await?;
 
     assert_eq!(response.token_usage.input_tokens, 100);
     assert_eq!(response.token_usage.output_tokens, 50);
@@ -106,6 +108,21 @@ async fn run_once_surfaces_structured_token_usage_when_provider_reports_it() -> 
     assert!(response
         .render_text()
         .contains("Token usage: input 100, output 50, total 150"));
+    let events = host
+        .agent_storage(&response.agent_id)?
+        .read_recent_events(50)?;
+    let provider_round = events
+        .iter()
+        .find(|event| event.kind == "provider_round_completed")
+        .expect("provider round completion should be audited");
+    assert_eq!(
+        provider_round.data["provider_message_id"].as_str(),
+        Some("msg-provider-123")
+    );
+    assert_eq!(
+        provider_round.data["provider_request_id"].as_str(),
+        Some("req-provider-456")
+    );
     Ok(())
 }
 
@@ -147,6 +164,8 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
                 input_tokens: 10,
                 output_tokens: 12,
                 cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
             });
         }
@@ -166,6 +185,8 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -189,6 +210,8 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -220,6 +243,8 @@ impl AgentProvider for WorkItemDeliverySummaryProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -376,6 +401,8 @@ impl AgentProvider for FileEditingProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -388,6 +415,8 @@ impl AgentProvider for FileEditingProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -458,6 +487,8 @@ impl AgentProvider for MultiMutatingToolsProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -470,6 +501,8 @@ impl AgentProvider for MultiMutatingToolsProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -556,6 +589,8 @@ impl AgentProvider for TerminalDeliveryProvider {
                 input_tokens: 100,
                 output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
             }),
             2 => Ok(ProviderTurnResponse {
@@ -575,6 +610,8 @@ impl AgentProvider for TerminalDeliveryProvider {
                 input_tokens: 100,
                 output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
             }),
             _ => panic!("unexpected extra provider round: {:?}", request.tools),
@@ -625,6 +662,8 @@ impl AgentProvider for SleepOnlyTerminalProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             2 => Ok(ProviderTurnResponse {
@@ -639,6 +678,8 @@ impl AgentProvider for SleepOnlyTerminalProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => panic!("unexpected extra provider round: {:?}", request.tools),
@@ -675,6 +716,8 @@ impl AgentProvider for EmptyTerminalDeliveryProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             2 => Ok(ProviderTurnResponse {
@@ -694,6 +737,8 @@ impl AgentProvider for EmptyTerminalDeliveryProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => panic!("unexpected extra provider round: {:?}", request.tools),
@@ -790,6 +835,8 @@ impl AgentProvider for SleepTaskProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -802,6 +849,8 @@ impl AgentProvider for SleepTaskProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -863,6 +912,8 @@ impl AgentProvider for CommandTaskProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -875,6 +926,8 @@ impl AgentProvider for CommandTaskProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -1065,6 +1118,8 @@ impl AgentProvider for DelegatedRunOnceProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -1085,6 +1140,8 @@ impl AgentProvider for DelegatedRunOnceProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => Ok(ProviderTurnResponse {
@@ -1095,6 +1152,8 @@ impl AgentProvider for DelegatedRunOnceProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
         }
@@ -1126,6 +1185,8 @@ impl AgentProvider for TwoRoundProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -1137,6 +1198,8 @@ impl AgentProvider for TwoRoundProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -1265,6 +1328,8 @@ impl AgentProvider for WorktreeTaskProvider {
                 input_tokens: 50,
                 output_tokens: 20,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -1285,6 +1350,8 @@ impl AgentProvider for WorktreeTaskProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -1297,6 +1364,8 @@ impl AgentProvider for WorktreeTaskProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/tests/support/runtime_compaction_providers.rs
+++ b/tests/support/runtime_compaction_providers.rs
@@ -65,6 +65,8 @@ impl AgentProvider for MaxOutputRecoveryProvider {
                 input_tokens: 100,
                 output_tokens: 1000,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -94,6 +96,8 @@ impl AgentProvider for MaxOutputRecoveryProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -150,6 +154,8 @@ impl AgentProvider for RepeatedCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             2 => Ok(ProviderTurnResponse {
@@ -170,6 +176,8 @@ impl AgentProvider for RepeatedCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             3 => Ok(ProviderTurnResponse {
@@ -190,6 +198,8 @@ impl AgentProvider for RepeatedCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             4 => Ok(ProviderTurnResponse {
@@ -201,6 +211,8 @@ impl AgentProvider for RepeatedCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => Ok(ProviderTurnResponse {
@@ -212,6 +224,8 @@ impl AgentProvider for RepeatedCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
         }
@@ -256,6 +270,8 @@ impl AgentProvider for MaxOutputThenCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 1500,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             2 => Ok(ProviderTurnResponse {
@@ -278,6 +294,8 @@ impl AgentProvider for MaxOutputThenCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 60,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             3 => Ok(ProviderTurnResponse {
@@ -299,6 +317,8 @@ impl AgentProvider for MaxOutputThenCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 60,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             4 => Ok(ProviderTurnResponse {
@@ -310,6 +330,8 @@ impl AgentProvider for MaxOutputThenCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 30,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => Ok(ProviderTurnResponse {
@@ -320,6 +342,8 @@ impl AgentProvider for MaxOutputThenCompactionProvider {
                 input_tokens: 100,
                 output_tokens: 20,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
         }
@@ -384,7 +408,9 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
-                request_diagnostics: None,
+                provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
             }),
             2 => Ok(ProviderTurnResponse {
                 blocks: vec![
@@ -407,7 +433,9 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
-                request_diagnostics: None,
+                provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
             }),
             3 => {
                 let task_id = self
@@ -437,7 +465,9 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                     input_tokens: 0,
                     output_tokens: 0,
                     cache_usage: None,
-                    request_diagnostics: None,
+                    provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
                 })
             }
             4 => Ok(ProviderTurnResponse {
@@ -461,7 +491,9 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
-                request_diagnostics: None,
+                provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
             }),
             _ => Ok(ProviderTurnResponse {
                 blocks: vec![ModelBlock::Text {
@@ -471,7 +503,9 @@ impl AgentProvider for MultiPassCompactionRecoveryFlowProvider {
                 input_tokens: 0,
                 output_tokens: 0,
                 cache_usage: None,
-                request_diagnostics: None,
+                provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
             }),
         }
     }

--- a/tests/support/runtime_providers.rs
+++ b/tests/support/runtime_providers.rs
@@ -58,6 +58,8 @@ impl AgentProvider for ToolUsingProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -71,6 +73,8 @@ impl AgentProvider for ToolUsingProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -119,6 +123,8 @@ impl AgentProvider for FileEditingProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -132,6 +138,8 @@ impl AgentProvider for FileEditingProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -185,6 +193,8 @@ impl AgentProvider for TerminalResultBriefProvider {
                     input_tokens: 100,
                     output_tokens: 50,
                     cache_usage: None,
+                    provider_message_id: None,
+                    provider_request_id: None,
                     request_diagnostics: None,
                 })
             }
@@ -205,6 +215,8 @@ impl AgentProvider for TerminalResultBriefProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => {
@@ -220,7 +232,9 @@ impl AgentProvider for TerminalResultBriefProvider {
                     input_tokens: 100,
                     output_tokens: 50,
                     cache_usage: None,
-                    request_diagnostics: None,
+                    provider_message_id: None,
+            provider_request_id: None,
+            request_diagnostics: None,
                 })
             }
         }
@@ -267,6 +281,8 @@ impl AgentProvider for SleepOnlyCompletionAfterTextProvider {
                     input_tokens: 100,
                     output_tokens: 50,
                     cache_usage: None,
+                    provider_message_id: None,
+                    provider_request_id: None,
                     request_diagnostics: None,
                 })
             }
@@ -282,6 +298,8 @@ impl AgentProvider for SleepOnlyCompletionAfterTextProvider {
                 input_tokens: 100,
                 output_tokens: 20,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => anyhow::bail!("unexpected provider call"),
@@ -321,6 +339,8 @@ impl AgentProvider for ShellProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -348,6 +368,8 @@ impl AgentProvider for ShellProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -389,6 +411,8 @@ impl AgentProvider for TruncatedShellReinjectionProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -419,6 +443,8 @@ impl AgentProvider for TruncatedShellReinjectionProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -456,6 +482,8 @@ impl AgentProvider for LongShellProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -485,6 +513,8 @@ impl AgentProvider for LongShellProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -519,6 +549,8 @@ impl AgentProvider for DelegatedBoundaryProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -552,6 +584,8 @@ impl AgentProvider for WakeHintProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         } else {
@@ -563,6 +597,8 @@ impl AgentProvider for WakeHintProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             })
         }
@@ -634,6 +670,8 @@ impl AgentProvider for RecordingPromptProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -684,6 +722,8 @@ impl AgentProvider for ToolErrorProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -725,6 +765,8 @@ impl AgentProvider for ToolErrorProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -792,6 +834,8 @@ impl AgentProvider for UseWorkspaceProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             });
         }
@@ -821,6 +865,8 @@ impl AgentProvider for UseWorkspaceProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -872,6 +918,8 @@ impl AgentProvider for WorktreeLifecycleProvider {
                     input_tokens: 100,
                     output_tokens: 50,
                     cache_usage: None,
+                    provider_message_id: None,
+                    provider_request_id: None,
                     request_diagnostics: None,
                 })
             }
@@ -883,6 +931,8 @@ impl AgentProvider for WorktreeLifecycleProvider {
                 input_tokens: 100,
                 output_tokens: 50,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             3 => {
@@ -899,6 +949,8 @@ impl AgentProvider for WorktreeLifecycleProvider {
                     input_tokens: 100,
                     output_tokens: 50,
                     cache_usage: None,
+                    provider_message_id: None,
+                    provider_request_id: None,
                     request_diagnostics: None,
                 })
             }
@@ -923,6 +975,8 @@ impl AgentProvider for WorktreeLifecycleProvider {
                     input_tokens: 100,
                     output_tokens: 50,
                     cache_usage: None,
+                    provider_message_id: None,
+                    provider_request_id: None,
                     request_diagnostics: None,
                 })
             }
@@ -934,6 +988,8 @@ impl AgentProvider for WorktreeLifecycleProvider {
                 input_tokens: 50,
                 output_tokens: 20,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
         }
@@ -974,6 +1030,8 @@ impl AgentProvider for WorktreeCapturingProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -994,6 +1052,8 @@ impl AgentProvider for DelayedTextProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/tests/support/runtime_tasks.rs
+++ b/tests/support/runtime_tasks.rs
@@ -99,6 +99,8 @@ impl AgentProvider for SleepThenRecordTaskResultProvider {
                 input_tokens: 10,
                 output_tokens: 5,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             2 => Ok(ProviderTurnResponse {
@@ -109,6 +111,8 @@ impl AgentProvider for SleepThenRecordTaskResultProvider {
                 input_tokens: 10,
                 output_tokens: 5,
                 cache_usage: None,
+                provider_message_id: None,
+                provider_request_id: None,
                 request_diagnostics: None,
             }),
             _ => anyhow::bail!("unexpected provider call {call}"),

--- a/tests/wt201_multiple_worktree_tasks.rs
+++ b/tests/wt201_multiple_worktree_tasks.rs
@@ -114,6 +114,8 @@ impl AgentProvider for ParallelWorktreeProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/tests/wt202_worktree_task_summary.rs
+++ b/tests/wt202_worktree_task_summary.rs
@@ -113,6 +113,8 @@ impl AgentProvider for ParallelWorktreeProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/tests/wt203_task_owned_worktree_cleanup.rs
+++ b/tests/wt203_task_owned_worktree_cleanup.rs
@@ -125,6 +125,8 @@ impl AgentProvider for DelayedTextProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }
@@ -144,6 +146,8 @@ impl AgentProvider for SlowTextProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/tests/wt204_parallel_worktree_workflow.rs
+++ b/tests/wt204_parallel_worktree_workflow.rs
@@ -136,6 +136,8 @@ impl AgentProvider for DelayedProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }

--- a/tests/wt205_worktree_lifecycle_edge_cases.rs
+++ b/tests/wt205_worktree_lifecycle_edge_cases.rs
@@ -217,6 +217,8 @@ impl AgentProvider for DelayedSuccessProvider {
             input_tokens: 100,
             output_tokens: 50,
             cache_usage: None,
+            provider_message_id: None,
+            provider_request_id: None,
             request_diagnostics: None,
         })
     }


### PR DESCRIPTION
## Summary
- add provider_message_id and provider_request_id to ProviderTurnResponse
- capture Anthropic/OpenAI provider message ids and request ids where available
- include provider identifiers in provider_round_completed audit events

Fixes #1968

## Verification
- cargo fmt --all -- --check
- cargo test --test run_once run_once_surfaces_structured_token_usage_when_provider_reports_it
- RUSTFLAGS="-D warnings" cargo check --all-targets