### PR TITLE
chore: prepare v0.22.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,20 +105,19 @@ jobs:
 
           Holon ${GITHUB_REF_NAME} is part of the Rust runtime line. The Rust runtime is now the main \`holon\` binary.
 
-          This release adds the latest Volcengine models, implements real skills update compatible with npx skills v3 lock, makes skills CLI refresh and catalog refresh APIs explicit, and raises the default max_turns from 12 to 35, alongside fixes for orphaned wait conditions and operator_input recheck recovery, internal refactors to split storage and runtime_db into module trees, and web GUI skill panel and agent sidebar fixes.
+          This release adds a workspace file browsing API for the Web GUI, supports extended thinking for Anthropic transport with thinking block audit visibility, improves Web GUI task list and overview panel, unifies CLI HTTP communication through LocalClient, and fixes skill catalog infinite loops and agent-scoped skill detail endpoints.
 
           Supported binary assets for this release are Linux amd64, macOS amd64, and macOS arm64.
 
           ## Changes
 
-          - Add latest Volcengine models including Seed 2.0, DeepSeek V4, GLM-5.2, and Kimi K2.6/K2.7 ([#1995](https://github.com/holon-run/holon/pull/1995)).
-          - Implement real skills update compatible with npx skills v3 lock and add a generic job API for skill installs ([#1987](https://github.com/holon-run/holon/pull/1987), [#1978](https://github.com/holon-run/holon/pull/1978)).
-          - Make skills CLI refresh and catalog refresh API explicit and improve TUI skill command feedback ([#1990](https://github.com/holon-run/holon/pull/1990), [#1977](https://github.com/holon-run/holon/pull/1977)).
-          - Raise default max_turns from 12 to 35 and audit provider response identifiers ([3913a92](https://github.com/holon-run/holon/commit/3913a92f), [#1975](https://github.com/holon-run/holon/pull/1975)).
-          - Fix orphaned wait conditions where cancel fails when the work item is already Completed ([#1991](https://github.com/holon-run/holon/pull/1991)).
-          - Fix operator_input wait with expired recheck that never recovers because the scheduler ignores the recheck deadline ([#1992](https://github.com/holon-run/holon/pull/1992)).
-          - Fix web GUI skill panel, agent sidebar, and agent template rendering ([#1999](https://github.com/holon-run/holon/pull/1999)).
-          - Refactor storage.rs, runtime_db.rs, and tool name constants into module trees for clearer storage responsibility boundaries ([#1996](https://github.com/holon-run/holon/pull/1996), [#1997](https://github.com/holon-run/holon/pull/1997), [#1998](https://github.com/holon-run/holon/pull/1998)).
+          - Add workspace file browsing API for the Web GUI ([#2006](https://github.com/holon-run/holon/pull/2006)).
+          - Support extended thinking for Anthropic transport with thinking block audit visibility ([#2005](https://github.com/holon-run/holon/pull/2005)).
+          - Improve Web GUI task list and overview panel ([#2001](https://github.com/holon-run/holon/pull/2001)).
+          - Unify CLI HTTP communication through LocalClient ([#2010](https://github.com/holon-run/holon/pull/2010)).
+          - Fix skill catalog infinite loop on persistent fetch errors ([#2012](https://github.com/holon-run/holon/pull/2012)).
+          - Fix agent-scoped skill detail endpoint and remove legacy_id compat ([#2008](https://github.com/holon-run/holon/pull/2008)).
+          - Improve error message when workdir does not exist ([#2009](https://github.com/holon-run/holon/pull/2009)).
 
           ## Install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holon"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holon"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 authors = ["Holon Contributors"]
 description = "A headless, event-driven runtime for long-lived agents"

--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ For more detailed explanations, see [Concepts](docs/website/concepts/).
 ## Current release
 
 The current recommended release is
-[`v0.21.0`](https://github.com/holon-run/holon/releases/tag/v0.21.0).
+[`v0.22.0`](https://github.com/holon-run/holon/releases/tag/v0.22.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project will maintain
 compatibility for the CLI, daemon/API semantics, and local persistent storage.
 
 See the full changes in the
-[v0.21.0 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.21.0).
+[v0.22.0 Release Notes](https://github.com/holon-run/holon/releases/tag/v0.22.0).
 
 ## Status and compatibility
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -100,7 +100,7 @@ waitable, delegable, and deliverable.
 ## Status and compatibility
 
 The current recommended release is
-[`v0.21.0`](https://github.com/holon-run/holon/releases/tag/v0.21.0).
+[`v0.22.0`](https://github.com/holon-run/holon/releases/tag/v0.22.0).
 
 `v0.15.0` is the baseline release where the Holon Rust runtime enters public
 compatibility maintenance. Starting from this version, the project maintains

--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -4612,7 +4612,7 @@
   "info": {
     "description": "Generated baseline for Holon's current HTTP control-plane surface. It is intentionally conservative: many response bodies remain JSON placeholders until the success/error envelope contracts stabilize.",
     "title": "Holon HTTP control-plane API",
-    "version": "0.21.0"
+    "version": "0.22.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -914,7 +914,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       set((state) => ({
-        skillCatalog: { ...state.skillCatalog, error: message },
+        skillCatalog: { ...state.skillCatalog, source: "http", error: message },
         skillCatalogLoading: false,
         skillCatalogError: message,
       }));


### PR DESCRIPTION
Bump version to 0.22.0 in Cargo.toml and Cargo.lock, update README and docs/website README release references, refresh OpenAPI snapshot, and update release workflow notes for v0.22.0 changes.

## Changes since v0.21.0

- Add workspace file browsing API for the Web GUI (#2006)
- Support extended thinking for Anthropic transport with thinking block audit visibility (#2005)
- Improve Web GUI task list and overview panel (#2001)
- Unify CLI HTTP communication through LocalClient (#2010)
- Fix skill catalog infinite loop on persistent fetch errors (#2012)
- Fix agent-scoped skill detail endpoint and remove legacy_id compat (#2008)
- Improve error message when workdir does not exist (#2009)

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo check` ✅
- `cargo test --test openapi_snapshot` ✅ (snapshot refreshed)