### PR TITLE
refactor: workspace module stabilization (Phase 1-4 + API unify + test coverage)

### DIFF
--- a/docs/implementation-decisions/063-workspace-migration-deprecation-plan.md
+++ b/docs/implementation-decisions/063-workspace-migration-deprecation-plan.md
@@ -1,0 +1,28 @@
+# Workspace migration deprecation plan
+
+## Context
+
+Two migration functions exist to handle legacy workspace state from before
+deterministic workspace ID generation was introduced:
+
+1. `canonicalize_agent_home_bindings` (`src/runtime/workspace.rs`) – rewrites
+   agent state that still references the old constant `AGENT_HOME_WORKSPACE_ID`
+   instead of the canonical agent-specific ID.
+
+2. `migrate_workspace_id` (`src/host_registry.rs` → `src/storage/mod.rs`) –
+   lazily rewrites non-deterministic (random) workspace IDs to deterministic
+   IDs in the shared workspace entry table.
+
+## Decision
+
+Both functions are marked as deprecated migration paths via doc comments and
+emit `tracing::info!` logs with the `workspace migration:` prefix each time
+they execute. This gives operators a concrete signal to determine when all
+agents have migrated and the code can be safely removed.
+
+## Removal criteria
+
+Remove both migration functions after **3 minor releases** with zero migration
+log entries, or when the next major release occurs, whichever comes first.
+At that point also remove `AGENT_HOME_WORKSPACE_ID` legacy alias resolution
+and the `migrate_workspace_id` storage method.

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,12 +21,11 @@ use crate::{
     model_catalog::BuiltInModelMetadata,
     system::ExecutionSnapshot,
     types::{
-        ActiveWorkspaceEntry, AgentListEntry, AgentSummary, AuthorityClass, BriefRecord,
-        ExternalTriggerStateSnapshot, MessageEnvelope, OperatorNotificationRecord,
-        ResolvedModelAvailability, TaskInputResult, TaskOutputResult, TaskRecord,
-        TaskStatusSnapshot, TaskStopResult, TimerRecord, ToolExecutionRecord, TranscriptEntry,
-        TurnTerminalRecord, WaitingIntentRecord, WorkItemRecord, WorkspaceOccupancyRecord,
-        WorktreeSession,
+        AgentListEntry, AgentSummary, AuthorityClass, BriefRecord, ExternalTriggerStateSnapshot,
+        MessageEnvelope, OperatorNotificationRecord, ResolvedModelAvailability, TaskInputResult,
+        TaskOutputResult, TaskRecord, TaskStatusSnapshot, TaskStopResult, TimerRecord,
+        ToolExecutionRecord, TranscriptEntry, TurnTerminalRecord, WaitingIntentRecord,
+        WorkItemRecord,
     },
 };
 
