### PR TITLE
feat: add GPT-5.6 Sol/Terra/Luna model catalog entries

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -747,6 +747,33 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
         ),
         catalog_model(
             "openai-codex",
+            "gpt-5.6-sol",
+            "GPT-5.6 Sol (Codex)",
+            272_000,
+            128_000,
+            true,
+            true,
+        ),
+        catalog_model(
+            "openai-codex",
+            "gpt-5.6-terra",
+            "GPT-5.6 Terra (Codex)",
+            272_000,
+            128_000,
+            true,
+            true,
+        ),
+        catalog_model(
+            "openai-codex",
+            "gpt-5.6-luna",
+            "GPT-5.6 Luna (Codex)",
+            272_000,
+            128_000,
+            true,
+            true,
+        ),
+        catalog_model(
+            "openai-codex",
             "gpt-5.4-mini",
             "GPT-5.4 Mini (Codex)",
             272_000,
@@ -758,6 +785,33 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             "openai-codex",
             "gpt-5.2",
             "GPT-5.2 (Codex)",
+            272_000,
+            128_000,
+            true,
+            true,
+        ),
+        catalog_model(
+            "openai",
+            "gpt-5.6-sol",
+            "GPT-5.6 Sol",
+            272_000,
+            128_000,
+            true,
+            true,
+        ),
+        catalog_model(
+            "openai",
+            "gpt-5.6-terra",
+            "GPT-5.6 Terra",
+            272_000,
+            128_000,
+            true,
+            true,
+        ),
+        catalog_model(
+            "openai",
+            "gpt-5.6-luna",
+            "GPT-5.6 Luna",
             272_000,
             128_000,
             true,
@@ -2667,6 +2721,32 @@ mod tests {
         assert_eq!(policy.runtime_max_output_tokens, 384_000);
         assert!(policy.capabilities.reasoning_summaries);
         assert_eq!(policy.source, ModelMetadataSource::BuiltInCatalog);
+
+        // GPT-5.6 family (Sol/Terra/Luna) added from the OpenAI limited preview.
+        let sol = catalog.resolve_policy(
+            &ModelRef::parse("openai/gpt-5.6-sol").unwrap(),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            &base_context(),
+            8192,
+        );
+        assert_eq!(sol.display_name, "GPT-5.6 Sol");
+        assert_eq!(sol.context_window_tokens, Some(272_000));
+        assert_eq!(sol.runtime_max_output_tokens, 128_000);
+        assert!(sol.capabilities.image_input);
+        assert!(sol.capabilities.reasoning_summaries);
+        assert_eq!(sol.source, ModelMetadataSource::BuiltInCatalog);
+
+        assert!(catalog
+            .get(&ModelRef::parse("openai/gpt-5.6-terra").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("openai/gpt-5.6-luna").unwrap())
+            .is_some());
+        assert!(catalog
+            .get(&ModelRef::parse("openai-codex/gpt-5.6-sol").unwrap())
+            .is_some());
 
         let nearai = catalog.resolve_policy(
             &ModelRef::parse("nearai/zai-org/GLM-5.1-FP8").unwrap(),


### PR DESCRIPTION
## Summary

Add GPT-5.6 model family entries to the built-in model catalog.

GPT-5.6 was announced on 2026-06-26 as a limited preview. Unlike previous GPT-5.x releases that use version-only model IDs, GPT-5.6 uses codename suffixes:

| Model | Model ID | Tier | API Pricing (input/output per 1M) |
|---|---|---|---|
| GPT-5.6 Sol | `gpt-5.6-sol` | Flagship | $5 / $30 |
| GPT-5.6 Terra | `gpt-5.6-terra` | Balanced (~2x cheaper than GPT-5.5) | $2.50 / $15 |
| GPT-5.6 Luna | `gpt-5.6-luna` | Fastest, most cost-efficient | $1 / $6 |

Source: [OpenAI Help Center](https://help.openai.com/en/articles/20001325-a-preview-of-gpt-56-sol-terra-and-luna) and [GPT-5.6 Preview System Card](https://deploymentsafety.openai.com/gpt-5-6-preview)

## Changes

- Add `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` entries to both `openai` and `openai-codex` providers in `compatible_provider_model_entries()`
- 272K context window and 128K max output tokens, aligned with existing GPT-5.x entries
- Context window is conservative pending official API documentation during the preview period
- Add test assertions verifying catalog resolution for all GPT-5.6 variants

## Verification

- `cargo check --lib` ✅
- `cargo test --lib model_catalog` ✅ (15 tests pass)
- `cargo fmt --all -- --check` ✅

## Notes

GPT-5.6 is currently in limited preview (trusted partners only). Broad API availability is expected in coming weeks. These catalog entries allow users with preview access to use the models with Holon; parameters can be refined once official API docs are published.