### PR TITLE
fix: fallback prompt budget + non-trimmable token deduction in degraded rounds

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -8,7 +8,7 @@ use crate::context::ContextConfig;
 const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT: u8 = 95;
 const DEFAULT_COMPACTION_TRIGGER_PERCENT: u8 = 90;
 const DEFAULT_KEEP_RECENT_PERCENT: u8 = 38;
-const DEFAULT_UNKNOWN_FALLBACK_PROMPT_BUDGET_ESTIMATED_TOKENS: usize = 64_000;
+const DEFAULT_UNKNOWN_FALLBACK_PROMPT_BUDGET_ESTIMATED_TOKENS: usize = 128_000;
 const DEFAULT_TOOL_OUTPUT_TRUNCATION_ESTIMATED_TOKENS: usize = 2_500;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -3047,9 +3047,9 @@ mod tests {
             8192,
         );
 
-        assert_eq!(policy.prompt_budget_estimated_tokens, 64_000);
-        assert_eq!(policy.compaction_trigger_estimated_tokens, 57_600);
-        assert_eq!(policy.compaction_keep_recent_estimated_tokens, 21_888);
+        assert_eq!(policy.prompt_budget_estimated_tokens, 128_000);
+        assert_eq!(policy.compaction_trigger_estimated_tokens, 115_200);
+        assert_eq!(policy.compaction_keep_recent_estimated_tokens, 43_776);
         assert_eq!(policy.source, ModelMetadataSource::UnknownFallback);
     }
 

--- a/src/runtime/turn/projection.rs
+++ b/src/runtime/turn/projection.rs
@@ -266,7 +266,20 @@ pub(super) fn degraded_round_messages(
         return (exact_round_messages(round), false);
     }
 
-    let available_chars = available_tokens.saturating_mul(4);
+    // Estimate token cost of non-trimmable blocks (ToolUse, Thinking,
+    // RedactedThinking) and subtract from the budget so they don't silently
+    // consume the per-item char allocation reserved for trimmable content.
+    // Without this deduction, I/O-heavy rounds with large tool calls would
+    // exceed the intended degradation budget.
+    let non_trimmable_estimated_tokens: usize = round
+        .assistant_blocks
+        .iter()
+        .filter(|block| !matches!(block, ModelBlock::Text { .. }))
+        .map(estimate_model_block_tokens)
+        .sum();
+    let trimmable_available_tokens =
+        available_tokens.saturating_sub(non_trimmable_estimated_tokens);
+    let available_chars = trimmable_available_tokens.saturating_mul(4);
     let per_item_char_limit =
         (available_chars / trimmable_count).max(DEGRADED_ROUND_MINIMUM_CONTENT_CHARS);
 

--- a/src/runtime/turn/tests.rs
+++ b/src/runtime/turn/tests.rs
@@ -2034,6 +2034,39 @@ fn degraded_round_messages_preserves_follow_up_texts() {
     }
 }
 
+#[test]
+fn degraded_round_messages_deducts_non_trimmable_tokens() {
+    // Large ToolUse input (~200 tokens) is non-trimmable. Without deducting
+    // it from the budget, the 800-char text would fit within 300*4=1200 chars
+    // per item and NOT be trimmed. With the deduction, only ~93 tokens remain
+    // for the text (~372 chars), so the text IS trimmed.
+    let large_input = serde_json::json!({
+        "data": "x".repeat(800),
+    });
+    let large_text = "content ".repeat(100); // 800 chars
+    let round = fixture_round_with_tool(1, &large_text, "BigTool", large_input);
+
+    let (messages, trimmed) = degraded_round_messages(&round, 300);
+    assert!(
+        trimmed,
+        "text should be trimmed because non-trimmable ToolUse tokens reduce the available budget"
+    );
+
+    let assistant_msg = messages
+        .iter()
+        .find(|m| matches!(m, ConversationMessage::AssistantBlocks(_)));
+    assert!(assistant_msg.is_some());
+    if let Some(ConversationMessage::AssistantBlocks(blocks)) = assistant_msg {
+        let has_trim_marker = blocks.iter().any(|b| {
+            matches!(b, ModelBlock::Text { text } if text.contains("[runtime: assistant text trimmed"))
+        });
+        assert!(
+            has_trim_marker,
+            "trimmed text should contain the runtime trim marker"
+        );
+    }
+}
+
 // -----------------------------------------------------------------------
 // completion_report_texts_by_tool_id tests
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes two budget calculation bugs:

### #2028: Fallback prompt budget too conservative
`DEFAULT_UNKNOWN_FALLBACK_PROMPT_BUDGET_ESTIMATED_TOKENS` was 64K. For modern 200K-context models (Claude Sonnet, etc.), this fallback was too conservative, causing premature compaction/degradation when the catalog couldn't resolve a model.

**Fix**: Increased to 128K — a safe middle ground for current mainstream models.

### #2022: degraded_round doesn't deduct non-trimmable content
`degraded_round_messages` only counted `Text` blocks and `tool_results` as trimmable items, but `ToolUse`, `Thinking`, and `RedactedThinking` blocks also consume tokens without being deducted from the available budget. For I/O-heavy rounds, this meant the actual degraded message tokens far exceeded the budget.

**Fix**: Before allocating per-item char limits, estimate non-trimmable block tokens and subtract from the available budget. Uses the existing `estimate_model_block_tokens` function for consistency.

## Test plan
- [x] `cargo fmt --all -- --check` ✅
- [x] `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- [x] All 7 `degraded_round_messages` tests pass (including new test for non-trimmable deduction)
- [x] `resolves_unknown_model_with_larger_default_fallback_budget` test updated and passes

Closes #2028
Closes #2022