### PR TITLE
fix: improve TUI skill command feedback

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,7 +11,8 @@ use crate::{
     tui_markdown::{render_markdown_text, render_markdown_text_spaced},
     types::{
         AgentListEntry, AgentSummary, AuthorityClass, MessageBody, OperatorMessageRecord,
-        OperatorMessageStatus, ResolvedModelAvailability, TaskRecord,
+        OperatorMessageStatus, ResolvedModelAvailability, SkillCatalogEntry, SkillScope,
+        TaskRecord,
     },
 };
 use anyhow::{anyhow, Result};
@@ -49,7 +50,9 @@ mod state;
 mod view_model;
 
 use app::TuiApp;
-use chat::{chat_text_for_width, paragraph_max_scroll_unframed, ChatScrollState};
+use chat::{
+    chat_text_for_width, paragraph_max_scroll_unframed, ChatScrollState, LocalCommandOutput,
+};
 use composer::ComposerState;
 use logging::TuiLogWriter;
 use overlay::OverlayState;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,4 +1,4 @@
-use super::chat::CachedChatText;
+use super::chat::{CachedChatText, LocalCommandOutput};
 use super::state::{tui_state_path, TuiClientState};
 use super::*;
 use std::path::PathBuf;
@@ -18,6 +18,7 @@ pub(super) struct TuiApp {
     pub(super) client: LocalClient,
     pub(super) agents: Vec<AgentSummary>,
     pub(super) model_availability: Vec<ResolvedModelAvailability>,
+    pub(super) local_command_outputs: Vec<LocalCommandOutput>,
     pub(super) optimistic_operator_messages: Vec<OperatorMessageRecord>,
     pub(super) tasks: Vec<TaskRecord>,
     pub(super) projection: Option<TuiProjection>,
@@ -79,6 +80,7 @@ impl TuiApp {
             client,
             agents: Vec::new(),
             model_availability: Vec::new(),
+            local_command_outputs: Vec::new(),
             optimistic_operator_messages: Vec::new(),
             tasks: Vec::new(),
             projection: None,

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -6,6 +6,14 @@ use crate::tui::projection::{
 use crossterm::event::KeyCode;
 use unicode_width::UnicodeWidthChar;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct LocalCommandOutput {
+    pub(super) created_at: DateTime<chrono::Utc>,
+    pub(super) title: String,
+    pub(super) body: String,
+    pub(super) is_error: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ChatScrollState {
     follow_tail: bool,
@@ -226,6 +234,26 @@ pub(super) fn collect_chat_items(app: &TuiApp) -> Vec<ConversationCell> {
                 }
             }
         }
+    }
+
+    for output in &app.local_command_outputs {
+        cells.push(ConversationCell::SystemNotice {
+            created_at: output.created_at,
+            event_seq: 0,
+            speaker: if output.is_error {
+                "command error".into()
+            } else {
+                "command".into()
+            },
+            body: output.body.clone(),
+            display_kind: ConversationDisplayKind::Narrative,
+            group_id: Some(format!(
+                "local-command:{}:{}",
+                output.created_at.timestamp_nanos_opt().unwrap_or_default(),
+                output.title
+            )),
+            header_hint: Some(output.title.clone()),
+        });
     }
 
     for message in &app.optimistic_operator_messages {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -536,6 +536,17 @@ fn json_array_names(value: &serde_json::Value, field: &str) -> Option<Vec<String
         })
 }
 
