### PR TITLE
fix: preserve real error in wait condition row decoding

### DIFF
--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -919,7 +919,7 @@ impl WaitConditionRepository<'_> {
              ORDER BY wait_condition_id ASC",
         )?;
         let rows = statement.query_map([], |row| {
-            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+            decode_wait_condition_row(row).map_err(wait_condition_decode_error)
         })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
@@ -941,7 +941,7 @@ impl WaitConditionRepository<'_> {
              LIMIT ?1",
         )?;
         let rows = statement.query_map([limit], |row| {
-            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+            decode_wait_condition_row(row).map_err(wait_condition_decode_error)
         })?;
         let mut records: Vec<_> = rows
             .collect::<std::result::Result<Vec<_>, _>>()
@@ -971,7 +971,7 @@ impl WaitConditionRepository<'_> {
              LIMIT ?2",
         )?;
         let rows = statement.query_map(params![agent_id, limit], |row| {
-            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+            decode_wait_condition_row(row).map_err(wait_condition_decode_error)
         })?;
         let mut records: Vec<_> = rows
             .collect::<std::result::Result<Vec<_>, _>>()
@@ -992,7 +992,7 @@ impl WaitConditionRepository<'_> {
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
         )?;
         let rows = statement.query_map([agent_id], |row| {
-            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+            decode_wait_condition_row(row).map_err(wait_condition_decode_error)
         })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
@@ -1010,7 +1010,7 @@ impl WaitConditionRepository<'_> {
              ORDER BY updated_at DESC, created_at DESC, wait_condition_id ASC",
         )?;
         let rows = statement.query_map([], |row| {
-            decode_wait_condition_row(row).map_err(|_| rusqlite::Error::InvalidQuery)
+            decode_wait_condition_row(row).map_err(wait_condition_decode_error)
         })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("reading wait conditions: {e}"))
@@ -3215,6 +3215,19 @@ pub(crate) fn parse_timestamp(value: &str) -> Result<DateTime<Utc>> {
 
 pub(crate) fn parse_optional_timestamp(value: Option<&str>) -> Result<Option<DateTime<Utc>>> {
     value.map(parse_timestamp).transpose()
+}
+
+/// Convert an [`anyhow::Error`] from row decoding into a [`rusqlite::Error`]
+/// that preserves the original message. Previously these errors were mapped to
+/// [`rusqlite::Error::InvalidQuery`] whose Display text ("Query is not
+/// read-only") is completely unrelated to the actual failure (e.g. a malformed
+/// timestamp or invalid enum value), making diagnosis nearly impossible.
+fn wait_condition_decode_error(e: anyhow::Error) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        0,
+        rusqlite::types::Type::Text,
+        format!("{e:#}").into(),
+    )
 }
 
 pub(crate) fn decode_wait_condition_row(row: &rusqlite::Row<'_>) -> Result<WaitConditionRecord> {


### PR DESCRIPTION
## Problem

`decode_wait_condition_row` decoding errors (malformed timestamp, invalid enum value, etc.) were mapped to `rusqlite::Error::InvalidQuery`, whose `Display` text is **"Query is not read-only"** — completely unrelated to the actual failure.

This made diagnosis nearly impossible. A recent incident where a manual data cleanup wrote non-RFC-3339 timestamps produced intermittent "Query is not read-only" errors across multiple agents, and the true root cause (timestamp format mismatch) was hidden behind the misleading error text.

## Fix

Replace `.map_err(|_| rusqlite::Error::InvalidQuery)` with `wait_condition_decode_error`, which converts the `anyhow::Error` into `rusqlite::Error::FromSqlConversionFailure` while preserving the full error chain via `format!("{e:#}")`.

Now the same failure produces: `Invalid column type Text at index 0, error: parsing timestamp: 2026-06-26 01:55:54` — immediately actionable.

## Scope

Only `src/runtime_db/repositories.rs`, 5 call sites in `WaitConditionRepository` + 1 new helper function. No behavior change for successful queries.