### PR TITLE
refactor: unify CLI HTTP communication through LocalClient

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -810,14 +810,14 @@ impl LocalClient {
         .await
     }
 
-    async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+    pub async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
         let path = api_path(path);
         let body = self.send(RequestSpec::get(&path), false).await?;
         serde_json::from_slice(&body)
             .with_context(|| format!("failed to decode response body for GET {}", path))
     }
 
-    async fn post_json<B: Serialize, T: DeserializeOwned>(
+    pub async fn post_json<B: Serialize, T: DeserializeOwned>(
         &self,
         path: &str,
         payload: &B,
@@ -830,14 +830,14 @@ impl LocalClient {
             .with_context(|| format!("failed to decode response body for POST {}", path))
     }
 
-    async fn get_control_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+    pub async fn get_control_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
         let path = api_path(path);
         let body = self.send(RequestSpec::get(&path), true).await?;
         serde_json::from_slice(&body)
             .with_context(|| format!("failed to decode response body for GET {}", path))
     }
 
-    async fn post_control_json<B: Serialize, T: DeserializeOwned>(
+    pub async fn post_control_json<B: Serialize, T: DeserializeOwned>(
         &self,
         path: &str,
         payload: &B,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3029,70 +3029,14 @@ async fn post_control_json<T: serde::Serialize>(
     path: &str,
     payload: &T,
 ) -> Result<()> {
-    post_json_with_auth(config, path, payload, true).await
-}
-
-fn api_path(path: &str) -> String {
-    if path == "/" {
-        "/api/".to_string()
-    } else if path.starts_with("/api/") {
-        path.to_string()
-    } else {
-        format!("/api{path}")
-    }
+    let client = LocalClient::new(config.clone())?;
+    let value: serde_json::Value = client.post_control_json(path, payload).await?;
+    print_json(&value)
 }
 
 async fn get_json(config: &AppConfig, path: &str) -> Result<serde_json::Value> {
-    let path = api_path(path);
-    let request = reqwest::Client::new().get(format!("http://{}{}", config.http_addr, path));
-    let response = request.send().await.context("HTTP request failed")?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("GET {} returned {}: {}", path, status, body);
-    }
-    let body = response
-        .text()
-        .await
-        .context("failed to read response body")?;
-    serde_json::from_str(&body).context("failed to parse JSON response")
-}
-
-async fn post_json_with_auth<T: serde::Serialize>(
-    config: &AppConfig,
-    path: &str,
-    payload: &T,
-    include_control_auth: bool,
-) -> Result<()> {
-    let path = api_path(path);
-    let mut request = reqwest::Client::new()
-        .post(format!("http://{}{}", config.http_addr, path))
-        .json(payload);
-    if include_control_auth {
-        if let Some(token) = &config.control_token {
-            request = request.bearer_auth(token);
-        }
-    }
-    let response = request
-        .send()
-        .await
-        .with_context(|| format!("failed to post {}", path))?;
-    let status = response.status();
-    let body = response
-        .text()
-        .await
-        .with_context(|| format!("failed to read response body from POST {path}"))?;
-    if !status.is_success() {
-        anyhow::bail!("POST {path} returned {status}: {body}");
-    }
-    let value = parse_json_response_body("POST", &path, &body)?;
-    print_json(&value)?;
-    Ok(())
-}
-
-fn parse_json_response_body(method: &str, path: &str, body: &str) -> Result<serde_json::Value> {
-    serde_json::from_str(body)
-        .with_context(|| format!("failed to parse JSON response body from {method} {path}"))
+    let client = LocalClient::new(config.clone())?;
+    client.get_json(path).await
 }
 
 async fn handle_config_command(command: ConfigCommands) -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #2007.

The CLI had two independent HTTP communication paths:
- **`LocalClient`** (`src/client.rs`): socket-first → HTTP fallback, unified auth handling — used by most commands (prompt, tail, events, task, work-item, agent, workspace)
- **standalone helpers** (`src/main.rs`): plain HTTP via `reqwest::Client::new()`, inconsistent auth — used by skills, timer, control, agent create/abort, task run

When the runtime only exposes a Unix socket, commands using the standalone helpers would fail because they bypass the socket path entirely.

## Changes

- **Commit 1**: Make `LocalClient`'s `get_json`, `post_json`, `get_control_json`, and `post_control_json` methods `pub` (they were private)
- **Commit 2**: Replace `main.rs` standalone helpers (`post_control_json`, `get_json`) with `LocalClient` delegation using `serde_json::Value` as the unified return type. Remove `post_json_with_auth`, `parse_json_response_body`, and `api_path` — all now handled by `LocalClient` internally

Net: **-61 lines** of duplicate HTTP logic removed.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test` ✅ (all tests pass)