@@ -113,13 +112,14 @@ pub struct StateSessionSnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct StateWorkspaceSnapshot {
     #[serde(default)]
-    pub attached_workspaces: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_workspace_entry: Option<ActiveWorkspaceEntry>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_workspace_occupancy: Option<WorkspaceOccupancyRecord>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub worktree_session: Option<WorktreeSession>,
+    pub workspaces: Vec<crate::types::AgentWorkspaceInfo>,
+}
+
+impl StateWorkspaceSnapshot {
+    /// Returns the active workspace entry, if any.
+    pub fn active_workspace(&self) -> Option<&crate::types::AgentWorkspaceInfo> {
+        self.workspaces.iter().find(|w| w.is_active)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -216,7 +216,13 @@ impl RuntimeRegistry {
         {
             // Lazy migration: migrate non-deterministic workspace IDs in place
             // and record an alias so old references in agent state still resolve.
+            // Deprecated: planned for removal once migration logs go quiet.
             if existing.workspace_id != det_id {
+                tracing::info!(
+                    old_id = %existing.workspace_id,
+                    new_id = %det_id,
+                    "workspace migration: migrated non-deterministic workspace ID to deterministic ID"
+                );
                 self.inner
                     .host_storage
                     .migrate_workspace_id(&existing.workspace_id, &det_id)?;

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -289,3 +289,314 @@ pub(crate) fn validate_agent_id_format(agent_id: &str) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AppConfig;
+    use crate::runtime_db::RuntimeDb;
+    use tempfile::tempdir;
+
+    fn test_registry() -> (tempfile::TempDir, RuntimeRegistry) {
+        let home = tempdir().unwrap();
+        std::fs::write(
+            home.path().join("config.json"),
+            r#"{"model":{"default":"openai/gpt-5.4"}}"#,
+        )
+        .unwrap();
+        let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
+        let runtime_db =
+            RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+                .unwrap();
+        let registry = RuntimeRegistry::new(config, runtime_db).unwrap();
+        (home, registry)
+    }
+
+    const ROOT_ID: &str = "canonical_root:ws_test";
+    const WS_ID: &str = "ws_test";
+
+    // ── SharedRead conflict matrix ──
+
+    #[test]
+    fn multiple_shared_read_on_same_root_succeed() {
+        let (_home, registry) = test_registry();
+
+        let r1 = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-a", WorkspaceAccessMode::SharedRead)
+            .unwrap();
+        assert!(r1.is_some());
+
+        let r2 = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-b", WorkspaceAccessMode::SharedRead)
+            .unwrap();
+        assert!(r2.is_some());
+
+        // Both should be active.
+        let active = registry
+            .active_workspace_occupancies_for_root(ROOT_ID)
+            .unwrap();
+        assert_eq!(active.len(), 2);
+    }
+
+    #[test]
+    fn same_agent_same_mode_acquiry_is_idempotent() {
+        let (_home, registry) = test_registry();
+
+        let r1 = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-a", WorkspaceAccessMode::SharedRead)
+            .unwrap()
+            .unwrap();
+
+        let r2 = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-a", WorkspaceAccessMode::SharedRead)
+            .unwrap()
+            .unwrap();
+
+        // Should return the same record, not create a new one.
+        assert_eq!(r1.occupancy_id, r2.occupancy_id);
+
+        let active = registry
+            .active_workspace_occupancies_for_root(ROOT_ID)
+            .unwrap();
+        assert_eq!(
+            active.len(),
+            1,
+            "idempotent acquire should not create duplicate"
+        );
+    }
+
+    // ── ExclusiveWrite conflict matrix ──
+
+    #[test]
+    fn exclusive_write_blocks_other_exclusive_write() {
+        let (_home, registry) = test_registry();
+
+        registry
+            .acquire_workspace_occupancy(
+                WS_ID,
+                ROOT_ID,
+                "agent-a",
+                WorkspaceAccessMode::ExclusiveWrite,
+            )
+            .unwrap();
+
+        let err = registry
+            .acquire_workspace_occupancy(
+                WS_ID,
+                ROOT_ID,
+                "agent-b",
+                WorkspaceAccessMode::ExclusiveWrite,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("already has an exclusive_write holder"),
+            "second exclusive_write from different agent should fail"
+        );
+    }
+
+    #[test]
+    fn same_agent_exclusive_write_is_idempotent() {
+        let (_home, registry) = test_registry();
+
+        let r1 = registry
+            .acquire_workspace_occupancy(
+                WS_ID,
+                ROOT_ID,
+                "agent-a",
+                WorkspaceAccessMode::ExclusiveWrite,
+            )
+            .unwrap()
+            .unwrap();
+
+        // Same agent + same mode should be idempotent even for ExclusiveWrite.
+        let r2 = registry
+            .acquire_workspace_occupancy(
+                WS_ID,
+                ROOT_ID,
+                "agent-a",
+                WorkspaceAccessMode::ExclusiveWrite,
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(r1.occupancy_id, r2.occupancy_id);
+    }
+
+    #[test]
+    fn exclusive_write_then_shared_read_from_other_agent_allowed() {
+        // Documents current behavior: ExclusiveWrite does not block SharedRead
+        // from another agent. The conflict check only blocks ExclusiveWrite × ExclusiveWrite.
+        let (_home, registry) = test_registry();
+
+        registry
+            .acquire_workspace_occupancy(
+                WS_ID,
+                ROOT_ID,
+                "agent-a",
+                WorkspaceAccessMode::ExclusiveWrite,
+            )
+            .unwrap();
+
+        let r2 = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-b", WorkspaceAccessMode::SharedRead)
+            .unwrap();
+        assert!(
+            r2.is_some(),
+            "SharedRead from another agent is allowed alongside ExclusiveWrite"
+        );
+    }
+
+    // ── Release behavior ──
+
+    #[test]
+    fn release_marks_occupancy_as_released() {
+        let (_home, registry) = test_registry();
+
+        let record = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-a", WorkspaceAccessMode::SharedRead)
+            .unwrap()
+            .unwrap();
+
+        let released = registry
+            .release_workspace_occupancy(&record.occupancy_id)
+            .unwrap();
+        assert!(released.is_some());
+        assert!(released.unwrap().released_at.is_some());
+
+        let active = registry
+            .active_workspace_occupancies_for_root(ROOT_ID)
+            .unwrap();
+        assert!(
+            active.is_empty(),
+            "released occupancy should not appear in active list"
+        );
+    }
+
+    #[test]
+    fn release_is_idempotent() {
+        let (_home, registry) = test_registry();
+
+        let record = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-a", WorkspaceAccessMode::SharedRead)
+            .unwrap()
+            .unwrap();
+
+        // First release.
+        let first = registry
+            .release_workspace_occupancy(&record.occupancy_id)
+            .unwrap();
+        assert!(first.is_some());
+
+        // Second release should also return the record (already released).
+        let second = registry
+            .release_workspace_occupancy(&record.occupancy_id)
+            .unwrap();
+        assert!(second.is_some());
+        assert!(second.unwrap().released_at.is_some());
+    }
+
+    #[test]
+    fn release_nonexistent_id_returns_none() {
+        let (_home, registry) = test_registry();
+        let result = registry
+            .release_workspace_occupancy("occ_nonexistent")
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    // ── active_workspace_occupancies_for_root ──
+
+    #[test]
+    fn active_occupancies_filter_excludes_released() {
+        let (_home, registry) = test_registry();
+
+        let r1 = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-a", WorkspaceAccessMode::SharedRead)
+            .unwrap()
+            .unwrap();
+        let _r2 = registry
+            .acquire_workspace_occupancy(WS_ID, ROOT_ID, "agent-b", WorkspaceAccessMode::SharedRead)
+            .unwrap()
+            .unwrap();
+
+        // Release one.
+        registry
+            .release_workspace_occupancy(&r1.occupancy_id)
+            .unwrap();
+
+        let active = registry
+            .active_workspace_occupancies_for_root(ROOT_ID)
+            .unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].holder_agent_id, "agent-b");
+    }
+
+    #[test]
+    fn active_occupancies_filter_by_root_id() {
+        let (_home, registry) = test_registry();
+
+        registry
+            .acquire_workspace_occupancy(
+                WS_ID,
+                "canonical_root:ws_a",
+                "agent-a",
+                WorkspaceAccessMode::SharedRead,
+            )
+            .unwrap();
+        registry
+            .acquire_workspace_occupancy(
+                WS_ID,
+                "canonical_root:ws_b",
+                "agent-b",
+                WorkspaceAccessMode::SharedRead,
+            )
+            .unwrap();
+
+        let active_a = registry
+            .active_workspace_occupancies_for_root("canonical_root:ws_a")
+            .unwrap();
+        assert_eq!(active_a.len(), 1);
+        assert_eq!(active_a[0].holder_agent_id, "agent-a");
+    }
+
+    // ── ensure_workspace_entry ──
+
+    #[test]
+    fn ensure_workspace_entry_creates_deterministic_id() {
+        let (_home, registry) = test_registry();
+        let dir = tempdir().unwrap();
+
+        let entry = registry
+            .ensure_workspace_entry(dir.path().to_path_buf())
+            .unwrap();
+        let expected_id = ids::deterministic_workspace_id(dir.path());
+        assert_eq!(entry.workspace_id, expected_id);
+    }
+
+    #[test]
+    fn ensure_workspace_entry_is_idempotent() {
+        let (_home, registry) = test_registry();
+        let dir = tempdir().unwrap();
+
+        let entry1 = registry
+            .ensure_workspace_entry(dir.path().to_path_buf())
+            .unwrap();
+        let entry2 = registry
+            .ensure_workspace_entry(dir.path().to_path_buf())
+            .unwrap();
+
+        assert_eq!(entry1.workspace_id, entry2.workspace_id);
+    }
+
+    #[test]
+    fn ensure_workspace_entry_extracts_repo_name() {
+        let (_home, registry) = test_registry();
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("my-repo-name")).unwrap();
+        let repo_path = dir.path().join("my-repo-name");
+
+        let entry = registry.ensure_workspace_entry(repo_path).unwrap();
+        assert_eq!(entry.repo_name.as_deref(), Some("my-repo-name"));
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -77,15 +77,14 @@ pub(crate) use crate::{
     storage::EventLogPageOrder,
     system::{ExecutionScopeKind, HostLocalBoundary},
     types::{
-        ActiveWorkspaceEntry, AdmissionContext, AgentRegistryStatus, AgentSummary, AgentVisibility,
-        AuditEvent, AuthorityClass, CallbackDeliveryPayload, CallbackDeliveryResult, ControlAction,
+        AdmissionContext, AgentRegistryStatus, AgentSummary, AgentVisibility, AuditEvent,
+        AuthorityClass, CallbackDeliveryPayload, CallbackDeliveryResult, ControlAction,
         ExternalTriggerStateSnapshot, MessageBody, MessageDeliverySurface, MessageEnvelope,
         MessageKind, MessageOrigin, OperatorTransportBinding, OperatorTransportBindingStatus,
         OperatorTransportCapabilities, OperatorTransportDeliveryAuth,
         OperatorTransportDeliveryAuthKind, Priority, TaskRecord, TaskStatus, TaskStatusSnapshot,
         TaskStopResult, TimerRecord, TodoItem, TranscriptEntry, TurnTerminalRecord,
         WaitingIntentRecord, WaitingReason, WorkItemPlanStatus, WorkItemRecord, WorkItemState,
-        WorkspaceOccupancyRecord, WorktreeSession,
     },
 };
 mod agents;

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -749,6 +749,159 @@ mod tests {
             "你..."
         );
     }
+
+    // ── build_worktree_info tests ──
+
+    use crate::types::{WorkspaceProjectionMetadata, WorktreeInfo, WorktreeSession};
+    use std::path::PathBuf;
+
+    #[test]
+    fn build_worktree_info_managed_worktree_metadata() {
+        let metadata = WorkspaceProjectionMetadata::ManagedWorktree {
+            original_cwd: PathBuf::from("/tmp/project"),
+            original_branch: "main".into(),
+            worktree_path: PathBuf::from("/tmp/project/.worktrees/feature"),
+            worktree_branch: "feature".into(),
+        };
+        let session = Some(WorktreeSession {
+            original_cwd: PathBuf::from("/tmp/project"),
+            original_branch: "main".into(),
+            worktree_path: PathBuf::from("/tmp/project/.worktrees/feature"),
+            worktree_branch: "feature".into(),
+        });
+
+        let info = super::build_worktree_info(Some(&metadata), session.as_ref());
+        let info = info.expect("should produce WorktreeInfo");
+        assert_eq!(info.branch.as_deref(), Some("feature"));
+        assert!(info
+            .path
+            .as_deref()
+            .unwrap()
+            .contains("/tmp/project/.worktrees/feature"));
+        assert_eq!(info.original_branch.as_deref(), Some("main"));
+        assert!(info
+            .original_cwd
+            .as_deref()
+            .unwrap()
+            .contains("/tmp/project"));
+    }
+
+    #[test]
+    fn build_worktree_info_existing_git_worktree_metadata() {
+        let metadata = WorkspaceProjectionMetadata::ExistingGitWorktree {
+            worktree_root: PathBuf::from("/tmp/existing-wt"),
+        };
+
+        let info = super::build_worktree_info(Some(&metadata), None);
+        let info = info.expect("should produce WorktreeInfo");
+        assert!(
+            info.branch.is_none(),
+            "existing git worktree should not have branch from metadata"
+        );
+        assert_eq!(info.path.as_deref(), Some("/tmp/existing-wt"));
+    }
+
+    #[test]
+    fn build_worktree_info_fallback_to_session_only() {
+        let session = WorktreeSession {
+            original_cwd: PathBuf::from("/tmp/project"),
+            original_branch: "main".into(),
+            worktree_path: PathBuf::from("/tmp/project/.worktrees/dev"),
+            worktree_branch: "dev".into(),
+        };
+
+        let info = super::build_worktree_info(None, Some(&session));
+        let info = info.expect("should produce WorktreeInfo from session");
+        assert_eq!(info.branch.as_deref(), Some("dev"));
+        assert!(info
+            .path
+            .as_deref()
+            .unwrap()
+            .contains("/tmp/project/.worktrees/dev"));
+        assert_eq!(info.original_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn build_worktree_info_returns_none_when_all_none() {
+        let info = super::build_worktree_info(None, None);
+        assert!(
+            info.is_none(),
+            "should return None when both metadata and session are absent"
+        );
+    }
+
+    #[test]
+    fn build_worktree_info_session_enriches_metadata_originals() {
+        let metadata = WorkspaceProjectionMetadata::ManagedWorktree {
+            original_cwd: PathBuf::from("/tmp/project"),
+            original_branch: "main".into(),
+            worktree_path: PathBuf::from("/tmp/wt"),
+            worktree_branch: "feat".into(),
+        };
+        let session = WorktreeSession {
+            original_cwd: PathBuf::from("/tmp/project"),
+            original_branch: "main".into(),
+            worktree_path: PathBuf::from("/tmp/wt"),
+            worktree_branch: "feat".into(),
+        };
+
+        let info = super::build_worktree_info(Some(&metadata), Some(&session));
+        let info = info.expect("should produce WorktreeInfo");
+        assert_eq!(info.original_branch.as_deref(), Some("main"));
+        assert!(info.original_cwd.is_some());
+    }
+
+    // ── AgentWorkspaceInfo serde round-trip ──
+
+    use crate::system::{WorkspaceAccessMode, WorkspaceProjectionKind};
+    use crate::types::AgentWorkspaceInfo;
+
+    #[test]
+    fn agent_workspace_info_serde_roundtrip_full() {
+        let info = AgentWorkspaceInfo {
+            workspace_id: "ws_abc".into(),
+            workspace_alias: Some("my-project".into()),
+            workspace_anchor: Some("/home/user/project".into()),
+            repo_name: Some("project".into()),
+            is_active: true,
+            execution_root_id: Some("canonical_root:ws_abc".into()),
+            execution_root: Some("/home/user/project".into()),
+            cwd: Some("/home/user/project/src".into()),
+            projection_kind: Some(WorkspaceProjectionKind::CanonicalRoot),
+            access_mode: Some(WorkspaceAccessMode::ExclusiveWrite),
+            worktree: Some(WorktreeInfo {
+                branch: Some("feature".into()),
+                path: Some("/tmp/wt".into()),
+                original_branch: Some("main".into()),
+                original_cwd: Some("/tmp/project".into()),
+            }),
+        };
+
+        let json = serde_json::to_string(&info).unwrap();
+        let decoded: AgentWorkspaceInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(info, decoded);
+    }
+
+    #[test]
+    fn agent_workspace_info_serde_roundtrip_minimal() {
+        let info = AgentWorkspaceInfo {
+            workspace_id: "ws_xyz".into(),
+            workspace_alias: None,
+            workspace_anchor: None,
+            repo_name: None,
+            is_active: false,
+            execution_root_id: None,
+            execution_root: None,
+            cwd: None,
+            projection_kind: None,
+            access_mode: None,
+            worktree: None,
+        };
+
+        let json = serde_json::to_string(&info).unwrap();
+        let decoded: AgentWorkspaceInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(info, decoded);
+    }
 }
 
 pub async fn briefs_default(

--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -465,40 +465,120 @@ fn state_workspace_snapshot(agent: &AgentSummary, state: &AppState) -> StateWork
             .unwrap_or_else(|| ws_id.to_string())
     };
 
-    let mut workspace_entries: Vec<WorkspaceEntrySummary> = agent
-        .agent
-        .attached_workspaces
-        .iter()
-        .filter_map(|ws_id| {
-            let resolved = resolve_id(ws_id);
-            all_entries
-                .iter()
-                .find(|e| e.workspace_id == resolved)
-                .map(WorkspaceEntrySummary::from_entry)
-        })
-        .collect();
+    use crate::types::AgentWorkspaceInfo;
+    use std::collections::HashSet;
+
+    let mut seen_ids: HashSet<String> = HashSet::new();
+    let mut workspaces: Vec<AgentWorkspaceInfo> = Vec::new();
+
+    // Add active workspace first (with full runtime info).
     if let Some(active_entry) = agent.agent.active_workspace_entry.as_ref() {
-        let resolved_active_id = resolve_id(&active_entry.workspace_id);
-        if !workspace_entries
-            .iter()
-            .any(|entry| entry.workspace_id == resolved_active_id)
-        {
-            if let Some(entry) = all_entries
-                .iter()
-                .find(|entry| entry.workspace_id == resolved_active_id)
-            {
-                workspace_entries.push(WorkspaceEntrySummary::from_entry(entry));
-            } else {
-                workspace_entries.push(WorkspaceEntrySummary::from_active_entry(active_entry));
-            }
+        let resolved_id = resolve_id(&active_entry.workspace_id);
+        seen_ids.insert(resolved_id.clone());
+
+        // Try to enrich with registry data (alias, repo_name).
+        let registry_entry = all_entries.iter().find(|e| e.workspace_id == resolved_id);
+        let worktree = build_worktree_info(
+            active_entry.projection_metadata.as_ref(),
+            agent.agent.worktree_session.as_ref(),
+        );
+
+        workspaces.push(AgentWorkspaceInfo {
+            workspace_id: active_entry.workspace_id.clone(),
+            workspace_alias: registry_entry.and_then(|e| e.workspace_alias.clone()),
+            workspace_anchor: Some(active_entry.workspace_anchor.display().to_string()),
+            repo_name: registry_entry.and_then(|e| e.repo_name.clone()),
+            is_active: true,
+            execution_root_id: Some(active_entry.execution_root_id.clone()),
+            execution_root: Some(active_entry.execution_root.display().to_string()),
+            cwd: Some(active_entry.cwd.display().to_string()),
+            projection_kind: Some(active_entry.projection_kind),
+            access_mode: Some(active_entry.access_mode),
+            worktree,
+        });
+    }
+
+    // Add remaining attached workspaces (identity-only info from registry).
+    for ws_id in &agent.agent.attached_workspaces {
+        let resolved = resolve_id(ws_id);
+        if seen_ids.contains(&resolved) {
+            continue;
+        }
+        seen_ids.insert(resolved.clone());
+
+        if let Some(entry) = all_entries.iter().find(|e| e.workspace_id == resolved) {
+            workspaces.push(AgentWorkspaceInfo {
+                workspace_id: entry.workspace_id.clone(),
+                workspace_alias: entry.workspace_alias.clone(),
+                workspace_anchor: Some(entry.workspace_anchor.display().to_string()),
+                repo_name: entry.repo_name.clone(),
+                is_active: false,
+                execution_root_id: None,
+                execution_root: None,
+                cwd: None,
+                projection_kind: None,
+                access_mode: None,
+                worktree: None,
+            });
+        } else {
+            // Fallback for IDs without a registry entry.
+            workspaces.push(AgentWorkspaceInfo {
+                workspace_id: ws_id.clone(),
+                workspace_alias: None,
+                workspace_anchor: None,
+                repo_name: None,
+                is_active: false,
+                execution_root_id: None,
+                execution_root: None,
+                cwd: None,
+                projection_kind: None,
+                access_mode: None,
+                worktree: None,
+            });
         }
     }
-    StateWorkspaceSnapshot {
-        attached_workspaces: agent.agent.attached_workspaces.clone(),
-        workspace_entries,
-        active_workspace_entry: agent.agent.active_workspace_entry.clone(),
-        active_workspace_occupancy: agent.active_workspace_occupancy.clone(),
-        worktree_session: agent.agent.worktree_session.clone(),
+
+    StateWorkspaceSnapshot { workspaces }
+}
+
+/// Merge projection_metadata and worktree_session into a unified WorktreeInfo.
+fn build_worktree_info(
+    metadata: Option<&crate::types::WorkspaceProjectionMetadata>,
+    session: Option<&crate::types::WorktreeSession>,
+) -> Option<crate::types::WorktreeInfo> {
+    use crate::types::WorkspaceProjectionMetadata;
+    let (branch, path) = match metadata {
+        Some(WorkspaceProjectionMetadata::ManagedWorktree {
+            worktree_branch,
+            worktree_path,
+            ..
+        }) => (
+            Some(worktree_branch.clone()),
+            Some(worktree_path.display().to_string()),
+        ),
+        Some(WorkspaceProjectionMetadata::ExistingGitWorktree { worktree_root }) => {
+            (None, Some(worktree_root.display().to_string()))
+        }
+        None => match session {
+            Some(s) => (
+                Some(s.worktree_branch.clone()),
+                Some(s.worktree_path.display().to_string()),
+            ),
+            None => (None, None),
+        },
+    };
+    let original_branch = session.map(|s| s.original_branch.clone());
+    let original_cwd = session.map(|s| s.original_cwd.display().to_string());
+
+    if branch.is_some() || path.is_some() || original_branch.is_some() || original_cwd.is_some() {
+        Some(crate::types::WorktreeInfo {
+            branch,
+            path,
+            original_branch,
+            original_cwd,
+        })
+    } else {
+        None
     }
 }
 

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -274,37 +274,13 @@ pub(crate) struct StateSessionSnapshot {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct StateWorkspaceSnapshot {
-    pub(crate) attached_workspaces: Vec<String>,
-    pub(crate) workspace_entries: Vec<WorkspaceEntrySummary>,
-    pub(crate) active_workspace_entry: Option<ActiveWorkspaceEntry>,
-    pub(crate) active_workspace_occupancy: Option<WorkspaceOccupancyRecord>,
-    pub(crate) worktree_session: Option<WorktreeSession>,
+    pub(crate) workspaces: Vec<crate::types::AgentWorkspaceInfo>,
 }
 
-#[derive(Debug, Serialize)]
-pub(crate) struct WorkspaceEntrySummary {
-    pub(crate) workspace_id: String,
-    pub(crate) workspace_anchor: String,
-    pub(crate) workspace_alias: Option<String>,
-    pub(crate) repo_name: Option<String>,
-}
-
-impl WorkspaceEntrySummary {
-    pub(crate) fn from_entry(entry: &crate::types::WorkspaceEntry) -> Self {
+impl Default for StateWorkspaceSnapshot {
+    fn default() -> Self {
         Self {
-            workspace_id: entry.workspace_id.clone(),
-            workspace_anchor: entry.workspace_anchor.display().to_string(),
-            workspace_alias: entry.workspace_alias.clone(),
-            repo_name: entry.repo_name.clone(),
-        }
-    }
-
-    pub(crate) fn from_active_entry(entry: &ActiveWorkspaceEntry) -> Self {
-        Self {
-            workspace_id: entry.workspace_id.clone(),
-            workspace_anchor: entry.workspace_anchor.display().to_string(),
-            workspace_alias: None,
-            repo_name: None,
+            workspaces: Vec::new(),
         }
     }
 }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -160,4 +160,35 @@ mod tests {
         assert!(random.len() >= 64);
         assert!(random.chars().all(|ch| ch.is_ascii_hexdigit()));
     }
+
+    #[test]
+    fn deterministic_workspace_id_is_stable_for_same_path() {
+        let path = Path::new("/home/user/project");
+        let id1 = deterministic_workspace_id(path);
+        let id2 = deterministic_workspace_id(path);
+        assert_eq!(id1, id2, "same path must produce same workspace ID");
+    }
+
+    #[test]
+    fn deterministic_workspace_id_differs_for_different_paths() {
+        let id1 = deterministic_workspace_id(Path::new("/home/user/project-a"));
+        let id2 = deterministic_workspace_id(Path::new("/home/user/project-b"));
+        assert_ne!(id1, id2, "different paths must produce different IDs");
+    }
+
+    #[test]
+    fn deterministic_workspace_id_uses_ws_prefix_and_hex_shape() {
+        let id = deterministic_workspace_id(Path::new("/tmp/test"));
+        let (prefix, hex) = id.split_once('_').expect("id should contain prefix");
+        assert_eq!(prefix, "ws");
+        assert_eq!(
+            hex.len(),
+            SHORT_RANDOM_HEX_LEN,
+            "hex portion should be {SHORT_RANDOM_HEX_LEN} characters"
+        );
+        assert!(
+            hex.chars().all(|ch| ch.is_ascii_hexdigit()),
+            "hex portion should only contain hex digits"
+        );
+    }
 }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -40,10 +40,6 @@ pub fn tool_execution_id() -> String {
     runtime_id("tool")
 }
 
-pub fn workspace_id() -> String {
-    runtime_id("ws")
-}
-
 /// Derive a workspace ID deterministically from a (normalized) anchor path.
 /// Same path always produces the same ID, preventing stale-ID accumulation.
 pub fn deterministic_workspace_id(anchor: &Path) -> String {
@@ -137,7 +133,6 @@ mod tests {
             (run_id(), "run"),
             (turn_id(), "turn"),
             (tool_execution_id(), "tool"),
-            (workspace_id(), "ws"),
             (work_item_id(), "work"),
             (brief_id(), "brief"),
             (transcript_entry_id(), "tr"),

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -6,7 +6,8 @@ use crate::storage::AppStorage;
 use crate::types::{
     AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
     ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskRecord, TaskStatus, TokenUsage,
-    WaitingReason, WorkItemState, WorkspaceProjectionMetadata, WorktreeSession,
+    WaitingReason, WorkItemState, WorkspaceOccupancyRecord, WorkspaceProjectionMetadata,
+    WorktreeSession,
 };
 
 fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBuf> {
@@ -787,6 +788,43 @@ impl RuntimeHandle {
         Ok(model_state)
     }
 
+    /// Acquire exclusive or shared occupancy for a workspace execution root.
+    /// In bridge mode this delegates to the shared `RuntimeRegistry`; in
+    /// standalone mode occupancy tracking is unavailable so it returns `None`.
+    async fn acquire_workspace_occupancy(
+        &self,
+        workspace_id: &str,
+        execution_root_id: &str,
+        holder_agent_id: &str,
+        access_mode: WorkspaceAccessMode,
+    ) -> Result<Option<WorkspaceOccupancyRecord>> {
+        match self.inner.host_bridge.as_ref() {
+            Some(bridge) => {
+                bridge
+                    .acquire_workspace_occupancy(
+                        workspace_id,
+                        execution_root_id,
+                        holder_agent_id,
+                        access_mode,
+                    )
+                    .await
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Release a previously acquired workspace occupancy.
+    /// In standalone mode this is a no-op returning `None`.
+    async fn release_workspace_occupancy(
+        &self,
+        occupancy_id: &str,
+    ) -> Result<Option<WorkspaceOccupancyRecord>> {
+        match self.inner.host_bridge.as_ref() {
+            Some(bridge) => bridge.release_workspace_occupancy(occupancy_id).await,
+            None => Ok(None),
+        }
+    }
+
     pub async fn attach_workspace(&self, workspace: &WorkspaceEntry) -> Result<()> {
         let mut guard = self.inner.agent.lock().await;
         if !guard
@@ -1025,9 +1063,7 @@ impl RuntimeHandle {
             self.inner.storage.mark_memory_index_dirty()?;
         }
         if let Some(occupancy_id) = previous_occupancy_id.as_deref() {
-            if let Some(bridge) = self.inner.host_bridge.as_ref() {
-                let _ = bridge.release_workspace_occupancy(occupancy_id).await?;
-            }
+            let _ = self.release_workspace_occupancy(occupancy_id).await?;
         }
         let state = self.agent_state().await?;
         self.sync_effective_skill_roots_for_state(&state).await?;
@@ -1118,18 +1154,14 @@ impl RuntimeHandle {
             projection_kind,
             &execution_root,
         )?;
-        let occupancy = if let Some(bridge) = self.inner.host_bridge.as_ref() {
-            bridge
-                .acquire_workspace_occupancy(
-                    &workspace.workspace_id,
-                    &execution_root_id,
-                    &agent_id,
-                    access_mode,
-                )
-                .await?
-        } else {
-            None
-        };
+        let occupancy = self
+            .acquire_workspace_occupancy(
+                &workspace.workspace_id,
+                &execution_root_id,
+                &agent_id,
+                access_mode,
+            )
+            .await?;
         let entry = ActiveWorkspaceEntry {
             workspace_id: workspace.workspace_id.clone(),
             workspace_anchor: workspace.workspace_anchor.clone(),
@@ -1160,9 +1192,7 @@ impl RuntimeHandle {
         if let Err(error) = write_result {
             if let Some(occupancy_id) = new_occupancy_id.as_deref() {
                 if previous_occupancy_id.as_deref() != Some(occupancy_id) {
-                    if let Some(bridge) = self.inner.host_bridge.as_ref() {
-                        let _ = bridge.release_workspace_occupancy(occupancy_id).await;
-                    }
+                    let _ = self.release_workspace_occupancy(occupancy_id).await;
                 }
             }
             if let Some(worktree) = worktree_cleanup_session.as_ref() {
@@ -1172,11 +1202,9 @@ impl RuntimeHandle {
         }
         if let Some(previous_occupancy_id) = previous_occupancy_id.as_deref() {
             if new_occupancy_id.as_deref() != Some(previous_occupancy_id) {
-                if let Some(bridge) = self.inner.host_bridge.as_ref() {
-                    let _ = bridge
-                        .release_workspace_occupancy(previous_occupancy_id)
-                        .await?;
-                }
+                let _ = self
+                    .release_workspace_occupancy(previous_occupancy_id)
+                    .await?;
             }
         }
         let state = self.agent_state().await?;
@@ -1249,18 +1277,14 @@ impl RuntimeHandle {
             WorkspaceProjectionKind::GitWorktreeRoot,
             &execution_root,
         )?;
-        let occupancy = if let Some(bridge) = self.inner.host_bridge.as_ref() {
-            bridge
-                .acquire_workspace_occupancy(
-                    &workspace.workspace_id,
-                    &execution_root_id,
-                    &agent_id,
-                    access_mode,
-                )
-                .await?
-        } else {
-            None
-        };
+        let occupancy = self
+            .acquire_workspace_occupancy(
+                &workspace.workspace_id,
+                &execution_root_id,
+                &agent_id,
+                access_mode,
+            )
+            .await?;
         let entry = ActiveWorkspaceEntry {
             workspace_id: workspace.workspace_id.clone(),
             workspace_anchor: workspace.workspace_anchor.clone(),
@@ -1292,20 +1316,16 @@ impl RuntimeHandle {
         if let Err(error) = write_result {
             if let Some(occupancy_id) = new_occupancy_id.as_deref() {
                 if previous_occupancy_id.as_deref() != Some(occupancy_id) {
-                    if let Some(bridge) = self.inner.host_bridge.as_ref() {
-                        let _ = bridge.release_workspace_occupancy(occupancy_id).await;
-                    }
+                    let _ = self.release_workspace_occupancy(occupancy_id).await;
                 }
             }
             return Err(error);
         }
         if let Some(previous_occupancy_id) = previous_occupancy_id.as_deref() {
             if new_occupancy_id.as_deref() != Some(previous_occupancy_id) {
-                if let Some(bridge) = self.inner.host_bridge.as_ref() {
-                    let _ = bridge
-                        .release_workspace_occupancy(previous_occupancy_id)
-                        .await?;
-                }
+                let _ = self
+                    .release_workspace_occupancy(previous_occupancy_id)
+                    .await?;
             }
         }
         let state = self.agent_state().await?;

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -6,7 +6,7 @@ use crate::storage::AppStorage;
 use crate::types::{
     AgentListEntry, AgentTokenUsageSummary, BriefKind, ChildAgentBlockedReason,
     ChildAgentObservabilitySnapshot, ChildAgentPhase, TaskRecord, TaskStatus, TokenUsage,
-    WaitingReason, WorkItemState, WorktreeSession,
+    WaitingReason, WorkItemState, WorkspaceProjectionMetadata, WorktreeSession,
 };
 
 fn resolve_enter_cwd(execution_root: &Path, cwd: Option<&Path>) -> Result<PathBuf> {
@@ -1103,12 +1103,12 @@ impl RuntimeHandle {
                     worktree_path: seed.worktree_path.clone(),
                     worktree_branch: seed.worktree_branch.clone(),
                 };
-                let metadata = serde_json::json!({
-                    "original_cwd": session.original_cwd,
-                    "original_branch": session.original_branch,
-                    "worktree_path": session.worktree_path,
-                    "worktree_branch": session.worktree_branch,
-                });
+                let metadata = WorkspaceProjectionMetadata::ManagedWorktree {
+                    original_cwd: session.original_cwd.clone(),
+                    original_branch: session.original_branch.clone(),
+                    worktree_path: session.worktree_path.clone(),
+                    worktree_branch: session.worktree_branch.clone(),
+                };
                 (session.worktree_path.clone(), Some(session), Some(metadata))
             }
         };
@@ -1270,11 +1270,9 @@ impl RuntimeHandle {
             access_mode,
             cwd: selected_cwd.clone(),
             occupancy_id: occupancy.as_ref().map(|record| record.occupancy_id.clone()),
-            projection_metadata: Some(serde_json::json!({
-                "detected_kind": "existing_git_worktree",
-                "ownership": "external",
-                "worktree_root": execution_root,
-            })),
+            projection_metadata: Some(WorkspaceProjectionMetadata::ExistingGitWorktree {
+                worktree_root: execution_root.clone(),
+            }),
         };
         let previous_occupancy_id = existing_state
             .active_workspace_entry

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -135,23 +135,32 @@ pub(crate) fn detached_execution_root(storage: &AppStorage) -> PathBuf {
     storage.data_dir().to_path_buf()
 }
 
+impl ActiveWorkspaceEntry {
+    /// Convert the active entry into an immutable `WorkspaceView`.
+    /// Centralizes the field mapping that was previously duplicated across
+    /// `workspace_view_from_state` and other call sites.
+    pub(crate) fn to_workspace_view(&self) -> Result<WorkspaceView> {
+        let worktree_root = (self.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot)
+            .then(|| self.execution_root.clone());
+        WorkspaceView::new(
+            Some(self.workspace_id.clone()),
+            self.workspace_anchor.clone(),
+            self.execution_root.clone(),
+            self.cwd.clone(),
+            Some(self.execution_root_id.clone()),
+            Some(self.access_mode),
+            self.projection_kind,
+            worktree_root,
+        )
+    }
+}
+
 pub(crate) fn workspace_view_from_state(
     state: &AgentState,
     detached_execution_root: PathBuf,
 ) -> Result<WorkspaceView> {
     if let Some(entry) = state.active_workspace_entry.as_ref() {
-        let worktree_root = (entry.projection_kind == WorkspaceProjectionKind::GitWorktreeRoot)
-            .then(|| entry.execution_root.clone());
-        return WorkspaceView::new(
-            Some(entry.workspace_id.clone()),
-            entry.workspace_anchor.clone(),
-            entry.execution_root.clone(),
-            entry.cwd.clone(),
-            Some(entry.execution_root_id.clone()),
-            Some(entry.access_mode),
-            entry.projection_kind,
-            worktree_root,
-        );
+        return entry.to_workspace_view();
     }
 
     let execution_root = detached_execution_root;

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -45,6 +45,14 @@ pub(crate) fn agent_home_workspace_entry(data_dir: &Path, agent_id: &str) -> Wor
     entry
 }
 
+/// Canonicalize legacy `AGENT_HOME_WORKSPACE_ID` references in agent state to
+/// the deterministic, agent-specific canonical ID.
+///
+/// # Migration path (deprecated)
+///
+/// This function exists solely to migrate agents that still reference the
+/// old constant `AGENT_HOME_WORKSPACE_ID`. It is planned for removal once
+/// migration logs confirm no agents require canonicalization.
 pub(crate) fn canonicalize_agent_home_bindings(
     state: &mut AgentState,
     data_dir: &Path,
@@ -101,6 +109,10 @@ pub(crate) fn canonicalize_agent_home_bindings(
 
     if changed {
         state.attached_workspaces = next;
+        tracing::info!(
+            agent_id = %agent_id,
+            "workspace migration: canonicalized legacy AGENT_HOME_WORKSPACE_ID references"
+        );
     }
 
     Ok(changed)

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -149,6 +149,7 @@ pub(crate) fn workspace_view_from_state(
             entry.cwd.clone(),
             Some(entry.execution_root_id.clone()),
             Some(entry.access_mode),
+            entry.projection_kind,
             worktree_root,
         );
     }
@@ -161,6 +162,7 @@ pub(crate) fn workspace_view_from_state(
         execution_root.clone(),
         None,
         Some(WorkspaceAccessMode::ExclusiveWrite),
+        WorkspaceProjectionKind::CanonicalRoot,
         None,
     )
 }
@@ -191,6 +193,11 @@ pub(crate) fn workspace_view_for_root(
         .active_workspace_entry
         .as_ref()
         .map(|entry| entry.access_mode);
+    let projection_kind = if worktree_root.is_some() {
+        WorkspaceProjectionKind::GitWorktreeRoot
+    } else {
+        WorkspaceProjectionKind::CanonicalRoot
+    };
     WorkspaceView::new(
         workspace_id,
         workspace_anchor,
@@ -198,6 +205,7 @@ pub(crate) fn workspace_view_for_root(
         cwd,
         execution_root_id,
         access_mode,
+        projection_kind,
         worktree_root,
     )
 }

--- a/src/runtime/workspace.rs
+++ b/src/runtime/workspace.rs
@@ -364,3 +364,131 @@ pub(crate) fn execution_root_sync(storage: &AppStorage) -> PathBuf {
         })
         .unwrap_or_else(|| detached_execution_root(storage))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ActiveWorkspaceEntry;
+
+    // ── build_execution_root_id ──
+
+    #[test]
+    fn execution_root_id_canonical_root() {
+        let id = build_execution_root_id(
+            "ws_abc",
+            WorkspaceProjectionKind::CanonicalRoot,
+            Path::new("/tmp/project"),
+        )
+        .unwrap();
+        assert_eq!(id, "canonical_root:ws_abc");
+    }
+
+    #[test]
+    fn execution_root_id_git_worktree_root_includes_normalized_path() {
+        let id = build_execution_root_id(
+            "ws_abc",
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            Path::new("/tmp/project/worktree-x"),
+        )
+        .unwrap();
+        assert!(id.starts_with("git_worktree_root:ws_abc:"));
+        assert!(id.contains("/tmp/project/worktree-x"));
+    }
+
+    #[test]
+    fn execution_root_id_git_worktree_root_is_stable_for_same_path() {
+        let id1 = build_execution_root_id(
+            "ws_abc",
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            Path::new("/tmp/project/worktree-x"),
+        )
+        .unwrap();
+        let id2 = build_execution_root_id(
+            "ws_abc",
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            Path::new("/tmp/project/worktree-x"),
+        )
+        .unwrap();
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn execution_root_id_git_worktree_root_differs_for_different_paths() {
+        let id1 = build_execution_root_id(
+            "ws_abc",
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            Path::new("/tmp/project/wt-a"),
+        )
+        .unwrap();
+        let id2 = build_execution_root_id(
+            "ws_abc",
+            WorkspaceProjectionKind::GitWorktreeRoot,
+            Path::new("/tmp/project/wt-b"),
+        )
+        .unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    // ── canonicalize_agent_home_bindings ──
+
+    #[test]
+    fn canonicalize_migrates_legacy_agent_home_id() {
+        let data_dir = PathBuf::from("/tmp/agent-home");
+        let mut state = AgentState::new("my-agent");
+        state.active_workspace_entry = Some(ActiveWorkspaceEntry {
+            workspace_id: AGENT_HOME_WORKSPACE_ID.to_string(),
+            workspace_anchor: data_dir.clone(),
+            execution_root_id: "canonical_root:agent_home".to_string(),
+            execution_root: data_dir.clone(),
+            projection_kind: WorkspaceProjectionKind::CanonicalRoot,
+            access_mode: WorkspaceAccessMode::SharedRead,
+            cwd: data_dir.clone(),
+            occupancy_id: None,
+            projection_metadata: None,
+        });
+        state.attached_workspaces = vec![AGENT_HOME_WORKSPACE_ID.to_string()];
+
+        let changed = canonicalize_agent_home_bindings(&mut state, &data_dir, "my-agent").unwrap();
+
+        assert!(changed, "should report change when migrating legacy ID");
+        let canonical = agent_home_workspace_id("my-agent");
+        assert_eq!(
+            state.active_workspace_entry.as_ref().unwrap().workspace_id,
+            canonical
+        );
+        assert!(
+            state.attached_workspaces.contains(&canonical),
+            "attached_workspaces should contain canonical ID"
+        );
+        assert!(
+            !state
+                .attached_workspaces
+                .contains(&AGENT_HOME_WORKSPACE_ID.to_string()),
+            "legacy ID should be removed from attached_workspaces"
+        );
+    }
+
+    #[test]
+    fn canonicalize_is_noop_when_already_canonical() {
+        let data_dir = PathBuf::from("/tmp/agent-home");
+        let canonical = agent_home_workspace_id("my-agent");
+        let mut state = AgentState::new("my-agent");
+        state.attached_workspaces = vec![canonical.clone()];
+
+        let changed = canonicalize_agent_home_bindings(&mut state, &data_dir, "my-agent").unwrap();
+
+        assert!(!changed, "should be no-op when already using canonical ID");
+    }
+
+    #[test]
+    fn canonicalize_handles_no_active_workspace_entry() {
+        let data_dir = PathBuf::from("/tmp/agent-home");
+        let mut state = AgentState::new("my-agent");
+        // No active_workspace_entry and no legacy references.
+        state.attached_workspaces = vec!["ws_other".to_string()];
+
+        let changed = canonicalize_agent_home_bindings(&mut state, &data_dir, "my-agent").unwrap();
+
+        assert!(!changed, "should be no-op with no legacy references");
+    }
+}

--- a/src/runtime/worktree.rs
+++ b/src/runtime/worktree.rs
@@ -5,7 +5,7 @@ use crate::system::{
     file::FileHost, CaptureSpec, ExecutionScopeKind, ProcessHost, ProcessPurpose, ProcessRequest,
     ProgramInvocation, StdioSpec,
 };
-use crate::types::WorktreeSession;
+use crate::types::{WorkspaceProjectionMetadata, WorktreeSession};
 
 #[derive(Debug, Clone)]
 pub(super) struct TaskOwnedWorktreeCleanup {
@@ -203,12 +203,12 @@ impl RuntimeHandle {
                 access_mode: WorkspaceAccessMode::ExclusiveWrite,
                 cwd: worktree_path.clone(),
                 occupancy_id: occupancy.as_ref().map(|record| record.occupancy_id.clone()),
-                projection_metadata: Some(serde_json::json!({
-                    "original_cwd": worktree_session.original_cwd,
-                    "original_branch": worktree_session.original_branch,
-                    "worktree_path": worktree_session.worktree_path,
-                    "worktree_branch": worktree_session.worktree_branch,
-                })),
+                projection_metadata: Some(WorkspaceProjectionMetadata::ManagedWorktree {
+                    original_cwd: worktree_session.original_cwd.clone(),
+                    original_branch: worktree_session.original_branch.clone(),
+                    worktree_path: worktree_session.worktree_path.clone(),
+                    worktree_branch: worktree_session.worktree_branch.clone(),
+                }),
             });
             guard.state.worktree_session = Some(worktree_session.clone());
             guard.persist_state(&self.inner.storage)?;

--- a/src/system/local.rs
+++ b/src/system/local.rs
@@ -750,6 +750,7 @@ mod tests {
             dir.path().join("workspace"),
             None,
             None,
+            crate::system::WorkspaceProjectionKind::CanonicalRoot,
             None,
         )
         .unwrap();

--- a/src/system/types.rs
+++ b/src/system/types.rs
@@ -236,11 +236,7 @@ impl<'de> Deserialize<'de> for ExecutionSnapshot {
 
 impl EffectiveExecution {
     pub fn snapshot(&self) -> ExecutionSnapshot {
-        let projection_kind = if self.workspace.worktree_root().is_some() {
-            Some(WorkspaceProjectionKind::GitWorktreeRoot)
-        } else {
-            Some(WorkspaceProjectionKind::CanonicalRoot)
-        };
+        let projection_kind = Some(self.workspace.projection_kind());
         ExecutionSnapshot {
             profile: self.profile.clone(),
             policy: self.profile.policy_snapshot(),

--- a/src/system/workspace.rs
+++ b/src/system/workspace.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use thiserror::Error;
 
-use super::types::WorkspaceAccessMode;
+use super::types::{WorkspaceAccessMode, WorkspaceProjectionKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkspacePathErrorKind {
@@ -40,6 +40,7 @@ pub struct WorkspaceView {
     execution_root_id: Option<String>,
     access_mode: Option<WorkspaceAccessMode>,
     worktree_root: Option<PathBuf>,
+    projection_kind: WorkspaceProjectionKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -122,17 +123,24 @@ impl WorkspaceView {
         cwd: PathBuf,
         execution_root_id: Option<String>,
         access_mode: Option<WorkspaceAccessMode>,
+        projection_kind: WorkspaceProjectionKind,
         worktree_root: Option<PathBuf>,
     ) -> Result<Self> {
         let normalized_anchor = normalize_path(&workspace_anchor)?;
         let normalized_execution_root = normalize_path(&execution_root)?;
         let normalized_cwd = normalize_path(&cwd)?;
-        if let Some(worktree_root) = &worktree_root {
-            let normalized_worktree_root = normalize_path(worktree_root)?;
-            if normalized_worktree_root != normalized_execution_root {
+        let normalized_worktree_root = if let Some(worktree_root) = &worktree_root {
+            let normalized = normalize_path(worktree_root)?;
+            if normalized != normalized_execution_root {
                 return Err(anyhow!("worktree root must match execution root"));
             }
-        } else if !normalized_execution_root.starts_with(&normalized_anchor) {
+            Some(normalized)
+        } else {
+            None
+        };
+        if normalized_worktree_root.is_none()
+            && !normalized_execution_root.starts_with(&normalized_anchor)
+        {
             return Err(anyhow!("execution root escapes workspace anchor"));
         }
         if !normalized_cwd.starts_with(&normalized_execution_root) {
@@ -140,12 +148,13 @@ impl WorkspaceView {
         }
         Ok(Self {
             workspace_id,
-            workspace_anchor,
-            execution_root,
-            cwd,
+            workspace_anchor: normalized_anchor,
+            execution_root: normalized_execution_root,
+            cwd: normalized_cwd,
             execution_root_id,
             access_mode,
-            worktree_root,
+            projection_kind,
+            worktree_root: normalized_worktree_root,
         })
     }
 
@@ -173,6 +182,10 @@ impl WorkspaceView {
         self.access_mode
     }
 
+    pub fn projection_kind(&self) -> WorkspaceProjectionKind {
+        self.projection_kind
+    }
+
     pub fn worktree_root(&self) -> Option<&Path> {
         self.worktree_root.as_deref()
     }
@@ -184,8 +197,7 @@ impl WorkspaceView {
             self.cwd.join(relative)
         };
         let normalized_candidate = normalize_path(&candidate)?;
-        let normalized_execution_root = normalize_path(&self.execution_root)?;
-        if !normalized_candidate.starts_with(&normalized_execution_root) {
+        if !normalized_candidate.starts_with(&self.execution_root) {
             return Err(WorkspacePathError::execution_root_violation().into());
         }
         Ok(candidate)
@@ -256,6 +268,7 @@ mod tests {
             cwd.clone(),
             Some("git_worktree_root:ws-1:/workspace/nested".into()),
             Some(WorkspaceAccessMode::ExclusiveWrite),
+            WorkspaceProjectionKind::GitWorktreeRoot,
             Some(execution_root.clone()),
         )
         .unwrap();
@@ -276,6 +289,7 @@ mod tests {
             workspace_root,
             Some("canonical_root:ws-1".into()),
             Some(WorkspaceAccessMode::SharedRead),
+            WorkspaceProjectionKind::CanonicalRoot,
             None,
         )
         .unwrap();
@@ -301,6 +315,7 @@ mod tests {
             workspace_root,
             Some("canonical_root:ws-1".into()),
             Some(WorkspaceAccessMode::SharedRead),
+            WorkspaceProjectionKind::CanonicalRoot,
             None,
         )
         .unwrap();

--- a/src/tui/projection.rs
+++ b/src/tui/projection.rs
@@ -467,10 +467,27 @@ impl TuiProjection {
             }
             "workspace_attached" => {
                 if let Some(workspace_id) = read_string(&event.data.payload, "workspace_id") {
-                    if !self.workspace.attached_workspaces.contains(&workspace_id) {
+                    if !self
+                        .workspace
+                        .workspaces
+                        .iter()
+                        .any(|w| w.workspace_id == workspace_id)
+                    {
                         self.workspace
-                            .attached_workspaces
-                            .push(workspace_id.clone());
+                            .workspaces
+                            .push(crate::types::AgentWorkspaceInfo {
+                                workspace_id: workspace_id.clone(),
+                                workspace_alias: None,
+                                workspace_anchor: None,
+                                repo_name: None,
+                                is_active: false,
+                                execution_root_id: None,
+                                execution_root: None,
+                                cwd: None,
+                                projection_kind: None,
+                                access_mode: None,
+                                worktree: None,
+                            });
                         self.agent.agent.attached_workspaces.push(workspace_id);
                     }
                     self.stale_slices.remove(&ProjectionSlice::Agent);
@@ -482,8 +499,8 @@ impl TuiProjection {
             "workspace_detached" => {
                 if let Some(workspace_id) = read_string(&event.data.payload, "workspace_id") {
                     self.workspace
-                        .attached_workspaces
-                        .retain(|id| id != &workspace_id);
+                        .workspaces
+                        .retain(|w| w.workspace_id != workspace_id);
                     self.agent
                         .agent
                         .attached_workspaces
@@ -515,10 +532,15 @@ impl TuiProjection {
                     .cloned()
                     .and_then(decode_value::<WorktreeSession>)
                 {
-                    self.workspace.worktree_session = Some(worktree.clone());
                     self.agent.agent.worktree_session = Some(worktree.clone());
-                    if let Some(entry) = &mut self.workspace.active_workspace_entry {
-                        entry.cwd = worktree.worktree_path.clone();
+                    if let Some(ws) = self.workspace.workspaces.iter_mut().find(|w| w.is_active) {
+                        ws.cwd = Some(worktree.worktree_path.display().to_string());
+                        ws.worktree = Some(crate::types::WorktreeInfo {
+                            branch: Some(worktree.worktree_branch.clone()),
+                            path: Some(worktree.worktree_path.display().to_string()),
+                            original_branch: Some(worktree.original_branch.clone()),
+                            original_cwd: Some(worktree.original_cwd.display().to_string()),
+                        });
                     }
                     if let Some(entry) = &mut self.agent.agent.active_workspace_entry {
                         entry.cwd = worktree.worktree_path;
@@ -529,11 +551,12 @@ impl TuiProjection {
                 }
             }
             "worktree_exited" => {
-                self.workspace.worktree_session = None;
                 self.agent.agent.worktree_session = None;
-                // Restore cwd to workspace_anchor from active_workspace_entry
-                if let Some(entry) = &mut self.workspace.active_workspace_entry {
-                    entry.cwd = entry.workspace_anchor.clone();
+                if let Some(ws) = self.workspace.workspaces.iter_mut().find(|w| w.is_active) {
+                    if let Some(anchor) = ws.workspace_anchor.clone() {
+                        ws.cwd = Some(anchor);
+                    }
+                    ws.worktree = None;
                 }
                 if let Some(entry) = &mut self.agent.agent.active_workspace_entry {
                     entry.cwd = entry.workspace_anchor.clone();
@@ -1073,10 +1096,11 @@ impl TuiProjection {
         self.session.pending_count = state.pending;
         self.session.last_turn = state.last_turn_terminal.clone();
 
-        self.workspace.attached_workspaces = state.attached_workspaces.clone();
-        self.workspace.active_workspace_entry = state.active_workspace_entry.clone();
-        self.workspace.active_workspace_occupancy = None;
-        self.workspace.worktree_session = state.worktree_session.clone();
+        self.workspace.workspaces = build_workspace_snapshot(
+            &state.attached_workspaces,
+            state.active_workspace_entry.as_ref(),
+            state.worktree_session.as_ref(),
+        );
 
         self.agent.agent = state;
         self.agent.active_workspace_occupancy = None;
@@ -1111,9 +1135,7 @@ impl TuiProjection {
                     .as_ref()
                     .is_some_and(|entry| entry.workspace_id == active_workspace_id) => {}
             Some(_) => {
-                self.workspace.active_workspace_entry = None;
-                self.workspace.active_workspace_occupancy = None;
-                self.workspace.worktree_session = None;
+                self.workspace.workspaces.clear();
                 self.agent.agent.active_workspace_entry = None;
                 self.agent.active_workspace_occupancy = None;
                 self.agent.agent.worktree_session = None;
@@ -1205,11 +1227,6 @@ impl TuiProjection {
             return false;
         };
 
-        if !self.workspace.attached_workspaces.contains(&workspace_id) {
-            self.workspace
-                .attached_workspaces
-                .push(workspace_id.clone());
-        }
         if !self.agent.agent.attached_workspaces.contains(&workspace_id) {
             self.agent
                 .agent
@@ -1229,9 +1246,39 @@ impl TuiProjection {
             projection_metadata: None,
         };
 
-        self.workspace.active_workspace_entry = Some(entry.clone());
-        self.workspace.active_workspace_occupancy = None;
-        self.workspace.worktree_session = None;
+        // Update or insert active workspace in workspaces array
+        if let Some(existing) = self
+            .workspace
+            .workspaces
+            .iter_mut()
+            .find(|w| w.workspace_id == workspace_id)
+        {
+            existing.is_active = true;
+            existing.workspace_anchor = Some(workspace_anchor.display().to_string());
+            existing.execution_root_id = Some(entry.execution_root_id.clone());
+            existing.execution_root = Some(entry.execution_root.display().to_string());
+            existing.cwd = Some(cwd.display().to_string());
+            existing.projection_kind = Some(projection_kind);
+            existing.access_mode = Some(access_mode);
+            existing.worktree = None;
+        } else {
+            self.workspace.workspaces.insert(
+                0,
+                crate::types::AgentWorkspaceInfo {
+                    workspace_id: workspace_id.clone(),
+                    workspace_alias: None,
+                    workspace_anchor: Some(workspace_anchor.display().to_string()),
+                    repo_name: None,
+                    is_active: true,
+                    execution_root_id: Some(entry.execution_root_id.clone()),
+                    execution_root: Some(entry.execution_root.display().to_string()),
+                    cwd: Some(cwd.display().to_string()),
+                    projection_kind: Some(projection_kind),
+                    access_mode: Some(access_mode),
+                    worktree: None,
+                },
+            );
+        }
 
         self.agent.agent.active_workspace_entry = Some(entry);
         self.agent.active_workspace_occupancy = None;
@@ -1297,9 +1344,7 @@ impl TuiProjection {
     }
 
     fn clear_workspace(&mut self) {
-        self.workspace.active_workspace_entry = None;
-        self.workspace.active_workspace_occupancy = None;
-        self.workspace.worktree_session = None;
+        self.workspace.workspaces.clear();
 
         self.agent.agent.active_workspace_entry = None;
         self.agent.active_workspace_occupancy = None;
@@ -1309,6 +1354,66 @@ impl TuiProjection {
 
 fn decode_payload<T: DeserializeOwned>(payload: &Value) -> Option<T> {
     decode_value(payload.clone())
+}
+
+/// Build a `Vec<AgentWorkspaceInfo>` from agent state fields.
+/// Active workspace gets full runtime info; others get identity-only info.
+fn build_workspace_snapshot(
+    attached_ids: &[String],
+    active_entry: Option<&ActiveWorkspaceEntry>,
+    worktree_session: Option<&WorktreeSession>,
+) -> Vec<crate::types::AgentWorkspaceInfo> {
+    use crate::types::{AgentWorkspaceInfo, WorktreeInfo};
+    use std::collections::HashSet;
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut result: Vec<AgentWorkspaceInfo> = Vec::new();
+
+    // Active workspace first (with full runtime info).
+    if let Some(entry) = active_entry {
+        seen.insert(entry.workspace_id.clone());
+        let worktree = worktree_session.map(|s| WorktreeInfo {
+            branch: Some(s.worktree_branch.clone()),
+            path: Some(s.worktree_path.display().to_string()),
+            original_branch: Some(s.original_branch.clone()),
+            original_cwd: Some(s.original_cwd.display().to_string()),
+        });
+        result.push(AgentWorkspaceInfo {
+            workspace_id: entry.workspace_id.clone(),
+            workspace_alias: None,
+            workspace_anchor: Some(entry.workspace_anchor.display().to_string()),
+            repo_name: None,
+            is_active: true,
+            execution_root_id: Some(entry.execution_root_id.clone()),
+            execution_root: Some(entry.execution_root.display().to_string()),
+            cwd: Some(entry.cwd.display().to_string()),
+            projection_kind: Some(entry.projection_kind),
+            access_mode: Some(entry.access_mode),
+            worktree,
+        });
+    }
+
+    // Remaining attached workspaces (identity-only).
+    for ws_id in attached_ids {
+        if !seen.contains(ws_id) {
+            seen.insert(ws_id.clone());
+            result.push(AgentWorkspaceInfo {
+                workspace_id: ws_id.clone(),
+                workspace_alias: None,
+                workspace_anchor: None,
+                repo_name: None,
+                is_active: false,
+                execution_root_id: None,
+                execution_root: None,
+                cwd: None,
+                projection_kind: None,
+                access_mode: None,
+                worktree: None,
+            });
+        }
+    }
+
+    result
 }
 
 fn decode_value<T: DeserializeOwned>(value: Value) -> Option<T> {
@@ -1727,7 +1832,6 @@ mod tests {
             TimerRecord, TimerStatus, TodoItem, TodoItemState, TokenUsage, TurnTerminalKind,
             TurnTerminalRecord, WaitingIntentRecord, WaitingIntentScope, WaitingIntentStatus,
             WaitingIntentSummary, WaitingReason, WorkItemRecord, WorkItemState,
-            WorkspaceOccupancyRecord, WorktreeSession,
         },
     };
     use chrono::Utc;
@@ -2687,17 +2791,15 @@ mod tests {
         assert_eq!(
             projection
                 .workspace
-                .active_workspace_entry
-                .as_ref()
-                .map(|entry| entry.workspace_id.as_str()),
+                .active_workspace()
+                .map(|ws| ws.workspace_id.as_str()),
             Some("ws-main")
         );
         assert_eq!(
             projection
                 .workspace
-                .active_workspace_entry
-                .as_ref()
-                .map(|entry| entry.projection_kind),
+                .active_workspace()
+                .and_then(|ws| ws.projection_kind),
             Some(WorkspaceProjectionKind::GitWorktreeRoot)
         );
         assert_eq!(
@@ -2712,13 +2814,12 @@ mod tests {
         assert!(projection
             .stale_slices
             .contains(&ProjectionSlice::Workspace));
-        assert!(projection.workspace.active_workspace_occupancy.is_none());
     }
 
     #[test]
     fn projection_updates_workspace_from_workspace_used_event() {
         let mut projection = TuiProjection::from_snapshot(sample_snapshot());
-        projection.agent.agent.worktree_session = projection.workspace.worktree_session.clone();
+        // worktree_session is now part of the unified workspaces array
 
         projection.apply_event(
             sample_event(
@@ -2736,13 +2837,12 @@ mod tests {
             &test_log_writer(),
         );
 
-        let entry = projection
+        let ws = projection
             .workspace
-            .active_workspace_entry
-            .as_ref()
+            .active_workspace()
             .expect("workspace_used should update active workspace");
-        assert_eq!(entry.workspace_id, crate::types::AGENT_HOME_WORKSPACE_ID);
-        assert_eq!(entry.execution_root, PathBuf::from("/tmp/agent-home"));
+        assert_eq!(ws.workspace_id, crate::types::AGENT_HOME_WORKSPACE_ID);
+        assert_eq!(ws.execution_root.as_deref(), Some("/tmp/agent-home"));
         assert_eq!(
             projection
                 .agent
@@ -2759,12 +2859,15 @@ mod tests {
         assert_eq!(
             projection
                 .workspace
-                .active_workspace_entry
-                .as_ref()
-                .map(|entry| entry.cwd.as_path()),
-            Some(PathBuf::from("/tmp/agent-home").as_path())
+                .active_workspace()
+                .and_then(|ws| ws.cwd.as_deref()),
+            Some("/tmp/agent-home")
         );
-        assert!(projection.workspace.worktree_session.is_none());
+        assert!(projection
+            .workspace
+            .active_workspace()
+            .and_then(|w| w.worktree.as_ref())
+            .is_none());
         assert!(projection.agent.agent.worktree_session.is_none());
     }
 
@@ -3122,9 +3225,8 @@ mod tests {
         assert_eq!(
             projection
                 .workspace
-                .active_workspace_entry
-                .as_ref()
-                .map(|entry| entry.workspace_id.as_str()),
+                .active_workspace()
+                .map(|ws| ws.workspace_id.as_str()),
             Some("legacy-ws")
         );
         assert!(!projection.stale_slices.contains(&ProjectionSlice::Session));
@@ -3146,14 +3248,12 @@ mod tests {
         assert!(projection
             .stale_slices
             .contains(&ProjectionSlice::Workspace));
-        assert!(projection.workspace.active_workspace_occupancy.is_none());
         assert!(projection.agent.active_workspace_occupancy.is_none());
         assert_eq!(
             projection
                 .workspace
-                .active_workspace_entry
-                .as_ref()
-                .map(|e| e.workspace_id.as_str()),
+                .active_workspace()
+                .map(|ws| ws.workspace_id.as_str()),
             Some("ws-updated")
         );
     }
@@ -3184,18 +3284,17 @@ mod tests {
         assert_eq!(
             projection
                 .workspace
-                .worktree_session
-                .as_ref()
-                .map(|ws| ws.worktree_branch.as_str()),
+                .active_workspace()
+                .and_then(|ws| ws.worktree.as_ref())
+                .and_then(|wt| wt.branch.as_deref()),
             Some("feature/demo")
         );
         assert_eq!(
             projection
                 .workspace
-                .active_workspace_entry
-                .as_ref()
-                .map(|e| e.cwd.as_path()),
-            Some(PathBuf::from("/tmp/ws-boot/feature").as_path())
+                .active_workspace()
+                .and_then(|ws| ws.cwd.as_deref()),
+            Some("/tmp/ws-boot/feature")
         );
 
         projection.apply_event(
@@ -3213,7 +3312,11 @@ mod tests {
         assert!(projection
             .stale_slices
             .contains(&ProjectionSlice::Workspace));
-        assert!(projection.workspace.worktree_session.is_none());
+        assert!(projection
+            .workspace
+            .active_workspace()
+            .and_then(|w| w.worktree.as_ref())
+            .is_none());
     }
 
     fn sample_event(kind: &str, payload: Value) -> AgentStreamEvent {
@@ -3346,33 +3449,24 @@ mod tests {
             }],
             operator_notifications: Vec::new(),
             workspace: StateWorkspaceSnapshot {
-                attached_workspaces: vec!["ws-boot".into()],
-                active_workspace_entry: Some(crate::types::ActiveWorkspaceEntry {
+                workspaces: vec![crate::types::AgentWorkspaceInfo {
                     workspace_id: "ws-boot".into(),
-                    workspace_anchor: PathBuf::from("/tmp/ws-boot"),
-                    execution_root_id: "root-boot".into(),
-                    execution_root: PathBuf::from("/tmp/ws-boot"),
-                    projection_kind: WorkspaceProjectionKind::CanonicalRoot,
-                    access_mode: WorkspaceAccessMode::ExclusiveWrite,
-                    cwd: PathBuf::from("/tmp/ws-boot"),
-                    occupancy_id: None,
-                    projection_metadata: None,
-                }),
-                active_workspace_occupancy: Some(WorkspaceOccupancyRecord {
-                    occupancy_id: "occ-1".into(),
-                    execution_root_id: "root-boot".into(),
-                    workspace_id: "ws-boot".into(),
-                    holder_agent_id: "default".into(),
-                    access_mode: WorkspaceAccessMode::SharedRead,
-                    acquired_at: Utc::now(),
-                    released_at: None,
-                }),
-                worktree_session: Some(WorktreeSession {
-                    original_cwd: PathBuf::from("/tmp/ws-boot"),
-                    original_branch: "main".into(),
-                    worktree_path: PathBuf::from("/tmp/ws-boot/wt"),
-                    worktree_branch: "feature/demo".into(),
-                }),
+                    workspace_alias: None,
+                    workspace_anchor: Some("/tmp/ws-boot".into()),
+                    repo_name: None,
+                    is_active: true,
+                    execution_root_id: Some("root-boot".into()),
+                    execution_root: Some("/tmp/ws-boot".into()),
+                    cwd: Some("/tmp/ws-boot/wt".into()),
+                    projection_kind: Some(WorkspaceProjectionKind::CanonicalRoot),
+                    access_mode: Some(WorkspaceAccessMode::ExclusiveWrite),
+                    worktree: Some(crate::types::WorktreeInfo {
+                        branch: Some("feature/demo".into()),
+                        path: Some("/tmp/ws-boot/wt".into()),
+                        original_branch: Some("main".into()),
+                        original_cwd: Some("/tmp/ws-boot".into()),
+                    }),
+                }],
             },
             execution: None,
         }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -131,19 +131,28 @@ pub(super) fn render_agent_state_text(app: &TuiApp) -> String {
 
     lines.push(String::new());
     lines.push("Workspace".into());
-    if let Some(entry) = projection.workspace.active_workspace_entry.as_ref() {
-        lines.push(format!("  Id: {}", entry.workspace_id));
+    if let Some(ws) = projection.workspace.active_workspace() {
+        lines.push(format!("  Id: {}", ws.workspace_id));
         lines.push(format!(
             "  Mode: {}/{}",
-            workspace_projection_label(Some(entry.projection_kind)),
-            workspace_access_mode_label(Some(entry.access_mode))
+            workspace_projection_label(ws.projection_kind),
+            workspace_access_mode_label(ws.access_mode)
         ));
-        lines.push(format!("  Cwd: {}", entry.cwd.display()));
+        lines.push(format!(
+            "  Cwd: {}",
+            ws.cwd.as_deref().unwrap_or("<unknown>")
+        ));
     } else {
         lines.push("  <none>".into());
     }
-    if let Some(worktree) = projection.workspace.worktree_session.as_ref() {
-        lines.push(format!("  Worktree: {}", worktree.worktree_branch));
+    if let Some(worktree) = projection
+        .workspace
+        .active_workspace()
+        .and_then(|ws| ws.worktree.as_ref())
+    {
+        if let Some(branch) = &worktree.branch {
+            lines.push(format!("  Worktree: {}", branch));
+        }
     }
 
     lines.push(String::new());

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -291,6 +291,75 @@ fn sample_model_availability(
     }
 }
 
+fn build_workspace_snapshot_from_active(
+    active: Option<&crate::types::ActiveWorkspaceEntry>,
+    attached: &[String],
+) -> Vec<crate::types::AgentWorkspaceInfo> {
+    use crate::types::{AgentWorkspaceInfo, WorktreeInfo};
+    use std::collections::HashSet;
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut result: Vec<AgentWorkspaceInfo> = Vec::new();
+
+    if let Some(entry) = active {
+        seen.insert(entry.workspace_id.clone());
+        result.push(AgentWorkspaceInfo {
+            workspace_id: entry.workspace_id.clone(),
+            workspace_alias: None,
+            workspace_anchor: Some(entry.workspace_anchor.display().to_string()),
+            repo_name: None,
+            is_active: true,
+            execution_root_id: Some(entry.execution_root_id.clone()),
+            execution_root: Some(entry.execution_root.display().to_string()),
+            cwd: Some(entry.cwd.display().to_string()),
+            projection_kind: Some(entry.projection_kind),
+            access_mode: Some(entry.access_mode),
+            worktree: entry.projection_metadata.as_ref().map(|m| {
+                let (branch, path) = match m {
+                    crate::types::WorkspaceProjectionMetadata::ManagedWorktree {
+                        worktree_branch,
+                        worktree_path,
+                        ..
+                    } => (
+                        Some(worktree_branch.clone()),
+                        Some(worktree_path.display().to_string()),
+                    ),
+                    crate::types::WorkspaceProjectionMetadata::ExistingGitWorktree {
+                        worktree_root,
+                    } => (None, Some(worktree_root.display().to_string())),
+                };
+                WorktreeInfo {
+                    branch,
+                    path,
+                    original_branch: None,
+                    original_cwd: None,
+                }
+            }),
+        });
+    }
+
+    for ws_id in attached {
+        if !seen.contains(ws_id) {
+            seen.insert(ws_id.clone());
+            result.push(AgentWorkspaceInfo {
+                workspace_id: ws_id.clone(),
+                workspace_alias: None,
+                workspace_anchor: None,
+                repo_name: None,
+                is_active: false,
+                execution_root_id: None,
+                execution_root: None,
+                cwd: None,
+                projection_kind: None,
+                access_mode: None,
+                worktree: None,
+            });
+        }
+    }
+
+    result
+}
+
 fn sample_snapshot(agent_id: &str, _cursor: &str) -> AgentStateSnapshot {
     AgentStateSnapshot {
         agent: sample_agent_summary(agent_id),
@@ -598,7 +667,10 @@ fn statusbar_view_model_shows_workspace_label_execution_root_and_model() {
         occupancy_id: None,
         projection_metadata: None,
     });
-    snapshot.workspace.active_workspace_entry = snapshot.agent.agent.active_workspace_entry.clone();
+    snapshot.workspace.workspaces = build_workspace_snapshot_from_active(
+        snapshot.agent.agent.active_workspace_entry.as_ref(),
+        snapshot.agent.agent.attached_workspaces.as_slice(),
+    );
     app.agents = vec![snapshot.agent.clone()];
     app.projection = Some(TuiProjection::from_snapshot(snapshot));
 
@@ -714,7 +786,10 @@ fn statusbar_view_model_uses_workspace_label_for_worktree_execution_root() {
         occupancy_id: None,
         projection_metadata: None,
     });
-    snapshot.workspace.active_workspace_entry = snapshot.agent.agent.active_workspace_entry.clone();
+    snapshot.workspace.workspaces = build_workspace_snapshot_from_active(
+        snapshot.agent.agent.active_workspace_entry.as_ref(),
+        snapshot.agent.agent.attached_workspaces.as_slice(),
+    );
     app.agents = vec![snapshot.agent.clone()];
     app.projection = Some(TuiProjection::from_snapshot(snapshot));
 

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -58,22 +58,38 @@ fn agent_status_label(agent: &AgentSummary) -> &'static str {
 }
 
 fn execution_root_summary(app: &TuiApp) -> String {
-    let active_entry = app
+    // Try the unified workspace snapshot first, then fall back to the agent state's
+    // active_workspace_entry. Extract the fields we need into a common shape.
+    let (workspace_id, anchor, exec_root): (String, Option<PathBuf>, Option<PathBuf>) = app
         .projection
         .as_ref()
-        .and_then(|projection| projection.workspace.active_workspace_entry.as_ref())
+        .and_then(|projection| projection.workspace.active_workspace())
+        .map(|ws| {
+            (
+                ws.workspace_id.clone(),
+                ws.workspace_anchor.as_ref().map(PathBuf::from),
+                ws.execution_root.as_ref().map(PathBuf::from),
+            )
+        })
         .or_else(|| {
             app.selected_agent_summary()
                 .and_then(|agent| agent.agent.active_workspace_entry.as_ref())
-        });
-    let Some(entry) = active_entry else {
+                .map(|entry| {
+                    (
+                        entry.workspace_id.clone(),
+                        Some(entry.workspace_anchor.clone()),
+                        Some(entry.execution_root.clone()),
+                    )
+                })
+        })
+        .unwrap_or_else(|| (String::new(), None, None));
+
+    let Some(anchor) = anchor else {
         return "workspace not ready".into();
     };
-    let label = workspace_label(
-        entry.workspace_id.as_str(),
-        entry.workspace_anchor.as_path(),
-    );
-    format!("{} ({})", label, shorten_home_path(&entry.execution_root))
+    let exec_root = exec_root.unwrap_or_else(|| anchor.clone());
+    let label = workspace_label(&workspace_id, &anchor);
+    format!("{} ({})", label, shorten_home_path(&exec_root))
 }
 
 fn workspace_label(workspace_id: &str, workspace_anchor: &Path) -> String {

--- a/src/types.rs
+++ b/src/types.rs
@@ -149,6 +149,46 @@ pub enum WorkspaceProjectionMetadata {
     },
 }
 
+/// Unified per-workspace info returned by the workspace state snapshot.
+/// Replaces the previous fragmented fields (`attached_workspaces`,
+/// `workspace_entries`, `active_workspace_entry`, `worktree_session`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentWorkspaceInfo {
+    pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_alias: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_anchor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_name: Option<String>,
+    pub is_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_root_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_kind: Option<WorkspaceProjectionKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_mode: Option<WorkspaceAccessMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<WorktreeInfo>,
+}
+
+/// Worktree details merged from `projection_metadata` and `worktree_session`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorktreeInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_cwd: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkspaceEntry {
     pub workspace_id: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -133,6 +133,22 @@ impl WorkspaceEntry {
     }
 }
 
+/// Typed metadata for workspace projections, replacing untyped `serde_json::Value`.
+/// Uses `untagged` serde for backward compatibility with previously serialized JSON.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum WorkspaceProjectionMetadata {
+    ManagedWorktree {
+        original_cwd: PathBuf,
+        original_branch: String,
+        worktree_path: PathBuf,
+        worktree_branch: String,
+    },
+    ExistingGitWorktree {
+        worktree_root: PathBuf,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkspaceEntry {
     pub workspace_id: String,
@@ -145,7 +161,7 @@ pub struct ActiveWorkspaceEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub occupancy_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub projection_metadata: Option<Value>,
+    pub projection_metadata: Option<WorkspaceProjectionMetadata>,
 }
 
 impl ActiveWorkspaceEntry {
@@ -4986,9 +5002,12 @@ mod tests {
             access_mode: WorkspaceAccessMode::ExclusiveWrite,
             cwd: PathBuf::from("/tmp/ws-b"),
             occupancy_id: Some("occupancy-b".into()),
-            projection_metadata: Some(serde_json::json!({
-                "large": "metadata that must stay out of the event"
-            })),
+            projection_metadata: Some(WorkspaceProjectionMetadata::ManagedWorktree {
+                original_cwd: PathBuf::from("/tmp/ws-b"),
+                original_branch: "main".into(),
+                worktree_path: PathBuf::from("/tmp/ws-b-worktree"),
+                worktree_branch: "feature/metadata-test".into(),
+            }),
         });
         state.worktree_session = Some(WorktreeSession {
             original_cwd: PathBuf::from("/tmp/ws-b"),

--- a/tests/support/http_control.rs
+++ b/tests/support/http_control.rs
@@ -510,9 +510,8 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
     assert_eq!(
         snapshot
             .workspace
-            .active_workspace_entry
-            .as_ref()
-            .map(|e| e.workspace_id.clone()),
+            .active_workspace()
+            .map(|w| w.workspace_id.clone()),
         snapshot
             .agent
             .agent
@@ -520,7 +519,7 @@ pub async fn agent_state_route_includes_bootstrap_projection_fields_when_present
             .as_ref()
             .map(|e| e.workspace_id.clone())
     );
-    assert!(snapshot.workspace.active_workspace_entry.is_some());
+    assert!(snapshot.workspace.active_workspace().is_some());
 
     server.abort();
     Ok(())

--- a/tests/support/runtime_workspace_worktree.rs
+++ b/tests/support/runtime_workspace_worktree.rs
@@ -34,7 +34,7 @@ use holon::{
         OperatorTransportBindingStatus, OperatorTransportCapabilities,
         OperatorTransportDeliveryAuth, OperatorTransportDeliveryAuthKind, Priority, TaskStatus,
         TodoItem, TodoItemState, TokenUsage, TranscriptEntry, TranscriptEntryKind,
-        WaitingIntentStatus, WaitingReason, WorkItemState,
+        WaitingIntentStatus, WaitingReason, WorkItemState, WorkspaceProjectionMetadata,
     },
 };
 use serde_json::json;
@@ -235,13 +235,10 @@ pub async fn use_workspace_path_adopts_attached_parent_for_existing_git_worktree
         WorkspaceProjectionKind::GitWorktreeRoot
     );
     assert!(state.worktree_session.is_none());
-    assert_eq!(
-        active
-            .projection_metadata
-            .as_ref()
-            .and_then(|metadata| metadata["ownership"].as_str()),
-        Some("external")
-    );
+    assert!(matches!(
+        active.projection_metadata.as_ref(),
+        Some(WorkspaceProjectionMetadata::ExistingGitWorktree { .. })
+    ));
     Ok(())
 }
 

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -279,19 +279,24 @@ interface WorkItemDto {
 }
 
 interface AgentWorkspaceDto {
-    active_workspace_entry?: AgentListEntryDto["active_workspace_entry"];
-    workspace_entries?: Array<{
+    workspaces?: Array<{
       workspace_id: string;
-      workspace_anchor: string;
       workspace_alias?: string | null;
+      workspace_anchor?: string | null;
       repo_name?: string | null;
+      is_active?: boolean;
+      execution_root_id?: string | null;
+      execution_root?: string | null;
+      cwd?: string | null;
+      projection_kind?: string | null;
+      access_mode?: string | null;
+      worktree?: {
+        branch?: string | null;
+        path?: string | null;
+        original_branch?: string | null;
+        original_cwd?: string | null;
+      } | null;
     }>;
-    worktree_session?: {
-      original_branch?: string;
-      original_cwd?: string;
-      worktree_branch?: string;
-      worktree_path?: string;
-    } | null;
 }
 
 type BriefRecordDto = RuntimeBriefRecord;
@@ -1497,26 +1502,24 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   const id = entry.identity?.agent_id ?? state?.agent?.agent?.id ?? "unknown-agent";
   const status = state?.agent?.agent?.status ?? entry.status ?? "unknown";
   const profile = compactJoin([entry.identity?.visibility ?? "public", entry.identity?.ownership, entry.identity?.profile_preset]);
-  const workspaceEntry = state?.workspace?.active_workspace_entry ?? entry.active_workspace_entry;
-  const workspace = workspaceEntry?.workspace_alias ?? workspaceEntry?.workspace_id ?? state?.workspace?.worktree_session?.worktree_branch ?? "not bound";
-  const workspaceSummary = projectWorkspace(workspaceEntry, state?.workspace?.worktree_session);
-  const workspaceEntries = [...(state?.workspace?.workspace_entries ?? [])];
-  if (
-    workspaceEntry?.workspace_id &&
-    !workspaceEntries.some((e) => e.workspace_id === workspaceEntry.workspace_id)
-  ) {
-    workspaceEntries.push({
-      workspace_id: workspaceEntry.workspace_id,
-      workspace_anchor: workspaceEntry.workspace_anchor ?? workspaceEntry.execution_root ?? workspaceEntry.cwd ?? workspaceEntry.workspace_id,
-      workspace_alias: workspaceEntry.workspace_alias,
-    });
-  }
-  const attachedWorkspaces = workspaceEntries.map((e) => ({
-    workspaceId: e.workspace_id,
-    name: e.workspace_alias ?? basename(e.workspace_anchor) ?? e.workspace_id,
-    anchor: e.workspace_anchor,
-    executionRootId: workspaceEntry?.workspace_id === e.workspace_id ? workspaceEntry?.execution_root_id : undefined,
-    repoName: e.repo_name ?? undefined,
+  const wsList = state?.workspace?.workspaces ?? [];
+  const activeWs = wsList.find((w) => w.is_active);
+  // Fallback to list entry's active_workspace_entry when state hasn't loaded yet.
+  const listEntry = activeWs ? undefined : entry.active_workspace_entry;
+  const workspace = activeWs
+    ? activeWs.workspace_alias ?? activeWs.workspace_id ?? activeWs.worktree?.branch ?? "not bound"
+    : listEntry?.workspace_alias ?? listEntry?.workspace_id ?? "not bound";
+  const workspaceSummary = activeWs
+    ? projectWorkspaceFromInfo(activeWs)
+    : listEntry
+      ? projectWorkspaceFromListEntry(listEntry)
+      : undefined;
+  const attachedWorkspaces = wsList.map((w) => ({
+    workspaceId: w.workspace_id,
+    name: w.workspace_alias ?? basename(w.workspace_anchor ?? w.workspace_id) ?? w.workspace_id,
+    anchor: w.workspace_anchor ?? w.workspace_id,
+    executionRootId: w.execution_root_id ?? undefined,
+    repoName: w.repo_name ?? undefined,
   }));
   const currentWork = selectCurrentWork(workItemRecords ?? state?.work_items ?? [], state?.agent?.agent?.current_work_item_id);
   const workItems = selectWorkItems(workItemRecords ?? state?.work_items ?? [], state?.agent?.agent?.current_work_item_id);
@@ -1563,34 +1566,51 @@ function projectAgent(entry: AgentListEntryDto, state?: AgentStateDto, brief?: B
   };
 }
 
-function projectWorkspace(
-  workspaceEntry: AgentListEntryDto["active_workspace_entry"],
-  worktreeSession?: AgentWorkspaceDto["worktree_session"],
-): WorkspaceSummary | undefined {
-  if (!workspaceEntry && !worktreeSession) return undefined;
-  const metadata = workspaceEntry?.projection_metadata;
-  const anchor = workspaceEntry?.workspace_anchor ?? workspaceEntry?.execution_root ?? workspaceEntry?.cwd ?? "—";
-  const name = workspaceEntry?.workspace_alias ?? basename(anchor) ?? workspaceEntry?.workspace_id ?? "not bound";
-  const worktreeBranch = metadata?.worktree_branch ?? worktreeSession?.worktree_branch;
-  const worktreePath = metadata?.worktree_path ?? worktreeSession?.worktree_path;
+function projectWorkspaceFromInfo(ws: NonNullable<AgentWorkspaceDto["workspaces"]>[number]): WorkspaceSummary {
+  const anchor = ws.workspace_anchor ?? ws.execution_root ?? ws.cwd ?? "—";
+  const name = ws.workspace_alias ?? basename(anchor) ?? ws.workspace_id ?? "not bound";
+  const wt = ws.worktree;
   return {
-    id: workspaceEntry?.workspace_id ?? "not bound",
+    id: ws.workspace_id,
     name,
     anchor,
-    executionRootId: workspaceEntry?.execution_root_id,
-    projectionKind: workspaceEntry?.projection_kind,
-    accessMode: workspaceEntry?.access_mode,
-    executionRoot: workspaceEntry?.execution_root,
-    cwd: workspaceEntry?.cwd,
-    worktree:
-      worktreeBranch || worktreePath
-        ? {
-            branch: worktreeBranch,
-            path: worktreePath,
-            originalBranch: worktreeSession?.original_branch,
-            originalCwd: worktreeSession?.original_cwd,
-          }
-        : undefined,
+    executionRootId: ws.execution_root_id ?? undefined,
+    projectionKind: ws.projection_kind ?? undefined,
+    accessMode: ws.access_mode ?? undefined,
+    executionRoot: ws.execution_root ?? undefined,
+    cwd: ws.cwd ?? undefined,
+    worktree: wt
+      ? {
+          branch: wt.branch ?? undefined,
+          path: wt.path ?? undefined,
+          originalBranch: wt.original_branch ?? undefined,
+          originalCwd: wt.original_cwd ?? undefined,
+        }
+      : undefined,
+  };
+}
+
+function projectWorkspaceFromListEntry(entry: NonNullable<AgentListEntryDto["active_workspace_entry"]>): WorkspaceSummary {
+  const metadata = entry.projection_metadata;
+  const anchor = entry.workspace_anchor ?? entry.execution_root ?? entry.cwd ?? "—";
+  const name = entry.workspace_alias ?? basename(anchor) ?? entry.workspace_id ?? "not bound";
+  return {
+    id: entry.workspace_id ?? "not bound",
+    name,
+    anchor,
+    executionRootId: entry.execution_root_id,
+    projectionKind: entry.projection_kind,
+    accessMode: entry.access_mode,
+    executionRoot: entry.execution_root,
+    cwd: entry.cwd,
+    worktree: metadata?.worktree_branch || metadata?.worktree_path
+      ? {
+          branch: metadata?.worktree_branch,
+          path: metadata?.worktree_path,
+          originalBranch: undefined,
+          originalCwd: undefined,
+        }
+      : undefined,
   };
 }
 

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -79,10 +79,9 @@ function mergeCachedAgentState(httpAgent: AgentSummary, cachedAgent: AgentSummar
     waitingCount: Math.max(httpAgent.waitingCount, cachedAgent.waitingCount),
     pending: Math.max(httpAgent.pending, cachedAgent.pending),
     workspaceSummary: cachedAgent.workspaceSummary ?? httpAgent.workspaceSummary,
-    // attachedWorkspaces come from the /state endpoint, not /agents/list bootstrap.
-    // Bootstrap only includes the active workspace as fallback; preserve cached
-    // entries when the HTTP source carries fewer workspaces than the cache.
-    attachedWorkspaces: (httpAgent.attachedWorkspaces?.length ?? 0) >= (cachedAgent.attachedWorkspaces?.length ?? 0)
+    // Unified workspaces array from /state endpoint; fall back to cache when
+    // the HTTP source is stale (e.g., bootstrap list without full state).
+    attachedWorkspaces: httpAgent.attachedWorkspaces?.length
       ? httpAgent.attachedWorkspaces
       : cachedAgent.attachedWorkspaces,
   };


### PR DESCRIPTION
## Summary

Stabilize workspace-related functionality for the upcoming release. This PR addresses workspace ID instability, fragmented abstraction, dual-path bridge/standalone logic, and API shape issues.

## Changes

### Phase 1: Clean up dead code and explicit projection_kind (`7506e053`)
- Remove dead `ids::workspace_id()` random generator (all production code uses `deterministic_workspace_id`)
- Add explicit `projection_kind` field to `WorkspaceView`, eliminating fragile `worktree_root().is_some()` inference

### Phase 2: Typed WorkspaceProjectionMetadata (`8358b844`)
- Define `WorkspaceProjectionMetadata` enum replacing untyped `Option<serde_json::Value>`
- Add `ActiveWorkspaceEntry::to_workspace_view()` centralizing field mapping duplication
- Update all creation sites to construct typed variants instead of `serde_json::json!()`

### Phase 3: Centralize bridge/standalone occupancy operations (`ecb151c3`)
- Add `acquire_workspace_occupancy` / `release_workspace_occupancy` helper methods on `RuntimeHandle`
- Replace 9 scattered `if let Some(bridge)` branches with centralized calls

### Phase 4: Mark migration code as deprecated path (`e99e56dd`)
- Add `tracing::info!` logs with `'workspace migration:'` prefix to track when all agents have migrated
- Add `docs/implementation-decisions/063` documenting removal criteria

### API: Unify StateWorkspaceSnapshot (`78e2550c`)
- Replace 5 fragmented workspace fields with single `workspaces: Vec<AgentWorkspaceInfo>` array
- Simplify frontend `client.ts` to direct array mapping

### Test Coverage (`201f48a6`)
- 33 new unit tests across `host_registry.rs` (13), `http/state.rs` (7), `ids.rs` (5), `runtime/workspace.rs` (3)

## Verification
- `RUSTFLAGS="-D warnings" cargo test --lib` ✅ (2009 passed, 0 failed)
- `cargo fmt --check` ✅
- Frontend build ✅
