### PR TITLE
chore: prepare v0.21.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,18 +105,20 @@ jobs:
 
           Holon ${GITHUB_REF_NAME} is part of the Rust runtime line. The Rust runtime is now the main \`holon\` binary.
 
-          This release introduces web GUI skill management, a skill detail API, refreshed TUI skill commands, DashScope plan providers and new models, and a SkillsRegistry refresh mechanism, alongside fixes for skill lifecycle, provider parameter clamping, and runtime continuation edge cases.
+          This release adds the latest Volcengine models, implements real skills update compatible with npx skills v3 lock, makes skills CLI refresh and catalog refresh APIs explicit, and raises the default max_turns from 12 to 35, alongside fixes for orphaned wait conditions and operator_input recheck recovery, internal refactors to split storage and runtime_db into module trees, and web GUI skill panel and agent sidebar fixes.
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
 
           ## Changes
 
-          - Move Holon trigger orchestration into the GitHub Action so issue and PR automation can run with clearer event handling ([#1902](https://github.com/holon-run/holon/pull/1902)).
-          - Improve memory search excerpts and expandable source handling for clearer retrieval evidence ([#1907](https://github.com/holon-run/holon/pull/1907)).
-          - Index memory asynchronously and route rebuild/backfill work through the indexer for a more consistent memory maintenance path ([#1905](https://github.com/holon-run/holon/pull/1905), [#1915](https://github.com/holon-run/holon/pull/1915)).
-          - Refresh model discovery caches automatically and raise the unknown fallback prompt budget to reduce stale or undersized model-selection context ([#1909](https://github.com/holon-run/holon/pull/1909), [#1910](https://github.com/holon-run/holon/pull/1910)).
-          - Harden Holon Action behavior for cross-repo pull requests, active model reporting, and GitHub CLI installation ([#1918](https://github.com/holon-run/holon/pull/1918), [#1919](https://github.com/holon-run/holon/pull/1919), [#1920](https://github.com/holon-run/holon/pull/1920)).
-          - Fix runtime continuation and resume edge cases around stale work-item waits, legacy null message sequence values, conversation event sequence links, and completed \`run_once\` final status precedence ([#1898](https://github.com/holon-run/holon/pull/1898), [#1899](https://github.com/holon-run/holon/pull/1899), [#1921](https://github.com/holon-run/holon/pull/1921), [#1924](https://github.com/holon-run/holon/pull/1924)).
+          - Add latest Volcengine models including Seed 2.0, DeepSeek V4, GLM-5.2, and Kimi K2.6/K2.7 ([#1995](https://github.com/holon-run/holon/pull/1995)).
+          - Implement real skills update compatible with npx skills v3 lock and add a generic job API for skill installs ([#1987](https://github.com/holon-run/holon/pull/1987), [#1978](https://github.com/holon-run/holon/pull/1978)).
+          - Make skills CLI refresh and catalog refresh API explicit and improve TUI skill command feedback ([#1990](https://github.com/holon-run/holon/pull/1990), [#1977](https://github.com/holon-run/holon/pull/1977)).
+          - Raise default max_turns from 12 to 35 and audit provider response identifiers ([3913a92](https://github.com/holon-run/holon/commit/3913a92f), [#1975](https://github.com/holon-run/holon/pull/1975)).
+          - Fix orphaned wait conditions where cancel fails when the work item is already Completed ([#1991](https://github.com/holon-run/holon/pull/1991)).
+          - Fix operator_input wait with expired recheck that never recovers because the scheduler ignores the recheck deadline ([#1992](https://github.com/holon-run/holon/pull/1992)).
+          - Fix web GUI skill panel, agent sidebar, and agent template rendering ([#1999](https://github.com/holon-run/holon/pull/1999)).
+          - Refactor storage.rs, runtime_db.rs, and tool name constants into module trees for clearer storage responsibility boundaries ([#1996](https://github.com/holon-run/holon/pull/1996), [#1997](https://github.com/holon-run/holon/pull/1997), [#1998](https://github.com/holon-run/holon/pull/1998)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Current release
 
 The current recommended release is
-[`v0.20.0`](https://github.com/holon-run/holon/releases/tag/v0.20.0).
+[`v0.21.0`](https://github.com/holon-run/holon/releases/tag/v0.21.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project will maintain
 compatibility for the CLI, daemon/API semantics, and local persistent storage.
 
 See the full changes in the
-[v0.20.0 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.20.0).
+[v0.21.0 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.21.0).
 
 ## Status and compatibility
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -100,7 +100,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.20.0`](https://github.com/holon-run/holon/releases/tag/v0.20.0).
+[`v0.21.0`](https://github.com/holon-run/holon/releases/tag/v0.21.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -4612,7 +4612,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.20.0"
+    "version": "0.21.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
Prepare v0.21.0 release.

## Changes

- Bump version to 0.21.0 in `Cargo.toml` and `Cargo.lock`
- Update README and docs/website README release references to v0.21.0
- Update release workflow notes for v0.21.0

## Release highlights since v0.20.0

- Add latest Volcengine models (Seed 2.0, DeepSeek V4, GLM-5.2, Kimi K2.6/K2.7)
- Implement real skills update compatible with npx skills v3 lock
- Generic job API for skill installs
- Skills CLI refresh and catalog refresh API made explicit
- Raise default max_turns from 12 to 35
- Fix orphaned wait conditions (#1991)
- Fix operator_input wait with expired recheck never recovers (#1992)
- Fix web GUI skill panel, agent sidebar, and agent template rendering (#1999)
- Refactor storage.rs, runtime_db.rs, tool name constants into module trees

After merge, tag `v0.21.0` from the merged commit and push to trigger the release workflow.