### PR TITLE
feat: add generic job API for skill installs

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -7,8 +7,110 @@
         "type": "object"
       },
       "AddSkillRequest": {
-        "additionalProperties": true,
-        "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "properties": {
+          "kind": {
+            "oneOf": [
+              {
+                "properties": {
+                  "kind": {
+                    "const": "builtin",
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "const": "named",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "default": "linked",
+                    "enum": [
+                      "linked",
+                      "copied"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "const": "local",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "default": "linked",
+                    "enum": [
+                      "linked",
+                      "copied"
+                    ],
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "path"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "const": "remote",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "default": "linked",
+                    "enum": [
+                      "linked",
+                      "copied"
+                    ],
+                    "type": "string"
+                  },
+                  "package": {
+                    "type": "string"
+                  },
+                  "skill": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "kind",
+                  "package"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "title": "AddSkillRequest",
         "type": "object"
       },
       "AttachWorkspaceRequest": {
@@ -271,6 +373,25 @@
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
         "type": "object"
       },
+      "CreateJobRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "enum": [
+              "skill.install"
+            ],
+            "type": "string"
+          },
+          "params": {
+            "$ref": "#/components/schemas/AddSkillRequest"
+          }
+        },
+        "required": [
+          "kind",
+          "params"
+        ],
+        "type": "object"
+      },
       "CreateTimerRequest": {
         "additionalProperties": false,
         "properties": {
@@ -392,6 +513,83 @@
       "InstallSkillRequest": {
         "additionalProperties": true,
         "description": "Baseline request DTO schema. Per-field schemas will be tightened as HTTP envelope and DTO contracts stabilize.",
+        "type": "object"
+      },
+      "JobResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "job": {
+            "additionalProperties": true,
+            "properties": {
+              "created_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "error": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "phase": {
+                "type": "string"
+              },
+              "progress": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "result": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "status": {
+                "enum": [
+                  "queued",
+                  "running",
+                  "completed",
+                  "failed"
+                ],
+                "type": "string"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "updated_at": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "status",
+              "phase",
+              "progress",
+              "summary",
+              "items",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "object"
+          },
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok",
+          "job"
+        ],
         "type": "object"
       },
       "JsonValue": {
@@ -5883,6 +6081,112 @@
         "x-holon-openapi-source": "aide::axum::ApiRouter::api_route_docs"
       }
     },
