### PR TITLE
feat: add Codex device OAuth job

### DIFF
--- a/docs/website/reference/openapi.json
+++ b/docs/website/reference/openapi.json
@@ -6641,6 +6641,54 @@
         ]
       }
     },
+    "/auth/codex/device/start": {
+      "post": {
+        "description": "Request an OpenAI Codex device code and start a background job that persists the OAuth credential profile after user authorization.",
+        "operationId": "startCodexDeviceLogin",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonValue"
+                }
+              }
+            },
+            "description": "Successful JSON response. Baseline schema is intentionally loose until per-route response DTO contracts are stabilized."
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Client error JSON response."
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error JSON response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Start Codex device login",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/briefs": {
       "get": {
         "description": "Compatibility alias for the default agent briefs route. Query parameter: limit.",

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -233,11 +233,15 @@ pub async fn request_codex_device_code() -> Result<CodexDeviceCode> {
         .json::<DeviceUserCodeResponse>()
         .await
         .context("failed to parse OpenAI Codex device code response")?;
+    let expires_in = body
+        .expires_in
+        .unwrap_or(CODEX_DEVICE_AUTH_MAX_WAIT_SECONDS)
+        .clamp(1, CODEX_DEVICE_AUTH_MAX_WAIT_SECONDS);
     Ok(CodexDeviceCode {
         verification_url: format!("{base_url}/codex/device"),
         user_code: body.user_code,
         interval: body.interval,
-        expires_at: Utc::now() + chrono::Duration::seconds(CODEX_DEVICE_AUTH_MAX_WAIT_SECONDS),
+        expires_at: Utc::now() + chrono::Duration::seconds(expires_in),
         device_auth_id: body.device_auth_id,
     })
 }
@@ -405,6 +409,8 @@ struct DeviceUserCodeResponse {
     user_code: String,
     #[serde(default, deserialize_with = "deserialize_device_interval")]
     interval: u64,
+    #[serde(default, deserialize_with = "deserialize_optional_device_seconds")]
+    expires_in: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -419,13 +425,55 @@ struct DeviceAuthorizationResponse {
     code_verifier: String,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum DevicePollStatus {
+    Pending,
+    SlowDown,
+    Expired,
+    AccessDenied,
+    Failed(String),
+}
+
 fn deserialize_device_interval<'de, D>(deserializer: D) -> std::result::Result<u64, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     use serde::de::Error as _;
-    let value = String::deserialize(deserializer)?;
-    value.trim().parse::<u64>().map_err(D::Error::custom)
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::Number(number) => number
+            .as_u64()
+            .ok_or_else(|| D::Error::custom("device interval must be a positive integer")),
+        Value::String(value) => value.trim().parse::<u64>().map_err(D::Error::custom),
+        _ => Err(D::Error::custom(
+            "device interval must be a string or integer",
+        )),
+    }
+}
+
+fn deserialize_optional_device_seconds<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    let value = Option::<Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(number)) => number
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| D::Error::custom("device seconds must be a positive integer")),
+        Some(Value::String(value)) => value
+            .trim()
+            .parse::<i64>()
+            .map(Some)
+            .map_err(D::Error::custom),
+        Some(_) => Err(D::Error::custom(
+            "device seconds must be a string or integer",
+        )),
+    }
 }
 
 async fn poll_codex_device_code_for_authorization(
@@ -435,7 +483,8 @@ async fn poll_codex_device_code_for_authorization(
     let endpoint = format!("{base_url}/api/accounts/deviceauth/token");
     let started_at = Utc::now();
     let max_wait = chrono::Duration::seconds(CODEX_DEVICE_AUTH_MAX_WAIT_SECONDS);
-    let interval = device_code.interval.max(1);
+    let deadline = device_code.expires_at.min(started_at + max_wait);
+    let mut interval = device_code.interval.max(1);
     let client = reqwest::Client::new();
     loop {
         let response = client
@@ -455,15 +504,23 @@ async fn poll_codex_device_code_for_authorization(
                 .await
                 .context("failed to parse OpenAI Codex device authorization response");
         }
-        if status != reqwest::StatusCode::FORBIDDEN && status != reqwest::StatusCode::NOT_FOUND {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!(
-                "OpenAI Codex device login failed with HTTP {status}: {}",
-                try_parse_refresh_error_message(&body).unwrap_or(body)
-            );
+        let body = response.text().await.unwrap_or_default();
+        match classify_device_poll_status(status, &body) {
+            DevicePollStatus::Pending => {}
+            DevicePollStatus::SlowDown => {
+                interval = interval.saturating_add(5);
+            }
+            DevicePollStatus::Expired => {
+                anyhow::bail!("OpenAI Codex device login expired before authorization");
+            }
+            DevicePollStatus::AccessDenied => {
+                anyhow::bail!("OpenAI Codex device login was denied by the user");
+            }
+            DevicePollStatus::Failed(message) => {
+                anyhow::bail!("OpenAI Codex device login failed with HTTP {status}: {message}");
+            }
         }
-        let elapsed = Utc::now() - started_at;
-        if elapsed >= max_wait {
+        if Utc::now() >= deadline {
             anyhow::bail!("OpenAI Codex device login expired after 15 minutes");
         }
         tokio::time::sleep(Duration::from_secs(interval)).await;
@@ -835,6 +892,27 @@ fn try_parse_refresh_error_message(body: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+fn classify_device_poll_status(status: reqwest::StatusCode, body: &str) -> DevicePollStatus {
+    match extract_refresh_error_code(body).as_deref() {
+        Some("authorization_pending") => DevicePollStatus::Pending,
+        Some("slow_down") => DevicePollStatus::SlowDown,
+        Some("expired_token") => DevicePollStatus::Expired,
+        Some("access_denied") => DevicePollStatus::AccessDenied,
+        Some(code) => DevicePollStatus::Failed(
+            try_parse_refresh_error_message(body).unwrap_or_else(|| code.to_string()),
+        ),
+        None if status == reqwest::StatusCode::FORBIDDEN
+            || status == reqwest::StatusCode::NOT_FOUND =>
+        {
+            DevicePollStatus::Pending
+        }
+        None if status == reqwest::StatusCode::TOO_MANY_REQUESTS => DevicePollStatus::SlowDown,
+        None => DevicePollStatus::Failed(
+            try_parse_refresh_error_message(body).unwrap_or_else(|| body.to_string()),
+        ),
+    }
+}
+
 fn decode_jwt_payload(token: &str) -> Result<Value> {
     let mut parts = token.split('.');
     let (_header, payload, _sig) = match (parts.next(), parts.next(), parts.next()) {
@@ -941,6 +1019,73 @@ mod tests {
         assert_eq!(result.account_id.as_deref(), Some("acct_login"));
         assert_eq!(credential.account_id, "acct_login");
         assert_eq!(credential.source, "credential_profile:openai-codex");
+    }
+
+    #[test]
+    fn device_user_code_response_accepts_string_and_numeric_timing_fields() {
+        let response: DeviceUserCodeResponse = serde_json::from_value(json!({
+            "device_auth_id": "auth_123",
+            "usercode": "ABCD-EFGH",
+            "interval": "2",
+            "expires_in": "600"
+        }))
+        .expect("string timing fields should parse");
+
+        assert_eq!(response.device_auth_id, "auth_123");
+        assert_eq!(response.user_code, "ABCD-EFGH");
+        assert_eq!(response.interval, 2);
+        assert_eq!(response.expires_in, Some(600));
+
+        let response: DeviceUserCodeResponse = serde_json::from_value(json!({
+            "device_auth_id": "auth_456",
+            "user_code": "WXYZ-1234",
+            "interval": 5,
+            "expires_in": 300
+        }))
+        .expect("numeric timing fields should parse");
+
+        assert_eq!(response.interval, 5);
+        assert_eq!(response.expires_in, Some(300));
+    }
+
+    #[test]
+    fn classify_device_poll_status_uses_oauth_error_codes() {
+        assert_eq!(
+            classify_device_poll_status(
+                reqwest::StatusCode::BAD_REQUEST,
+                r#"{"error":"authorization_pending"}"#
+            ),
+            DevicePollStatus::Pending
+        );
+        assert_eq!(
+            classify_device_poll_status(
+                reqwest::StatusCode::TOO_MANY_REQUESTS,
+                r#"{"error":"slow_down"}"#
+            ),
+            DevicePollStatus::SlowDown
+        );
+        assert_eq!(
+            classify_device_poll_status(
+                reqwest::StatusCode::BAD_REQUEST,
+                r#"{"error":"expired_token"}"#
+            ),
+            DevicePollStatus::Expired
+        );
+        assert_eq!(
+            classify_device_poll_status(
+                reqwest::StatusCode::BAD_REQUEST,
+                r#"{"error":"access_denied"}"#
+            ),
+            DevicePollStatus::AccessDenied
+        );
+        assert_eq!(
+            classify_device_poll_status(reqwest::StatusCode::FORBIDDEN, ""),
+            DevicePollStatus::Pending
+        );
+        assert_eq!(
+            classify_device_poll_status(reqwest::StatusCode::TOO_MANY_REQUESTS, ""),
+            DevicePollStatus::SlowDown
+        );
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -53,6 +53,16 @@ pub struct CodexOAuthLoginResult {
     pub account_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct CodexDeviceCode {
+    pub verification_url: String,
+    pub user_code: String,
+    pub interval: u64,
+    pub expires_at: DateTime<Utc>,
+    #[serde(skip)]
+    device_auth_id: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CodexOAuthRefreshFailureKind {
     Expired,
@@ -192,9 +202,62 @@ const CODEX_REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 const CODEX_REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
 const CODEX_OAUTH_CALLBACK_PORT: u16 = 1455;
 const CODEX_OAUTH_CALLBACK_FALLBACK_PORT: u16 = 1457;
+const CODEX_DEVICE_AUTH_MAX_WAIT_SECONDS: i64 = 15 * 60;
 
 pub fn run_codex_oauth_login_profile_material() -> Result<CodexOAuthLoginResult> {
     run_codex_oauth_login_profile_material_with_browser(true)
+}
+
+pub async fn request_codex_device_code() -> Result<CodexDeviceCode> {
+    let issuer = std::env::var(CODEX_OAUTH_ISSUER_OVERRIDE_ENV_VAR)
+        .unwrap_or_else(|_| CODEX_OAUTH_ISSUER.to_string());
+    let base_url = issuer.trim_end_matches('/');
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/api/accounts/deviceauth/usercode"))
+        .header("Content-Type", "application/json")
+        .json(&DeviceUserCodeRequest {
+            client_id: CODEX_OAUTH_CLIENT_ID,
+        })
+        .send()
+        .await
+        .context("failed to request OpenAI Codex device code")?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "OpenAI Codex device code request failed with HTTP {status}: {}",
+            try_parse_refresh_error_message(&body).unwrap_or(body)
+        );
+    }
+    let body = response
+        .json::<DeviceUserCodeResponse>()
+        .await
+        .context("failed to parse OpenAI Codex device code response")?;
+    Ok(CodexDeviceCode {
+        verification_url: format!("{base_url}/codex/device"),
+        user_code: body.user_code,
+        interval: body.interval,
+        expires_at: Utc::now() + chrono::Duration::seconds(CODEX_DEVICE_AUTH_MAX_WAIT_SECONDS),
+        device_auth_id: body.device_auth_id,
+    })
+}
+
+pub async fn complete_codex_device_login(
+    device_code: CodexDeviceCode,
+) -> Result<CodexOAuthLoginResult> {
+    let issuer = std::env::var(CODEX_OAUTH_ISSUER_OVERRIDE_ENV_VAR)
+        .unwrap_or_else(|_| CODEX_OAUTH_ISSUER.to_string());
+    let base_url = issuer.trim_end_matches('/');
+    let code_response = poll_codex_device_code_for_authorization(base_url, &device_code).await?;
+    let redirect_uri = format!("{base_url}/deviceauth/callback");
+    let tokens = exchange_codex_oauth_code_for_tokens(
+        base_url,
+        &redirect_uri,
+        &code_response.code_verifier,
+        &code_response.authorization_code,
+    )
+    .await?;
+    codex_oauth_tokens_to_login_result(tokens)
 }
 
 fn run_codex_oauth_login_profile_material_with_browser(
@@ -328,6 +391,83 @@ struct LoginTokenResponse {
     id_token: String,
     access_token: String,
     refresh_token: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DeviceUserCodeRequest {
+    client_id: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceUserCodeResponse {
+    device_auth_id: String,
+    #[serde(alias = "usercode")]
+    user_code: String,
+    #[serde(default, deserialize_with = "deserialize_device_interval")]
+    interval: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct DeviceTokenPollRequest<'a> {
+    device_auth_id: &'a str,
+    user_code: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceAuthorizationResponse {
+    authorization_code: String,
+    code_verifier: String,
+}
+
+fn deserialize_device_interval<'de, D>(deserializer: D) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    let value = String::deserialize(deserializer)?;
+    value.trim().parse::<u64>().map_err(D::Error::custom)
+}
+
+async fn poll_codex_device_code_for_authorization(
+    base_url: &str,
+    device_code: &CodexDeviceCode,
+) -> Result<DeviceAuthorizationResponse> {
+    let endpoint = format!("{base_url}/api/accounts/deviceauth/token");
+    let started_at = Utc::now();
+    let max_wait = chrono::Duration::seconds(CODEX_DEVICE_AUTH_MAX_WAIT_SECONDS);
+    let interval = device_code.interval.max(1);
+    let client = reqwest::Client::new();
+    loop {
+        let response = client
+            .post(&endpoint)
+            .header("Content-Type", "application/json")
+            .json(&DeviceTokenPollRequest {
+                device_auth_id: &device_code.device_auth_id,
+                user_code: &device_code.user_code,
+            })
+            .send()
+            .await
+            .context("failed to poll OpenAI Codex device login")?;
+        let status = response.status();
+        if status.is_success() {
+            return response
+                .json::<DeviceAuthorizationResponse>()
+                .await
+                .context("failed to parse OpenAI Codex device authorization response");
+        }
+        if status != reqwest::StatusCode::FORBIDDEN && status != reqwest::StatusCode::NOT_FOUND {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "OpenAI Codex device login failed with HTTP {status}: {}",
+                try_parse_refresh_error_message(&body).unwrap_or(body)
+            );
+        }
+        let elapsed = Utc::now() - started_at;
+        if elapsed >= max_wait {
+            anyhow::bail!("OpenAI Codex device login expired after 15 minutes");
+        }
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+    }
 }
 
 fn bind_codex_oauth_callback_listener() -> Result<TcpListener> {

--- a/src/http/auth.rs
+++ b/src/http/auth.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[derive(Debug, Serialize)]
+struct CodexDeviceStartResponse {
+    ok: bool,
+    login_id: String,
+    verification_url: String,
+    user_code: String,
+    interval: u64,
+    expires_at: chrono::DateTime<Utc>,
+    job: jobs::JobSnapshot,
+}
+
+pub async fn start_codex_device_login(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    authorize_control(&headers, &state).map_err(|err| auth_required(err.to_string()))?;
+    let device_code = crate::auth::request_codex_device_code()
+        .await
+        .map_err(error_response)?;
+    let job = jobs::create_codex_device_login_job(state, device_code.clone());
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(CodexDeviceStartResponse {
+            ok: true,
+            login_id: job.id.clone(),
+            verification_url: device_code.verification_url,
+            user_code: device_code.user_code,
+            interval: device_code.interval,
+            expires_at: device_code.expires_at,
+            job,
+        }),
+    ))
+}

--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -12,7 +12,7 @@ pub struct JobRegistry {
 }
 
 impl JobRegistry {
-    fn insert(&self, job: JobSnapshot) {
+    pub(super) fn insert(&self, job: JobSnapshot) {
         self.jobs
             .lock()
             .expect("job registry lock")
@@ -27,7 +27,7 @@ impl JobRegistry {
             .cloned()
     }
 
-    fn update(&self, id: &str, update: impl FnOnce(&mut JobSnapshot)) {
+    pub(super) fn update(&self, id: &str, update: impl FnOnce(&mut JobSnapshot)) {
         let mut jobs = self.jobs.lock().expect("job registry lock");
         if let Some(job) = jobs.get_mut(id) {
             update(job);
@@ -235,6 +235,127 @@ async fn create_skill_install_job(
             "job": job,
         })),
     ))
+}
+
+pub(super) fn create_codex_device_login_job(
+    state: Arc<AppState>,
+    device_code: crate::auth::CodexDeviceCode,
+) -> JobSnapshot {
+    let id = format!("job_{}", Uuid::new_v4().simple());
+    let now = Utc::now();
+    let job = JobSnapshot {
+        id: id.clone(),
+        kind: "auth.codex.device_login".into(),
+        status: JobStatus::Queued,
+        phase: "waiting_for_user".into(),
+        progress: JobProgress {
+            current: 1,
+            total: 4,
+        },
+        summary: "Waiting for OpenAI Codex device authorization".into(),
+        items: vec![JobItem {
+            id: "device_authorization".into(),
+            status: JobStatus::Running,
+            summary: "Waiting for user to authorize the OpenAI Codex device code".into(),
+            error: None,
+        }],
+        result: None,
+        error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    state.jobs.insert(job.clone());
+
+    let jobs = state.jobs.clone();
+    let host = state.host.clone();
+    let job_id = id.clone();
+    tokio::spawn(async move {
+        jobs.update(&job_id, |job| {
+            job.status = JobStatus::Running;
+        });
+        match crate::auth::complete_codex_device_login(device_code).await {
+            Ok(login) => {
+                jobs.update(&job_id, |job| {
+                    job.phase = "persisting_credentials".into();
+                    job.progress.current = 3;
+                    job.summary = "Persisting OpenAI Codex OAuth credential".into();
+                    job.items = vec![JobItem {
+                        id: "credential_profile".into(),
+                        status: JobStatus::Running,
+                        summary: "Writing openai-codex credential profile".into(),
+                        error: None,
+                    }];
+                });
+                let config = host.config();
+                let profile = crate::config::OPENAI_CODEX_CREDENTIAL_PROFILE;
+                let credential_path = credential_store_path(&config.home_dir);
+                match set_credential_profile_at(
+                    &credential_path,
+                    profile,
+                    CredentialKind::OAuth,
+                    login.material,
+                ) {
+                    Ok(profile_status) => {
+                        if let Err(error) = host.reload_all_agents_config().await {
+                            tracing::warn!(
+                                error = %error,
+                                "OpenAI Codex device credential saved but hot-reload failed; restart needed"
+                            );
+                        }
+                        jobs.update(&job_id, |job| {
+                            job.status = JobStatus::Completed;
+                            job.phase = "completed".into();
+                            job.progress.current = 4;
+                            job.summary = "OpenAI Codex OAuth login completed".into();
+                            job.items = vec![JobItem {
+                                id: "credential_profile".into(),
+                                status: JobStatus::Completed,
+                                summary: "Configured openai-codex OAuth credential profile".into(),
+                                error: None,
+                            }];
+                            job.result = Some(json!({
+                                "provider_id": crate::config::ProviderId::OPENAI_CODEX,
+                                "profile": profile_status.profile,
+                                "auth_kind": profile_status.kind,
+                                "configured": true,
+                                "account_id": login.account_id,
+                            }));
+                        });
+                    }
+                    Err(error) => fail_codex_device_login_job(
+                        &jobs,
+                        &job_id,
+                        "OpenAI Codex credential persist failed",
+                        error.to_string(),
+                    ),
+                }
+            }
+            Err(error) => fail_codex_device_login_job(
+                &jobs,
+                &job_id,
+                "OpenAI Codex device login failed",
+                error.to_string(),
+            ),
+        }
+    });
+
+    job
+}
+
+fn fail_codex_device_login_job(jobs: &JobRegistry, job_id: &str, summary: &str, message: String) {
+    jobs.update(job_id, |job| {
+        job.status = JobStatus::Failed;
+        job.phase = "failed".into();
+        job.progress.current = job.progress.total;
+        job.summary = summary.into();
+        job.error = Some(message.clone());
+        job.items = vec![JobItem {
+            id: "auth.codex.device_login".into(),
+            status: JobStatus::Failed,
+            summary: summary.into(),
+            error: Some(message),
+        }];
+    });
 }
 
 fn skill_install_summary(kind: &crate::types::SkillInstallKind) -> String {

--- a/src/http/jobs.rs
+++ b/src/http/jobs.rs
@@ -250,7 +250,7 @@ pub(super) fn create_codex_device_login_job(
         phase: "waiting_for_user".into(),
         progress: JobProgress {
             current: 1,
-            total: 4,
+            total: 3,
         },
         summary: "Waiting for OpenAI Codex device authorization".into(),
         items: vec![JobItem {
@@ -277,7 +277,7 @@ pub(super) fn create_codex_device_login_job(
             Ok(login) => {
                 jobs.update(&job_id, |job| {
                     job.phase = "persisting_credentials".into();
-                    job.progress.current = 3;
+                    job.progress.current = 2;
                     job.summary = "Persisting OpenAI Codex OAuth credential".into();
                     job.items = vec![JobItem {
                         id: "credential_profile".into(),
@@ -305,7 +305,7 @@ pub(super) fn create_codex_device_login_job(
                         jobs.update(&job_id, |job| {
                             job.status = JobStatus::Completed;
                             job.phase = "completed".into();
-                            job.progress.current = 4;
+                            job.progress.current = 3;
                             job.summary = "OpenAI Codex OAuth login completed".into();
                             job.items = vec![JobItem {
                                 id: "credential_profile".into(),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -89,6 +89,7 @@ pub(crate) use crate::{
     },
 };
 mod agents;
+mod auth;
 mod control;
 mod events;
 mod ingress;
@@ -435,6 +436,10 @@ pub fn router(state: AppState) -> Router {
             patch(control::runtime_config_update),
         )
         .route("/control/runtime/shutdown", post(control::runtime_shutdown))
+        .route(
+            "/auth/codex/device/start",
+            post(auth::start_codex_device_login),
+        )
         .route(
             "/control/runtime/credentials",
             get(control::list_credentials),

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -134,6 +134,7 @@ const ROUTES: &[RouteSpec] = &[
     route("get", "/control/runtime/credentials", "runtimeCredentials", "runtime", "Runtime credential profiles", "List credential profiles stored in the runtime credential store.", None, AuthKind::Control),
     route("put", "/control/runtime/credentials/{profile}", "setRuntimeCredential", "runtime", "Set runtime credential", "Set an API key credential profile in the runtime credential store.", Some("SetCredentialRequest"), AuthKind::Control),
     route("delete", "/control/runtime/credentials/{profile}", "deleteRuntimeCredential", "runtime", "Delete runtime credential", "Remove a credential profile from the runtime credential store.", None, AuthKind::Control),
+    route("post", "/auth/codex/device/start", "startCodexDeviceLogin", "auth", "Start Codex device login", "Request an OpenAI Codex device code and start a background job that persists the OAuth credential profile after user authorization.", None, AuthKind::Control),
     route("post", "/control/runtime/shutdown", "runtimeShutdown", "runtime", "Runtime shutdown", "Request graceful runtime shutdown.", None, AuthKind::Control),
     route("post", "/control/agents/{agent_id}/debug-prompt", "debugPrompt", "control", "Debug prompt", "Render a diagnostic prompt preview.", Some("DebugPromptRequest"), AuthKind::Control),
     route("post", "/control/agents/{agent_id}/wake", "controlWake", "control", "Wake agent", "Submit a trusted wake hint.", Some("ControlWakeRequest"), AuthKind::Control),

--- a/tests/http_route_snapshot.rs
+++ b/tests/http_route_snapshot.rs
@@ -81,7 +81,7 @@ fn render_live_inventory() -> String {
             route
         })
         .collect();
-    assert_eq!(routes.len(), 86, "unexpected parsed HTTP route count");
+    assert_eq!(routes.len(), 87, "unexpected parsed HTTP route count");
 
     let openapi = holon::openapi::generate_openapi_json();
     let mut entries = Vec::new();

--- a/tests/snapshots/http_route_inventory.json
+++ b/tests/snapshots/http_route_inventory.json
@@ -1019,6 +1019,22 @@
   },
   {
     "method": "post",
+    "path": "/auth/codex/device/start",
+    "handler": "start_codex_device_login",
+    "operation_id": "startCodexDeviceLogin",
+    "tag": "auth",
+    "parameters": [],
+    "request_schema": null,
+    "request_strict": null,
+    "response_content_types": [
+      "application/json"
+    ],
+    "security": [
+      "BearerAuth"
+    ]
+  },
+  {
+    "method": "post",
     "path": "/callbacks/enqueue/{callback_token}",
     "handler": "callback_ingress_enqueue",
     "operation_id": "callbackEnqueue",


### PR DESCRIPTION
## Summary
- add Codex device code request and polling helpers
- add /api/auth/codex/device/start to return device login details plus a job
- extend HTTP job handling with auth.codex.device_login credential persistence

## Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-D warnings" cargo check --all-targets
- cargo test auth:: --lib