### PR TITLE
fix: cap dashscope-token-plan max_output_tokens to 65536

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -1473,7 +1473,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "deepseek-v4-pro",
             "DeepSeek V4 Pro",
             1_000_000,
-            384_000,
+            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
             true,
             false,
         ),
@@ -1482,7 +1482,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "deepseek-v4-flash",
             "DeepSeek V4 Flash",
             1_000_000,
-            384_000,
+            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
             true,
             false,
         ),
@@ -1500,7 +1500,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "kimi-k2.7-code",
             "kimi-k2.7-code",
             262_144,
-            98_304,
+            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
             true,
             true,
         ),
@@ -1509,7 +1509,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "kimi-k2.6",
             "kimi-k2.6",
             262_144,
-            98_304,
+            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
             true,
             true,
         ),
@@ -1527,7 +1527,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "glm-5.2",
             "glm-5.2",
             1_000_000,
-            131_072,
+            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
             true,
             false,
         ),
@@ -1536,7 +1536,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "glm-5.1",
             "glm-5.1",
             202_752,
-            131_072,
+            65_536, // Capped: DashScope gateway leaks </think> when max_output_tokens > 65536
             true,
             false,
         ),


### PR DESCRIPTION
## Problem

DashScope gateway leaks raw `</think>` tags into text output when `max_output_tokens` exceeds 65536. This was confirmed through HTTP trace analysis on `dashscope-token-plan/glm-5.2` requests where `thinking.budget_tokens: 65536` was set but `max_tokens: 131072` caused thinking content to leak into the text response.

DashScope support confirmed the issue and recommended setting `max_tokens` to 65536.

## Changes

Capped `max_output_tokens` to 65536 for all `dashscope-token-plan` models that exceeded this value:

| Model | Before | After |
|---|---|---|
| deepseek-v4-pro | 384,000 | 65,536 |
| deepseek-v4-flash | 384,000 | 65,536 |
| kimi-k2.7-code | 98,304 | 65,536 |
| kimi-k2.6 | 98,304 | 65,536 |
| glm-5.2 | 131,072 | 65,536 |
| glm-5.1 | 131,072 | 65,536 |

Models already at or below 65536 (qwen series, deepseek-v3.2, kimi-k2.5, glm-5, MiniMax-M2.5) are unchanged.