### PR TITLE
docs: document OpenAPI snapshot regeneration in release process

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -43,3 +43,25 @@ Before pushing the tag, verify:
 - when provider, context projection, compaction, or prompt-cache behavior
   changed, the ignored live LLM baseline in
   `docs/testing/live-llm-baseline.md` has been run manually
+- when the version number or HTTP API surface changed, regenerate the OpenAPI
+  snapshot (see below) — never edit `openapi.json` by hand
+
+## OpenAPI Snapshot
+
+A checked-in copy of the generated OpenAPI schema lives at
+`docs/website/reference/openapi.json`. The integration test
+`openapi_snapshot_matches_generated_schema` verifies that this snapshot matches
+the schema generated from the current crate version. Any version bump or HTTP
+API change will cause drift.
+
+**Do not edit `openapi.json` by hand.** After bumping the version in
+`Cargo.toml`, regenerate the snapshot:
+
+```bash
+cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored
+cargo test --test openapi_snapshot
+```
+
+The first command regenerates the file; the second verifies it matches. The
+generated output has no trailing newline — adding one manually causes the
+snapshot test to fail.


### PR DESCRIPTION
## Context

The v0.23.0 release-prep PR (#2036) hit a CI failure because `openapi.json` was edited by hand (version string changed 0.22.0 → 0.23.0) instead of being regenerated, introducing a trailing newline mismatch that caused `openapi_snapshot_matches_generated_schema` to fail.

## Change

Document the correct OpenAPI snapshot regeneration flow in `docs/release.md`:

1. Added a checklist item in **Pre-Tag Checklist**: regenerate the OpenAPI snapshot after version bumps or API changes — never edit `openapi.json` by hand.
2. Added an **OpenAPI Snapshot** section explaining:
   - The checked-in snapshot at `docs/website/reference/openapi.json` is verified against the generated schema by the integration test.
   - The correct workflow: `cargo test --test openapi_snapshot refresh_openapi_snapshot -- --ignored` then `cargo test --test openapi_snapshot`.
   - The generated output has no trailing newline.

This prevents the same CI retry on future releases.