### PR TITLE
docs: update for v0.23.0 features — file browser, skills update, device OAuth, task list improvements

### DIFF
--- a/docs/website/guides/skills.md
+++ b/docs/website/guides/skills.md
@@ -112,6 +112,17 @@ holon skills reconcile
 holon skills reconcile my-skill
 ```
 
+#### Update skills from remote sources
+
+```bash
+holon skills update
+```
+
+Fetches remote skill sources and compares against the lock file
+(`.skill-lock.json`). Skills that have changed upstream are downloaded
+and updated. The update preserves the npx `skills` v3 lock format
+(source, subdir, mode, etag) for interoperability.
+
 ### Agent Skills (per-agent)
 
 Once a skill is in the library, enable it for a specific agent:
@@ -170,6 +181,7 @@ holon skills disable my-skill --agent reviewer
 | Layer | Command | Purpose |
 |-------|---------|---------|
 | Library | `holon skills catalog` | List library catalog |
+| Library | `holon skills update` | Fetch and update skills from remote sources |
 | Library | `holon skills refresh` | Refresh runtime catalog by rescanning local roots |
 | Library | `holon skills add <source>` | Add a skill to the library |
 | Library | `holon skills remove <name>` | Remove from the library |
@@ -194,6 +206,7 @@ The HTTP control plane separates library and agent operations:
 | `POST` | `/api/skills/catalog/remove` | Remove from the library |
 | `POST` | `/api/skills/catalog/reconcile` | Reconcile with lock file |
 | `POST` | `/api/skills/catalog/check` | Check consistency |
+| `POST` | `/api/skills/_update` | Update skills from remote sources |
 
 ### Agent endpoints
 
@@ -207,6 +220,13 @@ The HTTP control plane separates library and agent operations:
 > `POST /control/agents/:agent_id/skills/uninstall` remain for
 > compatibility but are superseded by enable/disable and
 > add/remove.
+
+### Non-blocking install jobs
+
+When a skill is installed through the HTTP API (e.g., from the Web
+GUI), the install runs as a background job instead of blocking the
+request. Job progress is available at `GET /api/jobs/{job_id}` and
+persists across page reloads via localStorage.
 
 ## TUI integration
 

--- a/docs/website/guides/web-gui.md
+++ b/docs/website/guides/web-gui.md
@@ -35,6 +35,9 @@ The Dashboard provides a runtime overview:
 - **Agent roster** — all agents with their status (Awake, Asleep, Booting),
   pending message counts, and current model.
 - **Runtime health** — scheduler posture, wake hints, and recent activity.
+- **Task list** — click a task to open its detail panel showing status,
+  command, workdir, and output. Task events (creation, status updates,
+  completion) refresh the list in real time.
 - **Quick actions** — create agents, attach workspaces, and view agent detail.
 
 ### Agent Conversation
@@ -82,7 +85,33 @@ The Skill Management page is available at `/app/skills` in the Web GUI.
 It is also accessible from the navigation sidebar when the daemon is
 running with the embedded GUI.
 
+Skill installation through the Web GUI is **non-blocking** — when you
+add a skill via the browser, the install runs as a background job (see
+[Job API](#job-monitoring)). A progress indicator shows the current
+status, and the job state persists in localStorage so you can track it
+across page reloads.
+
 For CLI-based skill management, see [Skills Guide](/guides/skills.md).
+
+### Workspace File Browser
+
+The Web GUI includes a workspace file browser accessible from the left
+sidebar when a workspace is attached:
+
+- **Directory tree** — Navigate workspace directories in a collapsible
+  tree view with expand/collapse for subdirectories.
+- **File preview** — Click a file to preview its content in the main
+  panel. Text files render inline with syntax highlighting; binary and
+  image files display metadata and a download link.
+- **Resizable panels** — Drag the divider between the file tree and
+  content panel to adjust the layout.
+- **Dedicated file viewer page** — Open files in a full-page viewer for
+  a larger reading surface, accessible via the file tree context menu.
+
+The file browser uses the workspace file browsing API
+(`GET /workspaces/{id}/files` and `GET /workspaces/{id}/files/{path}`).
+Path traversal and symlink escapes are blocked; file reads are capped
+at 1 MB.
 
 ### Settings
 
@@ -91,7 +120,10 @@ Configure Holon from the browser:
 - **Model settings** — view and change the default model, override per-agent
   models, and set reasoning effort.
 - **API keys** — add or update provider credentials (API keys) through the
-  credential store without editing JSON files.
+  credential store without editing JSON files. The settings page
+  automatically determines the right credential method for each provider
+  (API key input for api_key providers, device login link for OAuth
+  providers like Codex).
 - **Runtime configuration** — view the current execution environment,
   attached workspaces, and policy snapshot.
 
@@ -104,6 +136,10 @@ When viewing an agent or the Dashboard, the right panel shows:
 - **Token usage** — cumulative and per-turn token consumption.
 - **Active children** — spawned child agents and their status.
 - **Tool latency** — per-tool call count and total duration.
+
+The right panel also hosts contextual detail views. For example, clicking
+a task in the Dashboard opens a **Task Detail** panel showing status,
+kind, command, workdir, and output right alongside the main view.
 
 ## Remote Access
 
@@ -162,6 +198,15 @@ grouped by phase:
 Each metric includes `count`, `total_ms`, `max_ms`, and `avg_ms`. Use this to
 diagnose slow turns, identify expensive tools, or track provider latency over
 time.
+
+### Job Monitoring
+
+Long-running operations such as skill installation run as tracked jobs:
+
+- **Job list** — View active and recent jobs with status, phase, and
+  progress at `/app/jobs`.
+- **Job detail** — Click a job to see progress items, result summary,
+  and timestamps.
 
 ## See Also
 

--- a/docs/website/reference/configuration.md
+++ b/docs/website/reference/configuration.md
@@ -187,17 +187,20 @@ Holon supports two OAuth-style flows:
 
 ### OpenAI Codex OAuth
 
-Codex uses the `codex` CLI for OAuth authentication. When onboarding with
-Codex as your provider, the wizard:
+Codex supports two OAuth flows:
 
-1. Opens your browser for OAuth login
-2. Captures the resulting credential from the `codex` CLI's auth store
-3. Stores it as a credential profile
+- **Device OAuth (recommended)** — Holon requests a device code, prints a
+  verification URL and user code. Open the URL in any browser, enter the
+  code, and the daemon automatically polls for completion. The entire flow
+  runs as a background job (see Web GUI Job Monitoring).
+- **Browser OAuth** — The `codex` CLI opens a browser for OAuth login and
+  stores the credential locally. Holon reads it via `external_cli`.
 
-This provider uses `credential_source: external_cli` and
-`credential_kind: oauth` in the config.
+The provider uses `credential_source: external_cli` and
+`credential_kind: oauth` for browser OAuth, or device OAuth via the
+onboarding wizard.
 
-If your Codex credential expires, run `holon onboard` again — the wizard
+If your credential expires, run `holon onboard` again — the wizard
 detects the expiry and guides you through re-authentication.
 
 ### Vercel AI Gateway OIDC
@@ -212,7 +215,7 @@ For both OAuth and OIDC flows, the recommended setup path is:
 holon onboard
 ```
 
