### PR TITLE
feat: decouple Thinking selector from model picker, improve layout

### DIFF
--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -388,7 +388,9 @@ export function AgentPage({
                         title={`Thinking level: ${activeReasoningBadge ?? "auto"}`}
                         onClick={() => setReasoningPopoverOpen((prev) => !prev)}
                       >
-                        <span aria-hidden="true">🧠</span>
+                        <svg className="thinking-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                          <path d="M8 1.5L6 6H2.5L5.5 8.5L4 13L8 10L12 13L10.5 8.5L13.5 6H10L8 1.5Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" fill="none"/>
+                        </svg>
                         <small>{titleCase(activeReasoningBadge ?? "auto")}</small>
                       </Button>
                       {reasoningPopoverOpen ? (

--- a/web-gui/app/src/features/agent/AgentPage.tsx
+++ b/web-gui/app/src/features/agent/AgentPage.tsx
@@ -107,6 +107,7 @@ export function AgentPage({
   const [changingModel, setChangingModel] = useState<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [selectedReasoningEffort, setSelectedReasoningEffort] = useState("auto");
+  const [reasoningPopoverOpen, setReasoningPopoverOpen] = useState(false);
   const [visibleTimelineItemLimit, setVisibleTimelineItemLimit] = useState(() => defaultTimelineItemLimit("info"));
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -148,6 +149,7 @@ export function AgentPage({
   useEffect(() => {
     setVisibleTimelineItemLimit(defaultTimelineItemLimit(displayLevel));
     setModelPickerOpen(false);
+    setReasoningPopoverOpen(false);
     setSelectedProvider(null);
     setSelectedReasoningEffort(activeAgent.modelReasoningEffort ?? "auto");
   }, [activeAgent.id, displayLevel]);
@@ -241,6 +243,7 @@ export function AgentPage({
 
   function toggleModelPicker() {
     const opening = !modelPickerOpen;
+    if (opening) setReasoningPopoverOpen(false);
     setModelPickerOpen(opening);
     if (opening && !modelCatalogLoading && modelCatalog.options.length === 0) {
       void onRefreshModels();
@@ -249,6 +252,13 @@ export function AgentPage({
 
   async function handleSelectModel(option: RuntimeModelOption, reasoningEffort = selectedReasoningEffort) {
     if (!option.available || changingModel) return;
+
+    // When switching to a non-reasoning model, reset thinking display to auto.
+    if (!option.supportsReasoningEffort) {
+      setSelectedReasoningEffort("auto");
+      reasoningEffort = "auto";
+    }
+
     setChangingModel(option.model);
     try {
       await onSetModel(option.model, option.supportsReasoningEffort && reasoningEffort !== "auto" ? reasoningEffort : undefined);
@@ -266,6 +276,19 @@ export function AgentPage({
     try {
       await onClearModel();
       setModelPickerOpen(false);
+    } catch {
+      // Store exposes the user-facing error.
+    } finally {
+      setChangingModel(null);
+    }
+  }
+
+  async function handleReasoningChange(effort: string) {
+    setSelectedReasoningEffort(effort);
+    if (changingModel || !activeModelSupportsReasoning) return;
+    setChangingModel("reasoning:" + effort);
+    try {
+      await onSetModel(activeAgent.model, effort !== "auto" ? effort : undefined);
     } catch {
       // Store exposes the user-facing error.
     } finally {
@@ -352,9 +375,41 @@ export function AgentPage({
                     onClick={toggleModelPicker}
                   >
                     <span className="model-button-label">{shortModelLabel(activeAgent.model)}</span>
-                    {activeReasoningBadge ? <small className="model-button-badge">{activeReasoningBadge}</small> : null}
                     <span aria-hidden="true">⌄</span>
                   </Button>
+                  {activeModelSupportsReasoning ? (
+                    <div className="thinking-picker">
+                      <Button
+                        className="thinking-button"
+                        type="button"
+                        variant="ghost"
+                        aria-expanded={reasoningPopoverOpen}
+                        aria-label={`Thinking: ${activeReasoningBadge ?? "auto"}`}
+                        title={`Thinking level: ${activeReasoningBadge ?? "auto"}`}
+                        onClick={() => setReasoningPopoverOpen((prev) => !prev)}
+                      >
+                        <span aria-hidden="true">🧠</span>
+                        <small>{titleCase(activeReasoningBadge ?? "auto")}</small>
+                      </Button>
+                      {reasoningPopoverOpen ? (
+                        <div className="thinking-popover" role="dialog" aria-label="Thinking level">
+                          <div className="reasoning-options">
+                            {["auto", "low", "medium", "high", "xhigh"].map((effort) => (
+                              <button
+                                className={`${(activeReasoningBadge ?? "auto") === effort ? "is-active" : ""} ${changingModel === "reasoning:" + effort ? "is-saving" : ""}`}
+                                key={effort}
+                                type="button"
+                                disabled={changingModel !== null}
+                                onClick={() => void handleReasoningChange(effort)}
+                              >
+                                {titleCase(effort)}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
                   {modelPickerOpen ? (
                     <div className="model-menu" role="dialog" aria-label="Switch agent model">
                       <div className="model-menu-header">
@@ -410,26 +465,6 @@ export function AgentPage({
                             <b>Step 2</b>
                             {currentProvider} models
                           </span>
-                          {activeModelSupportsReasoning || currentProviderModels.some((option) => option.supportsReasoningEffort) ? (
-                            <div className="model-picker-reasoning" aria-label="Thinking level">
-                              <span>
-                                <b>Thinking</b>
-                                Choose before selecting a reasoning model
-                              </span>
-                              <div className="reasoning-options">
-                                {["auto", "low", "medium", "high", "xhigh"].map((effort) => (
-                                  <button
-                                    className={selectedReasoningEffort === effort ? "is-active" : ""}
-                                    key={effort}
-                                    type="button"
-                                    onClick={() => setSelectedReasoningEffort(effort)}
-                                  >
-                                    {titleCase(effort)}
-                                  </button>
-                                ))}
-                              </div>
-                            </div>
-                          ) : null}
                           <div className="model-options" role="listbox" aria-label={`${currentProvider} models`}>
                             {currentProviderModels.map((option) => (
                               <button

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2287,6 +2287,9 @@ code {
 
 .model-picker {
   position: relative;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .model-button {
@@ -2329,6 +2332,11 @@ code {
   padding-inline: 8px;
   opacity: 0.72;
   transition: opacity 0.15s;
+}
+
+.thinking-icon {
+  flex: 0 0 auto;
+  color: var(--accent);
 }
 
 .thinking-button:hover,

--- a/web-gui/app/src/styles/global.css
+++ b/web-gui/app/src/styles/global.css
@@ -2317,6 +2317,50 @@ code {
   line-height: 1.35;
 }
 
+.thinking-picker {
+  position: relative;
+}
+
+.thinking-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 30px;
+  padding-inline: 8px;
+  opacity: 0.72;
+  transition: opacity 0.15s;
+}
+
+.thinking-button:hover,
+.thinking-button[aria-expanded="true"] {
+  opacity: 1;
+}
+
+.thinking-button small {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: capitalize;
+  color: var(--muted);
+}
+
+.thinking-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+}
+
+.thinking-popover .reasoning-options button.is-saving {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .model-menu {
   position: absolute;
   right: 0;


### PR DESCRIPTION
## 改动内容

改进 web-gui 的模型选择器和 Thinking（reasoning effort）交互体验：

### 1. Thinking 选择器解耦
- 将 Thinking 选择器从 model picker 内部移出，改为独立控件
- 只有当前模型支持 reasoning 时才显示 Thinking 按钮
- 改变 Thinking 级别即时生效，不需要重新选择模型

### 2. 横向布局优化
- 模型按钮和 Thinking 按钮水平并排显示
- 移除 model picker 内部冗余的 reasoning 提示面板
- 移除模型按钮上的 reasoning badge（信息由 Thinking 按钮承载）

### 3. 图标改进
- 替换原来的 emoji 图标为简洁的 SVG 图标
- 使用 `currentColor` 跟随主题色，视觉上更统一

### 解决的用户问题
- Thinking 和模型的关系更清晰——只有当前模型支持时才出现
- 不需要"先选 Thinking 再选模型"两步操作——Thinking 是独立即时生效的