### PR TITLE
fix: prune stale attached_workspaces when anchor paths become invalid

### DIFF
--- a/src/http/state.rs
+++ b/src/http/state.rs
@@ -215,6 +215,7 @@ pub async fn agent_state(
         .get_public_agent(&agent_id)
         .await
         .map_err(agent_access_error)?;
+    runtime.prune_stale_attached_workspaces().await.ok();
     let mut agent = runtime.agent_summary().await.map_err(error_response)?;
     let tasks_started = std::time::Instant::now();
     let tasks = runtime

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -919,6 +919,94 @@ impl RuntimeHandle {
         Ok(())
     }
 
+    /// Lazily remove stale entries from `attached_workspaces`.
+    ///
+    /// An entry is stale when its workspace ID is absent from the workspace
+    /// registry, or when the registry entry's anchor path no longer exists on
+    /// disk. The active workspace is always preserved, even if its anchor is
+    /// currently invalid, to avoid silently clearing the execution context.
+    ///
+    /// Returns the list of workspace IDs that were pruned (empty if nothing
+    /// changed). Each pruned ID emits a `workspace_detached` audit event with
+    /// `reason: "stale_workspace_anchor"`.
+    pub async fn prune_stale_attached_workspaces(&self) -> Result<Vec<String>> {
+        let bridge = match self.inner.host_bridge.as_ref() {
+            Some(b) => b,
+            None => return Ok(Vec::new()), // no registry to check against
+        };
+
+        let agent_id_snapshot = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.id.clone()
+        };
+        let canonical_agent_home_id = crate::types::agent_home_workspace_id(&agent_id_snapshot);
+
+        let active_workspace_id = {
+            let guard = self.inner.agent.lock().await;
+            guard
+                .state
+                .active_workspace_entry
+                .as_ref()
+                .map(|e| e.workspace_id.clone())
+        };
+
+        // Collect IDs to prune under the agent lock so we have a consistent
+        // snapshot of attached_workspaces.
+        let attached_ids: Vec<String> = {
+            let guard = self.inner.agent.lock().await;
+            guard.state.attached_workspaces.clone()
+        };
+
+        let mut stale_ids = Vec::new();
+        for ws_id in &attached_ids {
+            // Never prune the active workspace or AgentHome (virtual, may not be in registry).
+            if Some(ws_id) == active_workspace_id.as_ref()
+                || ws_id == AGENT_HOME_WORKSPACE_ID
+                || ws_id == &canonical_agent_home_id
+            {
+                continue;
+            }
+
+            // Check registry: entry must exist and its anchor must be a real directory.
+            let entry = bridge.workspace_entry_by_id(ws_id).await?;
+            let is_stale = match &entry {
+                None => true, // ID not in registry
+                Some(e) => !e.workspace_anchor.is_dir(),
+            };
+            if is_stale {
+                stale_ids.push(ws_id.clone());
+            }
+        }
+
+        if stale_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Remove stale IDs and persist.
+        let agent_id = {
+            let mut guard = self.inner.agent.lock().await;
+            guard
+                .state
+                .attached_workspaces
+                .retain(|id| !stale_ids.contains(id));
+            guard.persist_state(&self.inner.storage)?;
+            guard.state.id.clone()
+        };
+
+        for ws_id in &stale_ids {
+            self.inner.storage.append_event(&AuditEvent::new(
+                "workspace_detached",
+                serde_json::json!({
+                    "agent_id": &agent_id,
+                    "workspace_id": ws_id,
+                    "reason": "stale_workspace_anchor",
+                }),
+            ))?;
+        }
+
+        Ok(stale_ids)
+    }
+
     pub(crate) async fn ensure_workspace_entry_for_path(
         &self,
         path: PathBuf,

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -935,26 +935,25 @@ impl RuntimeHandle {
             None => return Ok(Vec::new()), // no registry to check against
         };
 
-        let agent_id_snapshot = {
+        // Collect all needed state under a single agent lock acquisition.
+        let (agent_id, canonical_agent_home_id, active_workspace_id, attached_ids): (
+            String,
+            String,
+            Option<String>,
+            Vec<String>,
+        ) = {
             let guard = self.inner.agent.lock().await;
-            guard.state.id.clone()
-        };
-        let canonical_agent_home_id = crate::types::agent_home_workspace_id(&agent_id_snapshot);
-
-        let active_workspace_id = {
-            let guard = self.inner.agent.lock().await;
-            guard
-                .state
-                .active_workspace_entry
-                .as_ref()
-                .map(|e| e.workspace_id.clone())
-        };
-
-        // Collect IDs to prune under the agent lock so we have a consistent
-        // snapshot of attached_workspaces.
-        let attached_ids: Vec<String> = {
-            let guard = self.inner.agent.lock().await;
-            guard.state.attached_workspaces.clone()
+            let canonical = crate::types::agent_home_workspace_id(&guard.state.id);
+            (
+                guard.state.id.clone(),
+                canonical,
+                guard
+                    .state
+                    .active_workspace_entry
+                    .as_ref()
+                    .map(|e| e.workspace_id.clone()),
+                guard.state.attached_workspaces.clone(),
+            )
         };
 
         let mut stale_ids = Vec::new();
@@ -968,7 +967,11 @@ impl RuntimeHandle {
             }
 
             // Check registry: entry must exist and its anchor must be a real directory.
-            let entry = bridge.workspace_entry_by_id(ws_id).await?;
+            // Skip entries with registry errors rather than aborting the entire prune.
+            let entry = match bridge.workspace_entry_by_id(ws_id).await {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
             let is_stale = match &entry {
                 None => true, // ID not in registry
                 Some(e) => !e.workspace_anchor.is_dir(),
@@ -983,15 +986,14 @@ impl RuntimeHandle {
         }
 
         // Remove stale IDs and persist.
-        let agent_id = {
+        {
             let mut guard = self.inner.agent.lock().await;
             guard
                 .state
                 .attached_workspaces
                 .retain(|id| !stale_ids.contains(id));
             guard.persist_state(&self.inner.storage)?;
-            guard.state.id.clone()
-        };
+        }
 
         for ws_id in &stale_ids {
             self.inner.storage.append_event(&AuditEvent::new(

--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -630,3 +630,146 @@ async fn wait_for_closure_blocks_until_foreground_work_clears() {
         .unwrap();
     assert_eq!(closure.outcome, ClosureOutcome::Completed);
 }
+
+// ---------------------------------------------------------------------------
+// prune_stale_attached_workspaces tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn prune_removes_workspace_id_missing_from_registry() {
+    let (_home, _host, runtime) = host_backed_test_runtime().await;
+
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.attached_workspaces = vec![
+            AGENT_HOME_WORKSPACE_ID.to_string(),
+            "ws-stale-not-in-registry".to_string(),
+        ];
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let pruned = runtime.prune_stale_attached_workspaces().await.unwrap();
+    assert_eq!(pruned, vec!["ws-stale-not-in-registry".to_string()]);
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.attached_workspaces,
+        vec![AGENT_HOME_WORKSPACE_ID.to_string()]
+    );
+}
+
+#[tokio::test]
+async fn prune_removes_workspace_with_deleted_anchor() {
+    let (_home, host, runtime) = host_backed_test_runtime().await;
+
+    let project = tempdir().unwrap();
+    let entry = host
+        .ensure_workspace_entry(project.path().to_path_buf())
+        .unwrap();
+    let stale_id = entry.workspace_id.clone();
+    drop(project);
+
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.attached_workspaces =
+            vec![AGENT_HOME_WORKSPACE_ID.to_string(), stale_id.clone()];
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let pruned = runtime.prune_stale_attached_workspaces().await.unwrap();
+    assert_eq!(pruned, vec![stale_id.clone()]);
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(
+        state.attached_workspaces,
+        vec![AGENT_HOME_WORKSPACE_ID.to_string()]
+    );
+}
+
+#[tokio::test]
+async fn prune_preserves_active_workspace_even_when_stale() {
+    let (_home, _host, runtime) = host_backed_test_runtime().await;
+
+    let stale_active_id = "ws-stale-active".to_string();
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.attached_workspaces =
+            vec![AGENT_HOME_WORKSPACE_ID.to_string(), stale_active_id.clone()];
+        guard.state.active_workspace_entry = Some(crate::types::ActiveWorkspaceEntry {
+            workspace_id: stale_active_id.clone(),
+            workspace_anchor: std::path::PathBuf::from("/nonexistent/path"),
+            execution_root_id: "canonical_root:ws-stale-active".into(),
+            execution_root: std::path::PathBuf::from("/nonexistent/path"),
+            projection_kind: WorkspaceProjectionKind::CanonicalRoot,
+            access_mode: WorkspaceAccessMode::ExclusiveWrite,
+            cwd: std::path::PathBuf::from("/nonexistent/path"),
+            occupancy_id: None,
+            projection_metadata: None,
+        });
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let pruned = runtime.prune_stale_attached_workspaces().await.unwrap();
+    assert!(pruned.is_empty());
+
+    let state = runtime.agent_state().await.unwrap();
+    assert!(state.attached_workspaces.contains(&stale_active_id));
+}
+
+#[tokio::test]
+async fn prune_preserves_valid_workspaces() {
+    let (_home, host, runtime) = host_backed_test_runtime().await;
+
+    let project = tempdir().unwrap();
+    let entry = host
+        .ensure_workspace_entry(project.path().to_path_buf())
+        .unwrap();
+    let valid_id = entry.workspace_id.clone();
+
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.attached_workspaces =
+            vec![AGENT_HOME_WORKSPACE_ID.to_string(), valid_id.clone()];
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let pruned = runtime.prune_stale_attached_workspaces().await.unwrap();
+    assert!(pruned.is_empty());
+
+    let state = runtime.agent_state().await.unwrap();
+    assert_eq!(state.attached_workspaces.len(), 2);
+    assert!(state.attached_workspaces.contains(&valid_id));
+}
+
+#[tokio::test]
+async fn prune_emits_audit_events_for_removed_workspaces() {
+    let (_home, _host, runtime) = host_backed_test_runtime().await;
+
+    {
+        let mut guard = runtime.inner.agent.lock().await;
+        guard.state.attached_workspaces = vec![
+            AGENT_HOME_WORKSPACE_ID.to_string(),
+            "ws-stale-a".to_string(),
+            "ws-stale-b".to_string(),
+        ];
+        runtime.inner.storage.write_agent(&guard.state).unwrap();
+    }
+
+    let pruned = runtime.prune_stale_attached_workspaces().await.unwrap();
+    assert_eq!(pruned.len(), 2);
+
+    let events = runtime.storage().read_recent_events(20).unwrap();
+    let detached_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.kind == "workspace_detached")
+        .collect();
+    assert_eq!(detached_events.len(), 2);
+
+    for event in &detached_events {
+        let data = event.data.as_object().unwrap();
+        assert_eq!(
+            data.get("reason").and_then(|v| v.as_str()),
+            Some("stale_workspace_anchor")
+        );
+    }
+}


### PR DESCRIPTION
## Problem

When a workspace's anchor path becomes invalid (worktree deleted, directory moved/deleted), the workspace ID remains in the agent's `attached_workspaces` list forever. Only `detach_workspace` removes entries; all other worktree cleanup paths (`cleanup_task_owned_worktree_in_detail`, `discard_managed_worktree`, `exit_worktree`) delete the physical worktree but never clean up the agent state.

This causes stale workspace entries to accumulate in the UI (workspace IDs with no path shown, not browsable).

Closes #2030.

## Solution

Add `prune_stale_attached_workspaces()` to `RuntimeHandle` that lazily removes stale workspace IDs from `attached_workspaces`. An entry is stale when:
- Its workspace ID is absent from the workspace registry, **or**
- The registry entry's anchor path no longer exists on disk

The prune runs from the `agent_state` HTTP handler before building the summary, so stale entries are cleaned on every state API read — the primary read path for the UI.

### Design choice: runtime-layer cleanup vs. projection-only

The issue proposed doing the cleanup inside `state_workspace_snapshot` (a pure projection function). Instead, the cleanup lives at the runtime layer (`RuntimeHandle::prune_stale_attached_workspaces`) because:
1. **Projection functions should be side-effect-free** — `state_workspace_snapshot` should not mutate agent state.
2. **Persistent cleanup** — stale IDs are removed from persisted agent state, not just hidden from one API response.
3. **Audit trail** — each pruned ID emits a `workspace_detached` audit event with `reason: "stale_workspace_anchor"`.

### Safety guarantees
- **Active workspace** is never pruned, even if its anchor is currently invalid, to avoid silently clearing the execution context.
- **AgentHome** (`agent_home` and `agent_home:{agent_id}`) is never pruned — it is a virtual workspace that may not be in the registry.

## Changes

| File | Change |
|---|---|
| `src/runtime/lifecycle.rs` | Add `prune_stale_attached_workspaces()` method |
| `src/http/state.rs` | Call prune before `agent_summary()` in `agent_state` handler |
| `src/runtime/tests/workspace.rs` | 5 unit tests covering all prune scenarios |

## Test plan

- [x] `prune_removes_workspace_id_missing_from_registry` — stale ID not in registry gets pruned
- [x] `prune_removes_workspace_with_deleted_anchor` — registry entry with deleted anchor dir gets pruned
- [x] `prune_preserves_active_workspace_even_when_stale` — active workspace is never pruned
- [x] `prune_preserves_valid_workspaces` — valid workspaces are preserved
- [x] `prune_emits_audit_events_for_removed_workspaces` — audit events with correct reason
- [x] `cargo fmt --all -- --check` passes
- [x] `RUSTFLAGS="-D warnings" cargo check --all-targets` passes