### PR TITLE
fix: operator_input wait with recheck never recovers — scheduler ignores expired recheck

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -846,15 +846,31 @@ pub(crate) fn wait_decision_for_projection(
     }
     projection.waiting_work_item.as_ref().and_then(|item| {
         match projection.waiting_work_item_scheduling_state {
-            Some(WorkItemSchedulingState::WaitingOperator) => Some(
-                SchedulerDecision::new(
-                    SchedulerDecisionKind::WaitForOperator,
-                    "work_item_needs_input",
+            Some(WorkItemSchedulingState::WaitingOperator) => {
+                // If recheck_at has expired and not been consumed, do not block on
+                // WaitForOperator — let the agent wake up to re-evaluate. This
+                // prevents permanent stalls when wake=operator_input is used with
+                // a recheck_after_ms fallback. (#1989)
+                if item
+                    .recheck_at
+                    .is_some_and(|recheck_at| recheck_at <= Utc::now())
+                    && item
+                        .recheck_consumed_at
+                        .zip(item.recheck_at)
+                        .is_none_or(|(consumed, recheck_at)| consumed < recheck_at)
+                {
+                    return None;
+                }
+                Some(
+                    SchedulerDecision::new(
+                        SchedulerDecisionKind::WaitForOperator,
+                        "work_item_needs_input",
+                    )
+                    .liveness_only(true)
+                    .work_item_id(item.id.clone())
+                    .evidence("work_item_scheduling_state=WaitingOperator"),
                 )
-                .liveness_only(true)
-                .work_item_id(item.id.clone())
-                .evidence("work_item_scheduling_state=WaitingOperator"),
-            ),
+            }
             Some(WorkItemSchedulingState::WaitingTask) => Some(
                 SchedulerDecision::new(SchedulerDecisionKind::WaitForTask, "work_item_task_wait")
                     .liveness_only(true)


### PR DESCRIPTION
## Problem

Fixes #1989

When an agent uses `WaitFor(wake=operator_input, recheck_after_ms=...)`, the work item is marked `WaitingOperator` with a `recheck_at` deadline. When `recheck_at` expires, a system tick is emitted to wake the agent. However, `wait_decision_for_projection` unconditionally returns `WaitForOperator` for any `WaitingOperator` work item, ignoring the expired `recheck_at`. This creates a permanent dead loop:

1. `recheck_at` expires → system tick emitted
2. System tick arrives → scheduler evaluates `wait_decision_for_projection`
3. Sees `WaitingOperator` → returns `WaitForOperator`
4. Agent stays asleep, never wakes up to re-evaluate
5. Repeat forever

This was observed on holon-dev: after completing a compilation task, the agent used `WaitFor(wake=operator_input)` with a `recheck_after_ms` fallback, then got permanently stuck in `waiting_for_operator` state.

## Fix

In `wait_decision_for_projection`, the `WaitingOperator` branch now checks whether `recheck_at` has expired (and has not yet been consumed). If expired, it returns `None` instead of `WaitForOperator`, allowing the agent to wake up and re-evaluate its state.

This is the same "recheck as fallback recovery" pattern already used by the blocked-work-item recheck mechanism, applied specifically to the `WaitingOperator` scheduling state which was missing it.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --lib runtime::tests::scheduler` — 22 passed ✅

## Related

- #1988 — separate wait cleanup bug (orphaned waits on completed work items), fixed in #1991
- #1980 — the original task context where holon-dev got stuck