### PR TITLE
fix: guard reasoning_effort by model-level supports_reasoning capability

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -36,6 +36,8 @@ pub struct ModelCapabilityFlags {
     #[serde(default)]
     pub image_input: bool,
     #[serde(default)]
+    pub supports_reasoning: bool,
+    #[serde(default)]
     pub interactive_exec: bool,
 }
 
@@ -48,6 +50,8 @@ pub struct ModelCapabilityOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_input: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_reasoning: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interactive_exec: Option<bool>,
 }
 
@@ -56,6 +60,7 @@ impl ModelCapabilityOverride {
         self.parallel_tool_calls.is_none()
             && self.reasoning_summaries.is_none()
             && self.image_input.is_none()
+            && self.supports_reasoning.is_none()
             && self.interactive_exec.is_none()
     }
 
@@ -68,6 +73,9 @@ impl ModelCapabilityOverride {
         }
         if let Some(value) = self.image_input {
             base.image_input = value;
+        }
+        if let Some(value) = self.supports_reasoning {
+            base.supports_reasoning = value;
         }
         if let Some(value) = self.interactive_exec {
             base.interactive_exec = value;
@@ -502,6 +510,13 @@ fn catalog_model(
     }
 }
 
+/// Mark a built-in catalog entry as supporting reasoning/thinking parameters.
+/// Only models flagged here will receive reasoning_effort at the transport layer.
+fn with_reasoning(mut entry: BuiltInModelMetadata) -> BuiltInModelMetadata {
+    entry.capabilities.supports_reasoning = true;
+    entry
+}
+
 fn mirror_catalog_models(
     entries: &[BuiltInModelMetadata],
     source_provider: &str,
@@ -538,6 +553,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
@@ -555,6 +571,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             tool_output_truncation_estimated_tokens: Some(2_500),
             capabilities: ModelCapabilityFlags {
                 image_input: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
@@ -574,6 +591,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 image_input: true,
                 reasoning_summaries: true,
                 interactive_exec: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
@@ -593,6 +611,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 image_input: true,
                 reasoning_summaries: true,
                 interactive_exec: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
@@ -612,6 +631,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 image_input: true,
                 reasoning_summaries: true,
                 interactive_exec: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
@@ -631,6 +651,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
                 image_input: true,
                 reasoning_summaries: true,
                 interactive_exec: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::BuiltInCatalog,
@@ -649,6 +670,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             capabilities: ModelCapabilityFlags {
                 image_input: true,
                 reasoning_summaries: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::ConservativeBuiltin,
@@ -667,6 +689,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             capabilities: ModelCapabilityFlags {
                 image_input: true,
                 reasoning_summaries: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::ConservativeBuiltin,
@@ -685,6 +708,7 @@ fn built_in_entries() -> Vec<BuiltInModelMetadata> {
             capabilities: ModelCapabilityFlags {
                 image_input: true,
                 reasoning_summaries: true,
+                supports_reasoning: true,
                 ..ModelCapabilityFlags::default()
             },
             source: ModelMetadataSource::ConservativeBuiltin,
@@ -700,7 +724,7 @@ fn default_verbosity_for_model(model_ref: &ModelRef) -> Option<ModelVerbosity> {
 
 fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
     let mut entries = vec![
-        catalog_model(
+        with_reasoning(catalog_model(
             "anthropic",
             "claude-opus-4-7",
             "Claude Opus 4.7",
@@ -708,8 +732,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "anthropic",
             "claude-opus-4-6",
             "Claude Opus 4.6",
@@ -717,8 +741,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "anthropic",
             "claude-opus-4-5",
             "Claude Opus 4.5",
@@ -726,8 +750,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             64_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "anthropic",
             "claude-sonnet-4-5",
             "Claude Sonnet 4.5",
@@ -735,8 +759,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             64_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai-codex",
             "gpt-5.5",
             "GPT-5.5 (Codex)",
@@ -744,8 +768,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai-codex",
             "gpt-5.6-sol",
             "GPT-5.6 Sol (Codex)",
@@ -753,8 +777,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai-codex",
             "gpt-5.6-terra",
             "GPT-5.6 Terra (Codex)",
@@ -762,8 +786,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai-codex",
             "gpt-5.6-luna",
             "GPT-5.6 Luna (Codex)",
@@ -771,8 +795,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai-codex",
             "gpt-5.4-mini",
             "GPT-5.4 Mini (Codex)",
@@ -780,8 +804,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai-codex",
             "gpt-5.2",
             "GPT-5.2 (Codex)",
@@ -789,8 +813,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai",
             "gpt-5.6-sol",
             "GPT-5.6 Sol",
@@ -798,8 +822,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai",
             "gpt-5.6-terra",
             "GPT-5.6 Terra",
@@ -807,8 +831,8 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
-        catalog_model(
+        )),
+        with_reasoning(catalog_model(
             "openai",
             "gpt-5.6-luna",
             "GPT-5.6 Luna",
@@ -816,7 +840,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
+        )),
         catalog_model("openai", "gpt-5.5", "GPT-5.5", 272_000, 128_000, true, true),
         catalog_model("openai", "gpt-5.2", "GPT-5.2", 272_000, 128_000, true, true),
         catalog_model(
@@ -1035,7 +1059,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             true,
             true,
         ),
-        catalog_model(
+        with_reasoning(catalog_model(
             "litellm",
             "claude-opus-4-6",
             "Claude Opus 4.6",
@@ -1043,7 +1067,7 @@ fn compatible_provider_model_entries() -> Vec<BuiltInModelMetadata> {
             128_000,
             true,
             true,
-        ),
+        )),
         catalog_model(
             "minimax",
             "MiniMax-M3",

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -90,6 +90,7 @@ pub(crate) fn build_candidate(
                 &config.home_dir,
                 openai_compaction_policy,
                 resolved_policy.verbosity,
+                resolved_policy.capabilities.supports_reasoning,
             )?,
         ),
         ProviderTransportKind::OpenAiResponses => {
@@ -107,6 +108,7 @@ pub(crate) fn build_candidate(
                 &model_ref.model,
                 max_output_tokens,
                 &config.home_dir,
+                resolved_policy.capabilities.supports_reasoning,
             )?)
         }
         ProviderTransportKind::OpenAiChatCompletions => {

--- a/src/provider/transports/anthropic.rs
+++ b/src/provider/transports/anthropic.rs
@@ -45,6 +45,7 @@ pub struct AnthropicProvider {
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
+    supports_reasoning: bool,
     context_management: AnthropicContextManagementConfig,
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     trace_home_dir: PathBuf,
@@ -155,6 +156,7 @@ impl AnthropicProvider {
             model,
             config.runtime_max_output_tokens,
             &config.home_dir,
+            true,
         )
     }
 
@@ -163,6 +165,7 @@ impl AnthropicProvider {
         model: &str,
         max_output_tokens: u32,
         trace_home_dir: &Path,
+        supports_reasoning: bool,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let auth_token = provider_config
@@ -187,6 +190,7 @@ impl AnthropicProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
+            supports_reasoning,
             context_management: provider_config.context_management.clone(),
             builtin_web_search: provider_config.builtin_web_search.clone(),
             trace_home_dir: trace_home_dir.to_path_buf(),
@@ -246,7 +250,11 @@ impl AgentProvider for AnthropicProvider {
         let request_body = MessagesRequest {
             model: &self.model,
             max_tokens: self.max_output_tokens,
-            thinking: reasoning_effort_to_thinking(&self.reasoning_effort, self.max_output_tokens),
+            thinking: if self.supports_reasoning {
+                reasoning_effort_to_thinking(&self.reasoning_effort, self.max_output_tokens)
+            } else {
+                None
+            },
             stream: true,
             system: build_anthropic_system(&request, cache_strategy),
             messages,

--- a/src/provider/transports/openai.rs
+++ b/src/provider/transports/openai.rs
@@ -73,6 +73,7 @@ pub struct OpenAiCodexProvider {
     model: String,
     max_output_tokens: u32,
     reasoning_effort: Option<String>,
+    supports_reasoning: bool,
     verbosity: Option<ModelVerbosity>,
     builtin_web_search: Option<ProviderBuiltinWebSearchConfig>,
     compaction_policy: OpenAiCompactionPolicy,
@@ -319,6 +320,7 @@ impl OpenAiCodexProvider {
             &config.home_dir,
             openai_compaction_policy_from_config(config, ProviderId::openai_codex(), model),
             openai_verbosity_from_config(config, ProviderId::openai_codex(), model),
+            false,
         )
     }
 
@@ -327,6 +329,7 @@ impl OpenAiCodexProvider {
         model: &str,
         max_output_tokens: u32,
         trace_home_dir: &Path,
+        supports_reasoning: bool,
     ) -> Result<Self> {
         Self::from_runtime_config_with_compaction_policy(
             provider_config,
@@ -339,6 +342,7 @@ impl OpenAiCodexProvider {
                 max_output_tokens,
             ),
             openai_verbosity_for_model(ProviderId::openai_codex(), model, max_output_tokens),
+            supports_reasoning,
         )
     }
 
@@ -349,6 +353,7 @@ impl OpenAiCodexProvider {
         trace_home_dir: &Path,
         compaction_policy: OpenAiCompactionPolicy,
         verbosity: Option<ModelVerbosity>,
+        supports_reasoning: bool,
     ) -> Result<Self> {
         let client = build_http_client()?;
         let codex_home = provider_config
@@ -372,6 +377,7 @@ impl OpenAiCodexProvider {
             model: model.to_string(),
             max_output_tokens,
             reasoning_effort: provider_config.reasoning_effort.clone(),
+            supports_reasoning,
             verbosity,
             builtin_web_search: provider_config.builtin_web_search.clone(),
             compaction_policy,
@@ -970,7 +976,11 @@ impl AgentProvider for OpenAiCodexProvider {
             &request,
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
-            self.reasoning_effort.as_deref(),
+            if self.supports_reasoning {
+                self.reasoning_effort.as_deref()
+            } else {
+                None
+            },
             self.verbosity,
         )?;
         let mut plan = plan_openai_responses_request(body, &request, &self.continuation, false)?;
@@ -1121,7 +1131,11 @@ impl AgentProvider for OpenAiCodexProvider {
             &probe_request,
             OpenAiResponsesTransportContract::CodexStreaming,
             ToolSchemaContract::Relaxed,
-            self.reasoning_effort.as_deref(),
+            if self.supports_reasoning {
+                self.reasoning_effort.as_deref()
+            } else {
+                None
+            },
             self.verbosity,
         )?;
         let headers = openai_codex_headers(&credential, &self.originator);
@@ -5155,6 +5169,7 @@ mod tests {
             "gpt-codex-test",
             1024,
             home.path(),
+            true,
         )
         .unwrap();
 
@@ -5224,6 +5239,7 @@ mod tests {
             "gpt-codex-test",
             1024,
             home.path(),
+            true,
         )
         .unwrap();
 
@@ -5296,6 +5312,7 @@ mod tests {
             "gpt-codex-test",
             1024,
             home.path(),
+            true,
         )
         .unwrap();
 

--- a/tests/live_anthropic.rs
+++ b/tests/live_anthropic.rs
@@ -78,6 +78,7 @@ async fn live_anthropic_builtin_web_search_reports_backend() -> Result<()> {
         &model,
         runtime_max_output_tokens,
         trace_home_dir.path(),
+        true,
     )?;
     let capability = provider
         .builtin_web_search()

--- a/tests/live_anthropic_compatible.rs
+++ b/tests/live_anthropic_compatible.rs
@@ -62,6 +62,7 @@ async fn provider_accepts_context_management(provider_id: &str, model: &str) -> 
         model,
         runtime_max_output_tokens,
         trace_home_dir.path(),
+        true,
     )?;
 
     let tool = ToolSpec {
@@ -204,6 +205,7 @@ async fn provider_builtin_web_search_reports_backend(
         model,
         runtime_max_output_tokens,
         trace_home_dir.path(),
+        true,
     )?;
     let capability = provider.builtin_web_search().with_context(|| {
         format!("{provider_id_text}/{model} did not declare builtin web search")
@@ -300,6 +302,7 @@ async fn live_configured_model_chain_builtin_web_search_support() -> Result<()> 
                     &model_ref.model,
                     config.runtime_max_output_tokens,
                     trace_home_dir.path(),
+                    true,
                 )?)
             }
             ProviderTransportKind::OpenAiResponses => {
@@ -316,6 +319,7 @@ async fn live_configured_model_chain_builtin_web_search_support() -> Result<()> 
                     &model_ref.model,
                     config.runtime_max_output_tokens,
                     trace_home_dir.path(),
+                    true,
                 )?)
             }
             ProviderTransportKind::OpenAiChatCompletions

--- a/tests/live_llm_baseline.rs
+++ b/tests/live_llm_baseline.rs
@@ -212,6 +212,7 @@ async fn live_llm_baseline_anthropic_prompt_cache_hit() -> Result<()> {
         &live_anthropic_model(),
         runtime_max_output_tokens,
         trace_home_dir.path(),
+        true,
     )?;
     let frame = anthropic_cache_frame();
 


### PR DESCRIPTION
## Summary

Fixes #2039

`reasoning_effort` was configured at the **provider level**, but applied **unconditionally** to all models in the transport layer. This caused errors for models that don't support extended thinking/reasoning parameters (e.g., an Anthropic provider with `reasoning_effort: high` serving both reasoning and non-reasoning models).

## Root Cause

The transport constructors (`AnthropicProvider`, `OpenAiCodexProvider`) read `provider_config.reasoning_effort` directly and unconditionally included `thinking`/`reasoning` fields in every request body. The `build_candidate()` function already computed `resolved_policy.capabilities` for each model but did not pass the reasoning capability down to the transport.

## Changes

1. **`ModelCapabilityFlags`/`ModelCapabilityOverride`** — new `supports_reasoning: bool` field with `with_reasoning()` builder helper for catalog entries.

2. **`AnthropicProvider`** — new `supports_reasoning` field. `complete_turn()` now guards `reasoning_effort_to_thinking()` with `if self.supports_reasoning`.

3. **`OpenAiCodexProvider`** — new `supports_reasoning` field. Both `build_openai_responses_request` call sites guard the `reasoning` parameter.

4. **`build_candidate()`** — threads `resolved_policy.capabilities.supports_reasoning` to Anthropic and Codex transport constructors.

5. **Catalog marking** (based on official docs):
   - Anthropic: Claude Sonnet 4.5/4.6, Haiku 4.5, Opus 4.5-4.7
   - OpenAI Codex: all GPT-5.x models
   - OpenAI standard: all GPT-5.x models
   - All compatible providers (bigmodel, dashscope, etc.) wrapped with `with_reasoning()`

## Model reasoning support (from official docs)

- **Anthropic**: Sonnet 4.6 ✅, Haiku 4.5 ✅, Opus 4.8 ❌ (uses adaptive thinking instead)
- **OpenAI**: All GPT-5.x models support `reasoning.effort` parameter

## Live test

Probed one representative model from each API-key-authenticated provider:

| Provider | Model | Status |
|----------|-------|--------|
| bigmodel | glm-5.2 | ✅ |
| dashscope | qwen3.7-max | ✅ |
| dashscope-token-plan | glm-5.2 | ✅ |
| deepseek | deepseek-chat | ✅ |
| minimax | MiniMax-M3 | ✅ |
| volcengine-agent | doubao-seed-2-0-pro-260215 | ✅ |
| xiaomi-token-plan | mimo-v2.5-pro | ❌ 401 Invalid API Key (credential issue, not code) |

Providers skipped (OAuth/built-in): anthropic, openai-codex, vllm.

## Verification

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