### PR TITLE
refactor: centralize tool name constants

### DIFF
--- a/src/operator_event.rs
+++ b/src/operator_event.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use crate::tool::names as tn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -2031,67 +2032,57 @@ fn tool_payload_detail(payload: &Value) -> Option<String> {
 }
 
 fn tool_friendly_label(tool_name: &str, failed: bool) -> &'static str {
-    match (tool_name, failed) {
-        ("ApplyPatch", false) => "Applied patch",
-        ("ApplyPatch", true) => "Patch failed",
-        ("ExecCommand", false) => "Command finished",
-        ("ExecCommand", true) => "Command failed",
-        ("ExecCommandBatch", false) => "Command batch finished",
-        ("ExecCommandBatch", true) => "Command batch failed",
-        ("ListWorkItems", false) => "Listed work items",
-        ("ListWorkItems", true) => "List work items failed",
-        ("CreateWorkItem", false) => "Created work item",
-        ("CreateWorkItem", true) => "Create work item failed",
-        ("UpdateWorkItem", false) => "Updated work item",
-        ("UpdateWorkItem", true) => "Update work item failed",
-        ("CompleteWorkItem", false) => "Completed work item",
-        ("CompleteWorkItem", true) => "Complete work item failed",
-        ("ListTasks", false) => "Listed tasks",
-        ("ListTasks", true) => "List tasks failed",
-        ("TaskList", false) => "Listed tasks",
-        ("TaskList", true) => "List tasks failed",
-        ("TaskOutput", false) => "Read task output",
-        ("TaskOutput", true) => "Read task output failed",
-        ("SpawnAgent", false) => "Started child agent",
-        ("SpawnAgent", true) => "Start child agent failed",
-        ("UseWorkspace", false) => "Workspace selected",
-        ("UseWorkspace", true) => "Workspace selection failed",
-        ("Sleep", false) => "Slept",
-        ("Sleep", true) => "Sleep failed",
-        ("WaitFor", false) => "Waiting",
-        ("WaitFor", true) => "Wait failed",
-        ("ReadSkill", false) => "Read skill",
-        ("ReadSkill", true) => "Read skill failed",
-        ("WebFetch", false) => "Fetched web page",
-        ("WebFetch", true) => "Fetch web page failed",
-        ("WebSearch", false) => "Searched web",
-        ("WebSearch", true) => "Search web failed",
-        (_, false) => "Tool finished",
-        (_, true) => "Tool failed",
+    // Order doesn't matter: each tool name maps to a unique pair of labels.
+    let (success, fail) = match tool_name {
+        tn::APPLY_PATCH => ("Applied patch", "Patch failed"),
+        tn::EXEC_COMMAND => ("Command finished", "Command failed"),
+        tn::EXEC_COMMAND_BATCH => ("Command batch finished", "Command batch failed"),
+        tn::LIST_WORK_ITEMS => ("Listed work items", "List work items failed"),
+        tn::CREATE_WORK_ITEM => ("Created work item", "Create work item failed"),
+        tn::UPDATE_WORK_ITEM => ("Updated work item", "Update work item failed"),
+        tn::COMPLETE_WORK_ITEM => ("Completed work item", "Complete work item failed"),
+        tn::LIST_TASKS => ("Listed tasks", "List tasks failed"),
+        tn::TASK_LIST => ("Listed tasks", "List tasks failed"),
+        tn::TASK_OUTPUT => ("Read task output", "Read task output failed"),
+        tn::SPAWN_AGENT => ("Started child agent", "Start child agent failed"),
+        tn::USE_WORKSPACE => ("Workspace selected", "Workspace selection failed"),
+        tn::SLEEP => ("Slept", "Sleep failed"),
+        tn::WAIT_FOR => ("Waiting", "Wait failed"),
+        "ReadSkill" => ("Read skill", "Read skill failed"),
+        tn::WEB_FETCH => ("Fetched web page", "Fetch web page failed"),
+        tn::WEB_SEARCH => ("Searched web", "Search web failed"),
+        _ => ("Tool finished", "Tool failed"),
+    };
+    if failed {
+        fail
+    } else {
+        success
     }
 }
 
 fn tool_friendly_label_is_generic(tool_name: &str) -> bool {
-    !matches!(
-        tool_name,
-        "ApplyPatch"
-            | "ExecCommand"
-            | "ExecCommandBatch"
-            | "ListWorkItems"
-            | "CreateWorkItem"
-            | "UpdateWorkItem"
-            | "CompleteWorkItem"
-            | "ListTasks"
-            | "TaskList"
-            | "TaskOutput"
-            | "SpawnAgent"
-            | "UseWorkspace"
-            | "Sleep"
-            | "WaitFor"
-            | "ReadSkill"
-            | "WebFetch"
-            | "WebSearch"
-    )
+    // `ReadSkill` is not a builtin tool name constant — it is a dynamic
+    // skill-read action.  Keep it as a literal here.
+    const KNOWN_LABEL_TOOLS: &[&str] = &[
+        tn::APPLY_PATCH,
+        tn::EXEC_COMMAND,
+        tn::EXEC_COMMAND_BATCH,
+        tn::LIST_WORK_ITEMS,
+        tn::CREATE_WORK_ITEM,
+        tn::UPDATE_WORK_ITEM,
+        tn::COMPLETE_WORK_ITEM,
+        tn::LIST_TASKS,
+        tn::TASK_LIST,
+        tn::TASK_OUTPUT,
+        tn::SPAWN_AGENT,
+        tn::USE_WORKSPACE,
+        tn::SLEEP,
+        tn::WAIT_FOR,
+        "ReadSkill",
+        tn::WEB_FETCH,
+        tn::WEB_SEARCH,
+    ];
+    !KNOWN_LABEL_TOOLS.contains(&tool_name)
 }
 
 fn category_title(category: OperatorEventCategory, kind: &str) -> String {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1570,25 +1570,27 @@ fn strip_preview_ellipsis(text: &str) -> String {
 }
 
 fn is_sleep_tool_event(event: &ProjectionEventRecord) -> bool {
-    event.payload.get("tool_name").and_then(Value::as_str) == Some("Sleep")
+    event.payload.get("tool_name").and_then(Value::as_str) == Some(crate::tool::names::SLEEP)
 }
 
 fn is_exec_command_tool_event(event: &ProjectionEventRecord) -> bool {
     matches!(
         event.payload.get("tool_name").and_then(Value::as_str),
-        Some("ExecCommand" | "ExecCommandBatch")
+        Some(name) if name == crate::tool::names::EXEC_COMMAND || name == crate::tool::names::EXEC_COMMAND_BATCH
     )
 }
 
 fn is_apply_patch_tool_event(event: &ProjectionEventRecord) -> bool {
-    event.payload.get("tool_name").and_then(Value::as_str) == Some("ApplyPatch")
+    event.payload.get("tool_name").and_then(Value::as_str) == Some(crate::tool::names::APPLY_PATCH)
 }
 
 fn list_work_items_snapshot_item(event: &ProjectionEventRecord) -> Option<PresentationItem> {
     if event.kind != "tool_executed" {
         return None;
     }
-    if event.payload.get("tool_name").and_then(Value::as_str) != Some("ListWorkItems") {
+    if event.payload.get("tool_name").and_then(Value::as_str)
+        != Some(crate::tool::names::LIST_WORK_ITEMS)
+    {
         return None;
     }
     if event.payload.get("status").and_then(Value::as_str) != Some("success") {
@@ -1736,7 +1738,11 @@ fn is_successful_work_item_tool_event(event: &ProjectionEventRecord) -> bool {
     }
     matches!(
         event.payload.get("tool_name").and_then(Value::as_str),
-        Some("CreateWorkItem" | "UpdateWorkItem" | "PickWorkItem" | "CompleteWorkItem")
+        Some(name)
+            if name == crate::tool::names::CREATE_WORK_ITEM
+            || name == crate::tool::names::UPDATE_WORK_ITEM
+            || name == crate::tool::names::PICK_WORK_ITEM
+            || name == crate::tool::names::COMPLETE_WORK_ITEM
     )
 }
 

--- a/src/prompt/tools.rs
+++ b/src/prompt/tools.rs
@@ -4,6 +4,7 @@
 //! Each tool section is emitted only when that tool is available.
 
 use super::{section, PromptSection, PromptStability};
+use crate::tool::names as tn;
 use crate::tool::{ApplyPatchSurface, ToolSpec};
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -46,37 +47,38 @@ pub fn tool_sections_with_context(
         .collect::<Vec<_>>();
     let apply_patch_tool = available_tools
         .iter()
-        .find(|tool| tool.name == "ApplyPatch");
+        .find(|tool| tool.name == tn::APPLY_PATCH);
 
-    if names.contains(&"WaitFor") {
+    if names.contains(&tn::WAIT_FOR) {
         sections.push(section(
             "tool_wait_for",
             PromptStability::Stable,
             guidance(include_str!("tool_guidance/tool_wait_for.md")),
         ));
     }
-    if names.contains(&"SpawnAgent") {
+    if names.contains(&tn::SPAWN_AGENT) {
         sections.push(section(
             "tool_spawn_agent",
             PromptStability::Stable,
             guidance(include_str!("tool_guidance/tool_spawn_agent.md")),
         ));
     }
-    if names.contains(&"AgentGet") {
+    if names.contains(&tn::AGENT_GET) {
         sections.push(section(
             "tool_agent_get",
             PromptStability::Stable,
             guidance(include_str!("tool_guidance/tool_agent_get.md")),
         ));
     }
-    if names.contains(&"Enqueue") {
+    if names.contains(&tn::ENQUEUE) {
         sections.push(section(
             "tool_enqueue",
             PromptStability::Stable,
             guidance(include_str!("tool_guidance/tool_enqueue.md")),
         ));
     }
-    if names.contains(&"CreateExternalTrigger") || names.contains(&"CancelExternalTrigger") {
+    if names.contains(&tn::CREATE_EXTERNAL_TRIGGER) || names.contains(&tn::CANCEL_EXTERNAL_TRIGGER)
+    {
         sections.push(section(
             "tool_external_trigger",
             PromptStability::Stable,
@@ -84,11 +86,11 @@ pub fn tool_sections_with_context(
         ));
     }
     if names.contains(&"CreateWorkItem")
-        || names.contains(&"PickWorkItem")
-        || names.contains(&"UpdateWorkItem")
-        || names.contains(&"CompleteWorkItem")
-        || names.contains(&"GetWorkItem")
-        || names.contains(&"ListWorkItems")
+        || names.contains(&tn::PICK_WORK_ITEM)
+        || names.contains(&tn::UPDATE_WORK_ITEM)
+        || names.contains(&tn::COMPLETE_WORK_ITEM)
+        || names.contains(&tn::GET_WORK_ITEM)
+        || names.contains(&tn::LIST_WORK_ITEMS)
     {
         sections.push(section(
             "tool_work_item_scheduling",
@@ -96,10 +98,10 @@ pub fn tool_sections_with_context(
             guidance(include_str!("tool_guidance/tool_work_item_scheduling.md")),
         ));
     }
-    if names.contains(&"CreateWorkItem")
-        || names.contains(&"PickWorkItem")
-        || names.contains(&"UpdateWorkItem")
-        || names.contains(&"CompleteWorkItem")
+    if names.contains(&tn::CREATE_WORK_ITEM)
+        || names.contains(&tn::PICK_WORK_ITEM)
+        || names.contains(&tn::UPDATE_WORK_ITEM)
+        || names.contains(&tn::COMPLETE_WORK_ITEM)
     {
         sections.push(section(
             "tool_work_item_write",
@@ -107,19 +109,19 @@ pub fn tool_sections_with_context(
             guidance(include_str!("tool_guidance/tool_work_item_write.md")),
         ));
     }
-    if names.contains(&"GetWorkItem") || names.contains(&"ListWorkItems") {
+    if names.contains(&tn::GET_WORK_ITEM) || names.contains(&tn::LIST_WORK_ITEMS) {
         sections.push(section(
             "tool_work_item_read",
             PromptStability::Stable,
             guidance(include_str!("tool_guidance/tool_work_item_read.md")),
         ));
     }
-    if names.contains(&"ListTasks")
-        || names.contains(&"TaskList")
-        || names.contains(&"TaskStatus")
-        || names.contains(&"TaskInput")
-        || names.contains(&"TaskOutput")
-        || names.contains(&"TaskStop")
+    if names.contains(&tn::LIST_TASKS)
+        || names.contains(&tn::TASK_LIST)
+        || names.contains(&tn::TASK_STATUS)
+        || names.contains(&tn::TASK_INPUT)
+        || names.contains(&tn::TASK_OUTPUT)
+        || names.contains(&tn::TASK_STOP)
     {
         sections.push(section(
             "tool_task_control",
@@ -127,14 +129,14 @@ pub fn tool_sections_with_context(
             guidance(include_str!("tool_guidance/tool_task_control.md")),
         ));
     }
-    if names.contains(&"ExecCommand") {
+    if names.contains(&tn::EXEC_COMMAND) {
         sections.push(section(
             "tool_exec_command",
             PromptStability::Stable,
             guidance(include_str!("tool_guidance/tool_exec_command.md")),
         ));
     }
-    if names.contains(&"ExecCommandBatch") {
+    if names.contains(&tn::EXEC_COMMAND_BATCH) {
         sections.push(section(
             "tool_exec_command_batch",
             PromptStability::Stable,
@@ -174,7 +176,7 @@ pub fn tool_sections_with_context(
             ),
         ));
     }
-    if names.contains(&"ApplyPatch") {
+    if names.contains(&tn::APPLY_PATCH) {
         let apply_patch_surface = context.apply_patch_surface.unwrap_or_else(|| {
             if apply_patch_tool
                 .and_then(|tool| tool.freeform_grammar.as_ref())
@@ -200,7 +202,7 @@ pub fn tool_sections_with_context(
             ),
         ));
     }
-    if names.contains(&"UseWorkspace") {
+    if names.contains(&tn::USE_WORKSPACE) {
         sections.push(section(
             "tool_workspace",
             PromptStability::Stable,

--- a/src/run_once.rs
+++ b/src/run_once.rs
@@ -818,7 +818,8 @@ async fn build_response(
         .iter()
         .rev()
         .find(|tool| {
-            tool.tool_name == "Sleep" && matches!(tool.status, ToolExecutionStatus::Success)
+            tool.tool_name == crate::tool::names::SLEEP
+                && matches!(tool.status, ToolExecutionStatus::Success)
         })
         .and_then(|tool| {
             tool.output

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1254,12 +1254,12 @@ impl RuntimeHandle {
                         .await?;
                 }
             }
-            "ExecCommand" => {
+            crate::tool::names::EXEC_COMMAND => {
                 if let Some(command) = input.get("cmd").and_then(|value| value.as_str()) {
                     self.record_skill_command_activation(command).await?;
                 }
             }
-            "ExecCommandBatch" => {
+            crate::tool::names::EXEC_COMMAND_BATCH => {
                 if let Some(batch) = result
                     .envelope
                     .result

--- a/src/runtime/command_task.rs
+++ b/src/runtime/command_task.rs
@@ -208,7 +208,8 @@ impl RuntimeHandle {
         duplicate_policy: ExecCommandDuplicatePolicy,
         authority_class: &AuthorityClass,
     ) -> Result<ExecCommandResult> {
-        self.ensure_process_execution_exposed("ExecCommand").await?;
+        self.ensure_process_execution_exposed(crate::tool::names::EXEC_COMMAND)
+            .await?;
         self.apply_command_output_policy(&mut spec);
         let diagnostics = self.command_cost_diagnostics_for(&spec);
         let resolved = self.resolve_command_task(&spec).await?;
@@ -354,7 +355,7 @@ impl RuntimeHandle {
         mut spec: CommandTaskSpec,
         _authority_class: &AuthorityClass,
     ) -> Result<ExecCommandResult> {
-        self.ensure_process_execution_exposed("ExecCommandBatch")
+        self.ensure_process_execution_exposed(crate::tool::names::EXEC_COMMAND_BATCH)
             .await?;
         self.apply_command_output_policy(&mut spec);
         let diagnostics = self.command_cost_diagnostics_for(&spec);

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -368,7 +368,7 @@ impl RuntimeHandle {
                     "SpawnAgent is not available in this runtime",
                 )
                 .with_details(serde_json::json!({
-                    "tool_name": "SpawnAgent",
+                    "tool_name": crate::tool::names::SPAWN_AGENT,
                     "required_capability": "child_agent_spawning",
                 }))
                 .with_recovery_hint(

--- a/src/runtime/turn/completion.rs
+++ b/src/runtime/turn/completion.rs
@@ -1,5 +1,6 @@
 //! Work-item completion report promotion during turns.
 
+use crate::tool::names as tn;
 use anyhow::Result;
 use serde_json::Value;
 
@@ -229,21 +230,21 @@ pub(super) fn update_tool_result_block_content(
 }
 
 pub(super) fn command_preview_field(call: &ToolCall) -> Option<String> {
-    (call.name == "ExecCommand")
+    (call.name == tn::EXEC_COMMAND)
         .then(|| call.input.get("cmd").and_then(Value::as_str))
         .flatten()
         .map(command_preview)
 }
 
 pub(super) fn command_display_field(call: &ToolCall) -> Option<String> {
-    (call.name == "ExecCommand")
+    (call.name == tn::EXEC_COMMAND)
         .then(|| call.input.get("cmd").and_then(Value::as_str))
         .flatten()
         .map(command_display)
 }
 
 pub(super) fn command_batch_preview_field(call: &ToolCall) -> Option<Value> {
-    if call.name != "ExecCommandBatch" {
+    if call.name != tn::EXEC_COMMAND_BATCH {
         return None;
     }
     let items = call.input.get("items").and_then(Value::as_array)?;
@@ -273,7 +274,7 @@ pub(super) fn exec_command_disposition_field(
     call: &ToolCall,
     envelope: &ToolResultEnvelope,
 ) -> Option<String> {
-    matches!(call.name.as_str(), "ExecCommand" | "ExecCommandBatch")
+    matches!(call.name.as_str(), name if name == tn::EXEC_COMMAND || name == tn::EXEC_COMMAND_BATCH)
         .then(|| envelope.result.as_ref())
         .flatten()
         .and_then(|result| result.get("disposition"))
@@ -285,7 +286,7 @@ pub(super) fn exec_command_exit_status_field(
     call: &ToolCall,
     envelope: &ToolResultEnvelope,
 ) -> Option<i32> {
-    matches!(call.name.as_str(), "ExecCommand" | "ExecCommandBatch")
+    matches!(call.name.as_str(), name if name == tn::EXEC_COMMAND || name == tn::EXEC_COMMAND_BATCH)
         .then(|| envelope.result.as_ref())
         .flatten()
         .and_then(|result| result.get("exit_status"))
@@ -297,7 +298,7 @@ pub(super) fn exec_command_task_handle_field(
     call: &ToolCall,
     envelope: &ToolResultEnvelope,
 ) -> Option<Value> {
-    matches!(call.name.as_str(), "ExecCommand" | "ExecCommandBatch")
+    matches!(call.name.as_str(), name if name == tn::EXEC_COMMAND || name == tn::EXEC_COMMAND_BATCH)
         .then(|| envelope.result.as_ref())
         .flatten()
         .and_then(|result| result.get("task_handle"))
@@ -309,7 +310,7 @@ pub(super) fn command_cost_field(
     default_tool_output_tokens: u64,
     max_tool_output_tokens: u64,
 ) -> Option<serde_json::Value> {
-    if call.name != "ExecCommand" {
+    if call.name != tn::EXEC_COMMAND {
         return None;
     }
     let cmd = call.input.get("cmd").and_then(Value::as_str)?;
@@ -333,12 +334,16 @@ pub(super) fn command_cost_field(
 pub(super) fn rejects_truncated_mutation_tool_call(tool_name: &str) -> bool {
     matches!(
         tool_name,
-        "ApplyPatch" | "CreateWorkItem" | "PickWorkItem" | "UpdateWorkItem" | "CompleteWorkItem"
+        tn::APPLY_PATCH
+            | tn::CREATE_WORK_ITEM
+            | tn::PICK_WORK_ITEM
+            | tn::UPDATE_WORK_ITEM
+            | tn::COMPLETE_WORK_ITEM
     )
 }
 
 pub(super) fn truncated_mutation_recovery_hint(tool_name: &str) -> &'static str {
-    if tool_name == "ApplyPatch" {
+    if tool_name == tn::APPLY_PATCH {
         "the previous ApplyPatch mutation was not executed because the provider stopped at the output limit; do not resend the same huge patch unchanged. Retry as a complete smaller patch, a sequence of smaller patches, or a bounded ExecCommand/scripted rewrite when cheaper to verify. Inspect only the necessary context, not broad surrounding files"
     } else {
         "the previous mutation was not executed because the provider stopped at the output limit; do not resend the same oversized tool call unchanged. Retry with a complete smaller tool call, or split the state update into a short sequence of complete tool calls after inspecting only the necessary context"

--- a/src/runtime/turn/context_management.rs
+++ b/src/runtime/turn/context_management.rs
@@ -96,5 +96,5 @@ pub(super) fn estimate_context_management_eligible_tool_results(
 }
 
 pub(super) fn is_context_management_excluded_tool(tool_name: Option<&str>) -> bool {
-    matches!(tool_name, Some("ApplyPatch"))
+    matches!(tool_name, Some(crate::tool::names::APPLY_PATCH))
 }

--- a/src/runtime/turn/execution.rs
+++ b/src/runtime/turn/execution.rs
@@ -1002,8 +1002,10 @@ impl TurnExecution<'_> {
             crate::diagnostics::record_turn_provider_round(provider_round_started.elapsed());
             crate::diagnostics::record_provider_round_total(provider_round_started.elapsed());
             let completed_round_assistant_blocks = assistant_blocks.clone();
-            let only_legacy_sleep_tool_calls =
-                !tool_calls.is_empty() && tool_calls.iter().all(|call| call.name == "Sleep");
+            let only_legacy_sleep_tool_calls = !tool_calls.is_empty()
+                && tool_calls
+                    .iter()
+                    .all(|call| call.name == crate::tool::names::SLEEP);
             let legacy_sleep_duration_ms = if only_legacy_sleep_tool_calls {
                 tool_calls
                     .iter()
@@ -1368,7 +1370,9 @@ impl TurnExecution<'_> {
                 }
                 let tool_call_id = call.id.clone();
                 let tool_name = call.name.clone();
-                if !allowed_tool_names.contains(&call.name) && call.name != "Sleep" {
+                if !allowed_tool_names.contains(&call.name)
+                    && call.name != crate::tool::names::SLEEP
+                {
                     let error = ToolError::new(
                         "tool_not_exposed_for_round",
                         format!("tool {tool_name} was not exposed in this round"),

--- a/src/runtime/turn/reminders.rs
+++ b/src/runtime/turn/reminders.rs
@@ -1,5 +1,6 @@
 //! Work-item stale reminders and runtime reminder injection.
 
+use crate::tool::names as tn;
 use std::env;
 
 use crate::provider::{ConversationMessage, ProviderPromptFrame};
@@ -25,11 +26,11 @@ pub(super) fn tool_result_invalidates_checkpoint_anchor(envelope: &ToolResultEnv
     envelope.status == ToolResultStatus::Success
         && matches!(
             envelope.tool_name.as_str(),
-            "CreateWorkItem"
-                | "PickWorkItem"
-                | "UpdateWorkItem"
-                | "CompleteWorkItem"
-                | "ApplyPatch"
+            tn::CREATE_WORK_ITEM
+                | tn::PICK_WORK_ITEM
+                | tn::UPDATE_WORK_ITEM
+                | tn::COMPLETE_WORK_ITEM
+                | tn::APPLY_PATCH
         )
 }
 
@@ -45,7 +46,10 @@ pub(super) fn round_updated_work_item(round: &TurnRoundRecord) -> bool {
         envelope.status == ToolResultStatus::Success
             && matches!(
                 envelope.tool_name.as_str(),
-                "CreateWorkItem" | "PickWorkItem" | "UpdateWorkItem" | "CompleteWorkItem"
+                tn::CREATE_WORK_ITEM
+                    | tn::PICK_WORK_ITEM
+                    | tn::UPDATE_WORK_ITEM
+                    | tn::COMPLETE_WORK_ITEM
             )
     })
 }

--- a/src/runtime/turn/tool_summary.rs
+++ b/src/runtime/turn/tool_summary.rs
@@ -1,5 +1,6 @@
 //! Tool result summarization and round recap generation.
 
+use crate::tool::names as tn;
 use serde_json::Value;
 
 use crate::tool::{
@@ -185,10 +186,10 @@ pub(super) fn summarize_tool_result_envelope(envelope: &ToolResultEnvelope) -> S
                 .result
                 .as_ref()
                 .and_then(|result| match envelope.tool_name.as_str() {
-                    "ExecCommand" => Some(summarize_exec_command_result(result)),
-                    "TaskOutput" => Some(summarize_task_output_result(result)),
-                    "SpawnAgent" => summarize_spawn_agent_result(result),
-                    "ViewImage" => summarize_view_image_result(result),
+                    tn::EXEC_COMMAND => Some(summarize_exec_command_result(result)),
+                    tn::TASK_OUTPUT => Some(summarize_task_output_result(result)),
+                    tn::SPAWN_AGENT => summarize_spawn_agent_result(result),
+                    tn::VIEW_IMAGE => summarize_view_image_result(result),
                     _ => None,
                 })
                 .or_else(|| envelope.summary_text.clone())
@@ -260,7 +261,7 @@ pub(super) fn build_round_recap_line(round: &TurnRoundRecord) -> String {
 
 pub(super) fn command_recap_receipt(call: &ToolCall) -> Option<String> {
     match call.name.as_str() {
-        "ExecCommand" => {
+        tn::EXEC_COMMAND => {
             let cmd = call.input.get("cmd").and_then(Value::as_str)?;
             Some(format!(
                 "ExecCommand tool_call_id={} cmd_digest={}",
@@ -268,7 +269,7 @@ pub(super) fn command_recap_receipt(call: &ToolCall) -> Option<String> {
                 command_digest(cmd)
             ))
         }
-        "ExecCommandBatch" => {
+        tn::EXEC_COMMAND_BATCH => {
             let items = call.input.get("items").and_then(Value::as_array)?;
             let refs = items
                 .iter()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1055,7 +1055,7 @@ impl AppStorage {
     ) -> Result<Vec<RuntimeIndexChange>> {
         let mut changes = Vec::new();
         match record.tool_name.as_str() {
-            "ExecCommand" => {
+            crate::tool::names::EXEC_COMMAND => {
                 if record.input.get("cmd").and_then(Value::as_str).is_some() {
                     let source_ref = command_receipt_source_ref(&record.id, None);
                     changes.push(self.runtime_index_upsert(
@@ -1068,7 +1068,7 @@ impl AppStorage {
                     )?);
                 }
             }
-            "ExecCommandBatch" => {
+            crate::tool::names::EXEC_COMMAND_BATCH => {
                 if let Some(items) = record.input.get("items").and_then(Value::as_array) {
                     for (offset, item) in items.iter().enumerate() {
                         if item.get("cmd").and_then(Value::as_str).is_some() {
@@ -1195,7 +1195,7 @@ impl AppStorage {
 
     fn enqueue_memory_index_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
         match record.tool_name.as_str() {
-            "ExecCommand" => {
+            crate::tool::names::EXEC_COMMAND => {
                 if record.input.get("cmd").and_then(Value::as_str).is_some() {
                     let source_ref = command_receipt_source_ref(&record.id, None);
                     self.enqueue_memory_index_source(
@@ -1205,7 +1205,7 @@ impl AppStorage {
                     )?;
                 }
             }
-            "ExecCommandBatch" => {
+            crate::tool::names::EXEC_COMMAND_BATCH => {
                 if let Some(items) = record.input.get("items").and_then(Value::as_array) {
                     for (offset, item) in items.iter().enumerate() {
                         if item.get("cmd").and_then(Value::as_str).is_some() {

--- a/src/tool/dispatch.rs
+++ b/src/tool/dispatch.rs
@@ -236,7 +236,7 @@ fn tool_invocation_surface(call: &ToolCall) -> Option<String> {
 }
 
 fn is_model_facing_tool(name: &str) -> bool {
-    name != "Sleep" && name != "TaskList"
+    !super::names::HIDDEN_FROM_MODEL_TOOLS.contains(&name)
 }
 
 fn tool_result_summary(result: &ToolResult) -> String {

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -6,16 +6,18 @@
 //! - `helpers`: Shared utility functions
 //! - `tools`: Builtin tool modules, one per tool
 
+use crate::tool::names as tn;
+use anyhow::Result;
+use serde_json::{json, Value};
+
 pub(crate) mod apply_patch;
 pub mod dispatch;
 pub mod error;
 pub(crate) mod helpers;
+pub mod names;
 pub(crate) mod schema_support;
 pub mod spec;
 pub(crate) mod tools;
-
-use anyhow::Result;
-use serde_json::{json, Value};
 
 pub(crate) use schema_support as schema;
 
@@ -79,71 +81,77 @@ pub fn model_tool_schema_inventory() -> Result<Value> {
 
 fn tool_stability_level(name: &str) -> &'static str {
     match name {
-        "CreateExternalTrigger" | "CancelExternalTrigger" => "deprecated",
-        "ApplyPatch" | "ExecCommand" | "ExecCommandBatch" | "Sleep" | "WaitFor" | "ListTasks"
-        | "TaskStatus" | "TaskInput" | "TaskOutput" | "TaskStop" | "CreateWorkItem"
-        | "PickWorkItem" | "GetWorkItem" | "ListWorkItems" | "UpdateWorkItem"
-        | "CompleteWorkItem" | "UseWorkspace" | "AgentGet" | "Enqueue" | "SpawnAgent"
-        | "ListModelProviders" | "ListProviderModels" | "MemorySearch" | "MemoryGet" => "stable",
+        n if tn::DEPRECATED_TOOL_NAMES.contains(&n) => "deprecated",
+        n if tn::STABLE_TOOL_NAMES.contains(&n) => "stable",
         _ => "experimental",
     }
 }
 
 fn tool_success_result_contract(name: &str) -> &'static str {
     match name {
-        "AgentGet" => "AgentGetResult",
-        "ApplyPatch" => "ApplyPatchResult",
-        "CompleteWorkItem" | "CreateWorkItem" | "UpdateWorkItem" => "WorkItemMutationResult",
-        "Enqueue" => "EnqueueResult",
-        "ExecCommand" => "ExecCommandResult",
-        "ExecCommandBatch" => "ExecCommandBatchResult",
-        "GetWorkItem" => "GetWorkItemResult",
-        "ListModelProviders" => "ListModelProvidersResult",
-        "ListProviderModels" => "ListProviderModelsResult",
-        "ListWorkItems" => "ListWorkItemsResult",
-        "MemoryGet" => "MemoryGetResponse",
-        "MemorySearch" => "MemorySearchResponse",
-        "PickWorkItem" => "PickWorkItemResult",
-        "Sleep" => "SleepResult",
-        "WaitFor" => "WaitForResult",
-        "SpawnAgent" => "SpawnAgentResult",
-        "TaskInput" => "TaskInputResult",
-        "ListTasks" => "ListTasksResult",
-        "TaskOutput" => "TaskOutputResult",
-        "TaskStatus" => "TaskStatusResult",
-        "TaskStop" => "TaskStopResult",
-        "UseWorkspace" => "UseWorkspaceResult",
-        "WebFetch" => "WebFetchResult",
-        "WebSearch" => "WebSearchResult",
+        tn::AGENT_GET => "AgentGetResult",
+        tn::APPLY_PATCH => "ApplyPatchResult",
+        tn::COMPLETE_WORK_ITEM | tn::CREATE_WORK_ITEM | tn::UPDATE_WORK_ITEM => {
+            "WorkItemMutationResult"
+        }
+        tn::ENQUEUE => "EnqueueResult",
+        tn::EXEC_COMMAND => "ExecCommandResult",
+        tn::EXEC_COMMAND_BATCH => "ExecCommandBatchResult",
+        tn::GET_WORK_ITEM => "GetWorkItemResult",
+        tn::LIST_MODEL_PROVIDERS => "ListModelProvidersResult",
+        tn::LIST_PROVIDER_MODELS => "ListProviderModelsResult",
+        tn::LIST_WORK_ITEMS => "ListWorkItemsResult",
+        tn::MEMORY_GET => "MemoryGetResponse",
+        tn::MEMORY_SEARCH => "MemorySearchResponse",
+        tn::PICK_WORK_ITEM => "PickWorkItemResult",
+        tn::SLEEP => "SleepResult",
+        tn::WAIT_FOR => "WaitForResult",
+        tn::SPAWN_AGENT => "SpawnAgentResult",
+        tn::TASK_INPUT => "TaskInputResult",
+        tn::LIST_TASKS => "ListTasksResult",
+        tn::TASK_OUTPUT => "TaskOutputResult",
+        tn::TASK_STATUS => "TaskStatusResult",
+        tn::TASK_STOP => "TaskStopResult",
+        tn::USE_WORKSPACE => "UseWorkspaceResult",
+        tn::WEB_FETCH => "WebFetchResult",
+        tn::WEB_SEARCH => "WebSearchResult",
         _ => "tool-specific JSON payload",
     }
 }
 
 fn tool_model_rendering_contract(name: &str) -> &'static str {
-    match name {
-        "ApplyPatch" | "ExecCommand" | "ExecCommandBatch" | "TaskOutput" | "ViewImage" => {
-            "custom_text_receipt"
-        }
-        _ => "canonical_json_envelope",
+    if tn::CUSTOM_TEXT_RECEIPT_TOOLS.contains(&name) {
+        "custom_text_receipt"
+    } else {
+        "canonical_json_envelope"
     }
 }
 
 fn related_surfaces_for_tool(name: &str) -> Vec<&'static str> {
     match name {
-        "ExecCommand" | "ExecCommandBatch" | "TaskInput" | "ListTasks" | "TaskOutput"
-        | "TaskStatus" | "TaskStop" => {
+        tn::EXEC_COMMAND
+        | tn::EXEC_COMMAND_BATCH
+        | tn::TASK_INPUT
+        | tn::LIST_TASKS
+        | tn::TASK_OUTPUT
+        | tn::TASK_STATUS
+        | tn::TASK_STOP => {
             vec!["CLI task/process wrappers", "HTTP control-plane task APIs"]
         }
-        "CreateWorkItem" | "PickWorkItem" | "GetWorkItem" | "ListWorkItems" | "UpdateWorkItem"
-        | "CompleteWorkItem" => {
+        tn::CREATE_WORK_ITEM
+        | tn::PICK_WORK_ITEM
+        | tn::GET_WORK_ITEM
+        | tn::LIST_WORK_ITEMS
+        | tn::UPDATE_WORK_ITEM
+        | tn::COMPLETE_WORK_ITEM => {
             vec!["CLI work-item wrappers", "HTTP control-plane WorkItem APIs"]
         }
-        "Sleep" | "WaitFor" | "Enqueue" | "AgentGet" | "SpawnAgent" => {
+        tn::SLEEP | tn::WAIT_FOR | tn::ENQUEUE | tn::AGENT_GET | tn::SPAWN_AGENT => {
             vec!["runtime agent lifecycle APIs"]
         }
-        "ApplyPatch" | "UseWorkspace" => vec!["workspace/runtime file APIs"],
-        "WebFetch" | "WebSearch" => vec!["web adapter APIs"],
-        "MemorySearch" | "MemoryGet" => vec!["memory/runtime APIs"],
+        tn::APPLY_PATCH | tn::USE_WORKSPACE => vec!["workspace/runtime file APIs"],
+        tn::WEB_FETCH | tn::WEB_SEARCH => vec!["web adapter APIs"],
+        tn::MEMORY_SEARCH | tn::MEMORY_GET => vec!["memory/runtime APIs"],
         _ => Vec::new(),
     }
 }

--- a/src/tool/names.rs
+++ b/src/tool/names.rs
@@ -1,0 +1,129 @@
+//! Centralized tool name constants.
+//!
+/// Every builtin tool exposes its name through a `pub(crate) const NAME` in its
+/// own module. This module re-exports those constants as a single catalog so
+/// that runtime / dispatch / presentation / prompt code references compile-time
+/// constants instead of raw string literals.
+///
+/// Importing `tool::names::TOOL_*` lets the compiler catch typos and makes
+/// renames a single-point edit.
+pub mod tool_names {
+    pub const AGENT_GET: &str = "AgentGet";
+    pub const APPLY_PATCH: &str = "ApplyPatch";
+    pub const CANCEL_EXTERNAL_TRIGGER: &str = "CancelExternalTrigger";
+    pub const COMPLETE_WORK_ITEM: &str = "CompleteWorkItem";
+    pub const CREATE_EXTERNAL_TRIGGER: &str = "CreateExternalTrigger";
+    pub const CREATE_WORK_ITEM: &str = "CreateWorkItem";
+    pub const ENQUEUE: &str = "Enqueue";
+    pub const EXEC_COMMAND: &str = "ExecCommand";
+    pub const EXEC_COMMAND_BATCH: &str = "ExecCommandBatch";
+    pub const GET_WORK_ITEM: &str = "GetWorkItem";
+    pub const LIST_MODEL_PROVIDERS: &str = "ListModelProviders";
+    pub const LIST_PROVIDER_MODELS: &str = "ListProviderModels";
+    pub const LIST_TASKS: &str = "ListTasks";
+    pub const LIST_WORK_ITEMS: &str = "ListWorkItems";
+    pub const MEMORY_GET: &str = "MemoryGet";
+    pub const MEMORY_SEARCH: &str = "MemorySearch";
+    pub const PICK_WORK_ITEM: &str = "PickWorkItem";
+    pub const SLEEP: &str = "Sleep";
+    pub const SPAWN_AGENT: &str = "SpawnAgent";
+    pub const TASK_INPUT: &str = "TaskInput";
+    /// Legacy alias kept for backward-compatible dispatch.
+    pub const TASK_LIST: &str = "TaskList";
+    pub const TASK_OUTPUT: &str = "TaskOutput";
+    pub const TASK_STATUS: &str = "TaskStatus";
+    pub const TASK_STOP: &str = "TaskStop";
+    pub const UPDATE_WORK_ITEM: &str = "UpdateWorkItem";
+    pub const USE_WORKSPACE: &str = "UseWorkspace";
+    pub const VIEW_IMAGE: &str = "ViewImage";
+    pub const WAIT_FOR: &str = "WaitFor";
+    pub const WEB_FETCH: &str = "WebFetch";
+    pub const WEB_SEARCH: &str = "WebSearch";
+}
+
+pub use tool_names::*;
+
+/// All builtin tool names that participate in stability-level classification.
+///
+/// Keep alphabetically sorted for readability.
+pub const STABLE_TOOL_NAMES: &[&str] = &[
+    AGENT_GET,
+    APPLY_PATCH,
+    COMPLETE_WORK_ITEM,
+    CREATE_WORK_ITEM,
+    ENQUEUE,
+    EXEC_COMMAND,
+    EXEC_COMMAND_BATCH,
+    GET_WORK_ITEM,
+    LIST_MODEL_PROVIDERS,
+    LIST_PROVIDER_MODELS,
+    LIST_TASKS,
+    LIST_WORK_ITEMS,
+    MEMORY_GET,
+    MEMORY_SEARCH,
+    PICK_WORK_ITEM,
+    SLEEP,
+    SPAWN_AGENT,
+    TASK_INPUT,
+    TASK_OUTPUT,
+    TASK_STATUS,
+    TASK_STOP,
+    UPDATE_WORK_ITEM,
+    USE_WORKSPACE,
+    WAIT_FOR,
+];
+
+pub const DEPRECATED_TOOL_NAMES: &[&str] = &[CREATE_EXTERNAL_TRIGGER, CANCEL_EXTERNAL_TRIGGER];
+
+/// All tool names whose result is rendered with `custom_text_receipt` rather
+/// than the canonical JSON envelope.
+pub const CUSTOM_TEXT_RECEIPT_TOOLS: &[&str] = &[
+    APPLY_PATCH,
+    EXEC_COMMAND,
+    EXEC_COMMAND_BATCH,
+    TASK_OUTPUT,
+    VIEW_IMAGE,
+];
+
+/// Tools that produce output needing the `function_json` envelope field.
+pub const FUNCTION_JSON_ENVELOPE_TOOLS: &[&str] = &[EXEC_COMMAND, EXEC_COMMAND_BATCH, TASK_OUTPUT];
+
+/// Tools that are **not** exposed to the model (hidden from tool specs).
+pub const HIDDEN_FROM_MODEL_TOOLS: &[&str] = &[SLEEP, TASK_LIST];
+
+/// Tools considered "sleep-like" for the `only_sleep_tools` aggregation.
+pub const SLEEP_LIKE_TOOLS: &[&str] = &[SLEEP, WAIT_FOR];
+
+/// All builtin tool names, alphabetically sorted.
+pub const ALL_TOOL_NAMES: &[&str] = &[
+    AGENT_GET,
+    APPLY_PATCH,
+    CANCEL_EXTERNAL_TRIGGER,
+    COMPLETE_WORK_ITEM,
+    CREATE_EXTERNAL_TRIGGER,
+    CREATE_WORK_ITEM,
+    ENQUEUE,
+    EXEC_COMMAND,
+    EXEC_COMMAND_BATCH,
+    GET_WORK_ITEM,
+    LIST_MODEL_PROVIDERS,
+    LIST_PROVIDER_MODELS,
+    LIST_TASKS,
+    LIST_WORK_ITEMS,
+    MEMORY_GET,
+    MEMORY_SEARCH,
+    PICK_WORK_ITEM,
+    SLEEP,
+    SPAWN_AGENT,
+    TASK_INPUT,
+    TASK_LIST,
+    TASK_OUTPUT,
+    TASK_STATUS,
+    TASK_STOP,
+    UPDATE_WORK_ITEM,
+    USE_WORKSPACE,
+    VIEW_IMAGE,
+    WAIT_FOR,
+    WEB_FETCH,
+    WEB_SEARCH,
+];

--- a/src/tool/tools/agent_get.rs
+++ b/src/tool/tools/agent_get.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::parse_tool_args;
 
-pub(crate) const NAME: &str = "AgentGet";
+pub(crate) const NAME: &str = crate::tool::names::AGENT_GET;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/apply_patch_tool.rs
+++ b/src/tool/tools/apply_patch_tool.rs
@@ -21,7 +21,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::{helpers::parse_tool_args, schema::tool_input_schema};
 
-pub(crate) const NAME: &str = "ApplyPatch";
+pub(crate) const NAME: &str = crate::tool::names::APPLY_PATCH;
 // Grammar matches OpenAI Codex's ApplyPatch DSL surface; Holon still applies
 // parsed edits through its own workspace guards and atomic apply path.
 const CODEX_DSL_LARK_GRAMMAR: &str = include_str!("apply_patch_tool_codex.lark");

--- a/src/tool/tools/cancel_external_trigger.rs
+++ b/src/tool/tools/cancel_external_trigger.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "CancelExternalTrigger";
+pub(crate) const NAME: &str = crate::tool::names::CANCEL_EXTERNAL_TRIGGER;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/complete_work_item.rs
+++ b/src/tool/tools/complete_work_item.rs
@@ -20,7 +20,7 @@ use super::{
     BuiltinToolDefinition,
 };
 
-pub(crate) const NAME: &str = "CompleteWorkItem";
+pub(crate) const NAME: &str = crate::tool::names::COMPLETE_WORK_ITEM;
 
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/create_external_trigger.rs
+++ b/src/tool/tools/create_external_trigger.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::parse_tool_args;
 
-pub(crate) const NAME: &str = "CreateExternalTrigger";
+pub(crate) const NAME: &str = crate::tool::names::CREATE_EXTERNAL_TRIGGER;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/src/tool/tools/create_work_item.rs
+++ b/src/tool/tools/create_work_item.rs
@@ -19,7 +19,7 @@ use super::{
     BuiltinToolDefinition,
 };
 
-pub(crate) const NAME: &str = "CreateWorkItem";
+pub(crate) const NAME: &str = crate::tool::names::CREATE_WORK_ITEM;
 
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/enqueue.rs
+++ b/src/tool/tools/enqueue.rs
@@ -15,7 +15,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "Enqueue";
+pub(crate) const NAME: &str = crate::tool::names::ENQUEUE;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/src/tool/tools/exec_command.rs
+++ b/src/tool/tools/exec_command.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::parse_tool_args;
 
-pub(crate) const NAME: &str = "ExecCommand";
+pub(crate) const NAME: &str = crate::tool::names::EXEC_COMMAND;
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/exec_command_batch.rs
+++ b/src/tool/tools/exec_command_batch.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use super::{serialize_success, BuiltinToolDefinition};
 
-pub(crate) const NAME: &str = "ExecCommandBatch";
+pub(crate) const NAME: &str = crate::tool::names::EXEC_COMMAND_BATCH;
 const MAX_ITEMS: usize = 12;
 const DEFAULT_BATCH_YIELD_TIME_MS: u64 = 30_000;
 

--- a/src/tool/tools/get_work_item.rs
+++ b/src/tool/tools/get_work_item.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "GetWorkItem";
+pub(crate) const NAME: &str = crate::tool::names::GET_WORK_ITEM;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/list_model_providers.rs
+++ b/src/tool/tools/list_model_providers.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::parse_tool_args;
 
-pub(crate) const NAME: &str = "ListModelProviders";
+pub(crate) const NAME: &str = crate::tool::names::LIST_MODEL_PROVIDERS;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/list_provider_models.rs
+++ b/src/tool/tools/list_provider_models.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{invalid_tool_input, normalize_optional_non_empty, parse_tool_args};
 
-pub(crate) const NAME: &str = "ListProviderModels";
+pub(crate) const NAME: &str = crate::tool::names::LIST_PROVIDER_MODELS;
 const DEFAULT_LIMIT: usize = 100;
 const MAX_LIMIT: usize = 500;
 

--- a/src/tool/tools/list_work_items.rs
+++ b/src/tool/tools/list_work_items.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::tool::helpers::parse_tool_args;
 
-pub(crate) const NAME: &str = "ListWorkItems";
+pub(crate) const NAME: &str = crate::tool::names::LIST_WORK_ITEMS;
 const DEFAULT_LIMIT: usize = 20;
 const MAX_LIMIT: usize = 100;
 

--- a/src/tool/tools/memory_get.rs
+++ b/src/tool/tools/memory_get.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::parse_tool_args;
 
-pub(crate) const NAME: &str = "MemoryGet";
+pub(crate) const NAME: &str = crate::tool::names::MEMORY_GET;
 const MAX_CHARS_MAX: usize = 50_000;
 
 #[derive(Serialize, Deserialize, JsonSchema)]

--- a/src/tool/tools/memory_search.rs
+++ b/src/tool/tools/memory_search.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "MemorySearch";
+pub(crate) const NAME: &str = crate::tool::names::MEMORY_SEARCH;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/pick_work_item.rs
+++ b/src/tool/tools/pick_work_item.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::{serialize_success, BuiltinToolDefinition};
 
-pub(crate) const NAME: &str = "PickWorkItem";
+pub(crate) const NAME: &str = crate::tool::names::PICK_WORK_ITEM;
 
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/sleep.rs
+++ b/src/tool/tools/sleep.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::BuiltinToolDefinition;
 use crate::tool::helpers::{invalid_tool_input, parse_tool_args};
 
-pub(crate) const NAME: &str = "Sleep";
+pub(crate) const NAME: &str = crate::tool::names::SLEEP;
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/spawn_agent.rs
+++ b/src/tool/tools/spawn_agent.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{invalid_tool_input, normalize_optional_non_empty, parse_tool_args};
 
-pub(crate) const NAME: &str = "SpawnAgent";
+pub(crate) const NAME: &str = crate::tool::names::SPAWN_AGENT;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/src/tool/tools/task_input.rs
+++ b/src/tool/tools/task_input.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "TaskInput";
+pub(crate) const NAME: &str = crate::tool::names::TASK_INPUT;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/task_list.rs
+++ b/src/tool/tools/task_list.rs
@@ -12,8 +12,8 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::parse_tool_args;
 
-pub(crate) const NAME: &str = "ListTasks";
-pub(crate) const LEGACY_NAME: &str = "TaskList";
+pub(crate) const NAME: &str = crate::tool::names::LIST_TASKS;
+pub(crate) const LEGACY_NAME: &str = crate::tool::names::TASK_LIST;
 const DEFAULT_LIMIT: usize = 20;
 const MAX_LIMIT: usize = 100;
 

--- a/src/tool/tools/task_output.rs
+++ b/src/tool/tools/task_output.rs
@@ -15,7 +15,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "TaskOutput";
+pub(crate) const NAME: &str = crate::tool::names::TASK_OUTPUT;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/task_status.rs
+++ b/src/tool/tools/task_status.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "TaskStatus";
+pub(crate) const NAME: &str = crate::tool::names::TASK_STATUS;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/task_stop.rs
+++ b/src/tool/tools/task_stop.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "TaskStop";
+pub(crate) const NAME: &str = crate::tool::names::TASK_STOP;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/update_work_item.rs
+++ b/src/tool/tools/update_work_item.rs
@@ -20,7 +20,7 @@ use super::{
     BuiltinToolDefinition,
 };
 
-pub(crate) const NAME: &str = "UpdateWorkItem";
+pub(crate) const NAME: &str = crate::tool::names::UPDATE_WORK_ITEM;
 
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/use_workspace.rs
+++ b/src/tool/tools/use_workspace.rs
@@ -16,7 +16,7 @@ use crate::tool::helpers::{
     invalid_tool_input, normalize_optional_non_empty, parse_tool_args, validate_non_empty,
 };
 
-pub(crate) const NAME: &str = "UseWorkspace";
+pub(crate) const NAME: &str = crate::tool::names::USE_WORKSPACE;
 
 #[derive(Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/src/tool/tools/view_image.rs
+++ b/src/tool/tools/view_image.rs
@@ -25,7 +25,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "ViewImage";
+pub(crate) const NAME: &str = crate::tool::names::VIEW_IMAGE;
 const VISUAL_OBSERVATION_SCHEMA: &str = "visual_observation.v1";
 const VIEW_IMAGE_OBSERVATION_GENERATION_POLICY: &str = "openai-compatible-image-input.v1";
 const MAX_IMAGE_BYTES: u64 = 20 * 1024 * 1024;

--- a/src/tool/tools/wait_for.rs
+++ b/src/tool/tools/wait_for.rs
@@ -19,7 +19,7 @@ use super::{
     BuiltinToolDefinition,
 };
 
-pub(crate) const NAME: &str = "WaitFor";
+pub(crate) const NAME: &str = crate::tool::names::WAIT_FOR;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/src/tool/tools/web_fetch.rs
+++ b/src/tool/tools/web_fetch.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "WebFetch";
+pub(crate) const NAME: &str = crate::tool::names::WEB_FETCH;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tool/tools/web_search.rs
+++ b/src/tool/tools/web_search.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{serialize_success, BuiltinToolDefinition};
 use crate::tool::helpers::{parse_tool_args, validate_non_empty};
 
-pub(crate) const NAME: &str = "WebSearch";
+pub(crate) const NAME: &str = crate::tool::names::WEB_SEARCH;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/tui/chat.rs
+++ b/src/tui/chat.rs
@@ -1137,7 +1137,7 @@ pub(super) fn conversation_event_body(
 
 #[cfg(test)]
 fn is_sleep_tool_event(event: &crate::tui::projection::ProjectionEventRecord) -> bool {
-    event.payload.get("tool_name").and_then(Value::as_str) == Some("Sleep")
+    event.payload.get("tool_name").and_then(Value::as_str) == Some(crate::tool::names::SLEEP)
 }
 
 #[cfg(test)]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -747,9 +747,9 @@ impl TaskOverlayAction {
 
     pub(super) fn tool_name(self) -> &'static str {
         match self {
-            Self::FullOutput | Self::FollowOutput => "TaskOutput",
-            Self::Stop => "TaskStop",
-            Self::Input => "TaskInput",
+            Self::FullOutput | Self::FollowOutput => crate::tool::names::TASK_OUTPUT,
+            Self::Stop => crate::tool::names::TASK_STOP,
+            Self::Input => crate::tool::names::TASK_INPUT,
         }
     }
 }

--- a/src/work_item_refs.rs
+++ b/src/work_item_refs.rs
@@ -130,7 +130,7 @@ pub fn extract_tool_refs(tool: &ToolExecutionRecord) -> Vec<WorkItemRef> {
                 }
             }
         }
-        "ExecCommand" => {
+        crate::tool::names::EXEC_COMMAND => {
             if let Some(cmd) = tool.input.get("cmd").and_then(Value::as_str) {
                 let cmd_ref = command_receipt_source_ref(&tool.id, None);
                 refs.push(work_ref(
@@ -154,7 +154,7 @@ pub fn extract_tool_refs(tool: &ToolExecutionRecord) -> Vec<WorkItemRef> {
                 ));
             }
         }
-        "ExecCommandBatch" => {
+        crate::tool::names::EXEC_COMMAND_BATCH => {
             if let Some(items) = tool.input.get("items").and_then(Value::as_array) {
                 for (offset, item) in items.iter().enumerate() {
                     if let Some(cmd) = item.get("cmd").and_then(Value::as_str) {
@@ -183,7 +183,7 @@ pub fn extract_tool_refs(tool: &ToolExecutionRecord) -> Vec<WorkItemRef> {
                 }
             }
         }
-        "MemoryGet" | "MemorySearch" => {
+        crate::tool::names::MEMORY_GET | crate::tool::names::MEMORY_SEARCH => {
             if let Some(source_ref) = tool.input.get("source_ref").and_then(Value::as_str) {
                 if let Some(work_ref) = work_ref_from_source_ref(source_ref, "runtime memory used")
                 {


### PR DESCRIPTION
## Summary

Introduces `src/tool/names.rs` as the single source of truth for all builtin tool name strings and replaces hardcoded tool name literals throughout the runtime with references to these constants.

## Changes

- **New: `src/tool/names.rs`** — 30 `pub const` tool name strings plus aggregate slices: `STABLE_TOOL_NAMES`, `DEPRECATED_TOOL_NAMES`, `CUSTOM_TEXT_RECEIPT_TOOLS`, `FUNCTION_JSON_ENVELOPE_TOOLS`, `HIDDEN_FROM_MODEL_TOOLS`, `SLEEP_LIKE_TOOLS`, `ALL_TOOL_NAMES`.
- **All 29 tool definition files** (`src/tool/tools/*.rs`) — `const NAME` now references `crate::tool::names::CONST`.
- **`src/tool/mod.rs`** — `tool_stability_level`, `tool_success_result_contract`, `tool_model_rendering_contract`, `related_surfaces_for_tool` use aggregate slices and constants.
- **`src/tool/dispatch.rs`** — `is_model_facing_tool` uses `HIDDEN_FROM_MODEL_TOOLS`.
- **Consumer files** — `presentation.rs`, `operator_event.rs`, `runtime/turn/{execution,completion,reminders,tool_summary,context_management}.rs`, `run_once.rs`, `prompt/tools.rs`, `runtime.rs`, `storage.rs`, `work_item_refs.rs`, `tui/{render,chat}.rs`, `runtime/command_task.rs`, `runtime/tasks.rs` — all reference centralized constants instead of string literals.

## Design notes

- Rust `match` patterns accept `const &str` values directly, so `matches!(name, tn::APPLY_PATCH | tn::CREATE_WORK_ITEM)` compiles. For `(name, bool)` tuple matches (`operator_event.rs`), refactored to single-dispatch `match name` with tuple return.
- Test fixtures and test assertions intentionally keep literal strings as validation data — they verify the actual tool names, not the constants.
- `"ReadSkill"` in `operator_event.rs` is a dynamic skill action, not a builtin tool — kept as literal.
- `SchedulerAction::Sleep => "Sleep"` in `scheduler.rs` is an enum Display impl for the scheduler action, not a tool name comparison — left unchanged.

Closes #1941.