### PR TITLE
feat(web-gui): real-time work item updates and plan file browser links

### DIFF
--- a/web-gui/app/src/app/App.tsx
+++ b/web-gui/app/src/app/App.tsx
@@ -551,6 +551,9 @@ export function App() {
           onBrowseFiles={(workspaceId: string, executionRootId?: string) => {
             showFileBrowser(selectedAgent.id, workspaceId, undefined, executionRootId);
           }}
+          onOpenPlanFile={(workspaceId: string, filePath: string) => {
+            showFileBrowser(selectedAgent.id, workspaceId, undefined, undefined, filePath);
+          }}
           onClose={() => setRightPanelOpen(false)}
         />
       ) : null}

--- a/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
+++ b/web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx
@@ -499,7 +499,7 @@ function WorkItemCard({
   );
 }
 
-export function WorkItemDetailPanel({ workItem, detailState }: { workItem: WorkItemSummary; detailState?: WorkItemDetailState }) {
+export function WorkItemDetailPanel({ workItem, detailState, onOpenPlanFile }: { workItem: WorkItemSummary; detailState?: WorkItemDetailState; onOpenPlanFile?: (workspaceId: string, filePath: string) => void }) {
   const loading = detailState?.loading && !detailState.workItem;
   const plan = workItem.planArtifact;
   return (
@@ -550,7 +550,15 @@ export function WorkItemDetailPanel({ workItem, detailState }: { workItem: WorkI
       {plan?.preview || plan?.path ? (
         <section className="work-item-detail-section">
           <h3>Plan</h3>
-          {plan.path ? <code>{plan.path}</code> : null}
+          {plan.path ? (
+            onOpenPlanFile && plan.workspaceId && plan.relativePath ? (
+              <a href="#" className="workspace-path-link" onClick={(e) => { e.preventDefault(); onOpenPlanFile(plan.workspaceId!, plan.relativePath!); }}>
+                <code>{plan.path}</code>
+              </a>
+            ) : (
+              <code>{plan.path}</code>
+            )
+          ) : null}
           {plan.preview ? <pre>{plan.preview}</pre> : null}
         </section>
       ) : null}

--- a/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
+++ b/web-gui/app/src/features/right-panel/FileBrowserPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createHighlighter, type Highlighter } from "shiki";
 
 import type { WorkspaceDirectoryListing, WorkspaceFileEntry } from "../../runtime/types";
@@ -7,6 +7,7 @@ import { useRuntimeStore } from "../../runtime/runtime-store";
 interface FileBrowserPanelProps {
   workspaceId: string;
   executionRootId?: string;
+  initialFilePath?: string;
   initialPath?: string;
 }
 
@@ -127,17 +128,20 @@ function useShikiHighlight(content: string | undefined, filePath: string | undef
   return highlighted;
 }
 
-export function FileBrowserPanel({ workspaceId, executionRootId, initialPath }: FileBrowserPanelProps) {
+export function FileBrowserPanel({ workspaceId, executionRootId, initialPath, initialFilePath }: FileBrowserPanelProps) {
   const browseWorkspaceDir = useRuntimeStore((s) => s.browseWorkspaceDir);
   const readWorkspaceFile = useRuntimeStore((s) => s.readWorkspaceFile);
   const workspaceFileUrl = useRuntimeStore((s) => s.workspaceFileUrl);
 
-  const [currentPath, setCurrentPath] = useState(initialPath ?? "");
+  const effectiveInitialPath =
+    initialPath ?? (initialFilePath ? initialFilePath.split("/").slice(0, -1).join("/") : "");
+  const [currentPath, setCurrentPath] = useState(effectiveInitialPath);
   const [listing, setListing] = useState<WorkspaceDirectoryListing | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
   const [showHidden, setShowHidden] = useState(false);
+  const autoOpenedRef = useRef(false);
 
   const highlightedHtml = useShikiHighlight(selectedFile?.content, selectedFile?.path);
 
@@ -160,8 +164,18 @@ export function FileBrowserPanel({ workspaceId, executionRootId, initialPath }: 
   );
 
   useEffect(() => {
-    void loadDir(initialPath ?? "");
-  }, [loadDir, initialPath]);
+    void loadDir(effectiveInitialPath);
+  }, [loadDir, effectiveInitialPath]);
+
+  // Auto-open the initial file after the directory listing loads.
+  useEffect(() => {
+    if (!listing || !initialFilePath || autoOpenedRef.current) return;
+    const fileName = initialFilePath.split("/").pop();
+    const entry = listing.entries.find((e) => e.name === fileName);
+    if (!entry) return;
+    autoOpenedRef.current = true;
+    void openEntry(entry);
+  }, [listing, initialFilePath]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const breadcrumbParts = currentPath.split("/").filter(Boolean);
 

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -115,7 +115,11 @@ export function RightSidePanel({
             ? "File browser"
           : "Agent overview";
   const detailState = activeView.kind === "work_item_detail" ? workItemDetailsById[activeView.workItem.id] : undefined;
-  const detailWorkItem = activeView.kind === "work_item_detail" ? detailState?.workItem ?? activeView.workItem : undefined;
+  const detailWorkItem = activeView.kind === "work_item_detail"
+    ? agent.workItems?.find((wi) => wi.id === activeView.workItem.id)
+      ?? detailState?.workItem
+      ?? activeView.workItem
+    : undefined;
   const taskDetailState = activeView.kind === "task_detail" ? activeView.detailState ?? taskDetailsById[activeView.task.id] : undefined;
 
   useEffect(() => {

--- a/web-gui/app/src/features/right-panel/RightSidePanel.tsx
+++ b/web-gui/app/src/features/right-panel/RightSidePanel.tsx
@@ -27,6 +27,7 @@ interface RightSidePanelProps {
   onOpenSkill: (skillId: string) => void;
   onShowAgentOverview: () => void;
   onBrowseFiles: (workspaceId: string, executionRootId?: string) => void;
+  onOpenPlanFile?: (workspaceId: string, filePath: string) => void;
   onClose: () => void;
 }
 
@@ -51,6 +52,7 @@ export function RightSidePanel({
   onOpenSkill,
   onShowAgentOverview,
   onBrowseFiles,
+  onOpenPlanFile,
   onClose,
 }: RightSidePanelProps) {
   const PANEL_MIN = 320;
@@ -169,14 +171,14 @@ export function RightSidePanel({
           <ActivityInspectorPanel activity={activeView.activity} detailState={activeView.detailState} />
         ) : activeView.kind === "work_item_detail" && detailWorkItem ? (
           <div className="inspector-stack">
-            <WorkItemDetailPanel workItem={detailWorkItem} detailState={detailState} />
+            <WorkItemDetailPanel workItem={detailWorkItem} detailState={detailState} onOpenPlanFile={onOpenPlanFile} />
           </div>
         ) : activeView.kind === "task_detail" ? (
           <div className="inspector-stack">
             <TaskDetailPanel task={activeView.task} detailState={taskDetailState} />
           </div>
         ) : activeView.kind === "file_browser" ? (
-          <FileBrowserPanel workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} />
+          <FileBrowserPanel workspaceId={activeView.workspaceId} executionRootId={activeView.executionRootId} initialPath={activeView.initialPath} initialFilePath={activeView.initialFilePath} />
         ) : (
           <AgentOverviewPanel
             agent={agent}

--- a/web-gui/app/src/runtime/client.ts
+++ b/web-gui/app/src/runtime/client.ts
@@ -254,6 +254,7 @@ interface WorkItemDto {
   plan_artifact?: {
     path?: string;
     relative_path?: string;
+    workspace_id?: string;
     workspace_alias?: string;
     preview?: string;
     preview_complete?: boolean;
@@ -1803,6 +1804,7 @@ function projectWorkItem(workItem: WorkItemDto | undefined, currentWorkItemId?: 
           path: planArtifact.path,
           relativePath: planArtifact.relative_path,
           workspaceAlias: planArtifact.workspace_alias,
+          workspaceId: planArtifact.workspace_id,
           preview: planArtifact.preview,
           previewComplete: planArtifact.preview_complete,
           updatedAt: planArtifact.updated_at,

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -2776,9 +2776,8 @@ function applyStreamEvents(set: StoreSet, agentId: string, events: StreamEventEn
 }
 
 function isWorkItemCacheInvalidationEvent(event: StreamEventEnvelopeDto): boolean {
-  if (event.type !== "work_item_written") return false;
-  const action = stringField(asRecord(event.payload), "action");
-  return action === "created" || action === "completed";
+  // Match all work_item_written events so updated/picked actions also refresh the cache.
+  return event.type === "work_item_written";
 }
 
 function isAgentStateCacheInvalidationEvent(event: StreamEventEnvelopeDto): boolean {

--- a/web-gui/app/src/runtime/runtime-store.ts
+++ b/web-gui/app/src/runtime/runtime-store.ts
@@ -211,7 +211,7 @@ export interface RuntimeStoreState {
   showWorkItemDetail: (agentId: string, workItem: WorkItemSummary) => void;
   showTaskDetail: (agentId: string, task: TaskSummary) => void;
   inspectActivity: (agentId: string, activity: AgentTimelineActivity) => void;
-  showFileBrowser: (agentId: string, workspaceId: string, initialPath?: string, executionRootId?: string) => void;
+  showFileBrowser: (agentId: string, workspaceId: string, initialPath?: string, executionRootId?: string, initialFilePath?: string) => void;
   browseWorkspaceDir: (workspaceId: string, path?: string, executionRootId?: string) => Promise<WorkspaceDirectoryListing>;
   readWorkspaceFile: (workspaceId: string, path: string, executionRootId?: string) => Promise<WorkspaceFileContent>;
   workspaceFileUrl: (workspaceId: string, path: string, download?: boolean, executionRootId?: string) => string;
@@ -745,10 +745,10 @@ export const useRuntimeStore = create<RuntimeStoreState>((set, get) => ({
       rightPanelOpen: true,
       rightPanelView: { kind: "task_detail", agentId, task },
     }),
-  showFileBrowser: (agentId, workspaceId, initialPath, executionRootId) =>
+  showFileBrowser: (agentId, workspaceId, initialPath, executionRootId, initialFilePath) =>
     set({
       rightPanelOpen: true,
-      rightPanelView: { kind: "file_browser", agentId, workspaceId, initialPath, executionRootId },
+      rightPanelView: { kind: "file_browser", agentId, workspaceId, initialPath, executionRootId, initialFilePath },
     }),
   browseWorkspaceDir: (workspaceId, path, executionRootId) => runtimeClient.browseWorkspaceDir(workspaceId, path, executionRootId),
   readWorkspaceFile: (workspaceId, path, executionRootId) => runtimeClient.readWorkspaceFile(workspaceId, path, executionRootId),

--- a/web-gui/app/src/runtime/types.ts
+++ b/web-gui/app/src/runtime/types.ts
@@ -79,6 +79,7 @@ export interface WorkItemPlanArtifactSummary {
   path?: string;
   relativePath?: string;
   workspaceAlias?: string;
+  workspaceId?: string;
   preview?: string;
   previewComplete?: boolean;
   updatedAt?: string;
@@ -478,6 +479,7 @@ export type RightPanelView =
       agentId: string;
       workspaceId: string;
       executionRootId?: string;
+      initialFilePath?: string;
       initialPath?: string;
     };
 


### PR DESCRIPTION
## Summary

Three web GUI improvements for work item display and interaction:

1. **Widen work item SSE cache invalidation** — `isWorkItemCacheInvalidationEvent` now matches all `work_item_written` events, not just `created`/`completed`. This ensures `UpdateWorkItem` (updated) and `PickWorkItem` (picked) actions also trigger `refreshAgentWorkItems`, so the UI reflects state changes in real time.

2. **Clickable plan file path** — The plan file path in work item detail panels is now a link. Clicking it opens the file in the right-side file browser. Adds `workspaceId` mapping to the frontend DTO and `initialFilePath` support in `FileBrowserPanel`.

3. **Live data for detail panel** — The work item detail panel now prioritizes looking up the latest work item from `agent.workItems` (which is refreshed on SSE events) instead of using a stale cached snapshot. This ensures `todo_list`, `plan_status`, and other fields update in real time.

## Changed files
- `web-gui/app/src/app/App.tsx`
- `web-gui/app/src/features/right-panel/AgentOverviewPanel.tsx`
- `web-gui/app/src/features/right-panel/FileBrowserPanel.tsx`
- `web-gui/app/src/features/right-panel/RightSidePanel.tsx`
- `web-gui/app/src/runtime/client.ts`
- `web-gui/app/src/runtime/runtime-store.ts`
- `web-gui/app/src/runtime/types.ts`

## Testing
- Built the web GUI with `npm run build` and verified the running server serves the updated dist.
- Manually verified work item lifecycle (create → update → plan_status change → complete) reflects in the UI in real time via SSE events.