+fn parse_skill_catalog_entries(value: &serde_json::Value) -> Option<Vec<SkillCatalogEntry>> {
+    serde_json::from_value(value.get("catalog")?.clone()).ok()
+}
+
+fn skill_install_mode_label(mode: &crate::types::SkillInstallMode) -> &'static str {
+    match mode {
+        crate::types::SkillInstallMode::Linked => "linked",
+        crate::types::SkillInstallMode::Copied => "copied",
+    }
+}
+
 fn summarize_names(prefix: &str, names: &[String]) -> String {
     if names.is_empty() {
         format!("{prefix}: none")
@@ -668,6 +679,30 @@ fn paste_single_line_text(text: &str) -> String {
 }
 
 impl TuiApp {
+    fn append_command_output(
+        &mut self,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        is_error: bool,
+    ) {
+        self.local_command_outputs.push(LocalCommandOutput {
+            created_at: chrono::Utc::now(),
+            title: title.into(),
+            body: body.into(),
+            is_error,
+        });
+        const MAX_LOCAL_COMMAND_OUTPUTS: usize = 50;
+        let overflow = self
+            .local_command_outputs
+            .len()
+            .saturating_sub(MAX_LOCAL_COMMAND_OUTPUTS);
+        if overflow > 0 {
+            self.local_command_outputs.drain(0..overflow);
+        }
+        self.chat_scroll.follow_tail();
+        self.chat_text_cache.borrow_mut().take();
+    }
+
     fn should_treat_enter_as_paste_newline(&self, key: KeyEvent) -> bool {
         should_treat_enter_as_paste_newline_state(
             self.composer.as_str(),
@@ -1017,10 +1052,21 @@ impl TuiApp {
             }
             SlashCommand::SkillCatalog => {
                 let response = self.client.skills_catalog().await?;
-                if let Some(names) = json_array_names(&response, "catalog") {
-                    self.status_line = summarize_names("Skill catalog", &names);
+                if let Some(catalog) = parse_skill_catalog_entries(&response) {
+                    let count = catalog.len();
+                    self.overlay = OverlayState::SkillCatalog {
+                        catalog,
+                        selected: 0,
+                        detail_scroll: 0,
+                    };
+                    self.status_line = format!("Opened Skill Catalog: {count} skills");
                 } else {
                     self.status_line = "Failed to list skill catalog".into();
+                    self.append_command_output(
+                        "Skill Catalog",
+                        "Failed to list skill catalog: response did not include a catalog array.",
+                        true,
+                    );
                 }
             }
             SlashCommand::SkillAdd => {
@@ -1031,6 +1077,13 @@ impl TuiApp {
                     .and_then(|name| name.as_str())
                     .unwrap_or("skill");
                 self.status_line = format!("Added skill to catalog: {skill_name}");
+                self.append_command_output(
+                    "Skill added",
+                    format!(
+                        "Added `{skill_name}` to the user_global Skill Library.\nUse `/skill-enable {skill_name}` to enable it for the selected agent."
+                    ),
+                    false,
+                );
             }
             SlashCommand::SkillRemove => {
                 let skill_name = args
@@ -1039,6 +1092,11 @@ impl TuiApp {
                     .expect("slash command /skill-remove requires one argument");
                 self.client.remove_skill(&skill_name).await?;
                 self.status_line = format!("Removed skill from catalog: {skill_name}");
+                self.append_command_output(
+                    "Skill removed",
+                    format!("Removed `{skill_name}` from the user_global Skill Library."),
+                    false,
+                );
             }
             SlashCommand::SkillEnable => {
                 let (skill_name, mode) = parse_skill_enable_args(&args)?;
@@ -1049,9 +1107,18 @@ impl TuiApp {
                         return Ok(());
                     }
                 };
+                let mode_label = skill_install_mode_label(&mode);
                 match self.client.enable_skill(&agent_id, &skill_name, mode).await {
                     Ok(_) => {
                         self.status_line = format!("Enabled skill for {agent_id}: {skill_name}");
+                        self.append_command_output(
+                            "Skill enabled",
+                            format!(
+                                "Enabled `{skill_name}` for agent `{agent_id}` with mode `{}`.\nThe selected agent is being bootstrapped so active skills refresh.",
+                                mode_label
+                            ),
+                            false,
+                        );
                         self.begin_bootstrap_selected_agent();
                     }
                     Err(error) => return Err(error),
@@ -1071,6 +1138,13 @@ impl TuiApp {
                 };
                 self.client.disable_skill(&agent_id, &skill_name).await?;
                 self.status_line = format!("Disabled skill for {agent_id}: {skill_name}");
+                self.append_command_output(
+                    "Skill disabled",
+                    format!(
+                        "Disabled `{skill_name}` for agent `{agent_id}`.\nThe selected agent is being bootstrapped so active skills refresh."
+                    ),
+                    false,
+                );
                 self.begin_bootstrap_selected_agent();
             }
         }
@@ -1191,6 +1265,50 @@ impl TuiApp {
                     }
                     _ => {
                         self.overlay = OverlayState::Tasks {
+                            selected,
+                            detail_scroll,
+                        };
+                    }
+                }
+                Ok(())
+            }
+            OverlayState::SkillCatalog {
+                catalog,
+                selected,
+                detail_scroll,
+            } => {
+                let mut selected = selected;
+                let mut detail_scroll = detail_scroll;
+                match resolve_key(KeyContext::TasksOverlay, key) {
+                    TuiKeyAction::OverlayClose => {}
+                    TuiKeyAction::OverlayMoveUp => {
+                        selected = selected.saturating_sub(1);
+                        self.overlay = OverlayState::SkillCatalog {
+                            catalog,
+                            selected,
+                            detail_scroll: 0,
+                        };
+                    }
+                    TuiKeyAction::OverlayMoveDown => {
+                        let max = catalog.len().saturating_sub(1);
+                        selected = (selected + 1).min(max);
+                        self.overlay = OverlayState::SkillCatalog {
+                            catalog,
+                            selected,
+                            detail_scroll: 0,
+                        };
+                    }
+                    TuiKeyAction::OverlayScroll(action) => {
+                        detail_scroll = adjust_scroll_for_action(detail_scroll, action);
+                        self.overlay = OverlayState::SkillCatalog {
+                            catalog,
+                            selected,
+                            detail_scroll,
+                        };
+                    }
+                    _ => {
+                        self.overlay = OverlayState::SkillCatalog {
+                            catalog,
                             selected,
                             detail_scroll,
                         };
@@ -2190,11 +2308,12 @@ impl TuiApp {
 mod tests {
     use super::{
         onboarding_runtime_config_status, parse_agent_slash_action, parse_composer_submission,
-        should_treat_enter_as_paste_newline_state, slash_command_spec, slash_help_lines,
-        slash_menu_enter_submission, slash_menu_specs, slash_prompt_lines, AgentSlashAction,
-        ComposerSubmission, SlashCommand,
+        parse_skill_catalog_entries, should_treat_enter_as_paste_newline_state, slash_command_spec,
+        slash_help_lines, slash_menu_enter_submission, slash_menu_specs, slash_prompt_lines,
+        AgentSlashAction, ComposerSubmission, SlashCommand,
     };
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use serde_json::json;
     use std::time::Instant;
 
     #[test]
@@ -2203,6 +2322,27 @@ mod tests {
             parse_composer_submission("hello world").unwrap(),
             Some(ComposerSubmission::Chat("hello world".into()))
         );
+    }
+
+    #[test]
+    fn parses_skill_catalog_entries_from_response() {
+        let entries = parse_skill_catalog_entries(&json!({
+            "catalog": [{
+                "name": "ghx",
+                "skill_id": "agent:ghx",
+                "legacy_id": null,
+                "description": "GitHub CLI workflows",
+                "scope": "agent",
+                "root_id": "agent_home:holon-dev",
+                "skill_dir": "ghx",
+                "path": "/agent/skills/ghx"
+            }]
+        }))
+        .expect("catalog entries");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "ghx");
+        assert_eq!(entries[0].description, "GitHub CLI workflows");
     }
 
     #[test]

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -25,6 +25,11 @@ pub(super) enum OverlayState {
         selected: usize,
         detail_scroll: u16,
     },
+    SkillCatalog {
+        catalog: Vec<SkillCatalogEntry>,
+        selected: usize,
+        detail_scroll: u16,
+    },
     ModelPicker {
         provider: Option<String>,
         filter: String,
@@ -63,6 +68,11 @@ pub(super) fn draw_overlay(frame: &mut Frame<'_>, app: &TuiApp) {
             selected,
             detail_scroll,
         } => draw_tasks_overlay(frame, app, *selected, *detail_scroll),
+        OverlayState::SkillCatalog {
+            catalog,
+            selected,
+            detail_scroll,
+        } => draw_skill_catalog_overlay(frame, catalog, *selected, *detail_scroll),
         OverlayState::ModelPicker {
             provider,
             filter,
@@ -305,6 +315,102 @@ fn draw_tasks_overlay(frame: &mut Frame<'_>, app: &TuiApp, selected: usize, deta
         .scroll((detail_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(detail, layout[1]);
+}
+
+fn draw_skill_catalog_overlay(
+    frame: &mut Frame<'_>,
+    catalog: &[SkillCatalogEntry],
+    selected: usize,
+    detail_scroll: u16,
+) {
+    let popup = centered_rect(92, 80, frame.area());
+    let layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(42), Constraint::Min(0)])
+        .split(popup);
+    frame.render_widget(Clear, popup);
+
+    let items = if catalog.is_empty() {
+        vec![ListItem::new("No skills in catalog")]
+    } else {
+        catalog
+            .iter()
+            .map(|skill| {
+                ListItem::new(format!(
+                    "[{}] {}\n  {}",
+                    skill_scope_label(skill.scope),
+                    skill.name,
+                    render::trim(&skill.description, 64)
+                ))
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut state = ListState::default();
+    if !catalog.is_empty() {
+        state.select(Some(selected.min(catalog.len().saturating_sub(1))));
+    }
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(format!("Skill Catalog ({})", catalog.len()))
+                .borders(Borders::ALL),
+        )
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(list, layout[0], &mut state);
+
+    let detail_text = catalog
+        .get(selected)
+        .map(render_skill_catalog_detail)
+        .unwrap_or_else(|| "No skill selected.".to_string());
+    let detail = Paragraph::new(detail_text)
+        .block(
+            Block::default()
+                .title("Skill Detail · Up/Down select · PgUp/PgDn scroll · Esc close")
+                .borders(Borders::ALL),
+        )
+        .scroll((detail_scroll, 0))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(detail, layout[1]);
+}
+
+fn render_skill_catalog_detail(skill: &SkillCatalogEntry) -> String {
+    let mut lines = vec![
+        format!("Name: {}", skill.name),
+        format!("Scope: {}", skill_scope_label(skill.scope)),
+        format!("Skill id: {}", skill.skill_id),
+    ];
+    if let Some(legacy_id) = skill.legacy_id.as_deref() {
+        lines.push(format!("Legacy id: {legacy_id}"));
+    }
+    lines.extend([
+        format!("Root: {}", skill.root_id),
+        format!("Directory: {}", skill.skill_dir),
+        format!("Path: {}", skill.path.display()),
+    ]);
+    if !skill.description.trim().is_empty() {
+        lines.extend(["".into(), "Description:".into(), skill.description.clone()]);
+    }
+    lines.extend([
+        "".into(),
+        format!(
+            "Use /skill-enable {} to enable this skill for the selected agent.",
+            skill.name
+        ),
+        format!(
+            "Use /skill-remove {} to remove it from the Skill Library.",
+            skill.name
+        ),
+    ]);
+    lines.join("\n")
+}
+
+fn skill_scope_label(scope: SkillScope) -> &'static str {
+    match scope {
+        SkillScope::Agent => "agent",
+        SkillScope::Workspace => "workspace",
+        SkillScope::UserGlobal => "user_global",
+    }
 }
 
 fn draw_model_picker_overlay(

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3,7 +3,7 @@ use super::{
     chat::{
         build_chat_text, build_chat_text_for_width, chat_text, collect_chat_items,
         is_operator_origin_value, paragraph_max_scroll, paragraph_max_scroll_unframed,
-        ChatScrollState, ConversationCell, ConversationDisplayKind,
+        ChatScrollState, ConversationCell, ConversationDisplayKind, LocalCommandOutput,
     },
     composer::ComposerState,
     determine_alt_screen_mode_for_terminal,
@@ -505,6 +505,35 @@ fn collect_chat_items_does_not_write_presentation_debug_log() {
 
     assert_eq!(first, second);
     assert!(!app.log_writer.root().join("presentation.jsonl").exists());
+}
+
+#[test]
+fn collect_chat_items_includes_local_command_outputs() {
+    let client = LocalClient::new(test_config()).unwrap();
+    let mut app = TuiApp::new(
+        client,
+        crate::tui::logging::TuiLogWriter::new_temp().unwrap(),
+    );
+    app.local_command_outputs.push(LocalCommandOutput {
+        created_at: Utc::now(),
+        title: "Skill added".into(),
+        body: "Added `ghx` to the user_global Skill Library.".into(),
+        is_error: false,
+    });
+
+    let items = collect_chat_items(&app);
+
+    assert!(items.iter().any(|item| matches!(
+        item,
+        ConversationCell::SystemNotice {
+            speaker,
+            body,
+            header_hint,
+            ..
+        } if speaker == "command"
+            && body.contains("Added `ghx`")
+            && header_hint.as_deref() == Some("Skill added")
+    )));
 }
 
 #[test]

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -162,7 +162,7 @@ fn overlay_hint(app: &TuiApp, slash_visible: bool) -> Option<&'static str> {
         | OverlayState::AgentState { .. }
         | OverlayState::DebugPromptView { .. }
         | OverlayState::HelpView { .. } => KeyContext::ScrollOverlay,
-        OverlayState::Tasks { .. } => KeyContext::TasksOverlay,
+        OverlayState::Tasks { .. } | OverlayState::SkillCatalog { .. } => KeyContext::TasksOverlay,
         OverlayState::ModelPicker { .. } => KeyContext::ModelPicker,
         OverlayState::ModelEffortPicker { .. } => KeyContext::ModelEffortPicker,
         OverlayState::DebugPromptInput { .. } => KeyContext::DebugPromptInput,


### PR DESCRIPTION
## Summary
- open /skill-catalog as a full Skill Catalog overlay with selectable details
- keep skill command status messages short while adding persistent command output for add/remove/enable/disable
- add focused tests for catalog parsing and local command output rendering

Fixes #1970

## Verification
- cargo fmt --all -- --check
- cargo test tui::
- RUSTFLAGS="-D warnings" cargo check --all-targets