### PR TITLE
refactor: migrate operator domains from JSONL to DB (issue #2029 batch 3)

### DIFF
--- a/src/runtime_db/migrations.rs
+++ b/src/runtime_db/migrations.rs
@@ -798,6 +798,43 @@ CREATE TABLE IF NOT EXISTS workspace_id_aliases (
 );
 "#,
     },
+    Migration {
+        version: 22,
+        name: "operator_domains",
+        sql: r#"
+CREATE TABLE IF NOT EXISTS operator_notifications (
+  notification_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (notification_id, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_notifications_agent_created
+  ON operator_notifications(agent_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS operator_transport_bindings (
+  binding_id TEXT PRIMARY KEY,
+  target_agent_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_transport_bindings_agent_status
+  ON operator_transport_bindings(target_agent_id, status);
+
+CREATE TABLE IF NOT EXISTS operator_delivery_records (
+  delivery_intent_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  payload_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_delivery_records_agent_created
+  ON operator_delivery_records(agent_id, created_at DESC);
+"#,
+    },
 ];
 
 pub(crate) fn ensure_migration_table(connection: &Connection) -> Result<()> {

--- a/src/runtime_db/mod.rs
+++ b/src/runtime_db/mod.rs
@@ -32,7 +32,8 @@ pub use crate::runtime_db::storage_domain::{
 };
 pub use crate::runtime_db::types::{
     AgentIdentityRepository, AgentStateRepository, AuditEventSink, ContextEpisodeRepository,
-    EvidenceRepository, ExternalTriggerRepository, MessageRepository, QueueEntryRepository,
+    EvidenceRepository, ExternalTriggerRepository, MessageRepository, OperatorDeliveryRepository,
+    OperatorNotificationRepository, OperatorTransportBindingRepository, QueueEntryRepository,
     TaskRepository, TimerRepository, TranscriptRepository, TurnRecordRepository,
     WaitConditionRepository, WorkItemContinuationRepository, WorkItemDelegationRepository,
     WorkItemRepository, WorkspaceEntryRepository, WorkspaceOccupancyRepository,
@@ -260,6 +261,18 @@ impl RuntimeDb {
 
     pub fn context_episodes(&self) -> ContextEpisodeRepository<'_> {
         ContextEpisodeRepository { db: self }
+    }
+
+    pub fn operator_notifications(&self) -> OperatorNotificationRepository<'_> {
+        OperatorNotificationRepository { db: self }
+    }
+
+    pub fn operator_transport_bindings(&self) -> OperatorTransportBindingRepository<'_> {
+        OperatorTransportBindingRepository { db: self }
+    }
+
+    pub fn operator_delivery_records(&self) -> OperatorDeliveryRepository<'_> {
+        OperatorDeliveryRepository { db: self }
     }
 
     pub fn runtime_index_outbox(&self) -> RuntimeIndexOutboxRepository<'_> {

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -827,6 +827,155 @@ impl ExternalTriggerRepository<'_> {
     }
 }
 
+impl OperatorNotificationRepository<'_> {
+    pub fn insert(&self, agent_id: &str, record: &OperatorNotificationRecord) -> Result<()> {
+        self.db
+            .transaction(|tx| insert_operator_notification_tx(tx, agent_id, record))
+    }
+
+    pub fn read_recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<OperatorNotificationRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM operator_notifications
+             WHERE agent_id = ?1
+             ORDER BY created_at DESC, notification_id DESC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_operator_notification_payload(&row?))
+            .collect()
+    }
+}
+
+impl OperatorTransportBindingRepository<'_> {
+    pub fn upsert(&self, agent_id: &str, record: &OperatorTransportBinding) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_operator_transport_binding_tx(tx, agent_id, record))
+    }
+
+    pub fn latest_for_agent(&self, agent_id: &str) -> Result<Vec<OperatorTransportBinding>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM operator_transport_bindings
+             WHERE target_agent_id = ?1
+             ORDER BY created_at DESC, binding_id ASC",
+        )?;
+        let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_operator_transport_binding_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn read_recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<OperatorTransportBinding>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM operator_transport_bindings
+             WHERE target_agent_id = ?1
+             ORDER BY created_at DESC, binding_id ASC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_operator_transport_binding_payload(&row?))
+            .collect()
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<OperatorTransportBinding>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM operator_transport_bindings
+             ORDER BY created_at DESC, binding_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_operator_transport_binding_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+}
+
+impl OperatorDeliveryRepository<'_> {
+    pub fn upsert(&self, agent_id: &str, record: &OperatorDeliveryRecord) -> Result<()> {
+        self.db
+            .transaction(|tx| upsert_operator_delivery_record_tx(tx, agent_id, record))
+    }
+
+    pub fn latest_for_agent(&self, agent_id: &str) -> Result<Vec<OperatorDeliveryRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM operator_delivery_records
+             WHERE agent_id = ?1
+             ORDER BY created_at DESC, delivery_intent_id DESC",
+        )?;
+        let rows = statement.query_map([agent_id], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_operator_delivery_record_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+
+    pub fn read_recent_for_agent(
+        &self,
+        agent_id: &str,
+        limit: usize,
+    ) -> Result<Vec<OperatorDeliveryRecord>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM operator_delivery_records
+             WHERE agent_id = ?1
+             ORDER BY created_at DESC, delivery_intent_id DESC
+             LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![agent_id, limit], |row| row.get::<_, String>(0))?;
+        rows.map(|row| decode_operator_delivery_record_payload(&row?))
+            .collect()
+    }
+
+    pub fn latest_all(&self) -> Result<Vec<OperatorDeliveryRecord>> {
+        let connection = self.db.connection()?;
+        let mut statement = connection.prepare(
+            "SELECT payload_json
+             FROM operator_delivery_records
+             ORDER BY created_at DESC, delivery_intent_id DESC",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        let mut records: Vec<_> = rows
+            .map(|row| decode_operator_delivery_record_payload(&row?))
+            .collect::<Result<_>>()?;
+        records.reverse();
+        Ok(records)
+    }
+}
+
 impl TaskRepository<'_> {
     pub fn import_legacy(&self, records: Vec<TaskRecord>) -> Result<()> {
         if self.db.storage_domain_is_complete("tasks", "db")? {
@@ -2408,6 +2557,77 @@ fn upsert_external_trigger_tx(tx: &Transaction<'_>, record: &ExternalTriggerReco
     Ok(())
 }
 
+fn insert_operator_notification_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    record: &OperatorNotificationRecord,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    tx.execute(
+        "INSERT OR IGNORE INTO operator_notifications (
+            notification_id, agent_id, created_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4)",
+        params![
+            record.notification_id,
+            agent_id,
+            timestamp(record.created_at),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_operator_transport_binding_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    record: &OperatorTransportBinding,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    let status = enum_string(&record.status)?;
+    tx.execute(
+        "INSERT INTO operator_transport_bindings (
+            binding_id, target_agent_id, status, created_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(binding_id) DO UPDATE SET
+            target_agent_id = excluded.target_agent_id,
+            status = excluded.status,
+            created_at = excluded.created_at,
+            payload_json = excluded.payload_json",
+        params![
+            record.binding_id,
+            agent_id,
+            status,
+            timestamp(record.created_at),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_operator_delivery_record_tx(
+    tx: &Transaction<'_>,
+    agent_id: &str,
+    record: &OperatorDeliveryRecord,
+) -> Result<()> {
+    let payload_json = serde_json::to_string(record)?;
+    tx.execute(
+        "INSERT INTO operator_delivery_records (
+            delivery_intent_id, agent_id, created_at, payload_json
+         ) VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(delivery_intent_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            created_at = excluded.created_at,
+            payload_json = excluded.payload_json",
+        params![
+            record.delivery_intent_id,
+            agent_id,
+            timestamp(record.created_at),
+            payload_json,
+        ],
+    )?;
+    Ok(())
+}
+
 fn upsert_work_item_tx(
     tx: &Transaction<'_>,
     record: &WorkItemRecord,
@@ -3282,6 +3502,26 @@ pub(crate) fn decode_context_episode_payload(payload: &str) -> Result<ContextEpi
 
 pub(crate) fn decode_external_trigger_payload(payload: &str) -> Result<ExternalTriggerRecord> {
     serde_json::from_str(payload).context("decoding external trigger payload from runtime db")
+}
+
+pub(crate) fn decode_operator_notification_payload(
+    payload: &str,
+) -> Result<OperatorNotificationRecord> {
+    serde_json::from_str(payload).context("decoding operator notification payload from runtime db")
+}
+
+pub(crate) fn decode_operator_transport_binding_payload(
+    payload: &str,
+) -> Result<OperatorTransportBinding> {
+    serde_json::from_str(payload)
+        .context("decoding operator transport binding payload from runtime db")
+}
+
+pub(crate) fn decode_operator_delivery_record_payload(
+    payload: &str,
+) -> Result<OperatorDeliveryRecord> {
+    serde_json::from_str(payload)
+        .context("decoding operator delivery record payload from runtime db")
 }
 
 pub(crate) fn decode_task_payload(payload: &str) -> Result<TaskRecord> {

--- a/src/runtime_db/types.rs
+++ b/src/runtime_db/types.rs
@@ -73,3 +73,15 @@ pub struct WorkItemContinuationRepository<'a> {
 pub struct ContextEpisodeRepository<'a> {
     pub(crate) db: &'a RuntimeDb,
 }
+
+pub struct OperatorNotificationRepository<'a> {
+    pub(crate) db: &'a RuntimeDb,
+}
+
+pub struct OperatorTransportBindingRepository<'a> {
+    pub(crate) db: &'a RuntimeDb,
+}
+
+pub struct OperatorDeliveryRepository<'a> {
+    pub(crate) db: &'a RuntimeDb,
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -85,9 +85,6 @@ pub struct AppStorage {
     queue_entries_path: PathBuf,
     wait_conditions_path: PathBuf,
     external_triggers_path: PathBuf,
-    operator_notifications_path: PathBuf,
-    operator_transport_bindings_path: PathBuf,
-    operator_delivery_records_path: PathBuf,
     context_episodes_path: PathBuf,
     workspaces_path: PathBuf,
     occupancies_path: PathBuf,
@@ -311,9 +308,6 @@ impl AppStorage {
             queue_entries_path: ledger_dir.join("queue_entries.jsonl"),
             wait_conditions_path: ledger_dir.join("wait_conditions.jsonl"),
             external_triggers_path: ledger_dir.join("external_triggers.jsonl"),
-            operator_notifications_path: ledger_dir.join("operator_notifications.jsonl"),
-            operator_transport_bindings_path: ledger_dir.join("operator_transport_bindings.jsonl"),
-            operator_delivery_records_path: ledger_dir.join("operator_delivery_records.jsonl"),
             context_episodes_path: ledger_dir.join("context_episodes.jsonl"),
             workspaces_path: ledger_dir.join("workspaces.jsonl"),
             occupancies_path: ledger_dir.join("workspace_occupancies.jsonl"),
@@ -756,18 +750,42 @@ impl AppStorage {
     }
 
     pub fn append_operator_notification(&self, record: &OperatorNotificationRecord) -> Result<()> {
-        self.append_jsonl(&self.operator_notifications_path, record)
+        let runtime_db = self.scheduler_control_plane_db()?.ok_or_else(|| {
+            anyhow::anyhow!("runtime db is required for operator_notification persistence")
+        })?;
+        let agent_id = self.current_agent_id()?.ok_or_else(|| {
+            anyhow::anyhow!("agent_id is required for operator_notification persistence")
+        })?;
+        runtime_db
+            .operator_notifications()
+            .insert(&agent_id, record)
     }
 
     pub fn append_operator_transport_binding(
         &self,
         record: &OperatorTransportBinding,
     ) -> Result<()> {
-        self.append_jsonl(&self.operator_transport_bindings_path, record)
+        let runtime_db = self.scheduler_control_plane_db()?.ok_or_else(|| {
+            anyhow::anyhow!("runtime db is required for operator_transport_binding persistence")
+        })?;
+        let agent_id = self.current_agent_id()?.ok_or_else(|| {
+            anyhow::anyhow!("agent_id is required for operator_transport_binding persistence")
+        })?;
+        runtime_db
+            .operator_transport_bindings()
+            .upsert(&agent_id, record)
     }
 
     pub fn append_operator_delivery_record(&self, record: &OperatorDeliveryRecord) -> Result<()> {
-        self.append_jsonl(&self.operator_delivery_records_path, record)
+        let runtime_db = self.scheduler_control_plane_db()?.ok_or_else(|| {
+            anyhow::anyhow!("runtime db is required for operator_delivery_record persistence")
+        })?;
+        let agent_id = self.current_agent_id()?.ok_or_else(|| {
+            anyhow::anyhow!("agent_id is required for operator_delivery_record persistence")
+        })?;
+        runtime_db
+            .operator_delivery_records()
+            .upsert(&agent_id, record)
     }
 
     pub fn append_context_episode(&self, record: &ContextEpisodeRecord) -> Result<()> {
@@ -1718,21 +1736,42 @@ impl AppStorage {
         &self,
         limit: usize,
     ) -> Result<Vec<OperatorNotificationRecord>> {
-        read_recent_jsonl(&self.operator_notifications_path, limit)
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .operator_notifications()
+                    .read_recent_for_agent(&agent_id, limit);
+            }
+        }
+        Ok(Vec::new())
     }
 
     pub fn read_recent_operator_transport_bindings(
         &self,
         limit: usize,
     ) -> Result<Vec<OperatorTransportBinding>> {
-        read_recent_jsonl(&self.operator_transport_bindings_path, limit)
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .operator_transport_bindings()
+                    .read_recent_for_agent(&agent_id, limit);
+            }
+        }
+        Ok(Vec::new())
     }
 
     pub fn read_recent_operator_delivery_records(
         &self,
         limit: usize,
     ) -> Result<Vec<OperatorDeliveryRecord>> {
-        read_recent_jsonl(&self.operator_delivery_records_path, limit)
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .operator_delivery_records()
+                    .read_recent_for_agent(&agent_id, limit);
+            }
+        }
+        Ok(Vec::new())
     }
 
     pub fn read_recent_context_episodes(&self, limit: usize) -> Result<Vec<ContextEpisodeRecord>> {
@@ -2723,21 +2762,25 @@ impl AppStorage {
     }
 
     pub fn latest_operator_transport_bindings(&self) -> Result<Vec<OperatorTransportBinding>> {
-        let records = self.read_recent_operator_transport_bindings(usize::MAX)?;
-        let mut latest = std::collections::BTreeMap::new();
-        for record in records {
-            latest.insert(record.binding_id.clone(), record);
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .operator_transport_bindings()
+                    .latest_for_agent(&agent_id);
+            }
         }
-        Ok(latest.into_values().collect())
+        Ok(Vec::new())
     }
 
     pub fn latest_operator_delivery_records(&self) -> Result<Vec<OperatorDeliveryRecord>> {
-        let records = self.read_recent_operator_delivery_records(usize::MAX)?;
-        let mut latest = std::collections::BTreeMap::new();
-        for record in records {
-            latest.insert(record.delivery_intent_id.clone(), record);
+        if let Some(runtime_db) = self.scheduler_control_plane_db()? {
+            if let Some(agent_id) = self.current_agent_id()? {
+                return runtime_db
+                    .operator_delivery_records()
+                    .latest_for_agent(&agent_id);
+            }
         }
-        Ok(latest.into_values().collect())
+        Ok(Vec::new())
     }
 
     pub fn latest_workspace_entries(&self) -> Result<Vec<WorkspaceEntry>> {


### PR DESCRIPTION
## Summary

Batch 3 of issue #2029 — migrate the last three JSONL-only operator domains to DB-backed storage.

### Changes

- **Migration v22** (`operator_domains`): new tables `operator_notifications`, `operator_transport_bindings`, `operator_delivery_records` with indexes
- **Repository layer** (`runtime_db/repositories.rs`, `runtime_db/types.rs`): `OperatorNotificationRepository`, `OperatorTransportBindingRepository`, `OperatorDeliveryRepository` with insert/upsert/read methods
- **DB accessors** (`runtime_db/mod.rs`): `operator_notifications()`, `operator_transport_bindings()`, `operator_delivery_records()`
- **AppStorage** (`storage/mod.rs`): replaced all JSONL `append_jsonl`/`read_recent_jsonl` calls for these three domains with DB repository calls; removed the three JSONL path fields

### What is removed
- `operator_notifications_path` (JSONL field)
- `operator_transport_bindings_path` (JSONL field)
- `operator_delivery_records_path` (JSONL field)

### Verification
- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- `cargo test --all-targets` ✅ (exit 0, all tests pass)

Part of #2029.

### Batch progress
- [x] Batch 1 — PR #2038 (MERGED)
- [x] Batch 2 — PR #2043 (MERGED)
- [x] Batch 3 — this PR
- [ ] Batch 4 — remove `legacy_jsonl.rs` module + final cleanup