### PR TITLE
fix: prevent skill catalog infinite loop on persistent fetch errors

### DIFF
--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -914,7 +914,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
-        skillCatalog: { ...state.skillCatalog, error: message },
+        skillCatalog: { ...state.skillCatalog, source: "http", error: message },
         skillCatalogLoading: false,
         skillCatalogError: message,
       }));


### PR DESCRIPTION
## Summary

Follow-up fix for a regression introduced in #1999 (web-gui-followup-3).

**Problem:** The skills page effect guard was changed from `catalog.length > 0` to `source !== "fixture"` to fix an infinite reload loop when the catalog is legitimately empty. However, the catch block in `refreshSkillCatalog` (`runtime-store.ts:918`) preserves the old `source` value:

```ts
// catch:
skillCatalog: { ...state.skillCatalog, error: message },
```

Since `emptySkillCatalog.source` is `"fixture"` and the error path does not change it, `source` stays `"fixture"` while `skillCatalogLoading` returns to `false`. The effect guard passes again, re-firing `refreshSkillCatalog` in a tight loop — the same freeze #1999 intended to fix, just shifted from empty-success to persistent-error.

**Fix:** Set `source: "http"` in the catch block so the guard recognizes a load attempt was made:

```ts
skillCatalog: { ...state.skillCatalog, source: "http", error: message },
```

This mirrors the existing pattern in `refreshSkillDetail` (line 942), which already sets `source: "http"` on error.

### Verification
- `npm run build` (typecheck + vite build) passes ✓

Identified by holonbot review on #1999.