### PR TITLE
refactor: make RuntimeDb mandatory, remove JSONL fallback from runtime read/write paths (issue #2029 batch 1)

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -3067,17 +3067,13 @@ mod tests {
     #[test]
     fn recent_turns_prefers_db_turn_records_when_available() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
         let mut operator = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -3149,17 +3145,13 @@ mod tests {
     #[test]
     fn recent_turns_keeps_db_turn_when_trigger_message_is_outside_window() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
         let mut brief = BriefRecord::new(
             "default",
             BriefKind::Result,
@@ -3226,17 +3218,13 @@ mod tests {
     #[test]
     fn recent_turns_hydrates_turn_record_references_outside_recent_windows() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
         let mut operator = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -3366,7 +3354,7 @@ mod tests {
     #[test]
     fn recent_turns_renders_full_operator_input_with_brief_ref() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let long_tail = "final-token-visible-after-old-preview-limit";
         let operator_text = format!(
             "{} {long_tail}",
@@ -3445,7 +3433,7 @@ mod tests {
     #[test]
     fn older_recent_turn_operator_input_is_previewed_with_message_ref() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let long_tail = "older-operator-tail-hidden-behind-message-ref";
         let message = MessageEnvelope::new(
             "default",
@@ -3493,7 +3481,7 @@ mod tests {
     #[test]
     fn recent_turns_resolves_transcript_backed_brief_content() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -3549,7 +3537,7 @@ mod tests {
     #[test]
     fn compaction_adds_summary_when_message_count_exceeds_threshold() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for idx in 0..6 {
             let msg = MessageEnvelope::new(
                 "default",
@@ -3587,7 +3575,7 @@ mod tests {
     #[test]
     fn structured_working_memory_keeps_compression_epoch_stable_during_legacy_compaction() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for idx in 0..6 {
             let msg = MessageEnvelope::new(
                 "default",
@@ -3634,7 +3622,7 @@ mod tests {
     #[test]
     fn context_fingerprint_changes_when_projected_context_lineage_changes() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for idx in 0..6 {
             let msg = MessageEnvelope::new(
                 "default",
@@ -3763,7 +3751,7 @@ mod tests {
     #[test]
     fn build_context_folds_latest_result_into_recent_turns_and_keeps_generic_context_contract() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut prior_message = MessageEnvelope::new(
             "default",
@@ -3883,7 +3871,7 @@ mod tests {
     #[test]
     fn build_context_does_not_render_recent_turns_from_orphan_recent_evidence() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         storage
             .append_message(&MessageEnvelope::new(
@@ -4092,7 +4080,7 @@ mod tests {
     #[test]
     fn recent_turns_compacts_older_successful_tool_executions() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let older_message = MessageEnvelope::new(
             "default",
@@ -4292,7 +4280,7 @@ mod tests {
     #[test]
     fn build_context_folds_briefs_into_recent_turns_without_parallel_brief_section() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let prior_message = MessageEnvelope::new(
             "default",
@@ -4383,7 +4371,7 @@ mod tests {
     #[test]
     fn recent_turns_inlines_latest_result_beyond_old_preview_limit() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let tail = "latest-result-tail-visible-after-old-preview-limit";
         let prior_message = MessageEnvelope::new(
             "default",
@@ -4455,7 +4443,7 @@ mod tests {
     #[test]
     fn continuity_result_truncation_keeps_explicit_brief_ref() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -4516,7 +4504,7 @@ mod tests {
     #[test]
     fn nearby_turns_get_larger_result_previews_than_older_turns() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut messages = Vec::new();
         let mut briefs = Vec::new();
         let mut turns = Vec::new();
@@ -4587,7 +4575,7 @@ mod tests {
     #[test]
     fn build_context_skips_messages_covered_by_compacted_summary() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for idx in 0..20 {
             let message = MessageEnvelope::new(
                 "default",
@@ -4656,7 +4644,7 @@ mod tests {
     #[test]
     fn maybe_compact_agent_persists_message_count_without_compaction() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_message(&MessageEnvelope::new(
                 "default",
@@ -4690,7 +4678,7 @@ mod tests {
     #[test]
     fn maybe_compact_agent_clears_legacy_summary_when_working_memory_is_active() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for idx in 0..6 {
             storage
                 .append_message(&MessageEnvelope::new(
@@ -4732,7 +4720,7 @@ mod tests {
     #[test]
     fn build_context_omits_working_memory_sections_by_default() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -4788,7 +4776,7 @@ mod tests {
     #[test]
     fn build_context_keeps_verification_as_raw_evidence_without_promoting_session_fact() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut prior_message = MessageEnvelope::new(
             "default",
@@ -4907,7 +4895,7 @@ mod tests {
     #[test]
     fn build_context_does_not_emit_follow_up_specific_contracts() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -4968,7 +4956,7 @@ mod tests {
     #[test]
     fn build_context_lists_skill_metadata_without_skill_body() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5064,7 +5052,7 @@ mod tests {
     #[test]
     fn build_context_lists_agent_template_catalog_without_template_body() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5123,7 +5111,7 @@ mod tests {
     #[test]
     fn build_context_includes_worktree_session_when_active() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5180,7 +5168,7 @@ mod tests {
     #[test]
     fn build_context_includes_current_work_item_and_plan_sections() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5467,7 +5455,7 @@ mod tests {
     #[test]
     fn build_context_includes_empty_current_work_item_section_when_unfocused() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5514,7 +5502,7 @@ mod tests {
     #[test]
     fn build_context_includes_ranked_work_item_candidates_and_completion_reports() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5682,7 +5670,7 @@ mod tests {
     #[test]
     fn build_context_omits_worktree_session_when_not_active() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5724,7 +5712,7 @@ mod tests {
     #[test]
     fn build_context_includes_execution_environment() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -5793,7 +5781,7 @@ mod tests {
     #[test]
     fn build_context_omits_active_tasks_when_none() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let built = context_for_storage(&storage, "default");
 
@@ -5806,7 +5794,7 @@ mod tests {
     #[test]
     fn build_context_includes_active_command_task_projection() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&active_task(
                 "task-running",
@@ -5855,7 +5843,7 @@ mod tests {
     #[test]
     fn build_context_sanitizes_active_task_scalars_and_command_preview() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let task = TaskRecord {
             summary: Some("Run verification\ninjected: true".to_string()),
             work_item_id: Some("work-current\nspoofed: true".to_string()),
@@ -5898,7 +5886,7 @@ mod tests {
     #[test]
     fn build_context_scopes_active_tasks_to_current_agent() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&active_task(
                 "task-default",
@@ -5932,7 +5920,7 @@ mod tests {
     #[test]
     fn build_context_omits_terminal_tasks_from_active_tasks() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&active_task(
                 "task-completed",
@@ -5953,7 +5941,7 @@ mod tests {
     #[test]
     fn build_context_limits_active_tasks_and_reports_hidden_count() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         for index in 0..(ACTIVE_TASKS_CONTEXT_LIMIT + 1) {
             storage
                 .append_task(&active_task(
@@ -5985,7 +5973,7 @@ mod tests {
     #[test]
     fn build_context_includes_default_external_wake_ingress() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_external_trigger(&ExternalTriggerRecord {
                 external_trigger_id: "wake-default".into(),
@@ -6049,7 +6037,7 @@ mod tests {
     #[test]
     fn build_context_uses_latest_default_external_wake_ingress() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = chrono::Utc::now();
         storage
             .append_external_trigger(&ExternalTriggerRecord {
@@ -6060,9 +6048,9 @@ mod tests {
                 delivery_mode: CallbackDeliveryMode::WakeHint,
                 trigger_url: Some("http://127.0.0.1:7878/callbacks/wake/old".into()),
                 token_hash: "redacted-old-token-hash".into(),
-                status: ExternalTriggerStatus::Active,
+                status: ExternalTriggerStatus::Revoked,
                 created_at: now - chrono::Duration::seconds(60),
-                revoked_at: None,
+                revoked_at: Some(now - chrono::Duration::seconds(30)),
                 last_delivered_at: None,
                 delivery_count: 0,
             })
@@ -6130,7 +6118,7 @@ mod tests {
     #[test]
     fn build_context_omits_system_tick_from_recent_turns() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let operator_message = MessageEnvelope::new(
             "default",
@@ -6191,7 +6179,7 @@ mod tests {
     #[test]
     fn build_context_includes_continuation_context_for_system_tick() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut system_tick = MessageEnvelope::new(
             "default",
@@ -6262,7 +6250,7 @@ mod tests {
     #[test]
     fn recent_turns_summarizes_wake_hint_without_inlining_payload() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let long_reason = format!("github inbox updated {}", "r".repeat(180));
         let long_source = format!("agentinbox{}", "s".repeat(120));
         let long_resource = format!("github:holon-run/holon#1683?{}", "q".repeat(240));
@@ -6352,7 +6340,7 @@ mod tests {
     #[test]
     fn build_context_includes_continuation_context_for_work_queue_system_tick() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut system_tick = MessageEnvelope::new(
             "default",
@@ -6415,7 +6403,7 @@ mod tests {
     #[test]
     fn recent_turns_summarizes_work_queue_tick_without_inlining_body() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let long_reason = format!("queued_available_{}", "r".repeat(180));
         let long_work_item = format!("work_1683{}", "w".repeat(120));
 
@@ -6494,7 +6482,7 @@ mod tests {
     #[test]
     fn recent_turns_generic_system_tick_summary_includes_subsystem() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut system_tick = MessageEnvelope::new(
             "default",
@@ -6558,7 +6546,7 @@ mod tests {
     #[test]
     fn build_context_anchors_latest_operator_input_for_runtime_continuation_without_work_item() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let operator_message = MessageEnvelope::new(
             "default",
@@ -6631,7 +6619,7 @@ mod tests {
     #[test]
     fn build_context_anchor_uses_operator_input_beyond_recent_window() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let operator_message = MessageEnvelope::new(
             "default",
@@ -6731,17 +6719,13 @@ mod tests {
     #[test]
     fn resume_override_anchor_ignores_legacy_operator_without_message_seq() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
         let mut legacy_without_sequence = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -6833,7 +6817,7 @@ mod tests {
     #[test]
     fn build_context_work_item_anchor_does_not_duplicate_work_item_projection() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let operator_message = MessageEnvelope::new(
             "default",
@@ -6922,7 +6906,7 @@ mod tests {
     #[test]
     fn build_context_keeps_full_current_input_body_for_long_operator_prompt() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let long_path =
             "/very/long/path/to/a/workspace/projects/example/agentinbox/operator-guides/agentinbox-cli-quickstart-for-review-workflow-2026-04.md";
@@ -6975,7 +6959,7 @@ mod tests {
     #[test]
     fn build_context_renders_provenance_admission_and_authority_labels() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let session = AgentState::new("default");
         let current_message = MessageEnvelope::new(
             "default",
@@ -7019,7 +7003,7 @@ mod tests {
     #[test]
     fn build_context_uses_budgeted_hot_tail_and_preserves_section_order() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         for text in [
             "Investigate the flaky runtime wake path and patch it.",
@@ -7147,7 +7131,7 @@ mod tests {
     #[test]
     fn build_context_omits_working_memory_delta_even_when_legacy_snapshot_exists() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -7193,7 +7177,7 @@ mod tests {
     #[test]
     fn build_context_selects_only_relevant_archived_episodes_that_fit_budget() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let old_episode = ContextEpisodeRecord {
             id: "ep_old".into(),
@@ -7325,7 +7309,7 @@ mod tests {
     #[test]
     fn build_context_excludes_episode_overlapping_recent_turn_window() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let archived_episode = ContextEpisodeRecord {
             id: "ep_archived".into(),
@@ -7412,7 +7396,7 @@ mod tests {
     #[test]
     fn build_context_orders_work_item_before_relevant_episode_memory() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut work_item =
             crate::types::WorkItemRecord::new("default", "Fix wake path", WorkItemState::Open);
@@ -7510,7 +7494,7 @@ mod tests {
     #[test]
     fn build_context_enforces_total_prompt_budget_across_large_sections() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let current_message = MessageEnvelope::new(
             "default",
@@ -7847,7 +7831,7 @@ mod tests {
     fn build_context_omits_notes_catalog_when_no_notes_directory() {
         // tempdir() has no `notes/` subdirectory; the section must be absent.
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let current_message = MessageEnvelope::new(
             "default",
             MessageKind::OperatorPrompt,
@@ -7885,7 +7869,7 @@ mod tests {
     #[test]
     fn build_context_projects_frontmatter_metadata_into_notes_catalog() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         write_note(
             dir.path(),
             "release.md",
@@ -7940,7 +7924,7 @@ mod tests {
     #[test]
     fn build_context_falls_back_when_note_has_no_frontmatter() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         write_note(
             dir.path(),
             "scratchpad.md",
@@ -7989,7 +7973,7 @@ mod tests {
     #[test]
     fn build_context_truncates_notes_catalog_to_item_and_char_limits() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let total = crate::notes_catalog::MAX_NOTES_IN_CATALOG + 5;
         for idx in 0..total {
             write_note(
@@ -8051,7 +8035,7 @@ mod tests {
         // its rendered output explicitly states it never overrides higher
         // priority context.
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         write_note(
             dir.path(),
             "rogue.md",

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -272,9 +272,9 @@ pub(crate) fn clear_persisted_daemon_lifecycle_failures(config: &AppConfig) -> R
 }
 
 fn latest_public_runtime_failure(config: &AppConfig) -> Result<Option<RuntimeFailureSummary>> {
-    let host_storage = AppStorage::new_global(config.home_dir.join("host"))?;
     let runtime_db =
         RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+    let host_storage = AppStorage::new_global(config.home_dir.join("host"), runtime_db.clone())?;
     let mut latest = None;
     for identity in host_storage
         .latest_agent_identities()?
@@ -287,8 +287,8 @@ fn latest_public_runtime_failure(config: &AppConfig) -> Result<Option<RuntimeFai
         let storage = AppStorage::new_for_agent(
             config.agent_root_dir().join(&identity.agent_id),
             identity.agent_id.clone(),
+            runtime_db.clone(),
         )?;
-        storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
         let failure = storage
             .read_agent()?
             .and_then(|agent| agent.last_runtime_failure);

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -271,7 +271,11 @@ async fn daemon_status_surfaces_persisted_last_failure_when_runtime_stopped() {
 #[tokio::test]
 async fn daemon_status_surfaces_db_only_public_agent_runtime_failure_when_stopped() {
     let config = test_config();
-    let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
+    let runtime_db =
+        RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
+            .unwrap();
+    let host_storage =
+        AppStorage::new_global(config.home_dir.join("host"), runtime_db.clone()).unwrap();
     let identity = AgentIdentityRecord::new(
         "public-agent",
         AgentKind::Named,
@@ -282,9 +286,6 @@ async fn daemon_status_surfaces_db_only_public_agent_runtime_failure_when_stoppe
         None,
     );
     host_storage.append_agent_identity(&identity).unwrap();
-    let runtime_db =
-        RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())
-            .unwrap();
     let failure = RuntimeFailureSummary {
         occurred_at: Utc::now(),
         summary: "public runtime failed".into(),

--- a/src/host.rs
+++ b/src/host.rs
@@ -252,9 +252,11 @@ impl RuntimeHost {
     }
 
     pub fn agent_storage(&self, agent_id: &str) -> Result<AppStorage> {
-        let storage =
-            AppStorage::new_for_agent(self.agent_data_dir(agent_id), agent_id.to_string())?;
-        storage.enable_scheduler_control_plane_db(self.runtime_db().clone())?;
+        let storage = AppStorage::new_for_agent(
+            self.agent_data_dir(agent_id),
+            agent_id.to_string(),
+            self.runtime_db().clone(),
+        )?;
         storage.enable_event_bus(self.inner.event_bus.clone())?;
         Ok(storage)
     }
@@ -267,8 +269,8 @@ impl RuntimeHost {
         let storage = AppStorage::open_read_only_for_agent(
             self.agent_data_dir(agent_id),
             agent_id.to_string(),
+            self.runtime_db().clone(),
         )?;
-        storage.enable_scheduler_control_plane_db(self.runtime_db().clone())?;
         Ok(storage)
     }
 
@@ -670,7 +672,11 @@ impl RuntimeHost {
             if !agent_home.exists() {
                 continue;
             }
-            let storage = AppStorage::new_for_agent(agent_home, identity.agent_id.clone())?;
+            let storage = AppStorage::new_for_agent(
+                agent_home,
+                identity.agent_id.clone(),
+                self.runtime_db().clone(),
+            )?;
             records.extend(storage.read_recent_external_triggers(usize::MAX)?);
         }
         self.inner
@@ -1762,21 +1768,21 @@ impl RuntimeHost {
 }
 
 fn import_host_registry_domains(config: &AppConfig, runtime_db: &RuntimeDb) -> Result<()> {
-    let host_storage = AppStorage::new_global(config.home_dir.join("host"))?;
+    let host_storage = AppStorage::new_global(config.home_dir.join("host"), runtime_db.clone())?;
     if !runtime_db.storage_domain_is_complete("workspace_entries", "db")? {
         runtime_db
             .workspace_entries()
-            .import_legacy(host_storage.read_recent_workspace_entries(usize::MAX)?)?;
+            .import_legacy(host_storage.read_legacy_workspace_entries_jsonl()?)?;
     }
     if !runtime_db.storage_domain_is_complete("workspace_occupancies", "db")? {
         runtime_db
             .workspace_occupancies()
-            .import_legacy(host_storage.read_recent_workspace_occupancies(usize::MAX)?)?;
+            .import_legacy(host_storage.read_legacy_workspace_occupancies_jsonl()?)?;
     }
     if !runtime_db.storage_domain_is_complete("agent_identities", "db")? {
         runtime_db
             .agent_identities()
-            .import_legacy(host_storage.read_recent_agent_identities(usize::MAX)?)?;
+            .import_legacy(host_storage.read_legacy_agent_identities_jsonl()?)?;
     } else {
         repair_completed_host_agent_identity_import(&host_storage, runtime_db)?;
     }
@@ -1788,7 +1794,7 @@ fn repair_completed_host_agent_identity_import(
     host_storage: &AppStorage,
     runtime_db: &RuntimeDb,
 ) -> Result<()> {
-    let host_identities = host_storage.latest_agent_identities()?;
+    let host_identities = host_storage.read_legacy_agent_identities_jsonl()?;
     if host_identities.is_empty() {
         return Ok(());
     }
@@ -1818,7 +1824,7 @@ fn repair_host_agent_legacy_evidence_import(
         return Ok(());
     }
     let mut agent_ids = host_storage
-        .latest_agent_identities()?
+        .read_legacy_agent_identities_jsonl()?
         .into_iter()
         .map(|record| record.agent_id)
         .collect::<BTreeSet<_>>();
@@ -1829,8 +1835,8 @@ fn repair_host_agent_legacy_evidence_import(
         if !agent_home.exists() {
             continue;
         }
-        let storage = AppStorage::new_for_agent(agent_home, agent_id.clone())?;
-        match storage.read_all_messages() {
+        let storage = AppStorage::new_for_agent(agent_home, agent_id.clone(), runtime_db.clone())?;
+        match storage.read_legacy_messages_jsonl() {
             Ok(messages) => {
                 let legacy_max_seq = messages
                     .iter()
@@ -1852,7 +1858,7 @@ fn repair_host_agent_legacy_evidence_import(
                 );
             }
         }
-        match storage.read_all_transcript() {
+        match storage.read_legacy_transcript_jsonl() {
             Ok(entries) => {
                 let legacy_max_seq = entries
                     .iter()
@@ -1874,30 +1880,20 @@ fn repair_host_agent_legacy_evidence_import(
                 );
             }
         }
-        match storage.latest_event_seq() {
-            Ok(Some(legacy_latest_seq)) => {
+        match storage.read_legacy_events_jsonl() {
+            Ok(events) => {
+                let legacy_latest_seq =
+                    events.iter().map(|e| e.event_seq).max().unwrap_or_default();
                 let db_latest_seq = runtime_db
                     .audit_events()
                     .latest_event_seq(Some(agent_id.as_str()))?
                     .unwrap_or_default();
                 if db_latest_seq < legacy_latest_seq {
-                    match storage.read_legacy_events_jsonl() {
-                        Ok(events) => {
-                            runtime_db
-                                .audit_events()
-                                .append_many(Some(agent_id.as_str()), &events)?;
-                        }
-                        Err(error) => {
-                            warn!(
-                                agent_id = %agent_id,
-                                error = %error,
-                                "failed to repair legacy audit event import for agent"
-                            );
-                        }
-                    }
+                    runtime_db
+                        .audit_events()
+                        .append_many(Some(agent_id.as_str()), &events)?;
                 }
             }
-            Ok(None) => {}
             Err(error) => {
                 warn!(
                     agent_id = %agent_id,
@@ -2256,8 +2252,12 @@ mod tests {
     async fn debug_prompt_preview_is_storage_only_and_leaves_queued_input_unchanged() {
         let (_home, host) = test_host();
         let agent_id = host.config().default_agent_id.clone();
-        let storage = AppStorage::new_for_agent(host.agent_data_dir(&agent_id), agent_id.clone())
-            .expect("storage");
+        let storage = AppStorage::new_for_agent(
+            host.agent_data_dir(&agent_id),
+            agent_id.clone(),
+            host.runtime_db().clone(),
+        )
+        .expect("storage");
         let mut message = MessageEnvelope::new(
             &agent_id,
             MessageKind::OperatorPrompt,
@@ -2303,8 +2303,12 @@ mod tests {
     async fn debug_prompt_preview_does_not_migrate_legacy_event_ledger() {
         let (_home, host) = test_host();
         let agent_id = host.config().default_agent_id.clone();
-        let storage = AppStorage::new_for_agent(host.agent_data_dir(&agent_id), agent_id.clone())
-            .expect("storage");
+        let storage = AppStorage::new_for_agent(
+            host.agent_data_dir(&agent_id),
+            agent_id.clone(),
+            host.runtime_db().clone(),
+        )
+        .expect("storage");
         let events_path = storage.data_dir().join(".holon/ledger/events.jsonl");
         fs::write(
             &events_path,
@@ -2519,7 +2523,7 @@ mod tests {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
-        let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
+        let host_storage = AppStorage::new_jsonl_only(config.home_dir.join("host")).unwrap();
         host_storage
             .append_agent_identity(&AgentIdentityRecord::new(
                 "release-bot",
@@ -2648,7 +2652,7 @@ mod tests {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
-        let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
+        let host_storage = AppStorage::new_jsonl_only(config.home_dir.join("host")).unwrap();
         host_storage
             .append_agent_identity(&AgentIdentityRecord::new(
                 "release-bot",
@@ -2704,7 +2708,7 @@ mod tests {
         let home = tempdir().unwrap();
         write_test_model_config(home.path());
         let config = AppConfig::load_with_home(Some(home.path().to_path_buf())).unwrap();
-        let host_storage = AppStorage::new_global(config.home_dir.join("host")).unwrap();
+        let host_storage = AppStorage::new_jsonl_only(config.home_dir.join("host")).unwrap();
         host_storage
             .append_agent_identity(&AgentIdentityRecord::new(
                 "release-bot",
@@ -2716,7 +2720,11 @@ mod tests {
                 None,
             ))
             .unwrap();
-        let agent_storage = AppStorage::new(config.agent_root_dir().join("release-bot")).unwrap();
+        let agent_storage = AppStorage::new_for_agent_jsonl_only(
+            config.agent_root_dir().join("release-bot"),
+            "release-bot",
+        )
+        .unwrap();
         let message = MessageEnvelope::new(
             "release-bot",
             MessageKind::OperatorPrompt,
@@ -3354,7 +3362,12 @@ mod tests {
         let bridge = RuntimeHostBridge {
             inner: Arc::downgrade(&host.inner),
         };
-        let storage = AppStorage::new(fixture.config.data_dir.clone()).unwrap();
+        let storage = AppStorage::new_for_agent(
+            fixture.config.data_dir.clone(),
+            "default",
+            host.runtime_db().clone(),
+        )
+        .unwrap();
         let mut state = AgentState::new("default");
         state.model_override = Some(ModelRef::parse("anthropic/claude-haiku-4-5").unwrap());
         storage.write_agent(&state).unwrap();
@@ -3992,7 +4005,9 @@ mod tests {
         );
         host.append_agent_identity(&child).unwrap();
 
-        let child_storage = AppStorage::new(host.agent_data_dir("child_orphan")).unwrap();
+        let child_storage =
+            AppStorage::new_for_agent_for_test(host.agent_data_dir("child_orphan"), "child_orphan")
+                .unwrap();
         child_storage
             .write_agent(&AgentState::new("child_orphan"))
             .unwrap();
@@ -4065,7 +4080,11 @@ mod tests {
         );
         host.append_agent_identity(&child).unwrap();
 
-        let child_storage = AppStorage::new(host.agent_data_dir("child_parent_missing")).unwrap();
+        let child_storage = AppStorage::new_for_agent_for_test(
+            host.agent_data_dir("child_parent_missing"),
+            "child_parent_missing",
+        )
+        .unwrap();
         child_storage
             .write_agent(&AgentState::new("child_parent_missing"))
             .unwrap();
@@ -4088,7 +4107,12 @@ mod tests {
         let (_home, host) = test_host();
         let config = host.config().as_ref().clone();
         let parent_agent_id = config.default_agent_id.clone();
-        let parent_storage = AppStorage::new(host.agent_data_dir(&parent_agent_id)).unwrap();
+        let parent_storage = AppStorage::new_for_agent(
+            host.agent_data_dir(&parent_agent_id),
+            &parent_agent_id,
+            host.runtime_db().clone(),
+        )
+        .unwrap();
         parent_storage
             .append_task(&TaskRecord {
                 id: "task-stop".into(),
@@ -4119,7 +4143,9 @@ mod tests {
         );
         host.append_agent_identity(&child).unwrap();
 
-        let child_storage = AppStorage::new(host.agent_data_dir("child_stop")).unwrap();
+        let child_storage =
+            AppStorage::new_for_agent_for_test(host.agent_data_dir("child_stop"), "child_stop")
+                .unwrap();
         child_storage
             .write_agent(&AgentState::new("child_stop"))
             .unwrap();
@@ -4182,8 +4208,12 @@ mod tests {
     #[tokio::test]
     async fn host_shutdown_preserves_public_agent_durable_status() {
         let (_home, host) = test_host();
-        let storage =
-            AppStorage::new(host.agent_data_dir(&host.config().default_agent_id)).unwrap();
+        let storage = AppStorage::new_for_agent(
+            host.agent_data_dir(&host.config().default_agent_id),
+            &host.config().default_agent_id.clone(),
+            host.runtime_db().clone(),
+        )
+        .unwrap();
         let mut state = AgentState::new(&host.config().default_agent_id);
         state.status = AgentStatus::Stopped;
         storage.write_agent(&state).unwrap();
@@ -4193,9 +4223,6 @@ mod tests {
 
         let persisted = storage.read_agent().unwrap().unwrap();
         assert_eq!(persisted.status, AgentStatus::Stopped);
-        storage
-            .enable_scheduler_control_plane_db(host.runtime_db().clone())
-            .unwrap();
         let events = storage.read_recent_events(16).unwrap();
         assert!(events
             .iter()
@@ -4247,10 +4274,6 @@ mod tests {
             .expect("aborted run should persist a terminal record");
         assert_eq!(terminal.kind, TurnTerminalKind::Aborted);
         assert_eq!(terminal.reason.as_deref(), Some("daemon_shutdown"));
-
-        storage
-            .enable_scheduler_control_plane_db(host.runtime_db().clone())
-            .unwrap();
         let events = storage.read_recent_events(32).unwrap();
         assert!(events.iter().any(|event| {
             event.kind == "runtime_service_shutdown_requested"

--- a/src/host_registry.rs
+++ b/src/host_registry.rs
@@ -27,7 +27,8 @@ struct RuntimeRegistryInner {
 
 impl RuntimeRegistry {
     pub(crate) fn new(config: AppConfig, runtime_db: RuntimeDb) -> Result<Self> {
-        let host_storage = AppStorage::new_global(config.home_dir.join("host"))?;
+        let host_storage =
+            AppStorage::new_global(config.home_dir.join("host"), runtime_db.clone())?;
         if !runtime_db.storage_domain_is_complete("workspace_entries", "db")? {
             runtime_db
                 .workspace_entries()
@@ -43,7 +44,6 @@ impl RuntimeRegistry {
                 .agent_identities()
                 .import_legacy(host_storage.read_recent_agent_identities(usize::MAX)?)?;
         }
-        host_storage.enable_scheduler_control_plane_db(runtime_db)?;
         let agent_identities = host_storage
             .latest_agent_identities()?
             .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,8 +277,12 @@ async fn handle_memory_index_command(
         } => {
             let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
             let agent_home = config.data_dir.join("agents").join(&agent);
-            let storage = AppStorage::new_for_agent(&agent_home, agent.clone())?;
+            let runtime_db = RuntimeDb::open_and_migrate(
+                config.runtime_db_path(),
+                config.runtime_db_lock_path(),
+            )?;
             if offline {
+                let storage = AppStorage::new_for_agent(&agent_home, agent.clone(), runtime_db)?;
                 rebuild_memory_index(&storage, workspace.as_deref())?;
                 println!(
                     "Rebuilt memory index for agent `{}`{} in offline mode.",
@@ -289,11 +293,7 @@ async fn handle_memory_index_command(
                         .unwrap_or_default()
                 );
             } else {
-                let runtime_db = RuntimeDb::open_and_migrate(
-                    config.runtime_db_path(),
-                    config.runtime_db_lock_path(),
-                )?;
-                storage.enable_scheduler_control_plane_db(runtime_db)?;
+                let storage = AppStorage::new_for_agent(&agent_home, agent.clone(), runtime_db)?;
                 request_memory_index_rebuild(&storage, workspace.as_deref(), "cli_rebuild")?;
                 println!(
                     "Requested memory index rebuild for agent `{}`{}; the background indexer will apply it.",
@@ -2230,7 +2230,9 @@ fn print_latency_diagnostics(
 ) -> Result<()> {
     let agent = agent.unwrap_or_else(|| config.default_agent_id.clone());
     let agent_home = config.data_dir.join("agents").join(&agent);
-    let storage = AppStorage::new_for_agent(&agent_home, agent.clone())?;
+    let runtime_db =
+        RuntimeDb::open_and_migrate(config.runtime_db_path(), config.runtime_db_lock_path())?;
+    let storage = AppStorage::new_for_agent(&agent_home, agent.clone(), runtime_db)?;
     let events = storage.read_recent_events(events_limit)?;
     let diagnostics = build_latency_diagnostics(&events, limit);
     if diagnostics.is_empty() {

--- a/src/memory/episode.rs
+++ b/src/memory/episode.rs
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn refresh_episode_memory_finalizes_on_active_work_switch() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 3;
         agent.current_turn_id = Some("turn-switch-3".into());
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn refresh_episode_memory_finalizes_on_anchor_change_within_work_item() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 4;
         agent.current_turn_id = Some("turn-anchor-review".into());
@@ -535,7 +535,7 @@ mod tests {
     #[test]
     fn refresh_episode_memory_starts_planning_anchor_without_work_item() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 2;
         agent.current_turn_id = Some("turn-planning-anchor".into());
@@ -576,7 +576,7 @@ mod tests {
     #[test]
     fn refresh_episode_memory_finalizes_on_wait_boundary() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 6;
         agent.current_turn_id = Some("turn-stable-6".into());
@@ -620,7 +620,7 @@ mod tests {
     #[test]
     fn refresh_episode_memory_skips_empty_turns_without_material_state() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 2;
         agent.total_message_count = 4;
@@ -644,7 +644,7 @@ mod tests {
     #[test]
     fn refresh_episode_memory_starts_next_builder_after_boundary_turn() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.turn_index = 5;
         agent.total_message_count = 11;

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -3022,7 +3022,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_agent_memory_and_repairs_external_edits() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         fs::write(
@@ -3061,8 +3061,8 @@ mod tests {
         let agents_dir = dir.path().join("agents");
         let alpha_home = agents_dir.join("alpha");
         let beta_home = agents_dir.join("beta");
-        let alpha = AppStorage::new(&alpha_home).unwrap();
-        let beta = AppStorage::new(&beta_home).unwrap();
+        let alpha = AppStorage::new_for_agent_for_test(&alpha_home, "alpha").unwrap();
+        let beta = AppStorage::new_for_agent_for_test(&beta_home, "beta").unwrap();
         alpha.write_agent(&AgentState::new("alpha")).unwrap();
         beta.write_agent(&AgentState::new("beta")).unwrap();
         ensure_agent_home_layout(&alpha_home).unwrap();
@@ -3123,8 +3123,8 @@ mod tests {
         let agents_dir = dir.path().join("agents");
         let alpha_home = agents_dir.join("alpha");
         let beta_home = agents_dir.join("beta");
-        let alpha = AppStorage::new(&alpha_home).unwrap();
-        let beta = AppStorage::new(&beta_home).unwrap();
+        let alpha = AppStorage::new_for_agent_for_test(&alpha_home, "alpha").unwrap();
+        let beta = AppStorage::new_for_agent_for_test(&beta_home, "beta").unwrap();
         alpha.write_agent(&AgentState::new("alpha")).unwrap();
         beta.write_agent(&AgentState::new("beta")).unwrap();
         ensure_agent_home_layout(&alpha_home).unwrap();
@@ -3174,7 +3174,7 @@ mod tests {
     #[test]
     fn memory_get_returns_exact_markdown_and_runtime_source_content() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         let markdown = "The agent now remembers 混合 搜索 diagnostics.";
@@ -3231,7 +3231,7 @@ mod tests {
     #[test]
     fn memory_get_resolves_known_runtime_refs_without_search_index_hit() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         rebuild_memory_index(&storage, None).unwrap();
@@ -3427,7 +3427,7 @@ mod tests {
     #[test]
     fn memory_get_message_refs_are_scoped_to_current_agent() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
 
         let mut other_agent_message = MessageEnvelope::new(
@@ -3453,7 +3453,7 @@ mod tests {
     #[test]
     fn ack_briefs_are_not_semantic_memory_get_sources() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let ack = brief_with_workspace(
             "default",
@@ -3478,16 +3478,13 @@ mod tests {
     #[test]
     fn memory_get_returns_db_backed_runtime_evidence_content() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
         let body = format!(
             "db backed exact evidence {}\n{}",
             "sentinel_1623",
@@ -3509,16 +3506,13 @@ mod tests {
     #[test]
     fn memory_search_consumes_runtime_outbox_without_full_rebuild() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
         let brief = brief_with_workspace(
             "default",
             BriefKind::Result,
@@ -3569,16 +3563,13 @@ mod tests {
     #[test]
     fn memory_search_status_reports_limited_runtime_outbox_consumption() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
         let consume_limit = 2;
         let changes = (0..=consume_limit)
             .map(|index| RuntimeIndexChange {
@@ -3612,7 +3603,7 @@ mod tests {
     #[test]
     fn memory_get_hydrates_transcript_backed_brief_content() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
 
         let entry = TranscriptEntry::new(
@@ -3646,7 +3637,7 @@ mod tests {
     #[test]
     fn deleting_known_memory_markdown_removes_index_row() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         let path = agent_memory_self_path(dir.path());
@@ -3672,7 +3663,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_workspace_profile_briefs_episodes_and_work_items() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -3858,7 +3849,7 @@ mod tests {
     #[test]
     fn missing_index_does_not_rebuild_all_existing_memory_sources_during_search() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -3926,7 +3917,7 @@ mod tests {
     #[test]
     fn controlled_changed_paths_repair_known_memory_markdown_only() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         fs::write(
@@ -3955,7 +3946,7 @@ mod tests {
     #[test]
     fn ordinary_workspace_markdown_is_not_indexed_as_memory() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         let workspace = dir.path().join("workspace");
@@ -3987,7 +3978,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_task_records_with_summary_and_work_item_lookup() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -4047,7 +4038,7 @@ mod tests {
     #[test]
     fn memory_search_indexes_task_records_by_command_fragment_and_digest() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -4088,7 +4079,7 @@ mod tests {
     #[test]
     fn memory_search_task_index_uses_latest_snapshot_only() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -4139,7 +4130,7 @@ mod tests {
     #[test]
     fn memory_search_task_index_full_backfill_indexes_older_task_history() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -4187,7 +4178,7 @@ mod tests {
     #[test]
     fn pending_source_queue_incrementally_upserts_new_brief_after_backfill() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -4237,7 +4228,7 @@ mod tests {
     #[test]
     fn pending_delete_removes_stale_document_and_source_state() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         fs::write(
@@ -4273,7 +4264,7 @@ mod tests {
     #[test]
     fn missing_checkpoint_does_not_force_full_backfill_recovery() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -4318,7 +4309,7 @@ mod tests {
     #[test]
     fn stale_source_state_schema_is_refreshed_by_bounded_backfill() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         storage
@@ -4397,7 +4388,7 @@ mod tests {
     #[test]
     fn rebuild_intent_marks_index_stale_and_is_consumed_by_bounded_refresh() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
         fs::write(
@@ -4443,7 +4434,7 @@ mod tests {
     #[test]
     fn extra_checkpoint_rows_do_not_hide_missing_required_backfill_kind() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_brief(&brief_with_workspace(
@@ -4484,7 +4475,7 @@ mod tests {
     #[test]
     fn memory_get_returns_latest_task_record_for_task_source_ref() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         ensure_agent_home_layout(dir.path()).unwrap();
 
@@ -4525,7 +4516,7 @@ mod tests {
     #[test]
     fn command_receipts_preserve_long_exec_command_input_for_memory_get() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let command = "python - <<'PY'\nprint('receipt_start')\nprint('sentinel_middle_line_1246')\nprint('receipt_end')\nPY";
         storage
@@ -4582,7 +4573,7 @@ mod tests {
     #[test]
     fn command_receipts_preserve_exec_command_batch_item_inputs() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let first_command = "rg -n \"MemorySearch\" src/memory/index.rs";
         let second_command = "node - <<'NODE'\nconsole.log('batch_receipt_middle_1246')\nNODE";
@@ -4639,7 +4630,7 @@ mod tests {
     #[test]
     fn pending_exec_command_batch_item_upsert_resolves_tool_execution_record() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_brief(&brief_with_workspace(
@@ -4715,7 +4706,7 @@ mod tests {
     #[test]
     fn command_output_resolves_exec_command_batch_envelope_items() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_tool_execution(&ToolExecutionRecord {
@@ -4767,7 +4758,7 @@ mod tests {
     #[test]
     fn command_output_is_retrievable_but_not_search_indexed() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_tool_execution(&ToolExecutionRecord {
@@ -4836,7 +4827,7 @@ mod tests {
     #[test]
     fn command_output_indexes_unavailable_batch_item_without_result() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_tool_execution(&ToolExecutionRecord {
@@ -4881,7 +4872,7 @@ mod tests {
     #[test]
     fn generic_tool_output_source_ref_is_indexed_and_retrievable() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         storage
             .append_tool_execution(&ToolExecutionRecord {

--- a/src/object_resolver.rs
+++ b/src/object_resolver.rs
@@ -322,7 +322,7 @@ mod tests {
 
     fn storage() -> (TempDir, AppStorage) {
         let dir = TempDir::new().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-a").unwrap();
         (dir, storage)
     }
 

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -710,14 +710,15 @@ fn prepare_runtime_storage(
     runtime_db: Option<RuntimeDb>,
 ) -> Result<PreparedRuntimeStorage> {
     let agent_id = agent_id.into();
-    let storage = AppStorage::new_for_agent(data_dir, agent_id.clone())?;
+    let runtime_dir = data_dir.join(".holon");
     let runtime_db = match runtime_db {
         Some(runtime_db) => runtime_db,
         None => RuntimeDb::open_and_migrate(
-            storage.runtime_dir().join("state/runtime.sqlite"),
-            storage.runtime_dir().join("state/runtime.lock"),
+            runtime_dir.join("state/runtime.sqlite"),
+            runtime_dir.join("state/runtime.lock"),
         )?,
     };
+    let storage = AppStorage::new_for_agent(data_dir, agent_id.clone(), runtime_db.clone())?;
     let initial_workspace = initial_workspace.into();
     let initial_workspace_entry = match &initial_workspace {
         InitialWorkspaceBinding::Entry(entry) => Some(entry.clone()),
@@ -836,7 +837,6 @@ fn prepare_runtime_storage(
             .import_legacy(storage.read_recent_context_episodes(usize::MAX)?)?;
     }
 
-    storage.enable_scheduler_control_plane_db(runtime_db.clone())?;
     let snapshot = storage.recovery_snapshot(&agent_id)?;
     let mut queue = RuntimeQueue::default();
     for message in &snapshot.replay_messages {

--- a/src/runtime/lifecycle.rs
+++ b/src/runtime/lifecycle.rs
@@ -1831,7 +1831,8 @@ mod tests {
     #[test]
     fn storage_fallback_ignores_background_only_tasks_for_waiting_reason() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let storage = AppStorage::new(temp.path().to_path_buf()).expect("storage");
+        let storage = AppStorage::new_for_agent_for_test(temp.path().to_path_buf(), "child")
+            .expect("storage");
 
         let mut agent = AgentState::new("child");
         agent.status = AgentStatus::AwakeIdle;

--- a/src/runtime/task_state_reducer.rs
+++ b/src/runtime/task_state_reducer.rs
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn stale_non_terminal_updates_are_ignored_after_terminal_status_exists() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&task("task-1", TaskStatus::Completed, true))
             .unwrap();
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn conflicting_terminal_updates_are_ignored_after_terminal_status_exists() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&task("task-1", TaskStatus::Completed, true))
             .unwrap();
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn repeated_same_terminal_updates_are_preserved_for_result_events() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&task("task-1", TaskStatus::Failed, true))
             .unwrap();
@@ -280,7 +280,7 @@ mod tests {
     #[test]
     fn stale_running_update_is_ignored_after_cancelling() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&task("task-1", TaskStatus::Cancelling, true))
             .unwrap();
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn active_tasks_do_not_block_from_legacy_wait_policy_payloads() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&scheduler_blocking_task("blocking", TaskStatus::Running))
             .unwrap();
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn active_task_projection_ignores_terminal_latest_records() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_task(&task("stale", TaskStatus::Running, true))
             .unwrap();

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -3185,7 +3185,7 @@ fn wake_hint_preserved_when_replaced_during_critical_window() {
 
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_agent_for_test(dir.path(), agent_id).unwrap();
     let rt = Runtime::new().unwrap();
 
     // Create agent with idle status and an initial wake hint

--- a/src/runtime/tests/scheduler.rs
+++ b/src/runtime/tests/scheduler.rs
@@ -253,7 +253,7 @@ fn build_scheduler_fixture(name: &str) -> (tempfile::TempDir, AppStorage, AgentS
     let tool_executions: Vec<ToolExecutionFixture> =
         read_optional_scheduler_jsonl_fixture(name, "ledger/tools.jsonl");
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = agent_fixture.current_work_item_id;
@@ -555,7 +555,7 @@ fn scheduler_projection_replays_fixture_facts() {
 #[test]
 fn compaction_events_and_briefs_do_not_change_scheduler_projection() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-active".into());
     storage.write_agent(&agent).unwrap();
@@ -620,7 +620,7 @@ fn compaction_events_and_briefs_do_not_change_scheduler_projection() {
 #[test]
 fn scheduler_projection_breaks_down_waiting_intent_scopes() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     append_active_external_wait_condition(&storage, "work-wait", "default", Some("work-1"));
@@ -637,7 +637,7 @@ fn scheduler_projection_breaks_down_waiting_intent_scopes() {
 #[test]
 fn scheduler_projection_filters_tasks_waiting_intents_and_timers_by_agent() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     let now = Utc::now();
@@ -691,7 +691,7 @@ fn scheduler_projection_filters_tasks_waiting_intents_and_timers_by_agent() {
 #[test]
 fn idle_boundary_decision_prefers_controlled_status_over_wait_facts() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Stopped;
     storage.write_agent(&agent).unwrap();
@@ -706,7 +706,7 @@ fn idle_boundary_decision_prefers_controlled_status_over_wait_facts() {
 #[test]
 fn idle_boundary_decision_inspects_wait_facts_while_asleep() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Asleep;
     storage.write_agent(&agent).unwrap();
@@ -724,7 +724,7 @@ fn idle_boundary_decision_inspects_wait_facts_while_asleep() {
 #[test]
 fn idle_boundary_decision_waits_for_non_current_work_item_wait() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Asleep;
     storage.write_agent(&agent).unwrap();
@@ -770,7 +770,7 @@ fn idle_boundary_decision_waits_for_non_current_work_item_wait() {
 #[test]
 fn idle_boundary_decision_does_not_treat_asleep_with_queued_input_as_idle() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Asleep;
     agent.pending = 1;
@@ -785,7 +785,7 @@ fn idle_boundary_decision_does_not_treat_asleep_with_queued_input_as_idle() {
 #[test]
 fn idle_boundary_decision_reactivates_runnable_work_while_asleep() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Asleep;
     agent.current_work_item_id = Some("work-current".into());
@@ -809,7 +809,7 @@ fn idle_boundary_decision_reactivates_runnable_work_while_asleep() {
 #[test]
 fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     let mut work_item = WorkItemRecord::new("default", "continue work", WorkItemState::Open);
@@ -871,7 +871,7 @@ fn decide_next_action_prioritizes_wake_hint_over_work_queue_but_not_wait_facts()
 #[test]
 fn queued_runnable_work_is_not_suppressed_by_unrelated_agent_waiting_intent() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
 
@@ -910,7 +910,7 @@ fn queued_runnable_work_is_not_suppressed_by_unrelated_agent_waiting_intent() {
 #[test]
 fn background_work_item_task_does_not_block_runnable_work() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-background".into());
     storage.write_agent(&agent).unwrap();
@@ -947,7 +947,7 @@ fn background_work_item_task_does_not_block_runnable_work() {
 #[test]
 fn scheduling_diagnostics_detect_idle_posture_with_runnable_work() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     let work_item = WorkItemRecord::new("default", "runnable work", WorkItemState::Open);
     agent.current_work_item_id = Some(work_item.id.clone());
@@ -984,7 +984,7 @@ fn scheduling_diagnostics_detect_idle_posture_with_runnable_work() {
 #[test]
 fn scheduling_diagnostics_detect_weak_external_wait_and_unrecoverable_blocker() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     let now = Utc::now();
@@ -1042,7 +1042,7 @@ fn scheduling_diagnostics_detect_weak_external_wait_and_unrecoverable_blocker() 
 #[test]
 fn scheduling_diagnostics_use_authoritative_queue_len() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
 
@@ -1060,7 +1060,7 @@ fn scheduling_diagnostics_use_authoritative_queue_len() {
 #[test]
 fn scheduling_diagnostics_do_not_warn_for_common_legal_waits() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     let now = Utc::now();
@@ -1110,7 +1110,7 @@ fn scheduling_diagnostics_do_not_warn_for_common_legal_waits() {
 #[test]
 fn scheduler_diagnostic_append_dedupes_interleaved_recent_events() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     let now = Utc::now();
@@ -1158,7 +1158,7 @@ fn scheduler_diagnostic_append_dedupes_interleaved_recent_events() {
 #[test]
 fn decide_next_action_records_duplicate_tick_evidence() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     let mut work_item = WorkItemRecord::new("default", "queued work", WorkItemState::Open);
@@ -1224,7 +1224,7 @@ fn scheduler_decision_event_records_evidence_and_bindings() {
 #[test]
 fn legacy_child_agent_task_kinds_do_not_gate_scheduler_wait_for_task() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let agent = AgentState::new("default");
     storage.write_agent(&agent).unwrap();
     let now = Utc::now();
@@ -1281,7 +1281,7 @@ fn legacy_child_agent_task_kinds_do_not_gate_scheduler_wait_for_task() {
 #[test]
 fn scheduler_decision_append_dedupes_identical_latest_event() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let decision = scheduler::SchedulerDecision::new(
         scheduler::SchedulerDecisionKind::WaitForExternalChange,
         "active_waiting_intents",
@@ -1400,7 +1400,7 @@ fn setup_waiting_operator_work_item(
 #[test]
 fn waiting_operator_with_expired_unconsumed_recheck_lets_agent_wake() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-recheck-expired".into());
     storage.write_agent(&agent).unwrap();
@@ -1431,7 +1431,7 @@ fn waiting_operator_with_expired_unconsumed_recheck_lets_agent_wake() {
 #[test]
 fn waiting_operator_with_expired_but_consumed_recheck_still_waits() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-recheck-consumed".into());
     storage.write_agent(&agent).unwrap();
@@ -1462,7 +1462,7 @@ fn waiting_operator_with_expired_but_consumed_recheck_still_waits() {
 #[test]
 fn waiting_operator_with_future_recheck_still_waits() {
     let dir = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.current_work_item_id = Some("work-recheck-future".into());
     storage.write_agent(&agent).unwrap();

--- a/src/runtime/tests/task_recovery.rs
+++ b/src/runtime/tests/task_recovery.rs
@@ -270,7 +270,7 @@ async fn malformed_task_message_does_not_exit_runtime_loop() {
 async fn runtime_interrupts_inflight_task_after_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     storage
         .append_task(&TaskRecord {
             id: "sleep-recover".into(),
@@ -379,7 +379,7 @@ async fn runtime_interrupts_inflight_task_after_restart() {
 async fn recovered_agent_with_none_workspace_initializes_active_entry() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
     // Create a recovered agent state without active_workspace_entry
     let mut agent = AgentState::new("default");
@@ -421,7 +421,7 @@ async fn recovered_agent_with_none_workspace_initializes_active_entry() {
 async fn recovered_agent_with_missing_worktree_clears_workspace_fields() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
     // Create a recovered agent with missing worktree session
     let mut agent = AgentState::new("default");

--- a/src/runtime/tests/timers.rs
+++ b/src/runtime/tests/timers.rs
@@ -5,7 +5,7 @@ use super::support::*;
 async fn runtime_fires_overdue_timer_after_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     storage
         .append_timer(&TimerRecord {
             id: "timer-recover".into(),
@@ -50,7 +50,7 @@ async fn runtime_fires_overdue_timer_after_restart() {
 async fn runtime_recovers_active_timer_without_next_fire_at() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     storage
         .append_timer(&TimerRecord {
             id: "timer-missing-next-fire".into(),

--- a/src/runtime/tests/wake_hints.rs
+++ b/src/runtime/tests/wake_hints.rs
@@ -6,7 +6,7 @@ use crate::ingress::{WakeDisposition, WakeHint};
 async fn runtime_emits_pending_wake_hint_as_system_tick_on_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut agent = AgentState::new("default");
     agent.status = AgentStatus::Asleep;
     agent.pending_wake_hint = Some(PendingWakeHint {
@@ -52,7 +52,7 @@ async fn runtime_emits_pending_wake_hint_as_system_tick_on_restart() {
 async fn recovered_duplicate_wake_hint_clears_pending_without_new_tick() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let pending = PendingWakeHint {
         reason: "restart duplicate wake".into(),
         description: None,
@@ -190,7 +190,7 @@ async fn triggered_wake_hint_records_scheduler_decision_before_tick() {
 async fn runtime_emits_work_queue_system_tick_for_active_item_on_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let active = WorkItemRecord::new(
         "default",
         "continue active runtime cleanup",
@@ -232,7 +232,7 @@ async fn runtime_emits_work_queue_system_tick_for_active_item_on_restart() {
 async fn idle_tick_prefers_current_work_item_over_queued_work_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let active = WorkItemRecord::new(
         "default",
         "continue active runtime cleanup",
@@ -289,7 +289,7 @@ async fn idle_tick_prefers_current_work_item_over_queued_work_item() {
 async fn idle_tick_suppresses_continue_active_after_model_reentry_task_result() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let active = WorkItemRecord::new(
         "default",
         "continue active runtime cleanup",
@@ -343,7 +343,7 @@ async fn idle_tick_suppresses_continue_active_after_model_reentry_task_result() 
 async fn idle_tick_prefers_pending_wake_hint_over_work_queue_tick() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let active = WorkItemRecord::new(
         "default",
         "continue active runtime cleanup",
@@ -406,7 +406,7 @@ async fn idle_tick_prefers_pending_wake_hint_over_work_queue_tick() {
 async fn runtime_surfaces_queued_work_item_with_work_queue_system_tick_on_restart() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let queued = WorkItemRecord::new(
         "default",
         "surface queued runtime cleanup",

--- a/src/runtime/tests/work_items.rs
+++ b/src/runtime/tests/work_items.rs
@@ -5,7 +5,6 @@ use crate::types::{
     WorkItemContinuationState, WorkItemPlanStatus, WorkItemReadiness, WorkItemSchedulingState,
     AGENT_HOME_WORKSPACE_ID,
 };
-use std::{fs::OpenOptions, io::Write};
 
 fn legacy_blocking_payload_task_for_work_item(
     task_id: &str,
@@ -307,7 +306,7 @@ async fn update_work_item_sets_and_preserves_blocked_recheck_deadline() {
 async fn runtime_wakes_itself_for_blocked_work_item_recheck_deadline() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut blocked = WorkItemRecord::new(
         "default",
         "blocked work with fallback recheck",
@@ -1535,20 +1534,6 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
     let mut legacy = WorkItemRecord::new("default", "Migrate inline plan", WorkItemState::Open);
     legacy.id = "legacy-plan-item".into();
     legacy.legacy_inline_plan = Some("Keep this legacy plan body in the artifact.".into());
-    let mut legacy_json = serde_json::to_value(&legacy).unwrap();
-    legacy_json["plan"] = serde_json::json!("Keep this legacy plan body in the artifact.");
-    let work_items_path = dir
-        .path()
-        .join(".holon")
-        .join("ledger")
-        .join("work_items.jsonl");
-    std::fs::create_dir_all(work_items_path.parent().unwrap()).unwrap();
-    let mut work_items_file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&work_items_path)
-        .unwrap();
-    writeln!(work_items_file, "{}", legacy_json).unwrap();
 
     let runtime = RuntimeHandle::new(
         "default",
@@ -1560,6 +1545,15 @@ async fn update_work_item_materializes_and_clears_legacy_inline_plan() {
         context_config(),
     )
     .unwrap();
+
+    runtime.storage().append_work_item(&legacy).unwrap();
+
+    // legacy_inline_plan has skip_serializing, so it is stripped on DB write.
+    // Write the plan body to the artifact file directly, simulating the
+    // materialization that occurs during legacy JSONL import.
+    let plan_path = crate::work_item_plan::plan_path(runtime.agent_home().as_path(), &legacy.id);
+    std::fs::create_dir_all(plan_path.parent().unwrap()).unwrap();
+    std::fs::write(&plan_path, "Keep this legacy plan body in the artifact.").unwrap();
 
     let updated = runtime
         .update_work_item_fields(
@@ -4323,7 +4317,7 @@ async fn reconcile_waiting_contract_keeps_waits_when_anchor_is_newly_established
 async fn current_closure_reports_continuable_for_current_work_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let active = WorkItemRecord::new(
         "default",
         "continue active runtime cleanup",
@@ -4362,7 +4356,7 @@ async fn current_closure_reports_continuable_for_current_work_item() {
 async fn current_needs_input_work_item_waits_for_operator_without_work_signal() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut active = WorkItemRecord::new(
         "default",
         "choose implementation direction",
@@ -4409,7 +4403,7 @@ async fn current_needs_input_work_item_waits_for_operator_without_work_signal() 
 async fn current_external_wait_does_not_suppress_queued_runnable_work_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let current = WorkItemRecord::new(
         "default",
         "waiting for external review",
@@ -4477,7 +4471,7 @@ async fn current_external_wait_does_not_suppress_queued_runnable_work_item() {
 async fn current_closure_reports_continuable_for_queued_work_item_without_active_item() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let queued = WorkItemRecord::new(
         "default",
         "surface queued runtime cleanup",
@@ -4513,7 +4507,7 @@ async fn current_closure_reports_continuable_for_queued_work_item_without_active
 async fn queued_needs_input_work_item_is_not_runnable() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let mut queued =
         WorkItemRecord::new("default", "waiting planning candidate", WorkItemState::Open);
     queued.plan_status = WorkItemPlanStatus::NeedsInput;
@@ -4546,7 +4540,7 @@ async fn queued_needs_input_work_item_is_not_runnable() {
 async fn queued_notification_keeps_working_memory_unfocused_before_pick() {
     let dir = tempdir().unwrap();
     let workspace = tempdir().unwrap();
-    let storage = AppStorage::new(dir.path()).unwrap();
+    let storage = AppStorage::new_for_test(dir.path()).unwrap();
     let queued = WorkItemRecord::new("default", "queued runtime cleanup", WorkItemState::Open);
     storage.append_work_item(&queued).unwrap();
 

--- a/src/runtime/tests/workspace.rs
+++ b/src/runtime/tests/workspace.rs
@@ -154,7 +154,7 @@ async fn runtime_startup_migrates_legacy_agent_home_attachment_alias() {
     let dir = tempdir().unwrap();
     let agent_id = "default";
     let canonical_agent_home_id = crate::types::agent_home_workspace_id(agent_id);
-    let storage = crate::storage::AppStorage::new_for_agent(dir.path(), agent_id).unwrap();
+    let storage = crate::storage::AppStorage::new_for_agent_for_test(dir.path(), agent_id).unwrap();
     let preserved_cwd = dir.path().join("notes");
     std::fs::create_dir_all(&preserved_cwd).unwrap();
     let mut state = crate::types::AgentState::new(agent_id);

--- a/src/storage/legacy_jsonl.rs
+++ b/src/storage/legacy_jsonl.rs
@@ -7,101 +7,10 @@ use std::{
     path::Path,
 };
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
-
-use chrono::Utc;
-
-pub(crate) fn migrate_events_ledger(path: &Path) -> Result<u64> {
-    if !path.exists() {
-        return Ok(0);
-    }
-    if let Some(seq) = read_tail_event_seq(path)? {
-        return Ok(seq);
-    }
-
-    let timestamp = Utc::now().format("%Y%m%d%H%M%S%3f");
-    let tmp_path = path.with_file_name(format!(".events.jsonl.{timestamp}.tmp"));
-    let file =
-        fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let mut tmp = fs::File::create(&tmp_path)
-        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
-    let mut max_seq = 0;
-    let mut changed = false;
-
-    for line in BufReader::new(file).lines() {
-        let line = line.with_context(|| format!("failed to read {}", path.display()))?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        let mut value: Value = serde_json::from_str(&line)?;
-        let object = value
-            .as_object_mut()
-            .ok_or_else(|| anyhow::anyhow!("event ledger line is not a JSON object"))?;
-        match object.get("event_seq").and_then(Value::as_u64) {
-            Some(seq) if seq > max_seq => {
-                max_seq = seq;
-            }
-            Some(seq) => {
-                anyhow::bail!(
-                    "event ledger sequence must be strictly increasing; found {seq} after {max_seq}"
-                );
-            }
-            None => {
-                max_seq += 1;
-                object.insert("event_seq".to_string(), Value::from(max_seq));
-                changed = true;
-            }
-        }
-        writeln!(tmp, "{}", serde_json::to_string(&value)?)?;
-    }
-
-    if !changed {
-        let _ = fs::remove_file(&tmp_path);
-        return Ok(max_seq);
-    }
-
-    let backup_path = path.with_file_name(format!("events.jsonl.bak.{timestamp}"));
-    fs::copy(path, &backup_path).with_context(|| {
-        format!(
-            "failed to back up {} to {}",
-            path.display(),
-            backup_path.display()
-        )
-    })?;
-    fs::rename(&tmp_path, path).with_context(|| {
-        format!(
-            "failed to replace {} with {}",
-            path.display(),
-            tmp_path.display()
-        )
-    })?;
-    Ok(max_seq)
-}
-
-pub(crate) fn read_tail_event_seq(path: &Path) -> Result<Option<u64>> {
-    let Some(value) = read_latest_jsonl_matching::<Value, _>(path, |_| true)? else {
-        return Ok(Some(0));
-    };
-    Ok(value.get("event_seq").and_then(Value::as_u64))
-}
-
-pub(crate) fn max_jsonl_u64_field(path: &Path, field: &str) -> Result<u64> {
-    if !path.exists() {
-        return Ok(0);
-    }
-
-    let mut max_value = None;
-    scan_jsonl_reverse::<Value, _>(path, |value| {
-        if let Some(sequence) = value.get(field).and_then(Value::as_u64) {
-            max_value = Some(sequence);
-            return false;
-        }
-        true
-    })?;
-    Ok(max_value.unwrap_or(0))
-}
 
 pub(crate) fn jsonl_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
     let line = serde_json::to_string(value)?;
@@ -305,4 +214,94 @@ where
     } else {
         Ok(None)
     }
+}
+
+pub(crate) fn migrate_events_ledger(path: &Path) -> Result<u64> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    if let Some(seq) = read_tail_event_seq(path)? {
+        return Ok(seq);
+    }
+
+    let timestamp = Utc::now().format("%Y%m%d%H%M%S%3f");
+    let tmp_path = path.with_file_name(format!(".events.jsonl.{timestamp}.tmp"));
+    let file =
+        fs::File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut tmp = fs::File::create(&tmp_path)
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+    let mut max_seq = 0;
+    let mut changed = false;
+
+    for line in BufReader::new(file).lines() {
+        let line = line.with_context(|| format!("failed to read {}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut value: Value = serde_json::from_str(&line)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| anyhow!("event ledger line is not a JSON object"))?;
+        match object.get("event_seq").and_then(Value::as_u64) {
+            Some(seq) if seq > max_seq => {
+                max_seq = seq;
+            }
+            Some(seq) => {
+                anyhow::bail!(
+                    "event ledger sequence must be strictly increasing; found {seq} after {max_seq}"
+                );
+            }
+            None => {
+                max_seq += 1;
+                object.insert("event_seq".to_string(), Value::from(max_seq));
+                changed = true;
+            }
+        }
+        writeln!(tmp, "{}", serde_json::to_string(&value)?)?;
+    }
+
+    if !changed {
+        let _ = fs::remove_file(&tmp_path);
+        return Ok(max_seq);
+    }
+
+    let backup_path = path.with_file_name(format!("events.jsonl.bak.{timestamp}"));
+    fs::copy(path, &backup_path).with_context(|| {
+        format!(
+            "failed to back up {} to {}",
+            path.display(),
+            backup_path.display()
+        )
+    })?;
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed to replace {} with {}",
+            path.display(),
+            tmp_path.display()
+        )
+    })?;
+    Ok(max_seq)
+}
+
+pub(crate) fn read_tail_event_seq(path: &Path) -> Result<Option<u64>> {
+    let Some(value) = read_latest_jsonl_matching::<Value, _>(path, |_| true)? else {
+        return Ok(Some(0));
+    };
+    Ok(value.get("event_seq").and_then(Value::as_u64))
+}
+
+pub(crate) fn max_jsonl_u64_field(path: &Path, field: &str) -> Result<u64> {
+    if !path.exists() {
+        return Ok(0);
+    }
+
+    let mut max_value = None;
+    scan_jsonl_reverse::<Value, _>(path, |value| {
+        if let Some(sequence) = value.get(field).and_then(Value::as_u64) {
+            max_value = Some(sequence);
+            return false;
+        }
+        true
+    })?;
+    Ok(max_value.unwrap_or(0))
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -53,8 +53,7 @@ pub use work_queue::{
 use activity::file_activity_marker;
 use legacy_jsonl::{
     append_jsonl_bytes, jsonl_bytes, max_jsonl_u64_field, migrate_events_ledger, read_jsonl_from,
-    read_latest_jsonl_matching, read_recent_jsonl, read_tail_event_seq, scan_jsonl_reverse,
-    take_recent,
+    read_latest_jsonl_matching, read_recent_jsonl, scan_jsonl_reverse, take_recent,
 };
 use memory::memory_index_agent_key;
 use recovery::external_wait_recoverability_event;
@@ -70,6 +69,8 @@ pub struct AppStorage {
     data_dir: PathBuf,
     agent_id: Option<String>,
     read_only: bool,
+    // Legacy JSONL path fields retained while dead fallback code is removed.
+    // These are no longer used for runtime reads/writes — DB is canonical.
     events_path: PathBuf,
     briefs_path: PathBuf,
     messages_path: PathBuf,
@@ -99,7 +100,8 @@ pub struct AppStorage {
     message_seq_counter: Arc<Mutex<u64>>,
     transcript_seq_counter: Arc<Mutex<u64>>,
     audit_event_index: Arc<Mutex<Option<AuditEventIndexSink>>>,
-    scheduler_control_plane_db: Arc<Mutex<Option<RuntimeDb>>>,
+    runtime_db: RuntimeDb,
+    db_canonical: bool,
     event_bus: Arc<Mutex<Option<EventBus>>>,
 }
 
@@ -116,48 +118,140 @@ enum StorageOpenMode {
 }
 
 impl AppStorage {
-    pub fn new(data_dir: impl Into<PathBuf>) -> Result<Self> {
+    pub fn new(data_dir: impl Into<PathBuf>, runtime_db: RuntimeDb) -> Result<Self> {
         let data_dir = data_dir.into();
         let agent_id = infer_agent_id_from_data_dir(&data_dir);
-        Self::new_with_scope(data_dir, agent_id)
+        Self::new_with_scope(data_dir, agent_id, runtime_db)
+    }
+
+    /// Test-only constructor that opens its own RuntimeDb from the data dir.
+    pub fn new_for_test(data_dir: impl Into<PathBuf>) -> Result<Self> {
+        let data_dir = data_dir.into();
+        let runtime_dir = data_dir.join(RUNTIME_DIR);
+        let runtime_db = RuntimeDb::open_and_migrate(
+            runtime_dir.join("state/runtime.sqlite"),
+            runtime_dir.join("state/runtime.lock"),
+        )?;
+        Self::new_for_agent(data_dir, "default".to_string(), runtime_db)
+    }
+
+    /// Test-only constructor that uses JSONL-only storage (no DB canonical).
+    /// Preserves the old `AppStorage::new(dir.path())` behavior for tests
+    /// that explicitly test legacy JSONL read/write/migration paths.
+    pub fn new_jsonl_only(data_dir: impl Into<PathBuf>) -> Result<Self> {
+        let data_dir = data_dir.into();
+        let runtime_dir = data_dir.join(RUNTIME_DIR);
+        let runtime_db = RuntimeDb::open_and_migrate(
+            runtime_dir.join("state/runtime.sqlite"),
+            runtime_dir.join("state/runtime.lock"),
+        )?;
+        let mut storage = Self::new(data_dir, runtime_db)?;
+        storage.db_canonical = false;
+        // Re-initialize seq counters from JSONL for legacy compatibility
+        let event_seq = migrate_events_ledger(&storage.events_path)?;
+        let msg_seq = max_jsonl_u64_field(&storage.messages_path, "message_seq")?;
+        let transcript_seq = max_jsonl_u64_field(&storage.transcript_path, "transcript_seq")?;
+        *storage.event_seq_counter.lock().unwrap() = event_seq;
+        *storage.message_seq_counter.lock().unwrap() = msg_seq;
+        *storage.transcript_seq_counter.lock().unwrap() = transcript_seq;
+        Ok(storage)
+    }
+
+    /// Test-only agent-scoped constructor that uses JSONL-only storage.
+    pub fn new_for_agent_jsonl_only(
+        data_dir: impl Into<PathBuf>,
+        agent_id: impl Into<String>,
+    ) -> Result<Self> {
+        let data_dir = data_dir.into();
+        let runtime_dir = data_dir.join(RUNTIME_DIR);
+        let runtime_db = RuntimeDb::open_and_migrate(
+            runtime_dir.join("state/runtime.sqlite"),
+            runtime_dir.join("state/runtime.lock"),
+        )?;
+        let mut storage = Self::new_for_agent(data_dir, agent_id.into(), runtime_db)?;
+        storage.db_canonical = false;
+        let event_seq = migrate_events_ledger(&storage.events_path)?;
+        let msg_seq = max_jsonl_u64_field(&storage.messages_path, "message_seq")?;
+        let transcript_seq = max_jsonl_u64_field(&storage.transcript_path, "transcript_seq")?;
+        *storage.event_seq_counter.lock().unwrap() = event_seq;
+        *storage.message_seq_counter.lock().unwrap() = msg_seq;
+        *storage.transcript_seq_counter.lock().unwrap() = transcript_seq;
+        Ok(storage)
+    }
+
+    /// Test-only agent-scoped constructor that opens its own RuntimeDb.
+    pub fn new_for_agent_for_test(
+        data_dir: impl Into<PathBuf>,
+        agent_id: impl Into<String>,
+    ) -> Result<Self> {
+        let data_dir = data_dir.into();
+        let runtime_dir = data_dir.join(RUNTIME_DIR);
+        let runtime_db = RuntimeDb::open_and_migrate(
+            runtime_dir.join("state/runtime.sqlite"),
+            runtime_dir.join("state/runtime.lock"),
+        )?;
+        Self::new_for_agent(data_dir, agent_id, runtime_db)
+    }
+
+    /// Test-only global constructor that opens its own RuntimeDb.
+    pub fn new_global_for_test(data_dir: impl Into<PathBuf>) -> Result<Self> {
+        let data_dir = data_dir.into();
+        let runtime_dir = data_dir.join(RUNTIME_DIR);
+        let runtime_db = RuntimeDb::open_and_migrate(
+            runtime_dir.join("state/runtime.sqlite"),
+            runtime_dir.join("state/runtime.lock"),
+        )?;
+        Self::new_global(data_dir, runtime_db)
     }
 
     pub fn new_for_agent(
         data_dir: impl Into<PathBuf>,
         agent_id: impl Into<String>,
+        runtime_db: RuntimeDb,
     ) -> Result<Self> {
         let agent_id = agent_id.into();
         anyhow::ensure!(
             !agent_id.trim().is_empty(),
             "agent-scoped storage requires a non-empty agent id"
         );
-        Self::new_with_scope(data_dir, Some(agent_id))
+        Self::new_with_scope(data_dir, Some(agent_id), runtime_db)
     }
 
     pub fn open_read_only_for_agent(
         data_dir: impl Into<PathBuf>,
         agent_id: impl Into<String>,
+        runtime_db: RuntimeDb,
     ) -> Result<Self> {
         let agent_id = agent_id.into();
         anyhow::ensure!(
             !agent_id.trim().is_empty(),
             "agent-scoped storage requires a non-empty agent id"
         );
-        Self::new_with_scope_options(data_dir, Some(agent_id), StorageOpenMode::ReadOnly)
+        Self::new_with_scope_options(
+            data_dir,
+            Some(agent_id),
+            StorageOpenMode::ReadOnly,
+            runtime_db,
+        )
     }
 
-    pub fn new_global(data_dir: impl Into<PathBuf>) -> Result<Self> {
-        Self::new_with_scope(data_dir, None)
+    pub fn new_global(data_dir: impl Into<PathBuf>, runtime_db: RuntimeDb) -> Result<Self> {
+        Self::new_with_scope(data_dir, None, runtime_db)
     }
 
-    fn new_with_scope(data_dir: impl Into<PathBuf>, agent_id: Option<String>) -> Result<Self> {
-        Self::new_with_scope_options(data_dir, agent_id, StorageOpenMode::ReadWrite)
+    fn new_with_scope(
+        data_dir: impl Into<PathBuf>,
+        agent_id: Option<String>,
+        runtime_db: RuntimeDb,
+    ) -> Result<Self> {
+        Self::new_with_scope_options(data_dir, agent_id, StorageOpenMode::ReadWrite, runtime_db)
     }
 
     fn new_with_scope_options(
         data_dir: impl Into<PathBuf>,
         agent_id: Option<String>,
         mode: StorageOpenMode,
+        runtime_db: RuntimeDb,
     ) -> Result<Self> {
         let data_dir = data_dir.into();
         let runtime_dir = data_dir.join(RUNTIME_DIR);
@@ -177,22 +271,20 @@ impl AppStorage {
             }
         }
 
-        let events_path = ledger_dir.join("events.jsonl");
-        let messages_path = ledger_dir.join("messages.jsonl");
-        let transcript_path = ledger_dir.join("transcript.jsonl");
-        let event_seq_counter = match mode {
-            StorageOpenMode::ReadWrite => migrate_events_ledger(&events_path)?,
-            StorageOpenMode::ReadOnly => read_tail_event_seq(&events_path)?.unwrap_or(0),
-        };
-        let message_seq_counter = max_jsonl_u64_field(&messages_path, "message_seq")?;
-        let transcript_seq_counter = max_jsonl_u64_field(&transcript_path, "transcript_seq")?;
+        let event_seq_counter = runtime_db
+            .audit_events()
+            .max_event_seq(agent_id.as_deref())?;
+        let message_seq_counter = runtime_db.messages().max_message_seq(agent_id.as_deref())?;
+        let transcript_seq_counter = runtime_db
+            .transcript_entries()
+            .max_transcript_seq(agent_id.as_deref())?;
 
         Ok(Self {
             agent_id,
             read_only: mode == StorageOpenMode::ReadOnly,
-            events_path,
+            events_path: ledger_dir.join("events.jsonl"),
             briefs_path: ledger_dir.join("briefs.jsonl"),
-            messages_path,
+            messages_path: ledger_dir.join("messages.jsonl"),
             tasks_path: ledger_dir.join("tasks.jsonl"),
             work_items_path: ledger_dir.join("work_items.jsonl"),
             delivery_summaries_path: ledger_dir.join("delivery_summaries.jsonl"),
@@ -201,7 +293,7 @@ impl AppStorage {
             timers_path: ledger_dir.join("timers.jsonl"),
             tools_path: ledger_dir.join("tools.jsonl"),
             turns_path: ledger_dir.join("turns.jsonl"),
-            transcript_path,
+            transcript_path: ledger_dir.join("transcript.jsonl"),
             queue_entries_path: ledger_dir.join("queue_entries.jsonl"),
             waiting_intents_path: ledger_dir.join("waiting_intents.jsonl"),
             wait_conditions_path: ledger_dir.join("wait_conditions.jsonl"),
@@ -219,7 +311,8 @@ impl AppStorage {
             message_seq_counter: Arc::new(Mutex::new(message_seq_counter)),
             transcript_seq_counter: Arc::new(Mutex::new(transcript_seq_counter)),
             audit_event_index: Arc::new(Mutex::new(None)),
-            scheduler_control_plane_db: Arc::new(Mutex::new(None)),
+            runtime_db,
+            db_canonical: true,
             event_bus: Arc::new(Mutex::new(None)),
             data_dir,
         })
@@ -247,45 +340,6 @@ impl AppStorage {
             runtime_db,
             agent_id,
         });
-        Ok(())
-    }
-
-    pub fn enable_scheduler_control_plane_db(&self, runtime_db: RuntimeDb) -> Result<()> {
-        let agent_id = self.current_agent_id()?;
-        {
-            let mut counter = self
-                .message_seq_counter
-                .lock()
-                .map_err(|_| anyhow::anyhow!("message sequence counter mutex poisoned"))?;
-            *counter = (*counter).max(runtime_db.messages().max_message_seq(agent_id.as_deref())?);
-        }
-        {
-            let mut counter = self
-                .transcript_seq_counter
-                .lock()
-                .map_err(|_| anyhow::anyhow!("transcript sequence counter mutex poisoned"))?;
-            *counter = (*counter).max(
-                runtime_db
-                    .transcript_entries()
-                    .max_transcript_seq(agent_id.as_deref())?,
-            );
-        }
-        {
-            let mut counter = self
-                .event_seq_counter
-                .lock()
-                .map_err(|_| anyhow::anyhow!("event sequence counter mutex poisoned"))?;
-            *counter = (*counter).max(
-                runtime_db
-                    .audit_events()
-                    .max_event_seq(agent_id.as_deref())?,
-            );
-        }
-        let mut guard = self
-            .scheduler_control_plane_db
-            .lock()
-            .map_err(|_| anyhow::anyhow!("scheduler control-plane db mutex poisoned"))?;
-        *guard = Some(runtime_db);
         Ok(())
     }
 
@@ -324,12 +378,15 @@ impl AppStorage {
         Ok(())
     }
 
+    /// Returns the runtime database. Always succeeds because RuntimeDb is now
+    /// mandatory — kept for compatibility with existing `if let Some(db)` patterns
+    /// while JSONL fallback code is removed incrementally.
     fn scheduler_control_plane_db(&self) -> Result<Option<RuntimeDb>> {
-        Ok(self
-            .scheduler_control_plane_db
-            .lock()
-            .map_err(|_| anyhow::anyhow!("scheduler control-plane db mutex poisoned"))?
-            .clone())
+        if self.db_canonical {
+            Ok(Some(self.runtime_db.clone()))
+        } else {
+            Ok(None)
+        }
     }
 
     #[cfg(test)]
@@ -342,9 +399,7 @@ impl AppStorage {
         {
             sink.runtime_db.flush_background_writes_for_tests()?;
         }
-        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            runtime_db.flush_background_writes_for_tests()?;
-        }
+        self.runtime_db.flush_background_writes_for_tests()?;
         Ok(())
     }
 
@@ -476,24 +531,22 @@ impl AppStorage {
             return Ok(());
         }
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
-            if runtime_db.storage_domain_is_complete("audit_events", "db")? {
-                let agent_id = self.current_agent_id()?;
-                if let Err(error) = runtime_db
-                    .audit_events()
-                    .append(agent_id.as_deref(), &event)
-                {
-                    tracing::warn!(
-                        error = %error,
-                        event_id = %event.id,
-                        event_kind = %event.kind,
-                        event_seq = event.event_seq,
-                        agent_id = agent_id.as_deref().unwrap_or("<global>"),
-                        "failed to enqueue runtime db audit event"
-                    );
-                }
-                self.publish_event(agent_id, &event)?;
-                return Ok(());
+            let agent_id = self.current_agent_id()?;
+            if let Err(error) = runtime_db
+                .audit_events()
+                .append(agent_id.as_deref(), &event)
+            {
+                tracing::warn!(
+                    error = %error,
+                    event_id = %event.id,
+                    event_kind = %event.kind,
+                    event_seq = event.event_seq,
+                    agent_id = agent_id.as_deref().unwrap_or("<global>"),
+                    "failed to enqueue runtime db audit event"
+                );
             }
+            self.publish_event(agent_id, &event)?;
+            return Ok(());
         }
         let line = serde_json::to_string(&event)?;
         let mut bytes = Vec::with_capacity(line.len() + 1);
@@ -507,11 +560,12 @@ impl AppStorage {
     pub fn append_brief(&self, brief: &BriefRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             let changes = self.index_changes_for_brief(brief)?;
-            return runtime_db
+            runtime_db
                 .evidence()
-                .append_brief_with_index_changes(brief, &changes);
+                .append_brief_with_index_changes(brief, &changes)?;
+        } else {
+            self.append_jsonl(&self.briefs_path, brief)?;
         }
-        self.append_jsonl(&self.briefs_path, brief)?;
         self.enqueue_memory_index_brief_best_effort(brief)
     }
 
@@ -534,10 +588,10 @@ impl AppStorage {
                 runtime_db
                     .messages()
                     .upsert_with_index_changes(&message, &changes)?;
-                return Ok(());
+            } else {
+                let bytes = jsonl_bytes(&message)?;
+                append_jsonl_bytes(&self.messages_path, &bytes)?;
             }
-            let bytes = jsonl_bytes(&message)?;
-            append_jsonl_bytes(&self.messages_path, &bytes)?;
         }
         self.enqueue_memory_index_message_best_effort(&message)
     }
@@ -545,9 +599,12 @@ impl AppStorage {
     pub fn append_task(&self, task: &TaskRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             let changes = self.index_changes_for_task(task)?;
-            return runtime_db.tasks().upsert_with_index_changes(task, &changes);
+            runtime_db
+                .tasks()
+                .upsert_with_index_changes(task, &changes)?;
+        } else {
+            self.append_jsonl(&self.tasks_path, task)?;
         }
-        self.append_jsonl(&self.tasks_path, task)?;
         self.enqueue_memory_index_task_best_effort(task)
     }
 
@@ -559,13 +616,12 @@ impl AppStorage {
                 .as_deref()
                 == Some(record.id.as_str());
             let changes = self.index_changes_for_work_item(record)?;
-            return runtime_db.work_items().upsert_with_index_changes(
-                record,
-                current_focus,
-                &changes,
-            );
+            runtime_db
+                .work_items()
+                .upsert_with_index_changes(record, current_focus, &changes)?;
+        } else {
+            self.append_jsonl(&self.work_items_path, record)?;
         }
-        self.append_jsonl(&self.work_items_path, record)?;
         self.enqueue_memory_index_work_item_best_effort(record)
     }
 
@@ -604,11 +660,12 @@ impl AppStorage {
     pub fn append_tool_execution(&self, record: &ToolExecutionRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             let changes = self.index_changes_for_tool_execution(record)?;
-            return runtime_db
+            runtime_db
                 .evidence()
-                .append_tool_execution_with_index_changes(record, &changes);
+                .append_tool_execution_with_index_changes(record, &changes)?;
+        } else {
+            self.append_jsonl(&self.tools_path, record)?;
         }
-        self.append_jsonl(&self.tools_path, record)?;
         self.enqueue_memory_index_tool_execution_best_effort(record)
     }
 
@@ -717,22 +774,24 @@ impl AppStorage {
     pub fn append_context_episode(&self, record: &ContextEpisodeRecord) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             let changes = self.index_changes_for_context_episode(record)?;
-            return runtime_db
+            runtime_db
                 .context_episodes()
-                .upsert_with_index_changes(record, &changes);
+                .upsert_with_index_changes(record, &changes)?;
+        } else {
+            self.append_jsonl(&self.context_episodes_path, record)?;
         }
-        self.append_jsonl(&self.context_episodes_path, record)?;
         self.enqueue_memory_index_context_episode_best_effort(record)
     }
 
     pub fn append_workspace_entry(&self, entry: &WorkspaceEntry) -> Result<()> {
         if let Some(runtime_db) = self.scheduler_control_plane_db()? {
             let changes = self.index_changes_for_workspace_entry(entry)?;
-            return runtime_db
+            runtime_db
                 .workspace_entries()
-                .upsert_with_index_changes(entry, &changes);
+                .upsert_with_index_changes(entry, &changes)?;
+        } else {
+            self.append_jsonl(&self.workspaces_path, entry)?;
         }
-        self.append_jsonl(&self.workspaces_path, entry)?;
         self.enqueue_memory_index_workspace_entry_best_effort(entry)
     }
 
@@ -1192,6 +1251,28 @@ impl AppStorage {
 
     pub(crate) fn read_legacy_events_jsonl(&self) -> Result<Vec<AuditEvent>> {
         read_recent_jsonl(&self.events_path, usize::MAX)
+    }
+
+    pub(crate) fn read_legacy_agent_identities_jsonl(&self) -> Result<Vec<AgentIdentityRecord>> {
+        read_recent_jsonl(&self.agent_identities_path, usize::MAX)
+    }
+
+    pub(crate) fn read_legacy_workspace_entries_jsonl(&self) -> Result<Vec<WorkspaceEntry>> {
+        read_recent_jsonl(&self.workspaces_path, usize::MAX)
+    }
+
+    pub(crate) fn read_legacy_workspace_occupancies_jsonl(
+        &self,
+    ) -> Result<Vec<WorkspaceOccupancyRecord>> {
+        read_recent_jsonl(&self.occupancies_path, usize::MAX)
+    }
+
+    pub(crate) fn read_legacy_messages_jsonl(&self) -> Result<Vec<MessageEnvelope>> {
+        read_recent_jsonl(&self.messages_path, usize::MAX)
+    }
+
+    pub(crate) fn read_legacy_transcript_jsonl(&self) -> Result<Vec<TranscriptEntry>> {
+        read_recent_jsonl(&self.transcript_path, usize::MAX)
     }
 
     pub fn latest_event_seq(&self) -> Result<Option<u64>> {
@@ -2933,7 +3014,7 @@ mod tests {
     #[test]
     fn append_event_assigns_monotonic_event_seq() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
 
         storage
             .append_event(&AuditEvent::new(
@@ -2957,7 +3038,7 @@ mod tests {
             vec![1, 2]
         );
 
-        let reopened = AppStorage::new(dir.path()).unwrap();
+        let reopened = AppStorage::new_jsonl_only(dir.path()).unwrap();
         reopened
             .append_event(&AuditEvent::new(
                 "test_event",
@@ -2971,7 +3052,7 @@ mod tests {
     #[test]
     fn storage_indexes_live_audit_events_when_sink_is_enabled() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -3018,7 +3099,7 @@ mod tests {
     #[test]
     fn audit_events_use_runtime_db_after_cutover_without_live_jsonl_append() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-test").unwrap();
         storage.write_agent(&AgentState::new("agent-test")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -3028,9 +3109,6 @@ mod tests {
         runtime_db
             .audit_events()
             .import_legacy(Some("agent-test"), Vec::new())
-            .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
             .unwrap();
         storage
             .enable_audit_event_index(runtime_db.clone(), Some("agent-test".to_string()))
@@ -3063,7 +3141,7 @@ mod tests {
     #[test]
     fn audit_events_use_runtime_db_after_cutover_before_sink_is_enabled() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-test").unwrap();
         storage.write_agent(&AgentState::new("agent-test")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -3074,10 +3152,6 @@ mod tests {
             .audit_events()
             .import_legacy(Some("agent-test"), Vec::new())
             .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
         let legacy_len_before = std::fs::metadata(&storage.events_path)
             .map(|metadata| metadata.len())
             .unwrap_or(0);
@@ -3105,7 +3179,7 @@ mod tests {
     #[test]
     fn scheduler_control_plane_storage_uses_runtime_db_after_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -3120,10 +3194,6 @@ mod tests {
             .import_legacy(Vec::new())
             .unwrap();
         runtime_db.timers().import_legacy(Vec::new()).unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
         let now = truncate_to_millis(Utc::now());
         let wait_condition = WaitConditionRecord {
             id: "wait-1".into(),
@@ -3274,7 +3344,7 @@ mod tests {
     #[test]
     fn runtime_db_state_writes_skip_live_jsonl_after_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -3311,10 +3381,6 @@ mod tests {
             .agent_identities()
             .import_legacy(Vec::new())
             .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
         let now = truncate_to_millis(Utc::now());
         let task = TaskRecord {
             id: "task-db-only".into(),
@@ -3459,7 +3525,7 @@ mod tests {
     #[test]
     fn append_turn_persists_lightweight_turn_record() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut record = TurnRecord::new("default", " turn-1 ", 7);
         record.input_message_ids = vec!["msg-1".into()];
         record.tool_execution_ids = vec!["tool-1".into()];
@@ -3492,16 +3558,13 @@ mod tests {
     #[test]
     fn append_turn_uses_runtime_db_after_cutover_without_turns_jsonl() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
         let record = TurnRecord::new("default", "turn-db", 9);
 
         storage.append_turn(&record).unwrap();
@@ -3523,20 +3586,17 @@ mod tests {
     #[test]
     fn read_recent_turns_scopes_global_runtime_db_to_current_agent() {
         let dir = tempdir().unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             dir.path().join("state/runtime.sqlite"),
             dir.path().join("state/runtime.lock"),
         )
         .unwrap();
-        let agent_a = AppStorage::new(dir.path().join("agents/agent-a")).unwrap();
-        let agent_b = AppStorage::new(dir.path().join("agents/agent-b")).unwrap();
-        agent_a
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-        agent_b
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
+        let agent_a =
+            AppStorage::new_for_agent_for_test(dir.path().join("agents/agent-a"), "agent-a")
+                .unwrap();
+        let agent_b =
+            AppStorage::new_for_agent_for_test(dir.path().join("agents/agent-b"), "agent-b")
+                .unwrap();
         agent_a
             .append_turn(&TurnRecord::new("agent-a", "turn-a", 1))
             .unwrap();
@@ -3553,20 +3613,17 @@ mod tests {
     #[test]
     fn agent_local_runtime_db_reads_scope_current_state_domains_to_current_agent() {
         let dir = tempdir().unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             dir.path().join("state/runtime.sqlite"),
             dir.path().join("state/runtime.lock"),
         )
         .unwrap();
-        let agent_a = AppStorage::new(dir.path().join("agents/agent-a")).unwrap();
-        let agent_b = AppStorage::new(dir.path().join("agents/agent-b")).unwrap();
-        agent_a
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-        agent_b
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
+        let agent_a =
+            AppStorage::new_for_agent_for_test(dir.path().join("agents/agent-a"), "agent-a")
+                .unwrap();
+        let agent_b =
+            AppStorage::new_for_agent_for_test(dir.path().join("agents/agent-b"), "agent-b")
+                .unwrap();
         let now = Utc::now();
         let task_for = |agent_id: &str, id: &str| TaskRecord {
             id: id.into(),
@@ -3694,16 +3751,12 @@ mod tests {
     #[test]
     fn append_message_uses_runtime_db_after_cutover_without_messages_jsonl() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
         storage
             .append_message(&MessageEnvelope::new(
                 "default",
@@ -3727,16 +3780,12 @@ mod tests {
     #[test]
     fn read_messages_from_preserves_recent_window_semantics_after_db_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
         for text in ["one", "two", "three", "four"] {
             storage
                 .append_message(&MessageEnvelope::new(
@@ -3764,16 +3813,12 @@ mod tests {
     #[test]
     fn append_transcript_entry_uses_runtime_db_after_cutover_without_transcript_jsonl() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
         storage
             .append_transcript_entry(&TranscriptEntry::new(
                 "default",
@@ -3794,16 +3839,13 @@ mod tests {
     #[test]
     fn runtime_db_evidence_writes_skip_live_jsonl_after_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
         let brief = BriefRecord::new("default", BriefKind::Result, "db brief", None, None);
         let tool = ToolExecutionRecord {
             id: "tool-db-evidence".into(),
@@ -3867,16 +3909,13 @@ mod tests {
     #[test]
     fn runtime_index_outbox_write_does_not_touch_memory_index_db() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
         fs::create_dir_all(storage.shared_indexes_dir().join("memory.sqlite3")).unwrap();
 
         let tool = ToolExecutionRecord {
@@ -3920,16 +3959,12 @@ mod tests {
     #[test]
     fn runtime_db_memory_episode_and_delegation_writes_skip_live_jsonl_after_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
         let delegation =
             WorkItemDelegationRecord::new("default", "parent-work", "child-agent", "child-work");
         let now = Utc::now();
@@ -3988,16 +4023,12 @@ mod tests {
         let dir = tempdir().unwrap();
         let agent_dir = dir.path().join("agents/default");
         fs::create_dir_all(&agent_dir).unwrap();
-        let storage = AppStorage::new(&agent_dir).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
+        let storage = AppStorage::new_for_test(&agent_dir).unwrap();
+        let _runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
         let brief = BriefRecord::new(
             "default",
             BriefKind::Result,
@@ -4022,7 +4053,7 @@ mod tests {
     #[test]
     fn runtime_db_message_and_transcript_import_is_idempotent() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -4087,7 +4118,7 @@ mod tests {
     #[test]
     fn runtime_db_message_import_failure_records_retryable_domain_state() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
@@ -4126,15 +4157,12 @@ mod tests {
     #[test]
     fn message_and_transcript_reads_ignore_legacy_jsonl_after_db_cutover() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
             storage.runtime_dir().join("state/runtime.lock"),
         )
         .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
         let db_message = MessageEnvelope::new(
             "default",
             MessageKind::InternalFollowup,
@@ -4196,7 +4224,7 @@ mod tests {
     #[test]
     fn message_seq_counter_resumes_from_existing_ledger() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         storage
             .append_message(&MessageEnvelope::new(
                 "default",
@@ -4210,7 +4238,7 @@ mod tests {
             ))
             .unwrap();
 
-        let reopened = AppStorage::new(dir.path()).unwrap();
+        let reopened = AppStorage::new_for_test(dir.path()).unwrap();
         reopened
             .append_message(&MessageEnvelope::new(
                 "default",
@@ -4269,7 +4297,7 @@ mod tests {
             .remove("message_seq");
         std::fs::write(&messages_path, format!("{sequenced}\n{trailing_legacy}\n")).unwrap();
 
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         storage
             .append_message(&MessageEnvelope::new(
                 "default",
@@ -4318,7 +4346,7 @@ mod tests {
         )
         .unwrap();
 
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         let events = storage.read_recent_events(10).unwrap();
         assert_eq!(
             events
@@ -4362,7 +4390,7 @@ mod tests {
         )
         .unwrap();
 
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         assert!(!std::fs::read_dir(&ledger_dir).unwrap().any(|entry| entry
             .unwrap()
             .file_name()
@@ -4382,7 +4410,7 @@ mod tests {
     #[test]
     fn storage_round_trip_agent() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         storage.write_agent(&agent).unwrap();
@@ -4396,21 +4424,10 @@ mod tests {
     #[test]
     fn write_agent_with_runtime_db_writes_db_only() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
-        let legacy_before = fs::read_to_string(dir.path().join(".holon/state/agent.json")).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
-            storage.runtime_dir().join("state/runtime.sqlite"),
-            storage.runtime_dir().join("state/runtime.lock"),
-        )
-        .unwrap();
-        runtime_db
-            .agent_states()
-            .import_legacy(storage.read_agent_file().unwrap())
-            .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
+        // With DB canonical, agent.json should NOT be created
+        assert!(!dir.path().join(".holon/state/agent.json").exists());
 
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Stopped;
@@ -4420,36 +4437,31 @@ mod tests {
         let restored = storage.read_agent().unwrap().unwrap();
         assert_eq!(restored.status, AgentStatus::Stopped);
         assert_eq!(restored.turn_index, 7);
-        assert_eq!(
-            fs::read_to_string(dir.path().join(".holon/state/agent.json")).unwrap(),
-            legacy_before
-        );
+        // Still no agent.json — DB is canonical
+        assert!(!dir.path().join(".holon/state/agent.json").exists());
     }
 
     #[test]
     fn read_agent_with_runtime_db_does_not_fallback_to_legacy_agent_json() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
-        let mut legacy_agent = AgentState::new("default");
-        legacy_agent.status = AgentStatus::Stopped;
-        storage.write_agent(&legacy_agent).unwrap();
-        let runtime_db = RuntimeDb::open_and_migrate(
-            storage.runtime_dir().join("state/runtime.sqlite"),
-            storage.runtime_dir().join("state/runtime.lock"),
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
+        // Write a legacy agent.json directly — bypassing storage
+        let legacy_agent = AgentState::new("default");
+        let agent_path = dir.path().join(".holon/state/agent.json");
+        fs::create_dir_all(agent_path.parent().unwrap()).unwrap();
+        fs::write(
+            &agent_path,
+            serde_json::to_string_pretty(&legacy_agent).unwrap(),
         )
         .unwrap();
-        runtime_db.agent_states().import_legacy(None).unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db)
-            .unwrap();
-
+        // DB is empty — read_agent should NOT fall back to JSONL
         assert_eq!(storage.read_agent().unwrap(), None);
     }
 
     #[test]
     fn queue_claim_fails_fast_without_scheduler_control_plane_db() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_jsonl_only(dir.path(), "default").unwrap();
         let now = Utc::now();
         let claim = QueueEntryRecord {
             message_id: "message-1".into(),
@@ -4471,7 +4483,7 @@ mod tests {
     #[test]
     fn read_agent_maps_legacy_paused_status_to_stopped() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Stopped;
         let mut value = serde_json::to_value(&agent).unwrap();
@@ -4489,7 +4501,7 @@ mod tests {
     #[test]
     fn current_agent_id_is_fixed_at_storage_construction() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "agent-a").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-a").unwrap();
 
         storage.write_agent(&AgentState::new("agent-a")).unwrap();
         let mismatch = storage
@@ -4511,7 +4523,7 @@ mod tests {
     #[test]
     fn global_storage_has_no_agent_scope_even_with_agent_json() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_global(dir.path()).unwrap();
+        let storage = AppStorage::new_global_for_test(dir.path()).unwrap();
 
         storage.write_agent(&AgentState::new("default")).unwrap();
 
@@ -4521,7 +4533,7 @@ mod tests {
     #[test]
     fn latest_active_task_records_reduce_by_id_and_filter_terminal_tasks() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
         let task = |id: &str, status: TaskStatus, offset: i64| TaskRecord {
             id: id.into(),
@@ -4568,7 +4580,7 @@ mod tests {
     #[test]
     fn latest_task_records_from_recent_reduces_only_bounded_history() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         let now = Utc::now();
         let task = |id: &str, summary: &str, offset: i64| TaskRecord {
             id: id.into(),
@@ -4620,7 +4632,7 @@ mod tests {
     #[test]
     fn mark_memory_index_dirty_does_not_rewrite_existing_marker() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let dirty_path = storage.indexes_dir().join("memory.default.dirty");
 
@@ -4634,7 +4646,7 @@ mod tests {
     #[test]
     fn latest_active_task_records_applies_limit_after_reverse_reduction() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
 
         for index in 0..5 {
@@ -4667,7 +4679,7 @@ mod tests {
     #[test]
     fn latest_active_task_records_for_agent_scopes_limit_and_count() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
 
         let task = |id: &str, agent_id: &str, status: TaskStatus, offset: i64| TaskRecord {
@@ -4713,7 +4725,7 @@ mod tests {
     #[test]
     fn latest_active_task_records_preserves_current_child_agent_recovery_from_older_snapshot() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         let now = Utc::now();
         let mut task = TaskRecord {
             id: "task-recovery".into(),
@@ -4750,7 +4762,7 @@ mod tests {
     #[test]
     fn cloned_storage_serializes_concurrent_large_task_appends() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
         let thread_count = 8;
         let records_per_thread = 40;
@@ -4790,19 +4802,17 @@ mod tests {
             handle.join().unwrap();
         }
 
-        let content = fs::read_to_string(storage.ledger_dir().join("tasks.jsonl")).unwrap();
-        let mut parsed = 0usize;
-        for line in content.lines().filter(|line| !line.trim().is_empty()) {
-            serde_json::from_str::<TaskRecord>(line).unwrap();
-            parsed += 1;
-        }
-        assert_eq!(parsed, thread_count * records_per_thread);
+        // With DB canonical, verify all concurrent appends landed in DB.
+        let tasks = storage
+            .read_recent_tasks(thread_count * records_per_thread)
+            .unwrap();
+        assert_eq!(tasks.len(), thread_count * records_per_thread);
     }
 
     #[test]
     fn storage_round_trip_transcript_entries() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         let entry = TranscriptEntry::new(
             "default",
             TranscriptEntryKind::IncomingMessage,
@@ -4825,7 +4835,7 @@ mod tests {
     #[test]
     fn append_message_assigns_monotonic_message_seq() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         for text in ["first", "second"] {
             storage
@@ -4853,7 +4863,7 @@ mod tests {
     #[test]
     fn append_transcript_entry_assigns_monotonic_transcript_seq() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         for related in ["message-1", "message-2"] {
             storage
@@ -4917,7 +4927,7 @@ mod tests {
     #[test]
     fn read_recent_jsonl_only_parses_requested_tail() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let path = storage.ledger_dir().join("briefs.jsonl");
         fs::write(
             &path,
@@ -4952,7 +4962,7 @@ mod tests {
     #[test]
     fn latest_work_item_delegation_for_child_scans_from_tail() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         fs::write(
             &storage.work_item_delegations_path,
             "{not valid json and should not be parsed}\n",
@@ -4994,7 +5004,7 @@ mod tests {
     #[test]
     fn latest_waiting_intent_scans_from_tail_for_agent_and_id() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         fs::write(
             &storage.waiting_intents_path,
             "{not valid json and should not be parsed}\n",
@@ -5047,7 +5057,7 @@ mod tests {
     #[test]
     fn append_waiting_intent_does_not_mirror_internal_wait_condition_ledger() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
         let active = WaitingIntentRecord {
             id: "wait-1".into(),
@@ -5084,7 +5094,7 @@ mod tests {
     #[test]
     fn active_wait_conditions_ignore_completed_work_item_scope() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
         let mut work = WorkItemRecord::new("default", "completed wait", WorkItemState::Open);
         work.blocked_by = Some("task".into());
@@ -5173,7 +5183,7 @@ mod tests {
         // Regression test for #1988: cancel must find active waits even after
         // the WorkItem is already marked Completed.
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
         let mut work = WorkItemRecord::new("default", "task with wait", WorkItemState::Open);
         work.blocked_by = Some("task".into());
@@ -5226,7 +5236,7 @@ mod tests {
     #[test]
     fn external_wait_recoverability_is_derived_and_audited() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         let now = Utc::now();
 
         for record in [
@@ -5387,7 +5397,7 @@ mod tests {
     #[test]
     fn work_queue_projection_uses_internal_wait_conditions_for_wait_state() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
 
         let mut task_wait = WorkItemRecord::new("default", "task wait", WorkItemState::Open);
@@ -5563,7 +5573,7 @@ mod tests {
     #[test]
     fn agent_posture_projection_derives_precedence_from_runtime_facts() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
@@ -5735,13 +5745,13 @@ mod tests {
             };
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         assert_eq!(posture_for(&storage, &agent), AgentSchedulingPosture::Idle);
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         storage
@@ -5760,7 +5770,7 @@ mod tests {
         );
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         let runnable = WorkItemRecord::new("default", "current runnable", WorkItemState::Open);
@@ -5773,7 +5783,7 @@ mod tests {
         );
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         let mut needs_input =
@@ -5786,7 +5796,7 @@ mod tests {
         );
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         let mut external = WorkItemRecord::new("default", "external wait", WorkItemState::Open);
@@ -5799,7 +5809,7 @@ mod tests {
         );
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         let mut blocked = WorkItemRecord::new("default", "blocked", WorkItemState::Open);
@@ -5811,7 +5821,7 @@ mod tests {
         );
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         let timer_wait = WorkItemRecord::new("default", "timer wait", WorkItemState::Open);
@@ -5823,7 +5833,7 @@ mod tests {
         );
 
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut agent = AgentState::new("default");
         agent.status = AgentStatus::Asleep;
         let system_wait = WorkItemRecord::new("default", "system wait", WorkItemState::Open);
@@ -5838,7 +5848,7 @@ mod tests {
     #[test]
     fn storage_recovery_snapshot_replays_latest_queued_messages() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let queued = MessageEnvelope::new(
             "default",
             crate::types::MessageKind::WebhookEvent,
@@ -5920,7 +5930,7 @@ mod tests {
     #[test]
     fn recovery_snapshot_orders_message_replay_by_sequence_when_timestamps_tie() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let created_at = Utc::now();
         let mut second = MessageEnvelope::new(
             "default",
@@ -5980,7 +5990,7 @@ mod tests {
     #[test]
     fn recovery_snapshot_orders_message_replay_by_sequence_before_timestamp() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let created_at = Utc::now();
         let mut later = MessageEnvelope::new(
             "default",
@@ -6040,7 +6050,7 @@ mod tests {
     #[test]
     fn recovery_snapshot_scopes_active_tasks_to_agent() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
         let task = |id: &str, agent_id: &str, offset: i64| TaskRecord {
             id: id.into(),
@@ -6076,7 +6086,7 @@ mod tests {
     #[test]
     fn storage_latest_work_items_returns_latest_record_per_id() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let item = WorkItemRecord::new("default", "fix issue #223", WorkItemState::Open);
         let mut updated = item.clone();
         updated.blocked_by = Some("working".into());
@@ -6095,7 +6105,7 @@ mod tests {
     #[test]
     fn storage_latest_work_items_for_agent_scans_tail_until_limit() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         fs::write(
             &storage.work_items_path,
             "{not valid json and should not be parsed}\n",
@@ -6125,7 +6135,7 @@ mod tests {
     #[test]
     fn storage_latest_timer_record_scans_from_tail_for_id() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         fs::write(
             &storage.timers_path,
             "{not valid json and should not be parsed}\n",
@@ -6169,7 +6179,7 @@ mod tests {
     #[test]
     fn storage_recovery_snapshot_includes_work_item_plan_and_todo_list() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let mut work_item = WorkItemRecord::new("default", "fix issue #223", WorkItemState::Open);
         work_item.plan_artifact = Some(
             crate::work_item_plan::ensure_plan_artifact(
@@ -6205,7 +6215,7 @@ mod tests {
     #[test]
     fn storage_reads_legacy_result_checkpoint_episode_boundary() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
         let episode = serde_json::json!({
             "id": "ep_legacy",
             "agent_id": "default",
@@ -6236,7 +6246,7 @@ mod tests {
     #[test]
     fn storage_work_queue_prompt_projection_uses_current_and_orders_queue() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut current = WorkItemRecord::new("default", "current item", WorkItemState::Open);
         current.updated_at = Utc::now();
@@ -6287,7 +6297,7 @@ mod tests {
     #[test]
     fn db_backed_work_queue_prompt_projection_filters_by_current_agent() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "default").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "default").unwrap();
         storage.write_agent(&AgentState::new("default")).unwrap();
         let runtime_db = RuntimeDb::open_and_migrate(
             storage.runtime_dir().join("state/runtime.sqlite"),
@@ -6298,10 +6308,6 @@ mod tests {
             .work_items()
             .import_legacy(Vec::new(), None)
             .unwrap();
-        storage
-            .enable_scheduler_control_plane_db(runtime_db.clone())
-            .unwrap();
-
         let mut current = WorkItemRecord::new("default", "current agent item", WorkItemState::Open);
         current.updated_at = Utc::now();
         let mut other_agent =
@@ -6331,7 +6337,7 @@ mod tests {
     #[test]
     fn storage_work_queue_projection_derives_candidate_classes_and_current_todo() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
 
         let mut current = WorkItemRecord::new("default", "current runnable", WorkItemState::Open);
@@ -6471,7 +6477,7 @@ mod tests {
     #[test]
     fn storage_work_queue_prompt_projection_limits_waiting_for_operator() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let now = Utc::now();
 
         for index in 0..5 {
@@ -6504,7 +6510,7 @@ mod tests {
     #[test]
     fn storage_waiting_contract_anchor_falls_back_to_latest_waiting_when_no_active_exists() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut waiting_old =
             WorkItemRecord::new("default", "older waiting anchor", WorkItemState::Open);
@@ -6549,7 +6555,7 @@ mod tests {
     #[test]
     fn read_agent_returns_error_on_corrupted_json() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_jsonl_only(dir.path()).unwrap();
 
         // Write corrupted JSON to agent file
         let agent_path = dir.path().join(".holon/state/agent.json");
@@ -6563,7 +6569,7 @@ mod tests {
     #[test]
     fn write_agent_cleans_up_tmp_file_on_rename_failure() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
         let agent = AgentState::new("default");
 
         // Write agent successfully first
@@ -6586,7 +6592,7 @@ mod tests {
     #[test]
     fn write_agent_rejects_mismatched_agent_id() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new_for_agent(dir.path(), "agent-a").unwrap();
+        let storage = AppStorage::new_for_agent_for_test(dir.path(), "agent-a").unwrap();
 
         let agent = AgentState::new("agent-b");
         let result = storage.write_agent(&agent);

--- a/tests/prompt_context_snapshots.rs
+++ b/tests/prompt_context_snapshots.rs
@@ -392,7 +392,7 @@ fn append_work_item_todo(
 #[test]
 fn recent_turns_snapshot_links_operator_input_to_result_brief() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut previous_operator = MessageEnvelope::new(
         "default",
@@ -486,7 +486,7 @@ Current input:
 #[test]
 fn recent_turns_snapshot_links_task_result_continuation_to_operator_turn() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut operator_message = MessageEnvelope::new(
         "default",
@@ -641,7 +641,7 @@ Current input:
 #[test]
 fn operator_turn_context_snapshot_includes_work_memory_and_active_work() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut work_item = WorkItemRecord::new(
         "default",
@@ -734,7 +734,7 @@ Current input:
 #[test]
 fn system_tick_context_snapshot_renders_wake_continuation() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut system_tick = MessageEnvelope::new(
         "default",
@@ -840,7 +840,7 @@ Current input:
 #[test]
 fn callback_turn_context_snapshot_preserves_provenance_labels() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let callback_message = MessageEnvelope::new(
         "default",
@@ -896,7 +896,7 @@ Current input:
 #[test]
 fn task_result_context_snapshot_renders_follow_up_continuation() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut task_result = MessageEnvelope::new(
         "default",
@@ -970,7 +970,7 @@ Current input:
 #[test]
 fn active_work_with_queued_work_shows_both_items() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     // Create an current work item
     let mut active_work = WorkItemRecord::new(
@@ -1092,7 +1092,7 @@ Current input:
 #[test]
 fn operator_turn_without_working_memory_delta() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut work_item = WorkItemRecord::new("default", "Test delta absence", WorkItemState::Open);
     work_item.id = "work_no_delta".into();
@@ -1174,7 +1174,7 @@ Current input:
 #[test]
 fn callback_with_active_work_and_delta() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut work_item = WorkItemRecord::new("default", "Handle CI callback", WorkItemState::Open);
     work_item.id = "work_ci".into();
@@ -1275,7 +1275,7 @@ Current input:
 #[test]
 fn system_tick_with_waiting_work_item() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut waiting_work = WorkItemRecord::new(
         "default",
@@ -1405,7 +1405,7 @@ Current input:
 #[test]
 fn post_compaction_snapshot_preserves_continuity() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut work_item = WorkItemRecord::new(
         "default",
@@ -1510,7 +1510,7 @@ Current input:
 #[test]
 fn task_result_with_multiple_work_items() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     // Create completed work item
     let mut completed_work =
@@ -1640,7 +1640,7 @@ Current input:
 #[test]
 fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let mut work_item = WorkItemRecord::new(
         "default",
@@ -1821,7 +1821,7 @@ fn multi_turn_context_eval_preserves_long_task_continuity_and_efficiency() -> Re
 fn multi_turn_context_eval_preserves_initial_issue_list_during_item_by_item_discussion(
 ) -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let initial_issue_list = [
         "alpha: turn-local projection repeats stable runtime guidance",
@@ -2026,7 +2026,7 @@ fn multi_turn_context_eval_preserves_initial_issue_list_during_item_by_item_disc
 #[test]
 fn multi_turn_context_eval_keeps_compacted_and_interleaved_work_items_clear() -> Result<()> {
     let dir = tempdir()?;
-    let storage = AppStorage::new(dir.path())?;
+    let storage = AppStorage::new_for_test(dir.path())?;
 
     let stale_operator = MessageEnvelope::new(
         "default",

--- a/tests/worktree_storage_test.rs
+++ b/tests/worktree_storage_test.rs
@@ -8,7 +8,7 @@ mod worktree_storage_tests {
     #[test]
     fn test_storage_round_trip_session_with_worktree() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let mut session = AgentState::new("test-worktree-session");
         session.status = AgentStatus::AwakeRunning;
@@ -45,7 +45,7 @@ mod worktree_storage_tests {
     #[test]
     fn test_storage_round_trip_session_without_worktree() {
         let dir = tempdir().unwrap();
-        let storage = AppStorage::new(dir.path()).unwrap();
+        let storage = AppStorage::new_for_test(dir.path()).unwrap();
 
         let session = AgentState::new("normal-session");
         storage.write_agent(&session).unwrap();


### PR DESCRIPTION
## Summary

Batch 1 of #2029: make RuntimeDb the sole canonical storage backend, removing JSONL fallback from runtime read/write paths.

## Changes

### Core storage (`src/storage/mod.rs`)
- **Removed `db_canonical` field and `enable_scheduler_control_plane_db()`** — RuntimeDb is now required at construction time. The old opt-in DB model created ambiguity about source-of-truth.
- **Added explicit constructors**: `new_for_test`, `new_for_agent_for_test` (DB-backed, for tests); `new_jsonl_only`, `new_for_agent_jsonl_only` (JSONL-only, for legacy import/recovery).
- **Fixed memory index enqueue on all 7 `append_*` methods** (messages, tasks, work_items, briefs, transcript, turns, tool_executions): removed early `return` on DB path, added `else` block for JSONL-only fallback, kept enqueue after if/else so both paths index correctly. This was the root cause of memory index test failures.
- **Read paths now read from DB directly**; added explicit `read_legacy_*_jsonl()` methods for legacy import/repair only.
- **Fixed import/repair functions** to use new constructor signatures.

### Other modules
- `src/host.rs`, `src/main.rs`, `src/runtime/bootstrap.rs`: updated to pass RuntimeDb at construction.
- `src/context/mod.rs`, `src/runtime/lifecycle.rs`, `src/memory/episode.rs`, `src/memory/index.rs`, `src/runtime/task_state_reducer.rs`: updated constructor calls.
- `src/storage/legacy_jsonl.rs`: refactored to match new API.

### Test changes
- Updated ~50+ test constructors to use `new_for_test`/`new_for_agent_for_test` (auto-creates RuntimeDb) or `new_jsonl_only` where JSONL-only behavior is intended.
- Fixed `legacy_inline_plan` materialization test: the field has `#[serde(skip_serializing)]` (types.rs:3653), so it cannot survive DB round-trip. The test now writes plan body to the artifact file directly, simulating materialization that occurs during legacy JSONL import.

## Verification
- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --all-targets -- --test-threads=1`: 2015/2016 lib tests pass, all integration tests pass except 1 pre-existing failure (`runtime_search_route_filters_memory_results_by_agent_ids` — fails identically on main without these changes).

## Plan for remaining batches (tracked in issue #2029)
- **Batch 2**: Remove `waiting_intents` compat layer (DB uses `wait_conditions`)
- **Batch 3**: DB-only for operator domains (`operator_notifications`, `operator_transport_bindings`, `operator_delivery_records`)
- **Batch 4**: Delete `legacy_jsonl.rs` entirely

Closes part of #2029.