### PR TITLE
test: cover double-slash absolute patch paths

### DIFF
--- a/src/tool/apply_patch.rs
+++ b/src/tool/apply_patch.rs
@@ -2052,6 +2052,16 @@ mod tests {
         assert!(!tokio::fs::try_exists(&doomed).await.unwrap());
     }
 
+    #[test]
+    fn strip_diff_prefix_preserves_only_double_slash_absolute_paths() {
+        assert_eq!(strip_diff_prefix("a/src/foo.rs"), "src/foo.rs");
+        assert_eq!(strip_diff_prefix("b/src/foo.rs"), "src/foo.rs");
+        assert_eq!(strip_diff_prefix("a//home/foo.rs"), "/home/foo.rs");
+        assert_eq!(strip_diff_prefix("b//home/foo.rs"), "/home/foo.rs");
+        assert_eq!(strip_diff_prefix("a/home/foo.rs"), "home/foo.rs");
+        assert_eq!(strip_diff_prefix("b/home/foo.rs"), "home/foo.rs");
+    }
+
     #[tokio::test]
     async fn apply_patch_strips_diff_prefix_from_absolute_paths() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Add a regression test for git-style double-slash absolute patch paths.
- Confirm `a//absolute/path` and `b//absolute/path` preserve the leading `/` after prefix stripping.
- Confirm normal `a/src/...` and ambiguous `a/home/...` paths remain relative.

## Context

This documents the safe compatibility case discussed in #2002 without changing the existing behavior for ambiguous single-slash paths.

## Verification

- `cargo fmt --check`
- `git diff --check`

Note: `cargo test strip_diff_prefix_preserves_only_double_slash_absolute_paths` could not complete on native Windows because current `main` fails to compile unrelated Windows-incompatible test/code paths, including `std::os::unix::fs::symlink` in `src/runtime/lifecycle.rs` and `process_group_id` fields in `src/system/local.rs`.

Closes #2002