+    "/api/jobs": {
+      "post": {
+        "description": "Create an asynchronous job. Currently supports kind=skill.install for Global Skill Library installation.",
+        "operationId": "createJob",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create job",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
+    "/api/jobs/{job_id}": {
+      "get": {
+        "description": "Return a generic asynchronous job snapshot by id.",
+        "operationId": "jobStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse"
+                }
+              }
+            },
+            "description": "Successful JSON response using a stable DTO schema."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Job status",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
     "/api/skills/catalog": {
       "get": {
         "description": "Return the global user Skill Library catalog. Query parameter: scope.",
@@ -9336,6 +9640,9 @@
     },
     {
       "name": "skills"
+    },
+    {
+      "name": "jobs"
     },
     {
       "name": "search"

--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -7,6 +7,7 @@ const USER_GLOBAL_LIBRARY_LABEL: &str = "user_global";
 
 #[derive(Clone, Default)]
 pub struct JobRegistry {
+    // TODO: retain terminal jobs for a bounded window before evicting them.
     jobs: Arc<Mutex<BTreeMap<String, JobSnapshot>>>,
 }
 
@@ -133,6 +134,7 @@ async fn create_skill_install_job(
     state.jobs.insert(job.clone());
 
     let jobs = state.jobs.clone();
+    let skill_install_jobs = state.skill_install_jobs.clone();
     let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
     let job_id = id.clone();
     tokio::spawn(async move {
@@ -148,8 +150,29 @@ async fn create_skill_install_job(
                 error: None,
             }];
         });
+        let permit = match skill_install_jobs.acquire_owned().await {
+            Ok(permit) => permit,
+            Err(error) => {
+                let message = format!("skill install queue closed: {error}");
+                jobs.update(&job_id, |job| {
+                    job.status = JobStatus::Failed;
+                    job.phase = "failed".into();
+                    job.progress.current = 1;
+                    job.summary = "Skill install queue closed".into();
+                    job.error = Some(message.clone());
+                    job.items = vec![JobItem {
+                        id: "skill.install".into(),
+                        status: JobStatus::Failed,
+                        summary: "Skill install queue closed".into(),
+                        error: Some(message),
+                    }];
+                });
+                return;
+            }
+        };
         let kind = request.kind.clone();
         let result = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
             crate::skills::add_library_skill(&user_home, &kind)
         })
         .await;

--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -1,0 +1,229 @@
+use super::*;
+use chrono::{DateTime, Utc};
+use std::{collections::BTreeMap, sync::Mutex};
+use uuid::Uuid;
+
+const USER_GLOBAL_LIBRARY_LABEL: &str = "user_global";
+
+#[derive(Clone, Default)]
+pub struct JobRegistry {
+    jobs: Arc<Mutex<BTreeMap<String, JobSnapshot>>>,
+}
+
+impl JobRegistry {
+    fn insert(&self, job: JobSnapshot) {
+        self.jobs
+            .lock()
+            .expect("job registry lock")
+            .insert(job.id.clone(), job);
+    }
+
+    fn get(&self, id: &str) -> Option<JobSnapshot> {
+        self.jobs
+            .lock()
+            .expect("job registry lock")
+            .get(id)
+            .cloned()
+    }
+
+    fn update(&self, id: &str, update: impl FnOnce(&mut JobSnapshot)) {
+        let mut jobs = self.jobs.lock().expect("job registry lock");
+        if let Some(job) = jobs.get_mut(id) {
+            update(job);
+            job.updated_at = Utc::now();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JobSnapshot {
+    pub id: String,
+    pub kind: String,
+    pub status: JobStatus,
+    pub phase: String,
+    pub progress: JobProgress,
+    pub summary: String,
+    pub items: Vec<JobItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct JobProgress {
+    pub current: usize,
+    pub total: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JobItem {
+    pub id: String,
+    pub status: JobStatus,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CreateJobRequest {
+    #[serde(rename = "skill.install")]
+    SkillInstall {
+        params: crate::types::AddSkillRequest,
+    },
+}
+
+pub async fn create_job(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreateJobRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    match request {
+        CreateJobRequest::SkillInstall { params } => create_skill_install_job(state, params).await,
+    }
+}
+
+pub async fn job_status(
+    Path(job_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_remote_access(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    match state.jobs.get(&job_id) {
+        Some(job) => Ok(Json(json!({ "ok": true, "job": job }))),
+        None => Err(http_error(
+            StatusCode::NOT_FOUND,
+            HttpErrorEnvelope::new(format!("job {job_id} was not found")).code("job_not_found"),
+        )),
+    }
+}
+
+async fn create_skill_install_job(
+    state: Arc<AppState>,
+    request: crate::types::AddSkillRequest,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let id = format!("job_{}", Uuid::new_v4().simple());
+    let now = Utc::now();
+    let job = JobSnapshot {
+        id: id.clone(),
+        kind: "skill.install".into(),
+        status: JobStatus::Queued,
+        phase: "queued".into(),
+        progress: JobProgress::default(),
+        summary: "Queued skill install job".into(),
+        items: Vec::new(),
+        result: None,
+        error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    state.jobs.insert(job.clone());
+
+    let jobs = state.jobs.clone();
+    let user_home = crate::agent_template::user_home_dir().map_err(error_response)?;
+    let job_id = id.clone();
+    tokio::spawn(async move {
+        jobs.update(&job_id, |job| {
+            job.status = JobStatus::Running;
+            job.phase = "installing".into();
+            job.summary = "Installing skill into the Global Skill Library".into();
+            job.progress.total = 1;
+            job.items = vec![JobItem {
+                id: "skill.install".into(),
+                status: JobStatus::Running,
+                summary: skill_install_summary(&request.kind),
+                error: None,
+            }];
+        });
+        let kind = request.kind.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            crate::skills::add_library_skill(&user_home, &kind)
+        })
+        .await;
+        match result {
+            Ok(Ok(skill_name)) => jobs.update(&job_id, |job| {
+                job.status = JobStatus::Completed;
+                job.phase = "completed".into();
+                job.progress.current = 1;
+                job.summary = format!("Installed {skill_name} to the Global Skill Library");
+                job.items = vec![JobItem {
+                    id: skill_name.clone(),
+                    status: JobStatus::Completed,
+                    summary: format!("Installed {skill_name}"),
+                    error: None,
+                }];
+                job.result = Some(json!({
+                    "skill_name": skill_name,
+                    "library": USER_GLOBAL_LIBRARY_LABEL,
+                }));
+            }),
+            Ok(Err(error)) => {
+                let message = error.to_string();
+                jobs.update(&job_id, |job| {
+                    job.status = JobStatus::Failed;
+                    job.phase = "failed".into();
+                    job.progress.current = 1;
+                    job.summary = "Skill install failed".into();
+                    job.error = Some(message.clone());
+                    job.items = vec![JobItem {
+                        id: "skill.install".into(),
+                        status: JobStatus::Failed,
+                        summary: "Skill install failed".into(),
+                        error: Some(message),
+                    }];
+                });
+            }
+            Err(error) => {
+                let message = format!("skill install worker failed: {error}");
+                jobs.update(&job_id, |job| {
+                    job.status = JobStatus::Failed;
+                    job.phase = "failed".into();
+                    job.progress.current = 1;
+                    job.summary = "Skill install worker failed".into();
+                    job.error = Some(message.clone());
+                    job.items = vec![JobItem {
+                        id: "skill.install".into(),
+                        status: JobStatus::Failed,
+                        summary: "Skill install worker failed".into(),
+                        error: Some(message),
+                    }];
+                });
+            }
+        }
+    });
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(json!({
+            "ok": true,
+            "job": job,
+        })),
+    ))
+}
+
+fn skill_install_summary(kind: &crate::types::SkillInstallKind) -> String {
+    match kind {
+        crate::types::SkillInstallKind::Builtin { name } => format!("Install builtin skill {name}"),
+        crate::types::SkillInstallKind::Named { name, .. } => format!("Install named skill {name}"),
+        crate::types::SkillInstallKind::Local { path, .. } => {
+            format!("Install local skill {}", path.display())
+        }
+        crate::types::SkillInstallKind::Remote { package, skill, .. } => match skill {
+            Some(skill) => format!("Install remote skill {package}@{skill}"),
+            None => format!("Install remote skill package {package}"),
+        },
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -289,8 +289,8 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/{agent_id}/briefs/{brief_id}", get(state::brief))
         .route("/agents/{agent_id}/state", get(state::agent_state))
         .route("/events/stream", get(events::global_events_stream))
-        .route("/jobs", post(jobs::create_job))
-        .route("/jobs/{job_id}", get(jobs::job_status))
+        .route("/api/jobs", post(jobs::create_job))
+        .route("/api/jobs/{job_id}", get(jobs::job_status))
         .route("/agents/{agent_id}/events", get(events::events))
         .route(
             "/agents/{agent_id}/events/stream",

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -92,6 +92,7 @@ mod agents;
 mod control;
 mod events;
 mod ingress;
+mod jobs;
 mod skills;
 mod state;
 mod tasks;
@@ -109,6 +110,7 @@ pub use agents::*;
 pub use control::*;
 pub use events::{events, events_stream, global_events_stream, message, messages_batch_get};
 pub use ingress::{callback_ingress_enqueue, callback_ingress_wake, generic_webhook};
+pub use jobs::{create_job, job_status, JobRegistry};
 pub use skills::{
     add_skill_to_catalog, disable_skill, enable_skill, install_skill, list_skills,
     remove_skill_from_catalog, skills_catalog, uninstall_skill,
@@ -169,6 +171,7 @@ pub struct AppState {
     pub advertise_url: Option<String>,
     pub web_dist: Option<Arc<PathBuf>>,
     pub skills_registry: Arc<tokio::sync::RwLock<SkillsRegistry>>,
+    pub jobs: JobRegistry,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -228,6 +231,7 @@ impl AppState {
             .config()
             .control_token_required(ControlTransportKind::Tcp);
         let skills_registry = host.skills_registry();
+        let jobs = JobRegistry::default();
         Self {
             host,
             require_control_token,
@@ -235,6 +239,7 @@ impl AppState {
             advertise_url: None,
             web_dist: None,
             skills_registry,
+            jobs,
         }
     }
 
@@ -248,6 +253,7 @@ impl AppState {
     ) -> Self {
         // Unix control is local IPC; filesystem permissions are the access boundary.
         let skills_registry = host.skills_registry();
+        let jobs = JobRegistry::default();
         Self {
             host,
             require_control_token: false,
@@ -255,6 +261,7 @@ impl AppState {
             advertise_url: None,
             web_dist: None,
             skills_registry,
+            jobs,
         }
     }
 
@@ -282,6 +289,8 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/{agent_id}/briefs/{brief_id}", get(state::brief))
         .route("/agents/{agent_id}/state", get(state::agent_state))
         .route("/events/stream", get(events::global_events_stream))
+        .route("/jobs", post(jobs::create_job))
+        .route("/jobs/{job_id}", get(jobs::job_status))
         .route("/agents/{agent_id}/events", get(events::events))
         .route(
             "/agents/{agent_id}/events/stream",

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -172,6 +172,7 @@ pub struct AppState {
     pub web_dist: Option<Arc<PathBuf>>,
     pub skills_registry: Arc<tokio::sync::RwLock<SkillsRegistry>>,
     pub jobs: JobRegistry,
+    pub skill_install_jobs: Arc<tokio::sync::Semaphore>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -232,6 +233,7 @@ impl AppState {
             .control_token_required(ControlTransportKind::Tcp);
         let skills_registry = host.skills_registry();
         let jobs = JobRegistry::default();
+        let skill_install_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         Self {
             host,
             require_control_token,
@@ -240,6 +242,7 @@ impl AppState {
             web_dist: None,
             skills_registry,
             jobs,
+            skill_install_jobs,
         }
     }
 
@@ -254,6 +257,7 @@ impl AppState {
         // Unix control is local IPC; filesystem permissions are the access boundary.
         let skills_registry = host.skills_registry();
         let jobs = JobRegistry::default();
+        let skill_install_jobs = Arc::new(tokio::sync::Semaphore::new(1));
         Self {
             host,
             require_control_token: false,
@@ -262,6 +266,7 @@ impl AppState {
             web_dist: None,
             skills_registry,
             jobs,
+            skill_install_jobs,
         }
     }
 

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -15,8 +15,8 @@ use crate::{
     },
     memory::MemoryGetResult,
     types::{
-        BriefRecord, TaskInputResult, TaskOutputResult, TaskStatusSnapshot, TaskStopResult,
-        TimerRecord, ToolExecutionRecord, WorkItemRecord,
+        AddSkillRequest, BriefRecord, TaskInputResult, TaskOutputResult, TaskStatusSnapshot,
+        TaskStopResult, TimerRecord, ToolExecutionRecord, WorkItemRecord,
     },
 };
 
@@ -93,6 +93,8 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/agents/{agent_id}/skills", "agentSkills", "skills", "List agent skills", "Return skills enabled/effective for an agent.", None, AuthKind::RemoteAccess),
     route("get", "/api/skills/catalog", "skillsCatalog", "skills", "Skills catalog", "Return the global user Skill Library catalog. Query parameter: scope.", None, AuthKind::RemoteAccess),
     route("get", "/api/skills/catalog/{skill_id}", "skillDetail", "skills", "Skill detail", "Return catalog metadata and SKILL.md content for a Global Skill Library skill.", None, AuthKind::RemoteAccess),
+    route_with_response("post", "/api/jobs", "createJob", "jobs", "Create job", "Create an asynchronous job. Currently supports kind=skill.install for Global Skill Library installation.", Some("CreateJobRequest"), "JobResponse", AuthKind::Control),
+    route_with_response("get", "/api/jobs/{job_id}", "jobStatus", "jobs", "Job status", "Return a generic asynchronous job snapshot by id.", None, "JobResponse", AuthKind::RemoteAccess),
     route("post", "/api/skills/catalog/add", "addSkillToCatalog", "skills", "Add skill to library", "Add or import a skill into the local Skill Library.", Some("AddSkillRequest"), AuthKind::Control),
     route("post", "/api/skills/catalog/remove", "removeSkillFromCatalog", "skills", "Remove skill from library", "Remove a skill from the local Skill Library.", Some("RemoveSkillRequest"), AuthKind::Control),
     route("post", "/api/skills/catalog/reconcile", "reconcileSkillCatalog", "skills", "Reconcile skill library lock", "Reconcile local Skill Library contents with .skill-lock.json, then check consistency. This does not fetch remote updates.", Some("ReconcileSkillRequest"), AuthKind::Control),
@@ -283,6 +285,7 @@ fn openapi_value() -> Value {
             { "name": "work-items" },
             { "name": "timers" },
             { "name": "skills" },
+            { "name": "jobs" },
             { "name": "search" },
             { "name": "callbacks", "description": "Capability-token callback ingress. Never publish real callback_token values." },
             { "name": "compat" }
@@ -503,6 +506,47 @@ fn component_schemas() -> Value {
         "description": "Raw callback request body. JSON and text bodies are parsed; other content types are represented internally as base64 JSON."
     }));
     schemas.insert(
+        "CreateJobRequest".into(),
+        json!({
+            "type": "object",
+            "properties": {
+                "kind": { "type": "string", "enum": ["skill.install"] },
+                "params": { "$ref": "#/components/schemas/AddSkillRequest" }
+            },
+            "required": ["kind", "params"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
+        "JobResponse".into(),
+        json!({
+            "type": "object",
+            "properties": {
+                "ok": { "type": "boolean" },
+                "job": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "kind": { "type": "string" },
+                        "status": { "type": "string", "enum": ["queued", "running", "completed", "failed"] },
+                        "phase": { "type": "string" },
+                        "progress": { "type": "object", "additionalProperties": true },
+                        "summary": { "type": "string" },
+                        "items": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+                        "result": { "type": "object", "additionalProperties": true },
+                        "error": { "type": "string" },
+                        "created_at": { "type": "string", "format": "date-time" },
+                        "updated_at": { "type": "string", "format": "date-time" }
+                    },
+                    "required": ["id", "kind", "status", "phase", "progress", "summary", "items", "created_at", "updated_at"],
+                    "additionalProperties": true
+                }
+            },
+            "required": ["ok", "job"],
+            "additionalProperties": false
+        }),
+    );
+    schemas.insert(
         "TaskStatusSnapshot".into(),
         component_schema::<TaskStatusSnapshot>(),
     );
@@ -582,6 +626,10 @@ fn component_schemas() -> Value {
         component_schema::<MemoryGetResult>(),
     );
     schemas.insert(
+        "AddSkillRequest".into(),
+        component_schema::<AddSkillRequest>(),
+    );
+    schemas.insert(
         "BatchGetMessagesRequest".into(),
         component_schema::<BatchGetMessagesRequest>(),
     );
@@ -624,7 +672,6 @@ fn component_schemas() -> Value {
         "SetCredentialRequest",
         "DebugPromptRequest",
         "ControlWakeRequest",
-        "AddSkillRequest",
         "RemoveSkillRequest",
         "EnableSkillRequest",
         "DisableSkillRequest",

--- a/src/types.rs
+++ b/src/types.rs
@@ -900,7 +900,7 @@ pub struct SkillsRuntimeView {
     pub active_skills: Vec<ActiveSkillRecord>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillInstallMode {
     Linked,
@@ -913,7 +913,7 @@ impl Default for SkillInstallMode {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SkillInstallKind {
     Builtin {
@@ -938,12 +938,12 @@ pub enum SkillInstallKind {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct InstallSkillRequest {
     pub kind: SkillInstallKind,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct AddSkillRequest {
     pub kind: SkillInstallKind,
 }

--- a/tests/http_control.rs
+++ b/tests/http_control.rs
@@ -26,6 +26,7 @@ http_async_tests!(
     skill_detail_returns_catalog_skill_markdown,
     install_skill_existing_destination_returns_conflict,
     add_skill_to_catalog_existing_destination_returns_conflict,
+    create_skill_install_job_installs_local_skill,
     skill_library_add_remove_and_agent_enable_disable_are_separate,
     skill_library_reconcile_and_check_lock_file,
     control_agent_model_override_set_and_clear_updates_status,

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -72,7 +72,7 @@ fn render_live_inventory() -> String {
     let source = std::fs::read_to_string(HTTP_SOURCE_PATH)
         .unwrap_or_else(|err| panic!("failed to read {HTTP_SOURCE_PATH}: {err}"));
     let routes = parse_axum_routes(&source);
-    assert_eq!(routes.len(), 81, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 83, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -503,6 +503,22 @@
   },
   {
     "method": "get",
+    "path": "/api/jobs/{job_id}",
+    "handler": "job_status",
+    "operation_id": "jobStatus",
+    "tag": "jobs",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "get",
     "path": "/api/skills/catalog",
     "handler": "skills_catalog",
     "operation_id": "skillsCatalog",
@@ -859,13 +875,29 @@
   },
   {
     "method": "post",
+    "path": "/api/jobs",
+    "handler": "create_job",
+    "operation_id": "createJob",
+    "tag": "jobs",
+    "parameters": [],
+    "request_schema": "CreateJobRequest",
+    "request_strict": true,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/api/skills/catalog/add",
     "handler": "add_skill_to_catalog",
     "operation_id": "addSkillToCatalog",
     "tag": "skills",
     "parameters": [],
     "request_schema": "AddSkillRequest",
-    "request_strict": false,
+    "request_strict": null,
     "response_content_types": [
       "application/json"
     ],

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -946,10 +946,7 @@ pub async fn create_skill_install_job_installs_local_skill() -> Result<()> {
         assert!(status.status().is_success());
         let body: serde_json::Value = status.json().await?;
         let job = &body["job"];
-        if matches!(
-            job["status"].as_str(),
-            Some("completed") | Some("failed") | Some("cancelled")
-        ) {
+        if matches!(job["status"].as_str(), Some("completed") | Some("failed")) {
             terminal = Some(job.clone());
             break;
         }

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -894,6 +894,81 @@ pub async fn add_skill_to_catalog_existing_destination_returns_conflict() -> Res
     Ok(())
 }
 
+pub async fn create_skill_install_job_installs_local_skill() -> Result<()> {
+    let (_host, base, server) = spawn_server().await?;
+    let client = Client::new();
+    let skill_name = format!("http-job-skill-{}", std::process::id());
+    let local_skill_root = tempdir()?;
+    let local_skill_path = local_skill_root.path().join(&skill_name);
+    std::fs::create_dir_all(&local_skill_path)?;
+    std::fs::write(
+        local_skill_path.join("SKILL.md"),
+        format!("# {skill_name}\n\nTemporary job API test skill.\n"),
+    )?;
+    let user_home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("HOME must be set for skill library tests"))?;
+    let library_root = [".agents/skills", ".codex/skills", ".claude/skills"]
+        .iter()
+        .map(|suffix| user_home.join(suffix))
+        .find(|path| path.is_dir())
+        .unwrap_or_else(|| user_home.join(".agents").join("skills"));
+    let library_path = library_root.join(&skill_name);
+    let _ = std::fs::remove_file(&library_path);
+    let _ = std::fs::remove_dir_all(&library_path);
+
+    let response = client
+        .post(format!("{base}/api/jobs"))
+        .json(&serde_json::json!({
+            "kind": "skill.install",
+            "params": {
+                "kind": {
+                    "kind": "local",
+                    "path": local_skill_path,
+                }
+            }
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
+    let body: serde_json::Value = response.json().await?;
+    let job_id = body["job"]["id"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("job id missing from response: {body}"))?
+        .to_string();
+
+    let mut terminal = None;
+    for _ in 0..40 {
+        let status = client
+            .get(format!("{base}/api/jobs/{job_id}"))
+            .send()
+            .await?;
+        assert!(status.status().is_success());
+        let body: serde_json::Value = status.json().await?;
+        let job = &body["job"];
+        if matches!(
+            job["status"].as_str(),
+            Some("completed") | Some("failed") | Some("cancelled")
+        ) {
+            terminal = Some(job.clone());
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    let terminal = terminal.ok_or_else(|| anyhow::anyhow!("skill install job did not finish"))?;
+    assert_eq!(terminal["kind"], "skill.install");
+    assert_eq!(terminal["status"], "completed");
+    assert_eq!(terminal["progress"]["current"], 1);
+    assert_eq!(terminal["result"]["skill_name"], skill_name);
+    assert!(library_path.join("SKILL.md").exists());
+
+    let _ = std::fs::remove_file(&library_path);
+    let _ = std::fs::remove_dir_all(&library_path);
+    server.abort();
+    Ok(())
+}
+
 pub async fn skill_library_add_remove_and_agent_enable_disable_are_separate() -> Result<()> {
     let config = test_config();
     let skill_name = format!("http-split-skill-{}", std::process::id());

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -215,6 +215,39 @@ describe("createRuntimeClient", () => {
     expect(seen).toEqual(["http://example.test:7878/api/agents/agent%2Fone/events?after_seq=739&limit=80&order=asc&max_level=info"]);
   });
 
+  it("installs skills through the generic job API", async () => {
+    const seen: Array<{ url: string; body?: unknown }> = [];
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      seen.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+      if (url.endsWith("/jobs") && init?.method === "POST") {
+        return Response.json({ job: { id: "job_123", kind: "skill.install", status: "queued" } }, { status: 202 });
+      }
+      if (url.endsWith("/jobs/job_123")) {
+        return Response.json({ job: { id: "job_123", kind: "skill.install", status: "completed" } });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = createRuntimeClient({
+      mode: "remote",
+      baseUrl: "http://example.test:7878",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.addSkillToCatalog({ kind: "remote", package: "owner/repo" })).resolves.toBeUndefined();
+    expect(seen).toEqual([
+      {
+        url: "http://example.test:7878/api/jobs",
+        body: {
+          kind: "skill.install",
+          params: { kind: { kind: "remote", package: "owner/repo" } },
+        },
+      },
+      { url: "http://example.test:7878/api/jobs/job_123", body: undefined },
+    ]);
+  });
+
   it("posts runtime search filters for cross-agent all-workspace search", async () => {
     const seen: Array<{ url: string; body: unknown }> = [];
     const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -41,7 +41,8 @@ export interface RuntimeClientOptions {
 const DEFAULT_DEV_API_BASE = "/api";
 const DEFAULT_REQUEST_TIMEOUT_MS = 8000;
 const OPTIONAL_DETAIL_TIMEOUT_MS = 4000;
-const SKILL_INSTALL_REQUEST_TIMEOUT_MS = 130_000;
+const JOB_POLL_INTERVAL_MS = 750;
+const JOB_WAIT_TIMEOUT_MS = 180_000;
 
 function fixtureAgentDetail(agentId: string): AgentDetail {
   return agentDetailFixtures[agentId] ?? agentDetailFixtures[Object.keys(agentDetailFixtures)[0]];
@@ -538,6 +539,19 @@ interface AgentSkillsResponseDto {
   skills?: SkillCatalogEntryDto[];
 }
 
+interface JobResponseDto {
+  job?: JobDto;
+}
+
+interface JobDto {
+  id?: string;
+  kind?: string;
+  status?: "queued" | "running" | "completed" | "failed" | "cancelled";
+  phase?: string;
+  summary?: string;
+  error?: string | null;
+}
+
 export interface RuntimeConfigUpdateEntry {
   key: string;
   value?: unknown;
@@ -713,9 +727,18 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
-      await postJson<unknown>(fetchImpl, baseUrl, "/skills/catalog/add", { kind: input }, requestHeaders, {
-        timeoutMs: SKILL_INSTALL_REQUEST_TIMEOUT_MS,
-      });
+      const response = await postJson<JobResponseDto>(
+        fetchImpl,
+        baseUrl,
+        "/jobs",
+        { kind: "skill.install", params: { kind: input } },
+        requestHeaders,
+      );
+      const jobId = response.job?.id;
+      if (!jobId) {
+        throw new Error("Skill install job response did not include a job id.");
+      }
+      await waitForJob(fetchImpl, baseUrl, requestHeaders, jobId);
     },
     async removeSkillFromCatalog(name: string): Promise<void> {
       if (!baseUrl) {
@@ -1198,6 +1221,34 @@ async function postJson<T>(
 
   const text = await response.text();
   return (text ? JSON.parse(text) : undefined) as T;
+}
+
+async function waitForJob(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  requestHeaders: Record<string, string>,
+  jobId: string,
+): Promise<JobDto> {
+  const deadline = Date.now() + JOB_WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const response = await getJson<JobResponseDto>(
+      fetchImpl,
+      baseUrl,
+      `/jobs/${encodeURIComponent(jobId)}`,
+      { headers: requestHeaders },
+    );
+    const job = response.job;
+    if (job?.status === "completed") return job;
+    if (job?.status === "failed" || job?.status === "cancelled") {
+      throw new Error(job.error || job.summary || `Job ${jobId} ${job.status}.`);
+    }
+    await sleep(JOB_POLL_INTERVAL_MS);
+  }
+  throw new Error(`Job ${jobId} did not complete within ${Math.round(JOB_WAIT_TIMEOUT_MS / 1000)} seconds.`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
 async function patchJson<T>(

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -546,7 +546,7 @@ interface JobResponseDto {
 interface JobDto {
   id?: string;
   kind?: string;
-  status?: "queued" | "running" | "completed" | "failed" | "cancelled";
+  status?: "queued" | "running" | "completed" | "failed";
   phase?: string;
   summary?: string;
   error?: string | null;
@@ -1239,7 +1239,7 @@ async function waitForJob(
     );
     const job = response.job;
     if (job?.status === "completed") return job;
-    if (job?.status === "failed" || job?.status === "cancelled") {
+    if (job?.status === "failed") {
       throw new Error(job.error || job.summary || `Job ${jobId} ${job.status}.`);
     }
     await sleep(JOB_POLL_INTERVAL_MS);


### PR DESCRIPTION
## Summary
- add a generic `/api/jobs` surface with a skills-specific `skill.install` async job implementation
- expose job snapshots with phase/progress/items/result so bulk skill installs can report partial progress
- switch the Web GUI skill install client to create a job and poll `/api/jobs/{job_id}` instead of one long synchronous request

Closes #1969

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test http_control create_skill_install_job_installs_local_skill`
- `cargo check --all-targets`
- `RUSTFLAGS="-D warnings" cargo check --all-targets`
- `npm --prefix web-gui/app test -- client.test.ts`
- `npm --prefix web-gui/app run typecheck`
