### PR TITLE
feat: workspace file browser panel

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -48,6 +48,7 @@ export function App() {
   const showAgentOverview = useRuntimeStore((state) => state.showAgentOverview);
   const showWorkItemDetail = useRuntimeStore((state) => state.showWorkItemDetail);
   const showTaskDetail = useRuntimeStore((state) => state.showTaskDetail);
+  const showFileBrowser = useRuntimeStore((state) => state.showFileBrowser);
   const toggleRightPanel = useRuntimeStore((state) => state.toggleRightPanel);
   const toggleNavCollapsed = useRuntimeStore((state) => state.toggleNavCollapsed);
   const setRuntimeConnection = useRuntimeStore((state) => state.setRuntimeConnection);
@@ -541,6 +542,10 @@ export function App() {
           }}
           onOpenSkill={navigateSkill}
           onShowAgentOverview={showAgentOverview}
+          onBrowseFiles={() => {
+            const wsId = selectedAgent.workspaceSummary?.id;
+            if (wsId) showFileBrowser(selectedAgent.id, wsId);
+          }}
           onClose={() => setRightPanelOpen(false)}
         />
       ) : null}

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -18,6 +18,7 @@ interface AgentOverviewPanelProps {
   onDisableAgentSkill: (name: string) => void;
   onOpenSkill: (skillId: string) => void;
   onOpenSkillManager: () => void;
+  onBrowseFiles: () => void;
 }
 
 function AgentSkillItem({
@@ -90,6 +91,7 @@ export function AgentOverviewPanel({
   onDisableAgentSkill,
   onOpenSkill,
   onOpenSkillManager,
+  onBrowseFiles,
 }: AgentOverviewPanelProps) {
   const workspace = agent.workspaceSummary;
   const workItems = agent.workItems ?? (agent.currentWork ? [agent.currentWork] : []);
@@ -191,6 +193,11 @@ export function AgentOverviewPanel({
               ) : null}
             </dl>
           </details>
+        ) : null}
+        {workspace?.id ? (
+          <button type="button" className="agent-skill-open" onClick={onBrowseFiles} style={{ marginTop: "0.5rem" }}>
+            Browse Files
+          </button>
         ) : null}
       </CollapsibleInspectorCard>
 

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { WorkspaceDirectoryListing, WorkspaceFileEntry } from "../../runtime/types";
+import { useRuntimeStore } from "../../runtime/runtime-store";
+
+interface FileBrowserPanelProps {
+  workspaceId: string;
+  initialPath?: string;
+}
+
+interface SelectedFile {
+  path: string;
+  content?: string;
+  mimeType?: string;
+  truncated?: boolean;
+  totalSize?: number;
+  loading: boolean;
+  error?: string;
+}
+
+function fileIcon(entry: WorkspaceFileEntry): string {
+  if (entry.type === "directory") return "📁";
+  if (entry.type === "symlink") return "🔗";
+  const ext = entry.name.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "rs": return "🦀";
+    case "ts": case "tsx": return "📘";
+    case "js": case "jsx": return "📙";
+    case "json": return "📋";
+    case "md": return "📝";
+    case "png": case "jpg": case "jpeg": case "gif": case "svg": case "webp": return "🖼️";
+    case "toml": case "yaml": case "yml": return "⚙️";
+    default: return "📄";
+  }
+}
+
+function isTextFile(mimeType?: string, name?: string): boolean {
+  if (!mimeType) return false;
+  if (mimeType.startsWith("text/")) return true;
+  const textTypes = [
+    "application/json",
+    "application/javascript",
+    "application/typescript",
+    "application/x-yaml",
+    "application/toml",
+    "application/x-sh",
+  ];
+  if (textTypes.some((t) => mimeType.startsWith(t))) return true;
+  if (name) {
+    const ext = name.split(".").pop()?.toLowerCase();
+    return ["rs", "ts", "tsx", "js", "jsx", "json", "md", "toml", "yaml", "yml", "sh", "css", "html", "sql", "py"].includes(ext ?? "");
+  }
+  return false;
+}
+
+function isImageFile(mimeType?: string): boolean {
+  return Boolean(mimeType?.startsWith("image/"));
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function FileBrowserPanel({ workspaceId, initialPath }: FileBrowserPanelProps) {
+  const browseWorkspaceDir = useRuntimeStore((s) => s.browseWorkspaceDir);
+  const readWorkspaceFile = useRuntimeStore((s) => s.readWorkspaceFile);
+  const workspaceFileUrl = useRuntimeStore((s) => s.workspaceFileUrl);
+
+  const [currentPath, setCurrentPath] = useState(initialPath ?? "");
+  const [listing, setListing] = useState<WorkspaceDirectoryListing | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
+  const [showHidden, setShowHidden] = useState(false);
+
+  const loadDir = useCallback(
+    async (path: string) => {
+      setLoading(true);
+      setError(undefined);
+      setSelectedFile(null);
+      try {
+        const result = await browseWorkspaceDir(workspaceId, path || undefined);
+        setListing(result);
+        setCurrentPath(path);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [workspaceId, browseWorkspaceDir],
+  );
+
+  useEffect(() => {
+    void loadDir(initialPath ?? "");
+  }, [loadDir, initialPath]);
+
+  const breadcrumbParts = currentPath.split("/").filter(Boolean);
+
+  const navigateToBreadcrumb = (index: number) => {
+    const target = breadcrumbParts.slice(0, index + 1).join("/");
+    void loadDir(target);
+  };
+
+  const openEntry = async (entry: WorkspaceFileEntry) => {
+    if (entry.type === "directory") {
+      const dirPath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+      void loadDir(dirPath);
+      return;
+    }
+
+    const filePath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+
+    if (isImageFile(entry.mimeType)) {
+      setSelectedFile({ path: filePath, loading: false, mimeType: entry.mimeType });
+      return;
+    }
+
+    if (!isTextFile(entry.mimeType, entry.name)) {
+      setSelectedFile({ path: filePath, loading: false, mimeType: entry.mimeType });
+      return;
+    }
+
+    setSelectedFile({ path: filePath, loading: true });
+    try {
+      const content = await readWorkspaceFile(workspaceId, filePath);
+      setSelectedFile({
+        path: filePath,
+        content: content.content,
+        mimeType: content.mimeType,
+        truncated: content.truncated,
+        totalSize: content.totalSize ?? content.size,
+        loading: false,
+      });
+    } catch (err) {
+      setSelectedFile({
+        path: filePath,
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const entries = listing?.entries ?? [];
+  const visibleEntries = showHidden
+    ? entries
+    : entries.filter((e) => !e.name.startsWith("."));
+  const dirs = visibleEntries.filter((e) => e.type === "directory" || e.type === "symlink");
+  const files = visibleEntries.filter((e) => e.type === "file");
+  const sortedEntries = [...dirs, ...files];
+
+  return (
+    <div className="file-browser">
+      <div className="file-browser-toolbar">
+        <nav className="file-browser-breadcrumb" aria-label="Path breadcrumb">
+          <button
+            type="button"
+            className="file-browser-crumb"
+            onClick={() => void loadDir("")}
+          >
+            root
+          </button>
+          {breadcrumbParts.map((part, i) => (
+            <span key={i} className="file-browser-crumb-group">
+              <span className="file-browser-sep">/</span>
+              <button
+                type="button"
+                className="file-browser-crumb"
+                onClick={() => navigateToBreadcrumb(i)}
+              >
+                {part}
+              </button>
+            </span>
+          ))}
+        </nav>
+        <label className="file-browser-hidden-toggle">
+          <input
+            type="checkbox"
+            checked={showHidden}
+            onChange={(e) => setShowHidden(e.target.checked)}
+          />
+          <small>hidden</small>
+        </label>
+        <button
+          type="button"
+          className="file-browser-refresh"
+          aria-label="Refresh directory"
+          onClick={() => void loadDir(currentPath)}
+        >
+          ↻
+        </button>
+      </div>
+
+      {error ? <p className="inspector-error">{error}</p> : null}
+
+      {loading && !listing ? (
+        <p className="inspector-muted">Loading…</p>
+      ) : sortedEntries.length === 0 ? (
+        <p className="inspector-muted">Empty directory</p>
+      ) : (
+        <ul className="file-browser-list">
+          {sortedEntries.map((entry) => (
+            <li key={entry.name}>
+              <button
+                type="button"
+                className="file-browser-entry"
+                data-selected={selectedFile?.path === (currentPath ? `${currentPath}/${entry.name}` : entry.name)}
+                onClick={() => void openEntry(entry)}
+              >
+                <span className="file-browser-entry-icon">{fileIcon(entry)}</span>
+                <span className="file-browser-entry-name">{entry.name}</span>
+                {entry.type === "file" ? (
+                  <small className="file-browser-entry-size">{formatSize(entry.size)}</small>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {selectedFile ? (
+        <div className="file-browser-viewer">
+          <div className="file-browser-viewer-head">
+            <strong>{selectedFile.path.split("/").pop()}</strong>
+            <button
+              type="button"
+              aria-label="Close file viewer"
+              onClick={() => setSelectedFile(null)}
+            >
+              ×
+            </button>
+          </div>
+          {selectedFile.loading ? (
+            <p className="inspector-muted">Loading file…</p>
+          ) : selectedFile.error ? (
+            <p className="inspector-error">{selectedFile.error}</p>
+          ) : isImageFile(selectedFile.mimeType) ? (
+            <img
+              className="file-browser-image"
+              src={workspaceFileUrl(workspaceId, selectedFile.path)}
+              alt={selectedFile.path}
+            />
+          ) : selectedFile.content != null ? (
+            <>
+              {selectedFile.truncated ? (
+                <p className="inspector-muted">
+                  File truncated — showing partial content
+                  {selectedFile.totalSize ? ` (${formatSize(selectedFile.totalSize)} total)` : ""}.
+                </p>
+              ) : null}
+              <pre className="file-browser-text">
+                <code>{selectedFile.content}</code>
+              </pre>
+            </>
+          ) : (
+            <p className="inspector-muted">
+              Binary file ({selectedFile.mimeType ?? "unknown type"}).
+              {" "}
+              <a
+                href={workspaceFileUrl(workspaceId, selectedFile.path, true)}
+                download
+              >
+                Download
+              </a>
+            </p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -4,6 +4,7 @@ import type { AgentSummary, RightPanelView, SkillCatalogState, TaskDetailState, 
 import type { TaskSummary } from "../../runtime/types";
 import { ActivityInspectorPanel, activityInspectorTitle } from "../inspector/ActivityInspectorPanel";
 import { AgentOverviewPanel, AgentSkillManagerPanel, TaskDetailPanel, WorkItemDetailPanel } from "./AgentOverviewPanel";
+import { FileBrowserPanel } from "./FileBrowserPanel";
 
 interface RightSidePanelProps {
   agent: AgentSummary;
@@ -25,6 +26,7 @@ interface RightSidePanelProps {
   onDisableAgentSkill: (name: string) => void;
   onOpenSkill: (skillId: string) => void;
   onShowAgentOverview: () => void;
+  onBrowseFiles: () => void;
   onClose: () => void;
 }
 
@@ -48,6 +50,7 @@ export function RightSidePanel({
   onDisableAgentSkill,
   onOpenSkill,
   onShowAgentOverview,
+  onBrowseFiles,
   onClose,
 }: RightSidePanelProps) {
   const [showSkillManager, setShowSkillManager] = useState(false);
@@ -62,6 +65,8 @@ export function RightSidePanel({
         ? "Work item detail"
         : activeView.kind === "task_detail"
           ? "Task detail"
+          : activeView.kind === "file_browser"
+            ? "File browser"
           : "Agent overview";
   const detailState = activeView.kind === "work_item_detail" ? workItemDetailsById[activeView.workItem.id] : undefined;
   const detailWorkItem = activeView.kind === "work_item_detail" ? detailState?.workItem ?? activeView.workItem : undefined;
@@ -123,6 +128,8 @@ export function RightSidePanel({
           <div className="inspector-stack">
             <TaskDetailPanel task={activeView.task} detailState={taskDetailState} />
           </div>
+        ) : activeView.kind === "file_browser" ? (
+          <FileBrowserPanel workspaceId={activeView.workspaceId} initialPath={activeView.initialPath} />
         ) : (
           <AgentOverviewPanel
             agent={agent}
@@ -137,6 +144,7 @@ export function RightSidePanel({
             onDisableAgentSkill={onDisableAgentSkill}
             onOpenSkill={onOpenSkill}
             onOpenSkillManager={openSkillManager}
+            onBrowseFiles={onBrowseFiles}
           />
         )}
       </div>

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -29,6 +29,9 @@ import type {
   WorkItemSummary,
   WorkspaceSummary,
   DisplayLevel,
+  WorkspaceDirectoryListing,
+  WorkspaceFileContent,
+  WorkspaceFileEntry,
 } from "./types";
 
 export interface RuntimeClientOptions {
@@ -549,6 +552,31 @@ interface JobDto {
   error?: string | null;
 }
 
+interface WorkspaceDirectoryEntryDto {
+  name: string;
+  type: string;
+  size: number;
+  mime_type?: string;
+}
+
+interface WorkspaceDirectoryListingDto {
+  type: string;
+  path: string;
+  workspace_id: string;
+  entries: WorkspaceDirectoryEntryDto[];
+}
+
+interface WorkspaceFileContentDto {
+  type: string;
+  path: string;
+  workspace_id: string;
+  size: number;
+  mime_type: string;
+  truncated: boolean;
+  total_size?: number;
+  content?: string;
+}
+
 export interface RuntimeConfigUpdateEntry {
   key: string;
   value?: unknown;
@@ -897,6 +925,54 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         requestHeaders,
       );
       return response.model;
+    },
+    async browseWorkspaceDir(workspaceId: string, path?: string): Promise<WorkspaceDirectoryListing> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      const encodedPath = path ? path.split("/").map(encodeURIComponent).join("/") : "";
+      const urlPath = encodedPath
+        ? `/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}`
+        : `/workspaces/${encodeURIComponent(workspaceId)}/files`;
+      const response = await getJson<WorkspaceDirectoryListingDto>(fetchImpl, baseUrl, urlPath, { headers: requestHeaders });
+      return {
+        type: "directory",
+        path: response.path,
+        workspaceId: response.workspace_id,
+        entries: (response.entries ?? []).map((e) => ({
+          name: e.name,
+          type: e.type as WorkspaceFileEntry["type"],
+          size: e.size,
+          mimeType: e.mime_type,
+        })),
+      };
+    },
+    async readWorkspaceFile(workspaceId: string, path: string): Promise<WorkspaceFileContent> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+      const response = await getJson<WorkspaceFileContentDto>(
+        fetchImpl,
+        baseUrl,
+        `/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}`,
+        { headers: requestHeaders },
+      );
+      return {
+        type: "file",
+        path: response.path,
+        workspaceId: response.workspace_id,
+        size: response.size,
+        mimeType: response.mime_type,
+        truncated: response.truncated,
+        totalSize: response.total_size,
+        content: response.content,
+      };
+    },
+    workspaceFileUrl(workspaceId: string, path: string, download?: boolean): string {
+      const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+      const query = download ? "?download=true" : "";
+      return `${baseUrl}/workspaces/${encodeURIComponent(workspaceId)}/files/${encodedPath}${query}`;
     },
   };
 }

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -44,6 +44,8 @@ import type {
   RuntimeToolExecutionRecord,
   WorkItemSummary,
   SearchResponse,
+  WorkspaceDirectoryListing,
+  WorkspaceFileContent,
 } from "./types";
 
 import type { AgentLiveStatus, AgentSessionState, WorkItemDetailState, TaskDetailState } from "./runtime-store-helpers";
@@ -202,6 +204,10 @@ export interface RuntimeStoreState {
   showWorkItemDetail: (agentId: string, workItem: WorkItemSummary) => void;
   showTaskDetail: (agentId: string, task: TaskSummary) => void;
   inspectActivity: (agentId: string, activity: AgentTimelineActivity) => void;
+  showFileBrowser: (agentId: string, workspaceId: string, initialPath?: string) => void;
+  browseWorkspaceDir: (workspaceId: string, path?: string) => Promise<WorkspaceDirectoryListing>;
+  readWorkspaceFile: (workspaceId: string, path: string) => Promise<WorkspaceFileContent>;
+  workspaceFileUrl: (workspaceId: string, path: string, download?: boolean) => string;
   toggleRightPanel: () => void;
   toggleNavCollapsed: () => void;
   setRuntimeConnection: (config: RuntimeConnectionConfig) => Promise<void>;
@@ -729,6 +735,14 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       rightPanelOpen: true,
       rightPanelView: { kind: "task_detail", agentId, task },
     }),
+  showFileBrowser: (agentId, workspaceId, initialPath) =>
+    set({
+      rightPanelOpen: true,
+      rightPanelView: { kind: "file_browser", agentId, workspaceId, initialPath },
+    }),
+  browseWorkspaceDir: (workspaceId, path) => runtimeClient.browseWorkspaceDir(workspaceId, path),
+  readWorkspaceFile: (workspaceId, path) => runtimeClient.readWorkspaceFile(workspaceId, path),
+  workspaceFileUrl: (workspaceId, path, download) => runtimeClient.workspaceFileUrl(workspaceId, path, download),
   inspectActivity: (agentId, activity) => {
     set({
       rightPanelOpen: true,

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -389,6 +389,31 @@ export interface TaskDetailState {
   output?: RuntimeTaskOutputResult;
 }
 
+export interface WorkspaceFileEntry {
+  name: string;
+  type: "directory" | "file" | "symlink";
+  size: number;
+  mimeType?: string;
+}
+
+export interface WorkspaceDirectoryListing {
+  type: "directory";
+  path: string;
+  workspaceId: string;
+  entries: WorkspaceFileEntry[];
+}
+
+export interface WorkspaceFileContent {
+  type: "file";
+  path: string;
+  workspaceId: string;
+  size: number;
+  mimeType: string;
+  truncated: boolean;
+  totalSize?: number;
+  content?: string;
+}
+
 export type RightPanelView =
   | {
       kind: "agent_overview";
@@ -410,6 +435,12 @@ export type RightPanelView =
       agentId: string;
       task: TaskSummary;
       detailState?: TaskDetailState;
+    }
+  | {
+      kind: "file_browser";
+      agentId: string;
+      workspaceId: string;
+      initialPath?: string;
     };
 
 export interface AgentTimelineItem {

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -3259,6 +3259,168 @@ code {
   gap: 14px;
 }
 
+.file-browser {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-browser-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.file-browser-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.file-browser-crumb {
+  background: none;
+  border: none;
+  color: var(--accent, #4a9eff);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.file-browser-crumb:hover {
+  text-decoration: underline;
+}
+
+.file-browser-sep {
+  color: var(--text-muted, #888);
+  font-size: 0.8125rem;
+}
+
+.file-browser-hidden-toggle {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.file-browser-hidden-toggle input {
+  margin: 0;
+}
+
+.file-browser-refresh {
+  background: none;
+  border: 1px solid var(--border, #ddd);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 2px 8px;
+  line-height: 1;
+}
+
+.file-browser-refresh:hover {
+  background: var(--hover-bg, #f0f0f0);
+}
+
+.file-browser-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.file-browser-list li {
+  margin: 0;
+  padding: 0;
+}
+
+.file-browser-entry {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 4px 8px;
+  text-align: left;
+  font-size: 0.8125rem;
+}
+
+.file-browser-entry:hover {
+  background: var(--hover-bg, #f0f0f0);
+}
+
+.file-browser-entry[data-selected="true"] {
+  background: var(--accent-bg, rgba(74, 158, 255, 0.12));
+}
+
+.file-browser-entry-icon {
+  flex-shrink: 0;
+  width: 1.25em;
+  text-align: center;
+}
+
+.file-browser-entry-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-browser-entry-size {
+  flex-shrink: 0;
+  color: var(--text-muted, #888);
+  font-size: 0.75rem;
+}
+
+.file-browser-viewer {
+  border-top: 1px solid var(--border, #ddd);
+  margin-top: 4px;
+  padding-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.file-browser-viewer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.file-browser-text {
+  background: var(--code-bg, #f5f5f5);
+  border-radius: 4px;
+  font-family: var(--mono-font, "SF Mono", "Fira Code", monospace);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  max-height: 400px;
+  overflow: auto;
+  padding: 10px;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.file-browser-text code {
+  font-family: inherit;
+}
+
+.file-browser-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
 .agent-skill-manager-head {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary

Adds a file browser panel to the Web GUI, accessible from the Workspace card on the Agent Overview panel.

## Changes

- **Client layer** (client.ts): New browseWorkspaceDir, readWorkspaceFile, and workspaceFileUrl methods that call the existing GET /api/workspaces/{id}/files API
- **Types** (types.ts): WorkspaceFileEntry, WorkspaceDirectoryListing, WorkspaceFileContent interfaces + file_browser variant on RightPanelView
- **Store** (runtime-store.ts): showFileBrowser action + data wrapper methods
- **New component** (FileBrowserPanel.tsx): 
  - Breadcrumb navigation (click any path segment to jump)
  - Directory listing with file-type icons and sizes
  - File viewer: text files (monospace), image preview, binary download link
  - Hidden files toggle and refresh button
- **Wiring**: AgentOverviewPanel (Browse Files button), RightSidePanel (view branch), App.tsx (callback), global.css (styles)

## Verification

- npm run build: pass
- npm run test: 112 tests passed