### PR TITLE
fix: introduce Interrupted queue status for daemon restart recovery (#1953, #1976)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1524,7 +1524,7 @@ impl RuntimeHandle {
                         message_id: message.id.clone(),
                         agent_id: message.agent_id.clone(),
                         priority: message.priority.clone(),
-                        status: QueueEntryStatus::Aborted,
+                        status: QueueEntryStatus::Interrupted,
                         created_at: message.created_at,
                         updated_at: Utc::now(),
                     })?;

--- a/src/runtime/delivery.rs
+++ b/src/runtime/delivery.rs
@@ -117,6 +117,7 @@ fn operator_message_status(
         QueueEntryStatus::Dequeued | QueueEntryStatus::Interjected => {
             OperatorMessageStatus::Processing
         }
+        QueueEntryStatus::Interrupted => OperatorMessageStatus::Queued,
         QueueEntryStatus::Processed => OperatorMessageStatus::Processed,
         QueueEntryStatus::Aborted => OperatorMessageStatus::Failed,
         QueueEntryStatus::Dropped => OperatorMessageStatus::Dropped,

--- a/src/runtime/tests/runtime_state.rs
+++ b/src/runtime/tests/runtime_state.rs
@@ -1855,7 +1855,7 @@ async fn abort_current_run_aborts_provider_turn_and_stops_agent() {
     let queue_entries = runtime.storage().latest_queue_entries().unwrap();
     assert!(queue_entries
         .iter()
-        .any(|entry| entry.status == QueueEntryStatus::Aborted));
+        .any(|entry| entry.status == QueueEntryStatus::Interrupted));
     let events = runtime.all_events().unwrap();
     assert!(events
         .iter()

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1340,8 +1340,7 @@ impl QueueEntryRepository<'_> {
     pub fn queued_for_agent(&self, agent_id: &str) -> Result<Vec<QueueEntryRecord>> {
         let connection = self.db.connection()?;
         let queued_status = enum_string(&crate::types::QueueEntryStatus::Queued)?;
-        let interrupted_status =
-            enum_string(&crate::types::QueueEntryStatus::Interrupted)?;
+        let interrupted_status = enum_string(&crate::types::QueueEntryStatus::Interrupted)?;
         let mut statement = connection.prepare(
             "SELECT payload_json
              FROM queue_entries

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1326,10 +1326,11 @@ impl QueueEntryRepository<'_> {
     pub fn has_queued_for_agent(&self, agent_id: &str) -> Result<bool> {
         let connection = self.db.connection()?;
         let status = enum_string(&crate::types::QueueEntryStatus::Queued)?;
+        let interrupted_status = enum_string(&crate::types::QueueEntryStatus::Interrupted)?;
         let exists: Option<i64> = connection
             .query_row(
-                "SELECT 1 FROM queue_entries WHERE agent_id = ?1 AND status = ?2 LIMIT 1",
-                params![agent_id, status],
+                "SELECT 1 FROM queue_entries WHERE agent_id = ?1 AND status IN (?2, ?3) LIMIT 1",
+                params![agent_id, status, interrupted_status],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?;
@@ -2874,6 +2875,7 @@ fn upsert_queue_entry_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Res
 
 fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) -> Result<bool> {
     let queued_status = enum_string(&QueueEntryStatus::Queued)?;
+    let interrupted_status = enum_string(&QueueEntryStatus::Interrupted)?;
     let mut claimed = record.clone();
     claimed.status = QueueEntryStatus::Dequeued;
     let payload_json = serde_json::to_string(&claimed)?;
@@ -2888,7 +2890,7 @@ fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) 
              payload_json = ?7
          WHERE message_id = ?1
            AND agent_id = ?2
-           AND status = ?8",
+           AND status IN (?8, ?9)",
         params![
             claimed.message_id,
             claimed.agent_id,
@@ -2898,6 +2900,7 @@ fn try_claim_queued_message_tx(tx: &Transaction<'_>, record: &QueueEntryRecord) 
             timestamp(claimed.updated_at),
             payload_json,
             queued_status,
+            interrupted_status,
         ],
     )?;
     Ok(changed == 1)

--- a/src/runtime_db/repositories.rs
+++ b/src/runtime_db/repositories.rs
@@ -1339,14 +1339,19 @@ impl QueueEntryRepository<'_> {
     /// Returns only entries currently queued for a specific agent.
     pub fn queued_for_agent(&self, agent_id: &str) -> Result<Vec<QueueEntryRecord>> {
         let connection = self.db.connection()?;
-        let status = enum_string(&crate::types::QueueEntryStatus::Queued)?;
+        let queued_status = enum_string(&crate::types::QueueEntryStatus::Queued)?;
+        let interrupted_status =
+            enum_string(&crate::types::QueueEntryStatus::Interrupted)?;
         let mut statement = connection.prepare(
             "SELECT payload_json
              FROM queue_entries
-             WHERE agent_id = ?1 AND status = ?2
+             WHERE agent_id = ?1 AND status IN (?2, ?3)
              ORDER BY updated_at DESC, created_at DESC, message_id ASC",
         )?;
-        let rows = statement.query_map(params![agent_id, status], |row| row.get::<_, String>(0))?;
+        let rows = statement.query_map(
+            params![agent_id, queued_status, interrupted_status],
+            |row| row.get::<_, String>(0),
+        )?;
         let mut records: Vec<_> = rows
             .map(|row| decode_queue_entry_payload(&row?))
             .collect::<Result<_>>()?;

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -1127,6 +1127,56 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn queued_for_agent_includes_interrupted_entries() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+
+        let queued_entry = QueueEntryRecord {
+            message_id: "msg-queued".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Queued,
+            created_at: now,
+            updated_at: now,
+        };
+        let interrupted_entry = QueueEntryRecord {
+            message_id: "msg-interrupted".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Interrupted,
+            created_at: now + chrono::Duration::seconds(1),
+            updated_at: now + chrono::Duration::seconds(1),
+        };
+        let aborted_entry = QueueEntryRecord {
+            message_id: "msg-aborted".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Aborted,
+            created_at: now + chrono::Duration::seconds(2),
+            updated_at: now + chrono::Duration::seconds(2),
+        };
+
+        db.queue_entries().upsert(&queued_entry)?;
+        db.queue_entries().upsert(&interrupted_entry)?;
+        db.queue_entries().upsert(&aborted_entry)?;
+
+        let entries = db.queue_entries().queued_for_agent("agent-a")?;
+        let message_ids: Vec<_> = entries.iter().map(|e| e.message_id.as_str()).collect();
+        assert!(message_ids.contains(&"msg-queued"), "Queued entry should be included");
+        assert!(
+            message_ids.contains(&"msg-interrupted"),
+            "Interrupted entry should be included for recovery replay"
+        );
+        assert!(
+            !message_ids.contains(&"msg-aborted"),
+            "Aborted entry should NOT be included"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn runtime_db_foreign_keys_are_enabled_per_connection() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -1163,7 +1163,10 @@ CREATE TABLE working_memory_deltas (
 
         let entries = db.queue_entries().queued_for_agent("agent-a")?;
         let message_ids: Vec<_> = entries.iter().map(|e| e.message_id.as_str()).collect();
-        assert!(message_ids.contains(&"msg-queued"), "Queued entry should be included");
+        assert!(
+            message_ids.contains(&"msg-queued"),
+            "Queued entry should be included"
+        );
         assert!(
             message_ids.contains(&"msg-interrupted"),
             "Interrupted entry should be included for recovery replay"

--- a/src/runtime_db/tests.rs
+++ b/src/runtime_db/tests.rs
@@ -1180,6 +1180,39 @@ CREATE TABLE working_memory_deltas (
     }
 
     #[test]
+    fn try_claim_succeeds_for_interrupted_entry() -> Result<()> {
+        let (_temp_dir, db_path, lock_path) = temp_paths()?;
+        let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;
+        let now = Utc::now();
+
+        let record = QueueEntryRecord {
+            message_id: "msg-interrupted".into(),
+            agent_id: "agent-a".into(),
+            priority: crate::types::Priority::Normal,
+            status: QueueEntryStatus::Interrupted,
+            created_at: now,
+            updated_at: now,
+        };
+        db.queue_entries().upsert(&record)?;
+
+        // An Interrupted entry must be claimable, otherwise recovery would
+        // silently drop it. See PR #2052 review feedback.
+        assert!(db.queue_entries().has_queued_for_agent("agent-a")?);
+        let mut claim = record.clone();
+        claim.status = QueueEntryStatus::Dequeued;
+        claim.updated_at = now + chrono::Duration::seconds(1);
+        assert!(
+            db.queue_entries().try_claim_queued_message(&claim)?,
+            "Interrupted entry should be claimable for replay"
+        );
+        assert_eq!(
+            db.queue_entries().latest_all()?[0].status,
+            QueueEntryStatus::Dequeued
+        );
+        Ok(())
+    }
+
+    #[test]
     fn runtime_db_foreign_keys_are_enabled_per_connection() -> Result<()> {
         let (_temp_dir, db_path, lock_path) = temp_paths()?;
         let db = RuntimeDb::open_and_migrate(&db_path, &lock_path)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -3878,8 +3878,8 @@ pub enum QueueEntryStatus {
     Dequeued,
     Processed,
     Interjected,
-    // TODO: remove `interrupted` alias after older queue ledgers have migrated.
-    #[serde(alias = "interrupted")]
+    /// Daemon shutdown interrupted processing; replay on recovery.
+    Interrupted,
     Aborted,
     Dropped,
 }
@@ -4922,10 +4922,10 @@ mod tests {
 
         let status: QueueEntryStatus =
             serde_json::from_value(serde_json::json!("interrupted")).unwrap();
-        assert_eq!(status, QueueEntryStatus::Aborted);
+        assert_eq!(status, QueueEntryStatus::Interrupted);
         assert_eq!(
             serde_json::to_value(status).unwrap(),
-            serde_json::json!("aborted")
+            serde_json::json!("interrupted")
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes daemon restart losing interrupted messages by introducing a dedicated `Interrupted` queue status.

### Problem

When the daemon shut down mid-processing, `CurrentRunAborted` caused messages to be written as `QueueEntryStatus::Aborted`. Recovery only replayed `Queued` entries, so:
- **#1953**: `system_tick` messages lost (regenerable but causes missed task resumption)
- **#1976**: Operator-triggered turns lost (**not regenerable** — the instruction is gone)

### Fix

**New `QueueEntryStatus::Interrupted` variant** with semantics "daemon shutdown interrupted processing; replay on recovery."

| Change | File |
|--------|------|
| Add `Interrupted` variant (replaces transitional `#[serde(alias)]` hack) | `src/types.rs` |
| `CurrentRunAborted` path writes `Interrupted` (not `Aborted`) | `src/runtime.rs` |
| Recovery SQL query includes both `Queued` and `Interrupted` | `src/runtime_db/repositories.rs` |
| `Interrupted` → `OperatorMessageStatus::Queued` for operator visibility | `src/runtime/delivery.rs` |

**Key design choice**: Genuine errors (non-abort) still write `Aborted` (permanent failure, no replay). Only `CurrentRunAborted` (daemon shutdown) writes `Interrupted`.

## Test plan
- [x] `cargo fmt --all -- --check` ✅
- [x] `RUSTFLAGS="-D warnings" cargo check --all-targets` ✅
- [x] All 1993 lib tests pass ✅
- [x] New: `queued_for_agent_includes_interrupted_entries` ✅
- [x] Updated: `abort_current_run` test expects `Interrupted` ✅
- [x] Updated: legacy deserialization test for new `Interrupted` semantics ✅

Closes #1953
Closes #1976
