### PR TITLE
feat: non-blocking skill install with localStorage job persistence

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -85,6 +85,7 @@ export function App() {
   );
   const addSkillToCatalog = useRuntimeStore((state) => state.addSkillToCatalog);
   const removeSkillFromCatalog = useRuntimeStore((state) => state.removeSkillFromCatalog);
+  const skillInstallJobs = useRuntimeStore((state) => state.skillInstallJobs);
   const agentSkillCatalog = useRuntimeStore((state) =>
     sidePanelAgentId ? state.agentSkillCatalogByAgentId[sidePanelAgentId] : undefined,
   );
@@ -468,6 +469,7 @@ export function App() {
             catalog={skillCatalog}
             loading={skillCatalogLoading}
             error={skillCatalogError}
+            installJobs={skillInstallJobs}
             onRefresh={refreshSkillCatalog}
             onAddSkill={addSkillToCatalog}
             onRemoveSkill={removeSkillFromCatalog}

--- a/web-gui/app/src/features/skills/SkillsPage.tsx
+++ b/web-gui/app/src/features/skills/SkillsPage.tsx
@@ -5,12 +5,14 @@ import { Card, CardContent, CardHeader } from "../../components/ui/Card";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { MarkdownContent } from "../../components/MarkdownContent";
 import { StatusBadge } from "../../components/ui/StatusChip";
+import type { SkillInstallJob } from "../../runtime/runtime-store";
 import type { AddSkillInput, SkillCatalogEntry, SkillCatalogState, SkillDetailState, SkillInstallMode } from "../../runtime/types";
 
 interface SkillsPageProps {
   catalog: SkillCatalogState;
   loading: boolean;
   error?: string;
+  installJobs: SkillInstallJob[];
   onRefresh: () => void;
   onAddSkill: (input: AddSkillInput) => Promise<boolean>;
   onRemoveSkill: (name: string) => Promise<boolean>;
@@ -23,6 +25,7 @@ export function SkillsPage({
   catalog,
   loading,
   error,
+  installJobs,
   onRefresh,
   onAddSkill,
   onRemoveSkill,
@@ -59,7 +62,7 @@ export function SkillsPage({
     if (ok) {
       setAddSource("");
       setAddSkillName("");
-      setMessage(`Installed ${source} to the Global Skill Library.`);
+      setMessage(`Installing ${source}…`);
     }
   }
 
@@ -104,6 +107,22 @@ export function SkillsPage({
       {message && !error ? (
         <div className="skills-message" role="status">
           {message}
+        </div>
+      ) : null}
+
+      {installJobs.length > 0 ? (
+        <div className="skills-install-jobs" role="status" aria-label="Skill install jobs">
+          {installJobs.map((job) => (
+            <div key={job.jobId} className="skills-install-job">
+              {(job.status === "queued" || job.status === "running") ? (
+                <span className="spinner" aria-hidden="true" />
+              ) : null}
+              <span className="skills-install-job-source">{job.source}</span>
+              <span className={`skills-install-job-status status-${job.status}`}>
+                {job.status === "failed" ? `failed: ${job.error ?? "unknown error"}` : job.status}
+              </span>
+            </div>
+          ))}
         </div>
       ) : null}
 

--- a/web-gui/app/src/runtime/client.test.ts
+++ b/web-gui/app/src/runtime/client.test.ts
@@ -235,7 +235,7 @@ describe("createRuntimeClient", () => {
       fetchImpl: fetchImpl as typeof fetch,
     });
 
-    await expect(client.addSkillToCatalog({ kind: "remote", package: "owner/repo" })).resolves.toBeUndefined();
+    await expect(client.addSkillToCatalog({ kind: "remote", package: "owner/repo" })).resolves.toBe("job_123");
     expect(seen).toEqual([
       {
         url: "http://example.test:7878/api/jobs",
@@ -244,7 +244,6 @@ describe("createRuntimeClient", () => {
           params: { kind: { kind: "remote", package: "owner/repo" } },
         },
       },
-      { url: "http://example.test:7878/api/jobs/job_123", body: undefined },
     ]);
   });
 

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -41,8 +41,6 @@ export interface RuntimeClientOptions {
 const DEFAULT_DEV_API_BASE = "/api";
 const DEFAULT_REQUEST_TIMEOUT_MS = 8000;
 const OPTIONAL_DETAIL_TIMEOUT_MS = 4000;
-const JOB_POLL_INTERVAL_MS = 750;
-const JOB_WAIT_TIMEOUT_MS = 180_000;
 
 function fixtureAgentDetail(agentId: string): AgentDetail {
   return agentDetailFixtures[agentId] ?? agentDetailFixtures[Object.keys(agentDetailFixtures)[0]];
@@ -722,7 +720,7 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         content: response.content ?? "",
       };
     },
-    async addSkillToCatalog(input: AddSkillInput): Promise<void> {
+    async addSkillToCatalog(input: AddSkillInput): Promise<string> {
       if (!baseUrl) {
         throw new Error("Holon API base URL is not configured.");
       }
@@ -737,7 +735,22 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
       if (!jobId) {
         throw new Error("Skill install job response did not include a job id.");
       }
-      await waitForJob(fetchImpl, baseUrl, requestHeaders, jobId);
+      return jobId;
+    },
+    async getJob(jobId: string): Promise<JobDto> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      const response = await getJson<JobResponseDto>(
+        fetchImpl,
+        baseUrl,
+        `/jobs/${encodeURIComponent(jobId)}`,
+        { headers: requestHeaders },
+      );
+      if (!response.job) {
+        throw new Error(`Job ${jobId} not found.`);
+      }
+      return response.job;
     },
     async removeSkillFromCatalog(name: string): Promise<void> {
       if (!baseUrl) {
@@ -1219,34 +1232,6 @@ async function postJson<T>(
 
   const text = await response.text();
   return (text ? JSON.parse(text) : undefined) as T;
-}
-
-async function waitForJob(
-  fetchImpl: typeof fetch,
-  baseUrl: string,
-  requestHeaders: Record<string, string>,
-  jobId: string,
-): Promise<JobDto> {
-  const deadline = Date.now() + JOB_WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const response = await getJson<JobResponseDto>(
-      fetchImpl,
-      baseUrl,
-      `/jobs/${encodeURIComponent(jobId)}`,
-      { headers: requestHeaders },
-    );
-    const job = response.job;
-    if (job?.status === "completed") return job;
-    if (job?.status === "failed") {
-      throw new Error(job.error || job.summary || `Job ${jobId} ${job.status}.`);
-    }
-    await sleep(JOB_POLL_INTERVAL_MS);
-  }
-  throw new Error(`Job ${jobId} did not complete within ${Math.round(JOB_WAIT_TIMEOUT_MS / 1000)} seconds.`);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
 async function patchJson<T>(

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -191,6 +191,7 @@ export interface RuntimeStoreState {
   searchResultContentErrorBySourceRef: Record<string, string | undefined>;
   rosterActivityByAgentId: Record<string, AgentRosterActivity>;
   sessionsByAgentId: Record<string, AgentSessionState>;
+  skillInstallJobs: SkillInstallJob[];
 
   setRoute: (route: RouteKey) => void;
   openAgent: (agentId: string, targetEventSeq?: number) => void;
@@ -247,6 +248,37 @@ const ROSTER_ACTIVITY_STORAGE_KEY = "holon.webGui.rosterActivityByRemote.v1";
 let runtimeConnectionConfig = readStoredRuntimeConnectionConfig();
 let runtimeClient = createRuntimeClient(runtimeClientOptions(runtimeConnectionConfig));
 const activeEventStreams = new Map<string, AgentEventStreamSubscription>();
+export interface SkillInstallJob {
+  jobId: string;
+  source: string;
+  status: "queued" | "running" | "completed" | "failed";
+  error?: string;
+}
+
+const SKILL_INSTALL_JOBS_STORAGE_KEY = "holon.webGui.skillInstallJobs.v1";
+
+function loadSkillInstallJobs(): SkillInstallJob[] {
+  try {
+    const raw = localStorage.getItem(SKILL_INSTALL_JOBS_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SkillInstallJob[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveSkillInstallJobs(jobs: SkillInstallJob[]): void {
+  try {
+    const active = jobs.filter((j) => j.status === "queued" || j.status === "running");
+    if (active.length) {
+      localStorage.setItem(SKILL_INSTALL_JOBS_STORAGE_KEY, JSON.stringify(active));
+    } else {
+      localStorage.removeItem(SKILL_INSTALL_JOBS_STORAGE_KEY);
+    }
+  } catch {
+    // localStorage unavailable; state is in-memory only
+  }
+}
+
 const pendingStreamEvents = new Map<string, StreamEventEnvelopeDto[]>();
 const streamFlushTimers = new Map<string, number>();
 const reconnectTimers = new Map<string, number>();
@@ -636,6 +668,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   credentialStoreError: undefined,
   rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig)),
   sessionsByAgentId: {},
+  skillInstallJobs: loadSkillInstallJobs(),
 
   setRoute: (route) => set({ route }),
   openSkill: (skillId) => set({ route: "skillDetail", selectedSkillId: skillId }),
@@ -949,19 +982,21 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   },
 
   addSkillToCatalog: async (input) => {
-    set({ skillCatalogLoading: true, skillCatalogError: undefined });
+    set({ skillCatalogError: undefined });
     try {
-      await runtimeClient.addSkillToCatalog(input);
-      const skillCatalog = await runtimeClient.getSkillCatalog();
-      set({ skillCatalog, skillCatalogLoading: false, skillCatalogError: skillCatalog.error });
+      const jobId = await runtimeClient.addSkillToCatalog(input);
+      const source = "package" in input ? input.package : "path" in input ? input.path : "name" in input ? input.name : "unknown";
+      const job: SkillInstallJob = { jobId, source, status: "queued" };
+      set((state) => {
+        const jobs = [...state.skillInstallJobs, job];
+        saveSkillInstallJobs(jobs);
+        return { skillInstallJobs: jobs };
+      });
+      void pollSkillInstallJob(set, get, jobId);
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      set((state) => ({
-        skillCatalog: { ...state.skillCatalog, error: message },
-        skillCatalogLoading: false,
-        skillCatalogError: message,
-      }));
+      set({ skillCatalogError: message });
       return false;
     }
   },
@@ -1612,6 +1647,15 @@ if (typeof window !== "undefined") {
   initSessionCacheForRemote((partial) => useRuntimeStore.setState(partial));
 }
 
+// Resume polling for any skill install jobs persisted from a previous session.
+if (typeof window !== "undefined") {
+  for (const job of useRuntimeStore.getState().skillInstallJobs) {
+    if (job.status === "queued" || job.status === "running") {
+      void pollSkillInstallJob(useRuntimeStore.setState, useRuntimeStore.getState, job.jobId);
+    }
+  }
+}
+
 function emptyAgentSession(): AgentSessionState {
   return {
     loading: false,
@@ -2116,6 +2160,58 @@ function scheduleBootstrapRefresh(get: () => RuntimeStoreState, delayMs = 1_000)
     bootstrapRefreshTimer = undefined;
     void get().refreshBootstrap({ background: true });
   }, delayMs);
+}
+
+const SKILL_JOB_POLL_INTERVAL_MS = 1_000;
+const SKILL_JOB_POLL_TIMEOUT_MS = 180_000;
+
+async function pollSkillInstallJob(
+  set: StoreSet,
+  get: () => RuntimeStoreState,
+  jobId: string,
+): Promise<void> {
+  const deadline = Date.now() + SKILL_JOB_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await new Promise((resolve) => globalThis.setTimeout(resolve, SKILL_JOB_POLL_INTERVAL_MS));
+      const job = await runtimeClient.getJob(jobId);
+      if (job.status === "completed") {
+        removeSkillInstallJob(set, get, jobId);
+        await get().refreshSkillCatalog();
+        return;
+      }
+      if (job.status === "failed") {
+        updateSkillInstallJob(set, jobId, "failed", job.error || job.summary);
+        removeSkillInstallJobAfterDelay(set, get, jobId, 10_000);
+        return;
+      }
+      updateSkillInstallJob(set, jobId, job.status === "running" ? "running" : "queued");
+    } catch {
+      // Network error — keep retrying until deadline
+    }
+  }
+  updateSkillInstallJob(set, jobId, "failed", "Timed out waiting for skill install.");
+  removeSkillInstallJobAfterDelay(set, get, jobId, 10_000);
+}
+
+function updateSkillInstallJob(set: StoreSet, jobId: string, status: SkillInstallJob["status"], error?: string): void {
+  set((state) => {
+    const jobs = state.skillInstallJobs.map((j) => j.jobId === jobId ? { ...j, status, error } : j);
+    saveSkillInstallJobs(jobs);
+    return { skillInstallJobs: jobs };
+  });
+}
+
+function removeSkillInstallJob(set: StoreSet, get: () => RuntimeStoreState, jobId: string): void {
+  set((state) => {
+    const jobs = state.skillInstallJobs.filter((j) => j.jobId !== jobId);
+    saveSkillInstallJobs(jobs);
+    return { skillInstallJobs: jobs };
+  });
+}
+
+function removeSkillInstallJobAfterDelay(set: StoreSet, get: () => RuntimeStoreState, jobId: string, delayMs: number): void {
+  window.setTimeout(() => removeSkillInstallJob(set, get, jobId), delayMs);
 }
 
 function mergeAgentIntoBootstrap(bootstrap: RuntimeBootstrap, updatedAgent: AgentSummary): RuntimeBootstrap {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2881,6 +2881,43 @@ code {
   font-size: 13px;
 }
 
+.skills-install-jobs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.skills-install-job {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--line));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 5%, var(--surface));
+  font-size: 13px;
+}
+
+.skills-install-job .spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+.skills-install-job-status.status-failed {
+  color: var(--danger, var(--attention));
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .skills-add-form {
   display: grid;
   grid-template-columns: minmax(130px, 170px) minmax(220px, 1fr) minmax(120px, 160px) minmax(110px, 130px) auto;


### PR DESCRIPTION
## Summary

Replace blocking skill install flow with fire-and-forget async pattern:

- **Non-blocking**: `addSkillToCatalog` returns immediately with `job_id` instead of blocking the UI until completion
- **Background polling**: `pollSkillInstallJob` polls job status (1s interval, 180s timeout) and updates UI progressively (queued → running → completed/failed)
- **localStorage persistence**: Pending jobs are saved to localStorage; on page refresh, polling resumes automatically
- **UI feedback**: Skills page shows install-in-progress items with spinner, source name, and live status. Failed installs show error and auto-dismiss after 10s
- **Cleanup**: Removed dead code (`waitForJob`, `sleep`, `JOB_POLL_INTERVAL_MS`, `JOB_WAIT_TIMEOUT_MS`)

## Changed files

- `client.ts`: `addSkillToCatalog` returns `string` (job_id); new `getJob()` method
- `runtime-store.ts`: `SkillInstallJob` type, `skillInstallJobs` state, `pollSkillInstallJob`, localStorage helpers, resume-on-mount
- `SkillsPage.tsx`: Install jobs UI section
- `App.tsx`: Wire `skillInstallJobs` to SkillsPage
- `global.css`: Spinner + install job styles
- `client.test.ts`: Update test for new return type

## Test plan
- [x] `npm run build` (typecheck + vite build) passes
- [x] `npm test -- --run` all 112 tests pass
- [ ] Manual: install a skill, verify non-blocking behavior + localStorage persistence on refresh