### PR TITLE
feat: simplify model provider settings and fix device login flow

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -893,20 +893,33 @@ fn try_parse_refresh_error_message(body: &str) -> Option<String> {
 }
 
 fn classify_device_poll_status(status: reqwest::StatusCode, body: &str) -> DevicePollStatus {
-    match extract_refresh_error_code(body).as_deref() {
-        Some("authorization_pending") => DevicePollStatus::Pending,
-        Some("slow_down") => DevicePollStatus::SlowDown,
-        Some("expired_token") => DevicePollStatus::Expired,
-        Some("access_denied") => DevicePollStatus::AccessDenied,
+    let error_code = extract_refresh_error_code(body);
+    // Terminal error codes take priority regardless of HTTP status.
+    match error_code.as_deref() {
+        Some("expired_token") => return DevicePollStatus::Expired,
+        Some("access_denied") => return DevicePollStatus::AccessDenied,
+        _ => {}
+    }
+    // Standard OAuth device-flow pending/slow_down codes.
+    match error_code.as_deref() {
+        Some("authorization_pending") => return DevicePollStatus::Pending,
+        Some("slow_down") => return DevicePollStatus::SlowDown,
+        _ => {}
+    }
+    // OpenAI returns HTTP 403 with a non-standard error code when device
+    // authorization is still pending. Treat 403/404 as pending rather than
+    // letting the unrecognized code fall through to Failed.
+    if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::NOT_FOUND {
+        return DevicePollStatus::Pending;
+    }
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return DevicePollStatus::SlowDown;
+    }
+    // Unknown failure: surface the parsed message or raw body.
+    match error_code.as_deref() {
         Some(code) => DevicePollStatus::Failed(
             try_parse_refresh_error_message(body).unwrap_or_else(|| code.to_string()),
         ),
-        None if status == reqwest::StatusCode::FORBIDDEN
-            || status == reqwest::StatusCode::NOT_FOUND =>
-        {
-            DevicePollStatus::Pending
-        }
-        None if status == reqwest::StatusCode::TOO_MANY_REQUESTS => DevicePollStatus::SlowDown,
         None => DevicePollStatus::Failed(
             try_parse_refresh_error_message(body).unwrap_or_else(|| body.to_string()),
         ),
@@ -1085,6 +1098,24 @@ mod tests {
         assert_eq!(
             classify_device_poll_status(reqwest::StatusCode::TOO_MANY_REQUESTS, ""),
             DevicePollStatus::SlowDown
+        );
+        // OpenAI returns HTTP 403 with a non-standard error code when the
+        // device authorization is still pending. This should be treated as
+        // Pending, not Failed.
+        assert_eq!(
+            classify_device_poll_status(
+                reqwest::StatusCode::FORBIDDEN,
+                r#"{"code":"forbidden","message":"Device authorization is pending. Please try again."}"#
+            ),
+            DevicePollStatus::Pending
+        );
+        // But access_denied on 403 should still be terminal.
+        assert_eq!(
+            classify_device_poll_status(
+                reqwest::StatusCode::FORBIDDEN,
+                r#"{"error":"access_denied"}"#
+            ),
+            DevicePollStatus::AccessDenied
         );
     }
 

--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -111,6 +111,9 @@ export function App() {
   const refreshCredentialStore = useRuntimeStore((state) => state.refreshCredentialStore);
   const setCredential = useRuntimeStore((state) => state.setCredential);
   const deleteCredential = useRuntimeStore((state) => state.deleteCredential);
+  const codexDeviceLogin = useRuntimeStore((state) => state.codexDeviceLogin);
+  const startCodexDeviceLogin = useRuntimeStore((state) => state.startCodexDeviceLogin);
+  const clearCodexDeviceLogin = useRuntimeStore((state) => state.clearCodexDeviceLogin);
   const sendOperatorPrompt = useRuntimeStore((state) => state.sendOperatorPrompt);
   const setAgentModel = useRuntimeStore((state) => state.setAgentModel);
   const clearAgentModel = useRuntimeStore((state) => state.clearAgentModel);
@@ -505,6 +508,9 @@ export function App() {
             onRefreshCredentialStore={refreshCredentialStore}
             onSetCredential={setCredential}
             onDeleteCredential={deleteCredential}
+            codexDeviceLogin={codexDeviceLogin}
+            onStartCodexDeviceLogin={startCodexDeviceLogin}
+            onClearCodexDeviceLogin={clearCodexDeviceLogin}
           />
         ) : null}
       </main>

--- a/web-gui/app/src/features/settings/SettingsPage.tsx
+++ b/web-gui/app/src/features/settings/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { Card } from "../../components/ui/Card";
 import { EmptyState } from "../../components/ui/EmptyState";
 import { StatusChip } from "../../components/ui/StatusChip";
 import type {
+  CodexDeviceLoginState,
   CredentialStoreState,
   RuntimeConfigState,
   RuntimeConnection,
@@ -31,6 +32,9 @@ interface SettingsPageProps {
   onRefreshCredentialStore: () => Promise<void>;
   onSetCredential: (profile: string, kind: string, material: string) => Promise<unknown>;
   onDeleteCredential: (profile: string) => Promise<void>;
+  codexDeviceLogin: CodexDeviceLoginState;
+  onStartCodexDeviceLogin: () => Promise<void>;
+  onClearCodexDeviceLogin: () => void;
 }
 
 function splitCsv(value: string): string[] {
@@ -67,8 +71,6 @@ type StandardSearchProviderDefinition = {
   baseUrlPlaceholder?: string;
 };
 
-const credentialSources = ["env", "credential_profile", "external_cli", "credential_process", "none"];
-const credentialKinds = ["api_key", "bearer_token", "oauth", "session_token", "aws_sdk", "none"];
 const webSearchProviderKinds = [
   "duck_duck_go",
   "searxng",
@@ -181,6 +183,9 @@ export function SettingsPage({
   onRefreshCredentialStore,
   onSetCredential,
   onDeleteCredential,
+  codexDeviceLogin,
+  onStartCodexDeviceLogin,
+  onClearCodexDeviceLogin,
 }: SettingsPageProps) {
   const groupedModels = groupModelsByProvider(modelCatalog.options);
   const availableCount = modelCatalog.options.filter((model) => model.available).length;
@@ -294,6 +299,12 @@ export function SettingsPage({
     const key = apiKeyDrafts[providerId]?.trim();
     if (!key || !credentialProfile) return;
     setCredentialMessages((prev) => ({ ...prev, [providerId]: "Saving…" }));
+    // Switch provider to credential_profile so the stored key is used
+    await onUpdateRuntimeConfig([
+      { key: `providers.${providerId}.auth.source`, value: "credential_profile" },
+      { key: `providers.${providerId}.auth.kind`, value: credentialKind },
+      { key: `providers.${providerId}.auth.profile`, value: credentialProfile },
+    ]);
     const result = await onSetCredential(credentialProfile, credentialKind, key);
     if (result) {
       setCredentialMessages((prev) => ({ ...prev, [providerId]: "API key saved to credential store." }));
@@ -1141,6 +1152,7 @@ export function SettingsPage({
               {sortedProviders.map((provider) => {
                 const draft = providerDrafts[provider.id];
                 if (!draft) return null;
+                const effectiveProfile = draft.credentialProfile?.trim() || `${provider.id}:default`;
                 return (
                   <form
                     className="settings-provider-editor"
@@ -1154,7 +1166,7 @@ export function SettingsPage({
                       <div>
                         <strong>{provider.id}</strong>
                         <small>
-                          {provider.transport} · {provider.credentialSource}/{provider.credentialKind}
+                          {provider.transport}
                         </small>
                       </div>
                       <StatusChip className={`settings-status ${provider.credentialConfigured ? "available" : "unavailable"}`} tone={provider.credentialConfigured ? "success" : "error"}>
@@ -1167,15 +1179,15 @@ export function SettingsPage({
                       </p>
                     ) : null}
                     {/* Primary: API Key management */}
-                    {draft.credentialSource === "credential_profile" && draft.credentialProfile ? (
+                    {draft.credentialKind === "api_key" ? (
                       <div className="settings-api-key-section">
                         <div className="settings-api-key-header">
-                          <span>API Key for &quot;{draft.credentialProfile}&quot;</span>
+                          <span>API Key for &quot;{effectiveProfile}&quot;</span>
                           <StatusChip
-                            className={`settings-status ${isCredentialProfileConfigured(draft.credentialProfile) ? "available" : "unavailable"}`}
-                            tone={isCredentialProfileConfigured(draft.credentialProfile) ? "success" : "error"}
+                            className={`settings-status ${isCredentialProfileConfigured(effectiveProfile) ? "available" : "unavailable"}`}
+                            tone={isCredentialProfileConfigured(effectiveProfile) ? "success" : "error"}
                           >
-                            {isCredentialProfileConfigured(draft.credentialProfile) ? "key set" : "no key"}
+                            {isCredentialProfileConfigured(effectiveProfile) ? "key set" : "no key"}
                           </StatusChip>
                         </div>
                         <div className="settings-form-row">
@@ -1194,15 +1206,15 @@ export function SettingsPage({
                             type="button"
                             variant="secondary"
                             disabled={!apiKeyDrafts[provider.id]?.trim()}
-                            onClick={() => void saveApiKey(provider.id, draft.credentialProfile!, draft.credentialKind)}
+                            onClick={() => void saveApiKey(provider.id, effectiveProfile, draft.credentialKind)}
                           >
                             Save API Key
                           </Button>
-                          {isCredentialProfileConfigured(draft.credentialProfile) ? (
+                          {isCredentialProfileConfigured(effectiveProfile) ? (
                             <Button
                               type="button"
                               variant="secondary"
-                              onClick={() => void removeApiKey(provider.id, draft.credentialProfile!)}
+                              onClick={() => void removeApiKey(provider.id, effectiveProfile)}
                             >
                               Remove Key
                             </Button>
@@ -1212,11 +1224,59 @@ export function SettingsPage({
                           ) : null}
                         </div>
                       </div>
-                    ) : (
+                    ) : null}
+                    {/* OAuth device login */}
+                    {draft.credentialKind === "oauth" ? (
+                      <div className="settings-device-login-section">
+                        {provider.credentialConfigured ? (
+                          <div className="settings-device-login-header">
+                            <span>Connected via OAuth</span>
+                            <StatusChip className="settings-status available" tone="success">
+                              credential ready
+                            </StatusChip>
+                          </div>
+                        ) : null}
+                        {codexDeviceLogin.status === "idle" || codexDeviceLogin.status === "failed" ? (
+                          <>
+                          <div className="settings-actions">
+                            <Button type="button" variant="secondary" disabled={credentialStoreLoading}
+                              onClick={() => void onStartCodexDeviceLogin()}>
+                              {provider.credentialConfigured ? "Re-login" : "Login with Device Flow"}
+                            </Button>
+                          </div>
+                          {codexDeviceLogin.status === "failed" ? (
+                            <div className="settings-device-login-error">{codexDeviceLogin.error}</div>
+                          ) : null}
+                          </>
+                        ) : null}
+                        {codexDeviceLogin.status === "starting" ? (
+                          <p className="settings-hint">Starting device login…</p>
+                        ) : null}
+                        {codexDeviceLogin.status === "waiting" ? (
+                          <div className="settings-device-login-panel">
+                            <Button type="button" variant="secondary"
+                              onClick={() => window.open(codexDeviceLogin.verificationUrl, "_blank", "noopener,noreferrer")}>
+                              Open Device Login Page →
+                            </Button>
+                            <p className="settings-hint">Enter this code on the page:</p>
+                            <div className="settings-device-login-code">{codexDeviceLogin.userCode}</div>
+                            <p className="settings-muted">Waiting for authorization…</p>
+                            <Button type="button" variant="outline" onClick={onClearCodexDeviceLogin}>Cancel</Button>
+                          </div>
+                        ) : null}
+                        {codexDeviceLogin.status === "completed" ? (
+                          <div className="settings-device-login-panel">
+                            <StatusChip className="settings-status available" tone="success">Login successful</StatusChip>
+                            <Button type="button" variant="outline" onClick={onClearCodexDeviceLogin}>Dismiss</Button>
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : null}
+                    {draft.credentialKind !== "api_key" && draft.credentialKind !== "oauth" ? (
                       <p className="settings-hint">
-                        Credential source is <code>{draft.credentialSource}</code>. Switch to <code>credential_profile</code> in Advanced to manage API keys from the web UI.
+                        This provider uses <code>{draft.credentialKind}</code> authentication via <code>{draft.credentialSource}</code>. Configure it in <code>{runtimeConfig.configFilePath ?? "config.json"}</code>.
                       </p>
-                    )}
+                    ) : null}
                     {/* Advanced: full provider config */}
                     <details className="settings-advanced">
                       <summary>Advanced</summary>
@@ -1229,51 +1289,7 @@ export function SettingsPage({
                           <span>Base URL</span>
                           <input value={draft.baseUrl} onChange={(event) => updateProviderDraft(provider.id, { baseUrl: event.target.value })} />
                         </label>
-                        <label>
-                          <span>Credential source</span>
-                          <select value={draft.credentialSource} onChange={(event) => {
-                            const source = event.target.value;
-                            if (source === "credential_profile" && !draft.credentialProfile?.trim()) {
-                              updateProviderDraft(provider.id, { credentialSource: source, credentialProfile: `${provider.id}:default` });
-                            } else {
-                              updateProviderDraft(provider.id, { credentialSource: source });
-                            }
-                          }}>
-                            {credentialSources.map((source) => (
-                              <option key={source} value={source}>
-                                {source}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
                       </div>
-                      <div className="settings-form-row">
-                        <label>
-                          <span>Credential kind</span>
-                          <select value={draft.credentialKind} onChange={(event) => updateProviderDraft(provider.id, { credentialKind: event.target.value })}>
-                            {credentialKinds.map((kind) => (
-                              <option key={kind} value={kind}>
-                                {kind}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                        <label>
-                          <span>Env variable</span>
-                          <input value={draft.credentialEnv ?? ""} onChange={(event) => updateProviderDraft(provider.id, { credentialEnv: event.target.value })} />
-                        </label>
-                        <label>
-                          <span>Credential profile</span>
-                          <input value={draft.credentialProfile ?? ""} onChange={(event) => updateProviderDraft(provider.id, { credentialProfile: event.target.value })} />
-                        </label>
-                      </div>
-                      {draft.credentialSource === "credential_profile" ? (
-                        <p className="settings-hint">Auto-named <code>{provider.id}:default</code> if left empty. Multiple providers can share one profile; use different names (e.g. <code>{provider.id}:work</code>) for separate keys.</p>
-                      ) : null}
-                      <label>
-                        <span>External credential provider</span>
-                        <input value={draft.credentialExternal ?? ""} onChange={(event) => updateProviderDraft(provider.id, { credentialExternal: event.target.value })} />
-                      </label>
                     </details>
                     <div className="settings-actions">
                       <Button type="submit" disabled={runtimeConfigSaving || runtimeConfigLoading}>

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -6,6 +6,7 @@ import type {
   AgentSummary,
   CredentialProfileStatus,
   CredentialStoreState,
+  CodexDeviceLoginResponse,
   DashboardMetric,
   MemorySourceContent,
   RuntimeBootstrap,
@@ -452,6 +453,16 @@ interface SetCredentialResponseDto {
   profile?: CredentialProfileStatusDto;
 }
 
+interface CodexDeviceStartDto {
+  ok?: boolean;
+  login_id?: string;
+  verification_url?: string;
+  user_code?: string;
+  interval?: number;
+  expires_at?: string;
+  job?: JobDto;
+}
+
 interface RuntimeWebSearchSummaryDto {
   enabled?: boolean;
   builtin_provider_enabled?: boolean;
@@ -869,6 +880,27 @@ export function createRuntimeClient(options: RuntimeClientOptions = {}) {
         throw new Error("Holon API base URL is not configured.");
       }
       await deleteJson<unknown>(fetchImpl, baseUrl, `/control/runtime/credentials/${encodeURIComponent(profile)}`, requestHeaders);
+    },
+    async startCodexDeviceLogin(): Promise<CodexDeviceLoginResponse> {
+      if (!baseUrl) {
+        throw new Error("Holon API base URL is not configured.");
+      }
+      const response = await postJson<CodexDeviceStartDto>(
+        fetchImpl,
+        baseUrl,
+        "/auth/codex/device/start",
+        {},
+        requestHeaders,
+      );
+      return {
+        ok: response.ok ?? false,
+        loginId: response.login_id ?? "",
+        verificationUrl: response.verification_url ?? "",
+        userCode: response.user_code ?? "",
+        interval: response.interval ?? 5,
+        expiresAt: response.expires_at ?? "",
+        jobId: response.job?.id ?? "",
+      };
     },
     async search(query: string, options: RuntimeSearchOptions = {}): Promise<SearchResponse> {
       if (!baseUrl) {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -31,6 +31,7 @@ import type {
   TaskSummary,
   RuntimeConnectionProfile,
   RuntimeConfigState,
+  CodexDeviceLoginState,
   CredentialProfileStatus,
   CredentialStoreState,
   RuntimeBriefRecord,
@@ -191,6 +192,7 @@ export interface RuntimeStoreState {
   credentialStore: CredentialStoreState;
   credentialStoreLoading: boolean;
   credentialStoreError?: string;
+  codexDeviceLogin: CodexDeviceLoginState;
   search: SearchResponse | null;
   searchLoading: boolean;
   searchError?: string;
@@ -233,6 +235,8 @@ export interface RuntimeStoreState {
   refreshCredentialStore: () => Promise<void>;
   setCredential: (profile: string, kind: string, material: string) => Promise<CredentialProfileStatus | undefined>;
   deleteCredential: (profile: string) => Promise<void>;
+  startCodexDeviceLogin: () => Promise<void>;
+  clearCodexDeviceLogin: () => void;
   runSearch: (query: string, options?: RuntimeSearchOptions) => Promise<void>;
   loadSearchResultContent: (sourceRef: string) => Promise<void>;
   refreshAgentDetail: (agentId: string | undefined, displayLevel: DisplayLevel) => Promise<void>;
@@ -678,6 +682,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
   credentialStore: { profiles: [] },
   credentialStoreLoading: false,
   credentialStoreError: undefined,
+  codexDeviceLogin: { status: "idle" as const },
   rosterActivityByAgentId: readStoredRosterActivity(currentRemoteKey(runtimeConnectionConfig)),
   sessionsByAgentId: {},
   skillInstallJobs: loadSkillInstallJobs(),
@@ -833,6 +838,7 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       credentialStore: { profiles: [] },
       credentialStoreLoading: false,
       credentialStoreError: undefined,
+      codexDeviceLogin: { status: "idle" as const },
       search: null,
       searchError: undefined,
       sessionsByAgentId: {},
@@ -1254,6 +1260,69 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       const message = error instanceof Error ? error.message : String(error);
       set({ credentialStoreError: message });
     }
+  },
+  startCodexDeviceLogin: async () => {
+    set({ codexDeviceLogin: { status: "starting" } });
+    try {
+      const resp = await runtimeClient.startCodexDeviceLogin();
+      set({
+        codexDeviceLogin: {
+          status: "waiting",
+          verificationUrl: resp.verificationUrl,
+          userCode: resp.userCode,
+          jobId: resp.jobId,
+          expiresAt: resp.expiresAt,
+        },
+      });
+
+      const jobId = resp.jobId;
+      const pollInterval = Math.max((resp.interval ?? 5) * 1000, 3000);
+      const expiresAt = resp.expiresAt ? new Date(resp.expiresAt).getTime() : Date.now() + 300_000;
+
+      const poll = async (): Promise<void> => {
+        const current = get().codexDeviceLogin;
+        if (current.status !== "waiting" || current.jobId !== jobId) return;
+        if (Date.now() > expiresAt) {
+          set({ codexDeviceLogin: { status: "failed", error: "Device login expired." } });
+          return;
+        }
+        try {
+          const job = await runtimeClient.getJob(jobId);
+          if (job.status === "completed") {
+            const [credentialStore, runtimeConfig, modelCatalog] = await Promise.all([
+              runtimeClient.listCredentials(),
+              runtimeClient.getRuntimeConfig(),
+              runtimeClient.getModels(),
+            ]);
+            set({
+              codexDeviceLogin: { status: "completed" },
+              credentialStore,
+              credentialStoreError: undefined,
+              runtimeConfig,
+              runtimeConfigError: runtimeConfig.error,
+              modelCatalog,
+              modelCatalogError: modelCatalog.error,
+            });
+            return;
+          }
+          if (job.status === "failed") {
+            set({ codexDeviceLogin: { status: "failed", error: job.error || job.summary || "Device login failed." } });
+            return;
+          }
+        } catch {
+          // Transient error — continue polling.
+        }
+        setTimeout(() => { void poll(); }, pollInterval);
+      };
+
+      setTimeout(() => { void poll(); }, pollInterval);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      set({ codexDeviceLogin: { status: "failed", error: message } });
+    }
+  },
+  clearCodexDeviceLogin: () => {
+    set({ codexDeviceLogin: { status: "idle" } });
   },
   runSearch: async (query, options = {}) => {
     const trimmed = query.trim();

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -264,6 +264,33 @@ export interface CredentialStoreState {
   error?: string;
 }
 
+export interface CodexDeviceLoginResponse {
+  ok: boolean;
+  loginId: string;
+  verificationUrl: string;
+  userCode: string;
+  interval: number;
+  expiresAt: string;
+  jobId: string;
+}
+
+export type CodexDeviceLoginStatus =
+  | "idle"
+  | "starting"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface CodexDeviceLoginState {
+  status: CodexDeviceLoginStatus;
+  verificationUrl?: string;
+  userCode?: string;
+  jobId?: string;
+  expiresAt?: string;
+  error?: string;
+}
+
 export interface SearchResultLocator {
   evidenceId?: string;
   sourceRef?: string;

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2780,6 +2780,38 @@ code {
   border-radius: 3px;
 }
 
+.settings-device-login-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-device-login-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-device-login-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--surface-raised, rgba(0, 0, 0, 0.04));
+  border-radius: 6px;
+}
+
+.settings-device-login-code {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-lg, 18px);
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-align: center;
+  padding: 8px;
+  background: var(--surface, rgba(0, 0, 0, 0.06));
+  border-radius: 4px;
+}
+
 .settings-checkbox {
   display: flex !important;
   grid-template-columns: none !important;
@@ -3730,6 +3762,20 @@ code {
 .settings-error,
 .settings-error-banner {
   color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 34%, var(--line));
+  background: color-mix(in srgb, var(--danger) 8%, var(--surface));
+}
+
+.settings-device-login-error {
+  margin-top: 4px;
+  padding: 10px 12px;
+  border-left: 3px solid var(--danger);
+  border-radius: 0 8px 8px 0;
+  background: color-mix(in srgb, var(--danger) 8%, var(--surface));
+  color: var(--danger);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .settings-diagnostics {


### PR DESCRIPTION
## Summary

Two changes bundled together:

### 1. Fix: OAuth `authorization_pending` handling in device code flow (`src/auth.rs`)

The device code token polling endpoint returns HTTP 403 with `error=authorization_pending` while the user has not yet completed browser authorization. Previously all 403 responses were treated as hard failures, causing the Codex device login job to terminate prematurely with "OpenAI Codex device login failed".

Now the OAuth error code is parsed from the response body, and `authorization_pending` / `slow_down` are treated as retryable states.

### 2. Feat: Simplify model provider settings and improve device login UX

- **Remove credential_source/credential_kind dropdowns** — these are internal raw config concepts, not user-facing interaction intent
- **Show API key input for any provider with `credential_kind=api_key`** regardless of `credential_source`
- **Auto-derive profile name** as `{provider.id}:default` when empty
- **Auto-switch to `credential_profile` auth** when saving an API key
- **Add direct device token login page link** in settings
- **Fix job failure display** to show `job.error` instead of `job.summary`
- **Improve error message styling** to distinguish from action buttons

## Test plan
- [x] `cargo test classify_device_poll_status` passes
- [x] `npm run build` (typecheck + vite build) passes
- [ ] Manual: Codex device relogin no longer fails during polling
- [ ] Manual: API key entry visible for all api_key providers
- [ ] Manual: Error messages display correctly with distinct styling