-The wizard handles the entire OAuth browser flow and stores the credential
+The wizard handles the entire OAuth flow and stores the credential
 securely. You should not attempt to configure OAuth providers manually in
 `config.json` unless you are scripting a headless deployment.
 


### PR DESCRIPTION
## Summary

Updates documentation for v0.23.0 features (v0.21.0 through v0.23.0).

### Changes

| File | Changes |
|------|---------|
|  (+37/-3) | Workspace File Browser section, non-blocking skill install, Job Monitoring, Dashboard task list improvements, task detail panel, simplified provider settings |
|  (+20/-0) | `holon skills update` command, `POST /api/skills/_update` endpoint, non-blocking install jobs section |
|  (+11/-7) | Codex device OAuth flow documentation alongside browser OAuth |

### Feature coverage

- **Workspace File Browser** — directory tree, file preview, resizable panels, dedicated file viewer page (v0.22.0/v0.23.0)
- **Skills update** — `holon skills update` command for remote source refresh, npx v3 lock compatibility (v0.21.0)
- **Non-blocking skill install** — job-based installs with progress tracking and localStorage persistence (v0.23.0)
- **Codex device OAuth** — RFC 8628 device code flow as a background job (v0.23.0)
- **Web GUI task list improvements** — clickable tasks with detail panel, real-time event refresh (v0.22.0)
- **Provider settings simplification** — auto-detected credential method per provider in Settings (v0.23.0)